### PR TITLE
Add list of course IDs to edX nightly dumps

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,7 +27,7 @@ repos:
     - '80'
     - --preserve-quotes
 - repo: https://github.com/adrienverge/yamllint.git
-  rev: v1.27.1
+  rev: v1.28.0
   hooks:
   - id: yamllint
     args: [--format, parsable, -d, relaxed]
@@ -89,7 +89,7 @@ repos:
     - types-pytz
     - types-pymysql
 - repo: https://github.com/sqlfluff/sqlfluff
-  rev: 1.3.0
+  rev: 1.3.1
   hooks:
   - id: sqlfluff-fix
       # Arbitrary arguments to show an example

--- a/src/ol_orchestrate/jobs/open_edx.py
+++ b/src/ol_orchestrate/jobs/open_edx.py
@@ -1,9 +1,12 @@
-from dagster import graph
+from dagster import fs_io_manager, graph
+from dagster_aws.s3.io_manager import s3_pickle_io_manager
+from dagster_aws.s3.resources import s3_resource
 
 from ol_orchestrate.lib.hooks import (
     notify_healthchecks_io_on_failure,
     notify_healthchecks_io_on_success,
 )
+from ol_orchestrate.lib.yaml_config_helper import load_yaml_config
 from ol_orchestrate.ops.open_edx import (
     course_enrollments,
     course_roles,
@@ -13,7 +16,15 @@ from ol_orchestrate.ops.open_edx import (
     list_courses,
     student_submissions,
     upload_extracted_data,
+    write_course_list_csv,
 )
+from ol_orchestrate.resources.healthchecks import (
+    healthchecks_dummy_resource,
+    healthchecks_io_resource,
+)
+from ol_orchestrate.resources.mysql_db import mysql_db_resource
+from ol_orchestrate.resources.outputs import daily_dir
+from ol_orchestrate.resources.sqlite_db import sqlite_db_resource
 
 
 @graph(
@@ -33,6 +44,7 @@ from ol_orchestrate.ops.open_edx import (
 def edx_course_pipeline():
     course_list = list_courses()
     extracts_upload = upload_extracted_data(
+        write_course_list_csv(edx_course_ids=course_list),
         enrolled_users(edx_course_ids=course_list),
         student_submissions(edx_course_ids=course_list),
         course_roles(edx_course_ids=course_list),
@@ -42,3 +54,39 @@ def edx_course_pipeline():
     export_edx_courses.with_hooks(
         {notify_healthchecks_io_on_success, notify_healthchecks_io_on_failure}
     )(course_list, extracts_upload)
+
+
+dev_resources = {
+    "sqldb": sqlite_db_resource,
+    "s3": s3_resource,
+    "results_dir": daily_dir,
+    "healthchecks": healthchecks_dummy_resource,
+    "io_manager": fs_io_manager,
+}
+
+production_resources = {
+    "sqldb": mysql_db_resource,
+    "s3": s3_resource,
+    "results_dir": daily_dir,
+    "healthchecks": healthchecks_io_resource,
+    "io_manager": s3_pickle_io_manager,
+}
+
+
+residential_edx_job = edx_course_pipeline.to_job(
+    name="residential_edx_course_pipeline",
+    resource_defs=production_resources,
+    config=load_yaml_config("/etc/dagster/residential_edx.yaml"),
+)
+
+xpro_edx_job = edx_course_pipeline.to_job(
+    name="xpro_edx_course_pipeline",
+    resource_defs=production_resources,
+    config=load_yaml_config("/etc/dagster/xpro_edx.yaml"),
+)
+
+mitxonline_edx_job = edx_course_pipeline.to_job(
+    name="mitxonline_edx_course_pipeline",
+    resource_defs=production_resources,
+    config=load_yaml_config("/etc/dagster/mitxonline_edx.yaml"),
+)

--- a/src/ol_orchestrate/repositories/open_edx.py
+++ b/src/ol_orchestrate/repositories/open_edx.py
@@ -1,46 +1,15 @@
-from dagster import fs_io_manager, repository
-from dagster_aws.s3 import s3_pickle_io_manager, s3_resource
+from dagster import repository
 
-from ol_orchestrate.jobs.open_edx import edx_course_pipeline
-from ol_orchestrate.lib.yaml_config_helper import load_yaml_config
-from ol_orchestrate.resources.healthchecks import (
-    healthchecks_dummy_resource,
-    healthchecks_io_resource,
-)
-from ol_orchestrate.resources.mysql_db import mysql_db_resource
-from ol_orchestrate.resources.outputs import daily_dir
-from ol_orchestrate.resources.sqlite_db import sqlite_db_resource
 from ol_orchestrate.schedules.open_edx import (
     mitxonline_edx_daily_schedule,
     residential_edx_daily_schedule,
     xpro_edx_daily_schedule,
 )
 
-dev_resources = {
-    "sqldb": sqlite_db_resource,
-    "s3": s3_resource,
-    "results_dir": daily_dir,
-    "healthchecks": healthchecks_dummy_resource,
-    "io_manager": fs_io_manager,
-}
-
-production_resources = {
-    "sqldb": mysql_db_resource,
-    "s3": s3_resource,
-    "results_dir": daily_dir,
-    "healthchecks": healthchecks_io_resource,
-    "io_manager": s3_pickle_io_manager,
-}
-
 
 @repository
 def residential_edx_repository():
     return [
-        edx_course_pipeline.to_job(
-            name="residential_edx_course_pipeline",
-            resource_defs=production_resources,
-            config=load_yaml_config("/etc/dagster/residential_edx.yaml"),
-        ),
         residential_edx_daily_schedule,
     ]
 
@@ -48,11 +17,6 @@ def residential_edx_repository():
 @repository
 def xpro_edx_repository():
     return [
-        edx_course_pipeline.to_job(
-            name="xpro_edx_course_pipeline",
-            resource_defs=production_resources,
-            config=load_yaml_config("/etc/dagster/xpro_edx.yaml"),
-        ),
         xpro_edx_daily_schedule,
     ]
 
@@ -60,10 +24,5 @@ def xpro_edx_repository():
 @repository
 def mitxonline_edx_repository():
     return [
-        edx_course_pipeline.to_job(
-            name="mitxonline_edx_course_pipeline",
-            resource_defs=production_resources,
-            config=load_yaml_config("/etc/dagster/mitxonline_edx.yaml"),
-        ),
         mitxonline_edx_daily_schedule,
     ]

--- a/src/ol_orchestrate/schedules/open_edx.py
+++ b/src/ol_orchestrate/schedules/open_edx.py
@@ -1,38 +1,47 @@
-from datetime import datetime, time
+from dagster import RunRequest, schedule
 
-from dagster import daily_schedule
-
+from ol_orchestrate.jobs.open_edx import (
+    mitxonline_edx_job,
+    residential_edx_job,
+    xpro_edx_job,
+)
 from ol_orchestrate.lib.yaml_config_helper import load_yaml_config
 
 
-@daily_schedule(
-    pipeline_name="residential_edx_course_pipeline",
-    start_date=datetime(2020, 9, 23),
-    execution_time=time(3, 0, 0),
-    tags_fn_for_date=lambda _: {"business_unit": "residential"},
+@schedule(
+    job=residential_edx_job,
+    cron_schedule="@daily",
     execution_timezone="Etc/UTC",
 )
 def residential_edx_daily_schedule(execution_date):
-    return load_yaml_config("/etc/dagster/residential_edx.yaml")
+    return RunRequest(
+        run_key="residential_edx_course_pipeline",
+        run_config=load_yaml_config("/etc/dagster/residential_edx.yaml"),
+        tags={"business_unit": "residential"},
+    )
 
 
-@daily_schedule(
-    pipeline_name="xpro_edx_course_pipeline",
-    start_date=datetime(2020, 9, 23),
-    execution_time=time(0, 0, 0),
-    tags_fn_for_date=lambda _: {"business_unit": "mitxpro"},
+@schedule(
+    job=xpro_edx_job,
+    cron_schedule="@daily",
     execution_timezone="Etc/UTC",
 )
 def xpro_edx_daily_schedule(execution_date):
-    return load_yaml_config("/etc/dagster/xpro_edx.yaml")
+    return RunRequest(
+        run_key="xpro_edx_course_pipeline",
+        run_config=load_yaml_config("/etc/dagster/xpro_edx.yaml"),
+        tags={"business_unit": "mitxpro"},
+    )
 
 
-@daily_schedule(
-    pipeline_name="mitxonline_edx_course_pipeline",
-    start_date=datetime(2021, 12, 18),
-    execution_time=time(0, 0, 0),
-    tags_fn_for_date=lambda _: {"business_unit": "mitxonline"},
+@schedule(
+    job=mitxonline_edx_job,
+    cron_schedule="@daily",
     execution_timezone="Etc/UTC",
 )
 def mitxonline_edx_daily_schedule(execution_date):
-    return load_yaml_config("/etc/dagster/mitxonline_edx.yaml")
+    return RunRequest(
+        run_key="mitxonline_edx_course_pipeline",
+        run_config=load_yaml_config("/etc/dagster/mitxonline_edx.yaml"),
+        tags={"business_unit": "mitxonline"},
+    )


### PR DESCRIPTION
In order to help filter out invalid tracking events it is useful to have a list of valid course IDs. This adds a list of course IDs that are active on an edX instance to the set of files in the nightly dump.

<!--- Provide a general summary of your changes in the Title above -->

## Description
This updates the Open edX pipeline definitions to account for the v1.x APIs for Dagster, as well as adding another operation to generate a CSV file consisting of a list of course IDs fetched from the Open edX instance.

## Motivation and Context
IRX has to waste a lot of time processing tracking logs for events that don't actually correspond to a legitimate course. This gives them a valid list of courses to work from.

## How Has This Been Tested?
Verified that the Dagit interface loads the newly added operation at the proper location in the graph and that no errors are generated during startup.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Enhancement (improves on existing behavior)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project. (Did you install and run the pre-commit hooks?)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
