### PR TITLE
user legaladdress staging

### DIFF
--- a/src/ol_dbt/models/staging/mitxpro/_mitxpro__sources.yml
+++ b/src/ol_dbt/models/staging/mitxpro/_mitxpro__sources.yml
@@ -73,3 +73,37 @@ sources:
       description: timestamp, specifying when an enrollment was initially created
     - name: updated_on
       description: timestamp, specifying when an enrollment was most recently updated
+  - name: raw__xpro__app__postgres__users_legaladdress
+    columns:
+    - name: id
+      description: int, primary key for table
+    - name: country
+      description: string, user country code
+    - name: user_id
+      description: int, foreign key to users_user
+    - name: last_name
+      description: string, user last name
+    - name: created_on
+      description: timestamp, when the record was created
+    - name: first_name
+      description: string, user first name
+    - name: updated_on
+      description: timestamp, when the record was updated
+    - name: street_address_1
+      description: string, first line of street address
+    - name: street_address_2
+      description: string, second line of street address
+    - name: street_address_3
+      description: string, third line of street address
+    - name: street_address_4
+      description: string, fourth line of street address
+    - name: street_address_5
+      description: string, fifth line of street address
+    - name: city
+      description: string, city
+    - name: country
+      description: string, country
+    - name: state_or_territory
+      description: string, state or territory
+    - name: postal_code
+      description: string, postal code

--- a/src/ol_dbt/models/staging/mitxpro/_stg_mitxpro__models.yml
+++ b/src/ol_dbt/models/staging/mitxpro/_stg_mitxpro__models.yml
@@ -29,3 +29,43 @@ models:
     description: timestamp, specifying when a user account was initially created
   - name: last_login
     description: timestamp, specifying when a user last logged in
+- name: stg__mitxpro__app__postgres__users_legaladdress
+  columns:
+  - name: id
+    description: int, sequential ID
+    tests:
+    - unique
+    - not_null
+  - name: user_address_country
+    description: string, user country code
+    tests:
+    - not_null
+  - name: user_id
+    description: int, foreign key to users_user
+    tests:
+    - unique
+    - not_null
+  - name: last_name
+    description: string, user last name
+    tests:
+    - not_null
+  - name: first_name
+    description: string, user first name
+    tests:
+    - not_null
+  - name: user_street_address
+    description: string, user street address
+    tests:
+    - not_null
+  - name: user_address_city
+    description: string, user city
+    tests:
+    - not_null
+  - name: user_address_state_or_territory
+    description: string, user state or territory
+    tests:
+    - not_null
+  - name: user_address_postal_code
+    description: string, user postal code
+    tests:
+    - not_null

--- a/src/ol_dbt/models/staging/mitxpro/stg__mitxpro__app__postgres__users_legaladdress.sql
+++ b/src/ol_dbt/models/staging/mitxpro/stg__mitxpro__app__postgres__users_legaladdress.sql
@@ -1,0 +1,29 @@
+-- MITx Online User Information
+
+with source as (
+    select * from {{ source('ol_warehouse_raw_data', 'raw__xpro__app__postgres__users_legaladdress') }}
+)
+
+, cleaned as (
+
+    select
+        id
+        , country as user_address_country
+        , user_id
+        , first_name
+        , last_name
+        , city as user_address_city
+        , state_or_territory as user_address_state_or_territory
+        , postal_code as user_address_postal_code
+        , concat_ws(
+            chr(10)
+            , nullif(street_address_1, '')
+            , nullif(street_address_2, '')
+            , nullif(street_address_3, '')
+            , nullif(street_address_4, '')
+            , nullif(street_address_5, '')
+        ) as user_street_address
+    from source
+)
+
+select * from cleaned


### PR DESCRIPTION
issue https://github.com/mitodl/ol-data-platform/issues/354

The table has the following columns:
```
    - name: id
      description: int, primary key for table
      action: keep as is 
    - name: country
      description: string, user country code
      action: keep as is 
    - name: user_id
      description: int, foreign key to users_user
      action: keep as is 
    - name: last_name
      description: string, user last name
      action: keep as is 
    - name: created_on
      description: timestamp, when the record was created
      action: drop, this is postgres internals and we will keep the created_on from users_user
    - name: first_name
      description: string, user first name
      action: keep as is 
    - name: updated_on
      description: timestamp, when the record was updated
      action: keep as is 
    - name: street_address_1
      description: string, first line of street address
    - name: street_address_2
      description: string, second line of street address
    - name: street_address_3
      description: string, third line of street address
    - name: street_address_4
      description: string, fourth line of street address
    - name: street_address_5
      description: string, fifth line of street address
```
I concatenated all the lines of the street address into one long string with new lines 
```
    - name: city
      description: string, city
      action: keep as is 
    - name: country
      description: string, country
      action: keep as is 
    - name: state_or_territory
      description: string, state or territory
      action: keep as is 
    - name: postal_code
      description: string, postal code
      action: keep as is 

```