### PR TITLE
intermediate xpro users

### DIFF
--- a/src/ol_dbt/models/intermediate/combined/int__combined__enrollments.sql
+++ b/src/ol_dbt/models/intermediate/combined/int__combined__enrollments.sql
@@ -6,10 +6,6 @@ with mitxonline_enrollments as (
     select * from {{ ref('int__mitxpro__enrollments') }}
 )
 
-, bootcamps_enrollments as (
-    select * from {{ ref('int__bootcamps__enrollments') }}
-)
-
 , join_ol_enrollments as (
     select
         *
@@ -22,13 +18,6 @@ with mitxonline_enrollments as (
         *
         , 'xPro' as platform
     from mitxpro_enrollments
-
-    union all
-
-    select
-        *
-        , 'Bootcamps' as platform
-    from bootcamps_enrollments
 )
 
 select * from join_ol_enrollments

--- a/src/ol_dbt/models/intermediate/combined/int__combined__users.sql
+++ b/src/ol_dbt/models/intermediate/combined/int__combined__users.sql
@@ -1,18 +1,20 @@
 with mitxonline_users as (
     select
-        id
-        , username
-        , email
+        user_id
+        , user_username
+        , user_email
     from {{ ref('int__mitxonline__users') }}
 )
 
 , mitxpro_users as (
-    select * from {{ ref('int__mitxpro__users') }}
+    select
+        user_id
+        , user_username
+        , user_email
+    from {{ ref('int__mitxpro__users') }}
 )
 
-, bootcamps_users as (
-    select * from {{ ref('int__bootcamps__users') }}
-)
+
 
 , join_ol_users as (
     select
@@ -26,13 +28,6 @@ with mitxonline_users as (
         *
         , 'xPro' as platform
     from mitxpro_users
-
-    union all
-
-    select
-        *
-        , 'Bootcamps' as platform
-    from bootcamps_users
 )
 
 select * from join_ol_users

--- a/src/ol_dbt/models/intermediate/mitxonline/_int_mitxonline__models.yml
+++ b/src/ol_dbt/models/intermediate/mitxonline/_int_mitxonline__models.yml
@@ -19,9 +19,9 @@ models:
     description: url for course where the user is enrolled
   - name: course_title
     description: title of the course where the user is enrolled
-  - name: username
+  - name: user_username
     description: str, name chosen by user
-  - name: email
+  - name: user_email
     description: str, email associated with the user account
 
 - name: int__mitxonline__course_runs
@@ -43,42 +43,34 @@ models:
 - name: int__mitxonline__users
   description: denormalized mitxonline users
   columns:
-  - name: id
+  - name: user_id
     description: int, primary key
     tests:
     - unique
     - not_null
-  - name: username
+  - name: user_username
     description: string, username
     tests:
     - unique
     - not_null
-  - name: full_name
+  - name: user_full_name
     description: string, full name
     tests:
     - not_null
-  - name: email
+  - name: user_email
     description: int, email
     tests:
     - unique
     - not_null
-  - name: joined_on
+  - name: user_joined_on
     description: timestamp, user join timestamp
-  - name: last_login
+  - name: user_last_login
     description: timestamp, user last log in
   - name: user_address_country
     description: string, country code for the user's address
     tests:
     - not_null
-  - name: first_name
-    description: string, first name
-    tests:
-    - not_null
-  - name: last_name
-    description: string, last name
-    tests:
-    - not_null
   tests:
   - equal_rowcount_with_filters:
       compare_model: ref('stg__mitxonline__app__postgres__users_user')
-      compare_filter: "is_active=true"
+      compare_filter: "user_is_active=true"

--- a/src/ol_dbt/models/intermediate/mitxonline/int__mitxonline__enrollments.sql
+++ b/src/ol_dbt/models/intermediate/mitxonline/int__mitxonline__enrollments.sql
@@ -15,9 +15,9 @@ with enrollments as (
 
 , users as (
     select
-        id
-        , username
-        , email
+        user_id
+        , user_username
+        , user_email
     from {{ ref('stg__mitxonline__app__postgres__users_user') }}
 )
 
@@ -29,11 +29,11 @@ with enrollments as (
         , enrollments.created_on
         , runs.courseware_url_path
         , runs.title as course_title
-        , users.username
-        , users.email
+        , users.user_username
+        , users.user_email
     from enrollments
     inner join runs on enrollments.run_id = runs.id
-    inner join users on enrollments.user_id = users.id
+    inner join users on enrollments.user_id = users.user_id
 )
 
 select * from mitxonline_enrollments

--- a/src/ol_dbt/models/intermediate/mitxonline/int__mitxonline__users.sql
+++ b/src/ol_dbt/models/intermediate/mitxonline/int__mitxonline__users.sql
@@ -9,15 +9,13 @@ with users as (
 )
 
 select
-    users.id
-    , users.username
-    , users.full_name
-    , users.email
-    , users.joined_on
-    , users.last_login
+    users.user_id
+    , users.user_username
+    , users.user_full_name
+    , users.user_email
+    , users.user_joined_on
+    , users.user_last_login
     , users_legaladdress.user_address_country
-    , users_legaladdress.first_name
-    , users_legaladdress.last_name
 from users
-left join users_legaladdress on users_legaladdress.user_id = users.id
-where users.is_active = true
+left join users_legaladdress on users_legaladdress.user_id = users.user_id
+where users.user_is_active = true

--- a/src/ol_dbt/models/intermediate/mitxpro/_int_mitxpro__models.yml
+++ b/src/ol_dbt/models/intermediate/mitxpro/_int_mitxpro__models.yml
@@ -35,17 +35,42 @@ models:
     description: str, url for course where the user is enrolled
   - name: course_title
     description: str, title of the course where the user is enrolled
-  - name: username
+  - name: user_username
     description: str, name chosen by user
-  - name: email
+  - name: user_email
     description: str, email associated with the user account
 
 - name: int__mitxpro__users
   description: Intermediate model of users in MIT xPro.
   columns:
-  - name: id
-    description: ""
-  - name: username
-    description: ""
-  - name: email
-    description: ""
+  - name: user_id
+    description: int, unique id assigned to the user
+    tests:
+    - unique
+    - not_null
+  - name: user_username
+    description: string, username
+    tests:
+    - unique
+    - not_null
+  - name: user_full_name
+    description: string, full name
+    tests:
+    - not_null
+  - name: user_email
+    description: int, email
+    tests:
+    - unique
+    - not_null
+  - name: user_joined_on
+    description: timestamp, user join timestamp
+  - name: user_last_login
+    description: timestamp, user last log in
+  - name: user_address_country
+    description: string, country code for the user's address
+    tests:
+    - not_null
+  tests:
+  - equal_rowcount_with_filters:
+      compare_model: ref('stg__mitxpro__app__postgres__users_user')
+      compare_filter: "user_is_active=true"

--- a/src/ol_dbt/models/intermediate/mitxpro/int__mitxpro__enrollments.sql
+++ b/src/ol_dbt/models/intermediate/mitxpro/int__mitxpro__enrollments.sql
@@ -14,9 +14,9 @@ with enrollments as (
 
 , users as (
     select
-        id
-        , username
-        , email
+        user_id
+        , user_username
+        , user_email
     from {{ ref('stg__mitxpro__app__postgres__users_user') }}
 )
 
@@ -28,11 +28,11 @@ with enrollments as (
         , enrollments.created_on
         , runs.courseware_url_path
         , runs.title as course_title
-        , users.username
-        , users.email
+        , users.user_username
+        , users.user_email
     from enrollments
     inner join runs on enrollments.run_id = runs.id
-    inner join users on enrollments.user_id = users.id
+    inner join users on enrollments.user_id = users.user_id
 )
 
 select * from mitxpro_enrollments

--- a/src/ol_dbt/models/intermediate/mitxpro/int__mitxpro__users.sql
+++ b/src/ol_dbt/models/intermediate/mitxpro/int__mitxpro__users.sql
@@ -1,9 +1,22 @@
 with users as (
-    select
-        id
-        , username
-        , email
+    select *
     from {{ ref('stg__mitxpro__app__postgres__users_user') }}
 )
 
-select * from users
+, users_legaladdress as (
+    select *
+    from {{ ref('stg__mitxpro__app__postgres__users_legaladdress') }}
+)
+
+
+select
+    users.user_id
+    , users.user_username
+    , users.user_full_name
+    , users.user_email
+    , users.user_joined_on
+    , users.user_last_login
+    , users_legaladdress.user_address_country
+from users
+left join users_legaladdress on users_legaladdress.user_id = users.user_id
+where users.user_is_active = true

--- a/src/ol_dbt/models/staging/mitxonline/_stg_mitxonline__models.yml
+++ b/src/ol_dbt/models/staging/mitxonline/_stg_mitxonline__models.yml
@@ -4,34 +4,34 @@ version: 2
 models:
 - name: stg__mitxonline__app__postgres__users_user
   columns:
-  - name: id
+  - name: user_id
     description: int, sequential ID representing one user in MITx Online
     tests:
     - unique
     - not_null
-  - name: username
+  - name: user_username
     description: str, name chosen by user
     tests:
     - unique
     - not_null
-  - name: email
+  - name: user_email
     description: str, user email associated with their account
     tests:
     - unique
     - not_null
-  - name: is_active
+  - name: user_is_active
     description: boolean, used to soft delete user accounts
-  - name: full_name
+  - name: user_full_name
     description: str, the user's full name
     tests:
     - not_null
-  - name: joined_on
+  - name: user_joined_on
     description: timestamp, specifying when a user account was initially created
   - name: last_login
     description: timestamp, specifying when a user last logged in
 - name: stg__mitxonline__app__postgres__users_legaladdress
   columns:
-  - name: id
+  - name: user_address_id
     description: int, sequential ID
     tests:
     - unique
@@ -45,11 +45,11 @@ models:
     tests:
     - unique
     - not_null
-  - name: last_name
+  - name: user_last_name
     description: string, user last name
     tests:
     - not_null
-  - name: first_name
+  - name: user_first_name
     description: string, user first name
     tests:
     - not_null

--- a/src/ol_dbt/models/staging/mitxonline/stg__mitxonline__app__postgres__users_legaladdress.sql
+++ b/src/ol_dbt/models/staging/mitxonline/stg__mitxonline__app__postgres__users_legaladdress.sql
@@ -7,11 +7,11 @@ with source as (
 , cleaned as (
 
     select
-        id
+        id as user_address_id
         , country as user_address_country
         , user_id
-        , first_name
-        , last_name
+        , first_name as user_first_name
+        , last_name as user_last_name
     from source
 )
 

--- a/src/ol_dbt/models/staging/mitxonline/stg__mitxonline__app__postgres__users_user.sql
+++ b/src/ol_dbt/models/staging/mitxonline/stg__mitxonline__app__postgres__users_user.sql
@@ -7,13 +7,13 @@ with source as (
 , cleaned as (
 
     select
-        id
-        , username
-        , email
-        , is_active
-        , name as full_name
-        , to_iso8601(from_iso8601_timestamp(created_on)) as joined_on
-        , to_iso8601(from_iso8601_timestamp(last_login)) as last_login
+        id as user_id
+        , username as user_username
+        , email as user_email
+        , is_active as user_is_active
+        , name as user_full_name
+        , to_iso8601(from_iso8601_timestamp(created_on)) as user_joined_on
+        , to_iso8601(from_iso8601_timestamp(last_login)) as user_last_login
     from source
 )
 

--- a/src/ol_dbt/models/staging/mitxpro/_stg_mitxpro__models.yml
+++ b/src/ol_dbt/models/staging/mitxpro/_stg_mitxpro__models.yml
@@ -4,34 +4,34 @@ version: 2
 models:
 - name: stg__mitxpro__app__postgres__users_user
   columns:
-  - name: id
+  - name: user_id
     description: int, sequential ID representing one user in xPro
     tests:
     - unique
     - not_null
-  - name: username
+  - name: user_username
     description: str, name chosen by user
     tests:
     - unique
     - not_null
-  - name: email
+  - name: user_email
     description: str, user email associated with their account
     tests:
     - unique
     - not_null
-  - name: is_active
+  - name: user_is_active
     description: boolean, used to soft delete user accounts
-  - name: full_name
+  - name: user_full_name
     description: str, the user's full name
     tests:
     - not_null
-  - name: joined_on
+  - name: user_joined_on
     description: timestamp, specifying when a user account was initially created
   - name: last_login
     description: timestamp, specifying when a user last logged in
 - name: stg__mitxpro__app__postgres__users_legaladdress
   columns:
-  - name: id
+  - name: user_address_id
     description: int, sequential ID
     tests:
     - unique
@@ -45,11 +45,11 @@ models:
     tests:
     - unique
     - not_null
-  - name: last_name
+  - name: user_last_name
     description: string, user last name
     tests:
     - not_null
-  - name: first_name
+  - name: user_first_name
     description: string, user first name
     tests:
     - not_null
@@ -71,7 +71,7 @@ models:
     - not_null
 - name: stg__mitxpro__app__postgres__users_profile
   columns:
-  - name: id
+  - name: user_profile_id
     description: int, sequential ID
     tests:
     - unique

--- a/src/ol_dbt/models/staging/mitxpro/stg__mitxpro__app__postgres__users_legaladdress.sql
+++ b/src/ol_dbt/models/staging/mitxpro/stg__mitxpro__app__postgres__users_legaladdress.sql
@@ -7,11 +7,11 @@ with source as (
 , cleaned as (
 
     select
-        id
+        id as user_address_id
         , country as user_address_country
         , user_id
-        , first_name
-        , last_name
+        , first_name as user_first_name
+        , last_name as user_last_name
         , city as user_address_city
         , state_or_territory as user_address_state_or_territory
         , postal_code as user_address_postal_code

--- a/src/ol_dbt/models/staging/mitxpro/stg__mitxpro__app__postgres__users_profile.sql
+++ b/src/ol_dbt/models/staging/mitxpro/stg__mitxpro__app__postgres__users_profile.sql
@@ -6,7 +6,7 @@ with source as (
 
 , cleaned as (
     select
-        id
+        id as user_profile_id
         , birth_year as user_birth_year
         , company as user_company
         , job_title as user_job_title

--- a/src/ol_dbt/models/staging/mitxpro/stg__mitxpro__app__postgres__users_user.sql
+++ b/src/ol_dbt/models/staging/mitxpro/stg__mitxpro__app__postgres__users_user.sql
@@ -6,13 +6,13 @@ with source as (
 
 , cleaned as (
     select
-        id
-        , username
-        , email
-        , is_active
-        , name as full_name
-        , to_iso8601(from_iso8601_timestamp(created_on)) as joined_on
-        , to_iso8601(from_iso8601_timestamp(last_login)) as last_login
+        id as user_id
+        , username as user_username
+        , email as user_email
+        , is_active as user_is_active
+        , name as user_full_name
+        , to_iso8601(from_iso8601_timestamp(created_on)) as user_joined_on
+        , to_iso8601(from_iso8601_timestamp(last_login)) as user_last_login
     from source
 )
 


### PR DESCRIPTION
This pr adds an intermediate model for xpro users. 

Also, since we decided to prefix course and program fields with course_ and program_ to avoid name collisions when joining intermediate models, I added user_ to fields from user tables.

I wasn't sure which columns to exclude for privacy reasons. I ended up including everything from users_legaladdress and  users_profile except address information that is more granular than state/region from users_legaladdress and user_birth_year from users_profile. I still don't have a good sense of what user information is too private to include and and at what point in the process we should exclude it.

We have a bunch of placeholder combined intermediate models in the codebase right now - I made the minimal changes to those so that the sql doesn't error. Those will be all completely re-written later
