### PR TITLE
staged courses_course_topics table from mitxonline

### DIFF
--- a/src/ol_dbt/models/staging/mitxonline/_mitxonline__sources.yml
+++ b/src/ol_dbt/models/staging/mitxonline/_mitxonline__sources.yml
@@ -138,3 +138,13 @@ sources:
       description: timestamp, specifying when a course topic was initially created
     - name: updated_on
       description: timestamp, specifying when a course topic was most recently updated
+  - name: raw__mitxonline__app__postgres__courses_course_topics
+    columns:
+    - name: id
+      description: int, primary key representing a single MITx Online course tagged
+        to a topic
+    - name: course_id
+      description: int, foreign key to courses_course representing a single course
+    - name: coursetopic_id
+      description: int, foreign key to courses_coursetopic representing a single course
+        topic

--- a/src/ol_dbt/models/staging/mitxonline/_stg_mitxonline__models.yml
+++ b/src/ol_dbt/models/staging/mitxonline/_stg_mitxonline__models.yml
@@ -256,3 +256,29 @@ models:
   tests:
   - dbt_expectations.expect_table_column_count_to_equal:
       value: 4
+
+- name: stg__mitxonline__app__postgres__courses_course_to_topic
+  columns:
+  - name: coursetotopic_id
+    description: int, primary key representing a single MITx Online course tagged
+      to a topic
+    tests:
+    - unique
+    - not_null
+    - dbt_expectations.expect_column_to_exist
+  - name: coursetopic_id
+    description: int, foreign key to courses_coursetopic representing a single course
+      topic
+    tests:
+    - not_null
+    - dbt_expectations.expect_column_to_exist
+  - name: course_id
+    description: int, foreign key to courses_course representing a single course
+    tests:
+    - not_null
+    - dbt_expectations.expect_column_to_exist
+  tests:
+  - dbt_expectations.expect_table_column_count_to_equal:
+      value: 3
+  - dbt_expectations.expect_compound_columns_to_be_unique:
+      column_list: ["coursetopic_id", "course_id"]

--- a/src/ol_dbt/models/staging/mitxonline/stg__mitxonline__app__postgres__courses_course_to_topic.sql
+++ b/src/ol_dbt/models/staging/mitxonline/stg__mitxonline__app__postgres__courses_course_to_topic.sql
@@ -1,0 +1,15 @@
+-- MITx Online Course to Topic Information
+
+with source as (
+    select * from {{ source('ol_warehouse_raw_data','raw__mitxonline__app__postgres__courses_course_topics') }}
+)
+
+, cleaned as (
+    select
+        id as coursetotopic_id
+        , course_id
+        , coursetopic_id
+    from source
+)
+
+select * from cleaned


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This PR stages the`courses_course_topics` table from MITxOnline, but renamed it to be `courses_course_to_topic` to avoid naming confusion with the lookup table `courses_coursetopic`

## Motivation and Context
https://github.com/mitodl/ol-data-platform/issues/384

## How Has This Been Tested?
Ran `dbt run --select select stg__mitxonline__app__postgres__courses_course_to_topic` against qa
```
12:44:03  Running with dbt=1.2.2

12:44:03  Found 29 models, 153 tests, 0 snapshots, 0 analyses, 721 macros, 0 operations, 0 seed files, 17 sources, 0 exposures, 0 metrics
12:44:03  
12:44:08  Concurrency: 1 threads (target='qa')
12:44:08  
12:44:08  1 of 1 START incremental model ol_warehouse_qa_staging.stg__mitxonline__app__postgres__courses_course_to_topic  [RUN]
12:44:11  1 of 1 OK created incremental model ol_warehouse_qa_staging.stg__mitxonline__app__postgres__courses_course_to_topic  [SUCCESS in 3.85s]
12:44:11  
12:44:11  Finished running 1 incremental model in 0 hours 0 minutes and 8.07 seconds (8.07s).
12:44:12  
12:44:12  Completed successfully
12:44:12  
12:44:12  Done. PASS=1 WARN=0 ERROR=0 SKIP=0 TOTAL=1
```
and Ran ` dbt test --select stg__mitxonline__app__postgres__courses_course_to_topic` for column integrity test

```
12:44:55  Running with dbt=1.2.2
12:44:55  [WARNING]: Configuration paths exist in your dbt_project.yml file which do not apply to any resources.
There are 1 unused configuration paths:
- models.open_learning.marts

12:44:55  Found 29 models, 153 tests, 0 snapshots, 0 analyses, 721 macros, 0 operations, 0 seed files, 17 sources, 0 exposures, 0 metrics
12:44:55  
12:44:57  Concurrency: 1 threads (target='qa')
12:44:57  
12:44:58  1 of 9 START test dbt_expectations_expect_column_to_exist_stg__mitxonline__app__postgres__courses_course_to_topic_course_id  [RUN]
12:44:59  1 of 9 PASS dbt_expectations_expect_column_to_exist_stg__mitxonline__app__postgres__courses_course_to_topic_course_id  [PASS in 1.57s]
12:44:59  2 of 9 START test dbt_expectations_expect_column_to_exist_stg__mitxonline__app__postgres__courses_course_to_topic_coursetopic_id  [RUN]
12:45:00  2 of 9 PASS dbt_expectations_expect_column_to_exist_stg__mitxonline__app__postgres__courses_course_to_topic_coursetopic_id  [PASS in 0.97s]
12:45:00  3 of 9 START test dbt_expectations_expect_column_to_exist_stg__mitxonline__app__postgres__courses_course_to_topic_coursetotopic_id  [RUN]
12:45:01  3 of 9 PASS dbt_expectations_expect_column_to_exist_stg__mitxonline__app__postgres__courses_course_to_topic_coursetotopic_id  [PASS in 0.95s]
12:45:01  4 of 9 START test dbt_expectations_expect_compound_columns_to_be_unique_stg__mitxonline__app__postgres__courses_course_to_topic_coursetopic_id__course_id  [RUN]
12:45:02  4 of 9 PASS dbt_expectations_expect_compound_columns_to_be_unique_stg__mitxonline__app__postgres__courses_course_to_topic_coursetopic_id__course_id  [PASS in 0.93s]
12:45:02  5 of 9 START test dbt_expectations_expect_table_column_count_to_equal_stg__mitxonline__app__postgres__courses_course_to_topic_3  [RUN]
12:45:03  5 of 9 PASS dbt_expectations_expect_table_column_count_to_equal_stg__mitxonline__app__postgres__courses_course_to_topic_3  [PASS in 1.02s]
12:45:03  6 of 9 START test not_null_stg__mitxonline__app__postgres__courses_course_to_topic_course_id  [RUN]
12:45:04  6 of 9 PASS not_null_stg__mitxonline__app__postgres__courses_course_to_topic_course_id  [PASS in 0.77s]
12:45:04  7 of 9 START test not_null_stg__mitxonline__app__postgres__courses_course_to_topic_coursetopic_id  [RUN]
12:45:04  7 of 9 PASS not_null_stg__mitxonline__app__postgres__courses_course_to_topic_coursetopic_id  [PASS in 0.61s]
12:45:04  8 of 9 START test not_null_stg__mitxonline__app__postgres__courses_course_to_topic_coursetotopic_id  [RUN]
12:45:05  8 of 9 PASS not_null_stg__mitxonline__app__postgres__courses_course_to_topic_coursetotopic_id  [PASS in 0.65s]
12:45:05  9 of 9 START test unique_stg__mitxonline__app__postgres__courses_course_to_topic_coursetotopic_id  [RUN]
12:45:06  9 of 9 PASS unique_stg__mitxonline__app__postgres__courses_course_to_topic_coursetotopic_id  [PASS in 0.68s]
12:45:06  
12:45:06  Finished running 9 tests in 0 hours 0 minutes and 10.26 seconds (10.26s).
12:45:06  
12:45:06  Completed successfully
12:45:06  
12:45:06  Done. PASS=9 WARN=0 ERROR=0 SKIP=0 TOTAL=9
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Enhancement (improves on existing behavior)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project. (Did you install and run the pre-commit hooks?)
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
