### PR TITLE
fix formating

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,10 +62,6 @@ build-backend = "poetry.core.masonry.api"
 templater = "jinja"
 dialect = "hive"
 sql_file_exts = ".sql,.sql.j2,.dml,.ddl"
-
-[tool.sqlfluff.rules]
-# Use leading commas for cleaner diffs
-comma_style = "leading"
 max_line_length = 120
 
 [tool.sqlfluff.templater]

--- a/src/ol_dbt/models/intermediate/edxorg/int__edxorg__mitx_courserun_certificates.sql
+++ b/src/ol_dbt/models/intermediate/edxorg/int__edxorg__mitx_courserun_certificates.sql
@@ -27,7 +27,8 @@ select
     , certificates.courseruncertificate_status
     , certificates.courseruncertificate_created_on
     , runs.courserun_title
-from certificates
+from
+    certificates
 ---- there are certificates issued for courses that don't exist in course model.
 --   this inner joins will eliminate those rows.
 --   if we want to show all the certificate, it needs to change to Left join

--- a/src/ol_dbt/models/intermediate/edxorg/int__edxorg__mitx_courserun_enrollments.sql
+++ b/src/ol_dbt/models/intermediate/edxorg/int__edxorg__mitx_courserun_enrollments.sql
@@ -29,7 +29,8 @@ with enrollments as (
         , enrollments.courserunenrollment_enrollment_mode
         , enrollments.courserunenrollment_is_active
         , runs.courserun_title
-    from enrollments
+    from
+        enrollments
     ---- there are certificates issued for courses that don't exist in course model.
     ---- this inner joins will eliminate those rows.
     ---- if we want to show all the certificate, it needs to change to Left join

--- a/src/ol_dbt/models/intermediate/edxorg/int__edxorg__mitx_courseruns.sql
+++ b/src/ol_dbt/models/intermediate/edxorg/int__edxorg__mitx_courseruns.sql
@@ -31,6 +31,7 @@ select
     , runs.courserun_end_date
     , runs.courserun_is_self_paced
     , micromasters_courses.program_id as micromasters_program_id
-from runs
+from
+    runs
 --- courserun_readable_id here is formatted as {org}/{course_number}/{run}
 left join micromasters_courses on runs.courserun_readable_id like micromasters_courses.course_readable_id || '%'

--- a/src/ol_dbt/models/intermediate/micromasters/int__micromasters__program_requirements.sql
+++ b/src/ol_dbt/models/intermediate/micromasters/int__micromasters__program_requirements.sql
@@ -39,7 +39,7 @@ with programs as (
         , electiveset.electiveset_required_number
     from electiveset_to_course
     inner join electiveset
-               on electiveset_to_course.electiveset_id = electiveset.electiveset_id
+        on electiveset_to_course.electiveset_id = electiveset.electiveset_id
 )
 
 --- courses that are not in elective_courses are core
@@ -49,7 +49,8 @@ with programs as (
         , courses.program_id
     from courses
     left join elective_courses
-        on courses.program_id = elective_courses.program_id
+        on
+            courses.program_id = elective_courses.program_id
             and courses.course_id = elective_courses.course_id
     where elective_courses.course_id is null
 )

--- a/src/ol_dbt/models/intermediate/mitxonline/int__mitxonline__ecommerce_order.sql
+++ b/src/ol_dbt/models/intermediate/mitxonline/int__mitxonline__ecommerce_order.sql
@@ -10,7 +10,8 @@ with lines as (
     select * from {{ ref('stg__mitxonline__app__postgres__reversion_version') }}
     where contenttype_id in (
         select contenttype_id from
-            contenttypes where contenttype_full_name = 'ecommerce_product'
+            contenttypes
+        where contenttype_full_name = 'ecommerce_product'
     )
 )
 

--- a/src/ol_dbt/models/intermediate/mitxonline/int__mitxonline__program_to_courses.sql
+++ b/src/ol_dbt/models/intermediate/mitxonline/int__mitxonline__program_to_courses.sql
@@ -20,7 +20,7 @@ with programrequirement as (
         , programrequirement.program_id
     from programrequirement
     inner join required_path
-               on programrequirement.programrequirement_path like required_path.programrequirement_path || '%'
+        on programrequirement.programrequirement_path like required_path.programrequirement_path || '%'
     where programrequirement.programrequirement_node_type = 'course'
 )
 
@@ -32,9 +32,11 @@ with programrequirement as (
         , programrequirement.program_id
     from programrequirement
     left join required_courses
-        on programrequirement.program_id = required_courses.program_id
+        on
+            programrequirement.program_id = required_courses.program_id
             and programrequirement.course_id = required_courses.course_id
-    where programrequirement.programrequirement_node_type = 'course'
+    where
+        programrequirement.programrequirement_node_type = 'course'
         and required_courses.program_id is null
 )
 


### PR DESCRIPTION
This changes the max line length back to 120 and fixes the linting to the new version of sqlfluff.

Sqlfluff now has slightly new rules for indents since version 2.0.0 no longer supports hanging indents https://docs.sqlfluff.com/en/stable/layout.html#hanging-indents