### PR TITLE
Restyle Staging SQL using CTEs and field descriptions/documentation

### DIFF
--- a/src/ol_dbt/models/staging/mitxonline/stg_mitxonline__app__postgres__course_courserunenrollment.sql
+++ b/src/ol_dbt/models/staging/mitxonline/stg_mitxonline__app__postgres__course_courserunenrollment.sql
@@ -1,9 +1,24 @@
-select
-    id
-    , active
-    , run_id
-    , user_id
-    , cast(created_on[1] as timestamp(6)) as created_on
-    , cast(updated_on[1] as timestamp(6)) as updated_on
-from
-    {{ source('ol_warehouse_raw_data','mitxonline__app__postgres__courses_courserunenrollment') }}
+-- MITx Online Course Run Enrollment Information 
+
+with source as (
+    select * from {{ source('ol_warehouse_raw_data','mitxonline__app__postgres__courses_courserunenrollment') }}
+),
+
+cleaned as (
+    select 
+        -- int, sequential ID tracking a single user enrollment
+        id
+        -- str, boolean describing whether the enrollment is active
+        , active
+        -- int, unique ID specifying a "run" of an MITx Online course
+        , run_id
+        -- int, unique ID for each user on the MITx Online platform
+        , user_id
+        -- timestamp, specifying when an enrollment was initially created
+        , cast(created_on[1] as timestamp(6)) as created_on
+        -- timestamp, specifying when an enrollment was most recently updated
+        , cast(updated_on[1] as timestamp(6)) as updated_on 
+    from source
+)
+
+select * from cleaned

--- a/src/ol_dbt/models/staging/mitxonline/stg_mitxonline__app__postgres__course_courserunenrollment.sql
+++ b/src/ol_dbt/models/staging/mitxonline/stg_mitxonline__app__postgres__course_courserunenrollment.sql
@@ -1,11 +1,11 @@
--- MITx Online Course Run Enrollment Information 
+-- MITx Online Course Run Enrollment Information
 
 with source as (
     select * from {{ source('ol_warehouse_raw_data','mitxonline__app__postgres__courses_courserunenrollment') }}
-),
+)
 
-cleaned as (
-    select 
+, cleaned as (
+    select
         -- int, sequential ID tracking a single user enrollment
         id
         -- str, boolean describing whether the enrollment is active
@@ -17,7 +17,7 @@ cleaned as (
         -- timestamp, specifying when an enrollment was initially created
         , cast(created_on[1] as timestamp(6)) as created_on
         -- timestamp, specifying when an enrollment was most recently updated
-        , cast(updated_on[1] as timestamp(6)) as updated_on 
+        , cast(updated_on[1] as timestamp(6)) as updated_on
     from source
 )
 

--- a/src/ol_dbt/models/staging/mitxonline/stg_mitxonline__app__postgres__courses_course.sql
+++ b/src/ol_dbt/models/staging/mitxonline/stg_mitxonline__app__postgres__courses_course.sql
@@ -1,10 +1,28 @@
-select
-    id
-    , live
-    , title
-    , program_id
-    , readable_id
-    , position_in_program
-    , cast(created_on[1] as timestamp(6)) as created_on
-    , cast(updated_on[1] as timestamp(6)) as updated_on
-from {{ source('ol_warehouse_raw_data','mitxonline__app__postgres__courses_course') }}
+-- MITx Online Course Information
+
+with source as (
+    select * from {{ source('ol_warehouse_raw_data','mitxonline__app__postgres__courses_course') }}
+),
+
+cleaned as (
+    select 
+        -- int, sequential ID tracking a single MITx Online course
+        id
+        -- boolean, indicating whether the course is available to users
+        , live
+        -- str, title of the course
+        , title
+        -- id, unique ID pointing to the "program" which this course is part of
+        , program_id
+        -- str, Open edX ID formatted as course-v1:{org}+{course code}
+        , readable_id
+        -- int, ...
+        , position_in_program
+        -- timestamp, specifying when an enrollment was initially created
+        , cast(created_on[1] as timestamp(6)) as created_on
+        -- timestamp, specifying when an enrollment was most recently updated
+        , cast(updated_on[1] as timestamp(6)) as updated_on
+    from source
+)
+
+select * from cleaned

--- a/src/ol_dbt/models/staging/mitxonline/stg_mitxonline__app__postgres__courses_course.sql
+++ b/src/ol_dbt/models/staging/mitxonline/stg_mitxonline__app__postgres__courses_course.sql
@@ -2,10 +2,10 @@
 
 with source as (
     select * from {{ source('ol_warehouse_raw_data','mitxonline__app__postgres__courses_course') }}
-),
+)
 
-cleaned as (
-    select 
+, cleaned as (
+    select
         -- int, sequential ID tracking a single MITx Online course
         id
         -- boolean, indicating whether the course is available to users

--- a/src/ol_dbt/models/staging/mitxonline/stg_mitxonline__app__postgres__courses_courserun.sql
+++ b/src/ol_dbt/models/staging/mitxonline/stg_mitxonline__app__postgres__courses_courserun.sql
@@ -1,10 +1,26 @@
-select
-    id
-    , live
-    , title
-    , course_id
-    , courseware_url_path
-    , cast(created_on[1] as timestamp(6)) as created_on
-    , cast(updated_on[1] as timestamp(6)) as updated_on
-from
-    {{ source('ol_warehouse_raw_data','mitxonline__app__postgres__courses_courserun') }}
+-- MITx Online Course Run Information
+
+with source as (
+    select * from {{ source('ol_warehouse_raw_data','mitxonline__app__postgres__courses_courserun') }}
+),
+
+cleaned as (
+    select
+        -- int, sequential ID tracking a single course run
+        id
+        -- boolean, indicating whether the course is available to users
+        , live
+        -- str, title of the course
+        , title
+        -- int, ID specifying a course in the courses_course table
+        , course_id
+        -- str, url location for the course in MITx Online
+        , courseware_url_path
+        -- timestamp, specifying when a course run was initially created
+        , cast(created_on[1] as timestamp(6)) as created_on
+        -- timestamp, specifying when a course run was most recently updated
+        , cast(updated_on[1] as timestamp(6)) as updated_on
+    from source
+)
+
+select * from cleaned

--- a/src/ol_dbt/models/staging/mitxonline/stg_mitxonline__app__postgres__courses_courserun.sql
+++ b/src/ol_dbt/models/staging/mitxonline/stg_mitxonline__app__postgres__courses_courserun.sql
@@ -2,9 +2,9 @@
 
 with source as (
     select * from {{ source('ol_warehouse_raw_data','mitxonline__app__postgres__courses_courserun') }}
-),
+)
 
-cleaned as (
+, cleaned as (
     select
         -- int, sequential ID tracking a single course run
         id

--- a/src/ol_dbt/models/staging/mitxonline/stg_mitxonline__app__postgres__users_user.sql
+++ b/src/ol_dbt/models/staging/mitxonline/stg_mitxonline__app__postgres__users_user.sql
@@ -1,7 +1,19 @@
-select
+-- MITx Online User Information
+
+with source as (
+    select * from {{ source('ol_warehouse_raw_data','mitxonline__app__postgres__users_user') }}
+),
+
+cleaned as (
+    -- int, sequential ID representing one user in MITx Online
     id
+    -- boolean, ...
     , is_active
+    -- timestamp, specifying when a user account was initially created
     , cast(created_on[1] as timestamp(6)) as created_on
+    -- timestamp, specifying when a user account was most recently updated
     , cast(updated_on[1] as timestamp(6)) as updated_on
-from
-    {{ source('ol_warehouse_raw_data','mitxonline__app__postgres__users_user') }}
+) 
+
+select * from cleaned
+    

--- a/src/ol_dbt/models/staging/mitxonline/stg_mitxonline__app__postgres__users_user.sql
+++ b/src/ol_dbt/models/staging/mitxonline/stg_mitxonline__app__postgres__users_user.sql
@@ -2,10 +2,10 @@
 
 with source as (
     select * from {{ source('ol_warehouse_raw_data','mitxonline__app__postgres__users_user') }}
-),
+)
 
-cleaned as (
-    select 
+, cleaned as (
+    select
         -- int, sequential ID representing one user in MITx Online
         id
         -- boolean, ...
@@ -15,6 +15,6 @@ cleaned as (
         -- timestamp, specifying when a user account was most recently updated
         , cast(updated_on[1] as timestamp(6)) as updated_on
     from source
-) 
+)
 
 select * from cleaned

--- a/src/ol_dbt/models/staging/mitxonline/stg_mitxonline__app__postgres__users_user.sql
+++ b/src/ol_dbt/models/staging/mitxonline/stg_mitxonline__app__postgres__users_user.sql
@@ -5,14 +5,15 @@ with source as (
 ),
 
 cleaned as (
-    -- int, sequential ID representing one user in MITx Online
-    id
-    -- boolean, ...
-    , is_active
-    -- timestamp, specifying when a user account was initially created
-    , cast(created_on[1] as timestamp(6)) as created_on
-    -- timestamp, specifying when a user account was most recently updated
-    , cast(updated_on[1] as timestamp(6)) as updated_on
+    select 
+        -- int, sequential ID representing one user in MITx Online
+        id
+        -- boolean, ...
+        , is_active
+        -- timestamp, specifying when a user account was initially created
+        , cast(created_on[1] as timestamp(6)) as created_on
+        -- timestamp, specifying when a user account was most recently updated
+        , cast(updated_on[1] as timestamp(6)) as updated_on
     from source
 ) 
 

--- a/src/ol_dbt/models/staging/mitxonline/stg_mitxonline__app__postgres__users_user.sql
+++ b/src/ol_dbt/models/staging/mitxonline/stg_mitxonline__app__postgres__users_user.sql
@@ -13,7 +13,7 @@ cleaned as (
     , cast(created_on[1] as timestamp(6)) as created_on
     -- timestamp, specifying when a user account was most recently updated
     , cast(updated_on[1] as timestamp(6)) as updated_on
+    from source
 ) 
 
 select * from cleaned
-    

--- a/src/ol_dbt/models/staging/mitxpro/stg_mitxpro__app__postgres__courses_course.sql
+++ b/src/ol_dbt/models/staging/mitxpro/stg_mitxpro__app__postgres__courses_course.sql
@@ -1,10 +1,29 @@
-select
-    id
-    , live
-    , title
-    , program_id
-    , readable_id
-    , position_in_program
-    , cast(created_on[1] as timestamp(6)) as created_on
-    , cast(updated_on[1] as timestamp(6)) as updated_on
-from {{ source('ol_warehouse_raw_data','mitxpro__app__postgres__courses_course') }}
+-- xPro Online Course Information
+
+with source as (
+    select * from {{ source('ol_warehouse_raw_data','mitxpro__app__postgres__courses_course') }}
+),
+
+cleaned as (
+    select 
+        -- int, sequential ID tracking a single xPro course
+        id
+        -- boolean, indicating whether the course is available to users
+        , live
+        -- str, title of the course
+        , title
+        -- int, unique ID pointing to the "program" which this course is part of
+        , program_id
+        -- str, Open edX ID formatted as course-v1:{org}+{course code}
+        , readable_id
+        -- int, ...
+        , position_in_program
+        -- timestamp, specifying when an enrollment was initially created
+        , cast(created_on[1] as timestamp(6)) as created_on
+        -- timestamp, specifying when an enrollment was most recently updated
+        , cast(updated_on[1] as timestamp(6)) as updated_on
+    from source
+)
+
+select * from cleaned
+    

--- a/src/ol_dbt/models/staging/mitxpro/stg_mitxpro__app__postgres__courses_course.sql
+++ b/src/ol_dbt/models/staging/mitxpro/stg_mitxpro__app__postgres__courses_course.sql
@@ -2,10 +2,10 @@
 
 with source as (
     select * from {{ source('ol_warehouse_raw_data','mitxpro__app__postgres__courses_course') }}
-),
+)
 
-cleaned as (
-    select 
+, cleaned as (
+    select
         -- int, sequential ID tracking a single xPro course
         id
         -- boolean, indicating whether the course is available to users
@@ -26,4 +26,3 @@ cleaned as (
 )
 
 select * from cleaned
-    

--- a/src/ol_dbt/models/staging/mitxpro/stg_mitxpro__app__postgres__courses_courserun.sql
+++ b/src/ol_dbt/models/staging/mitxpro/stg_mitxpro__app__postgres__courses_courserun.sql
@@ -2,10 +2,10 @@
 
 with source as (
     select * from {{ source('ol_warehouse_raw_data','mitxpro__app__postgres__courses_courserun') }}
-),
+)
 
-cleaned as (
-    select 
+, cleaned as (
+    select
         -- int, sequential ID tracking a single course run
         id
         -- boolean, indicating whether the course is available to users

--- a/src/ol_dbt/models/staging/mitxpro/stg_mitxpro__app__postgres__courses_courserun.sql
+++ b/src/ol_dbt/models/staging/mitxpro/stg_mitxpro__app__postgres__courses_courserun.sql
@@ -1,10 +1,26 @@
-select
-    id
-    , live
-    , title
-    , course_id
-    , courseware_url_path
-    , cast(created_on[1] as timestamp(6)) as created_on
-    , cast(updated_on[1] as timestamp(6)) as updated_on
-from
-    {{ source('ol_warehouse_raw_data','mitxpro__app__postgres__courses_courserun') }}
+-- xPro Course Run Information
+
+with source as (
+    select * from {{ source('ol_warehouse_raw_data','mitxpro__app__postgres__courses_courserun') }}
+),
+
+cleaned as (
+    select 
+        -- int, sequential ID tracking a single course run
+        id
+        -- boolean, indicating whether the course is available to users
+        , live
+        -- str, title of the course
+        , title
+        -- int, ID specifying a course in the courses_course table
+        , course_id
+        -- str, url location for the course in xPro
+        , courseware_url_path
+        -- timestamp, specifying when a course run was initially created
+        , cast(created_on[1] as timestamp(6)) as created_on
+        -- timestamp, specifying when a course run was most recently updated
+        , cast(updated_on[1] as timestamp(6)) as updated_on
+    from source
+)
+
+select * from cleaned

--- a/src/ol_dbt/models/staging/mitxpro/stg_mitxpro__app__postgres__courses_courserunenrollment.sql
+++ b/src/ol_dbt/models/staging/mitxpro/stg_mitxpro__app__postgres__courses_courserunenrollment.sql
@@ -1,10 +1,10 @@
--- xPro Course Run Enrollment Information 
+-- xPro Course Run Enrollment Information
 
 with source as (
     select * from {{ source('ol_warehouse_raw_data','mitxpro__app__postgres__courses_courserunenrollment') }}
-),
+)
 
-cleaned as (
+, cleaned as (
     select
         -- int, sequential ID tracking a single user enrollment
         id

--- a/src/ol_dbt/models/staging/mitxpro/stg_mitxpro__app__postgres__courses_courserunenrollment.sql
+++ b/src/ol_dbt/models/staging/mitxpro/stg_mitxpro__app__postgres__courses_courserunenrollment.sql
@@ -1,9 +1,24 @@
-select
-    id
-    , active
-    , run_id
-    , user_id
-    , cast(created_on[1] as timestamp(6)) as created_on
-    , cast(updated_on[1] as timestamp(6)) as updated_on
-from
-    {{ source('ol_warehouse_raw_data','mitxpro__app__postgres__courses_courserunenrollment') }}
+-- xPro Course Run Enrollment Information 
+
+with source as (
+    select * from {{ source('ol_warehouse_raw_data','mitxpro__app__postgres__courses_courserunenrollment') }}
+),
+
+cleaned as (
+    select
+        -- int, sequential ID tracking a single user enrollment
+        id
+        -- str, boolean describing whether the enrollment is active
+        , active
+        -- int, unique ID specifying a "run" of an xPro course
+        , run_id
+        -- int, unique ID for each user on the xPro platform
+        , user_id
+        -- timestamp, specifying when an enrollment was initially created
+        , cast(created_on[1] as timestamp(6)) as created_on
+        -- timestamp, specifying when an enrollment was most recently updated
+        , cast(updated_on[1] as timestamp(6)) as updated_on
+    from source
+)
+
+select * from cleaned

--- a/src/ol_dbt/models/staging/mitxpro/stg_mitxpro__app__postgres__users_user.sql
+++ b/src/ol_dbt/models/staging/mitxpro/stg_mitxpro__app__postgres__users_user.sql
@@ -1,6 +1,20 @@
-select
-    id
-    , is_active
-    , cast(created_on[1] as timestamp(6)) as created_on
-    , cast(updated_on[1] as timestamp(6)) as updated_on
-from {{ source('ol_warehouse_raw_data','mitxpro__app__postgres__users_user') }}
+-- xPro User Information
+
+with source as (
+    select * from {{ source('ol_warehouse_raw_data','mitxpro__app__postgres__users_user') }}
+),
+
+cleaned as (
+    select
+        -- int, sequential ID representing one user in xPro
+        id
+        -- boolean, ...
+        , is_active
+        -- timestamp, specifying when a user account was initially created
+        , cast(created_on[1] as timestamp(6)) as created_on
+        -- timestamp, specifying when a user account was most recently updated
+        , cast(updated_on[1] as timestamp(6)) as updated_on
+    from source
+)
+
+select * from cleaned

--- a/src/ol_dbt/models/staging/mitxpro/stg_mitxpro__app__postgres__users_user.sql
+++ b/src/ol_dbt/models/staging/mitxpro/stg_mitxpro__app__postgres__users_user.sql
@@ -2,9 +2,9 @@
 
 with source as (
     select * from {{ source('ol_warehouse_raw_data','mitxpro__app__postgres__users_user') }}
-),
+)
 
-cleaned as (
+, cleaned as (
     select
         -- int, sequential ID representing one user in xPro
         id


### PR DESCRIPTION
Using CTEs (Common Table Expressions) and field descriptions/documentation to restyle staging SQL for xPro and MITx Online. The goals of adopting this style are toward better collaboration:
* Easier readability.
* Documentation for all fields we are choosing for our underlying models.

@blarghmatey @shaidar @abeglova I would appreciate a review, as this restyling will impact how we all write code in the future. One sticky point for me was how to write the field descriptions; my style looks a little like Python.