### PR TITLE
xpro ecommerce basket

### DIFF
--- a/src/ol_dbt/models/intermediate/mitxpro/_int_mitxpro__models.yml
+++ b/src/ol_dbt/models/intermediate/mitxpro/_int_mitxpro__models.yml
@@ -2,6 +2,121 @@
 version: 2
 
 models:
+- name: int__mitxpro__ecommerce_basketrunselection
+  description: The course runs the user selected for the basket items in their basket.
+    If the basket item is a course run, there is one ecommerce_basketrunselection
+    record. If the basket item  is a program, there will be a record for each course
+    run from the program that is selected by the user. Once the user completes the
+    purchase, these records become records in ecommerce_linerunselection
+  columns:
+  - name: basketrunselection_id
+    description: int, primary key representing a basket course run selection
+    tests:
+    - dbt_expectations.expect_column_to_exist
+    - not_null
+    - unique
+  - name: basketrunselection_created_on
+    description: timestamp, specifying when the basket course run selection was initially
+      created
+    tests:
+    - dbt_expectations.expect_column_to_exist
+  - name: basketrunselection_updated_on
+    description: timestamp, specifying when the basket course run selection was most
+      recently updated
+    tests:
+    - dbt_expectations.expect_column_to_exist
+    - not_null
+  - name: courserun_id
+    description: int, primary key in courses_courserun
+    tests:
+    - dbt_expectations.expect_column_to_exist
+    - not_null
+  - name: basket_id
+    description: int, primary key in ecommerce_basket
+    tests:
+    - dbt_expectations.expect_column_to_exist
+    - not_null
+  - name: user_id
+    description: int, foreign key to the users_user table
+    tests:
+    - dbt_expectations.expect_column_to_exist
+    - not_null
+  tests:
+  - dbt_expectations.expect_table_column_count_to_equal:
+      value: 6
+  - dbt_expectations.expect_compound_columns_to_be_unique:
+      column_list: ["basket_id", "courserun_id"]
+  - dbt_expectations.expect_table_row_count_to_equal_other_table:
+      compare_model: ref('stg__mitxpro__app__postgres__ecommerce_basketrunselection')
+- name: int__mitxpro__ecommerce_basketitem
+  description: The ecommerce_products that the user has in their basket but has not
+    purchased yet
+  columns:
+  - name: basketitem_id
+    description: int, primary key representing a item in a user's basket
+    tests:
+    - dbt_expectations.expect_column_to_exist
+  - name: basketitem_created_on
+    description: timestamp, specifying when the basket item was initially created
+    tests:
+    - dbt_expectations.expect_column_to_exist
+  - name: basketitem_updated_on
+    description: timestamp, specifying when the basket item was most recently updated
+    tests:
+    - dbt_expectations.expect_column_to_exist
+  - name: basketitem_quantity
+    description: int, quantitiy of the item. Always 1
+    tests:
+    - dbt_expectations.expect_column_to_exist
+  - name: basket_id
+    description: int, foreign key referencing ecommerce_basket
+    tests:
+    - dbt_expectations.expect_column_to_exist
+  - name: product_id
+    description: int, foreign key referencing ecommerce_product
+    tests:
+    - dbt_expectations.expect_column_to_exist
+  - name: programrun_id
+    description: int, foreign key referencing courses_programrun, present if the product
+      is a program
+    tests:
+    - dbt_expectations.expect_column_to_exist
+  - name: user_id
+    description: int, foreign key to the users_user table
+    tests:
+    - dbt_expectations.expect_column_to_exist
+    - not_null
+  tests:
+  - dbt_expectations.expect_table_column_count_to_equal:
+      value: 8
+  - dbt_expectations.expect_table_row_count_to_equal_other_table:
+      compare_model: ref('stg__mitxpro__app__postgres__ecommerce_basketitem')
+- name: int__mitxpro__ecommerce_basket
+  description: Checkout basket that contains courseware that a users wants to purchase
+    but has not purchased yet
+  columns:
+  - name: basket_id
+    description: int, primary key representing a user basket
+    tests:
+    - dbt_expectations.expect_column_to_exist
+  - name: basket_created_on
+    description: timestamp, specifying when the basket was initially created
+    tests:
+    - dbt_expectations.expect_column_to_exist
+  - name: basket_updated_on
+    description: timestamp, specifying when the basket was most recently updated
+    tests:
+    - dbt_expectations.expect_column_to_exist
+  - name: user_id
+    description: int, foreign key to the users_user table
+    tests:
+    - dbt_expectations.expect_column_to_exist
+    - unique
+  tests:
+  - dbt_expectations.expect_table_column_count_to_equal:
+      value: 4
+  - dbt_expectations.expect_table_row_count_to_equal_other_table:
+      compare_model: ref('stg__mitxpro__app__postgres__ecommerce_basket')
 - name: int__mitxpro__ecommerce_receipt
   description: Data returned from cybersource when a user pays for an order
   columns:

--- a/src/ol_dbt/models/intermediate/mitxpro/int__mitxpro__ecommerce_basket.sql
+++ b/src/ol_dbt/models/intermediate/mitxpro/int__mitxpro__ecommerce_basket.sql
@@ -1,0 +1,11 @@
+with source as (
+    select *
+    from {{ ref('stg__mitxpro__app__postgres__ecommerce_basket') }}
+)
+
+select
+    basket_id
+    , user_id
+    , basket_created_on
+    , basket_updated_on
+from source

--- a/src/ol_dbt/models/intermediate/mitxpro/int__mitxpro__ecommerce_basketitem.sql
+++ b/src/ol_dbt/models/intermediate/mitxpro/int__mitxpro__ecommerce_basketitem.sql
@@ -1,0 +1,21 @@
+with basketitem as (
+    select *
+    from {{ ref('stg__mitxpro__app__postgres__ecommerce_basketitem') }}
+)
+
+, basket as (
+    select *
+    from {{ ref('stg__mitxpro__app__postgres__ecommerce_basket') }}
+)
+
+select
+    basketitem.basketitem_id
+    , basketitem.basketitem_quantity
+    , basketitem.basket_id
+    , basketitem.basketitem_created_on
+    , basketitem.product_id
+    , basketitem.basketitem_updated_on
+    , basketitem.programrun_id
+    , basket.user_id
+from basketitem
+inner join basket on basketitem.basket_id = basket.basket_id

--- a/src/ol_dbt/models/intermediate/mitxpro/int__mitxpro__ecommerce_basketrunselection.sql
+++ b/src/ol_dbt/models/intermediate/mitxpro/int__mitxpro__ecommerce_basketrunselection.sql
@@ -1,0 +1,19 @@
+with basketrunselection as (
+    select *
+    from {{ ref('stg__mitxpro__app__postgres__ecommerce_basketrunselection') }}
+)
+
+, basket as (
+    select *
+    from {{ ref('stg__mitxpro__app__postgres__ecommerce_basket') }}
+)
+
+select
+    basketrunselection.basketrunselection_id
+    , basketrunselection.basket_id
+    , basketrunselection.courserun_id
+    , basketrunselection.basketrunselection_created_on
+    , basketrunselection.basketrunselection_updated_on
+    , basket.user_id
+from basketrunselection
+inner join basket on basketrunselection.basket_id = basket.basket_id

--- a/src/ol_dbt/models/staging/mitxpro/_mitxpro__sources.yml
+++ b/src/ol_dbt/models/staging/mitxpro/_mitxpro__sources.yml
@@ -7,6 +7,128 @@ sources:
   database: 'ol_data_lake_{{ target.name }}'
   schema: 'ol_warehouse_{{ target.name }}_raw'
   tables:
+  - name: raw__xpro__app__postgres__ecommerce_orderaudit
+    columns:
+    - name: id
+      description: int, primary key representing a change to the orders table
+      tests:
+      - dbt_expectations.expect_column_to_exist
+    - name: created_on
+      description: timestamp, specifying when the order audit was initially created
+      tests:
+      - dbt_expectations.expect_column_to_exist
+    - name: updated_on
+      description: timestamp, specifying when the order audit was most recently updated
+      tests:
+      - dbt_expectations.expect_column_to_exist
+    - name: data_before
+      description: json, jsonified order object before the change
+      tests:
+      - dbt_expectations.expect_column_to_exist
+    - name: data_after
+      description: json, jsonified order object after the change
+      tests:
+      - dbt_expectations.expect_column_to_exist
+    - name: acting_user_id
+      description: int, reference to users_user table, the user who made the change
+      tests:
+      - dbt_expectations.expect_column_to_exist
+    - name: order_id
+      description: int, reference to ecommerce_order
+      tests:
+      - dbt_expectations.expect_column_to_exist
+    tests:
+    - dbt_expectations.expect_table_column_count_to_equal:
+        value: 7
+  - name: raw__xpro__app__postgres__ecommerce_courserunselection
+    description: The course runs the user selected for the basket items in their basket.
+      If the basket item is a course run, there is one ecommerce_courserunselection
+      record. If the basket item  is a program, there will be a record for each course
+      run from the program that is selected by the user. Once the user completes the
+      purchase, these records become records in ecommerce_linerunselection
+    columns:
+    - name: id
+      description: int, primary key representing a basket course run selection
+      tests:
+      - dbt_expectations.expect_column_to_exist
+    - name: created_on
+      description: timestamp, specifying when the basket course run selection was
+        initially created
+      tests:
+      - dbt_expectations.expect_column_to_exist
+    - name: updated_on
+      description: timestamp, specifying when the basket course run selection was
+        most recently updated
+      tests:
+      - dbt_expectations.expect_column_to_exist
+    - name: run_id
+      description: int, primary key in courses_courserun
+      tests:
+      - dbt_expectations.expect_column_to_exist
+    - name: basket_id
+      description: int, primary key in ecommerce_basket
+      tests:
+      - dbt_expectations.expect_column_to_exist
+    tests:
+    - dbt_expectations.expect_table_column_count_to_equal:
+        value: 5
+  - name: raw__xpro__app__postgres__ecommerce_basketitem
+    description: The ecommerce_products that the user has in their basket but has
+      not purchased yet
+    columns:
+    - name: id
+      description: int, primary key representing a item in a user's basket
+      tests:
+      - dbt_expectations.expect_column_to_exist
+    - name: created_on
+      description: timestamp, specifying when the basket item was initially created
+      tests:
+      - dbt_expectations.expect_column_to_exist
+    - name: updated_on
+      description: timestamp, specifying when the basket item was most recently updated
+      tests:
+      - dbt_expectations.expect_column_to_exist
+    - name: quantity
+      description: int, quantitiy of the item. Always 1
+      tests:
+      - dbt_expectations.expect_column_to_exist
+    - name: basket_id
+      description: int, foreign key referencing ecommerce_basket
+      tests:
+      - dbt_expectations.expect_column_to_exist
+    - name: product_id
+      description: int, foreign key referencing ecommerce_product
+      tests:
+      - dbt_expectations.expect_column_to_exist
+    - name: program_run_id
+      description: int, foreign key referencing courses_programrun, present if the
+        product is a program
+      tests:
+      - dbt_expectations.expect_column_to_exist
+    tests:
+    - dbt_expectations.expect_table_column_count_to_equal:
+        value: 7
+  - name: raw__xpro__app__postgres__ecommerce_basket
+    columns:
+    - name: id
+      description: int, primary key representing a user basket
+      tests:
+      - dbt_expectations.expect_column_to_exist
+    - name: created_on
+      description: timestamp, specifying when the basket was initially created
+      tests:
+      - dbt_expectations.expect_column_to_exist
+    - name: updated_on
+      description: timestamp, specifying when the basket was most recently updated
+      tests:
+      - dbt_expectations.expect_column_to_exist
+    - name: user_id
+      description: int, foreign key to the users_user table
+      tests:
+      - dbt_expectations.expect_column_to_exist
+    tests:
+    - dbt_expectations.expect_table_column_count_to_equal:
+        value: 4
   - name: raw__xpro__app__postgres__ecommerce_receipt
     description: Data returned from cybersource when a user pays for an order
     columns:

--- a/src/ol_dbt/models/staging/mitxpro/_stg_mitxpro__models.yml
+++ b/src/ol_dbt/models/staging/mitxpro/_stg_mitxpro__models.yml
@@ -2,6 +2,138 @@
 version: 2
 
 models:
+- name: stg__mitxpro__app__postgres__ecommerce_orderaudit
+  columns:
+  - name: orderaudit_id
+    description: int, primary key representing a change to the orders table
+    tests:
+    - dbt_expectations.expect_column_to_exist
+  - name: orderaudit_created_on
+    description: timestamp, specifying when the order audit was initially created
+    tests:
+    - dbt_expectations.expect_column_to_exist
+  - name: orderaudit_updated_on
+    description: timestamp, specifying when the order audit was most recently updated
+    tests:
+    - dbt_expectations.expect_column_to_exist
+  - name: orderaudit_data_before
+    description: json, jsonified order object before the change
+    tests:
+    - dbt_expectations.expect_column_to_exist
+  - name: orderaudit_data_after
+    description: json, jsonified order object after the change
+    tests:
+    - dbt_expectations.expect_column_to_exist
+  - name: orderaudit_acting_user_id
+    description: int, reference to users_user table, the user who made the change
+    tests:
+    - dbt_expectations.expect_column_to_exist
+  - name: order_id
+    description: int, reference to ecommerce_order
+    tests:
+    - dbt_expectations.expect_column_to_exist
+  tests:
+  - dbt_expectations.expect_table_column_count_to_equal:
+      value: 7
+- name: stg__mitxpro__app__postgres__ecommerce_basketrunselection
+  description: The course runs the user selected for the basket items in their basket.
+    If the basket item is a course run, there is one ecommerce_basketrunselection
+    record. If the basket item  is a program, there will be a record for each course
+    run from the program that is selected by the user. Once the user completes the
+    purchase, these records become records in the commerce_linerunselection
+  columns:
+  - name: basketrunselection_id
+    description: int, primary key representing a basket course run selection
+    tests:
+    - dbt_expectations.expect_column_to_exist
+    - not_null
+    - unique
+  - name: basketrunselection_created_on
+    description: timestamp, specifying when the basket course run selection was initially
+      created
+    tests:
+    - dbt_expectations.expect_column_to_exist
+  - name: basketrunselection_updated_on
+    description: timestamp, specifying when the basket course run selection was most
+      recently updated
+    tests:
+    - dbt_expectations.expect_column_to_exist
+    - not_null
+  - name: courserun_id
+    description: int, primary key in courses_courserun
+    tests:
+    - dbt_expectations.expect_column_to_exist
+    - not_null
+  - name: basket_id
+    description: int, primary key in ecommerce_basket
+    tests:
+    - dbt_expectations.expect_column_to_exist
+    - not_null
+  tests:
+  - dbt_expectations.expect_table_column_count_to_equal:
+      value: 5
+  - dbt_expectations.expect_compound_columns_to_be_unique:
+      column_list: ["basket_id", "courserun_id"]
+- name: stg__mitxpro__app__postgres__ecommerce_basketitem
+  description: The ecommerce_products that the user has in their basket but has not
+    purchased yet
+  columns:
+  - name: basketitem_id
+    description: int, primary key representing a item in a user's basket
+    tests:
+    - dbt_expectations.expect_column_to_exist
+  - name: basketitem_created_on
+    description: timestamp, specifying when the basket item was initially created
+    tests:
+    - dbt_expectations.expect_column_to_exist
+  - name: basketitem_updated_on
+    description: timestamp, specifying when the basket item was most recently updated
+    tests:
+    - dbt_expectations.expect_column_to_exist
+  - name: basketitem_quantity
+    description: int, quantitiy of the item. Always 1
+    tests:
+    - dbt_expectations.expect_column_to_exist
+  - name: basket_id
+    description: int, foreign key referencing ecommerce_basket
+    tests:
+    - dbt_expectations.expect_column_to_exist
+  - name: product_id
+    description: int, foreign key referencing ecommerce_product
+    tests:
+    - dbt_expectations.expect_column_to_exist
+  - name: programrun_id
+    description: int, foreign key referencing courses_programrun, present if the product
+      is a program
+    tests:
+    - dbt_expectations.expect_column_to_exist
+  tests:
+  - dbt_expectations.expect_table_column_count_to_equal:
+      value: 7
+- name: stg__mitxpro__app__postgres__ecommerce_basket
+  description: Checkout basket that contains courseware that a users wants to purchase
+    but has not purchased yet
+  columns:
+  - name: basket_id
+    description: int, primary key representing a user basket
+    tests:
+    - dbt_expectations.expect_column_to_exist
+  - name: basket_created_on
+    description: timestamp, specifying when the basket was initially created
+    tests:
+    - dbt_expectations.expect_column_to_exist
+  - name: basket_updated_on
+    description: timestamp, specifying when the basket was most recently updated
+    tests:
+    - dbt_expectations.expect_column_to_exist
+  - name: user_id
+    description: int, foreign key to the users_user table
+    tests:
+    - dbt_expectations.expect_column_to_exist
+    - unique
+  tests:
+  - dbt_expectations.expect_table_column_count_to_equal:
+      value: 4
 - name: stg__mitxpro__app__postgres__ecommerce_receipt
   description: Data returned from cybersource when a user pays for an order
   columns:

--- a/src/ol_dbt/models/staging/mitxpro/stg__mitxpro__app__postgres__ecommerce_basket.sql
+++ b/src/ol_dbt/models/staging/mitxpro/stg__mitxpro__app__postgres__ecommerce_basket.sql
@@ -1,0 +1,19 @@
+with source as (
+
+    select * from {{ source('ol_warehouse_raw_data', 'raw__xpro__app__postgres__ecommerce_basket') }}
+
+)
+
+, renamed as (
+
+    select
+        id as basket_id
+        , user_id
+        , to_iso8601(from_iso8601_timestamp(created_on)) as basket_created_on
+        , to_iso8601(from_iso8601_timestamp(updated_on)) as basket_updated_on
+
+    from source
+
+)
+
+select * from renamed

--- a/src/ol_dbt/models/staging/mitxpro/stg__mitxpro__app__postgres__ecommerce_basketitem.sql
+++ b/src/ol_dbt/models/staging/mitxpro/stg__mitxpro__app__postgres__ecommerce_basketitem.sql
@@ -1,0 +1,21 @@
+with source as (
+
+    select * from {{ source('ol_warehouse_raw_data', 'raw__xpro__app__postgres__ecommerce_basketitem') }}
+
+)
+
+, renamed as (
+
+    select
+        id as basketitem_id
+        , quantity as basketitem_quantity
+        , basket_id
+        , product_id
+        , program_run_id as programrun_id
+        , to_iso8601(from_iso8601_timestamp(created_on)) as basketitem_created_on
+        , to_iso8601(from_iso8601_timestamp(updated_on)) as basketitem_updated_on
+    from source
+
+)
+
+select * from renamed

--- a/src/ol_dbt/models/staging/mitxpro/stg__mitxpro__app__postgres__ecommerce_basketrunselection.sql
+++ b/src/ol_dbt/models/staging/mitxpro/stg__mitxpro__app__postgres__ecommerce_basketrunselection.sql
@@ -1,0 +1,19 @@
+with source as (
+
+    select * from {{ source('ol_warehouse_raw_data', 'raw__xpro__app__postgres__ecommerce_courserunselection') }}
+
+)
+
+, renamed as (
+
+    select
+        id as basketrunselection_id
+        , basket_id
+        , run_id as courserun_id
+        , to_iso8601(from_iso8601_timestamp(created_on)) as basketrunselection_created_on
+        , to_iso8601(from_iso8601_timestamp(updated_on)) as basketrunselection_updated_on
+    from source
+
+)
+
+select * from renamed

--- a/src/ol_dbt/models/staging/mitxpro/stg__mitxpro__app__postgres__ecommerce_orderaudit.sql
+++ b/src/ol_dbt/models/staging/mitxpro/stg__mitxpro__app__postgres__ecommerce_orderaudit.sql
@@ -1,0 +1,21 @@
+with source as (
+
+    select * from {{ source('ol_warehouse_raw_data', 'raw__xpro__app__postgres__ecommerce_orderaudit') }}
+
+)
+
+, renamed as (
+
+    select
+        id as orderaudit_id
+        , order_id
+        , acting_user_id as orderaudit_acting_user_id
+        , data_before as orderaudit_data_before
+        , data_after as orderaudit_data_after
+        , to_iso8601(from_iso8601_timestamp(created_on)) as orderaudit_created_on
+        , to_iso8601(from_iso8601_timestamp(updated_on)) as orderaudit_updated_on
+    from source
+
+)
+
+select * from renamed


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This pr adds 

int__mitxpro__ecommerce_basketrunselection
int__mitxpro__ecommerce_basketitem
int__mitxpro__ecommerce_basket

stg__mitxpro__app__postgres__ecommerce_orderaudit
stg__mitxpro__app__postgres__ecommerce_basketrunselection
stg__mitxpro__app__postgres__ecommerce_basketitem
stg__mitxpro__app__postgres__ecommerce_basket

## Motivation and Context
This pr is part of https://github.com/mitodl/ol-data-platform/issues/500
