### PR TITLE
Move documentation to yml files.

### DIFF
--- a/src/ol_dbt/models/staging/mitxonline/_mitxonline__sources.yml
+++ b/src/ol_dbt/models/staging/mitxonline/_mitxonline__sources.yml
@@ -60,7 +60,8 @@ sources:
     - name: title
       description: str, title of the course
     - name: program_id
-      description: id, unique ID pointing to the "program" which this course is part of
+      description: id, unique ID pointing to the "program" which this course is part
+        of
     - name: readable_id
       description: str, Open edX ID formatted as course-v1:{org}+{course code}
     - name: position_in_program

--- a/src/ol_dbt/models/staging/mitxonline/_mitxonline__sources.yml
+++ b/src/ol_dbt/models/staging/mitxonline/_mitxonline__sources.yml
@@ -10,35 +10,62 @@ sources:
   - name: mitxonline__app__postgres__courses_courserunenrollment
     columns:
     - name: id
+      description: int, sequential ID tracking a single user enrollment
     - name: active
+      description: str, boolean describing whether the enrollment is active
     - name: run_id
+      description: int, unique ID specifying a "run" of an MITx Online course
     - name: user_id
+      description: int, unique ID for each user on the MITx Online platform
     - name: created_on
+      description: timestamp, specifying when an enrollment was initially created
     - name: updated_on
+      description: timestamp, specifying when an enrollment was most recently updated
   - name: mitxonline__app__postgres__courses_courserun
     columns:
     - name: id
+      description: int, sequential ID tracking a single course run
     - name: live
+      description: boolean, indicating whether the course is available to users
     - name: title
+      description: str, title of the course
     - name: course_id
+      description: int, ID specifying a course in the courses_course table
     - name: courseware_url_path
+      description: str, url location for the course in MITx Online
     - name: created_on
+      description: timestamp, specifying when a course run was initially created
     - name: updated_on
+      description: timestamp, specifying when a course run was most recently updated
   - name: mitxonline__app__postgres__users_user
     columns:
     - name: id
+      description: int, sequential ID representing one user in MITx Online
     - name: username
+      description: str, name chosen by user
     - name: email
+      description: str, user email associated with their account
     - name: is_active
+      description: boolean, ...
     - name: created_on
+      description: timestamp, specifying when a user account was initially created
     - name: updated_on
+      description: timestamp, specifying when a user account was most recently updated
   - name: mitxonline__app__postgres__courses_course
     columns:
     - name: id
+      description: int, sequential ID tracking a single MITx Online course
     - name: live
+      description: boolean, indicating whether the course is available to users
     - name: title
+      description: str, title of the course
     - name: program_id
+      description: id, unique ID pointing to the "program" which this course is part of
     - name: readable_id
+      description: str, Open edX ID formatted as course-v1:{org}+{course code}
     - name: position_in_program
+      description: int, ...
     - name: created_on
+      description: timestamp, specifying when an enrollment was initially created
     - name: updated_on
+      description: timestamp, specifying when an enrollment was most recently updated

--- a/src/ol_dbt/models/staging/mitxonline/stg_mitxonline__app__postgres__course_courserunenrollment.sql
+++ b/src/ol_dbt/models/staging/mitxonline/stg_mitxonline__app__postgres__course_courserunenrollment.sql
@@ -6,17 +6,11 @@ with source as (
 
 , cleaned as (
     select
-        -- int, sequential ID tracking a single user enrollment
         id
-        -- str, boolean describing whether the enrollment is active
         , active
-        -- int, unique ID specifying a "run" of an MITx Online course
         , run_id
-        -- int, unique ID for each user on the MITx Online platform
         , user_id
-        -- timestamp, specifying when an enrollment was initially created
         , cast(created_on[1] as timestamp(6)) as created_on
-        -- timestamp, specifying when an enrollment was most recently updated
         , cast(updated_on[1] as timestamp(6)) as updated_on
     from source
 )

--- a/src/ol_dbt/models/staging/mitxonline/stg_mitxonline__app__postgres__courses_course.sql
+++ b/src/ol_dbt/models/staging/mitxonline/stg_mitxonline__app__postgres__courses_course.sql
@@ -6,21 +6,13 @@ with source as (
 
 , cleaned as (
     select
-        -- int, sequential ID tracking a single MITx Online course
         id
-        -- boolean, indicating whether the course is available to users
         , live
-        -- str, title of the course
         , title
-        -- id, unique ID pointing to the "program" which this course is part of
         , program_id
-        -- str, Open edX ID formatted as course-v1:{org}+{course code}
         , readable_id
-        -- int, ...
         , position_in_program
-        -- timestamp, specifying when an enrollment was initially created
         , cast(created_on[1] as timestamp(6)) as created_on
-        -- timestamp, specifying when an enrollment was most recently updated
         , cast(updated_on[1] as timestamp(6)) as updated_on
     from source
 )

--- a/src/ol_dbt/models/staging/mitxonline/stg_mitxonline__app__postgres__courses_courserun.sql
+++ b/src/ol_dbt/models/staging/mitxonline/stg_mitxonline__app__postgres__courses_courserun.sql
@@ -6,19 +6,12 @@ with source as (
 
 , cleaned as (
     select
-        -- int, sequential ID tracking a single course run
         id
-        -- boolean, indicating whether the course is available to users
         , live
-        -- str, title of the course
         , title
-        -- int, ID specifying a course in the courses_course table
         , course_id
-        -- str, url location for the course in MITx Online
         , courseware_url_path
-        -- timestamp, specifying when a course run was initially created
         , cast(created_on[1] as timestamp(6)) as created_on
-        -- timestamp, specifying when a course run was most recently updated
         , cast(updated_on[1] as timestamp(6)) as updated_on
     from source
 )

--- a/src/ol_dbt/models/staging/mitxonline/stg_mitxonline__app__postgres__users_user.sql
+++ b/src/ol_dbt/models/staging/mitxonline/stg_mitxonline__app__postgres__users_user.sql
@@ -6,17 +6,11 @@ with source as (
 
 , cleaned as (
     select
-        -- int, sequential ID representing one user in MITx Online
         id
-        -- str, name chosen by user
         , username
-        -- str, user email associated with their account
         , email
-        -- boolean, ...
         , is_active
-        -- timestamp, specifying when a user account was initially created
         , cast(created_on[1] as timestamp(6)) as created_on
-        -- timestamp, specifying when a user account was most recently updated
         , cast(updated_on[1] as timestamp(6)) as updated_on
     from source
 )

--- a/src/ol_dbt/models/staging/mitxpro/_mitxpro__sources.yml
+++ b/src/ol_dbt/models/staging/mitxpro/_mitxpro__sources.yml
@@ -10,35 +10,62 @@ sources:
   - name: mitxpro__app__postgres__courses_courserunenrollment
     columns:
     - name: id
+      description: int, sequential ID tracking a single user enrollment
     - name: active
+      description: str, boolean describing whether the enrollment is active
     - name: run_id
+      description: int, unique ID specifying a "run" of an xPro course
     - name: user_id
+      description: int, unique ID for each user on the xPro platform
     - name: created_on
+      description: timestamp, specifying when an enrollment was initially created
     - name: updated_on
+      description: timestamp, specifying when an enrollment was most recently updated
   - name: mitxpro__app__postgres__courses_courserun
     columns:
     - name: id
+      description: int, sequential ID tracking a single course run
     - name: live
+      description: boolean, indicating whether the course is available to users
     - name: title
+      description: str, title of the course
     - name: course_id
+      description: int, ID specifying a course in the courses_course table
     - name: courseware_url_path
+      description: str, url location for the course in xPro
     - name: created_on
+      description: timestamp, specifying when a course run was initially created
     - name: updated_on
+      description: timestamp, specifying when a course run was most recently updated
   - name: mitxpro__app__postgres__users_user
     columns:
     - name: id
+      description: int, sequential ID representing one user in xPro
     - name: username
+      description: str, name chosen by user
     - name: email
+      description: str, user email associated with their account
     - name: is_active
+      description: boolean, ...
     - name: created_on
+      description: timestamp, specifying when a user account was initially created
     - name: updated_on
+      description: timestamp, specifying when a user account was most recently updated
   - name: mitxpro__app__postgres__courses_course
     columns:
     - name: id
+      description: int, sequential ID tracking a single xPro course
     - name: live
+      description: boolean, indicating whether the course is available to users
     - name: title
+      description: str, title of the course
     - name: program_id
+      description: int, unique ID pointing to the "program" which this course is part of
     - name: readable_id
+      description: str, Open edX ID formatted as course-v1:{org}+{course code}
     - name: position_in_program
+      description: int, ...
     - name: created_on
+      description: timestamp, specifying when an enrollment was initially created
     - name: updated_on
+      description: timestamp, specifying when an enrollment was most recently updated

--- a/src/ol_dbt/models/staging/mitxpro/_mitxpro__sources.yml
+++ b/src/ol_dbt/models/staging/mitxpro/_mitxpro__sources.yml
@@ -60,7 +60,8 @@ sources:
     - name: title
       description: str, title of the course
     - name: program_id
-      description: int, unique ID pointing to the "program" which this course is part of
+      description: int, unique ID pointing to the "program" which this course is part
+        of
     - name: readable_id
       description: str, Open edX ID formatted as course-v1:{org}+{course code}
     - name: position_in_program

--- a/src/ol_dbt/models/staging/mitxpro/stg_mitxpro__app__postgres__courses_course.sql
+++ b/src/ol_dbt/models/staging/mitxpro/stg_mitxpro__app__postgres__courses_course.sql
@@ -6,21 +6,13 @@ with source as (
 
 , cleaned as (
     select
-        -- int, sequential ID tracking a single xPro course
         id
-        -- boolean, indicating whether the course is available to users
         , live
-        -- str, title of the course
         , title
-        -- int, unique ID pointing to the "program" which this course is part of
         , program_id
-        -- str, Open edX ID formatted as course-v1:{org}+{course code}
         , readable_id
-        -- int, ...
         , position_in_program
-        -- timestamp, specifying when an enrollment was initially created
         , cast(created_on[1] as timestamp(6)) as created_on
-        -- timestamp, specifying when an enrollment was most recently updated
         , cast(updated_on[1] as timestamp(6)) as updated_on
     from source
 )

--- a/src/ol_dbt/models/staging/mitxpro/stg_mitxpro__app__postgres__courses_courserun.sql
+++ b/src/ol_dbt/models/staging/mitxpro/stg_mitxpro__app__postgres__courses_courserun.sql
@@ -6,19 +6,12 @@ with source as (
 
 , cleaned as (
     select
-        -- int, sequential ID tracking a single course run
         id
-        -- boolean, indicating whether the course is available to users
         , live
-        -- str, title of the course
         , title
-        -- int, ID specifying a course in the courses_course table
         , course_id
-        -- str, url location for the course in xPro
         , courseware_url_path
-        -- timestamp, specifying when a course run was initially created
         , cast(created_on[1] as timestamp(6)) as created_on
-        -- timestamp, specifying when a course run was most recently updated
         , cast(updated_on[1] as timestamp(6)) as updated_on
     from source
 )

--- a/src/ol_dbt/models/staging/mitxpro/stg_mitxpro__app__postgres__courses_courserunenrollment.sql
+++ b/src/ol_dbt/models/staging/mitxpro/stg_mitxpro__app__postgres__courses_courserunenrollment.sql
@@ -6,17 +6,11 @@ with source as (
 
 , cleaned as (
     select
-        -- int, sequential ID tracking a single user enrollment
         id
-        -- str, boolean describing whether the enrollment is active
         , active
-        -- int, unique ID specifying a "run" of an xPro course
         , run_id
-        -- int, unique ID for each user on the xPro platform
         , user_id
-        -- timestamp, specifying when an enrollment was initially created
         , cast(created_on[1] as timestamp(6)) as created_on
-        -- timestamp, specifying when an enrollment was most recently updated
         , cast(updated_on[1] as timestamp(6)) as updated_on
     from source
 )

--- a/src/ol_dbt/models/staging/mitxpro/stg_mitxpro__app__postgres__users_user.sql
+++ b/src/ol_dbt/models/staging/mitxpro/stg_mitxpro__app__postgres__users_user.sql
@@ -6,17 +6,11 @@ with source as (
 
 , cleaned as (
     select
-        -- int, sequential ID representing one user in xPro
         id
-        -- str, name chosen by user
         , username
-        -- str, user email associated with their account
         , email
-        -- boolean, ...
         , is_active
-        -- timestamp, specifying when a user account was initially created
         , cast(created_on[1] as timestamp(6)) as created_on
-        -- timestamp, specifying when a user account was most recently updated
         , cast(updated_on[1] as timestamp(6)) as updated_on
     from source
 )


### PR DESCRIPTION
Realized I should be writing my documentation in the *.yml files, not in the SQL itself. Using the *.yml should let us create a site, generate docs, etc. more easily.

@blarghmatey Mind taking a look?