### PR TITLE
add xpro users_user staging

### DIFF
--- a/src/ol_dbt/models/intermediate/mitxonline/_int_mitxonline__models.yml
+++ b/src/ol_dbt/models/intermediate/mitxonline/_int_mitxonline__models.yml
@@ -62,7 +62,7 @@ models:
     tests:
     - unique
     - not_null
-  - name: user_joined_on
+  - name: joined_on
     description: timestamp, user join timestamp
   - name: last_login
     description: timestamp, user last log in

--- a/src/ol_dbt/models/staging/mitxpro/_mitxpro__sources.yml
+++ b/src/ol_dbt/models/staging/mitxpro/_mitxpro__sources.yml
@@ -45,12 +45,16 @@ sources:
       description: str, name chosen by user
     - name: email
       description: str, user email associated with their account
+    - name: name
+      description: str, the user's full name
     - name: is_active
-      description: boolean, ...
+      description: boolean, used to soft delete users
     - name: created_on
       description: timestamp, specifying when a user account was initially created
     - name: updated_on
       description: timestamp, specifying when a user account was most recently updated
+    - name: last_login
+      description: timestamp, user's last login
   - name: raw__xpro__app__postgres__courses_course
     columns:
     - name: id

--- a/src/ol_dbt/models/staging/mitxpro/_stg_mitxpro__models.yml
+++ b/src/ol_dbt/models/staging/mitxpro/_stg_mitxpro__models.yml
@@ -2,10 +2,10 @@
 version: 2
 
 models:
-- name: stg__mitxonline__app__postgres__users_user
+- name: stg__mitxpro__app__postgres__users_user
   columns:
   - name: id
-    description: int, sequential ID representing one user in MITx Online
+    description: int, sequential ID representing one user in xPro
     tests:
     - unique
     - not_null
@@ -29,27 +29,3 @@ models:
     description: timestamp, specifying when a user account was initially created
   - name: last_login
     description: timestamp, specifying when a user last logged in
-- name: stg__mitxonline__app__postgres__users_legaladdress
-  columns:
-  - name: id
-    description: int, sequential ID
-    tests:
-    - unique
-    - not_null
-  - name: user_address_country
-    description: string, user country code
-    tests:
-    - not_null
-  - name: user_id
-    description: int, foreign key to users_user
-    tests:
-    - unique
-    - not_null
-  - name: last_name
-    description: string, user last name
-    tests:
-    - not_null
-  - name: first_name
-    description: string, user first name
-    tests:
-    - not_null

--- a/src/ol_dbt/models/staging/mitxpro/stg__mitxpro__app__postgres__users_user.sql
+++ b/src/ol_dbt/models/staging/mitxpro/stg__mitxpro__app__postgres__users_user.sql
@@ -10,8 +10,9 @@ with source as (
         , username
         , email
         , is_active
-        , created_on
-        , updated_on
+        , name as full_name
+        , to_iso8601(from_iso8601_timestamp(created_on)) as joined_on
+        , to_iso8601(from_iso8601_timestamp(last_login)) as last_login
     from source
 )
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This pr creates the staging model for users user
The users_user table has the following columns

id - int postgres id for the table, keeping it as is
name - varchar renamed to full_name since user_legaladdress has first_name and last name
email - varchar keeping as is
is_staff - boolean dropping as per the discussion 
password - varchar dropping
username - varchar keeping
is_active - boolean flag used to "delete" users. Keeping as is for now. We should separate users with is_active=False into a separate table in the intermediate layer 
created_on- iso8601 string renamed to joined_on. Postgres sets this automatically when a row is created in the users table
last_login -  iso8601 string keeping
updated_on - iso8601 string, this is a field updated by postgres when the row is updated, Dropping, since it mostly tracks app internals. It should be just after last_login most of the time, whenever the script that updates that field actually runs
is_superuser - boolean dropping as per the discussion

## Motivation and Context
https://github.com/mitodl/ol-data-platform/issues/351

## How Has This Been Tested?
Tested locally

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Enhancement (improves on existing behavior)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project. (Did you install and run the pre-commit hooks?)
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.