### PR TITLE
add program requirement model for program to course relationship

### DIFF
--- a/src/ol_dbt/models/intermediate/mitxonline/_int_mitxonline__models.yml
+++ b/src/ol_dbt/models/intermediate/mitxonline/_int_mitxonline__models.yml
@@ -269,7 +269,7 @@ models:
   - dbt_expectations.expect_table_column_count_to_equal:
       value: 10
   - dbt_expectations.expect_table_row_count_to_equal_other_table:
-      compare_model: ref('stg__mitxonline__app__postgres__course_courserunenrollment')
+      compare_model: ref('stg__mitxonline__app__postgres__courses_courserunenrollment')
   - dbt_expectations.expect_compound_columns_to_be_unique:
       column_list: ["user_id", "courserun_id"]
 - name: int__mitxonline__programenrollments
@@ -332,7 +332,7 @@ models:
   - dbt_expectations.expect_table_column_count_to_equal:
       value: 10
   - dbt_expectations.expect_table_row_count_to_equal_other_table:
-      compare_model: ref('stg__mitxonline__app__postgres__course_courserunenrollment')
+      compare_model: ref('stg__mitxonline__app__postgres__courses_courserunenrollment')
   - dbt_expectations.expect_compound_columns_to_be_unique:
       column_list: ["user_id", "program_id"]
 - name: int__mitxonline__courses
@@ -642,6 +642,40 @@ models:
     - unique
     - not_null
     - dbt_expectations.expect_column_to_exist
+  tests:
+  - dbt_expectations.expect_table_column_count_to_equal:
+      value: 4
+
+- name: int__mitxonline__programrequirements
+  columns:
+  - name: programrequirement_id
+    description: int, primary key representing a MITx Online program requirement node
+    tests:
+    - dbt_expectations.expect_column_to_exist
+    - unique
+    - not_null
+  - name: course_id
+    description: int, foreign key to courses representing a single course
+    tests:
+    - dbt_expectations.expect_column_to_exist
+    - relationships:
+        to: ref('int__mitxonline__courses')
+        field: course_id
+  - name: program_id
+    description: int, foreign key to programs representing a single program
+    tests:
+    - dbt_expectations.expect_column_to_exist
+    - not_null
+    - relationships:
+        to: ref('int__mitxonline__programs')
+        field: program_id
+  - name: programrequirement_type
+    description: str, indicating the courses is either required or elective
+    tests:
+    - dbt_expectations.expect_column_to_exist
+    - not_null
+    - accepted_values:
+        values: ["Required Courses", "Elective Courses"]
   tests:
   - dbt_expectations.expect_table_column_count_to_equal:
       value: 4

--- a/src/ol_dbt/models/intermediate/mitxonline/int__mitxonline__programrequirements.sql
+++ b/src/ol_dbt/models/intermediate/mitxonline/int__mitxonline__programrequirements.sql
@@ -1,0 +1,59 @@
+-- Program Requirement for MITx Online
+-- course and program relationship in this model is many to many
+-- courses are grouped into "required" and "elective" categories
+
+
+with programrequirement as (
+    select * from {{ ref('stg__mitxonline__app__postgres__courses_programrequirement') }}
+)
+
+, required_path as (
+    select programrequirement_path
+    from programrequirement
+    where programrequirement_node_type = 'operator' and programrequirement_operator = 'all_of'
+)
+
+, required_courses as (
+    select
+        programrequirement.programrequirement_id
+        , programrequirement.course_id
+        , programrequirement.program_id
+    from programrequirement
+    inner join required_path
+               on programrequirement.programrequirement_path like required_path.programrequirement_path || '%'
+    where programrequirement.programrequirement_node_type = 'course'
+)
+
+--- elective courses could be nested. However, courses that are not required are elective
+, elective_courses as (
+    select
+        programrequirement.programrequirement_id
+        , programrequirement.course_id
+        , programrequirement.program_id
+    from programrequirement
+    left join required_courses
+        on programrequirement.program_id = required_courses.program_id
+            and programrequirement.course_id = required_courses.course_id
+    where programrequirement.programrequirement_node_type = 'course'
+        and required_courses.program_id is null
+)
+
+, combined as (
+    select
+        programrequirement_id
+        , course_id
+        , program_id
+        , 'Required Courses' as programrequirement_type
+    from required_courses
+
+    union all
+
+    select
+        programrequirement_id
+        , course_id
+        , program_id
+        , 'Elective Courses' as programrequirement_type
+    from elective_courses
+)
+
+select * from combined

--- a/src/ol_dbt/models/staging/mitxonline/_mitxonline__sources.yml
+++ b/src/ol_dbt/models/staging/mitxonline/_mitxonline__sources.yml
@@ -586,6 +586,60 @@ sources:
     tests:
     - dbt_expectations.expect_table_column_count_to_equal:
         value: 6
+
+  - name: raw__mitxonline__app__postgres__courses_programrequirement
+    columns:
+    - name: id
+      description: int, primary key representing a MITx Online program requirement
+        node
+      tests:
+      - dbt_expectations.expect_column_to_exist
+    - name: course_id
+      description: int, foreign key to courses_course representing a single course
+      tests:
+      - dbt_expectations.expect_column_to_exist
+    - name: program_id
+      description: int, foreign key to courses_program representing a single program
+      tests:
+      - dbt_expectations.expect_column_to_exist
+    - name: node_type
+      description: str, there are 3 types of nodes that exist in a requirement tree
+        - program_root (represent a program) - course (represent a reference to a
+        course) - operator (represent a logical operation over a set of courses)
+      tests:
+      - dbt_expectations.expect_column_to_exist
+    - name: path
+      description: str, the full materialized path for each node (readonly) e.g. 0001
+        is root path, 00010001 is the path to a node in this requirement tree
+      tests:
+      - dbt_expectations.expect_column_to_exist
+    - name: depth
+      description: int, depth of a node in the tree. A root node has a depth of 1.
+        (readonly)
+      tests:
+      - dbt_expectations.expect_column_to_exist
+    - name: numchild
+      description: int, the number of children of a node (readonly)
+      tests:
+      - dbt_expectations.expect_column_to_exist
+    - name: operator
+      description: str, the logical operation over a set of courses, it can be all_of,
+        min_number_of or blank
+      tests:
+      - dbt_expectations.expect_column_to_exist
+    - name: title
+      description: str, title of the operator for this requirement
+      tests:
+      - dbt_expectations.expect_column_to_exist
+    - name: operator_value
+      description: str, value of the operator for this requirement e.g. if operator
+        is all_of, the corresponding operator_value 3 means all of 3 courses
+      tests:
+      - dbt_expectations.expect_column_to_exist
+    tests:
+    - dbt_expectations.expect_table_column_count_to_equal:
+        value: 10
+
   - name: raw__mitxonline__app__postgres__courses_coursetopic
     columns:
     - name: id

--- a/src/ol_dbt/models/staging/mitxonline/_stg_mitxonline__models.yml
+++ b/src/ol_dbt/models/staging/mitxonline/_stg_mitxonline__models.yml
@@ -386,20 +386,11 @@ models:
     tests:
     - not_null
     - dbt_expectations.expect_column_to_exist
-  - name: program_id
-    description: id, foreign key to courses_program (deprecating)
-    tests:
-    - dbt_expectations.expect_column_to_exist
   - name: course_readable_id
     description: str, Open edX ID formatted as course-v1:{org}+{course code}
     tests:
     - unique
     - not_null
-    - dbt_expectations.expect_column_to_exist
-  - name: position_in_program
-    description: int, sequential number indicating the course position in a program
-      (deprecating)
-    tests:
     - dbt_expectations.expect_column_to_exist
   - name: course_created_on
     description: timestamp, specifying when a course was initially created
@@ -411,7 +402,7 @@ models:
     - dbt_expectations.expect_column_to_exist
   tests:
   - dbt_expectations.expect_table_column_count_to_equal:
-      value: 8
+      value: 6
 - name: stg__mitxonline__app__postgres__courses_program
   columns:
   - name: program_id
@@ -446,6 +437,76 @@ models:
   tests:
   - dbt_expectations.expect_table_column_count_to_equal:
       value: 6
+
+- name: stg__mitxonline__app__postgres__courses_programrequirement
+  columns:
+  - name: programrequirement_id
+    description: int, primary key representing a MITx Online program requirement node
+    tests:
+    - dbt_expectations.expect_column_to_exist
+    - unique
+    - not_null
+  - name: course_id
+    description: int, foreign key to courses_course representing a single course
+    tests:
+    - dbt_expectations.expect_column_to_exist
+    - relationships:
+        to: ref('stg__mitxonline__app__postgres__courses_course')
+        field: course_id
+  - name: program_id
+    description: int, foreign key to courses_program representing a single program
+    tests:
+    - dbt_expectations.expect_column_to_exist
+    - not_null
+    - relationships:
+        to: ref('stg__mitxonline__app__postgres__courses_program')
+        field: program_id
+  - name: programrequirement_node_type
+    description: str, there are 3 types of nodes that exist in a requirement tree
+      - program_root (represent a program) - course (represent a reference to a course)
+      - operator (represent a logical operation over a set of courses)
+    tests:
+    - dbt_expectations.expect_column_to_exist
+    - accepted_values:
+        values: ["program_root", "course", "operator"]
+  - name: programrequirement_path
+    description: str, the full materialized path for each node (readonly) e.g. 0001
+      is root path, 00010001 is the path to a node in this requirement tree
+    tests:
+    - dbt_expectations.expect_column_to_exist
+    - not_null
+  - name: programrequirement_depth
+    description: int, depth of a node in the tree. A root node has a depth of 1. (readonly)
+    tests:
+    - dbt_expectations.expect_column_to_exist
+    - not_null
+  - name: programrequirement_numchild
+    description: int, the number of children of a node (readonly)
+    tests:
+    - dbt_expectations.expect_column_to_exist
+    - not_null
+  - name: programrequirement_title
+    description: str, title of the requirement
+    tests:
+    - dbt_expectations.expect_column_to_exist
+  - name: programrequirement_operator
+    description: str, the logical operation over a set of courses, it can be all_of,
+      min_number_of or blank
+    tests:
+    - dbt_expectations.expect_column_to_exist
+    - accepted_values:
+        values: ["all_of", "min_number_of"]
+  - name: programrequirement_operator_value
+    description: str, value of the operator for this requirement e.g. if operator
+      is all_of, the corresponding operator_value 3 means all of 3 courses
+    tests:
+    - dbt_expectations.expect_column_to_exist
+  tests:
+  - dbt_expectations.expect_table_column_count_to_equal:
+      value: 10
+  - dbt_expectations.expect_compound_columns_to_be_unique:
+      column_list: ["program_id", "programrequirement_depth"]
+      row_condition: "programrequirement_depth=1"
 
 - name: stg__mitxonline__app__postgres__courses_courserun
   columns:

--- a/src/ol_dbt/models/staging/mitxonline/stg__mitxonline__app__postgres__courses_course.sql
+++ b/src/ol_dbt/models/staging/mitxonline/stg__mitxonline__app__postgres__courses_course.sql
@@ -9,9 +9,7 @@ with source as (
         id as course_id
         , live as course_is_live
         , title as course_title
-        , program_id  ---deprecating
         , readable_id as course_readable_id
-        , position_in_program ---deprecating
         , to_iso8601(from_iso8601_timestamp(created_on)) as course_created_on
         , to_iso8601(from_iso8601_timestamp(updated_on)) as course_updated_on
     from source

--- a/src/ol_dbt/models/staging/mitxonline/stg__mitxonline__app__postgres__courses_programrequirement.sql
+++ b/src/ol_dbt/models/staging/mitxonline/stg__mitxonline__app__postgres__courses_programrequirement.sql
@@ -1,0 +1,22 @@
+-- MITx Online Program Requirement Information
+
+with source as (
+    select * from {{ source('ol_warehouse_raw_data','raw__mitxonline__app__postgres__courses_programrequirement') }}
+)
+
+, cleaned as (
+    select
+        id as programrequirement_id
+        , course_id
+        , program_id
+        , path as programrequirement_path
+        , depth as programrequirement_depth
+        , node_type as programrequirement_node_type
+        , numchild as programrequirement_numchild
+        , title as programrequirement_title
+        , operator as programrequirement_operator
+        , operator_value as programrequirement_operator_value
+    from source
+)
+
+select * from cleaned


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This PR adds the following models to represent the program-to-course relationship

- stg__mitxonline__app__postgres__courses_programrequirement. (staging)
- int__mitxonline__programrequirements (intermediate)

  - programrequirement_id
  - course_id
  - program_id
  - programrequirement_type (either 'Required Courses' or 'Elective Courses')
    (We have `requirements` in API  https://rc.mitxonline.mit.edu/api/programs/1/)

also removing `course_id` and `position_in_program` from the staging model as these two fields are deprecating mentioned in the linked ticket

## Motivation and Context
https://github.com/mitodl/ol-data-platform/issues/453

## How Has This Been Tested?
Ran `dbt run --full-refresh`
and `dbt test --select stg__mitxonline__app__postgres__courses_programrequirement` and `dbt test --select int__mitxonline__programrequirements` 

Note that dbt test failed on the unique check as duplicates exist in `raw__mitxonline__app__postgres__courses_programrequirement`, not much I can fix until https://github.com/mitodl/ol-data-platform/issues/465 is resolved)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Enhancement (improves on existing behavior)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project. (Did you install and run the pre-commit hooks?)
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
