### PR TITLE
add edxorg users and additional certificates fields

### DIFF
--- a/src/ol_dbt/models/intermediate/edxorg/_int_edxorg__models.yml
+++ b/src/ol_dbt/models/intermediate/edxorg/_int_edxorg__models.yml
@@ -69,6 +69,12 @@ models:
 - name: int__edxorg__mitx_courserun_certificates
   description: Intermediate model for course run certificates from edx.org
   columns:
+  - name: courseruncertificate_id
+    description: int, sequential ID of the certificate
+    tests:
+    - dbt_expectations.expect_column_to_exist
+    - not_null
+    - unique
   - name: user_id
     description: int, Numerical user ID of a learner on the edX platform
     tests:
@@ -81,23 +87,58 @@ models:
     tests:
     - dbt_expectations.expect_column_to_exist
     - not_null
-  - name: courseruncertificate_status
-    description: str, one of downloadable, notpassing, audit_passing, unavailable,
-      audit_notpassing where downloadable should = earned
+  - name: user_username
+    description: str, The username of the learner on the edX platform
+    tests:
+    - dbt_expectations.expect_column_to_exist
+  - name: user_email
+    description: str, The email address of the learner on the edX platform
     tests:
     - dbt_expectations.expect_column_to_exist
   - name: courseruncertificate_created_on
-    description: timestamp, timestamp when certificate was generated (if applicable)
+    description: timestamp, Timestamp indicating when the certificate was created
     tests:
     - dbt_expectations.expect_column_to_exist
-  - name: courserun_title
-    description: str, The title of the course run
+  - name: courseruncertificate_updated_on
+    description: timestamp, Timestamp indicating the last time the certificate was
+      modified
     tests:
+    - dbt_expectations.expect_column_to_exist
+  - name: courseruncertificate_name
+    description: str, The name of the user that is listed on the certificate
+    tests:
+    - dbt_expectations.expect_column_to_exist
+  - name: courseruncertificate_status
+    description: str, Status of the generation of the certificate
+    tests:
+    - dbt_expectations.expect_column_to_exist
+  - name: courseruncertificate_download_url
+    description: str, the full URL to the certificate
+    tests:
+    - dbt_expectations.expect_column_to_exist
     - not_null
+  - name: courseruncertificate_download_uuid
+    description: str, A hash code that identifies this student’s certificate. Included
+      as part of the download_url.
+    tests:
+    - dbt_expectations.expect_column_to_exist
+    - not_null
+  - name: courseruncertificate_verify_uuid
+    description: str, A hash code that verifies the validity of a certificate. Included
+      on the certificate itself as part of a URL.
+    tests:
+    - dbt_expectations.expect_column_to_exist
+  - name: courseruncertificate_grade
+    description: float, The grade when the certificate was generated
+    tests:
+    - dbt_expectations.expect_column_to_exist
+  - name: courseruncertificate_mode
+    description: str, The enrollment mode associated with the certificate
+    tests:
     - dbt_expectations.expect_column_to_exist
   tests:
   - dbt_expectations.expect_table_column_count_to_equal:
-      value: 5
+      value: 15
 
 - name: int__edxorg__mitx_courserun_enrollments
   description: Intermediate model for course run enrollments from edx.org
@@ -116,6 +157,10 @@ models:
     - not_null
   - name: user_username
     description: str, username of a learner on the edX platform (some blank from source)
+    tests:
+    - dbt_expectations.expect_column_to_exist
+  - name: user_email
+    description: str, The email address of the learner on the edX platform
     tests:
     - dbt_expectations.expect_column_to_exist
   - name: courserunenrollment_created_on
@@ -137,4 +182,42 @@ models:
     - dbt_expectations.expect_column_to_exist
   tests:
   - dbt_expectations.expect_table_column_count_to_equal:
-      value: 7
+      value: 8
+  - dbt_expectations.expect_compound_columns_to_be_unique:
+      column_list: ["user_id", "courserun_readable_id"]
+
+- name: int__edxorg__mitx_users
+  description: Intermediate User model for edx.org that contains the most recent user
+    data
+  columns:
+  - name: user_id
+    description: int, Numerical user ID of a learner on the edX platform
+    tests:
+    - dbt_expectations.expect_column_to_exist
+    - not_null
+    - unique
+  - name: user_username
+    description: str, The username of the learner on the edX platform some usernames
+      are blank
+    tests:
+    - dbt_expectations.expect_column_to_exist
+  - name: user_email
+    description: str, The current default email address of the learner on the edX
+      platform
+    tests:
+    - dbt_expectations.expect_column_to_exist
+  - name: user_full_name
+    description: str, The full name of the user on the edX platform
+    tests:
+    - dbt_expectations.expect_column_to_exist
+  - name: user_country
+    description: str, Country provided by the learner
+    tests:
+    - dbt_expectations.expect_column_to_exist
+  - name: user_joined_on
+    description: timestamp, timestamp that the account was created.
+    tests:
+    - dbt_expectations.expect_column_to_exist
+  tests:
+  - dbt_expectations.expect_table_column_count_to_equal:
+      value: 6

--- a/src/ol_dbt/models/intermediate/edxorg/int__edxorg__mitx_courserun_certificates.sql
+++ b/src/ol_dbt/models/intermediate/edxorg/int__edxorg__mitx_courserun_certificates.sql
@@ -1,15 +1,42 @@
 -- Course Certificate information for edx.org
 
-with certificates as (
-    select
-        user_id
-        , courserun_readable_id
-        , courseruncertificate_is_earned
-        , courseruncertificate_status
-        , courseruncertificate_created_on
-        , courserunenrollment_is_active
+with person_courses as (
+    select *
     from {{ ref('stg__edxorg__bigquery__mitx_person_course') }}
     where courseruncertificate_is_earned = true
+)
+
+, user_info_combo as (
+    select *
+    from {{ ref('stg__edxorg__bigquery__mitx_user_info_combo') }}
+    where courseruncertificate_id is not null
+)
+
+, certificates as (
+    select
+        user_info_combo.courseruncertificate_id
+        , user_info_combo.courseruncertificate_courserun_readable_id as courserun_readable_id
+        , user_info_combo.courseruncertificate_mode
+        , user_info_combo.courseruncertificate_grade
+        , user_info_combo.courseruncertificate_download_url
+        , user_info_combo.courseruncertificate_download_uuid
+        , user_info_combo.courseruncertificate_verify_uuid
+        , user_info_combo.courseruncertificate_name
+        , user_info_combo.courseruncertificate_status
+        , user_info_combo.courseruncertificate_created_on
+        , user_info_combo.courseruncertificate_updated_on
+        , user_info_combo.user_id
+        , user_info_combo.user_email
+        , user_info_combo.user_username
+    from user_info_combo
+    inner join person_courses -- this join is needed to filter out courseruncertificate that are not earned
+        on
+            user_info_combo.user_id = person_courses.user_id
+            and user_info_combo.courseruncertificate_courserun_readable_id = person_courses.courserun_readable_id
+)
+
+, users as (
+    select * from {{ ref('int__edxorg__mitx_users') }}
 )
 
 , runs as (
@@ -19,17 +46,24 @@ with certificates as (
     from {{ ref('stg__edxorg__bigquery__mitx_courserun') }}
 )
 
----- placeholder for users
-
-select
-    certificates.user_id
+select distinct
+    certificates.courseruncertificate_id
     , certificates.courserun_readable_id
+    , certificates.courseruncertificate_mode
+    , certificates.courseruncertificate_grade
+    , certificates.courseruncertificate_download_url
+    , certificates.courseruncertificate_download_uuid
+    , certificates.courseruncertificate_verify_uuid
+    , certificates.courseruncertificate_name
     , certificates.courseruncertificate_status
     , certificates.courseruncertificate_created_on
+    , certificates.courseruncertificate_updated_on
+    , users.user_id
+    , users.user_email
+    , users.user_username
     , runs.courserun_title
-from
-    certificates
----- there are certificates issued for courses that don't exist in course model.
---   this inner joins will eliminate those rows.
---   if we want to show all the certificate, it needs to change to Left join
-inner join runs on certificates.courserun_readable_id = runs.courserun_readable_id
+from certificates
+inner join users
+    on certificates.user_id = users.user_id
+inner join runs
+    on certificates.courserun_readable_id = runs.courserun_readable_id

--- a/src/ol_dbt/models/intermediate/edxorg/int__edxorg__mitx_courserun_enrollments.sql
+++ b/src/ol_dbt/models/intermediate/edxorg/int__edxorg__mitx_courserun_enrollments.sql
@@ -18,22 +18,26 @@ with enrollments as (
     from {{ ref('stg__edxorg__bigquery__mitx_courserun') }}
 )
 
----- placeholder for users
+, users as (
+    select * from {{ ref('int__edxorg__mitx_users') }}
+)
 
 , edxorg_enrollments as (
     select
-        enrollments.user_id
-        , enrollments.user_username
-        , enrollments.courserun_readable_id
+        enrollments.courserun_readable_id
         , enrollments.courserunenrollment_created_on
         , enrollments.courserunenrollment_enrollment_mode
         , enrollments.courserunenrollment_is_active
+        , users.user_id
+        , users.user_email
+        , users.user_username
         , runs.courserun_title
-    from
-        enrollments
-    ---- there are certificates issued for courses that don't exist in course model.
-    ---- this inner joins will eliminate those rows.
-    ---- if we want to show all the certificate, it needs to change to Left join
+    from enrollments
+    inner join users on
+        enrollments.user_id = users.user_id
+---- there are certificates issued for courses that don't exist in course model.
+---- this inner joins will eliminate those rows.
+---- if we want to show all the certificate, it needs to change to Left join
     inner join runs on enrollments.courserun_readable_id = runs.courserun_readable_id
 )
 

--- a/src/ol_dbt/models/intermediate/edxorg/int__edxorg__mitx_users.sql
+++ b/src/ol_dbt/models/intermediate/edxorg/int__edxorg__mitx_users.sql
@@ -1,0 +1,26 @@
+--- Intermediate MITx users for edx.org
+--- user_info_combo contains user info for each course they enroll in, so need to aggregate it here
+--  to get the latest user info per user_id
+
+with user_info_combo as (
+    --- use window function to generate row number based on user_last_login for each user
+    select
+        user_id
+        , user_email
+        , user_username
+        , user_full_name
+        , user_country
+        , user_joined_on
+        , row_number() over (partition by user_id order by user_last_login desc) as seq
+    from {{ ref('stg__edxorg__bigquery__mitx_user_info_combo') }}
+)
+
+select
+    user_id
+    , user_email
+    , user_username
+    , user_full_name
+    , user_country
+    , user_joined_on
+from user_info_combo
+where seq = 1   -- use the latest row for each user

--- a/src/ol_dbt/models/staging/edxorg/_edxorg_sources.yml
+++ b/src/ol_dbt/models/staging/edxorg/_edxorg_sources.yml
@@ -543,3 +543,212 @@ sources:
     tests:
     - dbt_expectations.expect_table_column_count_to_equal:
         value: 85
+
+  - name: raw__irx__edxorg__bigquery__mitx_user_info_combo
+    description: source table contains edxorg user profile, enrollments and certificate
+      details in a course from IRx BigQuery. enrollment_course_id in this table is
+      not always populated.
+    columns:
+    - name: user_id
+      description: int, Numerical user ID of a learner on the edX platform (not unique)
+      tests:
+      - dbt_expectations.expect_column_to_exist
+    - name: username
+      description: str, The username of the learner on the edX platform (not unique)
+      tests:
+      - dbt_expectations.expect_column_to_exist
+    - name: email
+      description: str, The email address of the learner on the edX platform
+      tests:
+      - dbt_expectations.expect_column_to_exist
+    - name: id_map_hash_id
+      description: str, A hashed ID mapping learner user ID's to external systems
+      tests:
+      - dbt_expectations.expect_column_to_exist
+    - name: is_staff
+      description: int, Whether the user is a staff member of edx, 1 indicates staff
+        member
+      tests:
+      - dbt_expectations.expect_column_to_exist
+    - name: profile_language
+      description: str, Language selected by the user as their default profile language
+        (No longer used) History - User’s preferred language, asked during the sign
+        up process for the 6.002x prototype course given in the Spring of 2012. Sometimes
+        written in those languages. EdX stopped collecting this data after MITx transitioned
+        to edX, but never removed the values for the first group of students.
+      tests:
+      - dbt_expectations.expect_column_to_exist
+    - name: profile_location
+      description: str, location chosen by the user on their profile (No longer used)
+        History- User’s location, asked during the sign up process for the 6.002x
+        prototype course given in the Spring of 2012. edX stopped collecting this
+        column after MITx transitioned to edX, so it is only available for the first
+        batch of students.
+      tests:
+      - dbt_expectations.expect_column_to_exist
+    - name: profile_name
+      description: str, The full name of the user on the edX platform
+      tests:
+      - dbt_expectations.expect_column_to_exist
+    - name: profile_mailing_address
+      description: str, Mailing address provided by the learner on their profile
+      tests:
+      - dbt_expectations.expect_column_to_exist
+    - name: profile_allow_certificate
+      description: int, Whether or not the profile allows certificate (No longer used)
+        History - Prior to 10 Feb 2014, this field was set to 0 (false) if log analysis
+        revealed that the student was accessing the edX site from a country that the
+        U.S. had embargoed. This restriction is no longer in effect.
+      tests:
+      - dbt_expectations.expect_column_to_exist
+    - name: profile_goals
+      description: str, The intended goals of the learner provided on their profile
+      tests:
+      - dbt_expectations.expect_column_to_exist
+    - name: profile_gender
+      description: str, Gender selected by the user on their profile
+      tests:
+      - dbt_expectations.expect_column_to_exist
+    - name: profile_country
+      description: str, Country selected by the learner on their profile
+      tests:
+      - dbt_expectations.expect_column_to_exist
+    - name: profile_level_of_education
+      description: str, user's Level of education- blank means User did not specify
+        level of education. Null means this student signed up before this information
+        was collected
+      tests:
+      - dbt_expectations.expect_column_to_exist
+    - name: profile_year_of_birth
+      description: int, A year of birth provided by the learner on their profile
+      tests:
+      - dbt_expectations.expect_column_to_exist
+    - name: profile_meta
+      description: str, extra metadata on learner's profile. JSON data in text field
+      tests:
+      - dbt_expectations.expect_column_to_exist
+    - name: profile_courseware
+      description: str, The courseware under which the profile was created History
+        - At one point, it was part of a way to do A/B tests, but it has not been
+        used for anything meaningful since the conclusion of the prototype course
+        in the spring of 2012.
+      tests:
+      - dbt_expectations.expect_column_to_exist
+    - name: profile_city
+      description: str, City selected the learner on their profile (Not currently
+        used) History - Added in Jan 2014, not yet implemented.
+      tests:
+      - dbt_expectations.expect_column_to_exist
+    - name: date_joined
+      description: timestamp, timestamp that the account was created.
+      tests:
+      - dbt_expectations.expect_column_to_exist
+    - name: last_login
+      description: timestamp, Timestamp indicating the last time the user logged into
+        the edX platform
+      tests:
+      - dbt_expectations.expect_column_to_exist
+    - name: enrollment_course_id
+      description: str, course ID user is enrolling in. It's in the format as org/number/semester
+      tests:
+      - dbt_expectations.expect_column_to_exist
+    - name: enrollment_mode
+      description: str, indicate what kind of enrollment it is - mode, no-id-professional,
+        audit, honor, verified, professional, credit
+      tests:
+      - dbt_expectations.expect_column_to_exist
+    - name: enrollment_created
+      description: timestamp, Timestamp indicating when the enrollment event was created
+      tests:
+      - dbt_expectations.expect_column_to_exist
+    - name: enrollment_is_active
+      description: int, Whether or not the enrollment is active. 1 means active
+      tests:
+      - dbt_expectations.expect_column_to_exist
+    - name: certificate_id
+      description: int, The ID of the certificate obtained by the user. Null if the
+        user obtained no certificate.
+      tests:
+      - dbt_expectations.expect_column_to_exist
+    - name: certificate_course_id
+      description: str, The course ID associated with the certificate. It's in the
+        format as org/number/semester
+      tests:
+      - dbt_expectations.expect_column_to_exist
+    - name: certificate_user_id
+      description: int, The user ID tied to the certificate
+      tests:
+      - dbt_expectations.expect_column_to_exist
+    - name: certificate_mode
+      description: str, The enrollment mode associated with the certificate
+      tests:
+      - dbt_expectations.expect_column_to_exist
+    - name: certificate_distinction
+      description: int, This was used for letters of distinction for 188.1x, but is
+        not being used for any current courses
+      tests:
+      - dbt_expectations.expect_column_to_exist
+    - name: certificate_created_date
+      description: timestamp, Timestamp indicating when the certificate was created
+      tests:
+      - dbt_expectations.expect_column_to_exist
+    - name: certificate_modified_date
+      description: timestamp, Timestamp indicating the last time the certificate was
+        modified
+      tests:
+      - dbt_expectations.expect_column_to_exist
+    - name: certificate_name
+      description: str, The name of the user that is listed on the certificate
+      tests:
+      - dbt_expectations.expect_column_to_exist
+    - name: certificate_key
+      description: str, A random string that is used to match server requests to responses
+        sent to the LMS. Used internally only
+      tests:
+      - dbt_expectations.expect_column_to_exist
+    - name: certificate_status
+      description: str, Status of the generation of the certificate
+      tests:
+      - dbt_expectations.expect_column_to_exist
+    - name: certificate_download_url
+      description: str, the full URL to the certificate
+      tests:
+      - dbt_expectations.expect_column_to_exist
+    - name: certificate_download_uuid
+      description: str, A hash code that identifies this student’s certificate. Included
+        as part of the download_url.
+      tests:
+      - dbt_expectations.expect_column_to_exist
+    - name: certificate_verify_uuid
+      description: str, A hash code that verifies the validity of a certificate. Included
+        on the certificate itself as part of a URL.
+      tests:
+      - dbt_expectations.expect_column_to_exist
+    - name: certificate_grade
+      description: float, The grade when the certificate was generated
+      tests:
+      - dbt_expectations.expect_column_to_exist
+    - name: certificate_error_reason
+      description: str, indicate any errors encountered during certificate generation.
+        Used internally only.
+      tests:
+      - dbt_expectations.expect_column_to_exist
+    - name: edxinstructordash_grade
+      description: float, A grade downloaded separately from the instructor dashboards.
+        This is mostly null for all tables generated by the simeon CLI tool version
+        0.0.1
+      tests:
+      - dbt_expectations.expect_column_to_exist
+    - name: edxinstructordash_grade_timestamp
+      description: str, Timestamp indicating when the grades from the instructor dashboards
+        were generated
+      tests:
+      - dbt_expectations.expect_column_to_exist
+    - name: y1_anomalous
+      description: int, relic from processes that the edx2bigquery package used to
+        handle
+      tests:
+      - dbt_expectations.expect_column_to_exist
+    tests:
+    - dbt_expectations.expect_table_column_count_to_equal:
+        value: 42

--- a/src/ol_dbt/models/staging/edxorg/_stg__edxorg__models.yml
+++ b/src/ol_dbt/models/staging/edxorg/_stg__edxorg__models.yml
@@ -96,7 +96,7 @@ models:
             \ education", "Doctorate in science or engineering", "Doctorate in another\
             \ field", "", null]
   - name: user_birth_year
-    description: int, user's Year of birth
+    description: int, A year of birth provided by the learner on their profile
     tests:
     - dbt_expectations.expect_column_to_exist
   - name: user_profile_country
@@ -162,3 +162,161 @@ models:
       value: 19
   - dbt_expectations.expect_compound_columns_to_be_unique:
       column_list: ["user_id", "courserun_readable_id"]
+
+- name: stg__edxorg__bigquery__mitx_user_info_combo
+  description: This contains edxorg user profile, enrollments and certificate details
+    in a course from IRx BigQuery.
+  columns:
+  - name: user_id
+    description: int, Numerical user ID of a learner on the edX platform
+    tests:
+    - dbt_expectations.expect_column_to_exist
+    - not_null
+  - name: user_username
+    description: str, The username of the learner on the edX platform
+    tests:
+    - dbt_expectations.expect_column_to_exist
+  - name: user_full_name
+    description: str, The full name of the user on the edX platform
+    tests:
+    - dbt_expectations.expect_column_to_exist
+  - name: user_email
+    description: str, The email address of the learner on the edX platform (could
+      be blank)
+    tests:
+    - dbt_expectations.expect_column_to_exist
+  - name: user_map_hash_id
+    description: str, A hashed ID mapping learner user ID's to external systems
+    tests:
+    - dbt_expectations.expect_column_to_exist
+  - name: user_mailing_address
+    description: str, Mailing address provided by the learner on their profile
+    tests:
+    - dbt_expectations.expect_column_to_exist
+  - name: user_profile_goals
+    description: str, The intended goals of the learner provided on their profile
+    tests:
+    - dbt_expectations.expect_column_to_exist
+  - name: user_gender
+    description: str, Gender selected by the user on their profile
+    tests:
+    - dbt_expectations.expect_column_to_exist
+    - accepted_values:
+        values: ['Male', 'Female', 'Other/Prefer Not to Say', '', null]
+  - name: user_country
+    description: str, Country selected by the learner on their profile
+    tests:
+    - dbt_expectations.expect_column_to_exist
+  - name: user_highest_education
+    description: str, user's Level of education- blank means User did not specify
+      level of education. Null means this student signed up before this information
+      was collected
+    tests:
+    - dbt_expectations.expect_column_to_exist
+    - accepted_values:
+        values: ["Doctorate", "Master''s or professional degree", "Bachelor''s degree",
+          "Associate degree", "Secondary/high school", "Junior secondary/junior high/middle\
+            \ school", "Elementary/primary school", "No formal education", "Other\
+            \ education", "Doctorate in science or engineering", "Doctorate in another\
+            \ field", "", null]
+  - name: user_birth_year
+    description: int, A year of birth provided by the learner on their profile
+    tests:
+    - dbt_expectations.expect_column_to_exist
+  - name: user_profile_meta
+    description: str, extra metadata on learner's profile. JSON data in text field
+    tests:
+    - dbt_expectations.expect_column_to_exist
+  - name: user_joined_on
+    description: timestamp, timestamp that the account was created.
+    tests:
+    - dbt_expectations.expect_column_to_exist
+  - name: user_last_login
+    description: timestamp, Timestamp indicating the last time the user logged into
+      the edX platform
+    tests:
+    - dbt_expectations.expect_column_to_exist
+  - name: courserunenrollment_courserun_readable_id
+    description: str, course ID user is enrolling in. It's in the format as org/number/semester
+      this field is not always populated here, but it's always populated in person_course
+    tests:
+    - dbt_expectations.expect_column_to_exist
+  - name: courserunenrollment_mode
+    description: str, indicate what kind of enrollment it is - mode, no-id-professional,
+      audit, honor, verified, professional, credit
+    tests:
+    - dbt_expectations.expect_column_to_exist
+  - name: courserunenrollment_created_on
+    description: timestamp, Timestamp indicating when the enrollment event was created
+    tests:
+    - dbt_expectations.expect_column_to_exist
+  - name: courserunenrollment_is_active
+    description: int, Whether or not the enrollment is active. 1 means active
+    tests:
+    - dbt_expectations.expect_column_to_exist
+  - name: courseruncertificate_id
+    description: int, The ID of the certificate obtained by the user. Null if the
+      user obtained no certificate.
+    tests:
+    - dbt_expectations.expect_column_to_exist
+  - name: courseruncertificate_courserun_readable_id
+    description: str, The course ID associated with the certificate. It's in the format
+      as org/number/semester
+    tests:
+    - dbt_expectations.expect_column_to_exist
+  - name: courseruncertificate_user_id
+    description: int, The user ID tied to the certificate
+    tests:
+    - dbt_expectations.expect_column_to_exist
+  - name: courseruncertificate_mode
+    description: str, The enrollment mode associated with the certificate
+    tests:
+    - dbt_expectations.expect_column_to_exist
+  - name: courseruncertificate_distinction
+    description: int, This was used for letters of distinction for 188.1x, but is
+      not being used for any current courses
+    tests:
+    - dbt_expectations.expect_column_to_exist
+  - name: courseruncertificate_created_on
+    description: timestamp, Timestamp indicating when the certificate was created
+    tests:
+    - dbt_expectations.expect_column_to_exist
+  - name: courseruncertificate_updated_on
+    description: timestamp, Timestamp indicating the last time the certificate was
+      modified
+    tests:
+    - dbt_expectations.expect_column_to_exist
+  - name: courseruncertificate_name
+    description: str, The name of the user that is listed on the certificate
+    tests:
+    - dbt_expectations.expect_column_to_exist
+  - name: courseruncertificate_key
+    description: str, A random string that is used to match server requests to responses
+      sent to the LMS. Used internally only
+    tests:
+    - dbt_expectations.expect_column_to_exist
+  - name: courseruncertificate_status
+    description: str, Status of the generation of the certificate
+    tests:
+    - dbt_expectations.expect_column_to_exist
+  - name: courseruncertificate_download_url
+    description: str, the full URL to the certificate
+    tests:
+    - dbt_expectations.expect_column_to_exist
+  - name: courseruncertificate_download_uuid
+    description: str, A hash code that identifies this student’s certificate. Included
+      as part of the download_url.
+    tests:
+    - dbt_expectations.expect_column_to_exist
+  - name: courseruncertificate_verify_uuid
+    description: str, A hash code that verifies the validity of a certificate. Included
+      on the certificate itself as part of a URL.
+    tests:
+    - dbt_expectations.expect_column_to_exist
+  - name: courseruncertificate_grade
+    description: float, The grade when the certificate was generated
+    tests:
+    - dbt_expectations.expect_column_to_exist
+  tests:
+  - dbt_expectations.expect_table_column_count_to_equal:
+      value: 32

--- a/src/ol_dbt/models/staging/edxorg/stg__edxorg__bigquery__mitx_user_info_combo.sql
+++ b/src/ol_dbt/models/staging/edxorg/stg__edxorg__bigquery__mitx_user_info_combo.sql
@@ -1,0 +1,68 @@
+-- It contains user profiles, enrollments and certificate detail of learners in a given course
+-- There are some fields overlapping with person_course
+
+with source as (
+    select *
+    from {{ source('ol_warehouse_raw_data','raw__irx__edxorg__bigquery__mitx_user_info_combo') }}
+)
+
+, cleaned as (
+
+    select
+        user_id
+        , email as user_email
+        , username as user_username
+        , id_map_hash_id as user_map_hash_id
+        , profile_name as user_full_name
+        , profile_mailing_address as user_mailing_address
+        , profile_goals as user_profile_goals
+        , profile_country as user_country
+        , profile_year_of_birth as user_birth_year
+        , profile_meta as user_profile_meta
+        , enrollment_course_id as courserunenrollment_courserun_readable_id
+        , enrollment_is_active as courserunenrollment_is_active
+        , enrollment_mode as courserunenrollment_mode
+        , certificate_id as courseruncertificate_id
+        , certificate_user_id as courseruncertificate_user_id
+        , certificate_course_id as courseruncertificate_courserun_readable_id
+        , certificate_key as courseruncertificate_key
+        , certificate_mode as courseruncertificate_mode
+        , certificate_distinction as courseruncertificate_distinction
+        , certificate_grade as courseruncertificate_grade
+        , certificate_download_url as courseruncertificate_download_url
+        , certificate_download_uuid as courseruncertificate_download_uuid
+        , certificate_verify_uuid as courseruncertificate_verify_uuid
+        , certificate_name as courseruncertificate_name
+        , certificate_status as courseruncertificate_status
+        , case
+            when profile_gender = 'm' then 'Male'
+            when profile_gender = 'f' then 'Female'
+            when profile_gender = 'o' then 'Other/Prefer Not to Say'
+            else profile_gender
+        end as user_gender
+        , case
+            when profile_level_of_education = 'p' then 'Doctorate'
+            when profile_level_of_education = 'm' then 'Master''s or professional degree'
+            when profile_level_of_education = 'b' then 'Bachelor''s degree'
+            when profile_level_of_education = 'a' then 'Associate degree'
+            when profile_level_of_education = 'hs' then 'Secondary/high school'
+            when profile_level_of_education = 'jhs' then 'Junior secondary/junior high/middle school'
+            when profile_level_of_education = 'el' then 'Elementary/primary school'
+            when profile_level_of_education = 'none' then 'No formal education'
+            when profile_level_of_education = 'other' or profile_level_of_education = 'o' then 'Other education'
+            --- the following two are no longer used, but there are still user's profiles have these values
+            when profile_level_of_education = 'p_se' then 'Doctorate in science or engineering'
+            when profile_level_of_education = 'p_oth' then 'Doctorate in another field'
+            else profile_level_of_education
+        end as user_highest_education
+        , to_iso8601(from_iso8601_timestamp(date_joined)) as user_joined_on
+        , to_iso8601(from_iso8601_timestamp(last_login)) as user_last_login
+        , to_iso8601(from_iso8601_timestamp(enrollment_created)) as courserunenrollment_created_on
+        , to_iso8601(from_iso8601_timestamp(certificate_created_date)) as courseruncertificate_created_on
+        , to_iso8601(from_iso8601_timestamp(certificate_modified_date)) as courseruncertificate_updated_on
+    from source
+    --- user_id could be blank due to parsing error on edx data so filter out these
+    where user_id is not null
+)
+
+select * from cleaned


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This PR creates and updates the following models for edx.org 
- stg__edxorg__bigquery__mitx_user_info_combo
- int__edxorg__mitx_users 
   - aggregated from user_info_combo
- int__edxorg__mitx_courserun_certificates
  - added user and certificate details fields
- int__edxorg__mitx_courserun_enrollments
   - added users field

## Motivation and Context
https://github.com/mitodl/ol-data-platform/issues/451

## Test
ran `dbt run` and `dbt test`

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Enhancement (improves on existing behavior)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project. (Did you install and run the pre-commit hooks?)
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
