### PR TITLE
mitxpro ecommerce

### DIFF
--- a/src/ol_dbt/models/intermediate/mitxpro/_int_mitxpro__models.yml
+++ b/src/ol_dbt/models/intermediate/mitxpro/_int_mitxpro__models.yml
@@ -2,6 +2,271 @@
 version: 2
 
 models:
+- name: int__mitxpro__ecommerce_receipt
+  description: Data returned from cybersource when a user pays for an order
+  columns:
+  - name: receipt_id
+    description: int, primary key representing a receipt
+    tests:
+    - dbt_expectations.expect_column_to_exist
+    - not_null
+    - unique
+  - name: receipt_created_on
+    description: timestamp, specifying when the receipt was initially created
+    tests:
+    - dbt_expectations.expect_column_to_exist
+    - not_null
+  - name: receipt_updated_on
+    description: timestamp, specifying when the receipt most recently updated
+    tests:
+    - dbt_expectations.expect_column_to_exist
+    - not_null
+  - name: receipt_data
+    description: json, cybersource data for a payment
+    tests:
+    - dbt_expectations.expect_column_to_exist
+    - not_null
+  - name: order_id
+    description: int, primary key in ecommerce_order
+    tests:
+    - dbt_expectations.expect_column_to_exist
+  tests:
+  - dbt_expectations.expect_table_column_count_to_equal:
+      value: 5
+  - dbt_expectations.expect_table_row_count_to_equal_other_table:
+      compare_model: ref('stg__mitxpro__app__postgres__ecommerce_receipt')
+- name: int__mitxpro__ecommerce_order
+  columns:
+  - name: order_id
+    description: int, primary key representing a single xpro order
+    tests:
+    - dbt_expectations.expect_column_to_exist
+    - unique
+    - not_null
+  - name: order_state
+    description: string, order state. Options are "fulfilled", "failed", "created"
+      "refunded"
+    tests:
+    - dbt_expectations.expect_column_to_exist
+    - not_null
+    - accepted_values:
+        values: ['fulfilled', 'failed', 'created', 'refunded']
+  - name: order_total_price_paid
+    description: number, total order amount
+    tests:
+    - dbt_expectations.expect_column_to_exist
+    - not_null
+  - name: order_updated_on
+    description: timestamp, specifying when the order was most recently updated
+    tests:
+    - dbt_expectations.expect_column_to_exist
+    - not_null
+  - name: order_purchaser_user_id
+    description: int, primary key in users_user for the purchaser
+    tests:
+    - dbt_expectations.expect_column_to_exist
+    - not_null
+  - name: order_created_on
+    description: timestamp, specifying when the order was most created
+    tests:
+    - dbt_expectations.expect_column_to_exist
+    - not_null
+  tests:
+  - dbt_expectations.expect_table_column_count_to_equal:
+      value: 6
+  - dbt_expectations.expect_table_row_count_to_equal_other_table:
+      compare_model: ref('stg__mitxpro__app__postgres__ecommerce_order')
+- name: int__mitxpro__ecommerce_linerunselection
+  description: The course runs the user selected when purchsing the courseware object.
+    If the courseware object is a course run, there is one ecommerce_line_run_selection
+    record. If the courseware object is a program, there will be a record for each
+    course run from the program that is selected by the user
+  columns:
+  - name: linerunselection_id
+    description: int, primary key representing a line course run selection
+    tests:
+    - dbt_expectations.expect_column_to_exist
+    - not_null
+    - unique
+  - name: linerunselection_created_on
+    description: timestamp, specifying when the line course run selection was initially
+      created
+    tests:
+    - dbt_expectations.expect_column_to_exist
+  - name: linerunselection_updated_on
+    description: timestamp, specifying when the line course run selection was most
+      recently updated
+    tests:
+    - dbt_expectations.expect_column_to_exist
+    - not_null
+  - name: courserun_id
+    description: int, primary key in courses_courserun
+    tests:
+    - dbt_expectations.expect_column_to_exist
+    - not_null
+  - name: line_id
+    description: int, primary key in ecommerce_line
+    tests:
+    - dbt_expectations.expect_column_to_exist
+    - not_null
+  tests:
+  - dbt_expectations.expect_table_column_count_to_equal:
+      value: 5
+  - dbt_expectations.expect_compound_columns_to_be_unique:
+      column_list: ["line_id", "courserun_id"]
+  - dbt_expectations.expect_table_row_count_to_equal_other_table:
+      compare_model: ref('stg__mitxpro__app__postgres__ecommerce_linerunselection')
+- name: int__mitxpro__ecommerce_line
+  columns:
+  - name: line_id
+    description: int, primary key representing an ecommerce line
+    tests:
+    - dbt_expectations.expect_column_to_exist
+    - unique
+    - not_null
+  - name: order_id
+    description: int, foreign key in the orders_order table for the order that contains
+      the line
+    tests:
+    - dbt_expectations.expect_column_to_exist
+    - not_null
+  - name: line_created_on
+    description: timestamp, specifying when the line was initially created
+    tests:
+    - dbt_expectations.expect_column_to_exist
+  - name: line_updated_on
+    description: timestamp, specifying when the line was most recently updated
+    tests:
+    - dbt_expectations.expect_column_to_exist
+  - name: productversion_id
+    description: int, foreign key in the ecommerce_productversion table. Versioned
+      product
+    tests:
+    - dbt_expectations.expect_column_to_exist
+    - not_null
+  - name: courserun_id
+    description: int, primary key representing a single xPro course run
+    tests:
+    - dbt_expectations.expect_column_to_exist
+  - name: program_id
+    description: int, primary key representing a single xPro program
+    tests:
+    - dbt_expectations.expect_column_to_exist
+  - name: product_type
+    description: string, readable product type
+    tests:
+    - dbt_expectations.expect_column_to_exist
+    - not_null
+  - name: programrun_id
+    description: int, primary key representing a single MITxPro program run
+    tests:
+    - dbt_expectations.expect_column_to_exist
+  tests:
+  - dbt_expectations.expect_table_column_count_to_equal:
+      value: 10
+  - dbt_expectations.expect_table_row_count_to_equal_other_table:
+      compare_model: ref('stg__mitxpro__app__postgres__ecommerce_line')
+- name: int__mitxpro__ecommerce_productversion
+  columns:
+  - name: productversion_id
+    description: int, primary key representing an ecommerce product version
+    tests:
+    - dbt_expectations.expect_column_to_exist
+    - not_null
+    - unique
+  - name: productversion_created_on
+    description: timestamp, specifying when the product version was initially created
+    tests:
+    - dbt_expectations.expect_column_to_exist
+    - not_null
+  - name: productversion_updated_on
+    description: timestamp, specifying when the product version was most recently
+      updated
+    tests:
+    - dbt_expectations.expect_column_to_exist
+    - not_null
+  - name: productversion_price
+    description: numeric, the product price for this version
+    tests:
+    - dbt_expectations.expect_column_to_exist
+    - not_null
+  - name: productversion_description
+    description: string, product version discriptiom
+    tests:
+    - dbt_expectations.expect_column_to_exist
+    - not_null
+  - name: product_id
+    description: int, primary key in ecommerce_product
+    tests:
+    - dbt_expectations.expect_column_to_exist
+    - not_null
+  - name: productversion_readable_id
+    description: string, the readable_id field from the product object
+    tests:
+    - dbt_expectations.expect_column_to_exist
+  - name: productversion_requires_enrollment_code
+    description: boolean, true if the learner is required to enter an enrollment code
+      to enroll in the course or program at the checkout
+    tests:
+    - dbt_expectations.expect_column_to_exist
+    - not_null
+  tests:
+  - dbt_expectations.expect_table_column_count_to_equal:
+      value: 8
+  - dbt_expectations.expect_table_row_count_to_equal_other_table:
+      compare_model: ref('stg__mitxpro__app__postgres__ecommerce_productversion')
+- name: int__mitxpro__ecommerce_product
+  description: Intermediate model of xPro Products.
+  columns:
+  - name: product_id
+    description: int, sequential ID for ecommerce product
+    tests:
+    - not_null
+    - unique
+    - dbt_expectations.expect_column_to_exist
+  - name: product_is_active
+    description: boolean, whether the product is purchasable
+    tests:
+    - not_null
+    - dbt_expectations.expect_column_to_exist
+  - name: product_created_on
+    description: timestamp, the timestamp the product was created
+    tests:
+    - dbt_expectations.expect_column_to_exist
+  - name: product_updated_on
+    description: timestamp, the timestamp the product was last updated
+    tests:
+    - dbt_expectations.expect_column_to_exist
+  - name: product_is_visible_in_bulk_form
+    description: boolean, whether or not the product is purchasable through the bulk
+      form at /ecommerce/bulk
+    tests:
+    - dbt_expectations.expect_column_to_exist
+    - not_null
+  - name: courserun_id
+    description: int, primary key representing a single xPro course run
+    tests:
+    - dbt_expectations.expect_column_to_exist
+  - name: program_id
+    description: int, primary key representing a single xPro program
+    tests:
+    - dbt_expectations.expect_column_to_exist
+  - name: product_type
+    description: string, readable product type
+    tests:
+    - dbt_expectations.expect_column_to_exist
+    - not_null
+  - name: course_id
+    description: int, foreign key to courses_course representing a single xPro course
+    tests:
+    - dbt_expectations.expect_column_to_exist
+  tests:
+  - dbt_expectations.expect_table_column_count_to_equal:
+      value: 9
+  - dbt_expectations.expect_compound_columns_to_be_unique:
+      column_list: ["product_type", "program_id", "courserun_id"]
+  - dbt_expectations.expect_table_row_count_to_equal_other_table:
+      compare_model: ref('stg__mitxpro__app__postgres__ecommerce_product')
 - name: int__mitxpro__courserunenrollments
   description: Intermediate model of enrollments in xPro
   columns:

--- a/src/ol_dbt/models/intermediate/mitxpro/int__mitxpro__ecommerce_line.sql
+++ b/src/ol_dbt/models/intermediate/mitxpro/int__mitxpro__ecommerce_line.sql
@@ -1,0 +1,35 @@
+with lines as (
+    select *
+    from {{ ref('stg__mitxpro__app__postgres__ecommerce_line') }}
+)
+
+, productversions as (
+    select *
+    from {{ ref('stg__mitxpro__app__postgres__ecommerce_productversion') }}
+)
+
+, products as (
+    select *
+    from {{ ref('int__mitxpro__ecommerce_product') }}
+)
+
+, programrunlines as (
+    select *
+    from {{ ref('stg__mitxpro__app__postgres__ecommerce_programrunline') }}
+)
+
+select
+    lines.line_id
+    , lines.order_id
+    , lines.productversion_id
+    , lines.line_created_on
+    , lines.line_updated_on
+    , products.product_id
+    , products.courserun_id
+    , products.program_id
+    , products.product_type
+    , programrunlines.programrun_id
+from lines
+inner join productversions on productversions.productversion_id = lines.productversion_id
+inner join products on products.product_id = productversions.product_id
+left join programrunlines on programrunlines.line_id = lines.line_id

--- a/src/ol_dbt/models/intermediate/mitxpro/int__mitxpro__ecommerce_linerunselection.sql
+++ b/src/ol_dbt/models/intermediate/mitxpro/int__mitxpro__ecommerce_linerunselection.sql
@@ -1,0 +1,12 @@
+with linerunselection as (
+    select *
+    from {{ ref('stg__mitxpro__app__postgres__ecommerce_linerunselection') }}
+)
+
+select
+    linerunselection_id
+    , line_id
+    , courserun_id
+    , linerunselection_created_on
+    , linerunselection_updated_on
+from linerunselection

--- a/src/ol_dbt/models/intermediate/mitxpro/int__mitxpro__ecommerce_order.sql
+++ b/src/ol_dbt/models/intermediate/mitxpro/int__mitxpro__ecommerce_order.sql
@@ -1,0 +1,13 @@
+with orders as (
+    select *
+    from {{ ref('stg__mitxpro__app__postgres__ecommerce_order') }}
+)
+
+select
+    order_id
+    , order_state
+    , order_purchaser_user_id
+    , order_total_price_paid
+    , order_created_on
+    , order_updated_on
+from orders

--- a/src/ol_dbt/models/intermediate/mitxpro/int__mitxpro__ecommerce_product.sql
+++ b/src/ol_dbt/models/intermediate/mitxpro/int__mitxpro__ecommerce_product.sql
@@ -1,0 +1,42 @@
+with products as (
+    select *
+    from {{ ref('stg__mitxpro__app__postgres__ecommerce_product') }}
+)
+
+, contenttypes as (
+    select *
+    from {{ ref('stg__mitxpro__app__postgres__django_contenttype') }}
+)
+
+, courseruns as (
+    select *
+    from {{ ref('stg__mitxpro__app__postgres__courses_courserun') }}
+)
+
+, product_subquery as (
+    select
+        products.product_id
+        , products.product_is_active
+        , products.product_created_on
+        , products.product_updated_on
+        , products.product_is_visible_in_bulk_form
+        , case contenttypes.contenttype_full_name
+            when 'courses_courserun' then products.product_object_id
+        end as courserun_id
+        , case contenttypes.contenttype_full_name
+            when 'courses_program' then products.product_object_id
+        end as program_id
+        , case contenttypes.contenttype_full_name
+            when 'courses_courserun' then 'course run'
+            when 'courses_program' then 'program'
+            else contenttypes.contenttype_full_name
+        end as product_type
+    from products
+    inner join contenttypes on products.contenttype_id = contenttypes.contenttype_id
+)
+
+select
+    product_subquery.*
+    , courseruns.course_id
+from product_subquery
+left join courseruns on product_subquery.courserun_id = courseruns.courserun_id

--- a/src/ol_dbt/models/intermediate/mitxpro/int__mitxpro__ecommerce_productversion.sql
+++ b/src/ol_dbt/models/intermediate/mitxpro/int__mitxpro__ecommerce_productversion.sql
@@ -1,0 +1,15 @@
+with productversions as (
+    select *
+    from {{ ref('stg__mitxpro__app__postgres__ecommerce_productversion') }}
+)
+
+select
+    productversion_id
+    , productversion_readable_id
+    , productversion_price
+    , productversion_description
+    , product_id
+    , productversion_requires_enrollment_code
+    , productversion_updated_on
+    , productversion_created_on
+from productversions

--- a/src/ol_dbt/models/intermediate/mitxpro/int__mitxpro__ecommerce_receipt.sql
+++ b/src/ol_dbt/models/intermediate/mitxpro/int__mitxpro__ecommerce_receipt.sql
@@ -1,0 +1,12 @@
+with receipts as (
+    select *
+    from {{ ref('stg__mitxpro__app__postgres__ecommerce_receipt') }}
+)
+
+select
+    receipt_id
+    , receipt_created_on
+    , receipt_updated_on
+    , receipt_data
+    , order_id
+from receipts

--- a/src/ol_dbt/models/staging/mitxpro/_mitxpro__sources.yml
+++ b/src/ol_dbt/models/staging/mitxpro/_mitxpro__sources.yml
@@ -7,6 +7,245 @@ sources:
   database: 'ol_data_lake_{{ target.name }}'
   schema: 'ol_warehouse_{{ target.name }}_raw'
   tables:
+  - name: raw__xpro__app__postgres__ecommerce_receipt
+    description: Data returned from cybersource when a user pays for an order
+    columns:
+    - name: id
+      description: int, primary key representing a receipt
+      tests:
+      - dbt_expectations.expect_column_to_exist
+    - name: created_on
+      description: timestamp, specifying when the receipt was initially created
+      tests:
+      - dbt_expectations.expect_column_to_exist
+    - name: updated_on
+      description: timestamp, specifying when the receipt most recently updated
+      tests:
+      - dbt_expectations.expect_column_to_exist
+    - name: data
+      description: json, cybersource data for a payment
+      tests:
+      - dbt_expectations.expect_column_to_exist
+    - name: order_id
+      description: int, primary key in ecommerce_order
+      tests:
+      - dbt_expectations.expect_column_to_exist
+    tests:
+    - dbt_expectations.expect_table_column_count_to_equal:
+        value: 5
+  - name: raw__xpro__app__postgres__ecommerce_programrunline
+    description: The program run the user selected when purchsing a program.
+    columns:
+    - name: id
+      description: int, primary key representing a line program run selection
+      tests:
+      - dbt_expectations.expect_column_to_exist
+    - name: created_on
+      description: timestamp, specifying when the line program run selection was initially
+        created
+      tests:
+      - dbt_expectations.expect_column_to_exist
+    - name: updated_on
+      description: timestamp, specifying when the line program run selection was most
+        recently updated
+      tests:
+      - dbt_expectations.expect_column_to_exist
+    - name: program_run_id
+      description: int, primary key in courses_programrun
+      tests:
+      - dbt_expectations.expect_column_to_exist
+    - name: line_id
+      description: int, primary key in ecommerce_line
+      tests:
+      - dbt_expectations.expect_column_to_exist
+    tests:
+    - dbt_expectations.expect_table_column_count_to_equal:
+        value: 5
+  - name: raw__xpro__app__postgres__ecommerce_linerunselection
+    description: The course runs the user selected when purchsing the courseware object.
+      If the courseware object is a course run, there is one ecommerce_line_run_selection
+      record. If the courseware object is a program, there will be a record for each
+      course run from the program that is selected by the user
+    columns:
+    - name: id
+      description: int, primary key representing a line run selection
+      tests:
+      - dbt_expectations.expect_column_to_exist
+    - name: created_on
+      description: timestamp, specifying when the line run selection was initially
+        created
+      tests:
+      - dbt_expectations.expect_column_to_exist
+    - name: updated_on
+      description: timestamp, specifying when the line run selection was most recently
+        updated
+      tests:
+      - dbt_expectations.expect_column_to_exist
+    - name: run_id
+      description: int, primary key in courses_courserun
+      tests:
+      - dbt_expectations.expect_column_to_exist
+    - name: line_id
+      description: int, primary key in ecommerce_line
+      tests:
+      - dbt_expectations.expect_column_to_exist
+    tests:
+    - dbt_expectations.expect_table_column_count_to_equal:
+        value: 5
+  - name: raw__xpro__app__postgres__django_content_type
+    columns:
+    - name: id
+      description: int, sequential ID for the django model
+      tests:
+      - dbt_expectations.expect_column_to_exist
+    - name: model
+      description: string, the name of the django model
+      tests:
+      - dbt_expectations.expect_column_to_exist
+    - name: app_label
+      description: string, the  functional group the model belongs to
+      tests:
+      - dbt_expectations.expect_column_to_exist
+    tests:
+    - dbt_expectations.expect_table_column_count_to_equal:
+        value: 3
+  - name: raw__xpro__app__postgres__ecommerce_product
+    columns:
+    - name: id
+      description: int, primary key representing an ecommerce product
+      tests:
+      - dbt_expectations.expect_column_to_exist
+    - name: created_on
+      description: timestamp, specifying when the product was initially created
+      tests:
+      - dbt_expectations.expect_column_to_exist
+    - name: updated_on
+      description: timestamp, specifying when the product was most recently updated
+      tests:
+      - dbt_expectations.expect_column_to_exist
+    - name: content_type_id
+      description: int, primary key in django_contenttype of the courseware. It is
+        the key for courses_courserun or courses_program in production. There is a
+        record where the courseware is courses_course on rc
+      tests:
+      - dbt_expectations.expect_column_to_exist
+    - name: object_id
+      description: int, primary key in either courses_courserun or courses_program
+        table of the courseware
+      tests:
+      - dbt_expectations.expect_column_to_exist
+    - name: is_active
+      description: boolean, whether or not the product is currently purchasable
+      tests:
+      - dbt_expectations.expect_column_to_exist
+    - name: visible_in_bulk_form
+      description: boolean, whether or not the product is purchasable through the
+        bulk form at /ecommerce/bulk
+      tests:
+      - dbt_expectations.expect_column_to_exist
+    tests:
+    - dbt_expectations.expect_table_column_count_to_equal:
+        value: 7
+  - name: raw__xpro__app__postgres__ecommerce_productversion
+    columns:
+    - name: id
+      description: int, primary key representing an ecommerce product version
+      tests:
+      - dbt_expectations.expect_column_to_exist
+    - name: created_on
+      description: timestamp, specifying when the product version was initially created
+      tests:
+      - dbt_expectations.expect_column_to_exist
+    - name: updated_on
+      description: timestamp, specifying when the product version was most recently
+        updated
+      tests:
+      - dbt_expectations.expect_column_to_exist
+    - name: price
+      description: numeric, the product price for this version
+      tests:
+      - dbt_expectations.expect_column_to_exist
+    - name: description
+      description: string, product version discriptiom
+      tests:
+      - dbt_expectations.expect_column_to_exist
+    - name: product_id
+      description: int, primary key in ecommerce_product
+      tests:
+      - dbt_expectations.expect_column_to_exist
+    - name: text_id
+      description: string, the readable_id field from the product object
+      tests:
+      - dbt_expectations.expect_column_to_exist
+    - name: requires_enrollment_code
+      description: boolean, true if the learner is required to enter an enrollment
+        code to enroll in the course or program at the checkout
+      tests:
+      - dbt_expectations.expect_column_to_exist
+    tests:
+    - dbt_expectations.expect_table_column_count_to_equal:
+        value: 8
+  - name: raw__xpro__app__postgres__ecommerce_line
+    columns:
+    - name: id
+      description: int, primary key representing an ecommerce line
+      tests:
+      - dbt_expectations.expect_column_to_exist
+    - name: created_on
+      description: timestamp, specifying when the line was initially created
+      tests:
+      - dbt_expectations.expect_column_to_exist
+    - name: updated_on
+      description: timestamp, specifying when the line was most recently updated
+      tests:
+      - dbt_expectations.expect_column_to_exist
+    - name: quantity
+      description: int, quantitiy ordered, currently always 1
+      tests:
+      - dbt_expectations.expect_column_to_exist
+    - name: order_id
+      description: int, foreign key in the orders_order table for the order that contains
+        the line
+      tests:
+      - dbt_expectations.expect_column_to_exist
+    - name: product_version_id
+      description: int stored as string, foreign key in the ecommerce_productversion
+        table. Versioned product
+      tests:
+      - dbt_expectations.expect_column_to_exist
+    tests:
+    - dbt_expectations.expect_table_column_count_to_equal:
+        value: 6
+  - name: raw__xpro__app__postgres__ecommerce_order
+    columns:
+    - name: id
+      description: int, primary key representing a single xpro order
+      tests:
+      - dbt_expectations.expect_column_to_exist
+    - name: created_on
+      description: timestamp, specifying when the order was initially created
+      tests:
+      - dbt_expectations.expect_column_to_exist
+    - name: updated_on
+      description: timestamp, specifying when the order was most recently updated
+      tests:
+      - dbt_expectations.expect_column_to_exist
+    - name: status
+      description: string, order state. Options are "fulfilled", "failed", "created"
+        "refunded"
+      tests:
+      - dbt_expectations.expect_column_to_exist
+    - name: total_price_paid
+      description: number, total order amount
+      tests:
+      - dbt_expectations.expect_column_to_exist
+    - name: purchaser_id
+      description: int, primary key in users_user for the purchaser
+      tests:
+      - dbt_expectations.expect_column_to_exist
+    tests:
+    - dbt_expectations.expect_table_column_count_to_equal:
+        value: 6
   - name: raw__xpro__app__postgres__courses_courserunenrollment
     columns:
     - name: id

--- a/src/ol_dbt/models/staging/mitxpro/_stg_mitxpro__models.yml
+++ b/src/ol_dbt/models/staging/mitxpro/_stg_mitxpro__models.yml
@@ -2,6 +2,290 @@
 version: 2
 
 models:
+- name: stg__mitxpro__app__postgres__ecommerce_receipt
+  description: Data returned from cybersource when a user pays for an order
+  columns:
+  - name: receipt_id
+    description: int, primary key representing a receipt
+    tests:
+    - dbt_expectations.expect_column_to_exist
+    - not_null
+    - unique
+  - name: receipt_created_on
+    description: timestamp, specifying when the receipt was initially created
+    tests:
+    - dbt_expectations.expect_column_to_exist
+    - not_null
+  - name: receipt_updated_on
+    description: timestamp, specifying when the receipt most recently updated
+    tests:
+    - dbt_expectations.expect_column_to_exist
+    - not_null
+  - name: receipt_data
+    description: json, cybersource data for a payment
+    tests:
+    - dbt_expectations.expect_column_to_exist
+    - not_null
+  - name: order_id
+    description: int, primary key in ecommerce_order
+    tests:
+    - dbt_expectations.expect_column_to_exist
+  tests:
+  - dbt_expectations.expect_table_column_count_to_equal:
+      value: 5
+- name: stg__mitxpro__app__postgres__ecommerce_programrunline
+  description: The program run the user selected when purchsing a program.
+  columns:
+  - name: programrunline_id
+    description: int, primary key representing a line run selection
+    tests:
+    - dbt_expectations.expect_column_to_exist
+    - not_null
+    - unique
+  - name: programrunline_created_on
+    description: timestamp, specifying when the line program run selection was initially
+      created
+    tests:
+    - dbt_expectations.expect_column_to_exist
+  - name: programrunline_updated_on
+    description: timestamp, specifying when the line program run selection was most
+      recently updated
+    tests:
+    - dbt_expectations.expect_column_to_exist
+    - not_null
+  - name: programrun_id
+    description: int, primary key in courses_programrun
+    tests:
+    - dbt_expectations.expect_column_to_exist
+    - not_null
+  - name: line_id
+    description: int, primary key in ecommerce_line
+    tests:
+    - dbt_expectations.expect_column_to_exist
+    - not_null
+  tests:
+  - dbt_expectations.expect_table_column_count_to_equal:
+      value: 5
+- name: stg__mitxpro__app__postgres__ecommerce_linerunselection
+  description: The course runs the user selected when purchsing the courseware object.
+    If the courseware object is a course run, there is one ecommerce_line_run_selection
+    record. If the courseware object is a program, there will be a record for each
+    course run from the program that is selected by the user
+  columns:
+  - name: linerunselection_id
+    description: int, primary key representing a line course run selection
+    tests:
+    - dbt_expectations.expect_column_to_exist
+    - not_null
+    - unique
+  - name: linerunselection_created_on
+    description: timestamp, specifying when the line course run selection was initially
+      created
+    tests:
+    - dbt_expectations.expect_column_to_exist
+  - name: linerunselection_updated_on
+    description: timestamp, specifying when the line course run selection was most
+      recently updated
+    tests:
+    - dbt_expectations.expect_column_to_exist
+    - not_null
+  - name: courserun_id
+    description: int, primary key in courses_courserun
+    tests:
+    - dbt_expectations.expect_column_to_exist
+    - not_null
+  - name: line_id
+    description: int, primary key in ecommerce_line
+    tests:
+    - dbt_expectations.expect_column_to_exist
+    - not_null
+  tests:
+  - dbt_expectations.expect_table_column_count_to_equal:
+      value: 5
+  - dbt_expectations.expect_compound_columns_to_be_unique:
+      column_list: ["line_id", "courserun_id"]
+- name: stg__mitxpro__app__postgres__django_contenttype
+  columns:
+  - name: contenttype_id
+    description: int, sequential ID for the django model
+    tests:
+    - dbt_expectations.expect_column_to_exist
+    - unique
+    - not_null
+  - name: contenttype_full_name
+    description: string, name for django model. A combination of the models name and
+      functional group
+    tests:
+    - dbt_expectations.expect_column_to_exist
+    - unique
+    - not_null
+  tests:
+  - dbt_expectations.expect_table_column_count_to_equal:
+      value: 2
+- name: stg__mitxpro__app__postgres__ecommerce_product
+  columns:
+  - name: product_id
+    description: int, primary key representing an ecommerce product
+    tests:
+    - dbt_expectations.expect_column_to_exist
+    - not_null
+    - unique
+  - name: product_created_on
+    description: timestamp, specifying when the product was initially created
+    tests:
+    - dbt_expectations.expect_column_to_exist
+    - not_null
+  - name: product_updated_on
+    description: timestamp, specifying when the product was most recently updated
+    tests:
+    - dbt_expectations.expect_column_to_exist
+    - not_null
+  - name: contenttype_id
+    description: int, primary key in django_contenttype of the courseware. It is the
+      key for courses_courserun or courses_program in production. There is a record
+      where the courseware is courses_course on rc
+    tests:
+    - dbt_expectations.expect_column_to_exist
+    - not_null
+  - name: product_object_id
+    description: int, primary key in either courses_courserun or courses_program table
+      of the courseware
+    tests:
+    - dbt_expectations.expect_column_to_exist
+    - not_null
+  - name: product_is_active
+    description: boolean, whether or not the product is currently purchasable
+    tests:
+    - dbt_expectations.expect_column_to_exist
+    - not_null
+  - name: product_is_visible_in_bulk_form
+    description: boolean, whether or not the product is purchasable through the bulk
+      form at /ecommerce/bulk
+    tests:
+    - dbt_expectations.expect_column_to_exist
+    - not_null
+  tests:
+  - dbt_expectations.expect_table_column_count_to_equal:
+      value: 7
+  - dbt_expectations.expect_compound_columns_to_be_unique:
+      column_list: ["contenttype_id", "product_object_id"]
+- name: stg__mitxpro__app__postgres__ecommerce_productversion
+  columns:
+  - name: productversion_id
+    description: int, primary key representing an ecommerce product version
+    tests:
+    - dbt_expectations.expect_column_to_exist
+    - not_null
+    - unique
+  - name: productversion_created_on
+    description: timestamp, specifying when the product version was initially created
+    tests:
+    - dbt_expectations.expect_column_to_exist
+    - not_null
+  - name: productversion_updated_on
+    description: timestamp, specifying when the product version was most recently
+      updated
+    tests:
+    - dbt_expectations.expect_column_to_exist
+    - not_null
+  - name: productversion_price
+    description: numeric, the product price for this version
+    tests:
+    - dbt_expectations.expect_column_to_exist
+    - not_null
+  - name: productversion_description
+    description: string, product version discriptiom
+    tests:
+    - dbt_expectations.expect_column_to_exist
+    - not_null
+  - name: product_id
+    description: int, primary key in ecommerce_product
+    tests:
+    - dbt_expectations.expect_column_to_exist
+    - not_null
+  - name: productversion_readable_id
+    description: string, the readable_id field from the product object
+    tests:
+    - dbt_expectations.expect_column_to_exist
+  - name: productversion_requires_enrollment_code
+    description: boolean, true if the learner is required to enter an enrollment code
+      to enroll in the course or program at the checkout
+    tests:
+    - dbt_expectations.expect_column_to_exist
+    - not_null
+  tests:
+  - dbt_expectations.expect_table_column_count_to_equal:
+      value: 8
+- name: stg__mitxpro__app__postgres__ecommerce_line
+  columns:
+  - name: line_id
+    description: int, primary key representing an ecommerce line
+    tests:
+    - dbt_expectations.expect_column_to_exist
+    - unique
+    - not_null
+  - name: order_id
+    description: int, foreign key in the orders_order table for the order that contains
+      the line
+    tests:
+    - dbt_expectations.expect_column_to_exist
+    - not_null
+  - name: line_created_on
+    description: timestamp, specifying when the line was initially created
+    tests:
+    - dbt_expectations.expect_column_to_exist
+  - name: line_updated_on
+    description: timestamp, specifying when the line was most recently updated
+    tests:
+    - dbt_expectations.expect_column_to_exist
+  - name: productversion_id
+    description: int, foreign key in the ecommerce_productversion table. Versioned
+      product
+    tests:
+    - dbt_expectations.expect_column_to_exist
+    - not_null
+  tests:
+  - dbt_expectations.expect_table_column_count_to_equal:
+      value: 5
+- name: stg__mitxpro__app__postgres__ecommerce_order
+  columns:
+  - name: order_id
+    description: int, primary key representing a single xpro order
+    tests:
+    - dbt_expectations.expect_column_to_exist
+    - unique
+    - not_null
+  - name: order_state
+    description: string, order state. Options are "fulfilled", "failed", "created"
+      "refunded"
+    tests:
+    - dbt_expectations.expect_column_to_exist
+    - not_null
+    - accepted_values:
+        values: ['fulfilled', 'failed', 'created', 'refunded']
+  - name: order_total_price_paid
+    description: number, total order amount
+    tests:
+    - dbt_expectations.expect_column_to_exist
+    - not_null
+  - name: order_updated_on
+    description: timestamp, specifying when the order was most recently updated
+    tests:
+    - dbt_expectations.expect_column_to_exist
+    - not_null
+  - name: order_purchaser_user_id
+    description: int, primary key in users_user for the purchaser
+    tests:
+    - dbt_expectations.expect_column_to_exist
+    - not_null
+  - name: order_created_on
+    description: timestamp, specifying when the order was most created
+    tests:
+    - dbt_expectations.expect_column_to_exist
+    - not_null
+  tests:
+  - dbt_expectations.expect_table_column_count_to_equal:
+      value: 6
 - name: stg__mitxpro__app__postgres__users_user
   columns:
   - name: user_id

--- a/src/ol_dbt/models/staging/mitxpro/stg__mitxpro__app__postgres__django_contenttype.sql
+++ b/src/ol_dbt/models/staging/mitxpro/stg__mitxpro__app__postgres__django_contenttype.sql
@@ -1,0 +1,20 @@
+with source as (
+
+    select * from {{ source('ol_warehouse_raw_data', 'raw__xpro__app__postgres__django_content_type') }}
+
+)
+
+, renamed as (
+
+    select
+        id as contenttype_id
+        , concat_ws(
+            '_'
+            , app_label
+            , model
+        ) as contenttype_full_name
+    from source
+
+)
+
+select * from renamed

--- a/src/ol_dbt/models/staging/mitxpro/stg__mitxpro__app__postgres__ecommerce_line.sql
+++ b/src/ol_dbt/models/staging/mitxpro/stg__mitxpro__app__postgres__ecommerce_line.sql
@@ -1,0 +1,19 @@
+with source as (
+
+    select * from {{ source('ol_warehouse_raw_data', 'raw__xpro__app__postgres__ecommerce_line') }}
+
+)
+
+, renamed as (
+
+    select
+        id as line_id
+        , order_id
+        , product_version_id as productversion_id
+        , to_iso8601(from_iso8601_timestamp(created_on)) as line_created_on
+        , to_iso8601(from_iso8601_timestamp(updated_on)) as line_updated_on
+    from source
+
+)
+
+select * from renamed

--- a/src/ol_dbt/models/staging/mitxpro/stg__mitxpro__app__postgres__ecommerce_linerunselection.sql
+++ b/src/ol_dbt/models/staging/mitxpro/stg__mitxpro__app__postgres__ecommerce_linerunselection.sql
@@ -1,0 +1,19 @@
+with source as (
+
+    select * from {{ source('ol_warehouse_raw_data', 'raw__xpro__app__postgres__ecommerce_linerunselection') }}
+
+)
+
+, renamed as (
+
+    select
+        id as linerunselection_id
+        , line_id
+        , run_id as courserun_id
+        , to_iso8601(from_iso8601_timestamp(created_on)) as linerunselection_created_on
+        , to_iso8601(from_iso8601_timestamp(updated_on)) as linerunselection_updated_on
+    from source
+
+)
+
+select * from renamed

--- a/src/ol_dbt/models/staging/mitxpro/stg__mitxpro__app__postgres__ecommerce_order.sql
+++ b/src/ol_dbt/models/staging/mitxpro/stg__mitxpro__app__postgres__ecommerce_order.sql
@@ -1,0 +1,18 @@
+with source as (
+
+    select * from {{ source('ol_warehouse_raw_data', 'raw__xpro__app__postgres__ecommerce_order') }}
+
+)
+
+, renamed as (
+    select
+        id as order_id
+        , status as order_state
+        , total_price_paid as order_total_price_paid
+        , purchaser_id as order_purchaser_user_id
+        , to_iso8601(from_iso8601_timestamp(updated_on)) as order_updated_on
+        , to_iso8601(from_iso8601_timestamp(created_on)) as order_created_on
+    from source
+)
+
+select * from renamed

--- a/src/ol_dbt/models/staging/mitxpro/stg__mitxpro__app__postgres__ecommerce_product.sql
+++ b/src/ol_dbt/models/staging/mitxpro/stg__mitxpro__app__postgres__ecommerce_product.sql
@@ -1,0 +1,21 @@
+with source as (
+
+    select * from {{ source('ol_warehouse_raw_data', 'raw__xpro__app__postgres__ecommerce_product') }}
+
+)
+
+, renamed as (
+
+    select
+        id as product_id
+        , is_active as product_is_active
+        , object_id as product_object_id
+        , visible_in_bulk_form as product_is_visible_in_bulk_form
+        , content_type_id as contenttype_id
+        , to_iso8601(from_iso8601_timestamp(updated_on)) as product_updated_on
+        , to_iso8601(from_iso8601_timestamp(created_on)) as product_created_on
+    from source
+
+)
+
+select * from renamed

--- a/src/ol_dbt/models/staging/mitxpro/stg__mitxpro__app__postgres__ecommerce_productversion.sql
+++ b/src/ol_dbt/models/staging/mitxpro/stg__mitxpro__app__postgres__ecommerce_productversion.sql
@@ -1,0 +1,22 @@
+with source as (
+
+    select * from {{ source('ol_warehouse_raw_data', 'raw__xpro__app__postgres__ecommerce_productversion') }}
+
+)
+
+, renamed as (
+
+    select
+        id as productversion_id
+        , text_id as productversion_readable_id
+        , price as productversion_price
+        , description as productversion_description
+        , product_id
+        , requires_enrollment_code as productversion_requires_enrollment_code
+        , to_iso8601(from_iso8601_timestamp(updated_on)) as productversion_updated_on
+        , to_iso8601(from_iso8601_timestamp(created_on)) as productversion_created_on
+    from source
+
+)
+
+select * from renamed

--- a/src/ol_dbt/models/staging/mitxpro/stg__mitxpro__app__postgres__ecommerce_programrunline.sql
+++ b/src/ol_dbt/models/staging/mitxpro/stg__mitxpro__app__postgres__ecommerce_programrunline.sql
@@ -1,0 +1,19 @@
+with source as (
+
+    select * from {{ source('ol_warehouse_raw_data', 'raw__xpro__app__postgres__ecommerce_programrunline') }}
+
+)
+
+, renamed as (
+
+    select
+        id as programrunline_id
+        , line_id
+        , program_run_id as programrun_id
+        , to_iso8601(from_iso8601_timestamp(created_on)) as programrunline_created_on
+        , to_iso8601(from_iso8601_timestamp(updated_on)) as programrunline_updated_on
+    from source
+
+)
+
+select * from renamed

--- a/src/ol_dbt/models/staging/mitxpro/stg__mitxpro__app__postgres__ecommerce_receipt.sql
+++ b/src/ol_dbt/models/staging/mitxpro/stg__mitxpro__app__postgres__ecommerce_receipt.sql
@@ -1,0 +1,19 @@
+with source as (
+
+    select * from {{ source('ol_warehouse_raw_data', 'raw__xpro__app__postgres__ecommerce_receipt') }}
+
+)
+
+, renamed as (
+
+    select
+        id as receipt_id
+        , order_id
+        , data as receipt_data
+        , to_iso8601(from_iso8601_timestamp(created_on)) as receipt_created_on
+        , to_iso8601(from_iso8601_timestamp(updated_on)) as receipt_updated_on
+    from source
+
+)
+
+select * from renamed


### PR DESCRIPTION
## Description
This is the first pr of https://github.com/mitodl/ol-data-platform/issues/500

## Motivation and Context
This pr adds
int__mitxpro__ecommerce_receipt
int__mitxpro__ecommerce_order
int__mitxpro__ecommerce_linerunselection
int__mitxpro__ecommerce_line
int__mitxpro__ecommerce_productversion
int__mitxpro__ecommerce_product


stg__mitxpro__app__postgres__ecommerce_receipt
stg__mitxpro__app__postgres__ecommerce_programrunline
stg__mitxpro__app__postgres__ecommerce_linerunselection
stg__mitxpro__app__postgres__django_contenttype
stg__mitxpro__app__postgres__ecommerce_product
stg__mitxpro__app__postgres__ecommerce_productversion
stg__mitxpro__app__postgres__ecommerce_line
stg__mitxpro__app__postgres__ecommerce_order
## How Has This Been Tested?
dbt run and dbt test

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Enhancement (improves on existing behavior)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project. (Did you install and run the pre-commit hooks?)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
