### PR TITLE
bootcamps auth user

### DIFF
--- a/src/ol_dbt/models/intermediate/bootcamps/_int_bootcamps__models.yml
+++ b/src/ol_dbt/models/intermediate/bootcamps/_int_bootcamps__models.yml
@@ -17,9 +17,9 @@ models:
     description: ""
   - name: course_title
     description: ""
-  - name: username
+  - name: user_username
     description: ""
-  - name: email
+  - name: user_email
     description: ""
 
 - name: int__bootcamps__course_runs
@@ -41,9 +41,9 @@ models:
 - name: int__bootcamps__users
   description: ""
   columns:
-  - name: id
+  - name: user_id
     description: ""
-  - name: username
+  - name: user_username
     description: ""
-  - name: email
+  - name: user_email
     description: ""

--- a/src/ol_dbt/models/intermediate/bootcamps/int__bootcamps__enrollments.sql
+++ b/src/ol_dbt/models/intermediate/bootcamps/int__bootcamps__enrollments.sql
@@ -20,11 +20,11 @@ with enrollments as (
         , enrollments.created_on
         , '' as courseware_url_path
         , runs.title as course_title
-        , users.username
-        , users.email
+        , users.user_username
+        , users.user_email
     from enrollments
     inner join runs on runs.id = enrollments.bootcamp_run_id
-    inner join users on users.id = enrollments.user_id
+    inner join users on users.user_id = enrollments.user_id
 )
 
 select * from bootcamps_enrollments

--- a/src/ol_dbt/models/intermediate/bootcamps/int__bootcamps__users.sql
+++ b/src/ol_dbt/models/intermediate/bootcamps/int__bootcamps__users.sql
@@ -1,8 +1,8 @@
 with users as (
     select
-        id
-        , username
-        , email
+        user_id
+        , user_username
+        , user_email
     from {{ ref('stg__bootcamps__app__postgres__auth_user') }}
 )
 

--- a/src/ol_dbt/models/staging/bootcamps/_bootcamps__sources.yml
+++ b/src/ol_dbt/models/staging/bootcamps/_bootcamps__sources.yml
@@ -51,14 +51,24 @@ sources:
     description: ""
     columns:
     - name: id
-      description: ""
-    - name: email
-      description: ""
-    - name: username
-      description: ""
-    - name: is_active
-      description: ""
+      description: int, sequential ID representing one user
+    - name: password
+      description: str, hashed password
     - name: last_login
-      description: ""
+      description: timestamp, user's last login
+    - name: is_superuser
+      description: boolean, used for app permissions
+    - name: username
+      description: str, chosen by the user
+    - name: first_name
+      description: str, currently blank for all users on production
+    - name: last_name
+      description: str, currently blank for all users on production
+    - name: email
+      description: str, user email associated with their account
+    - name: is_staff
+      description: boolean, used for app permissions
+    - name: is_active
+      description: boolean, used to soft delete users
     - name: date_joined
-      description: ""
+      description: timestamp, specifying when a user account was initially created

--- a/src/ol_dbt/models/staging/bootcamps/_stg_bootcamps__models.yml
+++ b/src/ol_dbt/models/staging/bootcamps/_stg_bootcamps__models.yml
@@ -1,0 +1,26 @@
+---
+version: 2
+
+models:
+- name: stg__bootcamps__app__postgres__auth_user
+  columns:
+  - name: user_id
+    description: int, sequential ID representing one user in xPro
+    tests:
+    - unique
+    - not_null
+  - name: user_username
+    description: str, name chosen by user
+    tests:
+    - unique
+    - not_null
+  - name: user_email
+    description: str, user email associated with user account. Not unique
+    tests:
+    - not_null
+  - name: user_is_active
+    description: boolean, used to soft delete user accounts
+  - name: user_joined_on
+    description: timestamp, specifying when a user account was initially created
+  - name: user_last_login
+    description: timestamp, specifying when a user last logged in

--- a/src/ol_dbt/models/staging/bootcamps/stg__bootcamps__app__postgres__auth_user.sql
+++ b/src/ol_dbt/models/staging/bootcamps/stg__bootcamps__app__postgres__auth_user.sql
@@ -2,15 +2,16 @@ with source as (
     select * from {{ source('ol_warehouse_raw_data', 'raw__bootcamps__app__postgres__auth_user') }}
 )
 
-, renamed as (
+, cleaned as (
+
     select
-        id
-        , email
-        , username
-        , is_active
-        , last_login
-        , date_joined
+        id as user_id
+        , username as user_username
+        , email as user_email
+        , is_active as user_is_active
+        , to_iso8601(from_iso8601_timestamp(date_joined)) as user_joined_on
+        , to_iso8601(from_iso8601_timestamp(last_login)) as user_last_login
     from source
 )
 
-select * from renamed
+select * from cleaned


### PR DESCRIPTION
This pr brings in the auth_user table from bootcamps_ecommerce. The columns are: 

    - name: id
      description: int, sequential ID representing one user 
      action: renamed to user_id
    - name: password
      description: str, hashed password
      action: not imported
    - name: last_login
      description: timestamp, user's last login
      action: renamed to user_last_login
    - name: is_superuser
      description: boolean, used for app permissions
      action: not imported
    - name: username
      description: str, chosen by the user
      action: renamed to user_username
    - name: first_name
      description: str, currently blank for all users on production
      action: not imported
    - name: last_name
      description: str, currently blank for all users on production
      action: not imported
    - name: email
      description: str, user email associated with their account
      action: renamed to user_email
    - name: is_staff
      action: not imported
    - name: is_active
      description: boolean, used to soft delete users
      action: renamed to user_is_active
    - name: date_joined
      description: timestamp, specifying when a user account was initially created
      action: renamed to user_joined_on

