### PR TITLE
Stage email_opt_in and Update edx intermediate users table to use it for email and username

### DIFF
--- a/src/ol_dbt/models/intermediate/edxorg/_int_edxorg__models.yml
+++ b/src/ol_dbt/models/intermediate/edxorg/_int_edxorg__models.yml
@@ -80,6 +80,9 @@ models:
     tests:
     - dbt_expectations.expect_column_to_exist
     - not_null
+    - relationships:
+        to: ref('int__edxorg__mitx_users')
+        field: user_id
   - name: courserun_readable_id
     description: str, The canonical ID of the course run in the format as {org}/{course}/{run}.
       This is old format and could be different from courses in MITxOnline or MicroMasters
@@ -91,10 +94,12 @@ models:
     description: str, The username of the learner on the edX platform
     tests:
     - dbt_expectations.expect_column_to_exist
+    - not_null
   - name: user_email
     description: str, The email address of the learner on the edX platform
     tests:
     - dbt_expectations.expect_column_to_exist
+    - not_null
   - name: courseruncertificate_created_on
     description: timestamp, Timestamp indicating when the certificate was created
     tests:
@@ -148,6 +153,9 @@ models:
     tests:
     - dbt_expectations.expect_column_to_exist
     - not_null
+    - relationships:
+        to: ref('int__edxorg__mitx_users')
+        field: user_id
   - name: courserun_readable_id
     description: str, The canonical ID of the course run in the format as {org}/{course}/{run}.
       This is old format and could be different from courses in MITxOnline or MicroMasters
@@ -159,10 +167,12 @@ models:
     description: str, username of a learner on the edX platform (some blank from source)
     tests:
     - dbt_expectations.expect_column_to_exist
+    - not_null
   - name: user_email
     description: str, The email address of the learner on the edX platform
     tests:
     - dbt_expectations.expect_column_to_exist
+    - not_null
   - name: courserunenrollment_created_on
     description: timestamp, timestamp of user's enrollment in the course
     tests:
@@ -191,31 +201,33 @@ models:
     data
   columns:
   - name: user_id
-    description: int, Numerical user ID of a learner on the edX platform
+    description: int, Numerical user ID on the edX platform
     tests:
     - dbt_expectations.expect_column_to_exist
     - not_null
     - unique
   - name: user_username
-    description: str, The username of the learner on the edX platform some usernames
-      are blank
+    description: str, The unique username of the user on the edX platform
     tests:
     - dbt_expectations.expect_column_to_exist
+    - not_null
+    - unique
   - name: user_email
     description: str, The current default email address of the learner on the edX
       platform
     tests:
     - dbt_expectations.expect_column_to_exist
+    - not_null
   - name: user_full_name
     description: str, The full name of the user on the edX platform
     tests:
     - dbt_expectations.expect_column_to_exist
   - name: user_country
-    description: str, Country provided by the learner
+    description: str, Country provided by the user on the edX platform
     tests:
     - dbt_expectations.expect_column_to_exist
   - name: user_joined_on
-    description: timestamp, timestamp that the account was created.
+    description: timestamp, timestamp that the user's account was created.
     tests:
     - dbt_expectations.expect_column_to_exist
   tests:

--- a/src/ol_dbt/models/intermediate/edxorg/int__edxorg__mitx_users.sql
+++ b/src/ol_dbt/models/intermediate/edxorg/int__edxorg__mitx_users.sql
@@ -1,9 +1,52 @@
---- Intermediate MITx users for edx.org
---- user_info_combo contains user info for each course they enroll in, so need to aggregate it here
---  to get the latest user info per user_id
+---Intermediate MITx users for edx.org
+---user data is mostly in user_info_combo but email or username could be blank in user_info_combo in some older courses,
+---to get the most recent user data, we combine user_info_combo and email_opt_in here to always use username
+-- and email from email_opt_in and the rest profile fields from user_info_combo
+-- Both tables are unique on user_id + course_id
 
 with user_info_combo as (
-    --- use window function to generate row number based on user_last_login for each user
+    select * from {{ ref('stg__edxorg__bigquery__mitx_user_info_combo') }}
+)
+
+--- email_opt_in is one row per course_id with the same user_* data, use window function to pick one per user_id
+, email_opt_in as (
+    select
+        user_id
+        , user_email
+        , user_username
+        , user_full_name
+        , row_number() over (partition by user_id order by user_email_opt_in_updated_on desc) as row_num
+    from {{ ref('stg__edxorg__bigquery__mitx_user_email_opt_in') }}
+)
+
+, most_recent_user_info as (
+    select
+        user_id
+        , user_email
+        , user_username
+        , user_full_name
+    from email_opt_in
+    where row_num = 1
+)
+
+, combined_user_info as (
+    select
+        most_recent_user_info.user_id
+        , most_recent_user_info.user_email
+        , most_recent_user_info.user_username
+        , user_info_combo.user_full_name
+        , user_info_combo.user_country
+        , user_info_combo.user_joined_on
+        , row_number() over (partition by user_info_combo.user_id order by user_info_combo.user_last_login desc
+        ) as row_num
+    from user_info_combo
+    inner join most_recent_user_info
+        on
+            user_info_combo.user_id = most_recent_user_info.user_id
+            and user_info_combo.user_username = most_recent_user_info.user_username
+)
+
+, users as (
     select
         user_id
         , user_email
@@ -11,16 +54,8 @@ with user_info_combo as (
         , user_full_name
         , user_country
         , user_joined_on
-        , row_number() over (partition by user_id order by user_last_login desc) as seq
-    from {{ ref('stg__edxorg__bigquery__mitx_user_info_combo') }}
+    from combined_user_info
+    where row_num = 1
 )
 
-select
-    user_id
-    , user_email
-    , user_username
-    , user_full_name
-    , user_country
-    , user_joined_on
-from user_info_combo
-where seq = 1   -- use the latest row for each user
+select * from users

--- a/src/ol_dbt/models/staging/edxorg/_edxorg_sources.yml
+++ b/src/ol_dbt/models/staging/edxorg/_edxorg_sources.yml
@@ -546,8 +546,8 @@ sources:
 
   - name: raw__irx__edxorg__bigquery__mitx_user_info_combo
     description: source table contains edxorg user profile, enrollments and certificate
-      details in a course from IRx BigQuery. enrollment_course_id in this table is
-      not always populated.
+      details in a course from IRx BigQuery, but enrollment_course_id in this table
+      is not always populated.
     columns:
     - name: user_id
       description: int, Numerical user ID of a learner on the edX platform (not unique)
@@ -752,3 +752,42 @@ sources:
     tests:
     - dbt_expectations.expect_table_column_count_to_equal:
         value: 42
+
+  - name: raw__irx__edxorg__bigquery__email_opt_in
+    description: It contains email opt-in preferences for every user on every course
+      they enroll in. If users enroll in multiple courses, the email and username
+      in this table are the most recent data
+    columns:
+    - name: course_id
+      description: str, The canonical ID of the course in the format as {org}/{course}/{run}.
+      tests:
+      - dbt_expectations.expect_column_to_exist
+    - name: user_id
+      description: int, Numerical user ID of a learner on the edX platform
+      tests:
+      - dbt_expectations.expect_column_to_exist
+    - name: username
+      description: str, username of a learner on the edX platform
+      tests:
+      - dbt_expectations.expect_column_to_exist
+    - name: email
+      description: str, The email address of the learner on the edX platform
+      tests:
+      - dbt_expectations.expect_column_to_exist
+    - name: full_name
+      description: str, The full name of the user on the edX platform
+      tests:
+      - dbt_expectations.expect_column_to_exist
+    - name: is_opted_in_for_email
+      description: boolean, indicating if the learner has opted to receive marketing
+        emails
+      tests:
+      - dbt_expectations.expect_column_to_exist
+    - name: preference_set_datetime
+      description: timestamp, specifying when email opt in preference was most recently
+        updated
+      tests:
+      - dbt_expectations.expect_column_to_exist
+    tests:
+    - dbt_expectations.expect_table_column_count_to_equal:
+        value: 7

--- a/src/ol_dbt/models/staging/edxorg/_stg__edxorg__models.yml
+++ b/src/ol_dbt/models/staging/edxorg/_stg__edxorg__models.yml
@@ -320,3 +320,44 @@ models:
   tests:
   - dbt_expectations.expect_table_column_count_to_equal:
       value: 32
+
+- name: stg__edxorg__bigquery__mitx_user_email_opt_in
+  description: It contains email opt-in preferences for every user on every course
+    they enroll in. If users enroll in multiple courses, the email and username in
+    this table are the most recent data
+  columns:
+  - name: course_id
+    description: str, The canonical ID of the course in the format as {org}/{course}/{run}.
+    tests:
+    - dbt_expectations.expect_column_to_exist
+  - name: user_id
+    description: int, Numerical user ID of a learner on the edX platform
+    tests:
+    - dbt_expectations.expect_column_to_exist
+  - name: user_username
+    description: str, The username of the user on the edX platform
+    tests:
+    - dbt_expectations.expect_column_to_exist
+  - name: user_email
+    description: str, The email address of the user on the edX platform
+    tests:
+    - dbt_expectations.expect_column_to_exist
+  - name: user_full_name
+    description: str, The full name of the user on the edX platform
+    tests:
+    - dbt_expectations.expect_column_to_exist
+  - name: user_is_opted_in_for_email
+    description: boolean, indicating if the learner has opted to receive marketing
+      emails
+    tests:
+    - dbt_expectations.expect_column_to_exist
+  - name: user_email_opt_in_updated_on
+    description: timestamp, specifying when email opt in preference was most recently
+      updated
+    tests:
+    - dbt_expectations.expect_column_to_exist
+  tests:
+  - dbt_expectations.expect_table_column_count_to_equal:
+      value: 7
+  - dbt_expectations.expect_compound_columns_to_be_unique:
+      column_list: ["user_id", "courserun_id"]

--- a/src/ol_dbt/models/staging/edxorg/stg__edxorg__bigquery__mitx_user_email_opt_in.sql
+++ b/src/ol_dbt/models/staging/edxorg/stg__edxorg__bigquery__mitx_user_email_opt_in.sql
@@ -1,0 +1,19 @@
+with source as (
+    select *
+    from {{ source('ol_warehouse_raw_data','raw__irx__edxorg__bigquery__email_opt_in') }}
+)
+
+, cleaned as (
+
+    select
+        user_id
+        , email as user_email
+        , username as user_username
+        , full_name as user_full_name
+        , is_opted_in_for_email as user_is_opted_in_for_email
+        , to_iso8601(from_iso8601_timestamp(preference_set_datetime)) as user_email_opt_in_updated_on
+    from source
+
+)
+
+select * from cleaned


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This PR adds email_opt_in to the staging model and updates the logic in edx intermediate users model to use email_opt_in for email and username so these two fields are always populated

## Motivation and Context
The username and email fields could be blank in user_info_combo due to data issues found in some older courses (e.g. MITx/6.832x_2/3T2015). In order to get the most recent data for edx users, we should be combining user_info_combo and email_opt_in as email and username come straight from auth_user and should always be populated in email_opt_in report
see edx documentation for [email_opt_in](https://edx.readthedocs.io/projects/devdata/en/stable/internal_data_formats/institution_data.html#email-opt-in-report) (username is not mentioned in the doc but it's provided in the data file)

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Ran the following commands
dbt run --select staging.edxorg --full-refresh
dbt run --select intermediate.edxorg --full-refresh
dbt test --select staging.edxorg 
dbt test --select intermediate.edxorg 

verified username and email are not blank in int__edxorg__mitx_users

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Enhancement (improves on existing behavior)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project. (Did you install and run the pre-commit hooks?)
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
