### PR TITLE
mitxonline basket

### DIFF
--- a/src/ol_dbt/models/intermediate/mitxonline/_int_mitxonline__models.yml
+++ b/src/ol_dbt/models/intermediate/mitxonline/_int_mitxonline__models.yml
@@ -2,6 +2,97 @@
 version: 2
 
 models:
+- name: int__mitxonline__ecommerce_basketdiscount
+  columns:
+  - name: basketdiscount_id
+    description: int, primary key representing a discount in a user's basket
+    tests:
+    - dbt_expectations.expect_column_to_exist
+  - name: basketdiscount_created_on
+    description: timestamp, specifying when the basket discount was initially created
+    tests:
+    - dbt_expectations.expect_column_to_exist
+  - name: basketdiscount_updated_on
+    description: timestamp, specifying when the basket discount was most recently
+      updated
+    tests:
+    - dbt_expectations.expect_column_to_exist
+  - name: basketdiscount_applied_on
+    description: timestamp, specifying when the discount was applied to the basket
+    tests:
+    - dbt_expectations.expect_column_to_exist
+  - name: basket_id
+    description: int, foreign key referencing ecommerce_basket
+    tests:
+    - dbt_expectations.expect_column_to_exist
+  - name: user_id
+    description: int, foreign key referencing users_user
+    tests:
+    - dbt_expectations.expect_column_to_exist
+  - name: discount_id
+    description: int, foreign key referencing ecommerce_discount
+    tests:
+    - dbt_expectations.expect_column_to_exist
+  tests:
+  - dbt_expectations.expect_table_column_count_to_equal:
+      value: 7
+- name: int__mitxonline__ecommerce_basketitem
+  columns:
+  - name: basketitem_id
+    description: int, primary key representing a item in a user's basket
+    tests:
+    - dbt_expectations.expect_column_to_exist
+  - name: basketitem_created_on
+    description: timestamp, specifying when the basket item was initially created
+    tests:
+    - dbt_expectations.expect_column_to_exist
+  - name: basketitem_updated_on
+    description: timestamp, specifying when the basket item was most recently updated
+    tests:
+    - dbt_expectations.expect_column_to_exist
+  - name: basketitem_quantity
+    description: int, quantitiy of the item. Always 1
+    tests:
+    - dbt_expectations.expect_column_to_exist
+  - name: basket_id
+    description: int, foreign key referencing ecommerce_basket
+    tests:
+    - dbt_expectations.expect_column_to_exist
+  - name: product_id
+    description: int, foreign key referencing ecommerce_product
+    tests:
+    - dbt_expectations.expect_column_to_exist
+  tests:
+  - dbt_expectations.expect_table_column_count_to_equal:
+      value: 6
+  - dbt_expectations.expect_table_row_count_to_equal_other_table:
+      compare_model: ref('stg__mitxonline__app__postgres__ecommerce_basketitem')
+- name: int__mitxonline__ecommerce_basket
+  description: Checkout basket that contains courseware that a users wants to purchase
+    but has not purchased yet
+  columns:
+  - name: basket_id
+    description: int, primary key representing a user basket
+    tests:
+    - dbt_expectations.expect_column_to_exist
+  - name: basket_created_on
+    description: timestamp, specifying when the basket was initially created
+    tests:
+    - dbt_expectations.expect_column_to_exist
+  - name: basket_updated_on
+    description: timestamp, specifying when the basket was most recently updated
+    tests:
+    - dbt_expectations.expect_column_to_exist
+  - name: user_id
+    description: int, foreign key to the users_user table
+    tests:
+    - dbt_expectations.expect_column_to_exist
+    - unique
+  tests:
+  - dbt_expectations.expect_table_column_count_to_equal:
+      value: 4
+  - dbt_expectations.expect_table_row_count_to_equal_other_table:
+      compare_model: ref('stg__mitxonline__app__postgres__ecommerce_basket')
 - name: int__mitxonline__ecommerce_transaction
   columns:
   - name: transaction_id

--- a/src/ol_dbt/models/intermediate/mitxonline/int__mitxonline__ecommerce_basket.sql
+++ b/src/ol_dbt/models/intermediate/mitxonline/int__mitxonline__ecommerce_basket.sql
@@ -1,0 +1,11 @@
+with source as (
+    select *
+    from {{ ref('stg__mitxonline__app__postgres__ecommerce_basket') }}
+)
+
+select
+    basket_id
+    , user_id
+    , basket_created_on
+    , basket_updated_on
+from source

--- a/src/ol_dbt/models/intermediate/mitxonline/int__mitxonline__ecommerce_basketdiscount.sql
+++ b/src/ol_dbt/models/intermediate/mitxonline/int__mitxonline__ecommerce_basketdiscount.sql
@@ -1,0 +1,14 @@
+with source as (
+    select *
+    from {{ ref('stg__mitxonline__app__postgres__ecommerce_basketdiscount') }}
+)
+
+select
+    basketdiscount_id
+    , basketdiscount_created_on
+    , basketdiscount_updated_on
+    , user_id
+    , basketdiscount_applied_on
+    , basket_id
+    , discount_id
+from source

--- a/src/ol_dbt/models/intermediate/mitxonline/int__mitxonline__ecommerce_basketitem.sql
+++ b/src/ol_dbt/models/intermediate/mitxonline/int__mitxonline__ecommerce_basketitem.sql
@@ -1,0 +1,13 @@
+with source as (
+    select *
+    from {{ ref('stg__mitxonline__app__postgres__ecommerce_basketitem') }}
+)
+
+select
+    basketitem_id
+    , basketitem_quantity
+    , basket_id
+    , basketitem_created_on
+    , product_id
+    , basketitem_updated_on
+from source

--- a/src/ol_dbt/models/staging/mitxonline/_mitxonline__sources.yml
+++ b/src/ol_dbt/models/staging/mitxonline/_mitxonline__sources.yml
@@ -7,6 +7,90 @@ sources:
   database: 'ol_data_lake_{{ target.name }}'
   schema: 'ol_warehouse_{{ target.name }}_raw'
   tables:
+  - name: raw__mitxonline__app__postgres__ecommerce_basketdiscount
+    columns:
+    - name: id
+      description: int, primary key representing a discount in a user's basket
+      tests:
+      - dbt_expectations.expect_column_to_exist
+    - name: created_on
+      description: timestamp, specifying when the basket discount was initially created
+      tests:
+      - dbt_expectations.expect_column_to_exist
+    - name: updated_on
+      description: timestamp, specifying when the basket discount was most recently
+        updated
+      tests:
+      - dbt_expectations.expect_column_to_exist
+    - name: redemption_date
+      description: timestamp, specifying when the discount was applied to the basket
+      tests:
+      - dbt_expectations.expect_column_to_exist
+    - name: redeemed_basket_id
+      description: int, foreign key referencing ecommerce_basket
+      tests:
+      - dbt_expectations.expect_column_to_exist
+    - name: redeemed_by_id
+      description: int, foreign key referencing users_user
+      tests:
+      - dbt_expectations.expect_column_to_exist
+    - name: redeemed_discount_id
+      description: int, foreign key referencing ecommerce_discount
+      tests:
+      - dbt_expectations.expect_column_to_exist
+    tests:
+    - dbt_expectations.expect_table_column_count_to_equal:
+        value: 7
+  - name: raw__mitxonline__app__postgres__ecommerce_basketitem
+    columns:
+    - name: id
+      description: int, primary key representing a item in a user's basket
+      tests:
+      - dbt_expectations.expect_column_to_exist
+    - name: created_on
+      description: timestamp, specifying when the basket item was initially created
+      tests:
+      - dbt_expectations.expect_column_to_exist
+    - name: updated_on
+      description: timestamp, specifying when the basket item was most recently updated
+      tests:
+      - dbt_expectations.expect_column_to_exist
+    - name: quantity
+      description: int, quantitiy of the item. Always 1
+      tests:
+      - dbt_expectations.expect_column_to_exist
+    - name: basket_id
+      description: int, foreign key referencing ecommerce_basket
+      tests:
+      - dbt_expectations.expect_column_to_exist
+    - name: product_id
+      description: int, foreign key referencing ecommerce_product
+      tests:
+      - dbt_expectations.expect_column_to_exist
+    tests:
+    - dbt_expectations.expect_table_column_count_to_equal:
+        value: 6
+  - name: raw__mitxonline__app__postgres__ecommerce_basket
+    columns:
+    - name: id
+      description: int, primary key representing a user basket
+      tests:
+      - dbt_expectations.expect_column_to_exist
+    - name: created_on
+      description: timestamp, specifying when the basket was initially created
+      tests:
+      - dbt_expectations.expect_column_to_exist
+    - name: updated_on
+      description: timestamp, specifying when the basket was most recently updated
+      tests:
+      - dbt_expectations.expect_column_to_exist
+    - name: user_id
+      description: int, foreign key to the users_user table
+      tests:
+      - dbt_expectations.expect_column_to_exist
+    tests:
+    - dbt_expectations.expect_table_column_count_to_equal:
+        value: 4
   - name: raw__mitxonline__app__postgres__ecommerce_transaction
     columns:
     - name: id

--- a/src/ol_dbt/models/staging/mitxonline/_stg_mitxonline__models.yml
+++ b/src/ol_dbt/models/staging/mitxonline/_stg_mitxonline__models.yml
@@ -2,6 +2,93 @@
 version: 2
 
 models:
+- name: stg__mitxonline__app__postgres__ecommerce_basketdiscount
+  columns:
+  - name: basketdiscount_id
+    description: int, primary key representing a discount in a user's basket
+    tests:
+    - dbt_expectations.expect_column_to_exist
+  - name: basketdiscount_created_on
+    description: timestamp, specifying when the basket discount was initially created
+    tests:
+    - dbt_expectations.expect_column_to_exist
+  - name: basketdiscount_updated_on
+    description: timestamp, specifying when the basket discount was most recently
+      updated
+    tests:
+    - dbt_expectations.expect_column_to_exist
+  - name: basketdiscount_applied_on
+    description: timestamp, specifying when the discount was applied to the basket
+    tests:
+    - dbt_expectations.expect_column_to_exist
+  - name: basket_id
+    description: int, foreign key referencing ecommerce_basket
+    tests:
+    - dbt_expectations.expect_column_to_exist
+  - name: user_id
+    description: int, foreign key referencing users_user
+    tests:
+    - dbt_expectations.expect_column_to_exist
+  - name: discount_id
+    description: int, foreign key referencing ecommerce_discount
+    tests:
+    - dbt_expectations.expect_column_to_exist
+  tests:
+  - dbt_expectations.expect_table_column_count_to_equal:
+      value: 7
+- name: stg__mitxonline__app__postgres__ecommerce_basketitem
+  columns:
+  - name: basketitem_id
+    description: int, primary key representing a item in a user's basket
+    tests:
+    - dbt_expectations.expect_column_to_exist
+  - name: basketitem_created_on
+    description: timestamp, specifying when the basket item was initially created
+    tests:
+    - dbt_expectations.expect_column_to_exist
+  - name: basketitem_updated_on
+    description: timestamp, specifying when the basket item was most recently updated
+    tests:
+    - dbt_expectations.expect_column_to_exist
+  - name: basketitem_quantity
+    description: int, quantitiy of the item. Always 1
+    tests:
+    - dbt_expectations.expect_column_to_exist
+  - name: basket_id
+    description: int, foreign key referencing ecommerce_basket
+    tests:
+    - dbt_expectations.expect_column_to_exist
+  - name: product_id
+    description: int, foreign key referencing ecommerce_product
+    tests:
+    - dbt_expectations.expect_column_to_exist
+  tests:
+  - dbt_expectations.expect_table_column_count_to_equal:
+      value: 6
+- name: stg__mitxonline__app__postgres__ecommerce_basket
+  description: Checkout basket that contains courseware that a users wants to purchase
+    but has not purchased yet
+  columns:
+  - name: basket_id
+    description: int, primary key representing a user basket
+    tests:
+    - dbt_expectations.expect_column_to_exist
+  - name: basket_created_on
+    description: timestamp, specifying when the basket was initially created
+    tests:
+    - dbt_expectations.expect_column_to_exist
+  - name: basket_updated_on
+    description: timestamp, specifying when the basket was most recently updated
+    tests:
+    - dbt_expectations.expect_column_to_exist
+  - name: user_id
+    description: int, foreign key to the users_user table
+    tests:
+    - dbt_expectations.expect_column_to_exist
+    - unique
+  tests:
+  - dbt_expectations.expect_table_column_count_to_equal:
+      value: 4
 - name: stg__mitxonline__app__postgres__ecommerce_transaction
   columns:
   - name: transaction_id

--- a/src/ol_dbt/models/staging/mitxonline/stg__mitxonline__app__postgres__ecommerce_basket.sql
+++ b/src/ol_dbt/models/staging/mitxonline/stg__mitxonline__app__postgres__ecommerce_basket.sql
@@ -1,0 +1,19 @@
+with source as (
+
+    select * from {{ source('ol_warehouse_raw_data', 'raw__mitxonline__app__postgres__ecommerce_basket') }}
+
+)
+
+, renamed as (
+
+    select
+        id as basket_id
+        , user_id
+        , to_iso8601(from_iso8601_timestamp(created_on)) as basket_created_on
+        , to_iso8601(from_iso8601_timestamp(updated_on)) as basket_updated_on
+
+    from source
+
+)
+
+select * from renamed

--- a/src/ol_dbt/models/staging/mitxonline/stg__mitxonline__app__postgres__ecommerce_basketdiscount.sql
+++ b/src/ol_dbt/models/staging/mitxonline/stg__mitxonline__app__postgres__ecommerce_basketdiscount.sql
@@ -1,0 +1,22 @@
+with source as (
+
+    select * from {{ source('ol_warehouse_raw_data', 'raw__mitxonline__app__postgres__ecommerce_basketdiscount') }}
+
+)
+
+, renamed as (
+
+    select
+        id as basketdiscount_id
+        , redeemed_by_id as user_id
+        , redeemed_basket_id as basket_id
+        , redeemed_discount_id as discount_id
+        , to_iso8601(from_iso8601_timestamp(redemption_date)) as basketdiscount_applied_on
+        , to_iso8601(from_iso8601_timestamp(created_on)) as basketdiscount_created_on
+        , to_iso8601(from_iso8601_timestamp(updated_on)) as basketdiscount_updated_on
+
+    from source
+
+)
+
+select * from renamed

--- a/src/ol_dbt/models/staging/mitxonline/stg__mitxonline__app__postgres__ecommerce_basketitem.sql
+++ b/src/ol_dbt/models/staging/mitxonline/stg__mitxonline__app__postgres__ecommerce_basketitem.sql
@@ -1,0 +1,21 @@
+with source as (
+
+    select * from {{ source('ol_warehouse_raw_data', 'raw__mitxonline__app__postgres__ecommerce_basketitem') }}
+
+)
+
+, renamed as (
+
+    select
+        id as basketitem_id
+        , quantity as basketitem_quantity
+        , basket_id
+        , product_id
+        , to_iso8601(from_iso8601_timestamp(created_on)) as basketitem_created_on
+        , to_iso8601(from_iso8601_timestamp(updated_on)) as basketitem_updated_on
+
+    from source
+
+)
+
+select * from renamed


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This PR adds the mitxonline tables that are related to ecommerce baskets to ol-data-patform.

## Motivation and Context
Fixes https://github.com/mitodl/ol-data-platform/issues/450

## Types of changes
This PR creates staging and intermediate models for the following mitxonline postgres tables

ecommerce_basket
ecommerce_basketitem
ecommerce_basketdiscount

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project. (Did you install and run the pre-commit hooks?)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
