### PR TITLE
feat: Render the full ELT flow as an asset graph

### DIFF
--- a/dockerfiles/orchestrate/BUILD
+++ b/dockerfiles/orchestrate/BUILD
@@ -76,3 +76,15 @@ docker_image(
     tags=["data_pipeline", "docker_image"],
     image_tags=["{build_args.DAGSTER_VERSION}", "latest"],
 )
+
+docker_image(
+    name="lakehouse-assets-graph",
+    dependencies=[
+        ":ol-data-code-locations",
+        "src/ol_dbt:dbt_project",
+    ],
+    source="Dockerfile.dbt_pipeline",
+    extra_build_args=["PACKAGE_NAME=lakehouse-assets"],
+    tags=["data_pipeline", "docker_image", "data_lakehouse"],
+    image_tags=["{build_args.DAGSTER_VERSION}", "latest"],
+)

--- a/src/ol_orchestrate/BUILD
+++ b/src/ol_orchestrate/BUILD
@@ -13,6 +13,20 @@ python_distribution(
     ],
     provides=python_artifact(
         name="dagster-pipeline",
-        version="0.5.3",
+        version="0.6.0",
     ),
+)
+
+python_distribution(
+    name="ol-data-code-locations",
+    dependencies=[
+        "//:requirements#dagster-postgres",
+        "//:requirements#dagster-aws",
+        "//:requirements#dbt-trino",
+        "./definitions",
+    ],
+    provides=python_artifact(
+        name="dagster-pipeline",
+        version="0.6.0",
+    )
 )

--- a/src/ol_orchestrate/definitions/elt.py
+++ b/src/ol_orchestrate/definitions/elt.py
@@ -1,0 +1,50 @@
+import os
+from pathlib import Path
+
+from dagster import AssetSelection, Definitions, build_asset_reconciliation_sensor
+from dagster_airbyte import airbyte_resource, load_assets_from_airbyte_instance
+from dagster_dbt import dbt_cli_resource, load_assets_from_dbt_project
+from requests.auth import HTTPBasicAuth
+
+dagster_deployment = os.getenv("DAGSTER_ENVIRONMENT", "dev")
+configured_airbyte_resource = airbyte_resource.configured(
+    {
+        "host": {"env": "DAGSTER_AIRBYTE_HOST"},
+        "port": {"env": "DAGSTER_AIRBYTE_PORT"},
+        "use_https": False,
+        "request_additional_params": {
+            "auth": HTTPBasicAuth(*os.getenv("DAGSTER_AIRBYTE_AUTH", "").split(":")),
+            "verify": False,
+        },
+    }
+)
+
+dbt_repo_dir = str(
+    Path(__file__).parent.parent.parent.joinpath("ol_dbt")
+    if dagster_deployment == "dev"
+    else Path("/opt/dbt")
+)
+
+dbt_config = {"project_dir": dbt_repo_dir, "profiles_dir": dbt_repo_dir}
+configured_dbt_cli = dbt_cli_resource.configured(dbt_config)
+
+elt = Definitions(
+    assets=[
+        load_assets_from_airbyte_instance(
+            configured_airbyte_resource,
+            # This key_prefix is how Dagster knows to map the Airbyte outputs to the dbt
+            # sources, since they are defined as ol_warehouse_raw_data in the
+            # sources.yml files. (TMM 2023-01-18)
+            key_prefix="ol_warehouse_raw_data",
+        ),
+        *load_assets_from_dbt_project(**dbt_config),
+    ],
+    resources={"dbt": configured_dbt_cli},
+    sensors=[
+        build_asset_reconciliation_sensor(
+            name="elt_asset_sensor",
+            asset_selection=AssetSelection.all(),
+            minimum_interval_seconds=60 * 5,
+        )
+    ],
+)

--- a/src/ol_orchestrate/workspace.yaml
+++ b/src/ol_orchestrate/workspace.yaml
@@ -12,21 +12,7 @@ load_from:
     host: edx-gcs-courses-pipeline
     port: 4000
     location_name: 'edx-gcs-courses-pipeline'
-#- python_package:
-#    package_name: ol_orchestrate.edx.repositories
-#    attribute: residential_edx_repository
-#- python_package:
-#    package_name: ol_orchestrate.edx.repositories
-#    attribute: xpro_edx_repository
-#- python_package:
-#    package_name: ol_orchestrate.edx.repositories
-#    attribute: mitxonline_edx_repository
-#- python_package:
-#    package_name: ol_orchestrate.mitx_bigquery.repositories
-#    attribute: mitx_bigquery_repository
-#- python_package:
-#    package_name: ol_orchestrate.open_discussions.repositories
-#    attribute: open_data_repository
-# - python_package:
-#     package_name: ol_orchestrate.micromasters.repositories
-#     attribute: micromasters_repository
+- grpc_server:
+    host: lakehouse-assets-graph
+    port: 4000
+    location_name: lakehouse-assets-graph


### PR DESCRIPTION
We would like to be able to treat the entire Airbyte -> dbt workflow as a single representation.

<!--- Provide a general summary of your changes in the Title above -->

## Description
This adds a definition which renders all available Airbyte connections and dbt models as a single graph and allows updates to propagate throughout the graph automatically.

## Motivation and Context
We want to keep all production tables in the data lake up to date automatically using Dagster.

## How Has This Been Tested?
I ran the associated code location locally and validated that the entire asset graph was rendered and the lineage was properly represented.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Enhancement (improves on existing behavior)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project. (Did you install and run the pre-commit hooks?)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
