### PR TITLE
Ab/ecommerce coupon

### DIFF
--- a/src/ol_dbt/models/intermediate/mitxpro/_int_mitxpro__models.yml
+++ b/src/ol_dbt/models/intermediate/mitxpro/_int_mitxpro__models.yml
@@ -2,6 +2,237 @@
 version: 2
 
 models:
+- name: int__mitxpro__ecommerce_couponproduct
+  description: This table is used to limit coupons to a specific product. Coupons
+    which do not have a record in this table are redeemable for all products
+  columns:
+  - name: couponproduct_id
+    description: int, primary key representing a coupon product combo
+    tests:
+    - dbt_expectations.expect_column_to_exist
+    - not_null
+  - name: couponproduct_created_on
+    description: timestamp, specifying when the coupon product association was initially
+      created
+    tests:
+    - dbt_expectations.expect_column_to_exist
+    - not_null
+  - name: couponproduct_updated_on
+    description: timestamp, specifying when the coupon product association was most
+      recently updated
+    tests:
+    - dbt_expectations.expect_column_to_exist
+    - not_null
+  - name: coupon_id
+    description: int, foreign key for ecommerce_coupon
+    tests:
+    - dbt_expectations.expect_column_to_exist
+    - not_null
+  - name: product_id
+    description: int, foreign key for ecommerce_product
+    tests:
+    - dbt_expectations.expect_column_to_exist
+    - not_null
+  - name: programrun_id
+    description: int, foreign key for courses_programrun, may be set when the product
+      type is a program
+    tests:
+    - dbt_expectations.expect_column_to_exist
+  tests:
+  - dbt_expectations.expect_table_column_count_to_equal:
+      value: 6
+  - dbt_expectations.expect_compound_columns_to_be_unique:
+      column_list: ["coupon_id", "product_id"]
+  - dbt_expectations.expect_table_row_count_to_equal_other_table:
+      compare_model: ref('stg__mitxpro__app__postgres__ecommerce_couponproduct')
+- name: int__mitxpro__ecommerce_couponpaymentversion
+  description: The ecommerce_couponpaymentversion holds information about a batch
+    of coupons. A coupon payment version has information about the dollar of percentage
+    amount of the discount, the number of available coupons that can be used to redeem
+    the discount, how many times they can be redeemed and the source of the coupons.
+    Coupon groups can be generated internally, for example to allow staff to enroll
+    in courses without paying or marketing to create promos that allow learners to
+    take a percentage or dollar amount off the full course price. Other coupon groups
+    are created when a company buys bulk seats in a course for their employees, which
+    generates a batch of 100% off coupons that learners can use to enroll in a course
+    or program.
+  columns:
+  - name: couponpaymentversion_id
+    description: int, primary key representing a coupon payment version
+    tests:
+    - dbt_expectations.expect_column_to_exist
+    - not_null
+  - name: couponpaymentversion_created_on
+    description: timestamp, specifying when the coupon payment version was initially
+      created
+    tests:
+    - dbt_expectations.expect_column_to_exist
+    - not_null
+  - name: couponpaymentversion_updated_on
+    description: timestamp, specifying when the coupon paymemt  version was most recently
+      updated
+    tests:
+    - dbt_expectations.expect_column_to_exist
+    - not_null
+  - name: couponpaymentversion_coupon_type
+    description: string, one of 'single-use' or 'promo'. Promo coupon codes can be
+      used multiple times
+    tests:
+    - dbt_expectations.expect_column_to_exist
+    - not_null
+  - name: couponpaymentversion_num_coupon_codes
+    description: int, number of coupon objects associated with the payment version
+    tests:
+    - dbt_expectations.expect_column_to_exist
+    - not_null
+  - name: couponpaymentversion_max_redemptions
+    description: int, maximum number of redemptions for the coupon payment version
+    tests:
+    - dbt_expectations.expect_column_to_exist
+    - not_null
+  - name: couponpaymentversion_max_redemptions_per_user
+    description: int, maximum number of redemptions per user for the coupon payment
+      version
+    tests:
+    - dbt_expectations.expect_column_to_exist
+    - not_null
+  - name: couponpaymentversion_discount_amount
+    description: number, either dollar amount or percentage (between 0 and 1) discount
+    tests:
+    - dbt_expectations.expect_column_to_exist
+    - not_null
+  - name: couponpayment_name
+    description: string, human readable name for the coupon payment
+    tests:
+    - dbt_expectations.expect_column_to_exist
+    - not_null
+  - name: couponpaymentversion_expires_on
+    description: timestamp, expiration timestamp for the coupon payment version
+    tests:
+    - dbt_expectations.expect_column_to_exist
+  - name: couponpaymentversion_activated_on
+    description: timestamp, activation timestamp for the coupon payment version
+    tests:
+    - dbt_expectations.expect_column_to_exist
+  - name: couponpaymentversion_is_automatic
+    description: boolean, whether the coupon should be automatically applied to eligible
+      orders
+    tests:
+    - dbt_expectations.expect_column_to_exist
+    - not_null
+  - name: couponpaymentversion_payment_type
+    description: string, one of "credit_card", "purchase_order", "marketing, "sales",
+      "staff". "staff" coupons are used to allow staff to enroll in courses. "marketing"
+      coupons are promos for discounts generated by marketing. "credit_card", "purchase_order"
+      and "sales" correspond to different ways that companies can pay for vouchers
+      for their employees to enroll in courses or programs
+    tests:
+    - dbt_expectations.expect_column_to_exist
+  - name: couponpaymentversion_payment_transaction
+    description: string, string that identifies the payment invoice for coupon purchases
+      by companies
+    tests:
+    - dbt_expectations.expect_column_to_exist
+  - name: couponpaymentversion_tag
+    description: string, optional string tag used to identify the coupon payment version
+    tests:
+    - dbt_expectations.expect_column_to_exist
+  - name: company_id
+    description: foreign key referencing ecommerce_company
+    tests:
+    - dbt_expectations.expect_column_to_exist
+  - name: couponpaymentversion_discount_type
+    description: one of percent-off or dollars-off
+    tests:
+    - dbt_expectations.expect_column_to_exist
+    - not_null
+  tests:
+  - dbt_expectations.expect_table_column_count_to_equal:
+      value: 17
+  - dbt_expectations.expect_table_row_count_to_equal_other_table:
+      compare_model: ref('stg__mitxpro__app__postgres__ecommerce_couponpaymentversion')
+- name: int__mitxpro__ecommerce_coupon
+  description: A coupon code that can be used to recieve a discount on a course or
+    program
+  columns:
+  - name: coupon_id
+    description: int, primary key representing a coupon
+    tests:
+    - dbt_expectations.expect_column_to_exist
+    - unique
+    - not_null
+  - name: coupon_created_on
+    description: timestamp, specifying when the coupon was initially created
+    tests:
+    - dbt_expectations.expect_column_to_exist
+    - not_null
+  - name: coupon_updated_on
+    description: timestamp, specifying when the coupon was most recently updated
+    tests:
+    - dbt_expectations.expect_column_to_exist
+    - not_null
+  - name: coupon_code
+    description: string, coupon code for the coupon
+    tests:
+    - dbt_expectations.expect_column_to_exist
+    - not_null
+  - name: couponpayment_name
+    description: string, human readable tag for coupon payment associated with the
+      coupon
+    tests:
+    - dbt_expectations.expect_column_to_exist
+    - not_null
+  - name: coupon_is_active
+    description: boolean, whethere or not the coupon is currently active
+    tests:
+    - dbt_expectations.expect_column_to_exist
+    - not_null
+  - name: coupon_applies_to_future_runs
+    description: boolean, if true the coupon is automatically enabled for future runs
+      of the product the coupon is associated with
+    tests:
+    - dbt_expectations.expect_column_to_exist
+    - not_null
+  - name: coupon_is_global
+    description: boolean, if true the coupon is valid for all products
+    tests:
+    - dbt_expectations.expect_column_to_exist
+    - not_null
+  tests:
+  - dbt_expectations.expect_table_column_count_to_equal:
+      value: 8
+  - dbt_expectations.expect_table_row_count_to_equal_other_table:
+      compare_model: ref('stg__mitxpro__app__postgres__ecommerce_coupon')
+- name: int__mitxpro__ecommerce_company
+  description: A company that purchases bulk enrollments to xpro courses or programs
+  columns:
+  - name: company_id
+    description: int, primary key representing a company
+    tests:
+    - dbt_expectations.expect_column_to_exist
+    - unique
+    - not_null
+  - name: company_created_on
+    description: timestamp, specifying when the company record was initially created
+    tests:
+    - dbt_expectations.expect_column_to_exist
+    - not_null
+  - name: company_updated_on
+    description: timestamp, specifying when the company record was most recently updated
+    tests:
+    - dbt_expectations.expect_column_to_exist
+    - not_null
+  - name: company_name
+    description: string, company name
+    tests:
+    - dbt_expectations.expect_column_to_exist
+    - unique
+    - not_null
+  tests:
+  - dbt_expectations.expect_table_column_count_to_equal:
+      value: 4
+  - dbt_expectations.expect_table_row_count_to_equal_other_table:
+      compare_model: ref('stg__mitxpro__app__postgres__ecommerce_company')
 - name: int__mitxpro__ecommerce_basketrunselection
   description: The course runs the user selected for the basket items in their basket.
     If the basket item is a course run, there is one ecommerce_basketrunselection
@@ -112,9 +343,13 @@ models:
     tests:
     - dbt_expectations.expect_column_to_exist
     - unique
+  - name: coupon_id
+    description: int, foreign key to the ecommerce_coupons table
+    tests:
+    - dbt_expectations.expect_column_to_exist
   tests:
   - dbt_expectations.expect_table_column_count_to_equal:
-      value: 4
+      value: 5
   - dbt_expectations.expect_table_row_count_to_equal_other_table:
       compare_model: ref('stg__mitxpro__app__postgres__ecommerce_basket')
 - name: int__mitxpro__ecommerce_receipt
@@ -186,9 +421,18 @@ models:
     tests:
     - dbt_expectations.expect_column_to_exist
     - not_null
+  - name: coupon_id
+    description: int, foreign key to ecommerce_coupon for orders that use a coupon
+    tests:
+    - dbt_expectations.expect_column_to_exist
+  - name: couponpaymentversion_id
+    description: int, foreign key to ecommerce_couponpaymentversion for orders that
+      use a coupon
+    tests:
+    - dbt_expectations.expect_column_to_exist
   tests:
   - dbt_expectations.expect_table_column_count_to_equal:
-      value: 6
+      value: 8
   - dbt_expectations.expect_table_row_count_to_equal_other_table:
       compare_model: ref('stg__mitxpro__app__postgres__ecommerce_order')
 - name: int__mitxpro__ecommerce_linerunselection

--- a/src/ol_dbt/models/intermediate/mitxpro/int__mitxpro__ecommerce_basket.sql
+++ b/src/ol_dbt/models/intermediate/mitxpro/int__mitxpro__ecommerce_basket.sql
@@ -1,11 +1,18 @@
-with source as (
+with basket as (
     select *
     from {{ ref('stg__mitxpro__app__postgres__ecommerce_basket') }}
 )
 
+, couponbasket as (
+    select *
+    from {{ ref('stg__mitxpro__app__postgres__ecommerce_couponbasket') }}
+)
+
 select
-    basket_id
-    , user_id
-    , basket_created_on
-    , basket_updated_on
-from source
+    basket.basket_id
+    , basket.user_id
+    , basket.basket_created_on
+    , basket.basket_updated_on
+    , couponbasket.coupon_id
+from basket
+left join couponbasket on couponbasket.basket_id = basket.basket_id

--- a/src/ol_dbt/models/intermediate/mitxpro/int__mitxpro__ecommerce_company.sql
+++ b/src/ol_dbt/models/intermediate/mitxpro/int__mitxpro__ecommerce_company.sql
@@ -1,0 +1,11 @@
+with company as (
+    select *
+    from {{ ref('stg__mitxpro__app__postgres__ecommerce_company') }}
+)
+
+select
+    company_id
+    , company_name
+    , company_updated_on
+    , company_created_on
+from company

--- a/src/ol_dbt/models/intermediate/mitxpro/int__mitxpro__ecommerce_coupon.sql
+++ b/src/ol_dbt/models/intermediate/mitxpro/int__mitxpro__ecommerce_coupon.sql
@@ -1,0 +1,21 @@
+with coupon as (
+    select *
+    from {{ ref('stg__mitxpro__app__postgres__ecommerce_coupon') }}
+)
+
+, couponpayment as (
+    select *
+    from {{ ref('stg__mitxpro__app__postgres__ecommerce_couponpayment') }}
+)
+
+select
+    coupon.coupon_id
+    , coupon.coupon_code
+    , couponpayment.couponpayment_name
+    , coupon.coupon_is_active
+    , coupon.coupon_applies_to_future_runs
+    , coupon.coupon_is_global
+    , coupon.coupon_updated_on
+    , coupon.coupon_created_on
+from coupon
+inner join couponpayment on couponpayment.couponpayment_id = coupon.couponpayment_id

--- a/src/ol_dbt/models/intermediate/mitxpro/int__mitxpro__ecommerce_couponpaymentversion.sql
+++ b/src/ol_dbt/models/intermediate/mitxpro/int__mitxpro__ecommerce_couponpaymentversion.sql
@@ -1,0 +1,30 @@
+with couponpaymentversion as (
+    select *
+    from {{ ref('stg__mitxpro__app__postgres__ecommerce_couponpaymentversion') }}
+)
+
+, couponpayment as (
+    select *
+    from {{ ref('stg__mitxpro__app__postgres__ecommerce_couponpayment') }}
+)
+
+select
+    couponpaymentversion.couponpaymentversion_id
+    , couponpaymentversion.couponpaymentversion_expires_on
+    , couponpaymentversion.company_id
+    , couponpaymentversion.couponpaymentversion_num_coupon_codes
+    , couponpaymentversion.couponpaymentversion_activated_on
+    , couponpaymentversion.couponpaymentversion_coupon_type
+    , couponpaymentversion.couponpaymentversion_created_on
+    , couponpaymentversion.couponpaymentversion_discount_amount
+    , couponpaymentversion.couponpaymentversion_updated_on
+    , couponpaymentversion.couponpaymentversion_max_redemptions_per_user
+    , couponpayment.couponpayment_name
+    , couponpaymentversion.couponpaymentversion_is_automatic
+    , couponpaymentversion.couponpaymentversion_payment_type
+    , couponpaymentversion.couponpaymentversion_payment_transaction
+    , couponpaymentversion.couponpaymentversion_tag
+    , couponpaymentversion.couponpaymentversion_discount_type
+    , couponpaymentversion.couponpaymentversion_max_redemptions
+from couponpaymentversion
+inner join couponpayment on couponpayment.couponpayment_id = couponpaymentversion.couponpayment_id

--- a/src/ol_dbt/models/intermediate/mitxpro/int__mitxpro__ecommerce_couponproduct.sql
+++ b/src/ol_dbt/models/intermediate/mitxpro/int__mitxpro__ecommerce_couponproduct.sql
@@ -1,0 +1,13 @@
+with couponproduct as (
+    select *
+    from {{ ref('stg__mitxpro__app__postgres__ecommerce_couponproduct') }}
+)
+
+select
+    couponproduct_id
+    , product_id
+    , coupon_id
+    , couponproduct_created_on
+    , couponproduct_updated_on
+    , programrun_id
+from couponproduct

--- a/src/ol_dbt/models/intermediate/mitxpro/int__mitxpro__ecommerce_order.sql
+++ b/src/ol_dbt/models/intermediate/mitxpro/int__mitxpro__ecommerce_order.sql
@@ -3,11 +3,25 @@ with orders as (
     from {{ ref('stg__mitxpro__app__postgres__ecommerce_order') }}
 )
 
+, couponredemption as (
+    select *
+    from {{ ref('stg__mitxpro__app__postgres__ecommerce_couponredemption') }}
+)
+
+, couponversion as (
+    select *
+    from {{ ref('stg__mitxpro__app__postgres__ecommerce_couponversion') }}
+)
+
 select
-    order_id
-    , order_state
-    , order_purchaser_user_id
-    , order_total_price_paid
-    , order_created_on
-    , order_updated_on
+    orders.order_id
+    , orders.order_state
+    , orders.order_purchaser_user_id
+    , orders.order_total_price_paid
+    , orders.order_created_on
+    , orders.order_updated_on
+    , couponversion.coupon_id
+    , couponversion.couponpaymentversion_id
 from orders
+left join couponredemption on couponredemption.order_id = orders.order_id
+left join couponversion on couponversion.couponversion_id = couponredemption.couponversion_id

--- a/src/ol_dbt/models/staging/mitxpro/_mitxpro__sources.yml
+++ b/src/ol_dbt/models/staging/mitxpro/_mitxpro__sources.yml
@@ -7,6 +7,302 @@ sources:
   database: 'ol_data_lake_{{ target.name }}'
   schema: 'ol_warehouse_{{ target.name }}_raw'
   tables:
+  - name: raw__xpro__app__postgres__ecommerce_couponselection
+    description: A row in this table is added when a coupon code is added to the users
+      basket for a course or product they have not yet purchased
+    columns:
+    - name: id
+      description: int, primary key representing a coupon selection
+      tests:
+      - dbt_expectations.expect_column_to_exist
+    - name: created_on
+      description: timestamp, specifying when the coupon was added to the basket
+      tests:
+      - dbt_expectations.expect_column_to_exist
+    - name: updated_on
+      description: timestamp, specifying when the coupon selection was updated most
+        recently updated
+      tests:
+      - dbt_expectations.expect_column_to_exist
+    - name: coupon_id
+      description: int, foreign key for ecommerce_coupon
+      tests:
+      - dbt_expectations.expect_column_to_exist
+    - name: basket_id
+      description: int, foreign key for ecommerce_basket
+      tests:
+      - dbt_expectations.expect_column_to_exist
+    tests:
+    - dbt_expectations.expect_table_column_count_to_equal:
+        value: 5
+  - name: raw__xpro__app__postgres__ecommerce_couponredemption
+    description: A row in this table is added when an order uses a coupon code
+    columns:
+    - name: id
+      description: int, primary key representing a coupon redemption
+      tests:
+      - dbt_expectations.expect_column_to_exist
+    - name: created_on
+      description: timestamp, specifying when the coupon was redeemed
+      tests:
+      - dbt_expectations.expect_column_to_exist
+    - name: updated_on
+      description: timestamp, specifying when the coupon redemption was updated most
+        recently updated
+      tests:
+      - dbt_expectations.expect_column_to_exist
+    - name: coupon_version_id
+      description: int, foreign key for ecommerce_couponversion
+      tests:
+      - dbt_expectations.expect_column_to_exist
+    - name: order_id
+      description: int, foreign key for ecommerce_order
+      tests:
+      - dbt_expectations.expect_column_to_exist
+    tests:
+    - dbt_expectations.expect_table_column_count_to_equal:
+        value: 5
+  - name: raw__xpro__app__postgres__ecommerce_couponeligibility
+    description: This table is used to limit coupons to a specific product. Coupons
+      which do not have a record in this table are redeemable for all products
+    columns:
+    - name: id
+      description: int, primary key representing a coupon product combo
+      tests:
+      - dbt_expectations.expect_column_to_exist
+    - name: created_on
+      description: timestamp, specifying when the coupon product association was initially
+        created
+      tests:
+      - dbt_expectations.expect_column_to_exist
+    - name: updated_on
+      description: timestamp, specifying when the coupon product association was most
+        recently updated
+      tests:
+      - dbt_expectations.expect_column_to_exist
+    - name: coupon_id
+      description: int, foreign key for ecommerce_coupon
+      tests:
+      - dbt_expectations.expect_column_to_exist
+    - name: product_id
+      description: int, foreign key for ecommerce_product
+      tests:
+      - dbt_expectations.expect_column_to_exist
+    - name: program_run_id
+      description: int, foreign key for courses_programrun, may be set when the product
+        type is a program
+      tests:
+      - dbt_expectations.expect_column_to_exist
+    tests:
+    - dbt_expectations.expect_table_column_count_to_equal:
+        value: 6
+  - name: raw__xpro__app__postgres__ecommerce_company
+    description: A company that purchases bulk enrollments to xpro courses or programs
+    columns:
+    - name: id
+      description: int, primary key representing a company
+      tests:
+      - dbt_expectations.expect_column_to_exist
+    - name: created_on
+      description: timestamp, specifying when the company record was initially created
+      tests:
+      - dbt_expectations.expect_column_to_exist
+    - name: updated_on
+      description: timestamp, specifying when the company record was most recently
+        updated
+      tests:
+      - dbt_expectations.expect_column_to_exist
+    - name: name
+      description: string, company name
+      tests:
+      - dbt_expectations.expect_column_to_exist
+    tests:
+    - dbt_expectations.expect_table_column_count_to_equal:
+        value: 4
+  - name: raw__xpro__app__postgres__ecommerce_couponpaymentversion
+    description: The ecommerce_couponpaymentversion holds information about a batch
+      of coupons. A coupon payment version has information about the dollar of percentage
+      amount of the discount, the number of available coupons that can be used to
+      redeem the discount, how many times they can be redeemed and the source of the
+      coupons. Coupon groups can be generated internally, for example to allow staff
+      to enroll in courses without paying or marketing to create promos that allow
+      learners to take a percentage or dollar amount off the full course price. Other
+      coupon groups are created when a company buys bulk seats in a course for their
+      employees, which generates a batch of 100% off coupons that learners can use
+      to enroll in a course or program.
+    columns:
+    - name: id
+      description: int, primary key representing a coupon payment version
+      tests:
+      - dbt_expectations.expect_column_to_exist
+    - name: created_on
+      description: timestamp, specifying when the coupon payment version was initially
+        created
+      tests:
+      - dbt_expectations.expect_column_to_exist
+    - name: updated_on
+      description: timestamp, specifying when the coupon paymemt  version was most
+        recently updated
+      tests:
+      - dbt_expectations.expect_column_to_exist
+    - name: coupon_type
+      description: string, one of 'single-use' or 'promo'.
+      tests:
+      - dbt_expectations.expect_column_to_exist
+    - name: num_coupon_codes
+      description: int, number of coupon (and coupon version) objects associated with
+        the payment version
+      tests:
+      - dbt_expectations.expect_column_to_exist
+    - name: max_redemptions
+      description: int, maximum number of redemptions for the coupon payment version
+      tests:
+      - dbt_expectations.expect_column_to_exist
+    - name: max_redemptions_per_user
+      description: int, maximum number of redemptions per user for the coupon payment
+        version
+      tests:
+      - dbt_expectations.expect_column_to_exist
+    - name: amount
+      description: number, either dollar amount or percentage (between 0 and 1) discount
+      tests:
+      - dbt_expectations.expect_column_to_exist
+    - name: expiration_date
+      description: timestamp, expiration timestamp for the coupon payment version
+      tests:
+      - dbt_expectations.expect_column_to_exist
+    - name: activation_date
+      description: timestamp, activation timestamp for the coupon payment version
+      tests:
+      - dbt_expectations.expect_column_to_exist
+    - name: automatic
+      description: boolean, whether the coupon should be automatically applied to
+        eligible orders
+      tests:
+      - dbt_expectations.expect_column_to_exist
+    - name: payment_type
+      description: string, one of "credit_card", "purchase_order", "marketing, "sales",
+        "staff". "staff" coupons are used to allow staff to enroll in courses. "marketing"
+        coupons are promos for discounts generated by marketing. "credit_card", "purchase_order"
+        and "sales" correspond to different ways that companies can pay for vouchers
+        for their employees to enroll in courses or programs
+      tests:
+      - dbt_expectations.expect_column_to_exist
+    - name: payment_transaction
+      description: string, string that identifies the payment invoice for coupon purchases
+        by companies
+      tests:
+      - dbt_expectations.expect_column_to_exist
+    - name: tag
+      description: string, optional string tag used to identify the coupon payment
+        version
+      tests:
+      - dbt_expectations.expect_column_to_exist
+    - name: company_id
+      description: foreign key is ecommerce_company
+      tests:
+      - dbt_expectations.expect_column_to_exist
+    - name: payment_id
+      description: int, foreign key to ecommerce_couponpayment
+      tests:
+      - dbt_expectations.expect_column_to_exist
+    - name: discount_type
+      description: one of percent-off or dollars-off
+      tests:
+      - dbt_expectations.expect_column_to_exist
+    tests:
+    - dbt_expectations.expect_table_column_count_to_equal:
+        value: 17
+  - name: raw__xpro__app__postgres__ecommerce_couponpayment
+    description: Most of the information for coupon payments is in couponpaymentversion
+    columns:
+    - name: id
+      description: int, primary key representing a coupon payment
+      tests:
+      - dbt_expectations.expect_column_to_exist
+    - name: created_on
+      description: timestamp, specifying when the coupon payment was initially created
+      tests:
+      - dbt_expectations.expect_column_to_exist
+    - name: updated_on
+      description: timestamp, specifying when the coupon paymemt was most recently
+        updated
+      tests:
+      - dbt_expectations.expect_column_to_exist
+    - name: name
+      description: string, human readable name for the coupon payment
+      tests:
+      - dbt_expectations.expect_column_to_exist
+    tests:
+    - dbt_expectations.expect_table_column_count_to_equal:
+        value: 4
+  - name: raw__xpro__app__postgres__ecommerce_couponversion
+    description: A version of a coupon linked to a specific couponpaymentversion record
+    columns:
+    - name: id
+      description: int, primary key representing a coupon version
+      tests:
+      - dbt_expectations.expect_column_to_exist
+    - name: created_on
+      description: timestamp, specifying when the coupon version was initially created
+      tests:
+      - dbt_expectations.expect_column_to_exist
+    - name: updated_on
+      description: timestamp, specifying when the coupon version was most recently
+        updated
+      tests:
+      - dbt_expectations.expect_column_to_exist
+    - name: coupon_id
+      description: int, foreign key referencing ecommerce_coupon
+      tests:
+      - dbt_expectations.expect_column_to_exist
+    - name: payment_version_id
+      description: int, foreign key to ecommerce_paymentversion
+      tests:
+      - dbt_expectations.expect_column_to_exist
+    tests:
+    - dbt_expectations.expect_table_column_count_to_equal:
+        value: 5
+  - name: raw__xpro__app__postgres__ecommerce_coupon
+    description: A coupon code that can be used to recieve a discount on a course
+      or program
+    columns:
+    - name: id
+      description: int, primary key representing a coupon
+      tests:
+      - dbt_expectations.expect_column_to_exist
+    - name: created_on
+      description: timestamp, specifying when the coupon was initially created
+      tests:
+      - dbt_expectations.expect_column_to_exist
+    - name: updated_on
+      description: timestamp, specifying when the coupon was most recently updated
+      tests:
+      - dbt_expectations.expect_column_to_exist
+    - name: coupon_code
+      description: string, coupon code for the coupon
+      tests:
+      - dbt_expectations.expect_column_to_exist
+    - name: payment_id
+      description: int, foreign key to ecommerce_payment
+      tests:
+      - dbt_expectations.expect_column_to_exist
+    - name: enabled
+      description: boolean, whethere or not the coupon is currently active
+      tests:
+      - dbt_expectations.expect_column_to_exist
+    - name: include_future_runs
+      description: boolean, if true the coupon is automatically enabled for future
+        runs of the product the coupon is associated with
+      tests:
+      - dbt_expectations.expect_column_to_exist
+    - name: is_global
+      description: boolean, if true the coupon is valid for all products
+      tests:
+      - dbt_expectations.expect_column_to_exist
+    tests:
+    - dbt_expectations.expect_table_column_count_to_equal:
+        value: 8
   - name: raw__xpro__app__postgres__ecommerce_orderaudit
     columns:
     - name: id

--- a/src/ol_dbt/models/staging/mitxpro/_stg_mitxpro__models.yml
+++ b/src/ol_dbt/models/staging/mitxpro/_stg_mitxpro__models.yml
@@ -2,6 +2,355 @@
 version: 2
 
 models:
+- name: stg__mitxpro__app__postgres__ecommerce_basketcoupon
+  description: A row in this table is added when a coupon code is added to the users
+    basket for a course or product they have not yet purchased
+  columns:
+  - name: basketcoupon_id
+    description: int, primary key representing a coupon in a user's basket
+    tests:
+    - dbt_expectations.expect_column_to_exist
+    - not_null
+  - name: basketcoupon_created_on
+    description: timestamp, specifying when the coupon was added to a users basket
+    tests:
+    - dbt_expectations.expect_column_to_exist
+    - not_null
+  - name: basketcoupon_updated_on
+    description: timestamp, specifying when the coupon basket selection was updated
+      most recently updated
+    tests:
+    - dbt_expectations.expect_column_to_exist
+    - not_null
+  - name: coupon_id
+    description: int, foreign key for ecommerce_coupon
+    tests:
+    - dbt_expectations.expect_column_to_exist
+    - not_null
+  - name: basket_id
+    description: int, foreign key for ecommerce_basket
+    tests:
+    - dbt_expectations.expect_column_to_exist
+    - not_null
+  tests:
+  - dbt_expectations.expect_table_column_count_to_equal:
+      value: 5
+- name: stg__mitxpro__app__postgres__ecommerce_couponredemption
+  description: A row in this table is added when an order uses a coupon code
+  columns:
+  - name: couponredemption_id
+    description: int, primary key representing a coupon redemption
+    tests:
+    - dbt_expectations.expect_column_to_exist
+    - not_null
+  - name: couponredemption_created_on
+    description: timestamp, specifying when the coupon was redeemed
+    tests:
+    - dbt_expectations.expect_column_to_exist
+    - not_null
+  - name: couponredemption_updated_on
+    description: timestamp, specifying when the coupon redemption was updated most
+      recently updated
+    tests:
+    - dbt_expectations.expect_column_to_exist
+    - not_null
+  - name: couponversion_id
+    description: int, foreign key for ecommerce_couponversion
+    tests:
+    - dbt_expectations.expect_column_to_exist
+    - not_null
+  - name: order_id
+    description: int, foreign key for ecommerce_order
+    tests:
+    - dbt_expectations.expect_column_to_exist
+    - not_null
+  tests:
+  - dbt_expectations.expect_table_column_count_to_equal:
+      value: 5
+  - dbt_expectations.expect_compound_columns_to_be_unique:
+      column_list: ["couponversion_id", "order_id"]
+- name: stg__mitxpro__app__postgres__ecommerce_couponproduct
+  description: This table is used to limit coupons to a specific product. Coupons
+    which do not have a record in this table are redeemable for all products
+  columns:
+  - name: couponproduct_id
+    description: int, primary key representing a coupon product combo
+    tests:
+    - dbt_expectations.expect_column_to_exist
+    - not_null
+  - name: couponproduct_created_on
+    description: timestamp, specifying when the coupon product association was initially
+      created
+    tests:
+    - dbt_expectations.expect_column_to_exist
+    - not_null
+  - name: couponproduct_updated_on
+    description: timestamp, specifying when the coupon product association was most
+      recently updated
+    tests:
+    - dbt_expectations.expect_column_to_exist
+    - not_null
+  - name: coupon_id
+    description: int, foreign key for ecommerce_coupon
+    tests:
+    - dbt_expectations.expect_column_to_exist
+    - not_null
+  - name: product_id
+    description: int, foreign key for ecommerce_product
+    tests:
+    - dbt_expectations.expect_column_to_exist
+    - not_null
+  - name: programrun_id
+    description: int, foreign key for courses_programrun, may be set when the product
+      type is a program
+    tests:
+    - dbt_expectations.expect_column_to_exist
+  tests:
+  - dbt_expectations.expect_table_column_count_to_equal:
+      value: 6
+  - dbt_expectations.expect_compound_columns_to_be_unique:
+      column_list: ["coupon_id", "product_id"]
+- name: stg__mitxpro__app__postgres__ecommerce_company
+  description: A company that purchases bulk enrollments to xpro courses or programs
+  columns:
+  - name: company_id
+    description: int, primary key representing a company
+    tests:
+    - dbt_expectations.expect_column_to_exist
+    - unique
+    - not_null
+  - name: company_created_on
+    description: timestamp, specifying when the company record was initially created
+    tests:
+    - dbt_expectations.expect_column_to_exist
+    - not_null
+  - name: company_updated_on
+    description: timestamp, specifying when the company record was most recently updated
+    tests:
+    - dbt_expectations.expect_column_to_exist
+    - not_null
+  - name: company_name
+    description: string, company name
+    tests:
+    - dbt_expectations.expect_column_to_exist
+    - unique
+    - not_null
+  tests:
+  - dbt_expectations.expect_table_column_count_to_equal:
+      value: 4
+- name: stg__mitxpro__app__postgres__ecommerce_couponpaymentversion
+  description: The ecommerce_couponpaymentversion holds information about a batch
+    of coupons. A coupon payment version has information about the dollar of percentage
+    amount of the discount, the number of available coupons that can be used to redeem
+    the discount, how many times they can be redeemed and the source of the coupons.
+    Coupon groups can be generated internally, for example to allow staff to enroll
+    in courses without paying or marketing to create promos that allow learners to
+    take a percentage or dollar amount off the full course price. Other coupon groups
+    are created when a company buys bulk seats in a course for their employees, which
+    generates a batch of 100% off coupons that learners can use to enroll in a course
+    or program.
+  columns:
+  - name: couponpaymentversion_id
+    description: int, primary key representing a coupon payment version
+    tests:
+    - dbt_expectations.expect_column_to_exist
+    - not_null
+  - name: couponpaymentversion_created_on
+    description: timestamp, specifying when the coupon payment version was initially
+      created
+    tests:
+    - dbt_expectations.expect_column_to_exist
+    - not_null
+  - name: couponpaymentversion_updated_on
+    description: timestamp, specifying when the coupon paymemt  version was most recently
+      updated
+    tests:
+    - dbt_expectations.expect_column_to_exist
+    - not_null
+  - name: couponpaymentversion_coupon_type
+    description: string, one of 'single-use' or 'promo'.
+    tests:
+    - dbt_expectations.expect_column_to_exist
+    - not_null
+  - name: couponpaymentversion_num_coupon_codes
+    description: int, number of coupon (and coupon version) objects associated with
+      the payment version
+    tests:
+    - dbt_expectations.expect_column_to_exist
+    - not_null
+  - name: couponpaymentversion_max_redemptions
+    description: int, maximum number of redemptions for the coupon payment version
+    tests:
+    - dbt_expectations.expect_column_to_exist
+    - not_null
+  - name: couponpaymentversion_max_redemptions_per_user
+    description: int, maximum number of redemptions per user for the coupon payment
+      version
+    tests:
+    - dbt_expectations.expect_column_to_exist
+    - not_null
+  - name: couponpaymentversion_discount_amount
+    description: number, either dollar amount or percentage (between 0 and 1) discount
+    tests:
+    - dbt_expectations.expect_column_to_exist
+    - not_null
+  - name: couponpayment_id
+    description: int, foreign key to ecommerce_couponpayment
+    tests:
+    - dbt_expectations.expect_column_to_exist
+    - not_null
+  - name: couponpaymentversion_expires_on
+    description: timestamp, expiration timestamp for the coupon payment version
+    tests:
+    - dbt_expectations.expect_column_to_exist
+  - name: couponpaymentversion_activated_on
+    description: timestamp, activation timestamp for the coupon payment version
+    tests:
+    - dbt_expectations.expect_column_to_exist
+  - name: couponpaymentversion_is_automatic
+    description: boolean, whether the coupon should be automatically applied to eligible
+      orders
+    tests:
+    - dbt_expectations.expect_column_to_exist
+    - not_null
+  - name: couponpaymentversion_payment_type
+    description: string, one of "credit_card", "purchase_order", "marketing, "sales",
+      "staff". "staff" coupons are used to allow staff to enroll in courses. "marketing"
+      coupons are promos for discounts generated by marketing. "credit_card", "purchase_order"
+      and "sales" correspond to different ways that companies can pay for vouchers
+      for their employees to enroll in courses or programs
+    tests:
+    - dbt_expectations.expect_column_to_exist
+  - name: couponpaymentversion_payment_transaction
+    description: string, string that identifies the payment invoice for coupon purchases
+      by companies
+    tests:
+    - dbt_expectations.expect_column_to_exist
+  - name: couponpaymentversion_tag
+    description: string, optional string tag used to identify the coupon payment version
+    tests:
+    - dbt_expectations.expect_column_to_exist
+  - name: company_id
+    description: foreign key referencing ecommerce_company
+    tests:
+    - dbt_expectations.expect_column_to_exist
+  - name: couponpaymentversion_discount_type
+    description: one of percent-off or dollars-off
+    tests:
+    - dbt_expectations.expect_column_to_exist
+    - not_null
+  tests:
+  - dbt_expectations.expect_table_column_count_to_equal:
+      value: 17
+- name: stg__mitxpro__app__postgres__ecommerce_couponpayment
+  description: Most of the information for coupon payments is in couponpaymentversion
+  columns:
+  - name: couponpayment_id
+    description: int, primary key representing a coupon payment
+    tests:
+    - dbt_expectations.expect_column_to_exist
+    - unique
+    - not_null
+  - name: couponpayment_created_on
+    description: timestamp, specifying when the coupon payment was initially created
+    tests:
+    - dbt_expectations.expect_column_to_exist
+    - not_null
+  - name: couponpayment_updated_on
+    description: timestamp, specifying when the coupon paymemt was most recently updated
+    tests:
+    - dbt_expectations.expect_column_to_exist
+    - not_null
+  - name: couponpayment_name
+    description: string, human readable name for the coupon payment
+    tests:
+    - dbt_expectations.expect_column_to_exist
+    - unique
+    - not_null
+  tests:
+  - dbt_expectations.expect_table_column_count_to_equal:
+      value: 4
+- name: stg__mitxpro__app__postgres__ecommerce_couponversion
+  description: A version of a coupon linked to a specific couponpaymentversion record
+  columns:
+  - name: couponversion_id
+    description: int, primary key representing a coupon version
+    tests:
+    - dbt_expectations.expect_column_to_exist
+    - unique
+    - not_null
+  - name: couponversion_created_on
+    description: timestamp, specifying when the coupon version was initially created
+    tests:
+    - dbt_expectations.expect_column_to_exist
+    - not_null
+  - name: couponversion_updated_on
+    description: timestamp, specifying when the coupon version was most recently updated
+    tests:
+    - dbt_expectations.expect_column_to_exist
+    - not_null
+  - name: coupon_id
+    description: int, foreign key referencing ecommerce_coupon
+    tests:
+    - dbt_expectations.expect_column_to_exist
+    - not_null
+  - name: couponpaymentversion_id
+    description: int, foreign key to ecommerce_couponpaymentversion
+    tests:
+    - dbt_expectations.expect_column_to_exist
+    - not_null
+  tests:
+  - dbt_expectations.expect_table_column_count_to_equal:
+      value: 5
+- name: stg__mitxpro__app__postgres__ecommerce_coupon
+  description: A coupon code that can be used to recieve a discount on a course or
+    program
+  columns:
+  - name: coupon_id
+    description: int, primary key representing a coupon
+    tests:
+    - dbt_expectations.expect_column_to_exist
+    - unique
+    - not_null
+  - name: coupon_created_on
+    description: timestamp, specifying when the coupon was initially created
+    tests:
+    - dbt_expectations.expect_column_to_exist
+    - not_null
+  - name: coupon_updated_on
+    description: timestamp, specifying when the coupon was most recently updated
+    tests:
+    - dbt_expectations.expect_column_to_exist
+    - not_null
+  - name: coupon_code
+    description: string, coupon code for the coupon
+    tests:
+    - dbt_expectations.expect_column_to_exist
+    - not_null
+  - name: couponpayment_id
+    description: int, foreign key to ecommerce_couponpayment
+    tests:
+    - dbt_expectations.expect_column_to_exist
+    - not_null
+  - name: coupon_is_active
+    description: boolean, whethere or not the coupon is currently active
+    tests:
+    - dbt_expectations.expect_column_to_exist
+    - not_null
+  - name: coupon_applies_to_future_runs
+    description: boolean, if true the coupon is automatically enabled for future runs
+      of the product the coupon is associated with
+    tests:
+    - dbt_expectations.expect_column_to_exist
+    - not_null
+  - name: coupon_is_global
+    description: boolean, if true the coupon is valid for all products
+    tests:
+    - dbt_expectations.expect_column_to_exist
+    - not_null
+  tests:
+  - dbt_expectations.expect_table_column_count_to_equal:
+      value: 8
 - name: stg__mitxpro__app__postgres__ecommerce_orderaudit
   columns:
   - name: orderaudit_id

--- a/src/ol_dbt/models/staging/mitxpro/stg__mitxpro__app__postgres__ecommerce_company.sql
+++ b/src/ol_dbt/models/staging/mitxpro/stg__mitxpro__app__postgres__ecommerce_company.sql
@@ -1,0 +1,16 @@
+with source as (
+
+    select * from {{ source('ol_warehouse_raw_data', 'raw__xpro__app__postgres__ecommerce_company') }}
+
+)
+
+, renamed as (
+    select
+        id as company_id
+        , name as company_name
+        , to_iso8601(from_iso8601_timestamp(updated_on)) as company_updated_on
+        , to_iso8601(from_iso8601_timestamp(created_on)) as company_created_on
+    from source
+)
+
+select * from renamed

--- a/src/ol_dbt/models/staging/mitxpro/stg__mitxpro__app__postgres__ecommerce_coupon.sql
+++ b/src/ol_dbt/models/staging/mitxpro/stg__mitxpro__app__postgres__ecommerce_coupon.sql
@@ -1,0 +1,20 @@
+with source as (
+
+    select * from {{ source('ol_warehouse_raw_data', 'raw__xpro__app__postgres__ecommerce_coupon') }}
+
+)
+
+, renamed as (
+    select
+        id as coupon_id
+        , coupon_code
+        , payment_id as couponpayment_id
+        , enabled as coupon_is_active
+        , include_future_runs as coupon_applies_to_future_runs
+        , is_global as coupon_is_global
+        , to_iso8601(from_iso8601_timestamp(updated_on)) as coupon_updated_on
+        , to_iso8601(from_iso8601_timestamp(created_on)) as coupon_created_on
+    from source
+)
+
+select * from renamed

--- a/src/ol_dbt/models/staging/mitxpro/stg__mitxpro__app__postgres__ecommerce_couponbasket.sql
+++ b/src/ol_dbt/models/staging/mitxpro/stg__mitxpro__app__postgres__ecommerce_couponbasket.sql
@@ -1,0 +1,19 @@
+with source as (
+
+    select * from {{ source('ol_warehouse_raw_data', 'raw__xpro__app__postgres__ecommerce_couponselection') }}
+
+)
+
+, renamed as (
+
+    select
+        id as couponbasket_id
+        , basket_id
+        , coupon_id
+        , to_iso8601(from_iso8601_timestamp(created_on)) as couponbasket_created_on
+        , to_iso8601(from_iso8601_timestamp(updated_on)) as couponbasket_updated_on
+    from source
+
+)
+
+select * from renamed

--- a/src/ol_dbt/models/staging/mitxpro/stg__mitxpro__app__postgres__ecommerce_couponpayment.sql
+++ b/src/ol_dbt/models/staging/mitxpro/stg__mitxpro__app__postgres__ecommerce_couponpayment.sql
@@ -1,0 +1,16 @@
+with source as (
+
+    select * from {{ source('ol_warehouse_raw_data', 'raw__xpro__app__postgres__ecommerce_couponpayment') }}
+
+)
+
+, renamed as (
+    select
+        id as couponpayment_id
+        , name as couponpayment_name
+        , to_iso8601(from_iso8601_timestamp(updated_on)) as couponpayment_updated_on
+        , to_iso8601(from_iso8601_timestamp(created_on)) as couponpayment_created_on
+    from source
+)
+
+select * from renamed

--- a/src/ol_dbt/models/staging/mitxpro/stg__mitxpro__app__postgres__ecommerce_couponpaymentversion.sql
+++ b/src/ol_dbt/models/staging/mitxpro/stg__mitxpro__app__postgres__ecommerce_couponpaymentversion.sql
@@ -1,0 +1,32 @@
+with source as (
+
+    select * from {{ source('ol_warehouse_raw_data', 'raw__xpro__app__postgres__ecommerce_couponpaymentversion') }}
+
+)
+
+, renamed as (
+
+    select
+        id as couponpaymentversion_id
+        , company_id
+        , num_coupon_codes as couponpaymentversion_num_coupon_codes
+        , coupon_type as couponpaymentversion_coupon_type
+        , amount as couponpaymentversion_discount_amount
+        , max_redemptions_per_user as couponpaymentversion_max_redemptions_per_user
+        , payment_id as couponpayment_id
+        , automatic as couponpaymentversion_is_automatic
+        , payment_type as couponpaymentversion_payment_type
+        , payment_transaction as couponpaymentversion_payment_transaction
+        , tag as couponpaymentversion_tag
+        , discount_type as couponpaymentversion_discount_type
+        , max_redemptions as couponpaymentversion_max_redemptions
+        , to_iso8601(from_iso8601_timestamp(expiration_date)) as couponpaymentversion_expires_on
+        , to_iso8601(from_iso8601_timestamp(activation_date)) as couponpaymentversion_activated_on
+        , to_iso8601(from_iso8601_timestamp(created_on)) as couponpaymentversion_created_on
+        , to_iso8601(from_iso8601_timestamp(updated_on)) as couponpaymentversion_updated_on
+
+    from source
+
+)
+
+select * from renamed

--- a/src/ol_dbt/models/staging/mitxpro/stg__mitxpro__app__postgres__ecommerce_couponproduct.sql
+++ b/src/ol_dbt/models/staging/mitxpro/stg__mitxpro__app__postgres__ecommerce_couponproduct.sql
@@ -1,0 +1,20 @@
+with source as (
+
+    select * from {{ source('ol_warehouse_raw_data', 'raw__xpro__app__postgres__ecommerce_couponeligibility') }}
+
+)
+
+, renamed as (
+
+    select
+        id as couponproduct_id
+        , product_id
+        , coupon_id
+        , program_run_id as programrun_id
+        , to_iso8601(from_iso8601_timestamp(created_on)) as couponproduct_created_on
+        , to_iso8601(from_iso8601_timestamp(updated_on)) as couponproduct_updated_on
+    from source
+
+)
+
+select * from renamed

--- a/src/ol_dbt/models/staging/mitxpro/stg__mitxpro__app__postgres__ecommerce_couponredemption.sql
+++ b/src/ol_dbt/models/staging/mitxpro/stg__mitxpro__app__postgres__ecommerce_couponredemption.sql
@@ -1,0 +1,19 @@
+with source as (
+
+    select * from {{ source('ol_warehouse_raw_data', 'raw__xpro__app__postgres__ecommerce_couponredemption') }}
+
+)
+
+, renamed as (
+
+    select
+        id as couponredemption_id
+        , order_id
+        , coupon_version_id as couponversion_id
+        , to_iso8601(from_iso8601_timestamp(created_on)) as couponredemption_created_on
+        , to_iso8601(from_iso8601_timestamp(updated_on)) as couponredemption_updated_on
+    from source
+
+)
+
+select * from renamed

--- a/src/ol_dbt/models/staging/mitxpro/stg__mitxpro__app__postgres__ecommerce_couponversion.sql
+++ b/src/ol_dbt/models/staging/mitxpro/stg__mitxpro__app__postgres__ecommerce_couponversion.sql
@@ -1,0 +1,17 @@
+with source as (
+
+    select * from {{ source('ol_warehouse_raw_data', 'raw__xpro__app__postgres__ecommerce_couponversion') }}
+
+)
+
+, renamed as (
+    select
+        id as couponversion_id
+        , coupon_id
+        , payment_version_id as couponpaymentversion_id
+        , to_iso8601(from_iso8601_timestamp(updated_on)) as couponversion_updated_on
+        , to_iso8601(from_iso8601_timestamp(created_on)) as couponversion_created_on
+    from source
+)
+
+select * from renamed


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This adds

int__mitxpro__ecommerce_couponproduct
int__mitxpro__ecommerce_couponpaymentversion
int__mitxpro__ecommerce_coupon
int__mitxpro__ecommerce_company

stg__mitxpro__app__postgres__ecommerce_basketcoupon
stg__mitxpro__app__postgres__ecommerce_couponredemption
stg__mitxpro__app__postgres__ecommerce_couponproduct
stg__mitxpro__app__postgres__ecommerce_company
stg__mitxpro__app__postgres__ecommerce_couponpaymentversion
stg__mitxpro__app__postgres__ecommerce_couponpayment
stg__mitxpro__app__postgres__ecommerce_couponversion
stg__mitxpro__app__postgres__ecommerce_coupon

and modifies int__mitxpro__ecommerce_basket and int__mitxpro__ecommerce_order to add coupon information


## Motivation and Context
https://github.com/mitodl/ol-data-platform/issues/500

## How Has This Been Tested?
dbt run and dbt test

