### PR TITLE
Staging and intermediate models for MITxOnline courserun certificates + grades

### DIFF
--- a/src/ol_dbt/models/intermediate/mitxonline/_int_mitxonline__models.yml
+++ b/src/ol_dbt/models/intermediate/mitxonline/_int_mitxonline__models.yml
@@ -263,6 +263,241 @@ models:
   - dbt_expectations.expect_table_column_count_to_equal:
       value: 13
 
+- name: int__mitxonline__courserun_grades
+  description: Intermediate model for MITxOnline course run grades
+  columns:
+  - name: courserungrade_id
+    description: int, primary key representing a single MITxOnline grade record
+    tests:
+    - unique
+    - not_null
+    - dbt_expectations.expect_column_to_exist
+  - name: courserun_id
+    description: int, foreign key to courses_courserun representing a single course
+      run
+    tests:
+    - not_null
+    - dbt_expectations.expect_column_to_exist
+    - relationships:
+        to: ref('int__mitxonline__course_runs')
+        field: courserun_id
+  - name: courserun_title
+    description: str, title of the course run
+    tests:
+    - not_null
+    - dbt_expectations.expect_column_to_exist
+  - name: courserun_readable_id
+    description: str, Open edX Course ID formatted as course-v1:{org}+{course code}+{run_tag}
+    tests:
+    - not_null
+    - dbt_expectations.expect_column_to_exist
+  - name: courserun_url
+    description: str, url location for the course run in MITx Online
+    tests:
+    - dbt_expectations.expect_column_to_exist
+  - name: course_id
+    description: int, foreign key to courses_course representing a single course
+    tests:
+    - not_null
+    - dbt_expectations.expect_column_to_exist
+    - relationships:
+        to: ref('int__mitxonline__courses')
+        field: course_id
+  - name: courserungrade_grade
+    description: float, user's grade for the course (range between 0.0 to 1.0)
+    tests:
+    - not_null
+    - dbt_expectations.expect_column_to_exist
+  - name: courserungrade_letter_grade
+    description: str, letter grade defined in the edX grading policy (value may be
+      'A', 'B', 'C', 'D', 'Pass', none)
+    tests:
+    - dbt_expectations.expect_column_to_exist
+  - name: courserungrade_is_passing
+    description: boolean, indicating whether the user has passed the minimum passing
+      score set for this course
+    tests:
+    - dbt_expectations.expect_column_to_exist
+  - name: user_id
+    description: str, foreign key to users_user representing a single user
+    tests:
+    - not_null
+    - dbt_expectations.expect_column_to_exist
+    - relationships:
+        to: ref('int__mitxonline__users')
+        field: user_id
+  - name: user_username
+    description: string, username
+    tests:
+    - not_null
+    - dbt_expectations.expect_column_to_exist
+  - name: user_email
+    description: string, email
+    tests:
+    - not_null
+    - dbt_expectations.expect_column_to_exist
+  tests:
+  - dbt_expectations.expect_table_row_count_to_equal_other_table:
+      compare_model: ref('stg__mitxonline__app__postgres__courses_courserungrade')
+
+- name: int__mitxonline__courserun_certificates
+  columns:
+  - name: courseruncertificate_id
+    description: int, primary key representing a single MITxOnline course certificate
+      record
+    tests:
+    - unique
+    - not_null
+    - dbt_expectations.expect_column_to_exist
+  - name: courseruncertificate_uuid
+    description: str, unique identifier for the certificate
+    tests:
+    - unique
+    - not_null
+    - dbt_expectations.expect_column_to_exist
+  - name: courserun_id
+    description: int, foreign key to courses_courserun representing a single course
+      run
+    tests:
+    - not_null
+    - dbt_expectations.expect_column_to_exist
+    - relationships:
+        to: ref('int__mitxonline__course_runs')
+        field: courserun_id
+  - name: course_id
+    description: int, foreign key to courses_course representing a single course
+    tests:
+    - not_null
+    - dbt_expectations.expect_column_to_exist
+    - relationships:
+        to: ref('int__mitxonline__courses')
+        field: course_id
+  - name: user_id
+    description: str, foreign key to users_user representing a single user
+    tests:
+    - not_null
+    - dbt_expectations.expect_column_to_exist
+    - relationships:
+        to: ref('int__mitxonline__users')
+        field: user_id
+  - name: courseruncertificate_is_revoked
+    description: boolean, indicating whether the certificate is revoked and invalid
+    tests:
+    - dbt_expectations.expect_column_to_exist
+  - name: courserun_title
+    description: str, title of the course run
+    tests:
+    - not_null
+    - dbt_expectations.expect_column_to_exist
+  - name: courserun_readable_id
+    description: str, Open edX Course ID formatted as course-v1:{org}+{course code}+{run_tag}
+    tests:
+    - not_null
+    - dbt_expectations.expect_column_to_exist
+  - name: courserun_url
+    description: str, url location for the course run in MITx Online
+    tests:
+    - dbt_expectations.expect_column_to_exist
+  - name: user_username
+    description: string, username
+    tests:
+    - not_null
+    - dbt_expectations.expect_column_to_exist
+  - name: user_email
+    description: string, email
+    tests:
+    - not_null
+    - dbt_expectations.expect_column_to_exist
+  tests:
+  - dbt_expectations.expect_table_row_count_to_equal_other_table:
+      compare_model: ref('stg__mitxonline__app__postgres__courses_courseruncertificate')
+
+- name: int__mitxonline__programs
+  columns:
+  - name: program_id
+    description: int, primary key representing a single MITx Online program
+    tests:
+    - unique
+    - not_null
+    - dbt_expectations.expect_column_to_exist
+  - name: program_is_live
+    description: boolean, indicating whether the program is available to users
+    tests:
+    - dbt_expectations.expect_column_to_exist
+  - name: program_title
+    description: str, title of the program
+    tests:
+    - not_null
+    - dbt_expectations.expect_column_to_exist
+  - name: program_readable_id
+    description: str, Open edX ID formatted as program-v1:{org}+{program code}
+    tests:
+    - unique
+    - not_null
+    - dbt_expectations.expect_column_to_exist
+  tests:
+  - dbt_expectations.expect_table_column_count_to_equal:
+      value: 4
+
+- name: int__mitxonline__program_certificates
+  columns:
+  - name: programcertificate_id
+    description: int, primary key representing a single MITxOnline program certificate
+      record
+    tests:
+    - unique
+    - not_null
+    - dbt_expectations.expect_column_to_exist
+  - name: programcertificate_uuid
+    description: str, unique identifier for the program certificate
+    tests:
+    - unique
+    - not_null
+    - dbt_expectations.expect_column_to_exist
+  - name: program_id
+    description: int, foreign key to courses_program representing a single program
+    tests:
+    - not_null
+    - dbt_expectations.expect_column_to_exist
+    - relationships:
+        to: ref('int__mitxonline__programs')
+        field: program_id
+  - name: user_id
+    description: str, foreign key to users_user representing a single user
+    tests:
+    - not_null
+    - dbt_expectations.expect_column_to_exist
+    - relationships:
+        to: ref('int__mitxonline__users')
+        field: user_id
+  - name: programcertificate_is_revoked
+    description: boolean, indicating whether the certificate is revoked and invalid
+    tests:
+    - dbt_expectations.expect_column_to_exist
+  - name: program_title
+    description: str, title of the program
+    tests:
+    - not_null
+    - dbt_expectations.expect_column_to_exist
+  - name: program_readable_id
+    description: str, Open edX ID formatted as program-v1:{org}+{program code}
+    tests:
+    - not_null
+    - dbt_expectations.expect_column_to_exist
+  - name: user_username
+    description: string, username
+    tests:
+    - not_null
+    - dbt_expectations.expect_column_to_exist
+  - name: user_email
+    description: string, email
+    tests:
+    - not_null
+    - dbt_expectations.expect_column_to_exist
+  tests:
+  - dbt_expectations.expect_table_row_count_to_equal_other_table:
+      compare_model: ref('stg__mitxonline__app__postgres__courses_programcertificate')
+
 - name: int__mitxonline__users
   description: denormalized mitxonline users
   columns:
@@ -301,9 +536,10 @@ models:
     description: string, country code for the user's address
     tests:
     - dbt_expectations.expect_column_to_exist
+  - name: user_is_active
+    description: boolean, indicating if user is active or not
   tests:
   - dbt_expectations.expect_table_column_count_to_equal:
-      value: 7
+      value: 8
   - dbt_expectations.expect_table_row_count_to_equal_other_table:
       compare_model: ref('stg__mitxonline__app__postgres__users_user')
-      compare_row_condition: "user_is_active = true"

--- a/src/ol_dbt/models/intermediate/mitxonline/int__mitxonline__courserun_certificate.sql
+++ b/src/ol_dbt/models/intermediate/mitxonline/int__mitxonline__courserun_certificate.sql
@@ -1,0 +1,29 @@
+-- Course Certificate information for MITx Online
+
+with certificates as (
+    select * from {{ ref('stg__mitxonline__app__postgres__courses_courseruncertificate') }}
+)
+
+, runs as (
+    select * from {{ ref('stg__mitxonline__app__postgres__courses_courserun') }}
+)
+
+, users as (
+    select * from {{ ref('stg__mitxonline__app__postgres__users_user') }}
+)
+
+select
+    certificates.courseruncertificate_id
+    , certificates.courseruncertificate_uuid
+    , certificates.courserun_id
+    , runs.courserun_title
+    , runs.courserun_readable_id
+    , runs.courserun_url
+    , runs.course_id
+    , certificates.courseruncertificate_is_revoked
+    , certificates.user_id
+    , users.user_username
+    , users.user_email
+from certificates
+inner join runs on certificates.courserun_id = runs.courserun_id
+inner join users on certificates.user_id = users.user_id

--- a/src/ol_dbt/models/intermediate/mitxonline/int__mitxonline__courserun_grades.sql
+++ b/src/ol_dbt/models/intermediate/mitxonline/int__mitxonline__courserun_grades.sql
@@ -1,0 +1,30 @@
+-- Course Grade information for MITx Online
+
+with grades as (
+    select * from {{ ref('stg__mitxonline__app__postgres__courses_courserungrade') }}
+)
+
+, runs as (
+    select * from {{ ref('stg__mitxonline__app__postgres__courses_courserun') }}
+)
+
+, users as (
+    select * from {{ ref('stg__mitxonline__app__postgres__users_user') }}
+)
+
+select
+    grades.courserungrade_id
+    , grades.courserun_id
+    , runs.course_id
+    , runs.courserun_title
+    , runs.courserun_readable_id
+    , runs.courserun_url
+    , grades.courserungrade_grade
+    , grades.courserungrade_letter_grade
+    , grades.courserungrade_is_passing
+    , grades.user_id
+    , users.user_username
+    , users.user_email
+from grades
+inner join runs on grades.courserun_id = runs.courserun_id
+inner join users on grades.user_id = users.user_id

--- a/src/ol_dbt/models/intermediate/mitxonline/int__mitxonline__program_certificates.sql
+++ b/src/ol_dbt/models/intermediate/mitxonline/int__mitxonline__program_certificates.sql
@@ -1,0 +1,27 @@
+-- Program Certificate information for MITx Online
+
+with certificates as (
+    select * from {{ ref('stg__mitxonline__app__postgres__courses_programcertificate') }}
+)
+
+, programs as (
+    select * from {{ ref('stg__mitxonline__app__postgres__courses_program') }}
+)
+
+, users as (
+    select * from {{ ref('stg__mitxonline__app__postgres__users_user') }}
+)
+
+select
+    certificates.programcertificate_id
+    , certificates.programcertificate_uuid
+    , certificates.program_id
+    , programs.program_title
+    , programs.program_readable_id
+    , certificates.programcertificate_is_revoked
+    , certificates.user_id
+    , users.user_username
+    , users.user_email
+from certificates
+inner join programs on certificates.program_id = programs.program_id
+inner join users on certificates.user_id = users.user_id

--- a/src/ol_dbt/models/intermediate/mitxonline/int__mitxonline__programs.sql
+++ b/src/ol_dbt/models/intermediate/mitxonline/int__mitxonline__programs.sql
@@ -1,0 +1,12 @@
+-- Program information for MITx Online
+
+with programs as (
+    select * from {{ ref('stg__mitxonline__app__postgres__courses_program') }}
+)
+
+select
+    program_id
+    , program_title
+    , program_is_live
+    , program_readable_id
+from programs

--- a/src/ol_dbt/models/intermediate/mitxonline/int__mitxonline__users.sql
+++ b/src/ol_dbt/models/intermediate/mitxonline/int__mitxonline__users.sql
@@ -16,6 +16,6 @@ select
     , users.user_joined_on
     , users.user_last_login
     , users_legaladdress.user_address_country
+    , users.user_is_active
 from users
 left join users_legaladdress on users_legaladdress.user_id = users.user_id
-where users.user_is_active = true

--- a/src/ol_dbt/models/staging/mitxonline/_mitxonline__sources.yml
+++ b/src/ol_dbt/models/staging/mitxonline/_mitxonline__sources.yml
@@ -382,3 +382,123 @@ sources:
     tests:
     - dbt_expectations.expect_table_column_count_to_equal:
         value: 5
+
+  - name: raw__mitxonline__app__postgres__courses_courseruncertificate
+    columns:
+    - name: id
+      description: int, primary key representing a single MITxOnline course certificate
+        record
+      tests:
+      - dbt_expectations.expect_column_to_exist
+    - name: uuid
+      description: str, unique identifier for the certificate
+      tests:
+      - dbt_expectations.expect_column_to_exist
+    - name: course_run_id
+      description: int, foreign key to courses_courserun representing a single course
+        run
+      tests:
+      - dbt_expectations.expect_column_to_exist
+    - name: user_id
+      description: str, foreign key to users_user representing a single user
+      tests:
+      - dbt_expectations.expect_column_to_exist
+    - name: certificate_page_revision_id
+      description: int, foreign key to wagtailcore_pagerevision (could be blank)
+    - name: created_on
+      description: timestamp, specifying when a certificate was initially created
+      tests:
+      - dbt_expectations.expect_column_to_exist
+    - name: updated_on
+      description: timestamp, specifying when a certificate was most recently updated
+      tests:
+      - dbt_expectations.expect_column_to_exist
+    - name: is_revoked
+      description: boolean, indicating whether the certificate is revoked and invalid
+      tests:
+      - dbt_expectations.expect_column_to_exist
+    tests:
+    - dbt_expectations.expect_table_column_count_to_equal:
+        value: 8
+
+  - name: raw__mitxonline__app__postgres__courses_programcertificate
+    columns:
+    - name: id
+      description: int, primary key representing a single MITxOnline program certificate
+        record
+      tests:
+      - dbt_expectations.expect_column_to_exist
+    - name: uuid
+      description: str, unique identifier for the program certificate
+      tests:
+      - dbt_expectations.expect_column_to_exist
+    - name: program_id
+      description: int, foreign key to courses_program representing a single program
+      tests:
+      - dbt_expectations.expect_column_to_exist
+    - name: user_id
+      description: str, foreign key to users_user representing a single user
+      tests:
+      - dbt_expectations.expect_column_to_exist
+    - name: certificate_page_revision_id
+      description: int, foreign key to wagtailcore_pagerevision (could be blank)
+    - name: created_on
+      description: timestamp, specifying when a certificate was initially created
+      tests:
+      - dbt_expectations.expect_column_to_exist
+    - name: updated_on
+      description: timestamp, specifying when a certificate was most recently updated
+      tests:
+      - dbt_expectations.expect_column_to_exist
+    - name: is_revoked
+      description: boolean, indicating whether the certificate is revoked and invalid
+      tests:
+      - dbt_expectations.expect_column_to_exist
+    tests:
+    - dbt_expectations.expect_table_column_count_to_equal:
+        value: 8
+
+  - name: raw__mitxonline__app__postgres__courses_courserungrade
+    columns:
+    - name: id
+      description: int, primary key representing a single MITxOnline grade record
+      tests:
+      - dbt_expectations.expect_column_to_exist
+    - name: course_run_id
+      description: int, foreign key to courses_courserun representing a single course
+        run
+      tests:
+      - dbt_expectations.expect_column_to_exist
+    - name: user_id
+      description: str, foreign key to users_user representing a single user
+      tests:
+      - dbt_expectations.expect_column_to_exist
+    - name: grade
+      description: float, user's grade for the course (range between 0.0 to 1.0)
+      tests:
+      - dbt_expectations.expect_column_to_exist
+    - name: letter_grade
+      description: str, letter grade defined ib edX grading policy (value may be 'A',
+        'B', 'C', 'D', 'Pass', none)
+      tests:
+      - dbt_expectations.expect_column_to_exist
+    - name: set_by_admin
+      description: boolean, indicating whether this grade is set by a staff user
+      tests:
+      - dbt_expectations.expect_column_to_exist
+    - name: passed
+      description: boolean, indicating whether the user has passed the minimum passing
+        score set for this course
+      tests:
+      - dbt_expectations.expect_column_to_exist
+    - name: created_on
+      description: timestamp, specifying when a grade was initially created
+      tests:
+      - dbt_expectations.expect_column_to_exist
+    - name: updated_on
+      description: timestamp, specifying when a grade was most recently updated
+      tests:
+      - dbt_expectations.expect_column_to_exist
+    tests:
+    - dbt_expectations.expect_table_column_count_to_equal:
+        value: 9

--- a/src/ol_dbt/models/staging/mitxonline/_stg_mitxonline__models.yml
+++ b/src/ol_dbt/models/staging/mitxonline/_stg_mitxonline__models.yml
@@ -178,6 +178,9 @@ models:
     tests:
     - not_null
     - dbt_expectations.expect_column_to_exist
+    - relationships:
+        to: ref('stg__mitxonline__app__postgres__courses_course')
+        field: course_id
   - name: courserun_readable_id
     description: str, Open edX Course ID formatted as course-v1:{org}+{course code}+{run_tag}
     tests:
@@ -272,11 +275,17 @@ models:
     tests:
     - not_null
     - dbt_expectations.expect_column_to_exist
+    - relationships:
+        to: ref('stg__mitxonline__app__postgres__courses_coursetopic')
+        field: coursetopic_id
   - name: course_id
     description: int, foreign key to courses_course representing a single course
     tests:
     - not_null
     - dbt_expectations.expect_column_to_exist
+    - relationships:
+        to: ref('stg__mitxonline__app__postgres__courses_course')
+        field: course_id
   tests:
   - dbt_expectations.expect_table_column_count_to_equal:
       value: 3
@@ -301,6 +310,9 @@ models:
     tests:
     - not_null
     - dbt_expectations.expect_column_to_exist
+    - relationships:
+        to: ref('stg__mitxonline__app__postgres__courses_course')
+        field: course_id
   - name: blockedcountry_created_on
     description: timestamp, specifying when a blocked country record was initially
       created
@@ -316,109 +328,102 @@ models:
       value: 5
   - dbt_expectations.expect_compound_columns_to_be_unique:
       column_list: ["blockedcountry_code", "course_id"]
-- name: stg__mitxonline__app__postgres__courses_courserunenrollment
+
+- name: stg__mitxonline__app__postgres__courses_courseruncertificate
   columns:
-  - name: courserunenrollment_id
-    description: int, sequential ID tracking a single user enrollment
+  - name: courseruncertificate_id
+    description: int, primary key representing a single MITxOnline course certificate
+      record
     tests:
-    - dbt_expectations.expect_column_to_exist
     - unique
     - not_null
-  - name: courserunenrollment_created_on
-    description: timestamp, specifying when an enrollment was initially created
-    tests:
     - dbt_expectations.expect_column_to_exist
+  - name: courseruncertificate_uuid
+    description: str, unique identifier for the certificate
+    tests:
+    - unique
     - not_null
-  - name: courserunenrollment_updated_on
-    description: timestamp, specifying when an enrollment was most recently updated
-    tests:
     - dbt_expectations.expect_column_to_exist
-    - not_null
-  - name: courserunenrollment_enrollment_status
-    description: str, enrollment status for users whose enrollment changed. Options
-      are 'deferred', 'transferred', 'refunded', 'unenrolled', 'enrolled'
-    tests:
-    - dbt_expectations.expect_column_to_exist
-    - accepted_values:
-        values: ['deferred', 'transferred', 'refunded', 'enrolled', 'unenrolled',
-          '']
-  - name: courserunenrollment_is_active
-    description: boolean, indicating whether the user is still enrolled in the run
-    tests:
-    - dbt_expectations.expect_column_to_exist
-    - not_null
-  - name: courserunenrollment_is_edx_enrolled
-    description: boolean, indicating whether the user is enrolled on edx
-    tests:
-    - dbt_expectations.expect_column_to_exist
-    - not_null
   - name: courserun_id
-    description: int, unique ID specifying a "run" of an MITx Online course
+    description: int, foreign key to courses_courserun representing a single course
+      run
     tests:
-    - dbt_expectations.expect_column_to_exist
     - not_null
+    - dbt_expectations.expect_column_to_exist
+    - relationships:
+        to: ref('stg__mitxonline__app__postgres__courses_courserun')
+        field: courserun_id
   - name: user_id
-    description: int, unique ID for each user on the MITx Online platform
+    description: str, foreign key to users_user representing a single user
     tests:
-    - dbt_expectations.expect_column_to_exist
     - not_null
-  - name: courserunenrollment_enrollment_mode
-    description: str, enrollment mode for user
+    - dbt_expectations.expect_column_to_exist
+    - relationships:
+        to: ref('stg__mitxonline__app__postgres__users_user')
+        field: user_id
+  - name: certificate_page_revision_id
+    description: int, foreign key to wagtailcore_pagerevision (could be blank)
+  - name: courseruncertificate_created_on
+    description: timestamp, specifying when a certificate was initially created
     tests:
     - dbt_expectations.expect_column_to_exist
-  - name: courserunenrollment_has_edx_email_subscription
-    description: boolean, indicates whether the user should receive emails from edx
+  - name: courseruncertificate_updated_on
+    description: timestamp, specifying when a certificate was most recently updated
     tests:
     - dbt_expectations.expect_column_to_exist
-    - not_null
+  - name: courseruncertificate_is_revoked
+    description: boolean, indicating whether the certificate is revoked and invalid
+    tests:
+    - dbt_expectations.expect_column_to_exist
   tests:
   - dbt_expectations.expect_table_column_count_to_equal:
-      value: 10
+      value: 8
   - dbt_expectations.expect_compound_columns_to_be_unique:
       column_list: ["user_id", "courserun_id"]
-- name: stg__mitxonline__app__postgres__courses_programenrollment
+
+- name: stg__mitxonline__app__postgres__courses_programcertificate
   columns:
-  - name: programenrollment_id
-    description: int, sequential ID tracking a single user enrollment
+  - name: programcertificate_id
+    description: int, primary key representing a single MITxOnline program certificate
+      record
     tests:
-    - dbt_expectations.expect_column_to_exist
     - unique
     - not_null
-  - name: programenrollment_created_on
-    description: timestamp, specifying when an enrollment was initially created
-    tests:
     - dbt_expectations.expect_column_to_exist
+  - name: programcertificate_uuid
+    description: str, unique identifier for the program certificate
+    tests:
+    - unique
     - not_null
-  - name: programenrollment_updated_on
-    description: timestamp, specifying when an enrollment was most recently updated
-    tests:
     - dbt_expectations.expect_column_to_exist
-    - not_null
-  - name: programenrollment_enrollment_status
-    description: str, enrollment status for users whose enrollment changed Options
-      are 'deferred', 'transferred', 'refunded', 'enrolled', 'unenrolled'
-    tests:
-    - dbt_expectations.expect_column_to_exist
-    - accepted_values:
-        values: ['deferred', 'transferred', 'refunded', 'enrolled', 'unenrolled',
-          '']
-  - name: programenrollment_is_active
-    description: boolean, indicating whether the user is still enrolled in the program
-    tests:
-    - dbt_expectations.expect_column_to_exist
-    - not_null
   - name: program_id
-    description: int, unique ID specifying a "run" of an MITx Online course
+    description: int, foreign key to courses_program representing a single program
     tests:
-    - dbt_expectations.expect_column_to_exist
     - not_null
+    - dbt_expectations.expect_column_to_exist
+    - relationships:
+        to: ref('stg__mitxonline__app__postgres__courses_program')
+        field: program_id
   - name: user_id
-    description: int, unique ID for each user on the MITx Online platform
+    description: str, foreign key to users_user representing a single user
+    tests:
+    - not_null
+    - dbt_expectations.expect_column_to_exist
+    - relationships:
+        to: ref('stg__mitxonline__app__postgres__users_user')
+        field: user_id
+  - name: certificate_page_revision_id
+    description: int, foreign key to wagtailcore_pagerevision (could be blank)
+  - name: programcertificate_created_on
+    description: timestamp, specifying when a certificate was initially created
     tests:
     - dbt_expectations.expect_column_to_exist
-    - not_null
-  - name: programenrollment_enrollment_mode
-    description: str, enrollment mode for user
+  - name: programcertificate_updated_on
+    description: timestamp, specifying when a certificate was most recently updated
+    tests:
+    - dbt_expectations.expect_column_to_exist
+  - name: programcertificate_is_revoked
+    description: boolean, indicating whether the certificate is revoked and invalid
     tests:
     - dbt_expectations.expect_column_to_exist
   tests:
@@ -426,3 +431,61 @@ models:
       value: 8
   - dbt_expectations.expect_compound_columns_to_be_unique:
       column_list: ["user_id", "program_id"]
+
+- name: stg__mitxonline__app__postgres__courses_courserungrade
+  columns:
+  - name: courserungrade_id
+    description: int, primary key representing a single MITxOnline grade record
+    tests:
+    - unique
+    - not_null
+    - dbt_expectations.expect_column_to_exist
+  - name: courserun_id
+    description: int, foreign key to courses_courserun representing a single course
+      run
+    tests:
+    - not_null
+    - dbt_expectations.expect_column_to_exist
+    - relationships:
+        to: ref('stg__mitxonline__app__postgres__courses_courserun')
+        field: courserun_id
+  - name: user_id
+    description: str, foreign key to users_user representing a single user
+    tests:
+    - not_null
+    - dbt_expectations.expect_column_to_exist
+    - relationships:
+        to: ref('stg__mitxonline__app__postgres__users_user')
+        field: user_id
+  - name: courserungrade_grade
+    description: float, user's grade for the course (range between 0.0 to 1.0)
+    tests:
+    - not_null
+    - dbt_expectations.expect_column_to_exist
+  - name: courserungrade_letter_grade
+    description: str, letter grade defined in the edX grading policy (value may be
+      'A', 'B', 'C', 'D', 'Pass', none)
+    tests:
+    - dbt_expectations.expect_column_to_exist
+  - name: courserungrade_is_set_by_admin
+    description: boolean, indicating whether this grade is set by a staff user
+    tests:
+    - dbt_expectations.expect_column_to_exist
+  - name: courserungrade_is_passing
+    description: boolean, indicating whether the user has passed the minimum passing
+      score set for this course
+    tests:
+    - dbt_expectations.expect_column_to_exist
+  - name: courserungrade_created_on
+    description: timestamp, specifying when a grade was initially created
+    tests:
+    - dbt_expectations.expect_column_to_exist
+  - name: courserungrade_updated_on
+    description: timestamp, specifying when a grade was most recently updated
+    tests:
+    - dbt_expectations.expect_column_to_exist
+  tests:
+  - dbt_expectations.expect_table_column_count_to_equal:
+      value: 9
+  - dbt_expectations.expect_compound_columns_to_be_unique:
+      column_list: ["user_id", "courserun_id"]

--- a/src/ol_dbt/models/staging/mitxonline/stg__mitxonline__app__postgres__courses_courseruncertificate.sql
+++ b/src/ol_dbt/models/staging/mitxonline/stg__mitxonline__app__postgres__courses_courseruncertificate.sql
@@ -1,0 +1,20 @@
+-- MITx Online Users Course Certificate Information
+
+with source as (
+    select * from {{ source('ol_warehouse_raw_data','raw__mitxonline__app__postgres__courses_courseruncertificate') }}
+)
+
+, cleaned as (
+    select
+        id as courseruncertificate_id
+        , uuid as courseruncertificate_uuid
+        , course_run_id as courserun_id
+        , user_id
+        , certificate_page_revision_id  --- rename it after the referenced model is created
+        , is_revoked as courseruncertificate_is_revoked
+        , to_iso8601(from_iso8601_timestamp(created_on)) as courseruncertificate_created_on
+        , to_iso8601(from_iso8601_timestamp(updated_on)) as courseruncertificate_updated_on
+    from source
+)
+
+select * from cleaned

--- a/src/ol_dbt/models/staging/mitxonline/stg__mitxonline__app__postgres__courses_courserungrade.sql
+++ b/src/ol_dbt/models/staging/mitxonline/stg__mitxonline__app__postgres__courses_courserungrade.sql
@@ -1,0 +1,21 @@
+-- MITx Online Users Course Grades Information
+
+with source as (
+    select * from {{ source('ol_warehouse_raw_data','raw__mitxonline__app__postgres__courses_courserungrade') }}
+)
+
+, cleaned as (
+    select
+        id as courserungrade_id
+        , course_run_id as courserun_id
+        , user_id
+        , grade as courserungrade_grade
+        , letter_grade as courserungrade_letter_grade
+        , set_by_admin as courserungrade_is_set_by_admin
+        , passed as courserungrade_is_passing
+        , to_iso8601(from_iso8601_timestamp(created_on)) as courserungrade_created_on
+        , to_iso8601(from_iso8601_timestamp(updated_on)) as courserungrade_updated_on
+    from source
+)
+
+select * from cleaned

--- a/src/ol_dbt/models/staging/mitxonline/stg__mitxonline__app__postgres__courses_programcertificate.sql
+++ b/src/ol_dbt/models/staging/mitxonline/stg__mitxonline__app__postgres__courses_programcertificate.sql
@@ -1,0 +1,20 @@
+-- MITx Online Users Program Certificate Information
+
+with source as (
+    select * from {{ source('ol_warehouse_raw_data','raw__mitxonline__app__postgres__courses_programcertificate') }}
+)
+
+, cleaned as (
+    select
+        id as programcertificate_id
+        , uuid as programcertificate_uuid
+        , program_id
+        , user_id
+        , certificate_page_revision_id  --- rename it after the referenced model is created
+        , is_revoked as programcertificate_is_revoked
+        , to_iso8601(from_iso8601_timestamp(created_on)) as programcertificate_created_on
+        , to_iso8601(from_iso8601_timestamp(updated_on)) as programcertificate_updated_on
+    from source
+)
+
+select * from cleaned


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This PR adds staging and intermediate models for the following certificates and grades for MITxOnline
stg__mitxonline__app__postgres__courses_courserungrade
stg__mitxonline__app__postgres__courses_courseruncertificate
stg__mitxonline__app__postgres__courses_programcertificate

int__mitxonline__courserun_certificate
int__mitxonline__program_certificates
int__mitxonline__courserun_grades

## Motivation and Context
https://github.com/mitodl/ol-data-platform/issues/428

## How Has This Been Tested?
Ran `dbt run` and Ran `dbt test`
```
dbt test                                              
17:17:16  Running with dbt=1.2.2
17:17:16  [WARNING]: Configuration paths exist in your dbt_project.yml file which do not apply to any resources.
There are 1 unused configuration paths:
- models.open_learning.marts

17:17:16  Found 52 models, 634 tests, 0 snapshots, 0 analyses, 717 macros, 0 operations, 0 seed files, 28 sources, 0 exposures, 0 metrics
17:17:16  
17:17:18  Concurrency: 1 threads (target='qa')

---
17:28:51  
17:28:51  Finished running 634 tests in 0 hours 11 minutes and 34.93 seconds (694.93s).
17:28:51  
17:28:51  Completed successfully
17:28:51  
17:28:51  Done. PASS=634 WARN=0 ERROR=0 SKIP=0 TOTAL=634
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Enhancement (improves on existing behavior)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project. (Did you install and run the pre-commit hooks?)
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
