### PR TITLE
users_user staging

### DIFF
--- a/src/ol_dbt/models/staging/mitxonline/_mitxonline__sources.yml
+++ b/src/ol_dbt/models/staging/mitxonline/_mitxonline__sources.yml
@@ -51,12 +51,16 @@ sources:
       description: str, name chosen by user
     - name: email
       description: str, user email associated with their account
+    - name: name
+      description: str, the user's full name
     - name: is_active
-      description: boolean, ...
+      description: boolean, used to soft delete users
     - name: created_on
       description: timestamp, specifying when a user account was initially created
     - name: updated_on
       description: timestamp, specifying when a user account was most recently updated
+    - name: last_login
+      description: timestamp, user's last login
   - name: raw__mitxonline__app__postgres__courses_course
     columns:
     - name: id

--- a/src/ol_dbt/models/staging/mitxonline/_stg_mitxonline__models.yml
+++ b/src/ol_dbt/models/staging/mitxonline/_stg_mitxonline__models.yml
@@ -1,0 +1,31 @@
+---
+version: 2
+
+models:
+- name: stg__mitxonline__app__postgres__users_user
+  columns:
+  - name: id
+    description: int, sequential ID representing one user in MITx Online
+    tests:
+    - unique
+    - not_null
+  - name: username
+    description: str, name chosen by user
+    tests:
+    - unique
+    - not_null
+  - name: email
+    description: str, user email associated with their account
+    tests:
+    - unique
+    - not_null
+  - name: is_active
+    description: boolean, used to soft delete user accunts
+  - name: full_name
+    description: str, the user's full name
+    tests:
+    - not_null
+  - name: created_on
+    description: timestamp, specifying when a user account was initially created
+  - name: last_login
+    description: timestamp, specifying when a user last logged in

--- a/src/ol_dbt/models/staging/mitxonline/stg__mitxonline__app__postgres__users_user.sql
+++ b/src/ol_dbt/models/staging/mitxonline/stg__mitxonline__app__postgres__users_user.sql
@@ -5,13 +5,15 @@ with source as (
 )
 
 , cleaned as (
+
     select
         id
         , username
         , email
         , is_active
-        , created_on
-        , updated_on
+        , name as full_name
+        , to_iso8601(from_iso8601_timestamp(created_on)) as joined_on
+        , to_iso8601(from_iso8601_timestamp(last_login)) as last_login
     from source
 )
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This pr creates the staging model for users user
The users_user table has the following columns

id - int postgres id for the table, keeping it as is
name - varchar renamed to full_name since user_legaladdress has first_name and last name
email - varchar keeping as is
is_staff - boolean dropping as per the discussion 
password - varchar dropping
username - varchar keeping
is_active - boolean flag used to "delete" users. Keeping as is for now. We should separate users with is_active=False into a separate table in the intermediate layer 
created_on- iso8601 string renamed to joined_on. Postgres sets this automatically when a row is created in the users table
last_login -  iso8601 string keeping
updated_on - iso8601 string, this is a field updated by postgres when the row is updated, Dropping, since it mostly tracks app internals. It should be just after last_login most of the time, whenever the script that updates that field actually runs
is_superuser - boolean dropping as per the discussion

## Motivation and Context
https://github.com/mitodl/ol-data-platform/issues/334

## How Has This Been Tested?
Tested locally

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Enhancement (improves on existing behavior)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project. (Did you install and run the pre-commit hooks?)
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
