### PR TITLE
mitxonline discounts

### DIFF
--- a/src/ol_dbt/models/intermediate/mitxonline/_int_mitxonline__models.yml
+++ b/src/ol_dbt/models/intermediate/mitxonline/_int_mitxonline__models.yml
@@ -93,6 +93,395 @@ models:
       value: 4
   - dbt_expectations.expect_table_row_count_to_equal_other_table:
       compare_model: ref('stg__mitxonline__app__postgres__ecommerce_basket')
+- name: int__mitxonline__flexiblepricing_flexiblepriceapplication
+  description: An application for an income based discount.
+  columns:
+  - name: flexiblepriceapplication_id
+    description: int, primary key representing a flexible pricing application
+    tests:
+    - dbt_expectations.expect_column_to_exist
+    - not_null
+    - unique
+  - name: flexiblepriceapplication_created_on
+    description: timestamp, specifying when the table row was created
+    tests:
+    - dbt_expectations.expect_column_to_exist
+    - not_null
+  - name: flexiblepriceapplication_updated_on
+    description: timestamp, specifying when the table row was created
+    tests:
+    - dbt_expectations.expect_column_to_exist
+    - not_null
+  - name: flexiblepriceapplication_status
+    description: string, status of the application. One of "approved", "auto-approved",
+      "created", "pending-manual-approval", "denied", "reset"
+    tests:
+    - dbt_expectations.expect_column_to_exist
+    - not_null
+    - accepted_values:
+        values: ["approved", "auto-approved", "created", "pending-manual-approval",
+          "denied", "reset"]
+  - name: flexiblepriceapplication_income_usd
+    description: numeric, user income in usd
+    tests:
+    - dbt_expectations.expect_column_to_exist
+  - name: flexiblepriceapplication_original_income
+    description: numeric, user income in it's original currency
+    tests:
+    - dbt_expectations.expect_column_to_exist
+  - name: flexiblepriceapplication_original_currency
+    description: string, currency code of orginal income
+    tests:
+    - dbt_expectations.expect_column_to_exist
+  - name: flexiblepriceapplication_country_of_income
+    description: string, country code for user country of income
+    tests:
+    - dbt_expectations.expect_column_to_exist
+  - name: flexiblepriceapplication_exchange_rate_timestamp
+    description: timestamp, timestamp of exchange rate used to convert the original
+      income to usd
+    tests:
+    - dbt_expectations.expect_column_to_exist
+  - name: flexiblepriceapplication_date_documents_sent
+    description: date, date that the user sent documents that prove their income
+    tests:
+    - dbt_expectations.expect_column_to_exist
+  - name: flexiblepriceapplication_justification
+    description: string, explanation for flexible pricing application approval or
+      rejection
+    tests:
+    - dbt_expectations.expect_column_to_exist
+  - name: flexiblepriceapplication_country_of_residence
+    description: string, country code for user country of residece
+    tests:
+    - dbt_expectations.expect_column_to_exist
+    - not_null
+  - name: user_id
+    description: int, primary key in the users_user table of the user  requesting
+      flexible pricing
+    tests:
+    - dbt_expectations.expect_column_to_exist
+    - not_null
+  - name: courseware_type
+    description: string, type of courseware that the user is applying for a discount
+      for. May be either 'course' or 'program'
+    tests:
+    - dbt_expectations.expect_column_to_exist
+    - not_null
+    - accepted_values:
+        values: ["course", "program"]
+
+  - name: flexiblepricetier_id
+    description: int, primary key in flexiblepricing_flexiblepricetier of the price
+      tier the user applied for
+    tests:
+    - dbt_expectations.expect_column_to_exist
+  - name: course_id
+    description: int, primary key in either the courses_course table courseware_type
+      is "course"
+    tests:
+    - dbt_expectations.expect_column_to_exist
+    - dbt_expectations.expect_column_values_to_not_be_null:
+        row_condition: "courseware_type = 'course'"
+    - dbt_expectations.expect_column_values_to_be_null:
+        row_condition: "courseware_type = 'program'"
+  - name: program_id
+    description: int, primary key in either the courses_course table courseware_type
+      is "program"
+    tests:
+    - dbt_expectations.expect_column_to_exist
+    - dbt_expectations.expect_column_values_to_not_be_null:
+        row_condition: "courseware_type = 'program'"
+    - dbt_expectations.expect_column_values_to_be_null:
+        row_condition: "courseware_type = 'course'"
+  tests:
+  - dbt_expectations.expect_table_column_count_to_equal:
+      value: 17
+  - dbt_expectations.expect_compound_columns_to_be_unique:
+      column_list: ["course_id", "program_id", "user_id"]
+  - dbt_expectations.expect_table_row_count_to_equal_other_table:
+      compare_model: ref('stg__mitxonline__app__postgres__flexiblepricing_flexiblepriceapplication')
+- name: int__mitxonline__flexiblepricing_flexiblepricetier
+  columns:
+  - name: flexiblepricetier_id
+    description: int, primary key representing a flexible pricing tier
+    tests:
+    - dbt_expectations.expect_column_to_exist
+    - not_null
+    - unique
+  - name: flexiblepricetier_created_on
+    description: timestamp, specifying when the table row was created
+    tests:
+    - dbt_expectations.expect_column_to_exist
+    - not_null
+  - name: flexiblepricetier_updated_on
+    description: timestamp, specifying when the table row was updated
+    tests:
+    - dbt_expectations.expect_column_to_exist
+    - not_null
+  - name: contenttype_id
+    description: int, foreign key in django_contenttype for either course or program
+    tests:
+    - dbt_expectations.expect_column_to_exist
+    - not_null
+  - name: courseware_object_id
+    description: int, id for the courseware object in either the courses_course or
+      courses_program table
+    tests:
+    - dbt_expectations.expect_column_to_exist
+    - not_null
+  - name: flexiblepricetier_is_current
+    description: boolean, whether the flexible pricing tier is currently enabled
+    tests:
+    - dbt_expectations.expect_column_to_exist
+    - not_null
+  - name: flexiblepricetier_income_threshold_usd
+    description: numeric, maximum income in usd to qualify for the flexible price
+      tier
+    tests:
+    - dbt_expectations.expect_column_to_exist
+    - not_null
+  - name: discount_id
+    description: int, id of ecommerce_discount associated with the flexible price
+      tier
+    tests:
+    - dbt_expectations.expect_column_to_exist
+    - not_null
+  tests:
+  - dbt_expectations.expect_table_column_count_to_equal:
+      value: 8
+  - dbt_expectations.expect_table_row_count_to_equal_other_table:
+      compare_model: ref('stg__mitxonline__app__postgres__flexiblepricing_flexiblepricetier')
+- name: int__mitxonline__flexiblepricing_currencyexchangerate
+  columns:
+  - name: currencyexchangerate_id
+    description: int, primary key representing a country exchange rate
+    tests:
+    - dbt_expectations.expect_column_to_exist
+    - not_null
+    - unique
+  - name: currencyexchangerate_created_on
+    description: timestamp, specifying when the table row was created
+    tests:
+    - dbt_expectations.expect_column_to_exist
+    - not_null
+  - name: currencyexchangerate_updated_on
+    description: timestamp, specifying when the table row was updated
+    tests:
+    - dbt_expectations.expect_column_to_exist
+    - not_null
+  - name: currencyexchangerate_currency_code
+    description: string, currency code
+    tests:
+    - dbt_expectations.expect_column_to_exist
+    - not_null
+    - unique
+  - name: currencyexchangerate_exchange_rate
+    description: numeric, exchange rate to usd
+    tests:
+    - dbt_expectations.expect_column_to_exist
+    - not_null
+  - name: currencyexchangerate_description
+    description: string, readable currency name
+    tests:
+    - dbt_expectations.expect_column_to_exist
+  tests:
+  - dbt_expectations.expect_table_column_count_to_equal:
+      value: 6
+  - dbt_expectations.expect_table_row_count_to_equal_other_table:
+      compare_model: ref('stg__mitxonline__app__postgres__flexiblepricing_currencyexchangerate')
+- name: int__mitxonline__flexiblepricing_countryincomethreshold
+  columns:
+  - name: countryincomethreshold_id
+    description: int, primary key representing a country income threshold
+    tests:
+    - dbt_expectations.expect_column_to_exist
+    - not_null
+    - unique
+  - name: countryincomethreshold_created_on
+    description: timestamp, specifying when the table row was created
+    tests:
+    - dbt_expectations.expect_column_to_exist
+    - not_null
+  - name: countryincomethreshold_updated_on
+    description: timestamp, specifying when the table row was updated
+    tests:
+    - dbt_expectations.expect_column_to_exist
+    - not_null
+  - name: countryincomethreshold_country_code
+    description: string, country code
+    tests:
+    - dbt_expectations.expect_column_to_exist
+    - not_null
+    - unique
+  - name: countryincomethreshold_income_threshold
+    description: int, usd income threshold to quantity for flexible pricing
+    tests:
+    - dbt_expectations.expect_column_to_exist
+    - not_null
+  tests:
+  - dbt_expectations.expect_table_column_count_to_equal:
+      value: 5
+  - dbt_expectations.expect_table_row_count_to_equal_other_table:
+      compare_model: ref('stg__mitxonline__app__postgres__flexiblepricing_countryincomethreshold')
+- name: int__mitxonline__ecommerce_userdiscount
+  description: This table is used to pre-apply a discount when a user checks out
+  columns:
+  - name: userdiscount_id
+    description: int, primary key representing a discount user combo
+    tests:
+    - dbt_expectations.expect_column_to_exist
+    - not_null
+  - name: userdiscount_created_on
+    description: timestamp, specifying when the discount user association was initially
+      created
+    tests:
+    - dbt_expectations.expect_column_to_exist
+    - not_null
+  - name: userdiscount_updated_on
+    description: timestamp, specifying when the discount user association was updated
+    tests:
+    - dbt_expectations.expect_column_to_exist
+    - not_null
+  - name: discount_id
+    description: int, foreign key for ecommerce_discount
+    tests:
+    - dbt_expectations.expect_column_to_exist
+    - not_null
+  - name: user_id
+    description: int, foreign key for users_user
+    tests:
+    - dbt_expectations.expect_column_to_exist
+    - not_null
+  tests:
+  - dbt_expectations.expect_table_column_count_to_equal:
+      value: 5
+  - dbt_expectations.expect_table_row_count_to_equal_other_table:
+      compare_model: ref('stg__mitxonline__app__postgres__ecommerce_userdiscount')
+- name: int__mitxonline__ecommerce_discountproduct
+  description: This table is used to limit dicounts to a specific product. Discounts
+    which do not have a record in this table are redeemable for all products
+  columns:
+  - name: discountproduct_id
+    description: int, primary key representing a discount product combo
+    tests:
+    - dbt_expectations.expect_column_to_exist
+    - not_null
+  - name: discountproduct_created_on
+    description: timestamp, specifying when the discount product association was initially
+      created
+    tests:
+    - dbt_expectations.expect_column_to_exist
+  - name: discountproduct_updated_on
+    description: timestamp, specifying when the discount product association was updated
+    tests:
+    - dbt_expectations.expect_column_to_exist
+  - name: discount_id
+    description: int, foreign key for ecommerce_discount
+    tests:
+    - dbt_expectations.expect_column_to_exist
+    - not_null
+  - name: product_id
+    description: int, foreign key for ecommerce_product
+    tests:
+    - dbt_expectations.expect_column_to_exist
+  tests:
+  - dbt_expectations.expect_table_column_count_to_equal:
+      value: 5
+  - dbt_expectations.expect_table_row_count_to_equal_other_table:
+      compare_model: ref('stg__mitxonline__app__postgres__ecommerce_discountproduct')
+- name: int__mitxonline__ecommerce_discount
+  columns:
+  - name: discount_id
+    description: int, primary key representing a discount
+    tests:
+    - dbt_expectations.expect_column_to_exist
+    - not_null
+    - unique
+  - name: discount_created_on
+    description: timestamp, specifying when the discount was initially created
+    tests:
+    - dbt_expectations.expect_column_to_exist
+  - name: discount_updated_on
+    description: timestamp, specifying when the discount was most recently updated
+    tests:
+    - dbt_expectations.expect_column_to_exist
+  - name: discount_amount
+    description: numeric, discount amount. May be a precent or dollar amount
+    tests:
+    - dbt_expectations.expect_column_to_exist
+    - not_null
+  - name: discount_type
+    description: string, one of  "percent-off", "dollars-off" and "fixed-price". Specifys
+      if the ammount of the discount refers to a percent of, a dollar amount off or
+      a discounted price
+    tests:
+    - dbt_expectations.expect_column_to_exist
+    - not_null
+    - accepted_values:
+        values: ["percent-off", "dollars-off", "fixed-price"]
+  - name: discount_redemption_type
+    description: string, one of  "one-time",  "one-time-per-user" and "unlimited"
+    tests:
+    - dbt_expectations.expect_column_to_exist
+    - not_null
+    - accepted_values:
+        values: ["one-time", "one-time-per-user", "unlimited"]
+  - name: discount_max_redemptions
+    description: int, maximum times a coupon can be redeemed
+    tests:
+    - dbt_expectations.expect_column_to_exist
+  - name: discount_code
+    description: string, discount code
+    tests:
+    - dbt_expectations.expect_column_to_exist
+    - not_null
+  - name: discount_is_for_flexible_pricing
+    description: boolean, whether the discount was created for income based flexible
+      pricing
+    tests:
+    - dbt_expectations.expect_column_to_exist
+    - not_null
+  - name: discount_activated_on
+    description: timestamp, specifying when the discount is activated
+    tests:
+    - dbt_expectations.expect_column_to_exist
+  - name: discount_expires_on
+    description: timestamp, specifying when the discount is deactivated
+    tests:
+    - dbt_expectations.expect_column_to_exist
+  tests:
+  - dbt_expectations.expect_table_column_count_to_equal:
+      value: 11
+  - dbt_expectations.expect_table_row_count_to_equal_other_table:
+      compare_model: ref('stg__mitxonline__app__postgres__ecommerce_discount')
+- name: int__mitxonline__ecommerce_discountredemption
+  columns:
+  - name: discountredemption_id
+    description: int, primary key representing a discount redemption
+    tests:
+    - dbt_expectations.expect_column_to_exist
+  - name: discountredemption_timestamp
+    description: timestamp, specifying when the discount was redeemed by the user
+    tests:
+    - dbt_expectations.expect_column_to_exist
+  - name: user_id
+    description: int, foreign key for users_user
+    tests:
+    - dbt_expectations.expect_column_to_exist
+  - name: discount_id
+    description: int, foreign key for ecommerce_discount
+    tests:
+    - dbt_expectations.expect_column_to_exist
+  - name: order_id
+    description: int, foreign key for ecommerce_orders
+    tests:
+    - dbt_expectations.expect_column_to_exist
+  tests:
+  - dbt_expectations.expect_table_column_count_to_equal:
+      value: 5
+  - dbt_expectations.expect_table_row_count_to_equal_other_table:
+      compare_model: ref('stg__mitxonline__app__postgres__ecommerce_discountredemption')
 - name: int__mitxonline__ecommerce_transaction
   columns:
   - name: transaction_id

--- a/src/ol_dbt/models/intermediate/mitxonline/int__mitxonline__ecommerce_discount.sql
+++ b/src/ol_dbt/models/intermediate/mitxonline/int__mitxonline__ecommerce_discount.sql
@@ -1,0 +1,17 @@
+with discount as (
+    select * from {{ ref('stg__mitxonline__app__postgres__ecommerce_discount') }}
+)
+
+select
+    discount_id
+    , discount_amount
+    , discount_created_on
+    , discount_updated_on
+    , discount_code
+    , discount_type
+    , discount_activated_on
+    , discount_expires_on
+    , discount_max_redemptions
+    , discount_redemption_type
+    , discount_is_for_flexible_pricing
+from discount

--- a/src/ol_dbt/models/intermediate/mitxonline/int__mitxonline__ecommerce_discountproduct.sql
+++ b/src/ol_dbt/models/intermediate/mitxonline/int__mitxonline__ecommerce_discountproduct.sql
@@ -1,0 +1,11 @@
+with discountproduct as (
+    select * from {{ ref('stg__mitxonline__app__postgres__ecommerce_discountproduct') }}
+)
+
+select
+    discountproduct_id
+    , discountproduct_created_on
+    , discountproduct_updated_on
+    , product_id
+    , discount_id
+from discountproduct

--- a/src/ol_dbt/models/intermediate/mitxonline/int__mitxonline__ecommerce_discountredemption.sql
+++ b/src/ol_dbt/models/intermediate/mitxonline/int__mitxonline__ecommerce_discountredemption.sql
@@ -1,0 +1,12 @@
+with discountredemption as (
+    select * from {{ ref('stg__mitxonline__app__postgres__ecommerce_discountredemption') }}
+)
+
+
+select
+    discountredemption_id
+    , user_id
+    , discountredemption_timestamp
+    , order_id
+    , discount_id
+from discountredemption

--- a/src/ol_dbt/models/intermediate/mitxonline/int__mitxonline__ecommerce_userdiscount.sql
+++ b/src/ol_dbt/models/intermediate/mitxonline/int__mitxonline__ecommerce_userdiscount.sql
@@ -1,0 +1,11 @@
+with userdiscount as (
+    select * from {{ ref('stg__mitxonline__app__postgres__ecommerce_userdiscount') }}
+)
+
+select
+    userdiscount_id
+    , userdiscount_created_on
+    , userdiscount_updated_on
+    , user_id
+    , discount_id
+from userdiscount

--- a/src/ol_dbt/models/intermediate/mitxonline/int__mitxonline__flexiblepricing_countryincomethreshold.sql
+++ b/src/ol_dbt/models/intermediate/mitxonline/int__mitxonline__flexiblepricing_countryincomethreshold.sql
@@ -1,0 +1,11 @@
+with countryincomethreshold as (
+    select * from {{ ref('stg__mitxonline__app__postgres__flexiblepricing_countryincomethreshold') }}
+)
+
+select
+    countryincomethreshold_id
+    , countryincomethreshold_created_on
+    , countryincomethreshold_updated_on
+    , countryincomethreshold_country_code
+    , countryincomethreshold_income_threshold
+from countryincomethreshold

--- a/src/ol_dbt/models/intermediate/mitxonline/int__mitxonline__flexiblepricing_currencyexchangerate.sql
+++ b/src/ol_dbt/models/intermediate/mitxonline/int__mitxonline__flexiblepricing_currencyexchangerate.sql
@@ -1,0 +1,12 @@
+with source as (
+    select * from {{ ref('stg__mitxonline__app__postgres__flexiblepricing_currencyexchangerate') }}
+)
+
+select
+    currencyexchangerate_id
+    , currencyexchangerate_created_on
+    , currencyexchangerate_updated_on
+    , currencyexchangerate_description
+    , currencyexchangerate_currency_code
+    , currencyexchangerate_exchange_rate
+from source

--- a/src/ol_dbt/models/intermediate/mitxonline/int__mitxonline__flexiblepricing_flexiblepriceapplication.sql
+++ b/src/ol_dbt/models/intermediate/mitxonline/int__mitxonline__flexiblepricing_flexiblepriceapplication.sql
@@ -1,0 +1,39 @@
+with flexiblepriceapplication as (
+    select * from {{ ref('stg__mitxonline__app__postgres__flexiblepricing_flexiblepriceapplication') }}
+)
+
+, contenttypes as (
+    select *
+    from {{ ref('stg__mitxonline__app__postgres__django_contenttype') }}
+)
+
+select
+    flexiblepriceapplication.flexiblepriceapplication_id
+    , flexiblepriceapplication.flexiblepriceapplication_status
+    , flexiblepriceapplication.flexiblepricetier_id
+    , flexiblepriceapplication.user_id
+    , flexiblepriceapplication.flexiblepriceapplication_created_on
+    , flexiblepriceapplication.flexiblepriceapplication_income_usd
+    , flexiblepriceapplication.flexiblepriceapplication_updated_on
+    , flexiblepriceapplication.flexiblepriceapplication_justification
+    , flexiblepriceapplication.flexiblepriceapplication_original_income
+    , flexiblepriceapplication.flexiblepriceapplication_country_of_income
+    , flexiblepriceapplication.flexiblepriceapplication_original_currency
+    , flexiblepriceapplication.flexiblepriceapplication_exchange_rate_timestamp
+    , flexiblepriceapplication.flexiblepriceapplication_date_documents_sent
+    , flexiblepriceapplication.flexiblepriceapplication_country_of_residence
+
+    , case contenttypes.contenttype_full_name
+        when 'courses_course' then flexiblepriceapplication.courseware_object_id
+    end as course_id
+
+    , case contenttypes.contenttype_full_name
+        when 'courses_program' then flexiblepriceapplication.courseware_object_id
+    end as program_id
+
+    , case contenttypes.contenttype_full_name
+        when 'courses_course' then 'course'
+        when 'courses_program' then 'program'
+    end as courseware_type
+from flexiblepriceapplication
+inner join contenttypes on flexiblepriceapplication.contenttype_id = contenttypes.contenttype_id

--- a/src/ol_dbt/models/intermediate/mitxonline/int__mitxonline__flexiblepricing_flexiblepricetier.sql
+++ b/src/ol_dbt/models/intermediate/mitxonline/int__mitxonline__flexiblepricing_flexiblepricetier.sql
@@ -1,0 +1,15 @@
+with source as (
+    select * from {{ ref('stg__mitxonline__app__postgres__flexiblepricing_flexiblepricetier') }}
+)
+
+select
+    flexiblepricetier_id
+    , flexiblepricetier_is_current
+    , flexiblepricetier_created_on
+    , flexiblepricetier_updated_on
+    , discount_id
+    , courseware_object_id
+    , flexiblepricetier_income_threshold_usd
+    , contenttype_id
+
+from source

--- a/src/ol_dbt/models/staging/mitxonline/_mitxonline__sources.yml
+++ b/src/ol_dbt/models/staging/mitxonline/_mitxonline__sources.yml
@@ -91,6 +91,324 @@ sources:
     tests:
     - dbt_expectations.expect_table_column_count_to_equal:
         value: 4
+  - name: raw__mitxonline__app__postgres__flexiblepricing_flexibleprice
+    description: An application for an income based discount.
+    columns:
+    - name: id
+      description: int, primary key representing a flexible pricing application
+      tests:
+      - dbt_expectations.expect_column_to_exist
+    - name: created_on
+      description: timestamp, specifying when the table row was created
+      tests:
+      - dbt_expectations.expect_column_to_exist
+    - name: updated_on
+      description: timestamp, specifying when the table row was created
+      tests:
+      - dbt_expectations.expect_column_to_exist
+    - name: status
+      description: string, status of the application. One of "approved", "auto-approved",
+        "created", "pending-manual-approval", "denied", "reset"
+      tests:
+      - dbt_expectations.expect_column_to_exist
+    - name: income_usd
+      description: numeric, user income in usd
+      tests:
+      - dbt_expectations.expect_column_to_exist
+    - name: original_income
+      description: numeric, user income in it's original currency
+      tests:
+      - dbt_expectations.expect_column_to_exist
+    - name: original_currency
+      description: string, currency code of orginal income
+      tests:
+      - dbt_expectations.expect_column_to_exist
+    - name: country_of_income
+      description: string, country code for user country of income
+      tests:
+      - dbt_expectations.expect_column_to_exist
+    - name: date_exchange_rate
+      description: timestamp, timestamp of exchange rate used to convert the original
+        income to usd
+      tests:
+      - dbt_expectations.expect_column_to_exist
+    - name: date_documents_sent
+      description: date, date that the user sent documents that prove their income
+      tests:
+      - dbt_expectations.expect_column_to_exist
+    - name: justification
+      description: string, explanation for flexible pricing application approval or
+        rejection
+      tests:
+      - dbt_expectations.expect_column_to_exist
+    - name: country_of_residence
+      description: string, country code for user country of residece
+      tests:
+      - dbt_expectations.expect_column_to_exist
+    - name: user_id
+      description: int, primary key in the users_user table of the user  requesting
+        flexible pricing
+      tests:
+      - dbt_expectations.expect_column_to_exist
+    - name: cms_submission_id
+      description: int, primary key of the cms submission stored in the flexiblepricing_flexiblepricingrequestsubmission
+        table
+      tests:
+      - dbt_expectations.expect_column_to_exist
+    - name: courseware_content_type_id
+      description: int, primary key in django_contenttype of either courses_course
+        or courses_program
+      tests:
+      - dbt_expectations.expect_column_to_exist
+    - name: courseware_object_id
+      description: int, primary key in either the courses_course or courses_program
+        table of the courseware the user applied for flexible pricing for
+      tests:
+      - dbt_expectations.expect_column_to_exist
+    - name: tier_id
+      description: int, primary key in flexiblepricing_flexiblepricetier of the price
+        tier the user applied for
+      tests:
+      - dbt_expectations.expect_column_to_exist
+    tests:
+    - dbt_expectations.expect_table_column_count_to_equal:
+        value: 17
+  - name: raw__mitxonline__app__postgres__flexiblepricing_flexiblepricetier
+    columns:
+    - name: id
+      description: int, primary key representing a flexible pricing tier
+      tests:
+      - dbt_expectations.expect_column_to_exist
+    - name: created_on
+      description: timestamp, specifying when the table row was created
+      tests:
+      - dbt_expectations.expect_column_to_exist
+    - name: updated_on
+      description: timestamp, specifying when the table row was created
+      tests:
+      - dbt_expectations.expect_column_to_exist
+    - name: courseware_content_type_id
+      description: int, django_contenttype id for either course or program
+      tests:
+      - dbt_expectations.expect_column_to_exist
+    - name: courseware_object_id
+      description: int, id for the courseware object in either the courses_course
+        or courses_program table
+      tests:
+      - dbt_expectations.expect_column_to_exist
+    - name: current
+      description: boolean, whether the flexible pricing tier is currently enabled
+      tests:
+      - dbt_expectations.expect_column_to_exist
+    - name: income_threshold_usd
+      description: numeric, maximum income in usd to qualify for the flexible price
+        tier
+      tests:
+      - dbt_expectations.expect_column_to_exist
+    - name: discount_id
+      description: int, id of ecommerce_discount associated with the flexible price
+        tier
+      tests:
+      - dbt_expectations.expect_column_to_exist
+    tests:
+    - dbt_expectations.expect_table_column_count_to_equal:
+        value: 8
+  - name: raw__mitxonline__app__postgres__flexiblepricing_currencyexchangerate
+    columns:
+    - name: id
+      description: int, primary key representing a country exchange rate
+      tests:
+      - dbt_expectations.expect_column_to_exist
+    - name: created_on
+      description: timestamp, specifying when the table row was created
+      tests:
+      - dbt_expectations.expect_column_to_exist
+    - name: updated_on
+      description: timestamp, specifying when the table row was created
+      tests:
+      - dbt_expectations.expect_column_to_exist
+    - name: currency_code
+      description: string, currency code
+      tests:
+      - dbt_expectations.expect_column_to_exist
+    - name: exchange_rate
+      description: numeric, exchange rate to usd
+      tests:
+      - dbt_expectations.expect_column_to_exist
+    - name: description
+      description: string, readable currency name
+      tests:
+      - dbt_expectations.expect_column_to_exist
+    tests:
+    - dbt_expectations.expect_table_column_count_to_equal:
+        value: 6
+  - name: raw__mitxonline__app__postgres__flexiblepricing_countryincomethreshold
+    columns:
+    - name: id
+      description: int, primary key representing a country income threshold
+      tests:
+      - dbt_expectations.expect_column_to_exist
+    - name: created_on
+      description: timestamp, specifying when the table row was created
+      tests:
+      - dbt_expectations.expect_column_to_exist
+    - name: updated_on
+      description: timestamp, specifying when the table row was created
+      tests:
+      - dbt_expectations.expect_column_to_exist
+    - name: country_code
+      description: string, country code
+      tests:
+      - dbt_expectations.expect_column_to_exist
+    - name: income_threshold
+      description: int, usd income threshold to quantity for flexible pricing
+      tests:
+      - dbt_expectations.expect_column_to_exist
+    tests:
+    - dbt_expectations.expect_table_column_count_to_equal:
+        value: 5
+  - name: raw__mitxonline__app__postgres__ecommerce_discountredemption
+    columns:
+    - name: id
+      description: int, primary key representing a discount redemption
+      tests:
+      - dbt_expectations.expect_column_to_exist
+    - name: created_on
+      description: timestamp, specifying when the table row was created
+      tests:
+      - dbt_expectations.expect_column_to_exist
+    - name: redemption_date
+      description: timestamp, specifying when the discount was redeemed by the user
+      tests:
+      - dbt_expectations.expect_column_to_exist
+    - name: redeemed_by_id
+      description: int, foreign key for users_user
+      tests:
+      - dbt_expectations.expect_column_to_exist
+    - name: redeemed_discount_id
+      description: int, foreign key for ecommerce_discount
+      tests:
+      - dbt_expectations.expect_column_to_exist
+    - name: redeemed_order_id
+      description: int, foreign key for ecommerce_orders
+      tests:
+      - dbt_expectations.expect_column_to_exist
+    tests:
+    - dbt_expectations.expect_table_column_count_to_equal:
+        value: 7
+  - name: raw__mitxonline__app__postgres__ecommerce_userdiscount
+    description: This table is used to pre-apply a discount when a user checks out
+    columns:
+    - name: id
+      description: int, primary key representing a discount user combo
+      tests:
+      - dbt_expectations.expect_column_to_exist
+    - name: created_on
+      description: timestamp, specifying when the discount user association was initially
+        created
+      tests:
+      - dbt_expectations.expect_column_to_exist
+    - name: updated_on
+      description: timestamp, specifying when the discount user association was most
+        recently updated
+      tests:
+      - dbt_expectations.expect_column_to_exist
+    - name: discount_id
+      description: int, foreign key for ecommerce_discount
+      tests:
+      - dbt_expectations.expect_column_to_exist
+    - name: user_id
+      description: int, foreign key for users_user
+      tests:
+      - dbt_expectations.expect_column_to_exist
+    tests:
+    - dbt_expectations.expect_table_column_count_to_equal:
+        value: 5
+  - name: raw__mitxonline__app__postgres__ecommerce_discountproduct
+    description: This table is used to limit dicounts to a specific product. Discounts
+      which do not have a record in this table are redeemable for all products
+    columns:
+    - name: id
+      description: int, primary key representing a discount product combo
+      tests:
+      - dbt_expectations.expect_column_to_exist
+    - name: created_on
+      description: timestamp, specifying when the discount product association was
+        initially created
+      tests:
+      - dbt_expectations.expect_column_to_exist
+    - name: updated_on
+      description: timestamp, specifying when the discount product association was
+        most recently updated
+      tests:
+      - dbt_expectations.expect_column_to_exist
+    - name: discount_id
+      description: int, foreign key for ecommerce_discount
+      tests:
+      - dbt_expectations.expect_column_to_exist
+    - name: product_id
+      description: int, foreign key for ecommerce_product
+      tests:
+      - dbt_expectations.expect_column_to_exist
+    tests:
+    - dbt_expectations.expect_table_column_count_to_equal:
+        value: 5
+  - name: raw__mitxonline__app__postgres__ecommerce_discount
+    columns:
+    - name: id
+      description: int, primary key representing a discount
+      tests:
+      - dbt_expectations.expect_column_to_exist
+    - name: created_on
+      description: timestamp, specifying when the discount was initially created
+      tests:
+      - dbt_expectations.expect_column_to_exist
+    - name: updated_on
+      description: timestamp, specifying when the discount was most recently updated
+      tests:
+      - dbt_expectations.expect_column_to_exist
+    - name: amount
+      description: numeric, discount amount. May be a precent or dollar amount
+      tests:
+      - dbt_expectations.expect_column_to_exist
+    - name: automatic
+      description: boolean, currently unused and always false on production.
+      tests:
+      - dbt_expectations.expect_column_to_exist
+    - name: discount_type
+      description: string, one of  "percent-off", "dollars-off" and "fixed-price".
+        Specifys if the ammount of the discount refers to a percent of, a dollar amount
+        off or a discounted price
+      tests:
+      - dbt_expectations.expect_column_to_exist
+    - name: redemption_type
+      description: string, one of  "one-time",  "one-time-per-user" and "unlimited"
+      tests:
+      - dbt_expectations.expect_column_to_exist
+    - name: max_redemptions
+      description: int, maximum times a coupon can be redeemed
+      tests:
+      - dbt_expectations.expect_column_to_exist
+    - name: discount_code
+      description: string, discount code
+      tests:
+      - dbt_expectations.expect_column_to_exist
+    - name: for_flexible_pricing
+      description: boolean, whether the discount was created for income based flexible
+        pricing
+      tests:
+      - dbt_expectations.expect_column_to_exist
+    - name: activation_date
+      description: timestamp, specifying when the discount is activated
+      tests:
+      - dbt_expectations.expect_column_to_exist
+    - name: expiration_date
+      description: timestamp, specifying when the discount is deactivated
+      tests:
+      - dbt_expectations.expect_column_to_exist
+    tests:
+    - dbt_expectations.expect_table_column_count_to_equal:
+        value: 12
   - name: raw__mitxonline__app__postgres__ecommerce_transaction
     columns:
     - name: id

--- a/src/ol_dbt/models/staging/mitxonline/_stg_mitxonline__models.yml
+++ b/src/ol_dbt/models/staging/mitxonline/_stg_mitxonline__models.yml
@@ -89,6 +89,371 @@ models:
   tests:
   - dbt_expectations.expect_table_column_count_to_equal:
       value: 4
+- name: stg__mitxonline__app__postgres__flexiblepricing_flexiblepriceapplication
+  description: An application for an income based discount.
+  columns:
+  - name: flexiblepriceapplication_id
+    description: int, primary key representing a flexible pricing application
+    tests:
+    - dbt_expectations.expect_column_to_exist
+    - not_null
+    - unique
+  - name: flexiblepriceapplication_created_on
+    description: timestamp, specifying when the table row was created
+    tests:
+    - dbt_expectations.expect_column_to_exist
+    - not_null
+  - name: flexiblepriceapplication_updated_on
+    description: timestamp, specifying when the table row was updated
+    tests:
+    - dbt_expectations.expect_column_to_exist
+    - not_null
+  - name: flexiblepriceapplication_status
+    description: string, status of the application. One of "approved", "auto-approved",
+      "created", "pending-manual-approval", "denied", "reset"
+    tests:
+    - dbt_expectations.expect_column_to_exist
+    - not_null
+    - accepted_values:
+        values: ["approved", "auto-approved", "created", "pending-manual-approval",
+          "denied", "reset"]
+  - name: flexiblepriceapplication_income_usd
+    description: numeric, user income in usd
+    tests:
+    - dbt_expectations.expect_column_to_exist
+  - name: flexiblepriceapplication_original_income
+    description: numeric, user income in it's original currency
+    tests:
+    - dbt_expectations.expect_column_to_exist
+  - name: flexiblepriceapplication_original_currency
+    description: string, currency code of orginal income
+    tests:
+    - dbt_expectations.expect_column_to_exist
+  - name: flexiblepriceapplication_country_of_income
+    description: string, country code for user country of income
+    tests:
+    - dbt_expectations.expect_column_to_exist
+  - name: flexiblepriceapplication_exchange_rate_timestamp
+    description: timestamp, timestamp of exchange rate used to convert the original
+      income to usd
+    tests:
+    - dbt_expectations.expect_column_to_exist
+  - name: flexiblepriceapplication_date_documents_sent
+    description: date, date that the user sent documents that prove their income
+    tests:
+    - dbt_expectations.expect_column_to_exist
+  - name: flexiblepriceapplication_justification
+    description: string, explanation for flexible pricing application approval or
+      rejection
+    tests:
+    - dbt_expectations.expect_column_to_exist
+  - name: flexiblepriceapplication_country_of_residence
+    description: string, country code for user country of residece
+    tests:
+    - dbt_expectations.expect_column_to_exist
+    - not_null
+  - name: user_id
+    description: int, primary key in the users_user table of the user  requesting
+      flexible pricing
+    tests:
+    - dbt_expectations.expect_column_to_exist
+    - not_null
+  - name: flexiblepriceapplication_cms_submission_id
+    description: int, primary key of the cms submission stored in the flexiblepricing_flexiblepricingrequestsubmission
+      table
+    tests:
+    - dbt_expectations.expect_column_to_exist
+  - name: contenttype_id
+    description: int, primary key in django_contenttype of either courses_course or
+      courses_program
+    tests:
+    - dbt_expectations.expect_column_to_exist
+    - not_null
+  - name: courseware_object_id
+    description: int, primary key in either the courses_course or courses_program
+      table of the courseware the user applied for flexible pricing for
+    tests:
+    - dbt_expectations.expect_column_to_exist
+    - not_null
+  - name: flexiblepricetier_id
+    description: int, primary key in flexiblepricing_flexiblepricetier of the price
+      tier the user applied for
+    tests:
+    - dbt_expectations.expect_column_to_exist
+  tests:
+  - dbt_expectations.expect_table_column_count_to_equal:
+      value: 17
+  - dbt_expectations.expect_compound_columns_to_be_unique:
+      column_list: ["courseware_object_id", "contenttype_id", "user_id"]
+- name: stg__mitxonline__app__postgres__flexiblepricing_flexiblepricetier
+  columns:
+  - name: flexiblepricetier_id
+    description: int, primary key representing a flexible pricing tier
+    tests:
+    - dbt_expectations.expect_column_to_exist
+    - not_null
+    - unique
+  - name: flexiblepricetier_created_on
+    description: timestamp, specifying when the table row was created
+    tests:
+    - dbt_expectations.expect_column_to_exist
+    - not_null
+  - name: flexiblepricetier_updated_on
+    description: timestamp, specifying when the table row was updated
+    tests:
+    - dbt_expectations.expect_column_to_exist
+    - not_null
+  - name: contenttype_id
+    description: int, foreign key in django_contenttype for either course or program
+    tests:
+    - dbt_expectations.expect_column_to_exist
+    - not_null
+  - name: courseware_object_id
+    description: int, id for the courseware object in either the courses_course or
+      courses_program table
+    tests:
+    - dbt_expectations.expect_column_to_exist
+    - not_null
+  - name: flexiblepricetier_is_current
+    description: boolean, whether the flexible pricing tier is currently enabled
+    tests:
+    - dbt_expectations.expect_column_to_exist
+    - not_null
+  - name: flexiblepricetier_income_threshold_usd
+    description: numeric, maximum income in usd to qualify for the flexible price
+      tier
+    tests:
+    - dbt_expectations.expect_column_to_exist
+    - not_null
+  - name: discount_id
+    description: int, id of ecommerce_discount associated with the flexible price
+      tier
+    tests:
+    - dbt_expectations.expect_column_to_exist
+    - not_null
+  tests:
+  - dbt_expectations.expect_table_column_count_to_equal:
+      value: 8
+- name: stg__mitxonline__app__postgres__flexiblepricing_currencyexchangerate
+  columns:
+  - name: currencyexchangerate_id
+    description: int, primary key representing a country exchange rate
+    tests:
+    - dbt_expectations.expect_column_to_exist
+    - not_null
+    - unique
+  - name: currencyexchangerate_created_on
+    description: timestamp, specifying when the table row was created
+    tests:
+    - dbt_expectations.expect_column_to_exist
+    - not_null
+  - name: currencyexchangerate_updated_on
+    description: timestamp, specifying when the table row was updated
+    tests:
+    - dbt_expectations.expect_column_to_exist
+    - not_null
+  - name: currencyexchangerate_currency_code
+    description: string, currency code
+    tests:
+    - dbt_expectations.expect_column_to_exist
+    - not_null
+    - unique
+  - name: currencyexchangerate_exchange_rate
+    description: numeric, exchange rate to usd
+    tests:
+    - dbt_expectations.expect_column_to_exist
+    - not_null
+  - name: currencyexchangerate_description
+    description: string, readable currency name
+    tests:
+    - dbt_expectations.expect_column_to_exist
+  tests:
+  - dbt_expectations.expect_table_column_count_to_equal:
+      value: 6
+- name: stg__mitxonline__app__postgres__flexiblepricing_countryincomethreshold
+  columns:
+  - name: countryincomethreshold_id
+    description: int, primary key representing a country income threshold
+    tests:
+    - dbt_expectations.expect_column_to_exist
+    - not_null
+    - unique
+  - name: countryincomethreshold_created_on
+    description: timestamp, specifying when the table row was created
+    tests:
+    - dbt_expectations.expect_column_to_exist
+    - not_null
+  - name: countryincomethreshold_updated_on
+    description: timestamp, specifying when the table row was updated
+    tests:
+    - dbt_expectations.expect_column_to_exist
+    - not_null
+  - name: countryincomethreshold_country_code
+    description: string, country code
+    tests:
+    - dbt_expectations.expect_column_to_exist
+    - not_null
+    - unique
+  - name: countryincomethreshold_income_threshold
+    description: int, usd income threshold to quantity for flexible pricing
+    tests:
+    - dbt_expectations.expect_column_to_exist
+    - not_null
+  tests:
+  - dbt_expectations.expect_table_column_count_to_equal:
+      value: 5
+- name: stg__mitxonline__app__postgres__ecommerce_userdiscount
+  description: This table is used to pre-apply a discount when a user checks out
+  columns:
+  - name: userdiscount_id
+    description: int, primary key representing a discount user combo
+    tests:
+    - dbt_expectations.expect_column_to_exist
+    - not_null
+  - name: userdiscount_created_on
+    description: timestamp, specifying when the discount user association was initially
+      created
+    tests:
+    - dbt_expectations.expect_column_to_exist
+    - not_null
+  - name: userdiscount_updated_on
+    description: timestamp, specifying when the discount user association was initially
+      created
+    tests:
+    - dbt_expectations.expect_column_to_exist
+    - not_null
+  - name: discount_id
+    description: int, foreign key for ecommerce_discount
+    tests:
+    - dbt_expectations.expect_column_to_exist
+    - not_null
+  - name: user_id
+    description: int, foreign key for users_user
+    tests:
+    - dbt_expectations.expect_column_to_exist
+    - not_null
+  tests:
+  - dbt_expectations.expect_table_column_count_to_equal:
+      value: 5
+- name: stg__mitxonline__app__postgres__ecommerce_discountproduct
+  description: This table is used to limit dicounts to a specific product. Discounts
+    which do not have a record in this table are redeemable for all products
+  columns:
+  - name: discountproduct_id
+    description: int, primary key representing a discount product combo
+    tests:
+    - dbt_expectations.expect_column_to_exist
+    - not_null
+  - name: discountproduct_created_on
+    description: timestamp, specifying when the discount product association was initially
+      created
+    tests:
+    - dbt_expectations.expect_column_to_exist
+  - name: discountproduct_updated_on
+    description: timestamp, specifying when the discount product association was last
+      updated
+    tests:
+    - dbt_expectations.expect_column_to_exist
+  - name: discount_id
+    description: int, foreign key for ecommerce_discount
+    tests:
+    - dbt_expectations.expect_column_to_exist
+    - not_null
+  - name: product_id
+    description: int, foreign key for ecommerce_product
+    tests:
+    - dbt_expectations.expect_column_to_exist
+  tests:
+  - dbt_expectations.expect_table_column_count_to_equal:
+      value: 5
+- name: stg__mitxonline__app__postgres__ecommerce_discount
+  columns:
+  - name: discount_id
+    description: int, primary key representing a discount
+    tests:
+    - dbt_expectations.expect_column_to_exist
+    - not_null
+    - unique
+  - name: discount_created_on
+    description: timestamp, specifying when the discount was initially created
+    tests:
+    - dbt_expectations.expect_column_to_exist
+  - name: discount_updated_on
+    description: timestamp, specifying when the discount was most recently updated
+    tests:
+    - dbt_expectations.expect_column_to_exist
+  - name: discount_amount
+    description: numeric, discount amount. May be a precent or dollar amount
+    tests:
+    - dbt_expectations.expect_column_to_exist
+    - not_null
+  - name: discount_type
+    description: string, one of  "percent-off", "dollars-off" and "fixed-price". Specifys
+      if the ammount of the discount refers to a percent of, a dollar amount off or
+      a discounted price
+    tests:
+    - dbt_expectations.expect_column_to_exist
+    - not_null
+    - accepted_values:
+        values: ["percent-off", "dollars-off", "fixed-price"]
+  - name: discount_redemption_type
+    description: string, one of  "one-time",  "one-time-per-user" and "unlimited"
+    tests:
+    - dbt_expectations.expect_column_to_exist
+    - not_null
+    - accepted_values:
+        values: ["one-time", "one-time-per-user", "unlimited"]
+  - name: discount_max_redemptions
+    description: int, maximum times a coupon can be redeemed
+    tests:
+    - dbt_expectations.expect_column_to_exist
+  - name: discount_code
+    description: string, discount code
+    tests:
+    - dbt_expectations.expect_column_to_exist
+    - not_null
+  - name: discount_is_for_flexible_pricing
+    description: boolean, whether the discount was created for income based flexible
+      pricing
+    tests:
+    - dbt_expectations.expect_column_to_exist
+    - not_null
+  - name: discount_activated_on
+    description: timestamp, specifying when the discount is activated
+    tests:
+    - dbt_expectations.expect_column_to_exist
+  - name: discount_expires_on
+    description: timestamp, specifying when the discount is deactivated
+    tests:
+    - dbt_expectations.expect_column_to_exist
+  tests:
+  - dbt_expectations.expect_table_column_count_to_equal:
+      value: 11
+- name: stg__mitxonline__app__postgres__ecommerce_discountredemption
+  columns:
+  - name: discountredemption_id
+    description: int, primary key representing a discount redemption
+    tests:
+    - dbt_expectations.expect_column_to_exist
+  - name: discountredemption_timestamp
+    description: timestamp, specifying when the discount was redeemed by the user
+    tests:
+    - dbt_expectations.expect_column_to_exist
+  - name: user_id
+    description: int, foreign key for users_user
+    tests:
+    - dbt_expectations.expect_column_to_exist
+  - name: discount_id
+    description: int, foreign key for ecommerce_discount
+    tests:
+    - dbt_expectations.expect_column_to_exist
+  - name: order_id
+    description: int, foreign key for ecommerce_orders
+    tests:
+    - dbt_expectations.expect_column_to_exist
+  tests:
+  - dbt_expectations.expect_table_column_count_to_equal:
+      value: 5
 - name: stg__mitxonline__app__postgres__ecommerce_transaction
   columns:
   - name: transaction_id

--- a/src/ol_dbt/models/staging/mitxonline/stg__mitxonline__app__postgres__ecommerce_discount.sql
+++ b/src/ol_dbt/models/staging/mitxonline/stg__mitxonline__app__postgres__ecommerce_discount.sql
@@ -1,0 +1,26 @@
+with source as (
+
+    select * from {{ source('ol_warehouse_raw_data', 'raw__mitxonline__app__postgres__ecommerce_discount') }}
+
+)
+
+, renamed as (
+
+    select
+        id as discount_id
+        , amount as discount_amount
+        , discount_code
+        , discount_type
+        , max_redemptions as discount_max_redemptions
+        , redemption_type as discount_redemption_type
+        , for_flexible_pricing as discount_is_for_flexible_pricing
+        , to_iso8601(from_iso8601_timestamp(created_on)) as discount_created_on
+        , to_iso8601(from_iso8601_timestamp(updated_on)) as discount_updated_on
+        , to_iso8601(from_iso8601_timestamp(activation_date)) as discount_activated_on
+        , to_iso8601(from_iso8601_timestamp(expiration_date)) as discount_expires_on
+
+    from source
+
+)
+
+select * from renamed

--- a/src/ol_dbt/models/staging/mitxonline/stg__mitxonline__app__postgres__ecommerce_discountproduct.sql
+++ b/src/ol_dbt/models/staging/mitxonline/stg__mitxonline__app__postgres__ecommerce_discountproduct.sql
@@ -1,0 +1,20 @@
+with source as (
+
+    select * from {{ source('ol_warehouse_raw_data', 'raw__mitxonline__app__postgres__ecommerce_discountproduct') }}
+
+)
+
+, renamed as (
+
+    select
+        id as discountproduct_id
+        , product_id
+        , discount_id
+        , to_iso8601(from_iso8601_timestamp(created_on)) as discountproduct_created_on
+        , to_iso8601(from_iso8601_timestamp(updated_on)) as discountproduct_updated_on
+
+    from source
+
+)
+
+select * from renamed

--- a/src/ol_dbt/models/staging/mitxonline/stg__mitxonline__app__postgres__ecommerce_discountredemption.sql
+++ b/src/ol_dbt/models/staging/mitxonline/stg__mitxonline__app__postgres__ecommerce_discountredemption.sql
@@ -1,0 +1,20 @@
+with source as (
+
+    select * from {{ source('ol_warehouse_raw_data', 'raw__mitxonline__app__postgres__ecommerce_discountredemption') }}
+
+)
+
+, renamed as (
+
+    select
+        id as discountredemption_id
+        , redeemed_by_id as user_id
+        , redeemed_order_id as order_id
+        , redeemed_discount_id as discount_id
+        , to_iso8601(from_iso8601_timestamp(redemption_date)) as discountredemption_timestamp
+
+    from source
+
+)
+
+select * from renamed

--- a/src/ol_dbt/models/staging/mitxonline/stg__mitxonline__app__postgres__ecommerce_line.sql
+++ b/src/ol_dbt/models/staging/mitxonline/stg__mitxonline__app__postgres__ecommerce_line.sql
@@ -9,11 +9,11 @@ with source as (
     select
         id as line_id
         , order_id
-        , created_on as line_created_on
-        , updated_on as line_updated_on
         , product_version_id
         , purchased_object_id as product_object_id
         , purchased_content_type_id as contenttype_id
+        , to_iso8601(from_iso8601_timestamp(created_on)) as line_created_on
+        , to_iso8601(from_iso8601_timestamp(updated_on)) as line_updated_on
     from source
 
 )

--- a/src/ol_dbt/models/staging/mitxonline/stg__mitxonline__app__postgres__ecommerce_userdiscount.sql
+++ b/src/ol_dbt/models/staging/mitxonline/stg__mitxonline__app__postgres__ecommerce_userdiscount.sql
@@ -1,0 +1,19 @@
+with source as (
+
+    select * from {{ source('ol_warehouse_raw_data', 'raw__mitxonline__app__postgres__ecommerce_userdiscount') }}
+
+)
+
+, renamed as (
+
+    select
+        id as userdiscount_id
+        , user_id
+        , discount_id
+        , to_iso8601(from_iso8601_timestamp(created_on)) as userdiscount_created_on
+        , to_iso8601(from_iso8601_timestamp(updated_on)) as userdiscount_updated_on
+    from source
+
+)
+
+select * from renamed

--- a/src/ol_dbt/models/staging/mitxonline/stg__mitxonline__app__postgres__flexiblepricing_countryincomethreshold.sql
+++ b/src/ol_dbt/models/staging/mitxonline/stg__mitxonline__app__postgres__flexiblepricing_countryincomethreshold.sql
@@ -1,0 +1,21 @@
+with source as (
+
+    select *
+    from {{ source('ol_warehouse_raw_data', 'raw__mitxonline__app__postgres__flexiblepricing_countryincomethreshold') }}
+
+)
+
+, renamed as (
+
+    select
+        id as countryincomethreshold_id
+        , country_code as countryincomethreshold_country_code
+        , income_threshold as countryincomethreshold_income_threshold
+        , to_iso8601(from_iso8601_timestamp(created_on)) as countryincomethreshold_created_on
+        , to_iso8601(from_iso8601_timestamp(updated_on)) as countryincomethreshold_updated_on
+
+    from source
+
+)
+
+select * from renamed

--- a/src/ol_dbt/models/staging/mitxonline/stg__mitxonline__app__postgres__flexiblepricing_currencyexchangerate.sql
+++ b/src/ol_dbt/models/staging/mitxonline/stg__mitxonline__app__postgres__flexiblepricing_currencyexchangerate.sql
@@ -1,0 +1,22 @@
+with source as (
+
+    select *
+    from {{ source('ol_warehouse_raw_data', 'raw__mitxonline__app__postgres__flexiblepricing_currencyexchangerate') }}
+
+)
+
+, renamed as (
+
+    select
+        id as currencyexchangerate_id
+        , description as currencyexchangerate_description
+        , currency_code as currencyexchangerate_currency_code
+        , exchange_rate as currencyexchangerate_exchange_rate
+        , to_iso8601(from_iso8601_timestamp(created_on)) as currencyexchangerate_created_on
+        , to_iso8601(from_iso8601_timestamp(updated_on)) as currencyexchangerate_updated_on
+
+    from source
+
+)
+
+select * from renamed

--- a/src/ol_dbt/models/staging/mitxonline/stg__mitxonline__app__postgres__flexiblepricing_flexiblepriceapplication.sql
+++ b/src/ol_dbt/models/staging/mitxonline/stg__mitxonline__app__postgres__flexiblepricing_flexiblepriceapplication.sql
@@ -1,0 +1,32 @@
+with source as (
+
+    select * from {{ source('ol_warehouse_raw_data', 'raw__mitxonline__app__postgres__flexiblepricing_flexibleprice') }}
+
+)
+
+, renamed as (
+
+    select
+        id as flexiblepriceapplication_id
+        , status as flexiblepriceapplication_status
+        , tier_id as flexiblepricetier_id
+        , user_id
+        , income_usd as flexiblepriceapplication_income_usd
+        , justification as flexiblepriceapplication_justification
+        , original_income as flexiblepriceapplication_original_income
+        , cms_submission_id as flexiblepriceapplication_cms_submission_id
+        , country_of_income as flexiblepriceapplication_country_of_income
+        , original_currency as flexiblepriceapplication_original_currency
+        , country_of_residence as flexiblepriceapplication_country_of_residence
+        , courseware_object_id
+        , courseware_content_type_id as contenttype_id
+        , to_iso8601(from_iso8601_timestamp(date_exchange_rate)) as flexiblepriceapplication_exchange_rate_timestamp
+        , to_iso8601(from_iso8601_timestamp(date_documents_sent)) as flexiblepriceapplication_date_documents_sent
+        , to_iso8601(from_iso8601_timestamp(created_on)) as flexiblepriceapplication_created_on
+        , to_iso8601(from_iso8601_timestamp(updated_on)) as flexiblepriceapplication_updated_on
+
+    from source
+
+)
+
+select * from renamed

--- a/src/ol_dbt/models/staging/mitxonline/stg__mitxonline__app__postgres__flexiblepricing_flexiblepricetier.sql
+++ b/src/ol_dbt/models/staging/mitxonline/stg__mitxonline__app__postgres__flexiblepricing_flexiblepricetier.sql
@@ -1,0 +1,20 @@
+with source as (
+    select *
+    from {{ source('ol_warehouse_raw_data', 'raw__mitxonline__app__postgres__flexiblepricing_flexiblepricetier') }}
+)
+
+, renamed as (
+    select
+        source.id as flexiblepricetier_id
+        , source."current" as flexiblepricetier_is_current
+        , source.discount_id as discount_id
+        , source.courseware_object_id
+        , source.income_threshold_usd as flexiblepricetier_income_threshold_usd
+        , source.courseware_content_type_id as contenttype_id
+        , to_iso8601(from_iso8601_timestamp(source.created_on)) as flexiblepricetier_created_on
+        , to_iso8601(from_iso8601_timestamp(source.updated_on)) as flexiblepricetier_updated_on
+
+    from source
+)
+
+select * from renamed


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This PR adds the mitxonline tables that are related to  discounts to ol-data-patform.

## Motivation and Context
Fixes https://github.com/mitodl/ol-data-platform/issues/452

## Types of changes
This PR creates staging and intermediate models for the following mitxonline postgres tables

ecommerce_discount
ecommerce_discountredemption
ecommerce_discountproduct
ecommerce_userproduct
flexiblepricing_countryincomethreshold
flexiblepricing_currencyexchangerate
flexiblepricing_flexibleprice
flexiblepricing_flexiblepricetier


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project. (Did you install and run the pre-commit hooks?)
- [ ] My change requires a change- [ ] My change requires a change to the documentation.
 to the documentation.
- [ ] I have updated the documentation accordingly.
