### PR TITLE
Condense and simplify Dagster pipeline/container build

### DIFF
--- a/3rdparty/python/default.lock
+++ b/3rdparty/python/default.lock
@@ -88,13 +88,13 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "0a024d7f2de88d738d7395ff866997314c837be6104e90c5724350313dee4da4",
-              "url": "https://files.pythonhosted.org/packages/b3/c8/69600a8138a56794713ecdb8b75b14fbe32a410bc444683f27dbab93c0ca/alembic-1.8.1-py3-none-any.whl"
+              "hash": "e8a6ff9f3b1887e1fed68bfb8fb9a000d8f61c21bdcc85b67bb9f87fcbc4fce3",
+              "url": "https://files.pythonhosted.org/packages/f4/88/08b24576e30f73a8c327a36a08415781745b54ff4d7186e3cc7fb8b7cd55/alembic-1.9.2-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "cd0b5e45b14b706426b833f06369b9a6d5ee03f826ec3238723ce8caaf6e5ffa",
-              "url": "https://files.pythonhosted.org/packages/37/ab/80e6d86ca81235ea1a7104089dddf74de4b45f8af0a05d4b265be44d6ff9/alembic-1.8.1.tar.gz"
+              "hash": "6880dec4f28dd7bd999d2ed13fbe7c9d4337700a44d11a524c0ce0c59aaf0dbd",
+              "url": "https://files.pythonhosted.org/packages/1b/57/b2f76a894b5642c69a57df6d729e3e1b743d666353d7e5f1ab9f7c88cf13/alembic-1.9.2.tar.gz"
             }
           ],
           "project_name": "alembic",
@@ -106,7 +106,7 @@
             "python-dateutil; extra == \"tz\""
           ],
           "requires_python": ">=3.7",
-          "version": "1.8.1"
+          "version": "1.9.2"
         },
         {
           "artifacts": [
@@ -370,13 +370,13 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "c56caef774a929923696f09ceea0eadcb95c94b30e8ee4f9fc4f5867096caaeb",
-              "url": "https://files.pythonhosted.org/packages/c5/28/c6cf14c78126cb7ae65ee81ad28f74bff0fb7b9e0ea773d543ce73904718/asttokens-2.2.0-py2.py3-none-any.whl"
+              "hash": "6b0ac9e93fb0335014d382b8fa9b3afa7df546984258005da0b9e7095b3deb1c",
+              "url": "https://files.pythonhosted.org/packages/f3/e1/64679d9d0759db5b182222c81ff322c2fe2c31e156a59afd6e9208c960e5/asttokens-2.2.1-py2.py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "e27b1f115daebfafd4d1826fc75f9a72f0b74bd3ae4ee4d9380406d74d35e52c",
-              "url": "https://files.pythonhosted.org/packages/c8/a8/897876e62ff3e796ca948ab7e6d99e03dfed256da87da557c35f12b9ef7e/asttokens-2.2.0.tar.gz"
+              "hash": "4622110b2a6f30b77e1473affaa97e711bc2f07d3f10848420ff1898edbe94f3",
+              "url": "https://files.pythonhosted.org/packages/c8/e3/b0b4f32162621126fbdaba636c152c6b6baec486c99f48686e66343d638f/asttokens-2.2.1.tar.gz"
             }
           ],
           "project_name": "asttokens",
@@ -387,57 +387,53 @@
             "typing; python_version < \"3.5\""
           ],
           "requires_python": null,
-          "version": "2.2"
+          "version": "2.2.1"
         },
         {
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "86efa402f67bf2df34f51a335487cf46b1ec130d02b8d39fd248abfd30da551c",
-              "url": "https://files.pythonhosted.org/packages/f2/bc/d817287d1aa01878af07c19505fafd1165cd6a119e9d0821ca1d1c20312d/attrs-22.1.0-py2.py3-none-any.whl"
+              "hash": "29e95c7f6778868dbd49170f98f8818f78f3dc5e0e37c0b1f474e3561b240836",
+              "url": "https://files.pythonhosted.org/packages/fb/6e/6f83bf616d2becdf333a1640f1d463fef3150e2e926b7010cb0f81c95e88/attrs-22.2.0-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "29adc2665447e5191d0e7c568fde78b21f9672d344281d0c6e1ab085429b22b6",
-              "url": "https://files.pythonhosted.org/packages/1a/cb/c4ffeb41e7137b23755a45e1bfec9cbb76ecf51874c6f1d113984ecaa32c/attrs-22.1.0.tar.gz"
+              "hash": "c9227bfc2f01993c03f68db37d1d15c9690188323c067c641f1a35ca58185f99",
+              "url": "https://files.pythonhosted.org/packages/21/31/3f468da74c7de4fcf9b25591e682856389b3400b4b62f201e65f15ea3e07/attrs-22.2.0.tar.gz"
             }
           ],
           "project_name": "attrs",
           "requires_dists": [
-            "cloudpickle; platform_python_implementation == \"CPython\" and extra == \"dev\"",
-            "cloudpickle; platform_python_implementation == \"CPython\" and extra == \"tests\"",
+            "attrs[docs,tests]; extra == \"dev\"",
+            "attrs[tests-no-zope]; extra == \"tests\"",
+            "attrs[tests]; extra == \"cov\"",
+            "cloudpickle; platform_python_implementation == \"CPython\" and extra == \"tests-no-zope\"",
             "cloudpickle; platform_python_implementation == \"CPython\" and extra == \"tests_no_zope\"",
-            "coverage[toml]>=5.0.2; extra == \"dev\"",
-            "coverage[toml]>=5.0.2; extra == \"tests\"",
-            "coverage[toml]>=5.0.2; extra == \"tests_no_zope\"",
-            "furo; extra == \"dev\"",
+            "coverage-enable-subprocess; extra == \"cov\"",
+            "coverage[toml]>=5.3; extra == \"cov\"",
             "furo; extra == \"docs\"",
-            "hypothesis; extra == \"dev\"",
-            "hypothesis; extra == \"tests\"",
+            "hypothesis; extra == \"tests-no-zope\"",
             "hypothesis; extra == \"tests_no_zope\"",
-            "mypy!=0.940,>=0.900; extra == \"dev\"",
-            "mypy!=0.940,>=0.900; extra == \"tests\"",
-            "mypy!=0.940,>=0.900; extra == \"tests_no_zope\"",
-            "pre-commit; extra == \"dev\"",
-            "pympler; extra == \"dev\"",
-            "pympler; extra == \"tests\"",
+            "mypy<0.990,>=0.971; platform_python_implementation == \"CPython\" and extra == \"tests-no-zope\"",
+            "mypy<0.990,>=0.971; platform_python_implementation == \"CPython\" and extra == \"tests_no_zope\"",
+            "myst-parser; extra == \"docs\"",
+            "pympler; extra == \"tests-no-zope\"",
             "pympler; extra == \"tests_no_zope\"",
-            "pytest-mypy-plugins; extra == \"dev\"",
-            "pytest-mypy-plugins; extra == \"tests\"",
-            "pytest-mypy-plugins; extra == \"tests_no_zope\"",
-            "pytest>=4.3.0; extra == \"dev\"",
-            "pytest>=4.3.0; extra == \"tests\"",
+            "pytest-mypy-plugins; (platform_python_implementation == \"CPython\" and python_version < \"3.11\") and extra == \"tests-no-zope\"",
+            "pytest-mypy-plugins; (platform_python_implementation == \"CPython\" and python_version < \"3.11\") and extra == \"tests_no_zope\"",
+            "pytest-xdist[psutil]; extra == \"tests-no-zope\"",
+            "pytest-xdist[psutil]; extra == \"tests_no_zope\"",
+            "pytest>=4.3.0; extra == \"tests-no-zope\"",
             "pytest>=4.3.0; extra == \"tests_no_zope\"",
-            "sphinx-notfound-page; extra == \"dev\"",
             "sphinx-notfound-page; extra == \"docs\"",
-            "sphinx; extra == \"dev\"",
             "sphinx; extra == \"docs\"",
-            "zope.interface; extra == \"dev\"",
+            "sphinxcontrib-towncrier; extra == \"docs\"",
+            "towncrier; extra == \"docs\"",
             "zope.interface; extra == \"docs\"",
             "zope.interface; extra == \"tests\""
           ],
-          "requires_python": ">=3.5",
-          "version": "22.1"
+          "requires_python": ">=3.6",
+          "version": "22.2"
         },
         {
           "artifacts": [
@@ -555,73 +551,43 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "e41a86c6c650bcecc6633ee3180d80a025db041a8e2398dcc059b3afa8382cd4",
-              "url": "https://files.pythonhosted.org/packages/f2/23/f4278377cabf882298b4766e977fd04377f288d1ccef706953076a1e0598/black-22.10.0-1fixedarch-cp39-cp39-macosx_11_0_x86_64.whl"
+              "hash": "436cc9167dd28040ad90d3b404aec22cedf24a6e4d7de221bec2730ec0c97bcf",
+              "url": "https://files.pythonhosted.org/packages/0c/51/1f7f93c0555eaf4cbb628e26ba026e3256174a45bd9397ff1ea7cf96bad5/black-22.12.0-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "2039230db3c6c639bd84efe3292ec7b06e9214a2992cd9beb293d639c6402edb",
-              "url": "https://files.pythonhosted.org/packages/2c/11/f2737cd3b458d91401801e83a014e87c63e8904dc063200f77826c352f54/black-22.10.0-cp310-cp310-macosx_11_0_arm64.whl"
+              "hash": "7412e75863aa5c5411886804678b7d083c7c28421210180d67dfd8cf1221e1f4",
+              "url": "https://files.pythonhosted.org/packages/4c/49/420dcfccba3215dc4e5790fa47572ef14129df1c5e95dd87b5ad30211b01/black-22.12.0-cp311-cp311-win_amd64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "21199526696b8f09c3997e2b4db8d0b108d801a348414264d2eb8eb2532e540d",
-              "url": "https://files.pythonhosted.org/packages/56/df/913d71817c7034edba25d596c54f782c2f809b6af30367d2f00309e8890a/black-22.10.0-cp311-cp311-win_amd64.whl"
+              "hash": "159a46a4947f73387b4d83e87ea006dbb2337eab6c879620a3ba52699b1f4351",
+              "url": "https://files.pythonhosted.org/packages/71/57/975782465cc6b514f2c972421e29b933dfbb51d4a95948a4e0e94f36ea38/black-22.12.0-cp310-cp310-win_amd64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "974308c58d057a651d182208a484ce80a26dac0caef2895836a92dd6ebd725e0",
-              "url": "https://files.pythonhosted.org/packages/69/84/903cdf41514088d5a716538cb189c471ab34e56ae9a1c2da6b8bfe8e4dbf/black-22.10.0-cp39-cp39-macosx_11_0_arm64.whl"
+              "hash": "9eedd20838bd5d75b80c9f5487dbcb06836a43833a37846cf1d8c1cc01cef59d",
+              "url": "https://files.pythonhosted.org/packages/79/d9/60852a6fc2f85374db20a9767dacfe50c2172eb8388f46018c8daf836995/black-22.12.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "f513588da599943e0cde4e32cc9879e825d58720d6557062d1098c5ad80080e1",
-              "url": "https://files.pythonhosted.org/packages/a3/89/629fca2eea0899c06befaa58dc0f49d56807d454202bb2e54bd0d98c77f3/black-22.10.0.tar.gz"
+              "hash": "229351e5a18ca30f447bf724d007f890f97e13af070bb6ad4c0a441cd7596a2f",
+              "url": "https://files.pythonhosted.org/packages/a6/59/e873cc6807fb62c11131e5258ca15577a3b7452abad08dc49286cf8245e8/black-22.12.0.tar.gz"
             },
             {
               "algorithm": "sha256",
-              "hash": "14ff67aec0a47c424bc99b71005202045dc09270da44a27848d534600ac64fc7",
-              "url": "https://files.pythonhosted.org/packages/a5/5f/9cfc6dd95965f8df30194472543e6f0515a10d78ea5378426ef1546735c7/black-22.10.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+              "hash": "101c69b23df9b44247bd88e1d7e90154336ac4992502d4197bdac35dd7ee3320",
+              "url": "https://files.pythonhosted.org/packages/ba/32/954bcc56b2b3b4ef52a086e3c0bdbad88a38c9e739feb19dd2e6294cda42/black-22.12.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "5d8f74030e67087b219b032aa33a919fae8806d49c867846bfacde57f43972ef",
-              "url": "https://files.pythonhosted.org/packages/a6/84/5c3f3ffc4143fa7e208d745d2239d915e74d3709fdbc64c3e98d3fd27e56/black-22.10.0-1fixedarch-cp311-cp311-macosx_11_0_x86_64.whl"
+              "hash": "d30b212bffeb1e252b31dd269dfae69dd17e06d92b87ad26e23890f3efea366f",
+              "url": "https://files.pythonhosted.org/packages/e9/e0/6aa02d14785c4039b38bfed6f9ee28a952b2d101c64fc97b15811fa8bd04/black-22.12.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "432247333090c8c5366e69627ccb363bc58514ae3e63f7fc75c54b1ea80fa7de",
-              "url": "https://files.pythonhosted.org/packages/ab/15/61119d166a44699827c112d7c4726421f14323c2cb7aa9f4c26628f237f9/black-22.10.0-cp39-cp39-win_amd64.whl"
-            },
-            {
-              "algorithm": "sha256",
-              "hash": "5cc42ca67989e9c3cf859e84c2bf014f6633db63d1cbdf8fdb666dcd9e77e3fa",
-              "url": "https://files.pythonhosted.org/packages/ae/49/ea03c318a25be359b8e5178a359d47e2da8f7524e1522c74b8f74c66b6f8/black-22.10.0-1fixedarch-cp310-cp310-macosx_11_0_x86_64.whl"
-            },
-            {
-              "algorithm": "sha256",
-              "hash": "b8b49776299fece66bffaafe357d929ca9451450f5466e997a7285ab0fe28e3b",
-              "url": "https://files.pythonhosted.org/packages/b0/9e/fa912c5ae4b8eb6d36982fc8ac2d779cf944dbd7c3c1fe7a28acf462c1ed/black-22.10.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
-            },
-            {
-              "algorithm": "sha256",
-              "hash": "72ef3925f30e12a184889aac03d77d031056860ccae8a1e519f6cbb742736383",
-              "url": "https://files.pythonhosted.org/packages/b9/51/403b0b0eb9fb412ca02b79dc38472469f2f88c9aacc6bb5262143e4ff0bc/black-22.10.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
-            },
-            {
-              "algorithm": "sha256",
-              "hash": "c957b2b4ea88587b46cf49d1dc17681c1e672864fd7af32fc1e9664d572b3458",
-              "url": "https://files.pythonhosted.org/packages/ce/6f/74492b8852ee4f2ad2178178f6b65bc8fc80ad539abe56c1c23eab6732e2/black-22.10.0-py3-none-any.whl"
-            },
-            {
-              "algorithm": "sha256",
-              "hash": "5b9b29da4f564ba8787c119f37d174f2b69cdfdf9015b7d8c5c16121ddc054ae",
-              "url": "https://files.pythonhosted.org/packages/e2/2f/a8406a9e337a213802aa90a3e9fbf90c86f3edce92f527255fd381309b77/black-22.10.0-cp311-cp311-macosx_11_0_arm64.whl"
-            },
-            {
-              "algorithm": "sha256",
-              "hash": "819dc789f4498ecc91438a7de64427c73b45035e2e3680c92e18795a839ebb66",
-              "url": "https://files.pythonhosted.org/packages/ff/ce/22281871536b3d79474fd44d48dad48f7cbc5c3982bddf6a7495e7079d00/black-22.10.0-cp310-cp310-win_amd64.whl"
+              "hash": "559c7a1ba9a006226f09e4916060982fd27334ae1998e7a38b3f33a37f7a2148",
+              "url": "https://files.pythonhosted.org/packages/f2/b9/06fe2dd83a2104d83c2b737f41aa5679f5a4395630005443ba4fa6fece8b/black-22.12.0-cp39-cp39-win_amd64.whl"
             }
           ],
           "project_name": "black",
@@ -640,7 +606,7 @@
             "uvloop>=0.15.2; extra == \"uvloop\""
           ],
           "requires_python": ">=3.7",
-          "version": "22.10"
+          "version": "22.12"
         },
         {
           "artifacts": [
@@ -679,36 +645,36 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "4b4edf893b01c651007d61534c1d248cd2350d311a4e295039bd23fd60bf899a",
-              "url": "https://files.pythonhosted.org/packages/c2/e6/17fc2d334e86c78cb99180d3a8f011f0aacba65ef1be40ffeabd0c93559c/boto3-1.26.19-py3-none-any.whl"
+              "hash": "b4aefdc72191c40a0155511b9ce933c94dcbdd1834ffc1204e90a30e7849ef13",
+              "url": "https://files.pythonhosted.org/packages/55/6a/e1cb5f78101a4d85f5c67780edd5b63e3df3d57e2239f1126e5f30216a6e/boto3-1.26.51-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "59aa6c7810a815fb52671f834d10ac4cd80b9c7c01a3cbde670cb41330059464",
-              "url": "https://files.pythonhosted.org/packages/58/3e/c343789e53ac554416cfd76fdc591052ae381c7c38c12a91468d6536edbe/boto3-1.26.19.tar.gz"
+              "hash": "d599ce626b03e7236b0cda051c3cedc128fd75e0ec2f799fab9b2eabdf32d945",
+              "url": "https://files.pythonhosted.org/packages/7c/dd/bb5763394e574b2960e9bfa8783365bcfb5dc7c41b7cd4cd2aa2e0fb257c/boto3-1.26.51.tar.gz"
             }
           ],
           "project_name": "boto3",
           "requires_dists": [
-            "botocore<1.30.0,>=1.29.19",
+            "botocore<1.30.0,>=1.29.51",
             "botocore[crt]<2.0a0,>=1.21.0; extra == \"crt\"",
             "jmespath<2.0.0,>=0.7.1",
             "s3transfer<0.7.0,>=0.6.0"
           ],
           "requires_python": ">=3.7",
-          "version": "1.26.19"
+          "version": "1.26.51"
         },
         {
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "917807ee4ccca34a2f2848eb4fcf878d9e97a44a911a6965ff556d0830c471fd",
-              "url": "https://files.pythonhosted.org/packages/54/81/570ff698f56cb187d46a1da50318efc236f05b9b78aab3b34a3b0ece41e9/botocore-1.29.19-py3-none-any.whl"
+              "hash": "bbb92420902b4d9e4b854fcfae20d1029f1c3396e0579894f115278bc51d6198",
+              "url": "https://files.pythonhosted.org/packages/54/c8/f76bced9512b8078e14cf1b6d097051bc901baad3947cfb6ad3c0d611073/botocore-1.29.51-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "a54561e591f5d8e653657ce04dcad09c10ebca9dbefba73471976e522abf038a",
-              "url": "https://files.pythonhosted.org/packages/01/30/0825e911ad790c88bf357e359924bf8c598149ee5d3a1adbfd120245517c/botocore-1.29.19.tar.gz"
+              "hash": "f2f521fbd2343879f3c2d42392c88f1e7f15ea147a6dc5a3dab7b8686d90fcb6",
+              "url": "https://files.pythonhosted.org/packages/c3/e4/4225ec06a7bea8e579ff0bd68f826731a8930dce4a3d2f7b9485c4833f31/botocore-1.29.51.tar.gz"
             }
           ],
           "project_name": "botocore",
@@ -719,7 +685,7 @@
             "urllib3<1.27,>=1.25.4"
           ],
           "requires_python": ">=3.7",
-          "version": "1.29.19"
+          "version": "1.29.51"
         },
         {
           "artifacts": [
@@ -748,19 +714,19 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "f9f17d2aec496a9aa6b76f53e3b614c965223c061982d434d160f930c698a9db",
-              "url": "https://files.pythonhosted.org/packages/68/aa/5fc646cae6e997c3adf3b0a7e257cda75cff21fcba15354dffd67789b7bb/cachetools-5.2.0-py3-none-any.whl"
+              "hash": "8462eebf3a6c15d25430a8c27c56ac61340b2ecf60c9ce57afc2b97e450e47da",
+              "url": "https://files.pythonhosted.org/packages/a4/7e/9a87d3b3ca48e253b5c0e114a6601160b9b29f175f4268cb30e21d9e8b63/cachetools-5.2.1-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "6a94c6402995a99c3970cc7e4884bb60b4a8639938157eeed436098bf9831757",
-              "url": "https://files.pythonhosted.org/packages/c2/6f/278225c5a070a18a76f85db5f1238f66476579fa9b04cda3722331dcc90f/cachetools-5.2.0.tar.gz"
+              "hash": "5991bc0e08a1319bb618d3195ca5b6bc76646a49c21d55962977197b301cc1fe",
+              "url": "https://files.pythonhosted.org/packages/3d/cf/8bab81474cb9ec7879ba28aef71c8351db92cd03587d9eac8e908b2c1c23/cachetools-5.2.1.tar.gz"
             }
           ],
           "project_name": "cachetools",
           "requires_dists": [],
           "requires_python": "~=3.7",
-          "version": "5.2"
+          "version": "5.2.1"
         },
         {
           "artifacts": [
@@ -788,19 +754,19 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "90c1a32f1d68f940488354e36370f6cca89f0f106db09518524c88d6ed83f382",
-              "url": "https://files.pythonhosted.org/packages/1d/38/fa96a426e0c0e68aabc68e896584b83ad1eec779265a028e156ce509630e/certifi-2022.9.24-py3-none-any.whl"
+              "hash": "4ad3232f5e926d6718ec31cfc1fcadfde020920e278684144551c91769c7bc18",
+              "url": "https://files.pythonhosted.org/packages/71/4c/3db2b8021bd6f2f0ceb0e088d6b2d49147671f25832fb17970e9b583d742/certifi-2022.12.7-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "0d9c601124e5a6ba9712dbc60d9c53c21e34f5f641fe83002317394311bdce14",
-              "url": "https://files.pythonhosted.org/packages/cb/a4/7de7cd59e429bd0ee6521ba58a75adaec136d32f91a761b28a11d8088d44/certifi-2022.9.24.tar.gz"
+              "hash": "35824b4c3a97115964b408844d64aa14db1cc518f6562e8d7261699d1350a9e3",
+              "url": "https://files.pythonhosted.org/packages/37/f7/2b1b0ec44fdc30a3d31dfebe52226be9ddc40cd6c0f34ffc8923ba423b69/certifi-2022.12.7.tar.gz"
             }
           ],
           "project_name": "certifi",
           "requires_dists": [],
           "requires_python": ">=3.6",
-          "version": "2022.9.24"
+          "version": "2022.12.7"
         },
         {
           "artifacts": [
@@ -999,39 +965,262 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "d3e64f022d254183001eccc5db4040520c0f23b1a3f33d6413e099eb7f126557",
-              "url": "https://files.pythonhosted.org/packages/4c/d1/1b96dd69fa42f20b70701b5cd42a75dd5f0c7a24dc0abfef35cc146210dc/chardet-5.0.0-py3-none-any.whl"
+              "hash": "362777fb014af596ad31334fde1e8c327dfdb076e1960d1694662d46a6917ab9",
+              "url": "https://files.pythonhosted.org/packages/74/8f/8fc49109009e8d2169d94d72e6b1f4cd45c13d147ba7d6170fb41f22b08f/chardet-5.1.0-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "0368df2bfd78b5fc20572bb4e9bb7fb53e2c094f60ae9993339e8671d0afb8aa",
-              "url": "https://files.pythonhosted.org/packages/31/a2/12c090713b3d0e141f367236d3a8bdc3e5fca0d83ff3647af4892c16c205/chardet-5.0.0.tar.gz"
+              "hash": "0d62712b956bc154f85fb0a266e2a3c5913c2967e00348701b32411d6def31e5",
+              "url": "https://files.pythonhosted.org/packages/41/32/cdc91dcf83849c7385bf8e2a5693d87376536ed000807fa07f5eab33430d/chardet-5.1.0.tar.gz"
             }
           ],
           "project_name": "chardet",
           "requires_dists": [],
-          "requires_python": ">=3.6",
-          "version": "5"
+          "requires_python": ">=3.7",
+          "version": "5.1"
         },
         {
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "83e9a75d1911279afd89352c68b45348559d1fc0506b054b346651b5e7fee29f",
-              "url": "https://files.pythonhosted.org/packages/db/51/a507c856293ab05cdc1db77ff4bc1268ddd39f29e7dc4919aa497f0adbec/charset_normalizer-2.1.1-py3-none-any.whl"
+              "hash": "7e189e2e1d3ed2f4aebabd2d5b0f931e883676e51c7624826e0a4e5fe8a0bf24",
+              "url": "https://files.pythonhosted.org/packages/68/2b/02e9d6a98ddb73fa238d559a9edcc30b247b8dc4ee848b6184c936e99dc0/charset_normalizer-3.0.1-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "5a3d016c7c547f69d6f81fb0db9449ce888b418b5b9952cc5e6e66843e9dd845",
-              "url": "https://files.pythonhosted.org/packages/a1/34/44964211e5410b051e4b8d2869c470ae8a68ae274953b1c7de6d98bbcf94/charset-normalizer-2.1.1.tar.gz"
+              "hash": "72966d1b297c741541ca8cf1223ff262a6febe52481af742036a0b296e35fa5a",
+              "url": "https://files.pythonhosted.org/packages/01/ff/9ee4a44e8c32fe96dfc12daa42f29294608a55eadc88f327939327fb20fb/charset_normalizer-3.0.1-cp311-cp311-musllinux_1_1_aarch64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "87701167f2a5c930b403e9756fab1d31d4d4da52856143b609e30a1ce7160f3c",
+              "url": "https://files.pythonhosted.org/packages/02/49/78b4c1bc8b1b0e0fc66fb31ce30d8302f10a1412ba75de72c57532f0beb0/charset_normalizer-3.0.1-cp311-cp311-macosx_11_0_arm64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "0c0a590235ccd933d9892c627dec5bc7511ce6ad6c1011fdf5b11363022746c1",
+              "url": "https://files.pythonhosted.org/packages/12/e5/aa09a1c39c3e444dd223d63e2c816c18ed78d035cff954143b2a539bdc9e/charset_normalizer-3.0.1-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "8eade758719add78ec36dc13201483f8e9b5d940329285edcd5f70c0a9edbd7f",
+              "url": "https://files.pythonhosted.org/packages/17/67/4b25c0358a2e812312b551e734d58855d58f47d0e0e9d1573930003910cb/charset_normalizer-3.0.1-cp39-cp39-macosx_10_9_universal2.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "0f438ae3532723fb6ead77e7c604be7c8374094ef4ee2c5e03a3a17f1fca256c",
+              "url": "https://files.pythonhosted.org/packages/25/19/298089cef2eb82fd3810d982aa239d4226594f99e1fe78494cb9b47b03c9/charset_normalizer-3.0.1-cp39-cp39-musllinux_1_1_s390x.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "44ba614de5361b3e5278e1241fda3dc1838deed864b50a10d7ce92983797fa76",
+              "url": "https://files.pythonhosted.org/packages/2d/02/0f875eb6a1cf347bd3a6098f458f79796aafa3b51090fd7b2784736dc67d/charset_normalizer-3.0.1-cp310-cp310-musllinux_1_1_ppc64le.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "9ab77acb98eba3fd2a85cd160851816bfce6871d944d885febf012713f06659c",
+              "url": "https://files.pythonhosted.org/packages/2e/7b/5053a4a46fac017fd2aea3dc9abdd9983fd4cef153b6eb6aedcb0d7cb6e3/charset_normalizer-3.0.1-cp311-cp311-win_amd64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "ab5de034a886f616a5668aa5d098af2b5385ed70142090e2a31bcbd0af0fdb3d",
+              "url": "https://files.pythonhosted.org/packages/31/06/f6330ee70c041a032ee1a5d32785d69748cfa41f64b6d327cc08cae51de9/charset_normalizer-3.0.1-cp39-cp39-musllinux_1_1_aarch64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "f6f45710b4459401609ebebdbcfb34515da4fc2aa886f95107f556ac69a9147e",
+              "url": "https://files.pythonhosted.org/packages/31/af/67b7653a35dbd56f6bb9ff54652a551eae8420d1d0545f0042c5bdb15fb0/charset_normalizer-3.0.1-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "0298eafff88c99982a4cf66ba2efa1128e4ddaca0b05eec4c456bbc7db691d8d",
+              "url": "https://files.pythonhosted.org/packages/37/00/ca188e0a2b3cd3184cdd2521b8765cf579327d128caa8aedc3dc7614020a/charset_normalizer-3.0.1-cp311-cp311-macosx_10_9_universal2.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "31a9ddf4718d10ae04d9b18801bd776693487cbb57d74cc3458a7673f6f34639",
+              "url": "https://files.pythonhosted.org/packages/55/2b/35619e03725bfa4af4a902e1996c9ee8052d6bce005ff79c9bd988820cb4/charset_normalizer-3.0.1-cp310-cp310-musllinux_1_1_i686.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "8499ca8f4502af841f68135133d8258f7b32a53a1d594aa98cc52013fff55678",
+              "url": "https://files.pythonhosted.org/packages/6a/ab/3a00ecbddabe25132c20c1bd45e6f90c537b5f7a0b5bcaba094c4922928c/charset_normalizer-3.0.1-cp39-cp39-macosx_10_9_x86_64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "39cf9ed17fe3b1bc81f33c9ceb6ce67683ee7526e65fde1447c772afc54a1bb8",
+              "url": "https://files.pythonhosted.org/packages/6e/a3/997ff79260f76210b1d73463b9081ae7edbf16ff3d611b67f5e72c685cab/charset_normalizer-3.0.1-cp39-cp39-win32.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "772b87914ff1152b92a197ef4ea40efe27a378606c39446ded52c8f80f79702e",
+              "url": "https://files.pythonhosted.org/packages/6e/d7/1d4035fcbf7d0f2e89588a142628355d8d1cd652a227acefb9ec85908cd4/charset_normalizer-3.0.1-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "4a8fcf28c05c1f6d7e177a9a46a1c52798bfe2ad80681d275b10dcf317deaf0b",
+              "url": "https://files.pythonhosted.org/packages/80/54/183163f9910936e57a60ee618f4f5cc91c2f8333ee2d4ebc6c50f6c8684d/charset_normalizer-3.0.1-cp311-cp311-musllinux_1_1_s390x.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "761e8904c07ad053d285670f36dd94e1b6ab7f16ce62b9805c475b7aa1cffde6",
+              "url": "https://files.pythonhosted.org/packages/82/49/ab81421d5aa25bc8535896a017c93204cb4051f2a4e72b1ad8f3b594e072/charset_normalizer-3.0.1-cp311-cp311-musllinux_1_1_x86_64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "71140351489970dfe5e60fc621ada3e0f41104a5eddaca47a7acb3c1b851d6d3",
+              "url": "https://files.pythonhosted.org/packages/84/0e/5965dd90991e4f2588718b865115a78c8b040193ac3676f757b7fb6af9d0/charset_normalizer-3.0.1-cp311-cp311-win32.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "8ac7b6a045b814cf0c47f3623d21ebd88b3e8cf216a14790b455ea7ff0135d18",
+              "url": "https://files.pythonhosted.org/packages/84/ff/78a4942ef1ea4d1c464cc9a132122b36c5390c5cf6301ed0f9e3e6e24bd9/charset_normalizer-3.0.1-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "5995f0164fa7df59db4746112fec3f49c461dd6b31b841873443bdb077c13cfc",
+              "url": "https://files.pythonhosted.org/packages/86/eb/31c9025b4ed7eddd930c5f2ac269efb953de33140608c7539675d74a2081/charset_normalizer-3.0.1-cp311-cp311-musllinux_1_1_ppc64le.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "f9d0c5c045a3ca9bedfc35dca8526798eb91a07aa7a2c0fee134c6c6f321cbd7",
+              "url": "https://files.pythonhosted.org/packages/89/87/c237a299a658b35d19fd531eeb8247480627fc2fb4b7a471334b48850f45/charset_normalizer-3.0.1-cp311-cp311-musllinux_1_1_i686.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "a8d0fc946c784ff7f7c3742310cc8a57c5c6dc31631269876a88b809dbeff3d3",
+              "url": "https://files.pythonhosted.org/packages/90/59/941e2e5ae6828a688c6437ad16e026eb3606d0cfdd13ea5c9090980f3ffd/charset_normalizer-3.0.1-cp311-cp311-macosx_10_9_x86_64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "12db3b2c533c23ab812c2b25934f60383361f8a376ae272665f8e48b88e8e1c6",
+              "url": "https://files.pythonhosted.org/packages/92/00/b8dc8dd725297b05f1ab4929c9d7e879f31746131534221c5c8948bc7563/charset_normalizer-3.0.1-cp310-cp310-musllinux_1_1_s390x.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "ebea339af930f8ca5d7a699b921106c6e29c617fe9606fa7baa043c1cdae326f",
+              "url": "https://files.pythonhosted.org/packages/96/d7/1675d9089a1f4677df5eb29c3f8b064aa1e70c1251a0a8a127803158942d/charset-normalizer-3.0.1.tar.gz"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "c512accbd6ff0270939b9ac214b84fb5ada5f0409c44298361b2f5e13f9aed9e",
+              "url": "https://files.pythonhosted.org/packages/98/e4/d4685870fda1cc7c5e29899ec329500460418e54f4f5df76ee520e30689a/charset_normalizer-3.0.1-cp310-cp310-musllinux_1_1_x86_64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "601f36512f9e28f029d9481bdaf8e89e5148ac5d89cffd3b05cd533eeb423b59",
+              "url": "https://files.pythonhosted.org/packages/98/f4/5ca33ee1e0b3412cbd13eae230321a9fe819acf1a99ad6482420fb97cc6b/charset_normalizer-3.0.1-cp310-cp310-win_amd64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "3b590df687e3c5ee0deef9fc8c547d81986d9a1b56073d82de008744452d6541",
+              "url": "https://files.pythonhosted.org/packages/99/24/eb846dc9a797da58e6e5b3b5a71d3ff17264de3f424fb29aaa5d27173b55/charset_normalizer-3.0.1-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "2edb64ee7bf1ed524a1da60cdcd2e1f6e2b4f66ef7c077680739f1641f62f555",
+              "url": "https://files.pythonhosted.org/packages/9f/5a/9dc8932d1e5f8eeaa502e3c3fce91c86be20c04eb3ec202d2b7d74b567e5/charset_normalizer-3.0.1-cp310-cp310-musllinux_1_1_aarch64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "62595ab75873d50d57323a91dd03e6966eb79c41fa834b7a1661ed043b2d404d",
+              "url": "https://files.pythonhosted.org/packages/a3/4b/f565c852163312a0991c30598f403fd06796a12e408d7839cc46ca8d7f4a/charset_normalizer-3.0.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "70990b9c51340e4044cfc394a81f614f3f90d41397104d226f21e66de668730d",
+              "url": "https://files.pythonhosted.org/packages/af/63/2c00ff4e657fb9bb76306ffbc7878fd52067e39716f5e8b0dd5582caf1fa/charset_normalizer-3.0.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "88600c72ef7587fe1708fd242b385b6ed4b8904976d5da0893e31df8b3480cb6",
+              "url": "https://files.pythonhosted.org/packages/b2/4c/9a4f30042bfee22d34d80daf75f51817cdd23180d718e0160aab235c4faf/charset_normalizer-3.0.1-cp310-cp310-macosx_10_9_universal2.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "00d3ffdaafe92a5dc603cb9bd5111aaa36dfa187c8285c543be562e61b755f6b",
+              "url": "https://files.pythonhosted.org/packages/b5/1a/932d86fde86bb0d2992c74552c9a422883fe0890132bbc9a5e2211f03318/charset_normalizer-3.0.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "502218f52498a36d6bf5ea77081844017bf7982cdbe521ad85e64cabee1b608b",
+              "url": "https://files.pythonhosted.org/packages/b6/c2/da108d835354b49aa5c738906e9b6a197b071bc5d77d223f6cd98119172a/charset_normalizer-3.0.1-cp310-cp310-win32.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "14e76c0f23218b8f46c4d87018ca2e441535aed3632ca134b10239dfb6dadd6b",
+              "url": "https://files.pythonhosted.org/packages/c0/4d/6b82099e3f25a9ed87431e2f51156c14f3a9ce8fad73880a3856cd95f1d5/charset_normalizer-3.0.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "292d5e8ba896bbfd6334b096e34bffb56161c81408d6d036a7dfa6929cff8783",
+              "url": "https://files.pythonhosted.org/packages/c1/06/b7b1d3d186e0f288500b8a1161ede6b38a0abbf878c2033d667e815e6bd7/charset_normalizer-3.0.1-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "9cb3032517f1627cc012dbc80a8ec976ae76d93ea2b5feaa9d2a5b8882597579",
+              "url": "https://files.pythonhosted.org/packages/c4/d4/94f1ea460cce04483d2460efba6fd4d66e6f60ad6fc6075dba13e3501e48/charset_normalizer-3.0.1-cp39-cp39-musllinux_1_1_i686.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "608862a7bf6957f2333fc54ab4399e405baad0163dc9f8d99cb236816db169d4",
+              "url": "https://files.pythonhosted.org/packages/c9/dd/80a5e8c080b7e1cc2b0ca35f0d6aeedafd7bbd06d25031ac20868b1366d6/charset_normalizer-3.0.1-cp39-cp39-musllinux_1_1_ppc64le.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "ff6f3db31555657f3163b15a6b7c6938d08df7adbfc9dd13d9d19edad678f1e8",
+              "url": "https://files.pythonhosted.org/packages/d3/5b/4031145fcfb9ceaf49dad2fbf9a44e062eb2c08aff36f71d8aafbecf4567/charset_normalizer-3.0.1-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "79909e27e8e4fcc9db4addea88aa63f6423ebb171db091fb4373e3312cb6d603",
+              "url": "https://files.pythonhosted.org/packages/d9/7a/60d45c9453212b30eebbf8b5cddbdef330eebddfcf335bce7920c43fb72e/charset_normalizer-3.0.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "c2ac1b08635a8cd4e0cbeaf6f5e922085908d48eb05d44c5ae9eabab148512ca",
+              "url": "https://files.pythonhosted.org/packages/dc/ff/2c7655d83b1d6d6a0e132d50d54131fcb8da763b417ccc6c4a506aa0e08c/charset_normalizer-3.0.1-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "8c7fe7afa480e3e82eed58e0ca89f751cd14d767638e2550c77a92a9e749c317",
+              "url": "https://files.pythonhosted.org/packages/df/c5/dd3a17a615775d0ffc3e12b0e47833d8b7e0a4871431dad87a3f92382a19/charset_normalizer-3.0.1-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "c75ffc45f25324e68ab238cb4b5c0a38cd1c3d7f1fb1f72b5541de469e2247db",
+              "url": "https://files.pythonhosted.org/packages/e1/7f/64b51f144fa9e74da63fa690d9563eae627f4df6cc6ae5185a781e1912e5/charset_normalizer-3.0.1-cp310-cp310-macosx_10_9_x86_64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "3ae1de54a77dc0d6d5fcf623290af4266412a7c4be0b1ff7444394f03f5c54e3",
+              "url": "https://files.pythonhosted.org/packages/e3/96/8cdbce165c96cce5f2c9c7748f7ed8e0cf0c5d03e213bbc90b7c3e918bf5/charset_normalizer-3.0.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "0a11e971ed097d24c534c037d298ad32c6ce81a45736d31e0ff0ad37ab437d59",
+              "url": "https://files.pythonhosted.org/packages/e7/0d/5eaceb5abfc000cca204af9f50e9839462dc0bb1c4e0f4b14ed370e3febd/charset_normalizer-3.0.1-cp39-cp39-win_amd64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "db72b07027db150f468fbada4d85b3b2729a3db39178abf5c543b784c1254539",
+              "url": "https://files.pythonhosted.org/packages/f0/78/30d853a3073c866b47abede6d86b5532aa99ac67a95e86077d20be1ce481/charset_normalizer-3.0.1-cp310-cp310-macosx_11_0_arm64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "3fc1c4a2ffd64890aebdb3f97e1278b0cc72579a08ca4de8cd2c04799a3a22be",
+              "url": "https://files.pythonhosted.org/packages/f5/84/cac681144a28114bd9e40d3cdbfd961c14ecc2b56f1baec2094afd6744c7/charset_normalizer-3.0.1-cp39-cp39-macosx_11_0_arm64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "356541bf4381fa35856dafa6a965916e54bed415ad8a24ee6de6e37deccf2786",
+              "url": "https://files.pythonhosted.org/packages/f5/ec/a9bed59079bd0267d34ada58a4048c96a59b3621e7f586ea85840d41831d/charset_normalizer-3.0.1-cp39-cp39-musllinux_1_1_x86_64.whl"
             }
           ],
           "project_name": "charset-normalizer",
-          "requires_dists": [
-            "unicodedata2; extra == \"unicode_backport\""
-          ],
-          "requires_python": ">=3.6.0",
-          "version": "2.1.1"
+          "requires_dists": [],
+          "requires_python": null,
+          "version": "3.0.1"
         },
         {
           "artifacts": [
@@ -1142,6 +1331,27 @@
           "artifacts": [
             {
               "algorithm": "sha256",
+              "hash": "9f3abf3515112fa7c55a42a6a5ab358735c9dccc8b5910a9d8e3ef5998130666",
+              "url": "https://files.pythonhosted.org/packages/fc/04/e740a61ec9df8975bcb32e6698663bc9efa945ac6b2a585728deed6dcced/comm-0.1.2-py3-none-any.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "3e2f5826578e683999b93716285b3b1f344f157bf75fa9ce0a797564e742f062",
+              "url": "https://files.pythonhosted.org/packages/60/5b/0e55c73beb88043811601050c87e871bd1f6cab78c869dc077fa5d0a5b5b/comm-0.1.2.tar.gz"
+            }
+          ],
+          "project_name": "comm",
+          "requires_dists": [
+            "pytest; extra == \"test\"",
+            "traitlets>=5.3"
+          ],
+          "requires_python": ">=3.6",
+          "version": "0.1.2"
+        },
+        {
+          "artifacts": [
+            {
+              "algorithm": "sha256",
               "hash": "300f4b0825f57688b47b6d70c6a31de33512eb2fa1ac614f780939aa0cf91680",
               "url": "https://files.pythonhosted.org/packages/76/97/2a99f020be5e4a5a97ba10bc480e2e6a889b5087103a2c6b952b5f819d27/crashtest-0.3.1-py3-none-any.whl"
             },
@@ -1180,93 +1390,93 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "80ca53981ceeb3241998443c4964a387771588c4e4a5d92735a493af868294f9",
-              "url": "https://files.pythonhosted.org/packages/fb/28/0544f67e2ffdc15874d7a650a867c78a7dba245afe3392f51cfae363545c/cryptography-38.0.4-pp39-pypy39_pp73-win_amd64.whl"
+              "hash": "e0a05aee6a82d944f9b4edd6a001178787d1546ec7c6223ee9a848a7ade92e39",
+              "url": "https://files.pythonhosted.org/packages/43/7d/0d0756853ad357b7f12d63595a8aac66d255ea68061e3c1983f4cfebc73b/cryptography-39.0.0-pp39-pypy39_pp73-win_amd64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "4367da5705922cf7070462e964f66e4ac24162e22ab0a2e9d31f1b270dd78083",
-              "url": "https://files.pythonhosted.org/packages/0e/fc/417b674c05af65d8dc2856a439f20a866a3fa21b01496f99fb18f812c4ab/cryptography-38.0.4-pp39-pypy39_pp73-manylinux_2_24_x86_64.whl"
+              "hash": "f671c1bb0d6088e94d61d80c606d65baacc0d374e67bf895148883461cd848de",
+              "url": "https://files.pythonhosted.org/packages/06/b1/6b6f8dccd1432a6a998e92f75ff235b0f69e8a8c509b5739d673ea2ba548/cryptography-39.0.0-cp36-abi3-win32.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "1d7e632804a248103b60b16fb145e8df0bc60eed790ece0d12efe8cd3f3e7744",
-              "url": "https://files.pythonhosted.org/packages/0f/83/2cc749fdc39345c1343cb29dc38bc7de9a0a55b7761663e098410f98f902/cryptography-38.0.4-cp36-abi3-win32.whl"
+              "hash": "6f97109336df5c178ee7c9c711b264c502b905c2d2a29ace99ed761533a3460f",
+              "url": "https://files.pythonhosted.org/packages/0d/5c/b83623ce6e7d6653d858d5c85916217bb1e66a4c7a2da7051588fd5d9e0a/cryptography-39.0.0-cp36-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "10652dd7282de17990b88679cb82f832752c4e8237f0c714be518044269415db",
-              "url": "https://files.pythonhosted.org/packages/12/9c/e44f95e71aedc5fefe3425df662dd17c6f94fbf68470b56c4873c43f27d2/cryptography-38.0.4-cp36-abi3-manylinux_2_24_x86_64.whl"
+              "hash": "f964c7dcf7802d133e8dbd1565914fa0194f9d683d82411989889ecd701e8adf",
+              "url": "https://files.pythonhosted.org/packages/12/e3/c46c274cf466b24e5d44df5d5cd31a31ff23e57f074a2bb30931a8c9b01a/cryptography-39.0.0.tar.gz"
             },
             {
               "algorithm": "sha256",
-              "hash": "ce127dd0a6a0811c251a6cddd014d292728484e530d80e872ad9806cfb1c5b3c",
-              "url": "https://files.pythonhosted.org/packages/26/f8/a81170a816679fca9ccd907b801992acfc03c33f952440421c921af2cc57/cryptography-38.0.4-cp36-abi3-manylinux_2_28_x86_64.whl"
+              "hash": "80ee674c08aaef194bc4627b7f2956e5ba7ef29c3cc3ca488cf15854838a8f72",
+              "url": "https://files.pythonhosted.org/packages/13/56/7ebf13cfd85f2948480a45937bcc43d6f01edfde99dab47443e72aed564a/cryptography-39.0.0-cp36-abi3-macosx_10_12_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "50a1494ed0c3f5b4d07650a68cd6ca62efe8b596ce743a5c94403e6f11bf06c1",
-              "url": "https://files.pythonhosted.org/packages/32/ed/d7de730e1452ed714f2f8eee123669d4819080e03ec523b131d9b709d060/cryptography-38.0.4-cp36-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+              "hash": "f3ed2d864a2fa1666e749fe52fb8e23d8e06b8012e8bd8147c73797c506e86f1",
+              "url": "https://files.pythonhosted.org/packages/2d/62/7c62efcb4a1b1905ad16476f9dcb55a2913bf4dd0049a083390a622901c8/cryptography-39.0.0-cp36-abi3-musllinux_1_1_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "1f13ddda26a04c06eb57119caf27a524ccae20533729f4b1e4a69b54e07035eb",
-              "url": "https://files.pythonhosted.org/packages/52/1b/49ebc2b59e9126f1f378ae910e98704d54a3f48b78e2d6d6c8cfe6fbe06f/cryptography-38.0.4-cp36-abi3-macosx_10_10_x86_64.whl"
+              "hash": "887cbc1ea60786e534b00ba8b04d1095f4272d380ebd5f7a7eb4cc274710fad9",
+              "url": "https://files.pythonhosted.org/packages/2e/90/1fffa1dd2e0894cdd8ef33b7d95de7c4d6de5fb77fb23cd21b24b069047e/cryptography-39.0.0-cp36-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_24_aarch64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "2fb481682873035600b5502f0015b664abc26466153fab5c6bc92c1ea69d478b",
-              "url": "https://files.pythonhosted.org/packages/61/1a/35fd07185b10e3153c8c95d694fb2db1e1e3f55dcc8ef2763685705bf0dd/cryptography-38.0.4-pp39-pypy39_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+              "hash": "875aea1039d78557c7c6b4db2fe0e9d2413439f4676310a5f269dd342ca7a717",
+              "url": "https://files.pythonhosted.org/packages/34/b3/3011b5f6c5cc935113fc58f8b07d42fcdd03e7a76b1c3c8ba27d276e8833/cryptography-39.0.0-cp36-abi3-manylinux_2_28_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "a10498349d4c8eab7357a8f9aa3463791292845b79597ad1b98a543686fb1ec8",
-              "url": "https://files.pythonhosted.org/packages/63/d4/66b3b4ffe51b47a065b5a5a00e6a4c8aa6cdfa4f2453adfa0aac77fd3511/cryptography-38.0.4-cp36-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+              "hash": "e5d71c5d5bd5b5c3eebcf7c5c2bb332d62ec68921a8c593bea8c394911a005ce",
+              "url": "https://files.pythonhosted.org/packages/41/3f/8b3676edb61a9d2dc0e78ba9d450ebb75d958f70ed3dea9cb143262c8406/cryptography-39.0.0-pp39-pypy39_pp73-manylinux_2_24_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "8a4b2bdb68a447fadebfd7d24855758fe2d6fecc7fed0b78d190b1af39a8e3b0",
-              "url": "https://files.pythonhosted.org/packages/64/4e/04dced6a515032b7bf3e8f287c7ff73a7d1b438c8394aa50b9fceb4077e2/cryptography-38.0.4-cp36-abi3-musllinux_1_1_x86_64.whl"
+              "hash": "e324de6972b151f99dc078defe8fb1b0a82c6498e37bff335f5bc6b1e3ab5a1e",
+              "url": "https://files.pythonhosted.org/packages/44/0a/4170788974aef7baf5eab77947246887c64a0a2c371f769f79259835af89/cryptography-39.0.0-cp36-abi3-win_amd64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "2ec2a8714dd005949d4019195d72abed84198d877112abb5a27740e217e0ea8d",
-              "url": "https://files.pythonhosted.org/packages/6d/47/929f07e12ebbcfedddb95397c49677dd82bb5a0bb648582b10d5f65e321c/cryptography-38.0.4-cp36-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_24_aarch64.whl"
+              "hash": "bae6c7f4a36a25291b619ad064a30a07110a805d08dc89984f4f441f6c1f3f96",
+              "url": "https://files.pythonhosted.org/packages/4e/9e/102aae84e2f1c4733ab76fd311d0b4612699daaba04a3a872567274dc211/cryptography-39.0.0-cp36-abi3-manylinux_2_28_aarch64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "2fa36a7b2cc0998a3a4d5af26ccb6273f3df133d61da2ba13b3286261e7efb70",
-              "url": "https://files.pythonhosted.org/packages/75/7a/2ea7dd2202638cf1053aaa8fbbaddded0b78c78832b3d03cafa0416a6c84/cryptography-38.0.4-cp36-abi3-macosx_10_10_universal2.whl"
+              "hash": "c52a1a6f81e738d07f43dab57831c29e57d21c81a942f4602fac7ee21b27f288",
+              "url": "https://files.pythonhosted.org/packages/78/23/ca3a4d7cb681fb4b7f9a088e7392f0aa2c1a51017a8a23fff377bb155af7/cryptography-39.0.0-cp36-abi3-macosx_10_12_universal2.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "b4cad0cea995af760f82820ab4ca54e5471fc782f70a007f31531957f43e9dee",
-              "url": "https://files.pythonhosted.org/packages/7e/c5/de81357e353d1d7f50b327cb1c1d8ccd45ebd2a6949a2c819db8a7481a2b/cryptography-38.0.4-pp39-pypy39_pp73-manylinux_2_28_x86_64.whl"
+              "hash": "1a6915075c6d3a5e1215eab5d99bcec0da26036ff2102a1038401d6ef5bef25b",
+              "url": "https://files.pythonhosted.org/packages/7a/46/8b58d6b8244ff613ecb983b9428d1168dd0b014a34e13fb19737b9ba1fc1/cryptography-39.0.0-cp36-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "bfe6472507986613dc6cc00b3d492b2f7564b02b3b3682d25ca7f40fa3fd321b",
-              "url": "https://files.pythonhosted.org/packages/a2/8f/6c52b1f9d650863e8f67edbe062c04f1c8455579eaace1593d8fe469319a/cryptography-38.0.4-cp36-abi3-manylinux_2_28_aarch64.whl"
+              "hash": "f6c0db08d81ead9576c4d94bbb27aed8d7a430fa27890f39084c2d0e2ec6b0df",
+              "url": "https://files.pythonhosted.org/packages/b4/68/1857c44826171a995e65a11d4b507cd0aa0bace926c2842d7252d8b1dcca/cryptography-39.0.0-cp36-abi3-musllinux_1_1_aarch64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "53049f3379ef05182864d13bb9686657659407148f901f3f1eee57a733fb4b00",
-              "url": "https://files.pythonhosted.org/packages/b1/44/6d6cb7cff7f2dbc59fde50e5b82bc6df075e73af89a25eba1a6193c22165/cryptography-38.0.4-cp36-abi3-musllinux_1_1_aarch64.whl"
+              "hash": "844ad4d7c3850081dffba91cdd91950038ee4ac525c575509a42d3fc806b83c8",
+              "url": "https://files.pythonhosted.org/packages/dc/05/2cee803d6b83fef95229f9864646ba399f1ebda03333e34c2ddee210aaa1/cryptography-39.0.0-pp39-pypy39_pp73-manylinux_2_28_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "8e45653fb97eb2f20b8c96f9cd2b3a0654d742b47d638cf2897afbd97f80fa6d",
-              "url": "https://files.pythonhosted.org/packages/c0/eb/f52b165db2abd662cda0a76efb7579a291fed1a7979cf41146cdc19e0d7a/cryptography-38.0.4-cp36-abi3-win_amd64.whl"
+              "hash": "50386acb40fbabbceeb2986332f0287f50f29ccf1497bae31cf5c3e7b4f4b34f",
+              "url": "https://files.pythonhosted.org/packages/fa/31/52ccfb7147564fefe83fdbbebc9dbd4c6749663c019a053ab2c83469c47a/cryptography-39.0.0-pp39-pypy39_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "78e47e28ddc4ace41dd38c42e6feecfdadf9c3be2af389abbfeef1ff06822285",
-              "url": "https://files.pythonhosted.org/packages/d2/74/a70f68d888454640ea87f1aca9fe6d11d8824457006a1dfa94564cdc6fbf/cryptography-38.0.4-pp39-pypy39_pp73-macosx_10_10_x86_64.whl"
+              "hash": "76c24dd4fd196a80f9f2f5405a778a8ca132f16b10af113474005635fe7e066c",
+              "url": "https://files.pythonhosted.org/packages/fc/b2/3b946e24de214fc49adeefeea6214bcbc4bce2bd745877f074d1dd13c9a2/cryptography-39.0.0-cp36-abi3-manylinux_2_24_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "175c1a818b87c9ac80bb7377f5520b7f31b3ef2a0004e2420319beadedb67290",
-              "url": "https://files.pythonhosted.org/packages/e3/3f/41186b1f2fd86a542d399175f6b8e43f82cd4dfa51235a0b030a042b811a/cryptography-38.0.4.tar.gz"
+              "hash": "ad04f413436b0781f20c52a661660f1e23bcd89a0e9bb1d6d20822d048cf2856",
+              "url": "https://files.pythonhosted.org/packages/fd/59/bacaaed27787b87b660b7de016e1034a9bf2aaf5031d2b7d085cd83413f3/cryptography-39.0.0-pp39-pypy39_pp73-macosx_10_12_x86_64.whl"
             }
           ],
           "project_name": "cryptography",
@@ -1274,11 +1484,8 @@
             "bcrypt>=3.1.5; extra == \"ssh\"",
             "black; extra == \"pep8test\"",
             "cffi>=1.12",
-            "flake8-import-order; extra == \"pep8test\"",
-            "flake8; extra == \"pep8test\"",
             "hypothesis!=3.79.2,>=1.11.4; extra == \"test\"",
             "iso8601; extra == \"test\"",
-            "pep8-naming; extra == \"pep8test\"",
             "pretend; extra == \"test\"",
             "pyenchant>=1.6.11; extra == \"docstest\"",
             "pytest-benchmark; extra == \"test\"",
@@ -1287,55 +1494,53 @@
             "pytest-xdist; extra == \"test\"",
             "pytest>=6.2.0; extra == \"test\"",
             "pytz; extra == \"test\"",
+            "ruff; extra == \"pep8test\"",
             "setuptools-rust>=0.11.4; extra == \"sdist\"",
-            "sphinx!=1.8.0,!=3.1.0,!=3.1.1,>=1.6.5; extra == \"docs\"",
+            "sphinx!=1.8.0,!=3.1.0,!=3.1.1,!=5.2.0,!=5.2.0.post0,>=1.6.5; extra == \"docs\"",
             "sphinx-rtd-theme; extra == \"docs\"",
             "sphinxcontrib-spelling>=4.0.1; extra == \"docstest\"",
             "twine>=1.12.0; extra == \"docstest\""
           ],
           "requires_python": ">=3.6",
-          "version": "38.0.4"
+          "version": "39"
         },
         {
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "afdf957241b4e21e0a6eaaeeff73d34072fc3fd3c41f1c315cc6ed77aa976508",
-              "url": "https://files.pythonhosted.org/packages/35/d1/6cf672d0ce7c1037a9896c76ff157a6b9424b507497e43e2d56567f77983/dagit-1.1.3-py3-none-any.whl"
+              "hash": "71b755d2ea214222266e95b7dafb5c8c07c933ca1a4d3ea16ab975aefcdbd7c1",
+              "url": "https://files.pythonhosted.org/packages/b3/a7/767f2eed2e653ad66affea6404b5944454bc5d73bdcaf504d3314f7977b9/dagit-1.1.10-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "6b6dfb20f194af69f13abce7b7c14fa37477f71714d4749e47e7f8ef4d5772d5",
-              "url": "https://files.pythonhosted.org/packages/18/d4/a69bc25fa9e4a5891c9c7b413daa15fb517392f6e4c67664052d0e959190/dagit-1.1.3.tar.gz"
+              "hash": "283f6f9c25b07acb072f4962d4cb3bdeda23d9a178b98e115b8b9399ef1ea9dd",
+              "url": "https://files.pythonhosted.org/packages/69/86/1e722fdb8c457ec3ee27ada874c23874152b184d3eadb34e0a167fd6fe25/dagit-1.1.10.tar.gz"
             }
           ],
           "project_name": "dagit",
           "requires_dists": [
-            "PyYAML",
             "click<9.0,>=7.0",
-            "dagster-graphql==1.1.3",
-            "dagster==1.1.3",
+            "dagster-graphql==1.1.10",
+            "dagster==1.1.10",
             "nbconvert; extra == \"notebook\"",
-            "requests",
             "starlette",
             "starlette[full]; extra == \"test\"",
-            "uvicorn[standard]",
-            "watchdog>=0.8.3"
+            "uvicorn[standard]"
           ],
           "requires_python": null,
-          "version": "1.1.3"
+          "version": "1.1.10"
         },
         {
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "3b27066c946caaeeccedec6bdff4aaa4f9e79197f73d115128f2130581dd38c3",
-              "url": "https://files.pythonhosted.org/packages/84/b8/0e4f70b0f48ba751a66cb07ef7650e822dbd49b0a12479f046ee2cb50481/dagster-1.1.3-py3-none-any.whl"
+              "hash": "8a20d6da0adba8b947fc07d62d84e468252b8137016dea60bebae4024760c056",
+              "url": "https://files.pythonhosted.org/packages/16/b1/79cb7600373b73b3dd22253c74b03d77be3dfb8583042398225d6a717bb9/dagster-1.1.10-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "f3d969fad9f9a291f7b50832e7f3276601a59c346f1732948c3b00d8a6212cca",
-              "url": "https://files.pythonhosted.org/packages/c8/3e/2951f3def5e2003f9194cab5502b26fe01d6bd76b236a66b4c9f2881e7e9/dagster-1.1.3.tar.gz"
+              "hash": "17d647432548b6eb78c12c0d0d9efaf3c3f2694293488b80670c1ad1233c3b20",
+              "url": "https://files.pythonhosted.org/packages/a8/87/c32718a820bac80d36cbff2281380c4bef6b2540358cd0dc5adac1d41503/dagster-1.1.10.tar.gz"
             }
           ],
           "project_name": "dagster",
@@ -1343,30 +1548,28 @@
             "Jinja2",
             "PyYAML>=5.1",
             "alembic!=1.6.3,!=1.7.0,>=1.2.1",
-            "astroid; extra == \"test\"",
-            "black[jupyter]==22.3.0; extra == \"black\"",
+            "black[jupyter]==22.12.0; extra == \"black\"",
             "buildkite-test-collector; python_version >= \"3.8\" and extra == \"test\"",
             "click>=5.0",
             "coloredlogs<=14.0,>=6.1",
             "contextvars; python_version < \"3.7\"",
-            "coverage==5.3; extra == \"test\"",
             "croniter>=0.3.34",
             "docker; extra == \"docker\"",
             "docker; extra == \"test\"",
             "docstring-parser",
             "grpcio-health-checking<1.44.0,>=1.32.0",
             "grpcio-tools<1.44.0,>=1.32.0; extra == \"test\"",
-            "grpcio<1.48.1,>=1.32.0",
-            "isort==5.10.1; extra == \"isort\"",
+            "grpcio<1.48.1,>=1.32.0; python_version < \"3.10\"",
+            "grpcio>=1.32.0; python_version >= \"3.10\"",
             "mock==3.0.5; extra == \"test\"",
-            "mypy==0.950; extra == \"mypy\"",
+            "mypy==0.991; extra == \"mypy\"",
             "objgraph; extra == \"test\"",
             "packaging>=20.9",
             "pendulum",
             "protobuf<4,>=3.13.0",
             "protobuf==3.13.0; extra == \"test\"",
             "psutil>=1.0; platform_system == \"Windows\"",
-            "pylint==2.13.7; extra == \"test\"",
+            "pydantic",
             "pytest-cov==2.10.1; extra == \"test\"",
             "pytest-dependency==0.5.1; extra == \"test\"",
             "pytest-mock==3.3.1; extra == \"test\"",
@@ -1380,10 +1583,12 @@
             "pywin32!=226; platform_system == \"Windows\"",
             "requests",
             "responses==0.10.*; extra == \"test\"",
+            "ruff==0.0.212; extra == \"ruff\"",
             "setuptools",
             "snapshottest==0.6.0; extra == \"test\"",
             "sqlalchemy>=1.0",
             "tabulate",
+            "tomli",
             "toposort>=1.0",
             "tox==3.25.0; extra == \"test\"",
             "tqdm",
@@ -1406,54 +1611,54 @@
             "types-tabulate; extra == \"mypy\"",
             "types-toml; extra == \"mypy\"",
             "types-tzlocal; extra == \"mypy\"",
-            "typing-compat",
             "typing-extensions>=4.0.1",
             "universal-pathlib",
             "watchdog>=0.8.3",
             "yamllint; extra == \"test\""
           ],
           "requires_python": null,
-          "version": "1.1.3"
+          "version": "1.1.10"
         },
         {
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "713e0b6305207fdc54406a6a1f4a10cdacc47d979c1eee0f33fe246538652239",
-              "url": "https://files.pythonhosted.org/packages/98/9e/9a3840fc6ecef8a6708ee124bf26cf6597436e20145e9f285a404fe9f54e/dagster_airbyte-0.17.3-py3-none-any.whl"
+              "hash": "8bc8bef904d2d679910c1b976b71b188cd1cccd55e22a49699229474bcca7c55",
+              "url": "https://files.pythonhosted.org/packages/2b/f1/9f5fb495a25998b28e12fbb85e91443b77d165a4613dc627bd6653004f03/dagster_airbyte-0.17.10-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "0b6ed8cbc2dce94d187b2377e8db3d1ad48bd3c0801a9abf51bd507f66060d94",
-              "url": "https://files.pythonhosted.org/packages/3d/42/36d382e6949cc03014aa62aac5ff7fe5cda5b1388d73075f43629853a5f7/dagster-airbyte-0.17.3.tar.gz"
+              "hash": "d0dfa7f393c644354c87a640345d26c109da6503e75978475b0a7599679647b9",
+              "url": "https://files.pythonhosted.org/packages/d5/d9/93791e998972a5fac3c69a1ce95c70ffb97420c020cf4bb882f1624013a5/dagster-airbyte-0.17.10.tar.gz"
             }
           ],
           "project_name": "dagster-airbyte",
           "requires_dists": [
-            "dagster==1.1.3",
-            "requests"
+            "dagster==1.1.10",
+            "requests",
+            "requests-mock; extra == \"test\""
           ],
           "requires_python": null,
-          "version": "0.17.3"
+          "version": "0.17.10"
         },
         {
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "49520b61e34d15b8085137c18a4e0bcfbe49636782f25edef07446b4c6bd1b7a",
-              "url": "https://files.pythonhosted.org/packages/6a/dc/9d89ffb9de7fdb2c5c1fa90799325aff37cd1ca48d3bf3000abaf5de9c84/dagster_aws-0.17.3-py3-none-any.whl"
+              "hash": "6d9cb0d8b3d99105ee550ddae304e00dd40dedf29bab5947fcd900223d762b7e",
+              "url": "https://files.pythonhosted.org/packages/92/d5/434480cd47e3fcd434bb80e2d82e20939bfede0db9d0ce033a5d0e478b4f/dagster_aws-0.17.10-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "55fb5ab94ee094c39cdb937074f1eaa9429486d3916e5755d3db52b6aefac04b",
-              "url": "https://files.pythonhosted.org/packages/fe/7c/84d84aa839c861a356f9615b26edbb1f6588b6c74a562094dc04d5d14e18/dagster-aws-0.17.3.tar.gz"
+              "hash": "2301fd19060bf88b9a67f8a6493664303a6e131de12082cf5493e1bdd10e23fb",
+              "url": "https://files.pythonhosted.org/packages/ac/0e/5707c2ed7c6d41ebb3bce20d15db877de3f904c63222e5f78355e419dab1/dagster-aws-0.17.10.tar.gz"
             }
           ],
           "project_name": "dagster-aws",
           "requires_dists": [
             "boto3",
             "dagster-pyspark; extra == \"pyspark\"",
-            "dagster==1.1.3",
+            "dagster==1.1.10",
             "moto>=2.2.8; extra == \"test\"",
             "packaging",
             "psycopg2-binary; extra == \"redshift\"",
@@ -1462,19 +1667,19 @@
             "xmltodict==0.12.0; extra == \"test\""
           ],
           "requires_python": null,
-          "version": "0.17.3"
+          "version": "0.17.10"
         },
         {
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "4c28637713dd8adef0744c143dc2e68a93fde42b7a4d86b25b53588307573de8",
-              "url": "https://files.pythonhosted.org/packages/f7/6b/f78b951c1b755c6283207e9a0255a62887bb3d3e485f0adeb985924edec7/dagster_dbt-0.17.3-py3-none-any.whl"
+              "hash": "91405b6bf4424b0489bb61289f247889c4155534403ad3e41d58555749574969",
+              "url": "https://files.pythonhosted.org/packages/9e/1f/361c200c980b1ac651750ec50febf9e148abdd82b7732d2bbb3c50c52017/dagster_dbt-0.17.10-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "721625575e15f0777423f684e12e5b28679e805ef6c34796b1fe2a8afec89ebb",
-              "url": "https://files.pythonhosted.org/packages/dd/d6/e670226076027d6323524f820ad9879aecbfffec04b67480ee6b836c16df/dagster-dbt-0.17.3.tar.gz"
+              "hash": "25337cbc3f1a4982441ba5e1b2f939fc6162005195d2ebba7386da586b98b0e6",
+              "url": "https://files.pythonhosted.org/packages/ca/af/c34b78deaf6beac7ba303ae8441545433f1384afbd88c7ce44ac32e86070/dagster-dbt-0.17.10.tar.gz"
             }
           ],
           "project_name": "dagster-dbt",
@@ -1482,55 +1687,55 @@
             "Jinja2; extra == \"test\"",
             "agate",
             "attrs",
-            "dagster==1.1.3",
+            "dagster==1.1.10",
             "dbt-core",
             "dbt-postgres; extra == \"test\"",
-            "dbt-rpc; extra == \"test\"",
+            "dbt-rpc<0.3.0; extra == \"test\"",
             "matplotlib; extra == \"test\"",
             "requests"
           ],
           "requires_python": null,
-          "version": "0.17.3"
+          "version": "0.17.10"
         },
         {
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "dde74913c1a94e2175dc0e72a291b79d47b86a8b4449289607f7ec6c32db9bca",
-              "url": "https://files.pythonhosted.org/packages/9b/36/9982ca041134ab04c183d98767237829ca1db3768f7e05429ce34e0c6d98/dagster_docker-0.17.3-py3-none-any.whl"
+              "hash": "abd2aa03970b7a8b7eacc9390cd295ac3785b6933024bc1c6ca8b1be713e6886",
+              "url": "https://files.pythonhosted.org/packages/a6/c0/212fdb503418d831822ea3f32dbc869b816779c0ef6bcc133301c6d79fa6/dagster_docker-0.17.10-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "220f281372c22f242499252b303575a6c0b17a077d533237dcb3038bcba9414e",
-              "url": "https://files.pythonhosted.org/packages/00/a7/607edcc2ee082395f7efd03f9d1e158a275ddf43ff72c10c101ebecf90ed/dagster-docker-0.17.3.tar.gz"
+              "hash": "32d4fb96e11b405c8ae791fba8c63fa44c73090d6ed5f18c377c400f98cc1865",
+              "url": "https://files.pythonhosted.org/packages/da/5c/951d8b33e7e8e59d2bcad91ecc6b33c93e0cbeea1a390b7eb534320ac090/dagster-docker-0.17.10.tar.gz"
             }
           ],
           "project_name": "dagster-docker",
           "requires_dists": [
-            "dagster==1.1.3",
+            "dagster==1.1.10",
             "docker",
             "docker-image-py"
           ],
           "requires_python": null,
-          "version": "0.17.3"
+          "version": "0.17.10"
         },
         {
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "6c845252db4873d0bcf45252377c117142cb2bcb3d149eda2b7a4a49d9c9ec2d",
-              "url": "https://files.pythonhosted.org/packages/b7/51/dbecc43fc4fb35af9d83477b73a7ab75b067ab59b2704ad5edcb6f606b44/dagster_gcp-0.17.3-py3-none-any.whl"
+              "hash": "5fb9c5a4c4130906dcd43b5f8c04f05f3be5d860e5e1b384d36f0f5bd6e6100d",
+              "url": "https://files.pythonhosted.org/packages/3f/c0/eb4bb457d8d0e7e2a57d005450d3dc125dfa6431fa4587dd9d23184a639b/dagster_gcp-0.17.10-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "b0fa3f11e2a83bba570aa7f840eab149eb65f8ca3ac287c75544b52b543f4370",
-              "url": "https://files.pythonhosted.org/packages/e4/5a/cb9ed3e1fd5637e841ec06347b1f23075d2af70504c15abb6a4fbce1491b/dagster-gcp-0.17.3.tar.gz"
+              "hash": "d62b41077e8424e9ca3e7201f643dc8cc1263e38a5bd1a564e6b74f16b0606ee",
+              "url": "https://files.pythonhosted.org/packages/6a/a9/454909641f2377e77b69caa1a74a62aedd5b592bbfdf868e860e49cd9cd5/dagster-gcp-0.17.10.tar.gz"
             }
           ],
           "project_name": "dagster-gcp",
           "requires_dists": [
-            "dagster-pandas==0.17.3",
-            "dagster==1.1.3",
+            "dagster-pandas==0.17.10",
+            "dagster==1.1.10",
             "db-dtypes",
             "google-api-python-client",
             "google-cloud-bigquery",
@@ -1539,117 +1744,117 @@
             "pyarrow; extra == \"pyarrow\""
           ],
           "requires_python": null,
-          "version": "0.17.3"
+          "version": "0.17.10"
         },
         {
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "b687f9393d1827edc6c81cd41e5b845a7972918ff857b7f78d1c32222324802a",
-              "url": "https://files.pythonhosted.org/packages/12/2e/71ebe742e791261d91272797e797d62f268a3a466503b2c950ed5c251fb5/dagster_ge-0.17.3-py3-none-any.whl"
+              "hash": "dd52664aade64a59f1d382158d5f12c88e1ae09834452b57d0b16d954d79221e",
+              "url": "https://files.pythonhosted.org/packages/07/99/fe7016ae84204f1a817e3c90582829f20e4edc505bdae62f765428a2f3ff/dagster_ge-0.17.10-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "197e2e13e0932c6b12976586ba86a5b53a86481c3c9f53e3d0a3e940c742202f",
-              "url": "https://files.pythonhosted.org/packages/25/02/3c2d4e31d663d61bba37ec5137b4f66d8f987375cfd5ed06a70b9901d773/dagster-ge-0.17.3.tar.gz"
+              "hash": "7f540a2b8b6e1c25800e5c9651b990bb6a1a2b483b7e4742ae90a40615f67908",
+              "url": "https://files.pythonhosted.org/packages/64/0c/823c63b0ada472fff9cacdd0da7efba85ea474c39c1adbfd0ce561f7373b/dagster-ge-0.17.10.tar.gz"
             }
           ],
           "project_name": "dagster-ge",
           "requires_dists": [
-            "dagster-pandas==0.17.3",
-            "dagster==1.1.3",
+            "dagster-pandas==0.17.10",
+            "dagster==1.1.10",
             "great-expectations!=0.12.8,!=0.13.17,!=0.13.27,>=0.11.9",
             "pandas"
           ],
           "requires_python": null,
-          "version": "0.17.3"
+          "version": "0.17.10"
         },
         {
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "74d544d61850e5b20a4d46eb3437e6969072030382899a67d9f725d6ef93083f",
-              "url": "https://files.pythonhosted.org/packages/65/90/d18164bb0f00cdfaf6d18e731b244f9334c52f46e4d13343290b6ba0bf70/dagster_graphql-1.1.3-py3-none-any.whl"
+              "hash": "3d58430e4ecb47fc8ccf73da8cdc665d376b8c442d4ac04a53b2e3b1ab6c807b",
+              "url": "https://files.pythonhosted.org/packages/e3/e3/acc137852efd4333dc0d20b178f32d68020569f0ee85288fe446f2536da7/dagster_graphql-1.1.10-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "63440815e96ffa6785974f49cfe562e5379431fe69cba7431e99197a0bc32be5",
-              "url": "https://files.pythonhosted.org/packages/d2/18/cf3ba4c26c88edf3222a6db00b076004d0fe006a455acf5f7227ecf8d60d/dagster-graphql-1.1.3.tar.gz"
+              "hash": "a0cdd869deb1271ae7e01ef879e960364a93b6dc48f5bccc48bb66f414ee2106",
+              "url": "https://files.pythonhosted.org/packages/03/71/d982c0663b6aba29e5d9dc3e57b198ccf1aaed403b3775ab36ee75641c11/dagster-graphql-1.1.10.tar.gz"
             }
           ],
           "project_name": "dagster-graphql",
           "requires_dists": [
-            "dagster==1.1.3",
-            "gql[requests]",
+            "dagster==1.1.10",
+            "gql[requests]>=3.0.0",
             "graphene>=3",
             "requests",
             "starlette"
           ],
           "requires_python": null,
-          "version": "1.1.3"
+          "version": "1.1.10"
         },
         {
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "14e6d098f7beb7fa775a4a4d4be45d934f7a1469fb4d0b2face095b1b4e52ae7",
-              "url": "https://files.pythonhosted.org/packages/19/d2/81ccc9d2127d71ef152945139efeb766af1afd375d853b6560b87db5c13a/dagster_pandas-0.17.3-py3-none-any.whl"
+              "hash": "e4ac4cc46399dbf530d4a93811def06712bb385ad12d81d3f91b365966b64aa5",
+              "url": "https://files.pythonhosted.org/packages/88/c3/f11c4eac8cacb8d944b70692c6644b4be5ac291091a70511674385236729/dagster_pandas-0.17.10-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "afc503843b8f95f81583847698d4049c438c301bc44ce3abcedc6b79eeb71017",
-              "url": "https://files.pythonhosted.org/packages/ac/5a/37055caacead52aafbdc9b42d75d2137f12eac36dc60f86959bb4a8d706b/dagster-pandas-0.17.3.tar.gz"
+              "hash": "fd52d4908c0aabe17fb3d6d76ed9784e397507ef860466b9b90bfd6d192b31d2",
+              "url": "https://files.pythonhosted.org/packages/88/ad/a5a7b953af27f5123da1f27124647c96d6c88b85a2fba9cb6aa823e1e79f/dagster-pandas-0.17.10.tar.gz"
             }
           ],
           "project_name": "dagster-pandas",
           "requires_dists": [
-            "dagster==1.1.3",
+            "dagster==1.1.10",
             "pandas"
           ],
           "requires_python": null,
-          "version": "0.17.3"
+          "version": "0.17.10"
         },
         {
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "0bfa56f1a5fe442e1307d9327c2f9750d22eae82c80933a790beffd16361360d",
-              "url": "https://files.pythonhosted.org/packages/bb/ee/420e1a137e685431554403202e7783290e5998cba6c60bfa1e5a1b0b08e4/dagster_postgres-0.17.3-py3-none-any.whl"
+              "hash": "c1f1221dc42feadfb7f41b36e1770b0ae35f88eb0eaba8737dd8bde927a74f9c",
+              "url": "https://files.pythonhosted.org/packages/95/11/29cdf95d7ee0807f659b28cb75e2780dba44be598440640714e5aac9d267/dagster_postgres-0.17.10-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "e8ea22ba9bd3222940499087dcc6ab9f24d499a331f1cbac954862b37519e881",
-              "url": "https://files.pythonhosted.org/packages/d3/16/87303ef41550b5370f91fd0cc336401f5871c445abb1bba6c4d4502b74e4/dagster-postgres-0.17.3.tar.gz"
+              "hash": "4565baadc43c23a2de956a27b119f56b994884fbc2c9e27c856e873b0485c197",
+              "url": "https://files.pythonhosted.org/packages/d2/21/7ad38dcbb85a8aa72b9b1daf8c4fe15a1bb994bdd8eb2e891ec787287b94/dagster-postgres-0.17.10.tar.gz"
             }
           ],
           "project_name": "dagster-postgres",
           "requires_dists": [
-            "dagster==1.1.3",
+            "dagster==1.1.10",
             "psycopg2-binary"
           ],
           "requires_python": null,
-          "version": "0.17.3"
+          "version": "0.17.10"
         },
         {
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "1704915e831a5b83311e51f01119cd37f91c30c7d778f74df423a4973859da44",
-              "url": "https://files.pythonhosted.org/packages/af/11/eaced14313691cce6c2d85c8492d2198fc4b95415d46bb758f8c4a79493e/dagster_shell-0.17.3-py3-none-any.whl"
+              "hash": "91b2961b2f0579ee297f6f9b42594fc4a5968a83d449a69bac0a5101e18452ab",
+              "url": "https://files.pythonhosted.org/packages/8a/0c/3c855d560e0000410e86ddc96d400ff809fd3cd42ff2151bcbe4512ce1a4/dagster_shell-0.17.10-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "4a15b59d5665899c139ed6f742db072ac4859224522384bc97d5fba476771a20",
-              "url": "https://files.pythonhosted.org/packages/86/e9/97d8073df6e044db5023b0118833dbf739c1630bd5c753add1e79eaad4e5/dagster-shell-0.17.3.tar.gz"
+              "hash": "d1139c0dea0446d38fbb2a37fda39c54f15a0e911a27982fe112f6c63309abb1",
+              "url": "https://files.pythonhosted.org/packages/e5/e5/0a74a98bb2ab6e9527b66f4e705c13e7ea13dfac08bd8d5f02da86b20434/dagster-shell-0.17.10.tar.gz"
             }
           ],
           "project_name": "dagster-shell",
           "requires_dists": [
-            "dagster==1.1.3",
+            "dagster==1.1.10",
             "psutil; extra == \"test\""
           ],
           "requires_python": null,
-          "version": "0.17.3"
+          "version": "0.17.10"
         },
         {
           "artifacts": [
@@ -1673,13 +1878,13 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "996c0250051c0c3faef8a9bd02b30a182d553e6a9b8d34b5344a30fe2fb9de33",
-              "url": "https://files.pythonhosted.org/packages/08/22/ff302e48556550f7e75fb4c0977b3ac7d92dd272ea204b11849e3479a8a9/db_dtypes-1.0.4-py2.py3-none-any.whl"
+              "hash": "ab6782bf7a414dd7289ce4ba8ddea5ec44c1339d189c7738d7098efdfd148266",
+              "url": "https://files.pythonhosted.org/packages/1c/5b/4ebdcc8be6069d55fc90aefc58112ba2c4881e3a1a73c80bef404433aa03/db_dtypes-1.0.5-py2.py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "6527cd2ae956e1d91c6c79387fb2a2217938139efc14449f6c662bd768994e9e",
-              "url": "https://files.pythonhosted.org/packages/3d/09/bca7660e1b82d9259e7aa371ee938435f4d0e84014e600d7413d219afe33/db-dtypes-1.0.4.tar.gz"
+              "hash": "ee68f30cbccf343124ef0abebc7f8cc9a74ef8ed7ee4ff61f586117e8040a9d6",
+              "url": "https://files.pythonhosted.org/packages/ab/bf/95a29fdc089d72376e6910dd7dd214ad13e7244819ee06f02218fe945a90/db-dtypes-1.0.5.tar.gz"
             }
           ],
           "project_name": "db-dtypes",
@@ -1687,22 +1892,22 @@
             "numpy<2.0dev,>=1.16.6",
             "packaging>=17.0",
             "pandas<2.0dev,>=0.24.2",
-            "pyarrow<10.0dev,>=3.0.0"
+            "pyarrow>=3.0.0"
           ],
           "requires_python": ">=3.7",
-          "version": "1.0.4"
+          "version": "1.0.5"
         },
         {
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "733ab7ba1f5dde664c3a3c2340aba755cd71db7967901870fff1caec68e69c1a",
-              "url": "https://files.pythonhosted.org/packages/cb/9c/e43fc8fd4bbdaacc207161bf9522281397b1489ff1a1f9e4cc8f2012caf5/dbt_core-1.3.1-py3-none-any.whl"
+              "hash": "22caa8a68732b3fdf7d10fc94bce22ab01fb08bbb5b522a60c960cdf88a26b6a",
+              "url": "https://files.pythonhosted.org/packages/3a/45/dc25086e7e242da6c0d232118cc0d110e214a05f0a5449b4ec8f2e3aa9c3/dbt_core-1.3.2-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "5b46c1dd21dde6ed160a14b781f7c34e07ca0de321fe317d682c84f62cdcb802",
-              "url": "https://files.pythonhosted.org/packages/ae/a0/f2d8daaabe71c394722bfca4bd9f2818fe095fe7a99d022abd32f1e6c61a/dbt-core-1.3.1.tar.gz"
+              "hash": "029168f6f92350e2bc534eca59bc9d9e2cfc5a974046240a8549a50c8de81388",
+              "url": "https://files.pythonhosted.org/packages/af/ff/ae8f55f663541ba243e0648a8fadc276a487bc486992b30d169912b2122e/dbt-core-1.3.2.tar.gz"
             }
           ],
           "project_name": "dbt-core",
@@ -1730,7 +1935,7 @@
             "werkzeug<3,>=1"
           ],
           "requires_python": ">=3.7.2",
-          "version": "1.3.1"
+          "version": "1.3.2"
         },
         {
           "artifacts": [
@@ -1824,80 +2029,80 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "cb81ead2a606d2c7a5b2d7d6d6edc4182e1c6c6dd6091a26d3570a430b765399",
-              "url": "https://files.pythonhosted.org/packages/43/af/4266918cee25412bae2723c701ae980cc60bd29b1d2f084e1206d85f75aa/dbt_trino-1.3.1-py3-none-any.whl"
+              "hash": "47d9aa1d7fa0d75eb137266b34fd5066d3d22833240b098712f2e666d86bbfd2",
+              "url": "https://files.pythonhosted.org/packages/4f/1f/2ba23b64c267b3004cdf281cc5b1746b28ebb42674b9360a6b336a43aafc/dbt_trino-1.3.2-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "446f232289ae98def356e79a833dab883460fe55bd7088ec0ea553ac6ae8bd0b",
-              "url": "https://files.pythonhosted.org/packages/6e/8a/d595ffede5ea0ab5e13b3c2cb33216e1d152a0b2fa1d416e3f32ad50c11c/dbt-trino-1.3.1.tar.gz"
+              "hash": "7c67b947cdd46a2792fc16b0d4d94f9f93ba058345fa921c39ebfda6d535ef91",
+              "url": "https://files.pythonhosted.org/packages/0f/3e/dc6affffdd140820b56ed72677d9ad5e10f01284c31782d45f5f2ad3ede3/dbt-trino-1.3.2.tar.gz"
             }
           ],
           "project_name": "dbt-trino",
           "requires_dists": [
             "dbt-core~=1.3.0",
-            "trino==0.318.0"
+            "trino==0.319.0"
           ],
           "requires_python": ">=3.7",
-          "version": "1.3.1"
+          "version": "1.3.2"
         },
         {
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "e886a1296cd20a10172e94788009ce74b759e54229ebd64a43fa5c2b4e62cd76",
-              "url": "https://files.pythonhosted.org/packages/15/62/8242e8610fbfd837fb4106490f1d64b2e8270509ab230fabc97875efe704/debugpy-1.6.4-py2.py3-none-any.whl"
+              "hash": "8116e40a1cd0593bd2aba01d4d560ee08f018da8e8fbd4cbd24ff09b5f0e41ef",
+              "url": "https://files.pythonhosted.org/packages/b6/75/67d59b76830c44527167008dde863b51c4c671d8ec23b6b61205bf383b28/debugpy-1.6.5-py2.py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "6ae238943482c78867ac707c09122688efb700372b617ffd364261e5e41f7a2f",
-              "url": "https://files.pythonhosted.org/packages/2b/94/02ec51f54b75fa23b2cec7c214d0c495604990095830b579633973940431/debugpy-1.6.4-cp310-cp310-macosx_10_15_x86_64.whl"
+              "hash": "15bc5febe0edc79726517b1f8d57d7ac7c784567b5ba804aab8b1c9d07a57018",
+              "url": "https://files.pythonhosted.org/packages/01/d1/ca25645259d56eae64a4b4d330072b5aa8145cfb8cdcae50c1096a0ef826/debugpy-1.6.5-cp39-cp39-win32.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "e62b8034ede98932b92268669318848a0d42133d857087a3b9cec03bb844c615",
-              "url": "https://files.pythonhosted.org/packages/40/62/541bb8a3982671ed31d7f1577d3fde253c0c1fd0f0f5a6609026b52727c9/debugpy-1.6.4-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+              "hash": "8f3fab217fe7e2acb2d90732af1a871947def4e2b6654945ba1ebd94bd0bea26",
+              "url": "https://files.pythonhosted.org/packages/22/9a/610d08048464ac9a39238a9b07312052e3e6a1f6b6f2c6aa9e8daa6a7e68/debugpy-1.6.5-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "2a39e7da178e1f22f4bc04b57f085e785ed1bcf424aaf318835a1a7129eefe35",
-              "url": "https://files.pythonhosted.org/packages/97/3a/ee96867d2550c740c7c49735b585d6e5b74965b95bc03469343bc1691594/debugpy-1.6.4-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+              "hash": "5e55e6c79e215239dd0794ee0bf655412b934735a58e9d705e5c544f596f1603",
+              "url": "https://files.pythonhosted.org/packages/27/bf/5fb58a315f33860448ebe6481ec6bf15d67fe783e1f80f6c0868fa284f4d/debugpy-1.6.5.zip"
             },
             {
               "algorithm": "sha256",
-              "hash": "d2968e589bda4e485a9c61f113754a28e48d88c5152ed8e0b2564a1fadbe50a5",
-              "url": "https://files.pythonhosted.org/packages/98/ab/d2efd0a13b99e0a78f69ddcc4d4faf9b35dc46d336ba9e842468af88a3ae/debugpy-1.6.4-cp39-cp39-macosx_10_15_x86_64.whl"
+              "hash": "62a06eb78378292ba6c427d861246574dc8b84471904973797b29dd33c7c2495",
+              "url": "https://files.pythonhosted.org/packages/2b/65/d696eabc4f9e2b0e8704cbbd88d96327c16dfe134c6286b5f57ce388ba11/debugpy-1.6.5-cp310-cp310-win32.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "d5ab9bd3f4e7faf3765fd52c7c43c074104ab1e109621dc73219099ed1a5399d",
-              "url": "https://files.pythonhosted.org/packages/9b/d5/1d8718de85ff87a88db3c1a7eb1f0870de50dee858fd1e13659fa0af7e9f/debugpy-1.6.4.zip"
+              "hash": "7e84d9e4420122384cb2cc762a00b4e17cbf998022890f89b195ce178f78ff47",
+              "url": "https://files.pythonhosted.org/packages/31/12/3304fea2f4b3a241fe60ee6459cc16f2e7b7ef1a197669106dc416053bc9/debugpy-1.6.5-cp39-cp39-win_amd64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "143f79d0798a9acea21cd1d111badb789f19d414aec95fa6389cfea9485ddfb1",
-              "url": "https://files.pythonhosted.org/packages/bf/a1/242cfd5a819d9ada621eaba1c40e01aff1cb8dbf46713d9ab61ae8ebbcab/debugpy-1.6.4-cp310-cp310-win32.whl"
+              "hash": "9984fc00ab372c97f63786c400107f54224663ea293daab7b365a5b821d26309",
+              "url": "https://files.pythonhosted.org/packages/3e/14/b96f86b17d1faaf61259ad01ff7d4e6b390d7de30fb074ef12e519cffd7c/debugpy-1.6.5-cp310-cp310-win_amd64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "3d9c31baf64bf959a593996c108e911c5a9aa1693a296840e5469473f064bcec",
-              "url": "https://files.pythonhosted.org/packages/fc/aa/37d2471c156696d0c61621ed683821c5aa9d2395ced4a661d97bf88402b6/debugpy-1.6.4-cp39-cp39-win32.whl"
+              "hash": "500dd4a9ff818f5c52dddb4a608c7de5371c2d7d905c505eb745556c579a9f11",
+              "url": "https://files.pythonhosted.org/packages/74/1c/6ee0a088c450f85654ae6e2b4b6f6175c2d626d3d14f2f325dc5138c1ff0/debugpy-1.6.5-cp39-cp39-macosx_11_0_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "563f148f94434365ec0ce94739c749aabf60bf67339e68a9446499f3582d62f3",
-              "url": "https://files.pythonhosted.org/packages/fc/e2/9b8e2b671adec17f32f314282aa5214852bc5fec8d6722a68dc219f213b6/debugpy-1.6.4-cp310-cp310-win_amd64.whl"
+              "hash": "17039e392d6f38388a68bd02c5f823b32a92142a851e96ba3ec52aeb1ce9d900",
+              "url": "https://files.pythonhosted.org/packages/92/d5/b0f9b31b5fc902aa1611d0163652713b21661201f7008051fd5e512e851b/debugpy-1.6.5-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "ea4bf208054e6d41749f17612066da861dff10102729d32c85b47f155223cf2b",
-              "url": "https://files.pythonhosted.org/packages/ff/44/8db3d656d256add8ad270f4c45cf91eb0beaec1c7fafa32771e8a35e9141/debugpy-1.6.4-cp39-cp39-win_amd64.whl"
+              "hash": "696165f021a6a17da08163eaae84f3faf5d8be68fb78cd78488dd347e625279c",
+              "url": "https://files.pythonhosted.org/packages/bf/ca/b2a54608a5ab21fc9e0afa4d78f2e45c193f8147969c27d790666ed4a282/debugpy-1.6.5-cp310-cp310-macosx_11_0_x86_64.whl"
             }
           ],
           "project_name": "debugpy",
           "requires_dists": [],
           "requires_python": ">=3.7",
-          "version": "1.6.4"
+          "version": "1.6.5"
         },
         {
           "artifacts": [
@@ -1939,13 +2144,13 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "f6761f00725a10e0193491ba746d6462bf2c6b443a54fd5af7b6fa99a40126a3",
-              "url": "https://files.pythonhosted.org/packages/49/a2/f8ace4291a7d09db05b1a62de4f850d5ae031022b51252345626ec345104/diff_cover-7.1.1-py3-none-any.whl"
+              "hash": "02c77c97b2952a6900d12239db6ce1b5e1c400798aee768102e4d492d5341500",
+              "url": "https://files.pythonhosted.org/packages/30/d1/d56bbc4f043a16f72e06cb67168b50011f6f25242997d10493562d79e303/diff_cover-7.3.0-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "d4f5ca086ba73dab3df1709500057b9fb8a18ba516923abf42fe65b6681e7ba6",
-              "url": "https://files.pythonhosted.org/packages/76/09/3bede447505d8c7c6320efa57b86c2f487d531b2617d00145761eaeb003d/diff_cover-7.1.1.tar.gz"
+              "hash": "a9b1f2bbd14962cd5279d7358a3ba8d726b9a6cc03dbf409f89cc2076a424234",
+              "url": "https://files.pythonhosted.org/packages/42/d0/0b8207a228d70d608e8bfeb66f02740f9f6545cb8d44d347859e26243ba0/diff_cover-7.3.0.tar.gz"
             }
           ],
           "project_name": "diff-cover",
@@ -1958,7 +2163,7 @@
             "tomli>=1.2.1; extra == \"toml\""
           ],
           "requires_python": "<4.0.0,>=3.7.2",
-          "version": "7.1.1"
+          "version": "7.3"
         },
         {
           "artifacts": [
@@ -2141,13 +2346,13 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "542adf9dea4055530d6e1279602fa5cb11dab2395fa650b8674eaec35fc4a828",
-              "url": "https://files.pythonhosted.org/packages/ce/2e/9a327cc0d2d674ee2d570ee30119755af772094edba86d721dda94404d1a/exceptiongroup-1.0.4-py3-none-any.whl"
+              "hash": "327cbda3da756e2de031a3107b81ab7b3770a602c4d16ca618298c526f4bec1e",
+              "url": "https://files.pythonhosted.org/packages/e8/14/9c6a7e5f12294ccd6975a45e02899ed25468cd7c2c86f3d9725f387f9f5f/exceptiongroup-1.1.0-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "bd14967b79cd9bdb54d97323216f8fdf533e278df937aa2a90089e7d6e06e5ec",
-              "url": "https://files.pythonhosted.org/packages/fa/e1/4f89a2608978a78876a76e69e82fa1fc5ce3fb346297eed2a51dd3df2dcf/exceptiongroup-1.0.4.tar.gz"
+              "hash": "bcb67d800a4497e1b404c2dd44fca47d3b7a5e5433dbab67f96c1a685cdfdf23",
+              "url": "https://files.pythonhosted.org/packages/15/ab/dd27fb742b19a9d020338deb9ab9a28796524081bca880ac33c172c9a8f6/exceptiongroup-1.1.0.tar.gz"
             }
           ],
           "project_name": "exceptiongroup",
@@ -2155,7 +2360,7 @@
             "pytest>=6; extra == \"test\""
           ],
           "requires_python": ">=3.7",
-          "version": "1.0.4"
+          "version": "1.1"
         },
         {
           "artifacts": [
@@ -2212,28 +2417,28 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "617eb4e5eedc82fc5f47b6d61e4d11cb837c56cb4544e39081099fa17ad109d4",
-              "url": "https://files.pythonhosted.org/packages/94/b3/ff2845971788613e646e667043fdb5f128e2e540aefa09a3c55be8290d6d/filelock-3.8.0-py3-none-any.whl"
+              "hash": "f58d535af89bb9ad5cd4df046f741f8553a418c01a7856bf0d173bbc9f6bd16d",
+              "url": "https://files.pythonhosted.org/packages/14/4c/b201d0292ca4e0950f0741212935eac9996f69cd66b92a3587e594999163/filelock-3.9.0-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "55447caa666f2198c5b6b13a26d2084d26fa5b115c00d065664b2124680c4edc",
-              "url": "https://files.pythonhosted.org/packages/95/55/b897882bffb8213456363e646bf9e9fa704ffda5a7d140edf935a9e02c7b/filelock-3.8.0.tar.gz"
+              "hash": "7b319f24340b51f55a2bf7a12ac0755a9b03e718311dac567a0f4f7fabd2f5de",
+              "url": "https://files.pythonhosted.org/packages/0b/dc/eac02350f06c6ed78a655ceb04047df01b02c6b7ea3fc02d4df24ca87d24/filelock-3.9.0.tar.gz"
             }
           ],
           "project_name": "filelock",
           "requires_dists": [
-            "covdefaults>=2.2; extra == \"testing\"",
-            "coverage>=6.4.2; extra == \"testing\"",
-            "furo>=2022.6.21; extra == \"docs\"",
-            "pytest-cov>=3; extra == \"testing\"",
+            "covdefaults>=2.2.2; extra == \"testing\"",
+            "coverage>=7.0.1; extra == \"testing\"",
+            "furo>=2022.12.7; extra == \"docs\"",
+            "pytest-cov>=4; extra == \"testing\"",
             "pytest-timeout>=2.1; extra == \"testing\"",
-            "pytest>=7.1.2; extra == \"testing\"",
-            "sphinx-autodoc-typehints>=1.19.1; extra == \"docs\"",
-            "sphinx>=5.1.1; extra == \"docs\""
+            "pytest>=7.2; extra == \"testing\"",
+            "sphinx-autodoc-typehints>=1.19.5; extra == \"docs\"",
+            "sphinx>=5.3; extra == \"docs\""
           ],
           "requires_python": ">=3.7",
-          "version": "3.8"
+          "version": "3.9"
         },
         {
           "artifacts": [
@@ -2304,13 +2509,13 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "6ad0ab754507319060695e2f2be80e6d8977cfcea082293089a9226276bd825d",
-              "url": "https://files.pythonhosted.org/packages/c1/17/9bcf98e3071727ea54977840a64b8bec9e3b90a395ae0cb3ac17f76b20a1/flake8_bugbear-22.10.27-py3-none-any.whl"
+              "hash": "b69a510634f8a9c298dfda2b18a8036455e6b19ecac4fe582e4d7a0abfa50a30",
+              "url": "https://files.pythonhosted.org/packages/23/a1/ed74a6995d908bb89f9ffbe197e5f729c1546dba70d1995e7db70dfaafb5/flake8_bugbear-22.12.6-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "a6708608965c9e0de5fff13904fed82e0ba21ac929fe4896459226a797e11cd5",
-              "url": "https://files.pythonhosted.org/packages/e3/7d/8df9e2608a90a733be963de901954f83ae20c3e481fd17f31e04ce448c7e/flake8-bugbear-22.10.27.tar.gz"
+              "hash": "4cdb2c06e229971104443ae293e75e64c6107798229202fbe4f4091427a30ac0",
+              "url": "https://files.pythonhosted.org/packages/da/b5/83a89114a82a2764ddfe27451df6b69c46513f88a3f66206514265b6f447/flake8-bugbear-22.12.6.tar.gz"
             }
           ],
           "project_name": "flake8-bugbear",
@@ -2324,7 +2529,7 @@
             "tox; extra == \"dev\""
           ],
           "requires_python": ">=3.7",
-          "version": "22.10.27"
+          "version": "22.12.6"
         },
         {
           "artifacts": [
@@ -2458,8 +2663,8 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "633adca6fb8a08131536af0d750b44d6985b9aba46f498871e21588c3e6f525a",
-              "url": "https://files.pythonhosted.org/packages/31/82/f4f52cc489b3f08c5b5ce1f6306f12014ed9825c5089835e44761ff395a6/flake8-quotes-3.3.1.tar.gz"
+              "hash": "6e26892b632dacba517bf27219c459a8396dcfac0f5e8204904c5a4ba9b480e1",
+              "url": "https://files.pythonhosted.org/packages/88/89/7c5a8e671c17ae49e4b89b06d9d2db5608eea7c66b04d70d27390da9ddb9/flake8-quotes-3.3.2.tar.gz"
             }
           ],
           "project_name": "flake8-quotes",
@@ -2467,7 +2672,7 @@
             "flake8"
           ],
           "requires_python": null,
-          "version": "3.3.1"
+          "version": "3.3.2"
         },
         {
           "artifacts": [
@@ -2561,14 +2766,14 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "b1bead90b70cf6ec3f0710ae53a525360fa360d306a86583adc6bf83a4db537d",
-              "url": "https://files.pythonhosted.org/packages/45/0b/38b06fd9b92dc2b68d58b75f900e97884c45bedd2ff83203d933cf5851c9/future-0.18.2.tar.gz"
+              "hash": "34a17436ed1e96697a86f9de3d15a3b0be01d8bc8de9c1dffd59fb8234ed5307",
+              "url": "https://files.pythonhosted.org/packages/8f/2e/cf6accf7415237d6faeeebdc7832023c90e0282aa16fd3263db0eb4715ec/future-0.18.3.tar.gz"
             }
           ],
           "project_name": "future",
           "requires_dists": [],
           "requires_python": "!=3.0.*,!=3.1.*,!=3.2.*,>=2.6",
-          "version": "0.18.2"
+          "version": "0.18.3"
         },
         {
           "artifacts": [
@@ -2594,13 +2799,13 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "41eea0deec2deea139b459ac03656f0dd28fc4a3387240ec1d3c259a2c47850f",
-              "url": "https://files.pythonhosted.org/packages/1f/d3/020efb312a7d25fa00e144497a33378d415552e5581be080a99017af6d39/GitPython-3.1.29-py3-none-any.whl"
+              "hash": "cd455b0000615c60e286208ba540271af9fe531fa6a87cc590a7298785ab2882",
+              "url": "https://files.pythonhosted.org/packages/d0/7c/e6942be5f2c03a9de68a6c782373dcec7dc1d10664dd20652bfb7307f905/GitPython-3.1.30-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "cc36bfc4a3f913e66805a28e84703e419d9c264c1077e537b54f0e1af85dbefd",
-              "url": "https://files.pythonhosted.org/packages/22/ab/3dd8b8a24399cee9c903d5f7600d20e8703d48904020f46f7fa5ac5474e9/GitPython-3.1.29.tar.gz"
+              "hash": "769c2d83e13f5d938b7688479da374c4e3d49f71549aaf462b646db9602ea6f8",
+              "url": "https://files.pythonhosted.org/packages/ef/8d/50658d134d89e080bb33eb8e2f75d17563b5a9dfb75383ea1a78e1df6fff/GitPython-3.1.30.tar.gz"
             }
           ],
           "project_name": "gitpython",
@@ -2609,7 +2814,7 @@
             "typing-extensions>=3.7.4.3; python_version < \"3.8\""
           ],
           "requires_python": ">=3.7",
-          "version": "3.1.29"
+          "version": "3.1.30"
         },
         {
           "artifacts": [
@@ -2642,13 +2847,13 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "3b45110b638232959f75418231dfb487228102a4a91a7a3e64147684befaebee",
-              "url": "https://files.pythonhosted.org/packages/a0/17/f3d92ac464f96bcc89a1ba4b6e72f51cfdaab41af856f10e3ec00d75dcd7/google_api_python_client-2.66.0-py2.py3-none-any.whl"
+              "hash": "bafce2a02b06ee501df039eba5874afc7d28c9cf5ef92253327776448706556d",
+              "url": "https://files.pythonhosted.org/packages/89/63/44c9043af264db06a8c2fcc60a64ecd1002e1612458c09233fab885cea02/google_api_python_client-2.73.0-py2.py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "4cfaf0205aa7c538c8fb1772368be3d049dfed7886adf48597e9a766e9828a6e",
-              "url": "https://files.pythonhosted.org/packages/b8/ca/4fcfeb70d90f70f9784e10b79f6db41463278e5e4acef00606b8ef4e9bbb/google-api-python-client-2.66.0.tar.gz"
+              "hash": "7e860e3ec27b504fb797fa23c07c012a874dd736491fddbe50a20d3bdde8ace6",
+              "url": "https://files.pythonhosted.org/packages/4a/af/6e9ba1d552043c69bddeb761126fe9c9c0a8e896d35a304785d132571523/google-api-python-client-2.73.0.tar.gz"
             }
           ],
           "project_name": "google-api-python-client",
@@ -2660,19 +2865,19 @@
             "uritemplate<5,>=3.0.1"
           ],
           "requires_python": ">=3.7",
-          "version": "2.66"
+          "version": "2.73"
         },
         {
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "f5d8701633bebc12e0deea4df8abd8aff31c28b355360597f7f2ee60f2e4d016",
-              "url": "https://files.pythonhosted.org/packages/9b/9b/f40ea5c60762eabeb17cebdc05c395f44584c5c7fd7ce636a869c4f1e05d/google_auth-2.14.1-py2.py3-none-any.whl"
+              "hash": "5045648c821fb72384cdc0e82cc326df195f113a33049d9b62b74589243d2acc",
+              "url": "https://files.pythonhosted.org/packages/fb/55/c6e13b79a16688069b214cf726ebe49725c0b936367f045464b1122de083/google_auth-2.16.0-py2.py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "ccaa901f31ad5cbb562615eb8b664b3dd0bf5404a67618e642307f00613eda4d",
-              "url": "https://files.pythonhosted.org/packages/89/e3/b9002efddfc812af8afd59577ed04432cd3bfcc9c46e0210f3a1b56dfe4c/google-auth-2.14.1.tar.gz"
+              "hash": "ed7057a101af1146f0554a769930ac9de506aeca4fd5af6543ebe791851a9fbd",
+              "url": "https://files.pythonhosted.org/packages/a9/b8/106bf395ad5be94bfd1e4c157a36db6dfcca445f72ff63458358d9203157/google-auth-2.16.0.tar.gz"
             }
           ],
           "project_name": "google-auth",
@@ -2687,12 +2892,13 @@
             "pyopenssl>=20.0.0; extra == \"pyopenssl\"",
             "pyu2f>=0.1.5; extra == \"reauth\"",
             "requests<3.0.0dev,>=2.20.0; extra == \"aiohttp\"",
+            "requests<3.0.0dev,>=2.20.0; extra == \"requests\"",
             "rsa<4.6; python_version < \"3.6\"",
             "rsa<5,>=3.1.4; python_version >= \"3.6\"",
             "six>=1.9.0"
           ],
           "requires_python": "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,>=2.7",
-          "version": "2.14.1"
+          "version": "2.16"
         },
         {
           "artifacts": [
@@ -2720,28 +2926,31 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "1dec058c29dc9e5801bf790469400f5509305bf1bfd2259aeaa30e786a4a42ec",
-              "url": "https://files.pythonhosted.org/packages/46/62/9dabf583d71f25e48b9b084072b2a439577eb8032dcf5e68ec5f94166489/google_cloud_bigquery-3.4.0-py2.py3-none-any.whl"
+              "hash": "9e3dd435f026aae98969ef2b0073613f6571224e2f6da3f384830bee53cf822e",
+              "url": "https://files.pythonhosted.org/packages/b2/f6/c9604e88f007c136b5b9d0d38418d39d97369704470d68f53817fd066241/google_cloud_bigquery-3.4.1-py2.py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "054f97aa664a43549a152a6bd1ec059733d3f23b828e945a141ece4cdb7a0991",
-              "url": "https://files.pythonhosted.org/packages/08/e0/d9e9154cd072f649cfddbd2685fe513e28ecc9a466aab1dad9f1510a76be/google-cloud-bigquery-3.4.0.tar.gz"
+              "hash": "884689714d98a2364dde9c7c367e8228c7116108bbad7a6365dfde391638985b",
+              "url": "https://files.pythonhosted.org/packages/ff/09/3fbec5205f85d654a60cd681aa174cc8b479835fb1a18a6535c18cccd512/google-cloud-bigquery-3.4.1.tar.gz"
             }
           ],
           "project_name": "google-cloud-bigquery",
           "requires_dists": [
-            "Shapely<2.0dev,>=1.6.0; extra == \"all\"",
-            "Shapely<2.0dev,>=1.6.0; extra == \"geopandas\"",
+            "Shapely<2.0dev,>=1.8.4; extra == \"all\"",
+            "Shapely<2.0dev,>=1.8.4; extra == \"geopandas\"",
             "db-dtypes<2.0.0dev,>=0.3.0; extra == \"all\"",
             "db-dtypes<2.0.0dev,>=0.3.0; extra == \"pandas\"",
             "geopandas<1.0dev,>=0.9.0; extra == \"all\"",
             "geopandas<1.0dev,>=0.9.0; extra == \"geopandas\"",
             "google-api-core[grpc]!=2.0.*,!=2.1.*,!=2.2.*,!=2.3.0,<3.0.0dev,>=1.31.5",
-            "google-cloud-bigquery-storage<3.0.0dev,>=2.0.0",
+            "google-cloud-bigquery-storage<3.0.0dev,>=2.0.0; extra == \"all\"",
+            "google-cloud-bigquery-storage<3.0.0dev,>=2.0.0; extra == \"bqstorage\"",
             "google-cloud-core<3.0.0dev,>=1.4.1",
             "google-resumable-media<3.0dev,>=0.6.0",
             "grpcio<2.0dev,>=1.47.0",
+            "grpcio<2.0dev,>=1.47.0; extra == \"all\"",
+            "grpcio<2.0dev,>=1.47.0; extra == \"bqstorage\"",
             "ipython!=8.1.0,>=7.0.1; extra == \"all\"",
             "ipython!=8.1.0,>=7.0.1; extra == \"ipython\"",
             "ipywidgets==7.7.1; extra == \"all\"",
@@ -2753,43 +2962,20 @@
             "opentelemetry-sdk>=1.1.0; extra == \"all\"",
             "opentelemetry-sdk>=1.1.0; extra == \"opentelemetry\"",
             "packaging<22.0.0dev,>=14.3",
-            "pandas>=1.0.0; extra == \"all\"",
-            "pandas>=1.0.0; extra == \"pandas\"",
-            "proto-plus<2.0.0dev,>=1.22.0",
+            "pandas>=1.1.0; extra == \"all\"",
+            "pandas>=1.1.0; extra == \"pandas\"",
+            "proto-plus<2.0.0dev,>=1.15.0",
             "protobuf!=3.20.0,!=3.20.1,!=4.21.0,!=4.21.1,!=4.21.2,!=4.21.3,!=4.21.4,!=4.21.5,<5.0.0dev,>=3.19.5",
-            "pyarrow<11.0dev,>=3.0.0",
+            "pyarrow>=3.0.0; extra == \"all\"",
+            "pyarrow>=3.0.0; extra == \"bqstorage\"",
+            "pyarrow>=3.0.0; extra == \"pandas\"",
             "python-dateutil<3.0dev,>=2.7.2",
             "requests<3.0.0dev,>=2.21.0",
             "tqdm<5.0.0dev,>=4.7.4; extra == \"all\"",
             "tqdm<5.0.0dev,>=4.7.4; extra == \"tqdm\""
           ],
           "requires_python": ">=3.7",
-          "version": "3.4"
-        },
-        {
-          "artifacts": [
-            {
-              "algorithm": "sha256",
-              "hash": "d037f238d0ab417c1e102a262c3fdb4b80cc630303bab358b1179260f47af0b7",
-              "url": "https://files.pythonhosted.org/packages/b7/fd/c5e9775fb2be41be2fa77b21642493e3af0048497f0669827f2eec1e8a6b/google_cloud_bigquery_storage-2.16.2-py2.py3-none-any.whl"
-            },
-            {
-              "algorithm": "sha256",
-              "hash": "e6aca4f7b6f4eadb87f8510906177563518e1587c8b7b162bcf8e1c9e75ef416",
-              "url": "https://files.pythonhosted.org/packages/c7/1c/d524bf9ce4bbd4de0d22fe01f2470ceb6cb40fd7581b740c8c8ce07b66dd/google-cloud-bigquery-storage-2.16.2.tar.gz"
-            }
-          ],
-          "project_name": "google-cloud-bigquery-storage",
-          "requires_dists": [
-            "fastavro>=0.21.2; extra == \"fastavro\"",
-            "google-api-core[grpc]!=2.0.*,!=2.1.*,!=2.2.*,!=2.3.*,!=2.4.*,!=2.5.*,!=2.6.*,!=2.7.*,<3.0.0dev,>=1.32.0",
-            "pandas>=0.21.1; extra == \"pandas\"",
-            "proto-plus<2.0.0dev,>=1.22.0",
-            "protobuf!=3.20.0,!=3.20.1,!=4.21.0,!=4.21.1,!=4.21.2,!=4.21.3,!=4.21.4,!=4.21.5,<5.0.0dev,>=3.19.5",
-            "pyarrow>=0.15.0; extra == \"pyarrow\""
-          ],
-          "requires_python": ">=3.7",
-          "version": "2.16.2"
+          "version": "3.4.1"
         },
         {
           "artifacts": [
@@ -2817,13 +3003,13 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "4ad0415ff61abdd8bb2ae81c1f8f7ec7d91a1011613f2db87c614c550f97bfe9",
-              "url": "https://files.pythonhosted.org/packages/d9/2f/580e3dd26caffaa4146742c567b6a0adb2fb8126bb51a51ebc63ccd049ff/google_cloud_storage-2.6.0-py2.py3-none-any.whl"
+              "hash": "f78a63525e72dd46406b255bbdf858a22c43d6bad8dc5bdeb7851a42967e95a1",
+              "url": "https://files.pythonhosted.org/packages/6e/23/3add67cdd1f2116eb4425b0d4f3154117b8a79eaaf3022edc23a71d82cc2/google_cloud_storage-2.7.0-py2.py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "104ca28ae61243b637f2f01455cc8a05e8f15a2a18ced96cb587241cdd3820f5",
-              "url": "https://files.pythonhosted.org/packages/93/ad/2841b47923ea0f7edf44afdca9d61d47dbb521698185225878468710457e/google-cloud-storage-2.6.0.tar.gz"
+              "hash": "1ac2d58d2d693cb1341ebc48659a3527be778d9e2d8989697a2746025928ff17",
+              "url": "https://files.pythonhosted.org/packages/9f/9c/8cd4da7df57284832c3853aa565de278ca6d33a47ebe6722628488dc01ca/google-cloud-storage-2.7.0.tar.gz"
             }
           ],
           "project_name": "google-cloud-storage",
@@ -2836,7 +3022,7 @@
             "requests<3.0.0dev,>=2.18.0"
           ],
           "requires_python": ">=3.7",
-          "version": "2.6"
+          "version": "2.7"
         },
         {
           "artifacts": [
@@ -3059,13 +3245,13 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "a9f4a1d7f6d9809657b7f1316a1aa527f6664891531bcfcc13b6696e685f443c",
-              "url": "https://files.pythonhosted.org/packages/f0/2a/25d8c1ceedc5af97de37434c9c5e38ce28aaa45960aa2bd7aa215fc420c0/googleapis_common_protos-1.57.0-py2.py3-none-any.whl"
+              "hash": "ca3befcd4580dab6ad49356b46bf165bb68ff4b32389f028f1abd7c10ab9519a",
+              "url": "https://files.pythonhosted.org/packages/32/4e/ed585842aaa704d87495a0e99317aaa44c5007a597c05b995fa8cfc4dfbe/googleapis_common_protos-1.58.0-py2.py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "27a849d6205838fb6cc3c1c21cb9800707a661bb21c6ce7fb13e99eb1f8a0c46",
-              "url": "https://files.pythonhosted.org/packages/c5/db/9b98c3a9e148b5daaa2e26ce4faeb6ade28dc623dcc109f2ac7efee514de/googleapis-common-protos-1.57.0.tar.gz"
+              "hash": "c727251ec025947d545184ba17e3578840fc3a24a0516a020479edab660457df",
+              "url": "https://files.pythonhosted.org/packages/41/43/613cbd071413f6b2a3427f905bc8a8f0f3da202a6e715d78aa22b1f35271/googleapis-common-protos-1.58.0.tar.gz"
             }
           ],
           "project_name": "googleapis-common-protos",
@@ -3074,7 +3260,7 @@
             "protobuf!=3.20.0,!=3.20.1,!=4.21.1,!=4.21.2,!=4.21.3,!=4.21.4,!=4.21.5,<5.0.0dev,>=3.19.5"
           ],
           "requires_python": ">=3.7",
-          "version": "1.57"
+          "version": "1.58"
         },
         {
           "artifacts": [
@@ -3165,13 +3351,13 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "1c0d43560a86536b7816bb05e3685beebf140118e091a9c445cd10f55acb20fd",
-              "url": "https://files.pythonhosted.org/packages/be/8a/2a2b883b69af0e9a7622c8ab7f903a4f5467af76d78a675bd895064f37bb/graphene-3.1.1-py2.py3-none-any.whl"
+              "hash": "2ef689f514ba9e65e88961798cf4c637ca580e541168f9aee2ffbe21fd46f388",
+              "url": "https://files.pythonhosted.org/packages/b3/a2/40727944d4587b4d945799a92965f58eb51b1ef8b5bf4d45ce937fade347/graphene-3.2.1-py2.py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "ff251dbc39a6409106c41de444358d93b2c5588d161dce2245bea7d74b445c86",
-              "url": "https://files.pythonhosted.org/packages/7c/60/1916ea1fb3173aa77ad6c2ba28a44e827b00451d1bcde58bb298c0b8f758/graphene-3.1.1.tar.gz"
+              "hash": "722243a9da2caeab703b1af9ec0deec602589c97035f86c486106a52d0c67082",
+              "url": "https://files.pythonhosted.org/packages/c7/82/b5714a1082120f1ac71fb0d34b151d681c989e9a8f6c291b6d942387ace8/graphene-3.2.1.tar.gz"
             }
           ],
           "project_name": "graphene",
@@ -3187,8 +3373,6 @@
             "iso8601<2,>=1; extra == \"test\"",
             "mock<5,>=4; extra == \"dev\"",
             "mock<5,>=4; extra == \"test\"",
-            "promise<3,>=2.3; extra == \"dev\"",
-            "promise<3,>=2.3; extra == \"test\"",
             "pytest-asyncio<2,>=0.16; extra == \"dev\"",
             "pytest-asyncio<2,>=0.16; extra == \"test\"",
             "pytest-benchmark<4,>=3.4; extra == \"dev\"",
@@ -3205,7 +3389,7 @@
             "snapshottest<1,>=0.6; extra == \"test\""
           ],
           "requires_python": null,
-          "version": "3.1.1"
+          "version": "3.2.1"
         },
         {
           "artifacts": [
@@ -3252,13 +3436,13 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "82fbdb113dd5158f5236469ba352094df10f5faf9498517f2809440ca8689239",
-              "url": "https://files.pythonhosted.org/packages/a8/61/c3f89789ed9e29746976fc6513d19524eb567617c2a479e715a4c323f3cc/great_expectations-0.15.34-py3-none-any.whl"
+              "hash": "72ae1b54b21b6a0969d8df4d7b47ce74db0f4370c093a592977aff5bef5845a2",
+              "url": "https://files.pythonhosted.org/packages/01/aa/9b6cd3a852c4f06b9bf062971de7e485597e358092eac70e3d6b83d49583/great_expectations-0.15.43-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "09a4a3cb8d4648a410bc89fa349b16c885dcbcbffd3ff7808357d8bf7399b621",
-              "url": "https://files.pythonhosted.org/packages/60/06/b680ffc95be1d2c8620521336a3333ac8c7311fcc45629bed903cf2f1116/great_expectations-0.15.34.tar.gz"
+              "hash": "60c056f5b553f74e107104700cf8b9643d0def45fd60399f5b1d3f51d2b8cd96",
+              "url": "https://files.pythonhosted.org/packages/27/5f/8a247d45365729586394ca1dee8b7f4b13d3a06c7bd921c1e54e052a4aa1/great_expectations-0.15.43.tar.gz"
             }
           ],
           "project_name": "great-expectations",
@@ -3287,6 +3471,10 @@
             "boto3==1.17.106; extra == \"test\"",
             "colorama>=0.4.3",
             "cryptography>=3.2",
+            "darglint>=1.8.1; extra == \"dev\"",
+            "darglint>=1.8.1; extra == \"test\"",
+            "docstring-parser==0.15; extra == \"dev\"",
+            "docstring-parser==0.15; extra == \"test\"",
             "feather-format>=0.4.1; extra == \"arrow\"",
             "feather-format>=0.4.1; extra == \"dev\"",
             "flake8==5.0.4; extra == \"dev\"",
@@ -3298,6 +3486,9 @@
             "gcsfs>=0.5.1; extra == \"bigquery\"",
             "gcsfs>=0.5.1; extra == \"dev\"",
             "gcsfs>=0.5.1; extra == \"gcp\"",
+            "google-cloud-bigquery>=3.3.6; extra == \"bigquery\"",
+            "google-cloud-bigquery>=3.3.6; extra == \"dev\"",
+            "google-cloud-bigquery>=3.3.6; extra == \"gcp\"",
             "google-cloud-secret-manager>=1.0.0; extra == \"bigquery\"",
             "google-cloud-secret-manager>=1.0.0; extra == \"dev\"",
             "google-cloud-secret-manager>=1.0.0; extra == \"gcp\"",
@@ -3307,12 +3498,14 @@
             "importlib-metadata>=1.7.0",
             "invoke>=1.7.1; extra == \"dev\"",
             "invoke>=1.7.1; extra == \"test\"",
+            "ipykernel<=6.17.1; extra == \"dev\"",
+            "ipykernel<=6.17.1; extra == \"test\"",
             "ipywidgets>=7.5.1",
             "isort==5.10.1; extra == \"dev\"",
             "isort==5.10.1; extra == \"test\"",
             "jinja2>=2.10",
             "jsonpatch>=1.22",
-            "jsonschema<=4.7.2,>=2.5.1",
+            "jsonschema>=2.5.1",
             "makefun<2,>=1.7.0",
             "marshmallow<4.0.0,>=3.7.1",
             "mistune>=0.8.4",
@@ -3326,11 +3519,15 @@
             "nbconvert>=5; extra == \"test\"",
             "nbformat>=5.0",
             "notebook>=6.4.10",
-            "numpy>=1.18.5",
+            "numpy>=1.18.5; python_version <= \"3.7\"",
+            "numpy>=1.19.5; python_version == \"3.8\" or python_version == \"3.9\"",
+            "numpy>=1.23.0; python_version >= \"3.10\"",
             "openpyxl>=3.0.7; extra == \"dev\"",
             "openpyxl>=3.0.7; extra == \"excel\"",
             "packaging",
-            "pandas>=1.1.0",
+            "pandas>=1.1.0; python_version <= \"3.8\"",
+            "pandas>=1.1.3; python_version == \"3.9\"",
+            "pandas>=1.4.0; python_version >= \"3.10\"",
             "pre-commit>=2.6.0; extra == \"dev\"",
             "pre-commit>=2.6.0; extra == \"test\"",
             "psycopg2-binary>=2.7.6; extra == \"dev\"",
@@ -3342,8 +3539,8 @@
             "pyathena>=1.11; extra == \"athena\"",
             "pyathena>=1.11; extra == \"dev\"",
             "pydantic<2.0,>=1.0",
-            "pydantic<2.0,>=1.0; extra == \"dev\"",
-            "pydantic<2.0,>=1.0; extra == \"test\"",
+            "pydocstyle>=6.1.1; extra == \"dev\"",
+            "pydocstyle>=6.1.1; extra == \"test\"",
             "pyfakefs>=4.5.1; extra == \"dev\"",
             "pyfakefs>=4.5.1; extra == \"test\"",
             "pyodbc>=4.0.30; extra == \"dev\"",
@@ -3427,7 +3624,7 @@
             "xlrd<2.0.0,>=1.1.0; extra == \"excel\""
           ],
           "requires_python": null,
-          "version": "0.15.34"
+          "version": "0.15.43"
         },
         {
           "artifacts": [
@@ -3787,13 +3984,13 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "52c79095197178856724541e845f2db86d5f1527640d9254b5b8f6f6cebfdee6",
-              "url": "https://files.pythonhosted.org/packages/91/52/93f22e5441539256c0d113faf17e45284aee16eebdd95089e3ca6f480b18/httpcore-0.16.2-py3-none-any.whl"
+              "hash": "da1fb708784a938aa084bde4feb8317056c55037247c787bd7e19eb2c2949dc0",
+              "url": "https://files.pythonhosted.org/packages/04/7e/ef97af4623024e8159993b3114ce208de4f677098ae058ec5882a1bf7605/httpcore-0.16.3-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "c35c5176dc82db732acfd90b581a3062c999a72305df30c0fc8fafd8e4aca068",
-              "url": "https://files.pythonhosted.org/packages/9b/20/26f6cc4fd00391f8f1c57b0020f5c6eec23904723db04b6f7608e222d815/httpcore-0.16.2.tar.gz"
+              "hash": "c5d6f04e2fc530f39e0c077e6a30caa53f1451096120f1f38b954afd0b17c0cb",
+              "url": "https://files.pythonhosted.org/packages/61/42/5c456b02816845d163fab0f32936b6a5b649f3f915beff6f819f4f6c90b2/httpcore-0.16.3.tar.gz"
             }
           ],
           "project_name": "httpcore",
@@ -3806,7 +4003,7 @@
             "socksio==1.*; extra == \"socks\""
           ],
           "requires_python": ">=3.7",
-          "version": "0.16.2"
+          "version": "0.16.3"
         },
         {
           "artifacts": [
@@ -3953,13 +4150,13 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "0b9b1f0ee18b9978d637b0776bfd7f54e2ca278e063e3586d8f01cda89e042a8",
-              "url": "https://files.pythonhosted.org/packages/e1/74/cdce73069e021ad5913451b86c2707b027975cf302016ca557686d87eb41/httpx-0.23.1-py3-none-any.whl"
+              "hash": "a211fcce9b1254ea24f0cd6af9869b3d29aba40154e947d2a07bb499b3e310d6",
+              "url": "https://files.pythonhosted.org/packages/ac/a2/0260c0f5d73bdf06e8d3fc1013a82b9f0633dc21750c9e3f3cb1dba7bb8c/httpx-0.23.3-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "202ae15319be24efe9a8bd4ed4360e68fde7b38bcc2ce87088d416f026667d19",
-              "url": "https://files.pythonhosted.org/packages/8a/df/a3e8b91dfb452e645ef110985a30f0915276a1a2144004c7671c07bb203c/httpx-0.23.1.tar.gz"
+              "hash": "9818458eb565bb54898ccb9b8b251a28785dd4a55afbc23d0eb410754fe7d0f9",
+              "url": "https://files.pythonhosted.org/packages/f5/50/04d5e8ee398a10c767a341a25f59ff8711ae3adf0143c7f8b45fc560d72d/httpx-0.23.3.tar.gz"
             }
           ],
           "project_name": "httpx",
@@ -3977,7 +4174,7 @@
             "socksio==1.*; extra == \"socks\""
           ],
           "requires_python": ">=3.7",
-          "version": "0.23.1"
+          "version": "0.23.3"
         },
         {
           "artifacts": [
@@ -4026,13 +4223,13 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "a390fb696e164dbddb047a0db26e57972ae52fbd037ae68797e5ae2f4492485d",
-              "url": "https://files.pythonhosted.org/packages/6f/58/6893fdbe53c9184f3103405ed5bcbb3901b50defd51e3f97d0596fc50b67/identify-2.5.9-py2.py3-none-any.whl"
+              "hash": "8aa48ce56e38c28b6faa9f261075dea0a942dfbb42b341b4e711896cbb40f3f7",
+              "url": "https://files.pythonhosted.org/packages/09/e6/c7f8c5aadc19f1263f27bb5adb1c34ff93fbebddbb0c70e3339d66c03d94/identify-2.5.13-py2.py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "906036344ca769539610436e40a684e170c3648b552194980bb7b617a8daeb9f",
-              "url": "https://files.pythonhosted.org/packages/32/c2/c7b3d6e93055f31fee10867c56e5001bd3e0aad149bc13b60c98a588115a/identify-2.5.9.tar.gz"
+              "hash": "abb546bca6f470228785338a01b539de8a85bbf46491250ae03363956d8ebb10",
+              "url": "https://files.pythonhosted.org/packages/a6/d0/069b7c1771036a51df52310a5ae17920eff94f5b3c5c19dde39c3b2aebf1/identify-2.5.13.tar.gz"
             }
           ],
           "project_name": "identify",
@@ -4040,7 +4237,7 @@
             "ukkonen; extra == \"license\""
           ],
           "requires_python": ">=3.7",
-          "version": "2.5.9"
+          "version": "2.5.13"
         },
         {
           "artifacts": [
@@ -4064,13 +4261,13 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "d84d17e21670ec07990e1044a99efe8d615d860fd176fc29ef5c306068fda313",
-              "url": "https://files.pythonhosted.org/packages/e1/16/1f59f5d87d256012e9cdf0e8af8810965fa253e835cfecce64f4b11d4f2d/importlib_metadata-5.1.0-py3-none-any.whl"
+              "hash": "7efb448ec9a5e313a57655d35aa54cd3e01b7e1fbcf72dce1bf06119420f5bad",
+              "url": "https://files.pythonhosted.org/packages/26/a7/9da7d5b23fc98ab3d424ac2c65613d63c1f401efb84ad50f2fa27b2caab4/importlib_metadata-6.0.0-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "d5059f9f1e8e41f80e9c56c2ee58811450c31984dfa625329ffd7c0dad88a73b",
-              "url": "https://files.pythonhosted.org/packages/32/5a/e0d75c8010295ae6746f379f5324bc726076dfc426548bfa6f0763fce870/importlib_metadata-5.1.0.tar.gz"
+              "hash": "e354bedeb60efa6affdcc8ae121b73544a7aa74156d047311948f6d711cd378d",
+              "url": "https://files.pythonhosted.org/packages/90/07/6397ad02d31bddf1841c9ad3ec30a693a3ff208e09c2ef45c9a8a5f85156/importlib_metadata-6.0.0.tar.gz"
             }
           ],
           "project_name": "importlib-metadata",
@@ -4093,82 +4290,95 @@
             "pytest-perf>=0.9.2; extra == \"testing\"",
             "pytest>=6; extra == \"testing\"",
             "rst.linker>=1.9; extra == \"docs\"",
+            "sphinx-lint; extra == \"docs\"",
             "sphinx>=3.5; extra == \"docs\"",
             "typing-extensions>=3.6.4; python_version < \"3.8\"",
             "zipp>=0.5"
           ],
           "requires_python": ">=3.7",
-          "version": "5.1"
+          "version": "6"
         },
         {
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "011e24c64b7f47f6ebd835bb12a743f2fbe9a26d4cecaa7f53bc4f35ee9da8b3",
-              "url": "https://files.pythonhosted.org/packages/9b/dd/b3c12c6d707058fa947864b67f0c4e0c39ef8610988d7baea9578f3c48f3/iniconfig-1.1.1-py2.py3-none-any.whl"
+              "hash": "b6a85871a79d2e3b22d2d1b94ac2824226a63c6b741c88f7ae975f18b6778374",
+              "url": "https://files.pythonhosted.org/packages/ef/a6/62565a6e1cf69e10f5727360368e451d4b7f58beeac6173dc9db836a5b46/iniconfig-2.0.0-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "bc3af051d7d14b2ee5ef9969666def0cd1a000e121eaea580d4a313df4b37f32",
-              "url": "https://files.pythonhosted.org/packages/23/a2/97899f6bd0e873fed3a7e67ae8d3a08b21799430fb4da15cfedf10d6e2c2/iniconfig-1.1.1.tar.gz"
+              "hash": "2d91e135bf72d31a410b17c16da610a82cb55f6b0477d1a902134b24a455b8b3",
+              "url": "https://files.pythonhosted.org/packages/d7/4b/cbd8e699e64a6f16ca3a8220661b5f83792b3017d0f79807cb8708d33913/iniconfig-2.0.0.tar.gz"
             }
           ],
           "project_name": "iniconfig",
           "requires_dists": [],
-          "requires_python": null,
-          "version": "1.1.1"
+          "requires_python": ">=3.7",
+          "version": "2"
         },
         {
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "3a9a1b2ad6dbbd5879855aabb4557f08e63fa2208bffed897f03070e2bb436f6",
-              "url": "https://files.pythonhosted.org/packages/42/18/fbd80f9b2334bd75624270a05e7d27e0ac1644dcc4f49657cce2000dd0a1/ipykernel-6.17.1-py3-none-any.whl"
+              "hash": "5d0675d5f48bf6a95fd517d7b70bcb3b2c5631b2069949b5c2d6e1d7477fb5a0",
+              "url": "https://files.pythonhosted.org/packages/af/32/9594d9b081250cea091b687c7d8ecb2304a06293956f032d89336385c0d3/ipykernel-6.20.2-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "e178c1788399f93a459c241fe07c3b810771c607b1fb064a99d2c5d40c90c5d4",
-              "url": "https://files.pythonhosted.org/packages/ae/d4/4ab6bdab777c9fc69a5556053582b8c8c15f55c3c13a362513e4cf57582d/ipykernel-6.17.1.tar.gz"
+              "hash": "1893c5b847033cd7a58f6843b04a9349ffb1031bc6588401cadc9adb58da428e",
+              "url": "https://files.pythonhosted.org/packages/87/c0/16e5656247203e7ae67e528f580561c9b54166145c10b46e3ad117984902/ipykernel-6.20.2.tar.gz"
             }
           ],
           "project_name": "ipykernel",
           "requires_dists": [
             "appnope; platform_system == \"Darwin\"",
+            "comm>=0.1.1",
+            "coverage[toml]; extra == \"cov\"",
+            "curio; extra == \"cov\"",
             "debugpy>=1.0",
             "flaky; extra == \"test\"",
             "ipyparallel; extra == \"test\"",
             "ipython>=7.23.1",
             "jupyter-client>=6.1.12",
             "matplotlib-inline>=0.1",
+            "matplotlib; extra == \"cov\"",
             "myst-parser; extra == \"docs\"",
             "nest-asyncio",
             "packaging",
             "pre-commit; extra == \"test\"",
             "psutil",
             "pydata-sphinx-theme; extra == \"docs\"",
+            "pyqt5; extra == \"pyqt5\"",
+            "pyside6; extra == \"pyside6\"",
+            "pytest-asyncio; extra == \"test\"",
+            "pytest-cov; extra == \"cov\"",
             "pytest-cov; extra == \"test\"",
             "pytest-timeout; extra == \"test\"",
             "pytest>=7.0; extra == \"test\"",
             "pyzmq>=17",
+            "sphinx-autodoc-typehints; extra == \"docs\"",
             "sphinx; extra == \"docs\"",
             "sphinxcontrib-github-alt; extra == \"docs\"",
+            "sphinxcontrib-spelling; extra == \"docs\"",
             "tornado>=6.1",
-            "traitlets>=5.1.0"
+            "traitlets>=5.4.0",
+            "trio; extra == \"cov\"",
+            "trio; extra == \"docs\""
           ],
           "requires_python": ">=3.8",
-          "version": "6.17.1"
+          "version": "6.20.2"
         },
         {
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "352042ddcb019f7c04e48171b4dd78e4c4bb67bf97030d170e154aac42b656d9",
-              "url": "https://files.pythonhosted.org/packages/24/ef/af8899488ae62a35b0815aa955779db25e616defb0061a478203fc460f40/ipython-8.7.0-py3-none-any.whl"
+              "hash": "da01e6df1501e6e7c32b5084212ddadd4ee2471602e2cf3e0190f4de6b0ea481",
+              "url": "https://files.pythonhosted.org/packages/1f/aa/a6509b4059359edd00308e3f068212dca53b7252940862cc40981a2bd713/ipython-8.8.0-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "882899fe78d5417a0aa07f995db298fa28b58faeba2112d2e3a4c95fe14bb738",
-              "url": "https://files.pythonhosted.org/packages/82/2b/026af47da09998404f51064d328f5f1f68c78829082d2945be489343fde6/ipython-8.7.0.tar.gz"
+              "hash": "f3bf2c08505ad2c3f4ed5c46ae0331a8547d36bf4b21a451e8ae80c0791db95b",
+              "url": "https://files.pythonhosted.org/packages/f5/39/89664d8c3e4dfb0a73862cbbff8eb4028a1e3d4305da80ab0a493848ed9b/ipython-8.8.0.tar.gz"
             }
           ],
           "project_name": "ipython",
@@ -4243,7 +4453,7 @@
             "typing-extensions; extra == \"doc\""
           ],
           "requires_python": ">=3.8",
-          "version": "8.7"
+          "version": "8.8"
         },
         {
           "artifacts": [
@@ -4267,13 +4477,13 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "1dc3dd4ee19ded045ea7c86eb273033d238d8e43f9e7872c52d092683f263891",
-              "url": "https://files.pythonhosted.org/packages/e4/56/990c10ca8751182ace2464cb0e4baafb7087a40c185c9142b9cd18683fac/ipywidgets-8.0.2-py3-none-any.whl"
+              "hash": "ebb195e743b16c3947fe8827190fb87b4d00979c0fbf685afe4d2c4927059fa1",
+              "url": "https://files.pythonhosted.org/packages/f3/fc/bd076538811d63babf8ceea0ff3d8d024171569a47f5dba7757c5fd0462c/ipywidgets-8.0.4-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "08cb75c6e0a96836147cbfdc55580ae04d13e05d26ffbc377b4e1c68baa28b1f",
-              "url": "https://files.pythonhosted.org/packages/81/f7/86ef818eb0ecdd3fc8089209fbd6072243612563048bf5b5738f5bddd95d/ipywidgets-8.0.2.tar.gz"
+              "hash": "c0005a77a47d77889cafed892b58e33b4a2a96712154404c6548ec22272811ea",
+              "url": "https://files.pythonhosted.org/packages/26/2a/47bf74e71f2c172136e3a101d8a222807ec5cabc10321dfa14f58fda1cbf/ipywidgets-8.0.4.tar.gz"
             }
           ],
           "project_name": "ipywidgets",
@@ -4289,7 +4499,7 @@
             "widgetsnbextension~=4.0"
           ],
           "requires_python": ">=3.7",
-          "version": "8.0.2"
+          "version": "8.0.4"
         },
         {
           "artifacts": [
@@ -4315,25 +4525,25 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "6f62d78e2f89b4500b080fe3a81690850cd254227f27f75c3a0c491a1f351ba7",
-              "url": "https://files.pythonhosted.org/packages/b8/5b/f18e227df38b94b4ee30d2502fd531bebac23946a2497e5595067a561274/isort-5.10.1-py3-none-any.whl"
+              "hash": "c033fd0edb91000a7f09527fe5c75321878f98322a77ddcc81adbd83724afb7b",
+              "url": "https://files.pythonhosted.org/packages/91/3b/a63bafb8141b67c397841b36ad46e7469716af2b2d00cb0be2dfb9667130/isort-5.11.4-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "e8443a5e7a020e9d7f97f1d7d9cd17c88bcb3bc7e218bf9cf5095fe550be2951",
-              "url": "https://files.pythonhosted.org/packages/ab/e9/964cb0b2eedd80c92f5172f1f8ae0443781a9d461c1372a3ce5762489593/isort-5.10.1.tar.gz"
+              "hash": "6db30c5ded9815d813932c04c2f85a360bcdd35fed496f4d8f35495ef0a261b6",
+              "url": "https://files.pythonhosted.org/packages/76/46/004e2dd6c312e8bb7cb40a6c01b770956e0ef137857e82d47bd9c829356b/isort-5.11.4.tar.gz"
             }
           ],
           "project_name": "isort",
           "requires_dists": [
             "colorama<0.5.0,>=0.4.3; extra == \"colors\"",
-            "pip-api; extra == \"requirements_deprecated_finder\"",
-            "pipreqs; extra == \"pipfile_deprecated_finder\" or extra == \"requirements_deprecated_finder\"",
-            "requirementslib; extra == \"pipfile_deprecated_finder\"",
+            "pip-api; extra == \"requirements-deprecated-finder\"",
+            "pipreqs; extra == \"pipfile-deprecated-finder\" or extra == \"requirements-deprecated-finder\"",
+            "requirementslib; extra == \"pipfile-deprecated-finder\"",
             "setuptools; extra == \"plugins\""
           ],
-          "requires_python": "<4.0,>=3.6.1",
-          "version": "5.10.1"
+          "requires_python": ">=3.7.0",
+          "version": "5.11.4"
         },
         {
           "artifacts": [
@@ -4562,13 +4772,13 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "df56ae23b8e1da1b66f89dee1368e948b24a7f780fa822c5735187589fc4c157",
-              "url": "https://files.pythonhosted.org/packages/4b/b4/df6186d9d1c7e8d943febb8e1a17aedc031ab374924fd19193f9efb0fbb2/jupyter_client-7.4.7-py3-none-any.whl"
+              "hash": "214668aaea208195f4c13d28eb272ba79f945fc0cf3f11c7092c20b2ca1980e7",
+              "url": "https://files.pythonhosted.org/packages/fd/a7/ef3b7c8b9d6730a21febdd0809084e4cea6d2a7e43892436adecdd0acbd4/jupyter_client-7.4.9-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "330f6b627e0b4bf2f54a3a0dd9e4a22d2b649c8518168afedce2c96a1ceb2860",
-              "url": "https://files.pythonhosted.org/packages/03/4f/5477d37f816f746748fa2c86776830bd6cb273d8cea8be95dddff76702e3/jupyter_client-7.4.7.tar.gz"
+              "hash": "52be28e04171f07aed8f20e1616a5a552ab9fee9cbbe6c1896ae170c3880d392",
+              "url": "https://files.pythonhosted.org/packages/1e/33/71778cdd2c69445bcd3bb6029da2e43cc9b5cbbeef4f4982ef3aaf396650/jupyter_client-7.4.9.tar.gz"
             }
           ],
           "project_name": "jupyter-client",
@@ -4597,19 +4807,19 @@
             "traitlets"
           ],
           "requires_python": ">=3.7",
-          "version": "7.4.7"
+          "version": "7.4.9"
         },
         {
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "f5740d99606958544396914b08e67b668f45e7eff99ab47a7f4bcead419c02f4",
-              "url": "https://files.pythonhosted.org/packages/ba/88/c829e2cef67fa173ab512a054d1ba7047c2559b311e9f9e7c55b0a9d8278/jupyter_core-5.1.0-py3-none-any.whl"
+              "hash": "d23ab7db81ca1759f13780cd6b65f37f59bf8e0186ac422d5ca4982cc7d56716",
+              "url": "https://files.pythonhosted.org/packages/71/9e/0f10d4e7a634ae7afea30ff5aac281d84c5e03ceae8ea3bb670097c6ac11/jupyter_core-5.1.3-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "a5ae7c09c55c0b26f692ec69323ba2b62e8d7295354d20f6cd57b749de4a05bf",
-              "url": "https://files.pythonhosted.org/packages/99/db/4de1aaa121fcfa9db093554d6539a31c6b382480daac3172c6206a19367f/jupyter_core-5.1.0.tar.gz"
+              "hash": "82e1cff0ef804c38677eff7070d5ff1d45037fef01a2d9ba9e6b7b8201831e9f",
+              "url": "https://files.pythonhosted.org/packages/1f/05/7c8e5e534f1c0833512fa82f47d50733043b11adb4688d33dfbf89a645a6/jupyter_core-5.1.3.tar.gz"
             }
           ],
           "project_name": "jupyter-core",
@@ -4622,57 +4832,153 @@
             "pytest-timeout; extra == \"test\"",
             "pytest; extra == \"test\"",
             "pywin32>=1.0; sys_platform == \"win32\" and platform_python_implementation != \"PyPy\"",
+            "sphinx-autodoc-typehints; extra == \"docs\"",
             "sphinxcontrib-github-alt; extra == \"docs\"",
+            "sphinxcontrib-spelling; extra == \"docs\"",
             "traitlets; extra == \"docs\"",
             "traitlets>=5.3"
           ],
           "requires_python": ">=3.8",
-          "version": "5.1"
+          "version": "5.1.3"
         },
         {
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "438496cac509709cc85e60172e5538ca45b4c8a0862bb97cd73e49f2ace419cb",
-              "url": "https://files.pythonhosted.org/packages/2e/5e/70394c2d1b17b7c93308fcb6e9f9b27ac6812f2e88dff081a4773b3559b3/jupyter_server-1.23.3-py3-none-any.whl"
+              "hash": "57a2749f87ba387cd1bfd9b22a0875b889237dbf2edc2121ebb22bde47036c17",
+              "url": "https://files.pythonhosted.org/packages/ee/14/e11a93c1b47a69432ee7898f1b55f1da27f2f93b009a34dbdafb9b903f81/jupyter_events-0.6.3-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "f7f7a2f9d36f4150ad125afef0e20b1c76c8ff83eb5e39fb02d3b9df0f9b79ab",
-              "url": "https://files.pythonhosted.org/packages/ce/a6/828c59a1d7b80563bea3c9f1d538fb9d1ec44b459391d62ad5046dca177b/jupyter_server-1.23.3.tar.gz"
+              "hash": "9a6e9995f75d1b7146b436ea24d696ce3a35bfa8bfe45e0c33c334c79464d0b3",
+              "url": "https://files.pythonhosted.org/packages/d0/b0/7afcd1d66834f43d08ec47c861a5540d7ad57eab47605ccd83429c147755/jupyter_events-0.6.3.tar.gz"
+            }
+          ],
+          "project_name": "jupyter-events",
+          "requires_dists": [
+            "click; extra == \"cli\"",
+            "click; extra == \"test\"",
+            "coverage; extra == \"test\"",
+            "jsonschema[format-nongpl]>=3.2.0",
+            "jupyterlite-sphinx; extra == \"docs\"",
+            "myst-parser; extra == \"docs\"",
+            "pre-commit; extra == \"test\"",
+            "pydata-sphinx-theme; extra == \"docs\"",
+            "pytest-asyncio>=0.19.0; extra == \"test\"",
+            "pytest-console-scripts; extra == \"test\"",
+            "pytest-cov; extra == \"test\"",
+            "pytest>=7.0; extra == \"test\"",
+            "python-json-logger>=2.0.4",
+            "pyyaml>=5.3",
+            "rfc3339-validator",
+            "rfc3986-validator>=0.1.1",
+            "rich; extra == \"cli\"",
+            "rich; extra == \"test\"",
+            "sphinxcontrib-spelling; extra == \"docs\"",
+            "traitlets>=5.3"
+          ],
+          "requires_python": ">=3.7",
+          "version": "0.6.3"
+        },
+        {
+          "artifacts": [
+            {
+              "algorithm": "sha256",
+              "hash": "90cd6f2bd0581ddd9b2dbe82026a0f4c228a1d95c86e22460efbfdfc931fcf56",
+              "url": "https://files.pythonhosted.org/packages/53/9e/02d382c8154f8a65903ef727322134edeb4d6eadfe458d4e79912794718a/jupyter_server-2.1.0-py3-none-any.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "efaae5e4f0d5f22c7f2f2dc848635036ee74a2df02abed52d30d9d95121ad382",
+              "url": "https://files.pythonhosted.org/packages/13/4d/e55b46c9453c4d09bbb0612dd823886b17d4cfedbfe8b92e5cae56c3213b/jupyter_server-2.1.0.tar.gz"
             }
           ],
           "project_name": "jupyter-server",
           "requires_dists": [
-            "Send2Trash",
             "anyio<4,>=3.1.0",
             "argon2-cffi",
-            "coverage; extra == \"test\"",
+            "docutils<0.20; extra == \"docs\"",
+            "ipykernel; extra == \"docs\"",
             "ipykernel; extra == \"test\"",
             "jinja2",
-            "jupyter-client>=6.1.12",
-            "jupyter-core>=4.7.0",
+            "jinja2; extra == \"docs\"",
+            "jupyter-client; extra == \"docs\"",
+            "jupyter-client>=7.4.4",
+            "jupyter-core!=5.0.*,>=4.12",
+            "jupyter-events>=0.4.0",
+            "jupyter-server-terminals",
+            "jupyter-server; extra == \"docs\"",
+            "mistune<1.0.0; extra == \"docs\"",
+            "myst-parser; extra == \"docs\"",
             "nbconvert>=6.4.4",
-            "nbformat>=5.2.0",
+            "nbformat; extra == \"docs\"",
+            "nbformat>=5.3.0",
             "packaging",
             "pre-commit; extra == \"test\"",
             "prometheus-client",
+            "prometheus-client; extra == \"docs\"",
+            "pydata-sphinx-theme; extra == \"docs\"",
             "pytest-console-scripts; extra == \"test\"",
-            "pytest-cov; extra == \"test\"",
-            "pytest-mock; extra == \"test\"",
+            "pytest-jupyter[server]>=0.4; extra == \"test\"",
             "pytest-timeout; extra == \"test\"",
-            "pytest-tornasync; extra == \"test\"",
             "pytest>=7.0; extra == \"test\"",
             "pywinpty; os_name == \"nt\"",
-            "pyzmq>=17",
+            "pyzmq>=24",
             "requests; extra == \"test\"",
+            "send2trash",
+            "send2trash; extra == \"docs\"",
+            "sphinx-autodoc-typehints; extra == \"docs\"",
+            "sphinxcontrib-github-alt; extra == \"docs\"",
+            "sphinxcontrib-openapi; extra == \"docs\"",
+            "sphinxcontrib-spelling; extra == \"docs\"",
+            "sphinxemoji; extra == \"docs\"",
             "terminado>=0.8.3",
-            "tornado>=6.1.0",
-            "traitlets>=5.1",
+            "tornado; extra == \"docs\"",
+            "tornado>=6.2.0",
+            "traitlets>=5.6.0",
             "websocket-client"
           ],
-          "requires_python": ">=3.7",
-          "version": "1.23.3"
+          "requires_python": ">=3.8",
+          "version": "2.1"
+        },
+        {
+          "artifacts": [
+            {
+              "algorithm": "sha256",
+              "hash": "75779164661cec02a8758a5311e18bb8eb70c4e86c6b699403100f1585a12a36",
+              "url": "https://files.pythonhosted.org/packages/ea/7f/36db12bdb90f5237766dcbf59892198daab7260acbcf03fc75e2a2a82672/jupyter_server_terminals-0.4.4-py3-none-any.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "57ab779797c25a7ba68e97bcfb5d7740f2b5e8a83b5e8102b10438041a7eac5d",
+              "url": "https://files.pythonhosted.org/packages/54/e1/6bc19392e6957356f085b8d7ec33d6d0d721e646b7576c1c6758dd264c64/jupyter_server_terminals-0.4.4.tar.gz"
+            }
+          ],
+          "project_name": "jupyter-server-terminals",
+          "requires_dists": [
+            "coverage; extra == \"test\"",
+            "jinja2; extra == \"docs\"",
+            "jupyter-server; extra == \"docs\"",
+            "jupyter-server>=2.0.0; extra == \"test\"",
+            "mistune<3.0; extra == \"docs\"",
+            "myst-parser; extra == \"docs\"",
+            "nbformat; extra == \"docs\"",
+            "packaging; extra == \"docs\"",
+            "pydata-sphinx-theme; extra == \"docs\"",
+            "pytest-cov; extra == \"test\"",
+            "pytest-jupyter[server]>=0.5.3; extra == \"test\"",
+            "pytest-timeout; extra == \"test\"",
+            "pytest>=7.0; extra == \"test\"",
+            "pywinpty>=2.0.3; os_name == \"nt\"",
+            "sphinxcontrib-github-alt; extra == \"docs\"",
+            "sphinxcontrib-openapi; extra == \"docs\"",
+            "sphinxcontrib-spelling; extra == \"docs\"",
+            "sphinxemoji; extra == \"docs\"",
+            "terminado>=0.8.3",
+            "tornado; extra == \"docs\""
+          ],
+          "requires_python": ">=3.8",
+          "version": "0.4.4"
         },
         {
           "artifacts": [
@@ -4696,31 +5002,31 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "6aa1bc0045470d54d76b9c0b7609a8f8f0087573bae25700a370c11f82cb38c8",
-              "url": "https://files.pythonhosted.org/packages/d8/52/2f4b8f5975312fb58f4eacab2e6f6cfd2efd05704514a60a151a4e69d608/jupyterlab_widgets-3.0.3-py3-none-any.whl"
+              "hash": "a04a42e50231b355b7087e16a818f541e53589f7647144ea0344c4bf16f300e5",
+              "url": "https://files.pythonhosted.org/packages/df/82/4576cbc07ebace8c7734fe08b2c2f9123b7ebecd29e932a3b839b6bee2cb/jupyterlab_widgets-3.0.5-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "c767181399b4ca8b647befe2d913b1260f51bf9d8ef9b7a14632d4c1a7b536bd",
-              "url": "https://files.pythonhosted.org/packages/19/99/66292214fa2f920ceec0a8a6f6d1844016e2e7a9b6c498bda380fa945015/jupyterlab_widgets-3.0.3.tar.gz"
+              "hash": "eeaecdeaf6c03afc960ddae201ced88d5979b4ca9c3891bcb8f6631af705f5ef",
+              "url": "https://files.pythonhosted.org/packages/a8/59/1c1a0ae2dc4586c08c372aaee6f5f765327564a753752a8df2574ea1aa31/jupyterlab_widgets-3.0.5.tar.gz"
             }
           ],
           "project_name": "jupyterlab-widgets",
           "requires_dists": [],
           "requires_python": ">=3.7",
-          "version": "3.0.3"
+          "version": "3.0.5"
         },
         {
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "3dd30011d555f1345dec2c262f0153f2f0ca6bca041fb1dc4588349bb4c0ac1e",
-              "url": "https://files.pythonhosted.org/packages/3a/12/3750c13e0301a65f90f29ed3d5c853d80cea0ef5ae387a5d6866c26685b6/keyring-23.11.0-py3-none-any.whl"
+              "hash": "771ed2a91909389ed6148631de678f82ddc73737d85a927f382a8a1b157898cd",
+              "url": "https://files.pythonhosted.org/packages/62/db/0e9a09b2b95986dcd73ac78be6ed2bd73ebe8bac65cba7add5b83eb9d899/keyring-23.13.1-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "ad192263e2cdd5f12875dedc2da13534359a7e760e77f8d04b50968a821c2361",
-              "url": "https://files.pythonhosted.org/packages/1c/35/c22960f14f5e17384296b2f09da259f8b5244fb3831eccec71cf948a49c6/keyring-23.11.0.tar.gz"
+              "hash": "ba2e15a9b35e21908d0aaf4e0a47acc52d6ae33444df0da2b49d41a46ef6d678",
+              "url": "https://files.pythonhosted.org/packages/55/fe/282f4c205add8e8bb3a1635cbbac59d6def2e0891b145aa553a0e40dd2d0/keyring-23.13.1.tar.gz"
             }
           ],
           "project_name": "keyring",
@@ -4729,6 +5035,7 @@
             "flake8<5; extra == \"testing\"",
             "furo; extra == \"docs\"",
             "importlib-metadata>=4.11.4; python_version < \"3.12\"",
+            "importlib-resources; python_version < \"3.9\"",
             "jaraco.classes",
             "jaraco.packaging>=9; extra == \"docs\"",
             "jaraco.tidelift>=1.4; extra == \"docs\"",
@@ -4737,15 +5044,16 @@
             "pytest-checkdocs>=2.4; extra == \"testing\"",
             "pytest-cov; extra == \"testing\"",
             "pytest-enabler>=1.3; extra == \"testing\"",
-            "pytest-flake8; extra == \"testing\"",
+            "pytest-flake8; python_version < \"3.12\" and extra == \"testing\"",
             "pytest-mypy>=0.9.1; platform_python_implementation != \"PyPy\" and extra == \"testing\"",
             "pytest>=6; extra == \"testing\"",
-            "pywin32-ctypes!=0.1.0,!=0.1.1; sys_platform == \"win32\"",
+            "pywin32-ctypes>=0.2.0; sys_platform == \"win32\"",
             "rst.linker>=1.9; extra == \"docs\"",
+            "shtab; extra == \"completion\"",
             "sphinx>=3.5; extra == \"docs\""
           ],
           "requires_python": ">=3.7",
-          "version": "23.11"
+          "version": "23.13.1"
         },
         {
           "artifacts": [
@@ -4867,114 +5175,164 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "46d00d6cfecdde84d40e572d63735ef81423ad31184100411e6e3388d405e247",
-              "url": "https://files.pythonhosted.org/packages/71/dc/41cbfe0d9aefdf14226dbf4eccfd0079a0e297809a17c5b902c9a7a3cc9a/MarkupSafe-2.1.1-cp39-cp39-win_amd64.whl"
+              "hash": "0576fe974b40a400449768941d5d0858cc624e3249dfd1e0c33674e5c7ca7aed",
+              "url": "https://files.pythonhosted.org/packages/46/0c/10ee33673c5e36fa3809cf136971f81d951ca38516188ee11a965d9b2fe9/MarkupSafe-2.1.2-cp39-cp39-win_amd64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "e04e26803c9c3851c931eac40c695602c6295b8d432cbe78609649ad9bd2da8a",
-              "url": "https://files.pythonhosted.org/packages/06/7f/d5e46d7464360b6ac39c5b0b604770dba937e3d7cab485d2f3298454717b/MarkupSafe-2.1.1-cp39-cp39-macosx_10_9_universal2.whl"
+              "hash": "835fb5e38fd89328e9c81067fd642b3593c33e1e17e2fdbf77f5676abb14a156",
+              "url": "https://files.pythonhosted.org/packages/02/2c/18d55e5df6a9ea33709d6c33e08cb2e07d39e20ad05d8c6fbf9c9bcafd54/MarkupSafe-2.1.2-cp310-cp310-win_amd64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "8e3dcf21f367459434c18e71b2a9532d96547aef8a871872a5bd69a715c15f96",
-              "url": "https://files.pythonhosted.org/packages/0f/53/b14de4ede9c2bd76d28e7911033b065ac42896f1cfb258d3ff65cf0332d2/MarkupSafe-2.1.1-cp39-cp39-musllinux_1_1_x86_64.whl"
+              "hash": "085fd3201e7b12809f9e6e9bc1e5c96a368c8523fad5afb02afe3c051ae4afcc",
+              "url": "https://files.pythonhosted.org/packages/04/cf/9464c3c41b7cdb8df660cda75676697e7fb49ce1be7691a1162fc88da078/MarkupSafe-2.1.2-cp311-cp311-musllinux_1_1_i686.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "7f91197cc9e48f989d12e4e6fbc46495c446636dfc81b9ccf50bb0ec74b91d4b",
-              "url": "https://files.pythonhosted.org/packages/1d/97/2288fe498044284f39ab8950703e88abbac2abbdf65524d576157af70556/MarkupSafe-2.1.1.tar.gz"
+              "hash": "40dfd3fefbef579ee058f139733ac336312663c6706d1163b82b3003fb1925c4",
+              "url": "https://files.pythonhosted.org/packages/06/3b/d026c21cd1dbee89f41127e93113dcf5fa85c6660d108847760b59b3a66d/MarkupSafe-2.1.2-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "d4306c36ca495956b6d568d276ac11fdd9c30a36f1b6eb928070dc5360b22e1c",
-              "url": "https://files.pythonhosted.org/packages/25/c4/a75659da6d6b03d2d8ef296b2a8bc73e8c5b1533ee31569a958a292f0929/MarkupSafe-2.1.1-cp39-cp39-win32.whl"
+              "hash": "65608c35bfb8a76763f37036547f7adfd09270fbdbf96608be2bead319728fcd",
+              "url": "https://files.pythonhosted.org/packages/0a/88/78cb3d95afebd183d8b04442685ab4c70cfc1138b850ba20e2a07aff2f53/MarkupSafe-2.1.2-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "b87db4360013327109564f0e591bd2a3b318547bcef31b468a92ee504d07ae4f",
-              "url": "https://files.pythonhosted.org/packages/26/03/2c11ba1a8b2327adea3f59f1c9c9ee9c59e86023925f929e63c4f028b10a/MarkupSafe-2.1.1-cp39-cp39-macosx_10_9_x86_64.whl"
+              "hash": "7df70907e00c970c60b9ef2938d894a9381f38e6b9db73c5be35e59d92e06625",
+              "url": "https://files.pythonhosted.org/packages/19/00/3b8eb0093c885576a1ce7f2263e7b8c01e55b9977433f8246f57cd81b0be/MarkupSafe-2.1.2-cp311-cp311-win32.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "33b74d289bd2f5e527beadcaa3f401e0df0a89927c1559c8566c066fa4248ab7",
-              "url": "https://files.pythonhosted.org/packages/3a/fc/dccc18170917f2cc2a5b77aad97f5f27d992ef0f2b9fb9e334ee71bf5301/MarkupSafe-2.1.1-cp39-cp39-musllinux_1_1_aarch64.whl"
+              "hash": "1bea30e9bf331f3fef67e0a3877b2288593c98a21ccb2cf29b74c581a4eb3af0",
+              "url": "https://files.pythonhosted.org/packages/1f/20/76f6337f1e7238a626ab34405ddd634636011b2ff947dcbd8995f16a7776/MarkupSafe-2.1.2-cp311-cp311-musllinux_1_1_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "dda30ba7e87fbbb7eab1ec9f58678558fd9a6b8b853530e176eabd064da81417",
-              "url": "https://files.pythonhosted.org/packages/3d/4b/15e5b9d40c4b58e97ebcb8ed5845a215fa5b7cf49a7f1cc7908f8db9cf46/MarkupSafe-2.1.1-cp310-cp310-win_amd64.whl"
+              "hash": "137678c63c977754abe9086a3ec011e8fd985ab90631145dfb9294ad09c102a7",
+              "url": "https://files.pythonhosted.org/packages/22/88/9c0cae2f5ada778182f2842b377dd273d6be689953345c10b165478831eb/MarkupSafe-2.1.2-cp39-cp39-win32.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "694deca8d702d5db21ec83983ce0bb4b26a578e71fbdbd4fdcd387daa90e4d5e",
-              "url": "https://files.pythonhosted.org/packages/5c/1a/ac3a2b2a4ef1196c15dd8a143fc28eddeb6e6871d6d1de64dc44ef7f59b6/MarkupSafe-2.1.1-cp310-cp310-musllinux_1_1_i686.whl"
+              "hash": "ca244fa73f50a800cf8c3ebf7fd93149ec37f5cb9596aa8873ae2c1d23498601",
+              "url": "https://files.pythonhosted.org/packages/30/3e/0a69a24adb38df83e2f6989c38d68627a5f27181c82ecaa1fd03d1236dca/MarkupSafe-2.1.2-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "4a33dea2b688b3190ee12bd7cfa29d39c9ed176bda40bfa11099a3ce5d3a7ac6",
-              "url": "https://files.pythonhosted.org/packages/5e/3d/0a7df21deca52e20de81f8a895ac29df68944588c0030be9aa1e6c07877c/MarkupSafe-2.1.1-cp310-cp310-win32.whl"
+              "hash": "340bea174e9761308703ae988e982005aedf427de816d1afe98147668cc03036",
+              "url": "https://files.pythonhosted.org/packages/34/19/64b0abc021b22766e86efee32b0e2af684c4b731ce8ac1d519c791800c13/MarkupSafe-2.1.2-cp310-cp310-macosx_10_9_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "3ce11ee3f23f79dbd06fb3d63e2f6af7b12db1d46932fe7bd8afa259a5996603",
-              "url": "https://files.pythonhosted.org/packages/73/68/628f6dbbf5088723a2b939d97c0a2e059d0cc654ce92a6fac5c7959edaff/MarkupSafe-2.1.1-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl"
+              "hash": "665a36ae6f8f20a4676b53224e33d456a6f5a72657d9c83c2aa00765072f31f7",
+              "url": "https://files.pythonhosted.org/packages/37/b2/6f4d5cac75ba6fe9f17671304fe339ea45a73c5609b5f5e652aa79c915c8/MarkupSafe-2.1.2-cp310-cp310-macosx_10_9_universal2.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "99a2a507ed3ac881b975a2976d59f38c19386d128e7a9a18b7df6fff1fd4c1d6",
-              "url": "https://files.pythonhosted.org/packages/82/3d/523e40c45dc1f53b35e60c6e8563dec523f7b6c113f823d5e123dd431631/MarkupSafe-2.1.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+              "hash": "28057e985dace2f478e042eaa15606c7efccb700797660629da387eb289b9323",
+              "url": "https://files.pythonhosted.org/packages/3d/66/2f636ba803fd6eb4cee7b3106ae02538d1e84a7fb7f4f8775c6528a87d31/MarkupSafe-2.1.2-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "f121a1420d4e173a5d96e47e9a0c0dcff965afdf1626d28de1460815f7c4ee7a",
-              "url": "https://files.pythonhosted.org/packages/8c/96/7e608e1a942232cb8c81ca24093e71e07e2bacbeb2dad62a0f82da28ed54/MarkupSafe-2.1.1-cp310-cp310-macosx_10_9_x86_64.whl"
+              "hash": "c0a33bc9f02c2b17c3ea382f91b4db0e6cde90b63b296422a939886a7a80de1c",
+              "url": "https://files.pythonhosted.org/packages/41/54/6e88795c64ab5dcda31b06406c062c2740d1a64db18219d4e21fc90928c1/MarkupSafe-2.1.2-cp39-cp39-musllinux_1_1_i686.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "10c1bfff05d95783da83491be968e8fe789263689c02724e0c691933c52994f5",
-              "url": "https://files.pythonhosted.org/packages/9e/82/2e089c6f34e77c073aa5a67040d368aac0dfb9b8ccbb46d381452c26fc33/MarkupSafe-2.1.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+              "hash": "b8526c6d437855442cdd3d87eede9c425c4445ea011ca38d937db299382e6fa3",
+              "url": "https://files.pythonhosted.org/packages/50/41/1442b693a40eb76d835ca2016e86a01479f17d7fd8288f9830f6790e366a/MarkupSafe-2.1.2-cp39-cp39-musllinux_1_1_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "b7bd98b796e2b6553da7225aeb61f447f80a1ca64f41d83612e6139ca5213aa4",
-              "url": "https://files.pythonhosted.org/packages/a3/47/9dcc08eff8ab94f1e50f59f9cd322b710ef5db7e8590fdd8df924406fc9c/MarkupSafe-2.1.1-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl"
+              "hash": "40627dcf047dadb22cd25ea7ecfe9cbf3bbbad0482ee5920b582f3809c97654f",
+              "url": "https://files.pythonhosted.org/packages/52/36/b35c577c884ea352fc0c1eaed9ca4946ffc22cc9c3527a70408bfa9e9496/MarkupSafe-2.1.2-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "b09bf97215625a311f669476f44b8b318b075847b49316d3e28c08e41a7a573f",
-              "url": "https://files.pythonhosted.org/packages/ad/fa/292a72cddad41e3c06227b446a0af53ff642a40755fc5bd695f439c35ba8/MarkupSafe-2.1.1-cp310-cp310-musllinux_1_1_aarch64.whl"
+              "hash": "f2bfb563d0211ce16b63c7cb9395d2c682a23187f54c3d79bfec33e6705473c6",
+              "url": "https://files.pythonhosted.org/packages/5a/94/d056bf5dbadf7f4b193ee2a132b3d49ffa1602371e3847518b2982045425/MarkupSafe-2.1.2-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "43093fb83d8343aac0b1baa75516da6092f58f41200907ef92448ecab8825135",
-              "url": "https://files.pythonhosted.org/packages/ba/16/3627f852d8a846c0fc52ad1beac6e27894a8344cc2c26036db51acb82c3e/MarkupSafe-2.1.1-cp39-cp39-musllinux_1_1_i686.whl"
+              "hash": "22152d00bf4a9c7c83960521fc558f55a1adbc0631fbb00a9471e097b19d72e1",
+              "url": "https://files.pythonhosted.org/packages/5e/f6/8eb8a5692c1986b6e863877b0b8a83628aff14e5fbfaf11d9522b532bd9d/MarkupSafe-2.1.2-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "86b1f75c4e7c2ac2ccdaec2b9022845dbb81880ca318bb7a0a01fbf7813e3812",
-              "url": "https://files.pythonhosted.org/packages/d9/60/94e9de017674f88a514804e2924bdede9a642aba179d2045214719d6ec76/MarkupSafe-2.1.1-cp310-cp310-macosx_10_9_universal2.whl"
+              "hash": "8bca7e26c1dd751236cfb0c6c72d4ad61d986e9a41bbf76cb445f69488b2a2bd",
+              "url": "https://files.pythonhosted.org/packages/77/26/af46880038c6eac3832e751298f1965f3a550f38d1e9ddaabd674860076b/MarkupSafe-2.1.2-cp39-cp39-macosx_10_9_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "56442863ed2b06d19c37f94d999035e15ee982988920e12a5b4ba29b62ad1f77",
-              "url": "https://files.pythonhosted.org/packages/df/06/c515c5bc43b90462e753bc768e6798193c6520c9c7eb2054c7466779a9db/MarkupSafe-2.1.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+              "hash": "c4a549890a45f57f1ebf99c067a4ad0cb423a05544accaf2b065246827ed9603",
+              "url": "https://files.pythonhosted.org/packages/78/e6/91c9a20a943ea231c59024e181c4c5480097daf132428f2272670974637f/MarkupSafe-2.1.2-cp310-cp310-win32.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "efc1913fd2ca4f334418481c7e595c00aad186563bbc1ec76067848c7ca0a933",
-              "url": "https://files.pythonhosted.org/packages/fc/e4/78c7607352dd574d524daad079f855757d406d36b919b1864a5a07978390/MarkupSafe-2.1.1-cp310-cp310-musllinux_1_1_x86_64.whl"
+              "hash": "da25303d91526aac3672ee6d49a2f3db2d9502a4a60b55519feb1a4c7714e07d",
+              "url": "https://files.pythonhosted.org/packages/79/e2/b818bf277fa6b01244943498cb2127372c01dde5eff7682837cc72740618/MarkupSafe-2.1.2-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "a49907dd8420c5685cfa064a1335b6754b74541bbb3706c259c02ed65b644b3e",
-              "url": "https://files.pythonhosted.org/packages/ff/3a/42262a3aa6415befee33b275b31afbcef4f7f8d2f4380061b226c692ee2a/MarkupSafe-2.1.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+              "hash": "090376d812fb6ac5f171e5938e82e7f2d7adc2b629101cec0db8b267815c85e2",
+              "url": "https://files.pythonhosted.org/packages/7c/e6/454df09f18e0ea34d189b447a9e1a9f66c2aa332b77fd5577ebc7ca14d42/MarkupSafe-2.1.2-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "2e7821bffe00aa6bd07a23913b7f4e01328c3d5cc0b40b36c0bd81d362faeb65",
+              "url": "https://files.pythonhosted.org/packages/82/70/b3978786c7b576c25d84b009d2a20a11b5300d252fc3ce984e37b932e97c/MarkupSafe-2.1.2-cp39-cp39-musllinux_1_1_aarch64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "99625a92da8229df6d44335e6fcc558a5037dd0a760e11d84be2260e6f37002f",
+              "url": "https://files.pythonhosted.org/packages/82/e3/4efcd74f10a7999783955aec36386f71082e6d7dafcc06b77b9df72b325a/MarkupSafe-2.1.2-cp39-cp39-macosx_10_9_universal2.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "d9d971ec1e79906046aa3ca266de79eac42f1dbf3612a05dc9368125952bd1a1",
+              "url": "https://files.pythonhosted.org/packages/93/ca/1c3ae0c6a5712d4ba98610cada03781ea0448436b17d1dcd4759115b15a1/MarkupSafe-2.1.2-cp310-cp310-musllinux_1_1_aarch64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "abcabc8c2b26036d62d4c746381a6f7cf60aafcc653198ad678306986b09450d",
+              "url": "https://files.pythonhosted.org/packages/95/7e/68018b70268fb4a2a605e2be44ab7b4dd7ce7808adae6c5ef32e34f4b55a/MarkupSafe-2.1.2.tar.gz"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "7e007132af78ea9df29495dbf7b5824cb71648d7133cf7848a2a5dd00d36f9ff",
+              "url": "https://files.pythonhosted.org/packages/96/92/a873b4a7fa20c2e30bffe883bb560330f3b6ce03aaf278f75f96d161935b/MarkupSafe-2.1.2-cp310-cp310-musllinux_1_1_i686.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "9cad97ab29dfc3f0249b483412c85c8ef4766d96cdf9dcf5a1e3caa3f3661cf1",
+              "url": "https://files.pythonhosted.org/packages/cf/c1/d7596976a868fe3487212a382cc121358a53dc8e8d85ff2ee2c3d3b40f04/MarkupSafe-2.1.2-cp311-cp311-musllinux_1_1_aarch64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "2ec4f2d48ae59bbb9d1f9d7efb9236ab81429a764dedca114f5fdabbc3788013",
+              "url": "https://files.pythonhosted.org/packages/e3/a9/e366665c7eae59c9c9d34b747cd5a3994847719a2304e0c8dec8b604dd98/MarkupSafe-2.1.2-cp311-cp311-macosx_10_9_universal2.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "608e7073dfa9e38a85d38474c082d4281f4ce276ac0010224eaba11e929dd53a",
+              "url": "https://files.pythonhosted.org/packages/e6/ff/d2378ca3cb3ac4a37af767b820b0f0bf3f5e9193a6acce0eefc379425c1c/MarkupSafe-2.1.2-cp311-cp311-macosx_10_9_x86_64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "e55e40ff0cc8cc5c07996915ad367fa47da6b3fc091fdadca7f5403239c5fec3",
+              "url": "https://files.pythonhosted.org/packages/ea/60/2400ba59cf2465fa136487ee7299f52121a9d04b2cf8539ad43ad10e70e8/MarkupSafe-2.1.2-cp311-cp311-win_amd64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "7313ce6a199651c4ed9d7e4cfb4aa56fe923b1adf9af3b420ee14e6d9a73df65",
+              "url": "https://files.pythonhosted.org/packages/f9/aa/ebcd114deab08f892b1d70badda4436dbad1747f9e5b72cffb3de4c7129d/MarkupSafe-2.1.2-cp310-cp310-musllinux_1_1_x86_64.whl"
             }
           ],
           "project_name": "markupsafe",
           "requires_dists": [],
           "requires_python": ">=3.7",
-          "version": "2.1.1"
+          "version": "2.1.2"
         },
         {
           "artifacts": [
@@ -5257,164 +5615,239 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "4bae31803d708f6f15fd98be6a6ac0b6958fcf68fda3c77a048a4f9073704aae",
-              "url": "https://files.pythonhosted.org/packages/07/31/5b73b42a50c943f28cc311d19a807436f36193dcf2e65c760fdee6cfef79/multidict-6.0.2-cp39-cp39-win_amd64.whl"
+              "hash": "33029f5734336aa0d4c0384525da0387ef89148dc7191aae00ca5fb23d7aafc2",
+              "url": "https://files.pythonhosted.org/packages/f1/d2/d735d40355ce41f6d1c50a5d4feef47cd4aad0e2809dd2c8cb01601f04ac/multidict-6.0.4-cp39-cp39-win_amd64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "07a017cfa00c9890011628eab2503bee5872f27144936a52eaab449be5eaf032",
-              "url": "https://files.pythonhosted.org/packages/00/6f/05e5612827715de18f36a8e36fb373f58621927691213cc3f88dc24524b3/multidict-6.0.2-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+              "hash": "f70b98cd94886b49d91170ef23ec5c0e8ebb6f242d734ed7ed677b24d50c82cf",
+              "url": "https://files.pythonhosted.org/packages/0c/ff/342e4f8f1c83fb2bdbca067a78cb88e80a0b93aab5443c8095daa97bf94b/multidict-6.0.4-cp39-cp39-musllinux_1_1_aarch64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "19d9bad105dfb34eb539c97b132057a4e709919ec4dd883ece5838bcbf262b80",
-              "url": "https://files.pythonhosted.org/packages/01/4d/ca2d62993ce36d059ca571f2f5124217dab5eb8da8b8797820745a3bf402/multidict-6.0.2-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl"
+              "hash": "ee2a1ece51b9b9e7752e742cfb661d2a29e7bcdba2d27e66e28a99f1890e4fa0",
+              "url": "https://files.pythonhosted.org/packages/1a/5a/e31fc5799b6d8929da4db92cc166d9257e7f85b4d6c7245143c0dae29413/multidict-6.0.4-cp310-cp310-musllinux_1_1_s390x.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "d16cce709ebfadc91278a1c005e3c17dd5f71f5098bfae1035149785ea6e9c68",
-              "url": "https://files.pythonhosted.org/packages/0b/85/b4628d7d6449a4ede8c5c9ce32f145240d348385898475d4a556986c6409/multidict-6.0.2-cp39-cp39-musllinux_1_1_ppc64le.whl"
+              "hash": "4dcbb0906e38440fa3e325df2359ac6cb043df8e58c965bb45f4e406ecb162cc",
+              "url": "https://files.pythonhosted.org/packages/24/d1/56b6d5eb964161c55a8a7ad53fe4c93a694e44d04fd1405f3c1b98de5627/multidict-6.0.4-cp310-cp310-win_amd64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "041b81a5f6b38244b34dc18c7b6aba91f9cdaf854d9a39e5ff0b58e2b5773b9c",
-              "url": "https://files.pythonhosted.org/packages/14/7b/d11a6dec8996ca054e727f7d3b1578753b44ba9e378c9449404aef076b47/multidict-6.0.2-cp310-cp310-macosx_11_0_arm64.whl"
+              "hash": "7582a1d1030e15422262de9f58711774e02fa80df0d1578995c76214f6954988",
+              "url": "https://files.pythonhosted.org/packages/25/1f/b10a0abdfc33069b6c92935cff81b97dd7d034149b05025a92326972b371/multidict-6.0.4-cp310-cp310-musllinux_1_1_i686.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "0b9e95a740109c6047602f4db4da9949e6c5945cefbad34a1299775ddc9a62e2",
-              "url": "https://files.pythonhosted.org/packages/1d/35/0ea9ce0cc0aeb3b4c898595d807ac80ebbd295efefabc80c4f6c6bee8106/multidict-6.0.2-cp310-cp310-macosx_10_9_universal2.whl"
+              "hash": "01a3a55bd90018c9c080fbb0b9f4891db37d148a0a18722b42f94694f8b6d4c9",
+              "url": "https://files.pythonhosted.org/packages/27/ce/2207d548200d42c3a0b3cb11b8957f4d29f82f95977ae2cc8276a7d719e5/multidict-6.0.4-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "fcb91630817aa8b9bc4a74023e4198480587269c272c58b3279875ed7235c293",
-              "url": "https://files.pythonhosted.org/packages/23/31/c8736506ae534e20c8f0b1b090bc2ad89349d96e5e7c5928464c6c876599/multidict-6.0.2-cp310-cp310-win32.whl"
+              "hash": "8316a77808c501004802f9beebde51c9f857054a0c871bd6da8280e718444449",
+              "url": "https://files.pythonhosted.org/packages/28/a3/db4511fbc4bf75a6c0afea0f009605432561ce0bd2b4fddc2047e9cb0b6b/multidict-6.0.4-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "c207fff63adcdf5a485969131dc70e4b194327666b7e8a87a97fbc4fd80a53b2",
-              "url": "https://files.pythonhosted.org/packages/27/b9/109d1db7eeeee0dc96ce90cc7fba4489f3074699f5688f53baf3e81427a4/multidict-6.0.2-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl"
+              "hash": "52f2dffc8acaba9a2f27174c41c9e57f60b907bb9f096b36b1a1f3be71c6284d",
+              "url": "https://files.pythonhosted.org/packages/2a/7b/6900273aec2eef33e17094407b67dca697ceeb75e3ddb86cccbdafb46e4b/multidict-6.0.4-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "50bd442726e288e884f7be9071016c15a8742eb689a593a0cac49ea093eef0a7",
-              "url": "https://files.pythonhosted.org/packages/2a/c2/0f63e839b93a68dd2bcfbf30cc35dbdb4b172ad0078e32176628ec7d91d5/multidict-6.0.2-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl"
+              "hash": "16ab77bbeb596e14212e7bab8429f24c1579234a3a462105cda4a66904998664",
+              "url": "https://files.pythonhosted.org/packages/2f/38/e0514ddb9b454b06fc8b29eb8b45ae1861cf1850acc2b0f01ad38b047ad3/multidict-6.0.4-cp39-cp39-macosx_10_9_universal2.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "0556a1d4ea2d949efe5fd76a09b4a82e3a4a30700553a6725535098d8d9fb672",
-              "url": "https://files.pythonhosted.org/packages/31/b1/eb1a8cdb3bb177929dfee9543c0fd8074768c9e4431c7b3da7d01a3c66d8/multidict-6.0.2-cp310-cp310-musllinux_1_1_i686.whl"
+              "hash": "64da238a09d6039e3bd39bb3aee9c21a5e34f28bfa5aa22518581f910ff94af3",
+              "url": "https://files.pythonhosted.org/packages/3c/b3/1c8b525a7243c395a73d0ba35f4625333315c5261d01acc3bcde852a9548/multidict-6.0.4-cp311-cp311-macosx_10_9_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "8064b7c6f0af936a741ea1efd18690bacfbae4078c0c385d7c3f611d11f0cf87",
-              "url": "https://files.pythonhosted.org/packages/3f/44/83e4bd573cc80c41896394129f162b69fe1ed9fd7a99ca4153740e20349c/multidict-6.0.2-cp310-cp310-musllinux_1_1_s390x.whl"
+              "hash": "bf6774e60d67a9efe02b3616fee22441d86fab4c6d335f9d2051d19d90a40063",
+              "url": "https://files.pythonhosted.org/packages/3c/ee/7b419645f86d43ae393f2451bc95287aec2e7539e93af619b280aeda9b04/multidict-6.0.4-cp39-cp39-musllinux_1_1_i686.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "373ba9d1d061c76462d74e7de1c0c8e267e9791ee8cfefcf6b0b2495762c370c",
-              "url": "https://files.pythonhosted.org/packages/42/27/832795c2b276af8669c786fc1d80a4b58786723f9cedc13ed47b408f2cfe/multidict-6.0.2-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl"
+              "hash": "81a4f0b34bd92df3da93315c6a59034df95866014ac08535fc819f043bfd51f0",
+              "url": "https://files.pythonhosted.org/packages/3d/22/35539dddb1971eb8dc88bb19d22d636eb9efe1ad7549d2f319a7951cbbe7/multidict-6.0.4-cp311-cp311-win_amd64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "2e4a0785b84fb59e43c18a015ffc575ba93f7d1dbd272b4cdad9f5134b8a006c",
-              "url": "https://files.pythonhosted.org/packages/66/ba/5debd35601ccfa76a92fd6cab6d873791d16757142b99384d124ff8275f1/multidict-6.0.2-cp39-cp39-macosx_10_9_universal2.whl"
+              "hash": "64bdf1086b6043bf519869678f5f2757f473dee970d7abf6da91ec00acb9cb98",
+              "url": "https://files.pythonhosted.org/packages/42/b6/61cb83e174e77e4e2607f60f26ff8e975eb7961e143fa01682b8c3acb201/multidict-6.0.4-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "2d36e929d7f6a16d4eb11b250719c39560dd70545356365b494249e2186bc389",
-              "url": "https://files.pythonhosted.org/packages/69/d7/c49e9ca438846658191905f5df53a895738b478cdca98580f092b557802c/multidict-6.0.2-cp310-cp310-musllinux_1_1_x86_64.whl"
+              "hash": "52509b5be062d9eafc8170e53026fbc54cf3b32759a23d07fd935fb04fc22d95",
+              "url": "https://files.pythonhosted.org/packages/46/d2/0b1e4e8ad7097dc12543571333d65580e918dd19e26109dc4b8ec13b744c/multidict-6.0.4-cp39-cp39-musllinux_1_1_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "feba80698173761cddd814fa22e88b0661e98cb810f9f986c54aa34d281e4937",
-              "url": "https://files.pythonhosted.org/packages/70/88/194d6da561224f7a6622a940b59f011a3b0794cc55e669be85f0db3dff82/multidict-6.0.2-cp39-cp39-musllinux_1_1_x86_64.whl"
+              "hash": "3601a3cece3819534b11d4efc1eb76047488fddd0c85a3948099d5da4d504636",
+              "url": "https://files.pythonhosted.org/packages/47/a4/69f7255bc1398caa2c1eecf4c937d3ed6ae483327f39f8b1115b578905bb/multidict-6.0.4-cp311-cp311-win32.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "8cbf0132f3de7cc6c6ce00147cc78e6439ea736cee6bca4f068bcf892b0fd658",
-              "url": "https://files.pythonhosted.org/packages/72/e4/9ea1c573503ddf11ea56c48e9af49660fbd45a13ceb394a48e437c32eba9/multidict-6.0.2-cp310-cp310-win_amd64.whl"
+              "hash": "3666906492efb76453c0e7b97f2cf459b0682e7402c0489a95484965dbc1da49",
+              "url": "https://files.pythonhosted.org/packages/4a/15/bd620f7a6eb9aa5112c4ef93e7031bcd071e0611763d8e17706ef8ba65e0/multidict-6.0.4.tar.gz"
             },
             {
               "algorithm": "sha256",
-              "hash": "f4f052ee022928d34fe1f4d2bc743f32609fb79ed9c49a1710a5ad6b2198db20",
-              "url": "https://files.pythonhosted.org/packages/7e/21/73f8a51219fd9b4b04badcc7933ce5f5344ab33308492755220524bc4faf/multidict-6.0.2-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl"
+              "hash": "c5cb09abb18c1ea940fb99360ea0396f34d46566f157122c92dfa069d3e0e982",
+              "url": "https://files.pythonhosted.org/packages/4d/1f/83656180657d0d359b12866b9af77dbb58f46cb5f454301d2c37ec97a9e1/multidict-6.0.4-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "a007b1638e148c3cfb6bf0bdc4f82776cef0ac487191d093cdc316905e504071",
-              "url": "https://files.pythonhosted.org/packages/98/16/7af490ccfe470dad4b3d28fc69b1f3b4cdfe0fd5e279b299e103edbb8505/multidict-6.0.2-cp39-cp39-macosx_11_0_arm64.whl"
+              "hash": "36c63aaa167f6c6b04ef2c85704e93af16c11d20de1d133e39de6a0e84582a93",
+              "url": "https://files.pythonhosted.org/packages/56/b5/ac112889bfc68e6cf4eda1e4325789b166c51c6cd29d5633e28fb2c2f966/multidict-6.0.4-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "47e6a7e923e9cada7c139531feac59448f1f47727a79076c0b1ee80274cd8eee",
-              "url": "https://files.pythonhosted.org/packages/9b/a4/a8d3c6bb884d97fd1e9d37c5c9a8c46de799d7465e455b617f33dfbb52ba/multidict-6.0.2-cp310-cp310-musllinux_1_1_aarch64.whl"
+              "hash": "ff959bee35038c4624250473988b24f846cbeb2c6639de3602c073f10410ceba",
+              "url": "https://files.pythonhosted.org/packages/59/28/e50cc24c56609d11f7232606f73981620e94e3445791d9501e21c4c73a61/multidict-6.0.4-cp311-cp311-macosx_11_0_arm64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "de989b195c3d636ba000ee4281cd03bb1234635b124bf4cd89eeee9ca8fcb09d",
-              "url": "https://files.pythonhosted.org/packages/a6/54/3838c7306bd677f4a524ba910aa459c1fe77c0700d4ca2dc9151e514cc16/multidict-6.0.2-cp39-cp39-musllinux_1_1_aarch64.whl"
+              "hash": "dcfe792765fab89c365123c81046ad4103fcabbc4f56d1c1997e6715e8015461",
+              "url": "https://files.pythonhosted.org/packages/5c/4d/976b2e5fadc2b6e5e6208fb1566669460adde3f41d7622db3afa90fb2dbf/multidict-6.0.4-cp311-cp311-musllinux_1_1_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "bfba7c6d5d7c9099ba21f84662b037a0ffd4a5e6b26ac07d19e423e6fdf965a9",
-              "url": "https://files.pythonhosted.org/packages/b3/2d/d2bb7c2ac3bc4c1c60f9b82dde1bb084d074cf7a844f7f377477dc35de9b/multidict-6.0.2-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+              "hash": "281af09f488903fde97923c7744bb001a9b23b039a909460d0f14edc7bf59706",
+              "url": "https://files.pythonhosted.org/packages/5d/a0/33b0b030148e9e0882d8b9f2404b8b3cc5e4718041fe6856602ccad81fa9/multidict-6.0.4-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "7c40b7bbece294ae3a87c1bc2abff0ff9beef41d14188cda94ada7bcea99b0fb",
-              "url": "https://files.pythonhosted.org/packages/b5/4b/f773e1e3b276c92d3f6aa84b5164788bb161fd8901166e017b8ade4e4037/multidict-6.0.2-cp39-cp39-musllinux_1_1_i686.whl"
+              "hash": "458f37be2d9e4c95e2d8866a851663cbc76e865b78395090786f6cd9b3bbf4f4",
+              "url": "https://files.pythonhosted.org/packages/5f/eb/2023167c9533d62e2afcba7acb0dc98420bcf9fc27eff5a83c2bbd013b65/multidict-6.0.4-cp311-cp311-musllinux_1_1_aarch64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "3368bf2398b0e0fcbf46d85795adc4c259299fec50c1416d0f77c0a843a3eed9",
-              "url": "https://files.pythonhosted.org/packages/bf/b9/b8c9845853b7086476201ff18bcff5a169e945c5d8397e234ba4453a38d4/multidict-6.0.2-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl"
+              "hash": "d5e3fc56f88cc98ef8139255cf8cd63eb2c586531e43310ff859d6bb3a6b51f1",
+              "url": "https://files.pythonhosted.org/packages/69/48/2750fd3ace4d778b4e1f7110db3ad637906de3496abc9c450ce726b97337/multidict-6.0.4-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "6701bf8a5d03a43375909ac91b6980aea74b0f5402fbe9428fc3f6edf5d9677e",
-              "url": "https://files.pythonhosted.org/packages/c7/9f/ce1b2b964f573e09eda8a6e98b33972a7915304dd3737da4ae663e2f5057/multidict-6.0.2-cp39-cp39-macosx_10_9_x86_64.whl"
+              "hash": "16d232d4e5396c2efbbf4f6d4df89bfa905eb0d4dc5b3549d872ab898451f569",
+              "url": "https://files.pythonhosted.org/packages/8f/f9/e14b11f78b937d2a5982593d5a238058679bd120979b2c5b94ea8ba125fc/multidict-6.0.4-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "626fe10ac87851f4cffecee161fc6f8f9853f0f6f1035b59337a51d29ff3b4f9",
-              "url": "https://files.pythonhosted.org/packages/ce/b3/7b2ed0a1fca198da0e6354ccd0358757c12b56f204c179271cf81a7372ae/multidict-6.0.2-cp310-cp310-musllinux_1_1_ppc64le.whl"
+              "hash": "e69924bfcdda39b722ef4d9aa762b2dd38e4632b3641b1d9a57ca9cd18f2f83a",
+              "url": "https://files.pythonhosted.org/packages/94/e7/a1484aa7d711bc346a37dfa2f23895cc568f9f5a5f9e86498864d2e17b7e/multidict-6.0.4-cp39-cp39-musllinux_1_1_ppc64le.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "a2c34a93e1d2aa35fbf1485e5010337c72c6791407d03aa5f4eed920343dd360",
-              "url": "https://files.pythonhosted.org/packages/d0/54/b43675a2fbe33433aebdadd7564aa0eb2f3c57d018901c2ed4b4517f7264/multidict-6.0.2-cp39-cp39-musllinux_1_1_s390x.whl"
+              "hash": "ddff9c4e225a63a5afab9dd15590432c22e8057e1a9a13d28ed128ecf047bbdc",
+              "url": "https://files.pythonhosted.org/packages/96/9a/96830785d7eb3c72782fda15572ea9ed31fd67a071eab0ffad6859458e4d/multidict-6.0.4-cp310-cp310-musllinux_1_1_ppc64le.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "ac0e27844758d7177989ce406acc6a83c16ed4524ebc363c1f748cba184d89d3",
-              "url": "https://files.pythonhosted.org/packages/d2/67/ef1ef8f3539642d90c77bc7c86cc7283297cd2ab100b45d7541476ef641e/multidict-6.0.2-cp310-cp310-macosx_10_9_x86_64.whl"
+              "hash": "11bdf3f5e1518b24530b8241529d2050014c884cf18b6fc69c0c2b30ca248710",
+              "url": "https://files.pythonhosted.org/packages/9d/5a/34bd606569178ad8a931ea4d59cda926b046cfa4c01b0191c2e04cfd44c2/multidict-6.0.4-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "225383a6603c086e6cef0f2f05564acb4f4d5f019a4e3e983f572b8530f70c88",
-              "url": "https://files.pythonhosted.org/packages/df/93/34efbfa7aa778b04b365960f52f7071d7942ce386572aac8940ae032dd48/multidict-6.0.2-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+              "hash": "b41156839806aecb3641f3208c0dafd3ac7775b9c4c422d82ee2a45c34ba81ca",
+              "url": "https://files.pythonhosted.org/packages/9f/d2/49cf9fa8a79e5aa9df5139b54842bb45b6a4cacdefc2defcc1aa10e8b1ea/multidict-6.0.4-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "5fdda29a3c7e76a064f2477c9aab1ba96fd94e02e386f1e665bca1807fc5386f",
-              "url": "https://files.pythonhosted.org/packages/ee/a1/a7cc44b7ed84e430c2c176420ffa432a74a2432f7df4f71988365fa8772a/multidict-6.0.2-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+              "hash": "43644e38f42e3af682690876cff722d301ac585c5b9e1eacc013b7a3f7b696a0",
+              "url": "https://files.pythonhosted.org/packages/b0/6d/03a5b702a0ad4d3aa4cf101acd8758ff8438fef0311bf90e7c72a80152ef/multidict-6.0.4-cp310-cp310-musllinux_1_1_aarch64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "23b616fdc3c74c9fe01d76ce0d1ce872d2d396d8fa8e4899398ad64fb5aa214a",
-              "url": "https://files.pythonhosted.org/packages/f6/0d/ef468297b45d02dba047ee1b003cc2d185de906e6e04862d90e1441244b1/multidict-6.0.2-cp39-cp39-win32.whl"
+              "hash": "5979b5632c3e3534e42ca6ff856bb24b2e3071b37861c2c727ce220d80eee9ed",
+              "url": "https://files.pythonhosted.org/packages/b4/7a/3f0b0e533fd1b73662723cb45869f4d32df643458d78c2fa7b946be98494/multidict-6.0.4-cp311-cp311-musllinux_1_1_s390x.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "5ff3bd75f38e4c43f1f470f2df7a4d430b821c4ce22be384e1459cb57d6bb013",
-              "url": "https://files.pythonhosted.org/packages/fa/a7/71c253cdb8a1528802bac7503bf82fe674367e4055b09c28846fdfa4ab90/multidict-6.0.2.tar.gz"
+              "hash": "0b1a97283e0c85772d613878028fec909f003993e1007eafa715b24b377cb9b8",
+              "url": "https://files.pythonhosted.org/packages/bb/e4/ea5687129b0cb781aba596bd08abb2aca3c8051e41aabf989c966e93af04/multidict-6.0.4-cp310-cp310-macosx_10_9_universal2.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "0dfad7a5a1e39c53ed00d2dd0c2e36aed4650936dc18fd9a1826a5ae1cad6f03",
+              "url": "https://files.pythonhosted.org/packages/bb/ec/ea3435f339cfad0d0a5e9e533a362d230325029deea9cdba6730fcfc1e00/multidict-6.0.4-cp311-cp311-macosx_10_9_universal2.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "574b7eae1ab267e5f8285f0fe881f17efe4b98c39a40858247720935b893bba8",
+              "url": "https://files.pythonhosted.org/packages/bd/50/7beeed47a950011ea0abf50541fecd67d6880719ac0e797b3dc214d6f102/multidict-6.0.4-cp310-cp310-win32.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "c048099e4c9e9d615545e2001d3d8a4380bd403e1a0578734e0d31703d1b0c0b",
+              "url": "https://files.pythonhosted.org/packages/d0/21/d737fe1cac90fb89b0959194d12747024ea95d52032daef9d2ac3cf18ce0/multidict-6.0.4-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "7d6ae9d593ef8641544d6263c7fa6408cc90370c8cb2bbb65f8d43e5b0351d9c",
+              "url": "https://files.pythonhosted.org/packages/d5/eb/22de4f5935f4d754b0f53d323643a1b4b7fa796e02bf3a0df7dec150269f/multidict-6.0.4-cp311-cp311-musllinux_1_1_ppc64le.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "6b181d8c23da913d4ff585afd1155a0e1194c0b50c54fcfe286f70cdaf2b7176",
+              "url": "https://files.pythonhosted.org/packages/db/7e/f007ec4ea4d6626aa4e659ae3631345cb928ff07445577914884c3355277/multidict-6.0.4-cp39-cp39-musllinux_1_1_s390x.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "4ceef517eca3e03c1cceb22030a3e39cb399ac86bff4e426d4fc6ae49052cc60",
+              "url": "https://files.pythonhosted.org/packages/dd/bd/cce218536b377efbee70d8680a97fd282f4e1e9f7ebff95c4ea28deef87a/multidict-6.0.4-cp39-cp39-macosx_11_0_arm64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "27c523fbfbdfd19c6867af7346332b62b586eed663887392cff78d614f9ec313",
+              "url": "https://files.pythonhosted.org/packages/de/c2/2b6be6b6194064efe429b77994f3153ffd18a92b0b6422de3c702b58b150/multidict-6.0.4-cp39-cp39-win32.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "a2e4369eb3d47d2034032a26c7a80fcb21a2cb22e1173d761a162f11e562caa5",
+              "url": "https://files.pythonhosted.org/packages/e1/2b/e2b9ff85a5f973c7636d07e58ede554262a75b435eb6fe53e67ec4749953/multidict-6.0.4-cp310-cp310-musllinux_1_1_x86_64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "b1a2eeedcead3a41694130495593a559a668f382eee0727352b9a41e1c45759a",
+              "url": "https://files.pythonhosted.org/packages/e4/18/79a66879c57c37a2a721ca1aea18953f0f291ea8a8e7334fe5091a4c3111/multidict-6.0.4-cp311-cp311-musllinux_1_1_i686.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "666daae833559deb2d609afa4490b85830ab0dfca811a98b70a205621a6109fe",
+              "url": "https://files.pythonhosted.org/packages/e4/41/ade43649e3c35178a81827eb960a7480842fe36c51d4a16a2a68e396e0d6/multidict-6.0.4-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "d6d635d5209b82a3492508cf5b365f3446afb65ae7ebd755e70e18f287b0adf7",
+              "url": "https://files.pythonhosted.org/packages/eb/97/05b51bd39ba10ad7ae6530ae05e050a1cac91d42dcafd40c40d388e057b4/multidict-6.0.4-cp310-cp310-macosx_11_0_arm64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "bc779e9e6f7fda81b3f9aa58e3a6091d49ad528b11ed19f6621408806204ad35",
+              "url": "https://files.pythonhosted.org/packages/f0/c1/de389de822e8442717e7fda86496a47af8a132104e1601f3419d26dff334/multidict-6.0.4-cp39-cp39-macosx_10_9_x86_64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "ea20853c6dbbb53ed34cb4d080382169b6f4554d394015f1bef35e881bf83547",
+              "url": "https://files.pythonhosted.org/packages/f5/cf/416f84a8c7954c571881b01c839312ec81e222b3986c8baedc57f476cc1b/multidict-6.0.4-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "eeb6dcc05e911516ae3d1f207d4b0520d07f54484c49dfc294d6e7d63b734171",
+              "url": "https://files.pythonhosted.org/packages/fc/54/8e025ae4e31d899e4528a570941eb7048512392b454acccf69c2dccfcb0d/multidict-6.0.4-cp310-cp310-macosx_10_9_x86_64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "7d18748f2d30f94f498e852c67d61261c643b349b9d2a581131725595c45ec6c",
+              "url": "https://files.pythonhosted.org/packages/fc/5b/0a4205a1248fb152f596a03c971c6ef1585d0c98e56b6886dc35d084e366/multidict-6.0.4-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl"
             }
           ],
           "project_name": "multidict",
           "requires_dists": [],
           "requires_python": ">=3.7",
-          "version": "6.0.2"
+          "version": "6.0.4"
         },
         {
           "artifacts": [
@@ -5648,13 +6081,13 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "3e90e108bb5637b5b8a1422af1156af1368b39dd25369ff7faa7dfdcdef18f81",
-              "url": "https://files.pythonhosted.org/packages/37/33/0d339e81b7c6b77020059dd2268c16c4ba63473bdd984991f91ac7ad7ef7/nbconvert-7.2.5-py3-none-any.whl"
+              "hash": "ac57f2812175441a883f50c8ff113133ca65fe7ae5a9f1e3da3bfd1a70dce2ee",
+              "url": "https://files.pythonhosted.org/packages/21/be/5411c7d2e10f103bb760b8710955c594d2c9d9db04ecb51e763136beacfe/nbconvert-7.2.8-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "8fdc44fd7d9424db7fdc6e1e834a02f6b8620ffb653767388be2f9eb16f84184",
-              "url": "https://files.pythonhosted.org/packages/9b/48/5ff5813e92e339bf7f15db2b67819e72592262a9d7270f8f2ccfb56b57cd/nbconvert-7.2.5.tar.gz"
+              "hash": "ccedacde57a972836bfb46466485be29ed1364ed7c2f379f62bad47d340ece99",
+              "url": "https://files.pythonhosted.org/packages/78/10/f10deed3a5cd565c16d80088dbcb7eadd9f2f1f03061c98d4599100d4a45/nbconvert-7.2.8.tar.gz"
             }
           ],
           "project_name": "nbconvert",
@@ -5663,80 +6096,71 @@
             "bleach",
             "defusedxml",
             "importlib-metadata>=3.6; python_version < \"3.10\"",
-            "ipykernel; extra == \"all\"",
+            "ipykernel; extra == \"docs\"",
             "ipykernel; extra == \"test\"",
-            "ipython; extra == \"all\"",
             "ipython; extra == \"docs\"",
-            "ipywidgets>=7; extra == \"all\"",
             "ipywidgets>=7; extra == \"test\"",
             "jinja2>=3.0",
             "jupyter-core>=4.7",
             "jupyterlab-pygments",
             "markupsafe>=2.0",
             "mistune<3,>=2.0.3",
-            "myst-parser; extra == \"all\"",
             "myst-parser; extra == \"docs\"",
             "nbclient>=0.5.0",
+            "nbconvert[docs,qtpdf,serve,test,webpdf]; extra == \"all\"",
+            "nbconvert[qtpng]; extra == \"qtpdf\"",
             "nbformat>=5.1",
-            "nbsphinx>=0.2.12; extra == \"all\"",
             "nbsphinx>=0.2.12; extra == \"docs\"",
             "packaging",
             "pandocfilters>=1.4.1",
-            "pre-commit; extra == \"all\"",
             "pre-commit; extra == \"test\"",
+            "pydata-sphinx-theme; extra == \"docs\"",
             "pygments>=2.4.1",
-            "pyppeteer<1.1,>=1; extra == \"all\"",
-            "pyppeteer<1.1,>=1; extra == \"test\"",
             "pyppeteer<1.1,>=1; extra == \"webpdf\"",
-            "pyqtwebengine>=5.15; extra == \"all\"",
-            "pyqtwebengine>=5.15; extra == \"qtpdf\"",
             "pyqtwebengine>=5.15; extra == \"qtpng\"",
-            "pytest-cov; extra == \"all\"",
-            "pytest-cov; extra == \"test\"",
-            "pytest-dependency; extra == \"all\"",
             "pytest-dependency; extra == \"test\"",
-            "pytest; extra == \"all\"",
             "pytest; extra == \"test\"",
-            "sphinx-rtd-theme; extra == \"all\"",
-            "sphinx-rtd-theme; extra == \"docs\"",
-            "sphinx==5.0.2; extra == \"all\"",
             "sphinx==5.0.2; extra == \"docs\"",
+            "sphinxcontrib-spelling; extra == \"docs\"",
             "tinycss2",
-            "tornado>=6.1; extra == \"all\"",
             "tornado>=6.1; extra == \"serve\"",
             "traitlets>=5.0"
           ],
           "requires_python": ">=3.7",
-          "version": "7.2.5"
+          "version": "7.2.8"
         },
         {
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "1b05ec2c552c2f1adc745f4eddce1eac8ca9ffd59bb9fd859e827eaa031319f9",
-              "url": "https://files.pythonhosted.org/packages/5c/9f/957655d02f43b8bff77e6da08c94472b1229c13e7455bbd662163c9b78c0/nbformat-5.7.0-py3-none-any.whl"
+              "hash": "22a98a6516ca216002b0a34591af5bcb8072ca6c63910baffc901cfa07fefbf0",
+              "url": "https://files.pythonhosted.org/packages/21/ad/020fed74bfde983a3b70cc95843d6adbe59171aa9a3da5aab403aa722a17/nbformat-5.7.3-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "1d4760c15c1a04269ef5caf375be8b98dd2f696e5eb9e603ec2bf091f9b0d3f3",
-              "url": "https://files.pythonhosted.org/packages/9c/54/5b39dfc6585e1dfc8c119252754c19dd85ee974606b73e3fa8a2242413d2/nbformat-5.7.0.tar.gz"
+              "hash": "4b021fca24d3a747bf4e626694033d792d594705829e5e35b14ee3369f9f6477",
+              "url": "https://files.pythonhosted.org/packages/ce/42/fae44dfe70960c488e5b9b53c617dedd1c7932aff1962c59b2a923e82bb8/nbformat-5.7.3.tar.gz"
             }
           ],
           "project_name": "nbformat",
           "requires_dists": [
-            "check-manifest; extra == \"test\"",
             "fastjsonschema",
             "importlib-metadata>=3.6; python_version < \"3.8\"",
             "jsonschema>=2.6",
             "jupyter-core",
+            "myst-parser; extra == \"docs\"",
             "pep440; extra == \"test\"",
             "pre-commit; extra == \"test\"",
+            "pydata-sphinx-theme; extra == \"docs\"",
             "pytest; extra == \"test\"",
+            "sphinx; extra == \"docs\"",
+            "sphinxcontrib-github-alt; extra == \"docs\"",
+            "sphinxcontrib-spelling; extra == \"docs\"",
             "testpath; extra == \"test\"",
             "traitlets>=5.1"
           ],
           "requires_python": ">=3.7",
-          "version": "5.7"
+          "version": "5.7.3"
         },
         {
           "artifacts": [
@@ -5891,104 +6315,104 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "09b7847f7e83ca37c6e627682f145856de331049013853f344f37b0c9690e3df",
-              "url": "https://files.pythonhosted.org/packages/08/36/6589c7d5fc4fecda63de4453fefff7c58f6de2b1bb7dfbe7fa807bf85c46/numpy-1.23.5-cp39-cp39-win_amd64.whl"
+              "hash": "ddc7ab52b322eb1e40521eb422c4e0a20716c271a306860979d450decbb51b8e",
+              "url": "https://files.pythonhosted.org/packages/37/15/5667b269bf2c3473133823733fc0cd8fa44850e4c1d61b45bccc798a3e5a/numpy-1.24.1-cp39-cp39-win_amd64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "9c88793f78fca17da0145455f0d7826bcb9f37da4764af27ac945488116efe63",
-              "url": "https://files.pythonhosted.org/packages/0f/ae/dad4b8e7c65494cbbd1c063de114efaf9acd0f5f6171f044f0d4b6299787/numpy-1.23.5-cp310-cp310-macosx_10_9_x86_64.whl"
+              "hash": "87a118968fba001b248aac90e502c0b13606721b1343cdaddbc6e552e8dfb56f",
+              "url": "https://files.pythonhosted.org/packages/06/5c/d43e4b9eefc95bed55128cc08c535dfb0047cbeac5b7b3cd835a7a531974/numpy-1.24.1-cp39-cp39-win32.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "0cbe9848fad08baf71de1a39e12d1b6310f1d5b2d0ea4de051058e6e1076852d",
-              "url": "https://files.pythonhosted.org/packages/19/0d/b8c34e4baf258d77a8592bdce45183e9a12874c167f5966c7dd467b74ea9/numpy-1.23.5-cp311-cp311-win_amd64.whl"
+              "hash": "b31da69ed0c18be8b77bfce48d234e55d040793cebb25398e2a7d84199fbc7e2",
+              "url": "https://files.pythonhosted.org/packages/24/c1/44f013eba432b5f18a044b587f96aa76964ea4eacbf512bd6c947a9f78c9/numpy-1.24.1-cp310-cp310-win32.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "5039f55555e1eab31124a5768898c9e22c25a65c1e0037f4d7c495a45778c9f2",
-              "url": "https://files.pythonhosted.org/packages/2b/1a/9ac00116d3a64b5ea031fdb2ff071062a6e2140553fa0770b5f007b84252/numpy-1.23.5-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+              "hash": "b09804ff570b907da323b3d762e74432fb07955701b17b08ff1b5ebaa8cfe6a9",
+              "url": "https://files.pythonhosted.org/packages/39/5d/21ea2da2aa6f419a7e48a582b7f5c99ba62822dcd173a6e5a58b22748a36/numpy-1.24.1-cp310-cp310-macosx_11_0_arm64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "1b1766d6f397c18153d40015ddfc79ddb715cabadc04d2d228d4e5a8bc4ded1a",
-              "url": "https://files.pythonhosted.org/packages/42/38/775b43da55fa7473015eddc9a819571517d9a271a9f8134f68fb9be2f212/numpy-1.23.5.tar.gz"
+              "hash": "0e3463e6ac25313462e04aea3fb8a0a30fb906d5d300f58b3bc2c23da6a15398",
+              "url": "https://files.pythonhosted.org/packages/3d/17/2cc40e1ed44f37b0bab7d62e0c6ba88362da23f48e52833ffdd1b9dfc220/numpy-1.24.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "33161613d2269025873025b33e879825ec7b1d831317e68f4f2f0f84ed14c719",
-              "url": "https://files.pythonhosted.org/packages/4c/b9/038abd6fbd67b05b03cb1af590cfc02b7f1e5a37af7ac6a868f5093c29f5/numpy-1.23.5-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+              "hash": "ef85cf1f693c88c1fd229ccd1055570cb41cdf4875873b7728b6301f12cd05bf",
+              "url": "https://files.pythonhosted.org/packages/43/55/fea3342371187dea4044521c0ba82b90fb5a42fb92446be019b316dd3320/numpy-1.24.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "e9f4c4e51567b616be64e05d517c79a8a22f3606499941d97bb76f2ca59f982d",
-              "url": "https://files.pythonhosted.org/packages/4d/39/d33202cc56c21123a50c6d5e160d00c18ff685ab864dbd4bf80dd40a7af9/numpy-1.23.5-cp310-cp310-macosx_11_0_arm64.whl"
+              "hash": "179a7ef0889ab769cc03573b6217f54c8bd8e16cef80aad369e1e8185f994cd7",
+              "url": "https://files.pythonhosted.org/packages/6e/77/7b69133bf0f3a6b0000cdb6133ff5292734182ca0cd107ad7ff4c46e7bc1/numpy-1.24.1-cp310-cp310-macosx_10_9_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "bf837dc63ba5c06dc8797c398db1e223a466c7ece27a1f7b5232ba3466aafe3d",
-              "url": "https://files.pythonhosted.org/packages/5d/a1/cdac656aed8bc04dc86296490f8dbef68474c3294cc31af30f2bd0ec06de/numpy-1.23.5-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+              "hash": "de92efa737875329b052982e37bd4371d52cabf469f83e7b8be9bb7752d67e51",
+              "url": "https://files.pythonhosted.org/packages/73/39/f104eb30cc3da44d1e10622418c5e6eb5ac224f0f20c97dba44cf2de2af9/numpy-1.24.1-cp311-cp311-win_amd64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "7903ba8ab592b82014713c491f6c5d3a1cde5b4a3bf116404e08f5b52f6daf43",
-              "url": "https://files.pythonhosted.org/packages/67/6b/d7c93d458d16464da9b3f560a20c363a19e242ebbb019bd1e1d797523851/numpy-1.23.5-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+              "hash": "28bc9750ae1f75264ee0f10561709b1462d450a4808cd97c013046073ae64ab6",
+              "url": "https://files.pythonhosted.org/packages/81/3a/faa8aa531ec3001ff3b215892de791142e01516105da4c5e40a5686edca2/numpy-1.24.1-cp39-cp39-macosx_10_9_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "dbee87b469018961d1ad79b1a5d50c0ae850000b639bcb1b694e9981083243b6",
-              "url": "https://files.pythonhosted.org/packages/6a/03/ae6c3c307f9c5c7516de3df3e764ebb1de33e54e197f0370992138433ef4/numpy-1.23.5-cp310-cp310-win_amd64.whl"
+              "hash": "e274f0f6c7efd0d577744f52032fdd24344f11c5ae668fe8d01aac0422611df1",
+              "url": "https://files.pythonhosted.org/packages/85/92/4a280c9d31ec4950b0de759722b9feb9cc9d680726da3578f6b993ae6236/numpy-1.24.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "ce571367b6dfe60af04e04a1834ca2dc5f46004ac1cc756fb95319f64c095a96",
-              "url": "https://files.pythonhosted.org/packages/6e/7f/94797cfe0263a30805f3074e535adfde02b885ac43d1e4dac85f82213b0b/numpy-1.23.5-cp311-cp311-macosx_10_9_x86_64.whl"
+              "hash": "f1b739841821968798947d3afcefd386fa56da0caf97722a5de53e07c4ccedc7",
+              "url": "https://files.pythonhosted.org/packages/a0/a6/44d97c9d6ec619f0ff3a5a8471e5a1283a0ff492348214d512a79f32e9e4/numpy-1.24.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "8969bfd28e85c81f3f94eb4a66bc2cf1dbdc5c18efc320af34bffc54d6b1e38f",
-              "url": "https://files.pythonhosted.org/packages/8c/7a/171d3b4a54de835c8f95181dd2885607c0e04adca55ef99d9de559b4c9ba/numpy-1.23.5-cp39-cp39-macosx_10_9_x86_64.whl"
+              "hash": "8e669fbdcdd1e945691079c2cae335f3e3a56554e06bbd45d7609a6cf568c700",
+              "url": "https://files.pythonhosted.org/packages/ad/9a/98490aee9ca665cd04291658dd76e19c9b9d17680404aa9a122d5ef6ff79/numpy-1.24.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "b2a9ab7c279c91974f756c84c365a669a887efa287365a8e2c418f8b3ba73fb0",
-              "url": "https://files.pythonhosted.org/packages/9b/55/a2669debe264b1f22a8133734595128e40b96a8066e17e53e8d160168e41/numpy-1.23.5-cp311-cp311-win32.whl"
+              "hash": "84e789a085aabef2f36c0515f45e459f02f570c4b4c4c108ac1179c34d475ed7",
+              "url": "https://files.pythonhosted.org/packages/af/74/070f80c41427f41a48bd4c873768f4989aacac7b8c0a3060566402339ce9/numpy-1.24.1-cp39-cp39-macosx_11_0_arm64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "a7ac231a08bb37f852849bbb387a20a57574a97cfc7b6cabb488a4fc8be176de",
-              "url": "https://files.pythonhosted.org/packages/9e/9d/ff17c357f7144301da85f8c03d56593cfd2904e9ce89f86c8eefaa96d2d5/numpy-1.23.5-cp39-cp39-macosx_11_0_arm64.whl"
+              "hash": "28e418681372520c992805bb723e29d69d6b7aa411065f48216d8329d02ba032",
+              "url": "https://files.pythonhosted.org/packages/b8/a9/993477a7d6a3fdb1b7bb2287333d027303b9af7643d90088a4c74a15dc1d/numpy-1.24.1-cp311-cp311-macosx_11_0_arm64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "522e26bbf6377e4d76403826ed689c295b0b238f46c28a7251ab94716da0b280",
-              "url": "https://files.pythonhosted.org/packages/af/92/8efba008b9bda66456a1844a0e133dc76c08c5fb68c67a674f046211db29/numpy-1.23.5-cp310-cp310-win32.whl"
+              "hash": "7094891dcf79ccc6bc2a1f30428fa5edb1e6fb955411ffff3401fb4ea93780a8",
+              "url": "https://files.pythonhosted.org/packages/cd/9b/0398b0638ccdda7167d407f50494406560d6e4b7f4e23c33588704e2928b/numpy-1.24.1-cp311-cp311-macosx_10_9_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "56e454c7833e94ec9769fa0f86e6ff8e42ee38ce0ce1fa4cbb747ea7e06d56aa",
-              "url": "https://files.pythonhosted.org/packages/b8/d0/e6a2cb9a3f3e863a43e50949e9ae704be70baf398fd5af59355f65c8740a/numpy-1.23.5-cp311-cp311-macosx_11_0_arm64.whl"
+              "hash": "2386da9a471cc00a1f47845e27d916d5ec5346ae9696e01a8a34760858fe9dd2",
+              "url": "https://files.pythonhosted.org/packages/ce/b8/c170db50ec49d5845bd771bc5549fe734ee73083c5c52791915f95d8e2bc/numpy-1.24.1.tar.gz"
             },
             {
               "algorithm": "sha256",
-              "hash": "af1da88f6bc3d2338ebbf0e22fe487821ea4d8e89053e25fa59d1d79786e7481",
-              "url": "https://files.pythonhosted.org/packages/d5/95/f311e6fdaabe24f909eeb6d5482e3adef27fa8389cb8a84823ae560bf480/numpy-1.23.5-cp39-cp39-win32.whl"
+              "hash": "442feb5e5bada8408e8fcd43f3360b78683ff12a4444670a7d9e9824c1817d36",
+              "url": "https://files.pythonhosted.org/packages/d7/18/4491cefc090909c3615315722fd09864b791c34a1f174845d41716278d23/numpy-1.24.1-cp311-cp311-win32.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "5e05b1c973a9f858c74367553e236f287e749465f773328c8ef31abe18f691e1",
-              "url": "https://files.pythonhosted.org/packages/e4/f3/679b3a042a127de0d7c84874913c3e23bb84646eb3bc6ecab3f8c872edc9/numpy-1.23.5-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+              "hash": "0044f7d944ee882400890f9ae955220d29b33d809a038923d88e4e01d652acd9",
+              "url": "https://files.pythonhosted.org/packages/db/24/5343241cabd04224e4fc4f2cf12b35146a90a83f53bef9b541c439a7dada/numpy-1.24.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "58f545efd1108e647604a1b5aa809591ccd2540f468a880bedb97247e72db387",
-              "url": "https://files.pythonhosted.org/packages/e8/ad/b935c7421657a032fd2a5332eed098f3b9993a155afceb1daa280ff6611f/numpy-1.23.5-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+              "hash": "b07b40f5fb4fa034120a5796288f24c1fe0e0580bbfff99897ba6267af42def2",
+              "url": "https://files.pythonhosted.org/packages/ee/70/c9055fe381e9e5103222e2f5efeb0cfb4524ab3c7d75b4eedc330380f9f5/numpy-1.24.1-cp310-cp310-win_amd64.whl"
             }
           ],
           "project_name": "numpy",
           "requires_dists": [],
           "requires_python": ">=3.8",
-          "version": "1.23.5"
+          "version": "1.24.1"
         },
         {
           "artifacts": [
@@ -6247,19 +6671,19 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "db2317ff07c84c4c63648c9064a79fe9d9f5c7ce85a9099d4b6258b3db83225a",
-              "url": "https://files.pythonhosted.org/packages/e5/37/10e8a53f196cf0bcb93008daed42e2c47c7876430a7efd044ff4d647f30a/pbr-5.11.0-py2.py3-none-any.whl"
+              "hash": "567f09558bae2b3ab53cb3c1e2e33e726ff3338e7bae3db5dc954b3a44eef12b",
+              "url": "https://files.pythonhosted.org/packages/01/06/4ab11bf70db5a60689fc521b636849c8593eb67a2c6bdf73a16c72d16a12/pbr-5.11.1-py2.py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "b97bc6695b2aff02144133c2e7399d5885223d42b7912ffaec2ca3898e673bfe",
-              "url": "https://files.pythonhosted.org/packages/52/fb/630d52aaca8fc7634a0711b6ae12a0e828b6f9264bd8051225025c3ed075/pbr-5.11.0.tar.gz"
+              "hash": "aefc51675b0b533d56bb5fd1c8c6c0522fe31896679882e1c4c63d5e4a0fccb3",
+              "url": "https://files.pythonhosted.org/packages/02/d8/acee75603f31e27c51134a858e0dea28d321770c5eedb9d1d673eb7d3817/pbr-5.11.1.tar.gz"
             }
           ],
           "project_name": "pbr",
           "requires_dists": [],
           "requires_python": ">=2.6",
-          "version": "5.11"
+          "version": "5.11.1"
         },
         {
           "artifacts": [
@@ -6292,21 +6716,21 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "59e29e55c478db69cffbe14ab24b5bd2cd615c0413edf790d47d3fb7ba9a4e23",
-              "url": "https://files.pythonhosted.org/packages/7d/e3/9d7afb48ad9366c8ae9821ba8049f9b2b856e84c3fcbc44338387b0f9497/pep8_naming-0.13.2-py3-none-any.whl"
+              "hash": "1a86b8c71a03337c97181917e2b472f0f5e4ccb06844a0d6f0a33522549e7a80",
+              "url": "https://files.pythonhosted.org/packages/4f/48/9533518e0394fb858ac2b4b55fe18f24aa33c87c943f691336ec842d9728/pep8_naming-0.13.3-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "93eef62f525fd12a6f8c98f4dcc17fa70baae2f37fa1f73bec00e3e44392fa48",
-              "url": "https://files.pythonhosted.org/packages/50/53/a8b7a6eb08be99920c86d0eebbecb2782141a36252a710aaa5cc920d6d20/pep8-naming-0.13.2.tar.gz"
+              "hash": "1705f046dfcd851378aac3be1cd1551c7c1e5ff363bacad707d43007877fa971",
+              "url": "https://files.pythonhosted.org/packages/5b/c0/0db8b2867395a9a137e86af8bdf5a566e41d9c6453e509cd3042419ae29e/pep8-naming-0.13.3.tar.gz"
             }
           ],
           "project_name": "pep8-naming",
           "requires_dists": [
-            "flake8>=3.9.1"
+            "flake8>=5.0.0"
           ],
           "requires_python": ">=3.7",
-          "version": "0.13.2"
+          "version": "0.13.3"
         },
         {
           "artifacts": [
@@ -6352,13 +6776,13 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "8eb655f8d7fcc568c68f172507f5879a85a30c88ab944263b38dbe704044dfa8",
-              "url": "https://files.pythonhosted.org/packages/80/12/442f602dd30899fc92ab8c5411d6ae909bcb6c8ce4184e84f38adff53a77/pkginfo-1.9.1-py2.py3-none-any.whl"
+              "hash": "4b7a555a6d5a22169fcc9cf7bfd78d296b0361adad412a346c1226849af5e546",
+              "url": "https://files.pythonhosted.org/packages/b3/f2/6e95c86a23a30fa205ea6303a524b20cbae27fbee69216377e3d95266406/pkginfo-1.9.6-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "4955f1c299e374ccb918dd895c0328d67599bad836dfda2b4639148a113dafec",
-              "url": "https://files.pythonhosted.org/packages/68/5b/fe21e200ff6433866a69f5515a222f3cb6a04897bcfb38bc0d69925ea772/pkginfo-1.9.1.tar.gz"
+              "hash": "8fd5896e8718a4372f0ea9cc9d96f6417c9b986e23a4d116dda26b62cc29d046",
+              "url": "https://files.pythonhosted.org/packages/b4/1c/89b38e431c20d6b2389ed8b3926c2ab72f58944733ba029354c6d9f69129/pkginfo-1.9.6.tar.gz"
             }
           ],
           "project_name": "pkginfo",
@@ -6367,34 +6791,36 @@
             "pytest; extra == \"testing\""
           ],
           "requires_python": ">=3.6",
-          "version": "1.9.1"
+          "version": "1.9.6"
         },
         {
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "af0276409f9a02373d540bf8480021a048711d572745aef4b7842dad245eba10",
-              "url": "https://files.pythonhosted.org/packages/61/e0/15ba41c6716acb033c3793be3a02f26c53914ecd9bdd6b315001f8f5f581/platformdirs-2.5.4-py3-none-any.whl"
+              "hash": "83c8f6d04389165de7c9b6f0c682439697887bca0aa2f1c87ef1826be3584490",
+              "url": "https://files.pythonhosted.org/packages/c1/c7/9be9d651b93efce682b45142a6267034fc4215972780748618c02e236361/platformdirs-2.6.2-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "1006647646d80f16130f052404c6b901e80ee4ed6bef6792e1f238a8969106f7",
-              "url": "https://files.pythonhosted.org/packages/cb/5f/dda8451435f17ed8043eab5ffe04e47d703debe8fe845eb074f42260e50a/platformdirs-2.5.4.tar.gz"
+              "hash": "e1fea1fe471b9ff8332e229df3cb7de4f53eeea4998d3b6bfff542115e998bd2",
+              "url": "https://files.pythonhosted.org/packages/cf/4d/198b7e6c6c2b152f4f9f4cdf975d3590e33e63f1920f2d89af7f0390e6db/platformdirs-2.6.2.tar.gz"
             }
           ],
           "project_name": "platformdirs",
           "requires_dists": [
             "appdirs==1.4.4; extra == \"test\"",
-            "furo>=2022.9.29; extra == \"docs\"",
+            "covdefaults>=2.2.2; extra == \"test\"",
+            "furo>=2022.12.7; extra == \"docs\"",
             "proselint>=0.13; extra == \"docs\"",
             "pytest-cov>=4; extra == \"test\"",
             "pytest-mock>=3.10; extra == \"test\"",
             "pytest>=7.2; extra == \"test\"",
-            "sphinx-autodoc-typehints>=1.19.4; extra == \"docs\"",
-            "sphinx>=5.3; extra == \"docs\""
+            "sphinx-autodoc-typehints>=1.19.5; extra == \"docs\"",
+            "sphinx>=5.3; extra == \"docs\"",
+            "typing-extensions>=4.4; python_version < \"3.8\""
           ],
           "requires_python": ">=3.7",
-          "version": "2.5.4"
+          "version": "2.6.2"
         },
         {
           "artifacts": [
@@ -6493,13 +6919,13 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "51a5ba7c480ae8072ecdb6933df22d2f812dc897d5fe848778116129a681aac7",
-              "url": "https://files.pythonhosted.org/packages/b2/6c/9ccb5213a3d9fd3f8c0fd69d207951901eaef86b7a1a69bcc478364d3072/pre_commit-2.20.0-py2.py3-none-any.whl"
+              "hash": "e2f91727039fc39a92f58a588a25b87f936de6567eed4f0e673e0507edc75bad",
+              "url": "https://files.pythonhosted.org/packages/a6/6b/6cfe3a8b351b54f4b6c6d2ad4286804e3367f628dce379c603d3b96635f4/pre_commit-2.21.0-py2.py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "a978dac7bc9ec0bcee55c18a277d553b0f419d259dadb4b9418ff2d00eb43959",
-              "url": "https://files.pythonhosted.org/packages/1e/ba/8cf8b88d0e07588818de46877effc9971305541d9421bc6377b06639d135/pre_commit-2.20.0.tar.gz"
+              "hash": "31ef31af7e474a8d8995027fefdfcf509b5c913ff31f2015b4ec4beb26a6f658",
+              "url": "https://files.pythonhosted.org/packages/6b/00/1637ae945c6e10838ef5c41965f1c864e59301811bb203e979f335608e7c/pre_commit-2.21.0.tar.gz"
             }
           ],
           "project_name": "pre-commit",
@@ -6509,11 +6935,10 @@
             "importlib-metadata; python_version < \"3.8\"",
             "nodeenv>=0.11.1",
             "pyyaml>=5.1",
-            "toml",
-            "virtualenv>=20.0.8"
+            "virtualenv>=20.10.0"
           ],
           "requires_python": ">=3.7",
-          "version": "2.20"
+          "version": "2.21"
         },
         {
           "artifacts": [
@@ -6539,13 +6964,13 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "ced598b222f6f4029c0800cefaa6a17373fb580cd093223003475ce32805c35b",
-              "url": "https://files.pythonhosted.org/packages/58/87/cac418cef18781a9081cb2075cc2cf08c77e0679c1f9b474587d71bbf777/prompt_toolkit-3.0.33-py3-none-any.whl"
+              "hash": "aa64ad242a462c5ff0363a7b9cfe696c20d55d9fc60c11fd8e632d064804d305",
+              "url": "https://files.pythonhosted.org/packages/eb/37/791f1a6edd13c61cac85282368aa68cb0f3f164440fdf60032f2cc6ca34e/prompt_toolkit-3.0.36-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "535c29c31216c77302877d5120aef6c94ff573748a5b5ca5b1b1f76f5e700c73",
-              "url": "https://files.pythonhosted.org/packages/c4/6e/6ff7938f47981305a801a4c5b8d8ed282b58a28c01c394d43c1fbcfc810b/prompt_toolkit-3.0.33.tar.gz"
+              "hash": "3e163f254bef5a03b146397d7c1963bd3e2812f0964bb9a24e6ec761fd28db63",
+              "url": "https://files.pythonhosted.org/packages/fb/93/180be2342f89f16543ec4eb3f25083b5b84eba5378f68efff05409fb39a9/prompt_toolkit-3.0.36.tar.gz"
             }
           ],
           "project_name": "prompt-toolkit",
@@ -6553,19 +6978,19 @@
             "wcwidth"
           ],
           "requires_python": ">=3.6.2",
-          "version": "3.0.33"
+          "version": "3.0.36"
         },
         {
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "ea8982669a23c379f74495bc48e3dcb47c822c484ce8ee1d1d7beb339d4e34c5",
-              "url": "https://files.pythonhosted.org/packages/fd/5b/4567ec6de6d11cc49f76856cde967bcd0d1b47e9c7abdf5bec31aa288344/proto_plus-1.22.1-py3-none-any.whl"
+              "hash": "de34e52d6c9c6fcd704192f09767cb561bb4ee64e70eede20b0834d841f0be4d",
+              "url": "https://files.pythonhosted.org/packages/f5/0e/a277783e8b7544008e625956dee8bbdec8c65fc4ae103fc5065a290abe92/proto_plus-1.22.2-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "6c7dfd122dfef8019ff654746be4f5b1d9c80bba787fe9611b508dd88be3a2fa",
-              "url": "https://files.pythonhosted.org/packages/86/e0/6d69b391daa71b8f47eda04a1e77c73eb5e89bf93b186e28628e221c51e7/proto-plus-1.22.1.tar.gz"
+              "hash": "0e8cda3d5a634d9895b75c573c9352c16486cb75deb0e078b5fda34db4243165",
+              "url": "https://files.pythonhosted.org/packages/38/ab/d5916bd1a56dfc2c9c268effd12a635ef7bbb2c9dc9b0270da72122afabb/proto-plus-1.22.2.tar.gz"
             }
           ],
           "project_name": "proto-plus",
@@ -6574,7 +6999,7 @@
             "protobuf<5.0.0dev,>=3.19.0"
           ],
           "requires_python": ">=3.6",
-          "version": "1.22.1"
+          "version": "1.22.2"
         },
         {
           "artifacts": [
@@ -6923,96 +7348,83 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "607c53218732647dff4acdfcd50cb62615cedf612e72d1724fb1a0cc6405b378",
-              "url": "https://files.pythonhosted.org/packages/f6/f0/10642828a8dfb741e5f3fbaac830550a518a775c7fff6f04a007259b0548/py-1.11.0-py2.py3-none-any.whl"
+              "hash": "0ec7587d759153f452d5263dbc8b1af318c4609b607be2bd5127dcda6708cdb1",
+              "url": "https://files.pythonhosted.org/packages/6b/7d/dfde28d33a2dd22c95529d361203b6dc0cbdf87d82988f7d03224de35fcf/pyarrow-10.0.1-cp39-cp39-win_amd64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "51c75c4126074b472f746a24399ad32f6053d1b34b68d2fa41e558e6f4a98719",
-              "url": "https://files.pythonhosted.org/packages/98/ff/fec109ceb715d2a6b4c4a85a61af3b40c723a961e8828319fbcb15b868dc/py-1.11.0.tar.gz"
-            }
-          ],
-          "project_name": "py",
-          "requires_dists": [],
-          "requires_python": "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,>=2.7",
-          "version": "1.11"
-        },
-        {
-          "artifacts": [
-            {
-              "algorithm": "sha256",
-              "hash": "fe2ce795fa1d95e4e940fe5661c3c58aee7181c730f65ac5dd8794a77228de59",
-              "url": "https://files.pythonhosted.org/packages/06/f5/0374d6350f51e244b0176e463ffdd98d78ecdd5bd93c55774dadeb780729/pyarrow-9.0.0-cp39-cp39-win_amd64.whl"
+              "hash": "1a14f57a5f472ce8234f2964cd5184cccaa8df7e04568c64edc33b23eb285dd5",
+              "url": "https://files.pythonhosted.org/packages/11/71/dd884e86aa92b2d602ee2064a485106ce5b447f8cae644f1a6f6a2e72016/pyarrow-10.0.1.tar.gz"
             },
             {
               "algorithm": "sha256",
-              "hash": "4eebdab05afa23d5d5274b24c1cbeb1ba017d67c280f7d39fd8a8f18cbad2ec9",
-              "url": "https://files.pythonhosted.org/packages/18/a5/3473e3d2487fde603c6b00e75f83556dd1e4307895fda9152a0cb495266d/pyarrow-9.0.0-cp39-cp39-macosx_10_13_universal2.whl"
+              "hash": "254017ca43c45c5098b7f2a00e995e1f8346b0fb0be225f042838323bb55283c",
+              "url": "https://files.pythonhosted.org/packages/1e/6e/915b7dfb7cfd2efd092b9b4d6579cb5848ba1dced3543bdd963df59ee2b5/pyarrow-10.0.1-cp311-cp311-macosx_11_0_arm64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "3eef8a981f45d89de403e81fb83b8119c20824caddf1404274e41a5d66c73806",
-              "url": "https://files.pythonhosted.org/packages/24/b5/8152fe17207dddc5b5d3c1107bfea821708c626f514728767381b61b7aac/pyarrow-9.0.0-cp310-cp310-win_amd64.whl"
+              "hash": "6f7a7dbe2f7f65ac1d0bd3163f756deb478a9e9afc2269557ed75b1b25ab3610",
+              "url": "https://files.pythonhosted.org/packages/26/02/62c918edc87e91bf07fd003f7ed8468d45130471b415754b27cf4db95896/pyarrow-10.0.1-cp310-cp310-macosx_11_0_arm64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "767cafb14278165ad539a2918c14c1b73cf20689747c21375c38e3fe62884902",
-              "url": "https://files.pythonhosted.org/packages/56/b4/34927870cc4d50c2518974cd1d817c0765854d23b7d53c7084e925fb0050/pyarrow-9.0.0-cp310-cp310-macosx_10_13_universal2.whl"
+              "hash": "7b4ede715c004b6fc535de63ef79fa29740b4080639a5ff1ea9ca84e9282f349",
+              "url": "https://files.pythonhosted.org/packages/33/15/b62e72b04f48de27cc97a874c0f466cda8731444e380b75c58272a9fc649/pyarrow-10.0.1-cp310-cp310-win_amd64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "02b820ecd1da02012092c180447de449fc688d0c3f9ff8526ca301cdd60dacd0",
-              "url": "https://files.pythonhosted.org/packages/66/33/09f517e047da2fb9a50d3965ebeb60d84bed69c0fcabcca92458fc045d61/pyarrow-9.0.0-cp39-cp39-macosx_10_13_x86_64.whl"
+              "hash": "abb57334f2c57979a49b7be2792c31c23430ca02d24becd0b511cbe7b6b08649",
+              "url": "https://files.pythonhosted.org/packages/81/53/385279a985567a8a909bf9365cd15fc87c26ebe7db60a7220e4eeb407c87/pyarrow-10.0.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "f241bd488c2705df930eedfe304ada71191dcf67d6b98ceda0cc934fd2a8388e",
-              "url": "https://files.pythonhosted.org/packages/66/5c/ad8eec261ea6ef357b95aef6db92105edc6d8fa572191c4bd1bc8b8ea724/pyarrow-9.0.0-cp39-cp39-macosx_11_0_arm64.whl"
+              "hash": "1765a18205eb1e02ccdedb66049b0ec148c2a0cb52ed1fb3aac322dfc086a6ee",
+              "url": "https://files.pythonhosted.org/packages/90/69/9e0ea39bed0d281e84cc3cd4a693ebc86266b705d910af9cc939e66c5d03/pyarrow-10.0.1-cp311-cp311-win_amd64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "92f3977e901db1ef5cba30d6cc1d7942b8d94b910c60f89013e8f7bb86a86eef",
-              "url": "https://files.pythonhosted.org/packages/7c/ea/be7026f60cf777a712b1180e9c67e546431fcedc4562e7b6929af9d8286c/pyarrow-9.0.0-cp39-cp39-macosx_10_9_x86_64.whl"
+              "hash": "94fb4a0c12a2ac1ed8e7e2aa52aade833772cf2d3de9dde685401b22cec30002",
+              "url": "https://files.pythonhosted.org/packages/a4/48/19c8b4892d2d574dfbefa7065600aa4d7d8e8b864f7be5f58105c3fc0448/pyarrow-10.0.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "7fb02bebc13ab55573d1ae9bb5002a6d20ba767bf8569b52fce5301d42495ab7",
-              "url": "https://files.pythonhosted.org/packages/80/2e/22fb489b4be6bc5c7202b7afd4ea3e941f9b1d79c0e3f59f64be8e92160d/pyarrow-9.0.0.tar.gz"
+              "hash": "db0c5986bf0808927f49640582d2032a07aa49828f14e51f362075f03747d198",
+              "url": "https://files.pythonhosted.org/packages/b2/d2/77f002c442ed75f0cd19b744e34894544d25fc34bbdc8efeb33bd52d8de0/pyarrow-10.0.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "0238998dc692efcb4e41ae74738d7c1234723271ccf520bd8312dca07d49ef8d",
-              "url": "https://files.pythonhosted.org/packages/a1/62/f159d6c66ef148bcdb83646b82b0b9761c193876f355c0be7dd3f02ca6e8/pyarrow-9.0.0-cp310-cp310-macosx_10_13_x86_64.whl"
+              "hash": "b069602eb1fc09f1adec0a7bdd7897f4d25575611dfa43543c8b8a75d99d6874",
+              "url": "https://files.pythonhosted.org/packages/b6/14/208f66e1c2f213ffc053e3d37b10ba41d0580654501dcd620ad5d32d056e/pyarrow-10.0.1-cp39-cp39-macosx_11_0_arm64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "f59bcd5217a3ae1e17870792f82b2ff92df9f3862996e2c78e156c13e56ff62e",
-              "url": "https://files.pythonhosted.org/packages/b3/a5/ac3fa0c2b20a7b6782ead8a956c6c6bdb31d0ddde6d20e26734ca4760431/pyarrow-9.0.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+              "hash": "42ba7c5347ce665338f2bc64685d74855900200dac81a972d49fe127e8132f75",
+              "url": "https://files.pythonhosted.org/packages/b9/46/0050ff96706f27b766497d63ad60f8bace6a4e61565594bd8079b33e81af/pyarrow-10.0.1-cp39-cp39-macosx_10_14_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "29eb3e086e2b26202f3a4678316b93cfb15d0e2ba20f3ec12db8fd9cc07cde63",
-              "url": "https://files.pythonhosted.org/packages/b7/e6/cfd9cd4ec0f6c95336d410d9daf402649731f61cd8a25c8f14421a089d39/pyarrow-9.0.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+              "hash": "e00174764a8b4e9d8d5909b6d19ee0c217a6cf0232c5682e31fdfbd5a9f0ae52",
+              "url": "https://files.pythonhosted.org/packages/da/8a/9fa72ef41bd47816f11e6c3c5b68c0a913d2005a3e1aa327dfaa936debb9/pyarrow-10.0.1-cp310-cp310-macosx_10_14_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "1c5a073a930c632058461547e0bc572da1e724b17b6b9eb31a97da13f50cb6e0",
-              "url": "https://files.pythonhosted.org/packages/cb/d2/dd6854751db7870f3f98a3d8d36cd466c4e0fa90eddf8ed35627feced9aa/pyarrow-9.0.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+              "hash": "ba71e6fc348c92477586424566110d332f60d9a35cb85278f42e3473bc1373da",
+              "url": "https://files.pythonhosted.org/packages/db/9f/ef33d4f60089bbe32a5620e599cb485cfd9306bd1663bc603354759c28eb/pyarrow-10.0.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "55328348b9139c2b47450d512d716c2248fd58e2f04e2fc23a65e18726666d42",
-              "url": "https://files.pythonhosted.org/packages/e4/98/6f00d0b22becfb7f1090f47d65501c2418ce319c6496a991a17389282914/pyarrow-9.0.0-cp310-cp310-macosx_10_9_x86_64.whl"
+              "hash": "70acca1ece4322705652f48db65145b5028f2c01c7e426c5d16a30ba5d739c24",
+              "url": "https://files.pythonhosted.org/packages/ef/87/a0849cd20c75dd832683fdad0b321e6428281f3f3053e01c588269ae5b89/pyarrow-10.0.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "fc856628acd8d281652c15b6268ec7f27ebcb015abbe99d9baad17f02adc51f1",
-              "url": "https://files.pythonhosted.org/packages/ec/8d/f92689e1db1ba1144608fd5d54ad336c50eaee2bf7fe5e96195169c7ed9b/pyarrow-9.0.0-cp310-cp310-macosx_11_0_arm64.whl"
+              "hash": "e3fe5049d2e9ca661d8e43fab6ad5a4c571af12d20a57dffc392a014caebef65",
+              "url": "https://files.pythonhosted.org/packages/f8/fe/4e2d2cd7e0d544018d7c7fee3dcee80303e16111605716592dd5333a2212/pyarrow-10.0.1-cp311-cp311-macosx_10_14_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "2e753f8fcf07d8e3a0efa0c8bd51fef5c90281ffd4c5637c08ce42cd0ac297de",
-              "url": "https://files.pythonhosted.org/packages/fb/d2/ca22dc35b01cdf104a29ac7aa0ac1743d7202d13e92e3025f2bad22967c5/pyarrow-9.0.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+              "hash": "cb627673cb98708ef00864e2e243f51ba7b4c1b9f07a1d821f98043eccd3f585",
+              "url": "https://files.pythonhosted.org/packages/fd/3e/9f538cc3e048ae2de171ae4bb326c5482ba2bd63978c56bd29110e65ba09/pyarrow-10.0.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
             }
           ],
           "project_name": "pyarrow",
@@ -7020,7 +7432,7 @@
             "numpy>=1.16.6"
           ],
           "requires_python": ">=3.7",
-          "version": "9"
+          "version": "10.0.1"
         },
         {
           "artifacts": [
@@ -7100,149 +7512,150 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "1b6ee725bd6e83ec78b1aa32c5b1fa67a3a65badddde3976bca5fe4568f27709",
-              "url": "https://files.pythonhosted.org/packages/d4/ec/230ab377c457cd68cfda78759e2a57f8c08a9e9adb4cd53c4d2fc9100b15/pydantic-1.10.2-py3-none-any.whl"
+              "hash": "4948f264678c703f3877d1c8877c4e3b2e12e549c57795107f08cf70c6ec7774",
+              "url": "https://files.pythonhosted.org/packages/58/1b/0132040ef3e8ec0ce96142d4759bde9f16b52ab7eac5f2c1ce3a5b641f16/pydantic-1.10.4-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "05e00dbebbe810b33c7a7362f231893183bcc4251f3f2ff991c31d5c08240c42",
-              "url": "https://files.pythonhosted.org/packages/33/82/40effb1628768af97223df215ed909cc25e0d04d5503667cf7fb5266ee0d/pydantic-1.10.2-cp311-cp311-musllinux_1_1_i686.whl"
+              "hash": "05a81b006be15655b2a1bae5faa4280cf7c81d0e09fcb49b342ebf826abe5a72",
+              "url": "https://files.pythonhosted.org/packages/09/46/66c65d678e4c1b151c36bd61fd7ad9ebd1b48ecccc115d5dc77c1d7fe476/pydantic-1.10.4-cp311-cp311-musllinux_1_1_i686.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "6eb843dcc411b6a2237a694f5e1d649fc66c6064d02b204a7e9d194dff81eb4b",
-              "url": "https://files.pythonhosted.org/packages/4c/5f/11db15638a3f5b29c7ae6f24b43c1e7985f09b0fe983621d7ef1ff722020/pydantic-1.10.2-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+              "hash": "51bdeb10d2db0f288e71d49c9cefa609bca271720ecd0c58009bd7504a0c464c",
+              "url": "https://files.pythonhosted.org/packages/12/74/797cf42ee7093e73f740224ee7f9d3faba6e5f674243078a51fc38ba7a78/pydantic-1.10.4-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "a1f5a63a6dfe19d719b1b6e6106561869d2efaca6167f84f5ab9347887d78b98",
-              "url": "https://files.pythonhosted.org/packages/4c/a9/26873855ce8c1d84cc892036c3396dd1e2d3233201d0b7002451f679ad8d/pydantic-1.10.2-cp310-cp310-macosx_11_0_arm64.whl"
+              "hash": "6dc1cc241440ed7ca9ab59d9929075445da6b7c94ced281b3dd4cfe6c8cff817",
+              "url": "https://files.pythonhosted.org/packages/17/70/139ae58f5fa5e9000c63d49e1b74a256a74abf4064d7e9b236adc3e21251/pydantic-1.10.4-cp310-cp310-macosx_11_0_arm64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "7b5ba54d026c2bd2cb769d3468885f23f43710f651688e91f5fb1edcf0ee9283",
-              "url": "https://files.pythonhosted.org/packages/5d/96/3861db92c405d491d02abf17a88f04575311f36688bdb9fb086838d0b379/pydantic-1.10.2-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl"
+              "hash": "990406d226dea0e8f25f643b370224771878142155b879784ce89f633541a024",
+              "url": "https://files.pythonhosted.org/packages/36/78/1755a9fe87b0480775bce2e812049669adbe4b006787257d288806caa580/pydantic-1.10.4-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "e0bedafe4bc165ad0a56ac0bd7695df25c50f76961da29c050712596cf092d6d",
-              "url": "https://files.pythonhosted.org/packages/65/06/5925bb1302daaacc28cdf3ac832d62bd0f5fdda5c648409d98cce26d78a4/pydantic-1.10.2-cp39-cp39-musllinux_1_1_i686.whl"
+              "hash": "fdf8d759ef326962b4678d89e275ffc55b7ce59d917d9f72233762061fd04a2d",
+              "url": "https://files.pythonhosted.org/packages/49/0c/3cb9ddf7aba9a13c56585401ee7ea345ed583c2f848e783eec634c9726d3/pydantic-1.10.4-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "e9069e1b01525a96e6ff49e25876d90d5a563bc31c658289a8772ae186552236",
-              "url": "https://files.pythonhosted.org/packages/6e/fd/8ffad95e696caf36834c3819d1509f8fb146120501c8deb27c8bfb146b26/pydantic-1.10.2-cp310-cp310-musllinux_1_1_i686.whl"
+              "hash": "572066051eeac73d23f95ba9a71349c42a3e05999d0ee1572b7860235b850cc6",
+              "url": "https://files.pythonhosted.org/packages/49/90/ff3dd0265279a2f0607995dfcd77720f0130918cf11ee9449b106d99b942/pydantic-1.10.4-cp310-cp310-musllinux_1_1_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "37c90345ec7dd2f1bcef82ce49b6235b40f282b94d3eec47e801baf864d15525",
-              "url": "https://files.pythonhosted.org/packages/74/4f/ea30b0bc3ea6f41d73c9aaa26fd51bd9d4f6f755c62625b592c2c2b1b6f0/pydantic-1.10.2-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+              "hash": "8775d4ef5e7299a2f4699501077a0defdaac5b6c4321173bcb0f3c496fbadf85",
+              "url": "https://files.pythonhosted.org/packages/4a/52/79167d367d0765effd60faef145c54a213a5feab7a5c97055fa368f25031/pydantic-1.10.4-cp310-cp310-musllinux_1_1_i686.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "91b8e218852ef6007c2b98cd861601c6a09f1aa32bbbb74fab5b1c33d4a1e410",
-              "url": "https://files.pythonhosted.org/packages/7d/7d/58dd62f792b002fa28cce4e83cb90f4359809e6d12db86eedf26a752895c/pydantic-1.10.2.tar.gz"
+              "hash": "eb992a1ef739cc7b543576337bebfc62c0e6567434e522e97291b251a41dad7f",
+              "url": "https://files.pythonhosted.org/packages/4e/26/38b8e36129e1f9e4d5e4481cee0cbc49b778ac103777c50cb2fca714afbe/pydantic-1.10.4-cp39-cp39-macosx_11_0_arm64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "352aedb1d71b8b0736c6d56ad2bd34c6982720644b0624462059ab29bd6e5912",
-              "url": "https://files.pythonhosted.org/packages/87/f7/b02ec31ffd6eafdd2ca8a4a9f1a3ad2fa68ca8b850de82bbe99053e3d2c0/pydantic-1.10.2-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+              "hash": "b9a3859f24eb4e097502a3be1fb4b2abb79b6103dd9e2e0edb70613a4459a648",
+              "url": "https://files.pythonhosted.org/packages/53/17/34e54e352f6a3d304044e52d5ddd5cd621a62ec8fb7af08cc73af65dd3e1/pydantic-1.10.4.tar.gz"
             },
             {
               "algorithm": "sha256",
-              "hash": "19b3b9ccf97af2b7519c42032441a891a5e05c68368f40865a90eb88833c2559",
-              "url": "https://files.pythonhosted.org/packages/88/6f/69a98253109e15de3eba1b6ec5c621f01c9e3735c2d3e6a949b4f467d78e/pydantic-1.10.2-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl"
+              "hash": "d88c4c0e5c5dfd05092a4b271282ef0588e5f4aaf345778056fc5259ba098857",
+              "url": "https://files.pythonhosted.org/packages/54/7e/e111f6ff353af848d44bb4f40311c1ca7dfb284efbf8a41122a6091a0996/pydantic-1.10.4-cp311-cp311-musllinux_1_1_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "d49f3db871575e0426b12e2f32fdb25e579dea16486a26e5a0474af87cb1ab0a",
-              "url": "https://files.pythonhosted.org/packages/92/fb/0d5e414d3f72b43c50572f63647fab3abf41cc9f04f810bec97e4d61f09a/pydantic-1.10.2-cp311-cp311-macosx_11_0_arm64.whl"
+              "hash": "7feb6a2d401f4d6863050f58325b8d99c1e56f4512d98b11ac64ad1751dc647d",
+              "url": "https://files.pythonhosted.org/packages/5f/05/faa76cdd1d58066678b104a8bfa2b657144b1996773d655e2d5abb72bfeb/pydantic-1.10.4-cp310-cp310-win_amd64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "2e05aed07fa02231dbf03d0adb1be1d79cabb09025dd45aa094aa8b4e7b9dcda",
-              "url": "https://files.pythonhosted.org/packages/97/d5/dc4bd637ba0c2cefc58f40415116b9bbc315aa41da158dc3b81d9d981c1c/pydantic-1.10.2-cp39-cp39-musllinux_1_1_x86_64.whl"
+              "hash": "2b3ce5f16deb45c472dde1a0ee05619298c864a20cded09c4edd820e1454129f",
+              "url": "https://files.pythonhosted.org/packages/6b/85/c3c30a050f04668dccf4ce8df015242a7ccaea8dface44b342f173f68991/pydantic-1.10.4-cp39-cp39-musllinux_1_1_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "2d0567e60eb01bccda3a4df01df677adf6b437958d35c12a3ac3e0f078b0ee52",
-              "url": "https://files.pythonhosted.org/packages/a9/ce/f01d53fa974c954610e08be73058436f5df6a5125929a8d732030eeb19a8/pydantic-1.10.2-cp311-cp311-musllinux_1_1_x86_64.whl"
+              "hash": "2e82a6d37a95e0b1b42b82ab340ada3963aea1317fd7f888bb6b9dfbf4fff57c",
+              "url": "https://files.pythonhosted.org/packages/6e/00/7e25a76d3629999587ea4f30b0b15f52a14a43c811a80168900005500f9b/pydantic-1.10.4-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "c33602f93bfb67779f9c507e4d69451664524389546bacfe1bee13cae6dc7488",
-              "url": "https://files.pythonhosted.org/packages/af/cf/beecf80bc07c9bd1612219b053950af9b04eb597806c9905dbcfd75fa50d/pydantic-1.10.2-cp39-cp39-macosx_10_9_x86_64.whl"
+              "hash": "983e720704431a6573d626b00662eb78a07148c9115129f9b4351091ec95ecc3",
+              "url": "https://files.pythonhosted.org/packages/87/7e/aec14140cb0ee6b62b5777e9d28eea44813b4d590826ad518b7e197e1200/pydantic-1.10.4-cp311-cp311-macosx_11_0_arm64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "c6f981882aea41e021f72779ce2a4e87267458cc4d39ea990729e21ef18f0f8c",
-              "url": "https://files.pythonhosted.org/packages/b0/b5/b673ec4154429dcf152e993fd0a2146a3f8a2de3bc4a2dd0768ba051eefb/pydantic-1.10.2-cp311-cp311-win_amd64.whl"
+              "hash": "b5635de53e6686fe7a44b5cf25fcc419a0d5e5c1a1efe73d49d48fe7586db854",
+              "url": "https://files.pythonhosted.org/packages/88/b4/123955cfb978fb9d2cfde7a92b588cffca5cb3772702a09e4ab5807574b1/pydantic-1.10.4-cp310-cp310-macosx_10_9_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "4b8795290deaae348c4eba0cebb196e1c6b98bdbe7f50b2d0d9a4a99716342fe",
-              "url": "https://files.pythonhosted.org/packages/b2/74/961f37b2c2df5c021dd4ac981750a455f0eea312f3eb074a0b7f0fd4663d/pydantic-1.10.2-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl"
+              "hash": "78cec42b95dbb500a1f7120bdf95c401f6abb616bbe8785ef09887306792e66e",
+              "url": "https://files.pythonhosted.org/packages/9e/85/13eb8a5121d1d37826118ac8d88fe856229aad43396a3680307eaee8c73e/pydantic-1.10.4-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "a4c805731c33a8db4b6ace45ce440c4ef5336e712508b4d9e1aafa617dc9907f",
-              "url": "https://files.pythonhosted.org/packages/c4/ab/25e2515801f17d1434500ed59405a9f13030891896bd4fc90088f8bdf610/pydantic-1.10.2-cp311-cp311-macosx_10_9_x86_64.whl"
+              "hash": "9193d4f4ee8feca58bc56c8306bcb820f5c7905fd919e0750acdeeeef0615b28",
+              "url": "https://files.pythonhosted.org/packages/ae/97/c9716e8060e3ed0bbd954258babe4c2f75092ca923972101d791230dcb7e/pydantic-1.10.4-cp39-cp39-musllinux_1_1_i686.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "355639d9afc76bcb9b0c3000ddcd08472ae75318a6eb67a15866b87e2efa168c",
-              "url": "https://files.pythonhosted.org/packages/c6/9b/7a383fbd1f5f0ec8143fb9ebf57c22c4356fadedc0ca376262117e6f2878/pydantic-1.10.2-cp310-cp310-musllinux_1_1_x86_64.whl"
+              "hash": "a9a6747cac06c2beb466064dda999a13176b23535e4c496c9d48e6406f92d42d",
+              "url": "https://files.pythonhosted.org/packages/ba/7f/47a90201dc4c11a514dfba59c689491d5018b83be21f682aa602c845c125/pydantic-1.10.4-cp39-cp39-macosx_10_9_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "ae544c47bec47a86bc7d350f965d8b15540e27e5aa4f55170ac6a75e5f73b644",
-              "url": "https://files.pythonhosted.org/packages/d6/8b/9ec347ac3a848bb8c356ec6c6a5a5066300f37e985915b0fa68cf78f448a/pydantic-1.10.2-cp310-cp310-win_amd64.whl"
+              "hash": "75d52162fe6b2b55964fbb0af2ee58e99791a3138588c482572bb6087953113a",
+              "url": "https://files.pythonhosted.org/packages/d1/1a/44c9e2fa8d94cfb1d73352205960798d991a1236aec09d15bf702874ac64/pydantic-1.10.4-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "c1ba1afb396148bbc70e9eaa8c06c1716fdddabaf86e7027c5988bae2a829ab6",
-              "url": "https://files.pythonhosted.org/packages/ef/a8/c11b225b5eae30cf7c00be4d056705aaee42cc646e77e7bda9e407728619/pydantic-1.10.2-cp39-cp39-win_amd64.whl"
+              "hash": "6a05a9db1ef5be0fe63e988f9617ca2551013f55000289c671f71ec16f4985e3",
+              "url": "https://files.pythonhosted.org/packages/db/2a/41d60a843328d91b12c6efd1a18b17606bd2ebe498647e75721a9317b433/pydantic-1.10.4-cp311-cp311-win_amd64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "5760e164b807a48a8f25f8aa1a6d857e6ce62e7ec83ea5d5c5a802eac81bad41",
-              "url": "https://files.pythonhosted.org/packages/f8/91/814d1d833d4d53ae4854dcb23256c55758b0fc01b90b20a297ee2c76bb84/pydantic-1.10.2-cp39-cp39-macosx_11_0_arm64.whl"
+              "hash": "9cbdc268a62d9a98c56e2452d6c41c0263d64a2009aac69246486f01b4f594c4",
+              "url": "https://files.pythonhosted.org/packages/ea/45/86ec3475f45f02858808643f38700788c64bfef0896566936dc33a78d4ba/pydantic-1.10.4-cp39-cp39-win_amd64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "bb6ad4489af1bac6955d38ebcb95079a836af31e4c4f74aba1ca05bb9f6027bd",
-              "url": "https://files.pythonhosted.org/packages/fe/fd/8f7f8271d526378c927babd1229501e576760cef9a509909a3415eec3c0d/pydantic-1.10.2-cp310-cp310-macosx_10_9_x86_64.whl"
+              "hash": "39f4a73e5342b25c2959529f07f026ef58147249f9b7431e1ba8414a36761f53",
+              "url": "https://files.pythonhosted.org/packages/ec/f2/c136265b246eb0411b293763e1b5e18a22de2d8d6a084e5c3d7b9e6e796e/pydantic-1.10.4-cp311-cp311-macosx_10_9_x86_64.whl"
             }
           ],
           "project_name": "pydantic",
           "requires_dists": [
             "email-validator>=1.0.3; extra == \"email\"",
             "python-dotenv>=0.10.4; extra == \"dotenv\"",
-            "typing-extensions>=4.1.0"
+            "typing-extensions>=4.2.0"
           ],
           "requires_python": ">=3.7",
-          "version": "1.10.2"
+          "version": "1.10.4"
         },
         {
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "6987826d6775056839940041beef5c08cc7e3d71d63149b48e36727f70144dc4",
-              "url": "https://files.pythonhosted.org/packages/87/67/4df10786068766000518c6ad9c4a614e77585a12ab8f0654c776757ac9dc/pydocstyle-6.1.1-py3-none-any.whl"
+              "hash": "118762d452a49d6b05e194ef344a55822987a462831ade91ec5c06fd2169d019",
+              "url": "https://files.pythonhosted.org/packages/36/ea/99ddefac41971acad68f14114f38261c1f27dac0b3ec529824ebc739bdaa/pydocstyle-6.3.0-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "1d41b7c459ba0ee6c345f2eb9ae827cab14a7533a88c5c6f7e94923f72df92dc",
-              "url": "https://files.pythonhosted.org/packages/4c/30/4cdea3c8342ad343d41603afc1372167c224a04dc5dc0bf4193ccb39b370/pydocstyle-6.1.1.tar.gz"
+              "hash": "7ce43f0c0ac87b07494eb9c0b462c0b73e6ff276807f204d6b53edc72b7e44e1",
+              "url": "https://files.pythonhosted.org/packages/e9/5c/d5385ca59fd065e3c6a5fe19f9bc9d5ea7f2509fa8c9c22fb6b2031dd953/pydocstyle-6.3.0.tar.gz"
             }
           ],
           "project_name": "pydocstyle",
           "requires_dists": [
-            "snowballstemmer",
-            "toml; extra == \"toml\""
+            "importlib-metadata<5.0.0,>=2.0.0; python_version < \"3.8\"",
+            "snowballstemmer>=2.2.0",
+            "tomli>=1.2.3; python_version < \"3.11\" and extra == \"toml\""
           ],
           "requires_python": ">=3.6",
-          "version": "6.1.1"
+          "version": "6.3"
         },
         {
           "artifacts": [
@@ -7266,13 +7679,13 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "f643f331ab57ba3c9d89212ee4a2dabc6e94f117cf4eefde99a0574720d14c42",
-              "url": "https://files.pythonhosted.org/packages/4f/82/672cd382e5b39ab1cd422a672382f08a1fb3d08d9e0c0f3707f33a52063b/Pygments-2.13.0-py3-none-any.whl"
+              "hash": "fa7bd7bd2771287c0de303af8bfdfc731f51bd2c6a47ab69d117138893b82717",
+              "url": "https://files.pythonhosted.org/packages/0b/42/d9d95cc461f098f204cd20c85642ae40fbff81f74c300341b8d0e0df14e0/Pygments-2.14.0-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "56a8508ae95f98e2b9bdf93a6be5ae3f7d8af858b43e02c5a2ff083726be40c1",
-              "url": "https://files.pythonhosted.org/packages/e0/ef/5905cd3642f2337d44143529c941cc3a02e5af16f0f65f81cbef7af452bb/Pygments-2.13.0.tar.gz"
+              "hash": "b3ed06a9e8ac9a9aae5a6f5dbe78a8a58655d17b43b93c078f094ddc476ae297",
+              "url": "https://files.pythonhosted.org/packages/da/6a/c427c06913204e24de28de5300d3f0e809933f376e0b7df95194b2bb3f71/Pygments-2.14.0.tar.gz"
             }
           ],
           "project_name": "pygments",
@@ -7280,7 +7693,7 @@
             "importlib-metadata; python_version < \"3.8\" and extra == \"plugins\""
           ],
           "requires_python": ">=3.6",
-          "version": "2.13"
+          "version": "2.14"
         },
         {
           "artifacts": [
@@ -7390,81 +7803,106 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "ea6b79a02a28550c98b6ca9c35b9f492beaa54d7c5c9e9949555893c8a9234d0",
-              "url": "https://files.pythonhosted.org/packages/54/d3/986fcfeaf62047840c571a857fb8f3ad1e9622081d5e7d0ee5e3451ca2e7/pyrsistent-0.19.2-py3-none-any.whl"
+              "hash": "ccf0d6bd208f8111179f0c26fdf84ed7c3891982f2edaeae7422575f47e66b64",
+              "url": "https://files.pythonhosted.org/packages/64/de/375aa14daaee107f987da76ca32f7a907fea00fa8b8afb67dc09bec0de91/pyrsistent-0.19.3-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "f1258f4e6c42ad0b20f9cfcc3ada5bd6b83374516cd01c0960e3cb75fdca6770",
-              "url": "https://files.pythonhosted.org/packages/23/d9/3ffebba2a20084b56f8132ab1fa959161dcf6da4f27c85a4a4c9cc438db1/pyrsistent-0.19.2-cp39-cp39-macosx_10_9_universal2.whl"
+              "hash": "4c18264cb84b5e68e7085a43723f9e4c1fd1d935ab240ce02c0324a8e01ccb64",
+              "url": "https://files.pythonhosted.org/packages/40/04/f1d7813d4cdb62ed58e75b53e2ef481b47081ab5ad2a104cd284fa507042/pyrsistent-0.19.3-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "456cb30ca8bff00596519f2c53e42c245c09e1a4543945703acd4312949bfd41",
-              "url": "https://files.pythonhosted.org/packages/42/c2/019693915e5d6fc88a145f4a4846fb4dc2a83cfa0a04256c76771eafb015/pyrsistent-0.19.2-cp310-cp310-win32.whl"
+              "hash": "5a474fb80f5e0d6c9394d8db0fc19e90fa540b82ee52dba7d246a7791712f74a",
+              "url": "https://files.pythonhosted.org/packages/57/3e/50aa661939ba1bfc2cc78817ecb37ecb55aef9eda55a193f8da381a8b7a1/pyrsistent-0.19.3-cp310-cp310-win32.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "dec3eac7549869365fe263831f576c8457f6c833937c68542d08fde73457d291",
-              "url": "https://files.pythonhosted.org/packages/44/91/42f8dab8dbe3bb1f07409566085feeb237c28e9cf6e8957aa2377cad78c1/pyrsistent-0.19.2-cp39-cp39-win_amd64.whl"
+              "hash": "3ab2204234c0ecd8b9368dbd6a53e83c3d4f3cab10ecaf6d0e772f456c442393",
+              "url": "https://files.pythonhosted.org/packages/64/bd/b108e1a288a63871be1cf062176dcd5be922c748f843f316440104a45df3/pyrsistent-0.19.3-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "187d5730b0507d9285a96fca9716310d572e5464cadd19f22b63a6976254d77a",
-              "url": "https://files.pythonhosted.org/packages/54/d8/96308460ee237abf28b7798c491f8545a51e1c3e2f01895da4530c7bff86/pyrsistent-0.19.2-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+              "hash": "4b774f9288dda8d425adb6544e5903f1fb6c273ab3128a355c6b972b7df39dcf",
+              "url": "https://files.pythonhosted.org/packages/73/55/1e300772f5c24921a81fc1c8b3de8a06a199c4ebb523d7c5a85f4e74a32e/pyrsistent-0.19.3-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "b39725209e06759217d1ac5fcdb510e98670af9e37223985f330b611f62e7425",
-              "url": "https://files.pythonhosted.org/packages/5e/f7/31748ccbbe68eb990347f252c4a39fcb1766e22907314922262a1dc5e1f6/pyrsistent-0.19.2-cp310-cp310-win_amd64.whl"
+              "hash": "e42296a09e83028b3476f7073fcb69ffebac0e66dbbfd1bd847d61f74db30f19",
+              "url": "https://files.pythonhosted.org/packages/86/f2/fda71652a6baa0147891296a99b4145572538417609c164450beebcf8ebc/pyrsistent-0.19.3-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "bfd880614c6237243ff53a0539f1cb26987a6dc8ac6e66e0c5a40617296a045e",
-              "url": "https://files.pythonhosted.org/packages/8c/a8/bd70a21552061cc43e4ea9aa329990ca16af0ab747d3f8524d3778aba2f0/pyrsistent-0.19.2-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl"
+              "hash": "49c32f216c17148695ca0e02a5c521e28a4ee6c5089f97e34fe24163113722da",
+              "url": "https://files.pythonhosted.org/packages/87/72/e5b2347f136d14f09c8260a2e3a528be94e536d97e6635cc9f22cff2d88c/pyrsistent-0.19.3-cp310-cp310-win_amd64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "d6982b5a0237e1b7d876b60265564648a69b14017f3b5f908c5be2de3f9abb7a",
-              "url": "https://files.pythonhosted.org/packages/96/ad/a95f96af0f645ff74dc2145ab3d920c77a0d9d547dbaddb721c31bbeec53/pyrsistent-0.19.2-cp310-cp310-macosx_10_9_universal2.whl"
+              "hash": "99abb85579e2165bd8522f0c0138864da97847875ecbd45f3e7e2af569bfc6f2",
+              "url": "https://files.pythonhosted.org/packages/af/3e/7c94e58ade258179c2e13fb254f040830e97654d76dee8288200d30d575d/pyrsistent-0.19.3-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "71d332b0320642b3261e9fee47ab9e65872c2bd90260e5d225dabeed93cbd42b",
-              "url": "https://files.pythonhosted.org/packages/a1/96/15848046e77dfe560f11099face554dc2e4b50f8b28d152be0ed72cd5a08/pyrsistent-0.19.2-cp39-cp39-win32.whl"
+              "hash": "f0774bf48631f3a20471dd7c5989657b639fd2d285b861237ea9e82c36a415a9",
+              "url": "https://files.pythonhosted.org/packages/b1/46/3f9cfa75c46b8a55d3a235456bc129a26431a65e4922fc9af66aa4e2db7e/pyrsistent-0.19.3-cp311-cp311-macosx_10_9_universal2.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "bfa0351be89c9fcbcb8c9879b826f4353be10f58f8a677efab0c017bf7137ec2",
-              "url": "https://files.pythonhosted.org/packages/b8/ef/325da441a385a8a931b3eeb70db23cb52da42799691988d8d943c5237f10/pyrsistent-0.19.2.tar.gz"
+              "hash": "016ad1afadf318eb7911baa24b049909f7f3bb2c5b1ed7b6a8f21db21ea3faa8",
+              "url": "https://files.pythonhosted.org/packages/b2/ea/055a9c1884be7c77dd68d9a7891e7a39c776c86946aa4630f8f9f8e48169/pyrsistent-0.19.3-cp311-cp311-win_amd64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "21455e2b16000440e896ab99e8304617151981ed40c29e9507ef1c2e4314ee95",
-              "url": "https://files.pythonhosted.org/packages/cd/2d/cf7bcdfcf5aba1a68ced5b32620e7c165d0491bd962d6cd1e78b1c1b2d7a/pyrsistent-0.19.2-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+              "hash": "c74bed51f9b41c48366a286395c67f4e894374306b197e62810e0fdaf2364da2",
+              "url": "https://files.pythonhosted.org/packages/b3/e6/43c7f666703506f8d5c5d2c7bc223346c6fa0e0fe392074c2b5788a577f8/pyrsistent-0.19.3-cp39-cp39-win32.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "055ab45d5911d7cae397dc418808d8802fb95262751872c841c170b0dbf51eed",
-              "url": "https://files.pythonhosted.org/packages/d9/ca/47cbb30a777aa74e4c40221385fb0c5eee5adfdb5406d29b4d10170dd243/pyrsistent-0.19.2-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl"
+              "hash": "1a2994773706bbb4995c31a97bc94f1418314923bd1048c6d964837040376440",
+              "url": "https://files.pythonhosted.org/packages/bf/90/445a7dbd275c654c268f47fa9452152709134f61f09605cf776407055a89/pyrsistent-0.19.3.tar.gz"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "878433581fc23e906d947a6814336eee031a00e6defba224234169ae3d3d6a98",
+              "url": "https://files.pythonhosted.org/packages/c3/c7/185e37df78c1e34c14961cbd7c89945e27825b5a41bf455e2df2dd46e18e/pyrsistent-0.19.3-cp39-cp39-win_amd64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "b735e538f74ec31378f5a1e3886a26d2ca6351106b4dfde376a26fc32a044edc",
+              "url": "https://files.pythonhosted.org/packages/d5/bf/6ed2d861e3e94c5e92dbb1399eef672fb6add6e824d8c0f4b55d9cd9e733/pyrsistent-0.19.3-cp39-cp39-macosx_10_9_universal2.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "64220c429e42a7150f4bfd280f6f4bb2850f95956bde93c6fda1b70507af6ef3",
+              "url": "https://files.pythonhosted.org/packages/de/9e/10c5bf794eec650a3aab1b4fb1f6824f53011d111ddfdce1459dc357408a/pyrsistent-0.19.3-cp311-cp311-win32.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "20460ac0ea439a3e79caa1dbd560344b64ed75e85d8703943e0b66c2a6150e4a",
+              "url": "https://files.pythonhosted.org/packages/ed/7b/7d032130a6838b179b46dff1ee88909c11d518a10ec9bc70c4b72c7c2f80/pyrsistent-0.19.3-cp310-cp310-macosx_10_9_universal2.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "3a8cb235fa6d3fd7aae6a4f1429bbb1fec1577d978098da1252f0489937786f3",
+              "url": "https://files.pythonhosted.org/packages/f4/43/183384edb4d2788374aa7663b82ace4afe4a0c1fbfee064875eb40ada95b/pyrsistent-0.19.3-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl"
             }
           ],
           "project_name": "pyrsistent",
           "requires_dists": [],
           "requires_python": ">=3.7",
-          "version": "0.19.2"
+          "version": "0.19.3"
         },
         {
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "892f933d339f068883b6fd5a459f03d85bfcb355e4981e146d2c7616c21fef71",
-              "url": "https://files.pythonhosted.org/packages/67/68/a5eb36c3a8540594b6035e6cdae40c1ef1b6a2bfacbecc3d1a544583c078/pytest-7.2.0-py3-none-any.whl"
+              "hash": "c7c6ca206e93355074ae32f7403e8ea12163b1163c976fee7d4d84027c162be5",
+              "url": "https://files.pythonhosted.org/packages/cc/02/8f59bf194c9a1ceac6330850715e9ec11e21e2408a30a596c65d54cf4d2a/pytest-7.2.1-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "c4014eb40e10f11f355ad4e3c2fb2c6c6d1919c73f3b5a433de4708202cade59",
-              "url": "https://files.pythonhosted.org/packages/0b/21/055f39bf8861580b43f845f9e8270c7786fe629b2f8562ff09007132e2e7/pytest-7.2.0.tar.gz"
+              "hash": "d45e0952f3727241918b8fd0f376f5ff6b301cc0777c6f9a556935c92d8a7d42",
+              "url": "https://files.pythonhosted.org/packages/e5/6c/f3a15217ac72912c28c5d7a7a8e87ff6d6475c9530595ae9f0f8dedd8dd8/pytest-7.2.1.tar.gz"
             }
           ],
           "project_name": "pytest",
@@ -7486,7 +7924,7 @@
             "xmlschema; extra == \"testing\""
           ],
           "requires_python": ">=3.7",
-          "version": "7.2"
+          "version": "7.2.1"
         },
         {
           "artifacts": [
@@ -7532,6 +7970,24 @@
           "artifacts": [
             {
               "algorithm": "sha256",
+              "hash": "3b03487b14eb9e4f77e4fc2a023358b5394b82fd89cecf5586259baed57d8c6f",
+              "url": "https://files.pythonhosted.org/packages/cd/c7/beaf6614f94fcaf02f7f2e6dd29c15a4d4da863ee13b7a791964be24e87b/python_json_logger-2.0.4-py3-none-any.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "764d762175f99fcc4630bd4853b09632acb60a6224acb27ce08cd70f0b1b81bd",
+              "url": "https://files.pythonhosted.org/packages/0a/c9/3d58b02da0966cd3067ebf99f454bfa01b18d83cfa69b5fb09ddccf94066/python-json-logger-2.0.4.tar.gz"
+            }
+          ],
+          "project_name": "python-json-logger",
+          "requires_dists": [],
+          "requires_python": ">=3.5",
+          "version": "2.0.4"
+        },
+        {
+          "artifacts": [
+            {
+              "algorithm": "sha256",
               "hash": "003aee64f9fd955d111549f96c4b58a3f40b9319383c70fad6277a4974bbf570",
               "url": "https://files.pythonhosted.org/packages/63/65/d0d7c085964fdf0cb294299663b407c38e2c8e8dd13bafcf5681798c12db/python_slugify-7.0.0-py2.py3-none-any.whl"
             },
@@ -7571,19 +8027,19 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "222439474e9c98fced559f1709d89e6c9cbf8d79c794ff3eb9f8800064291427",
-              "url": "https://files.pythonhosted.org/packages/85/ac/92f998fc52a70afd7f6b788142632afb27cd60c8c782d1452b7466603332/pytz-2022.6-py2.py3-none-any.whl"
+              "hash": "78f4f37d8198e0627c5f1143240bb0206b8691d8d7ac6d78fee88b78733f8c4a",
+              "url": "https://files.pythonhosted.org/packages/2e/09/fbd3c46dce130958ee8e0090f910f1fe39e502cc5ba0aadca1e8a2b932e5/pytz-2022.7.1-py2.py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "e89512406b793ca39f5971bc999cc538ce125c0e51c27941bef4568b460095e2",
-              "url": "https://files.pythonhosted.org/packages/76/63/1be349ff0a44e4795d9712cc0b2d806f5e063d4d34631b71b832fac715a8/pytz-2022.6.tar.gz"
+              "hash": "01a0681c4b9684a28304615eba55d1ab31ae00bf68ec157ec3708a8182dbbcd0",
+              "url": "https://files.pythonhosted.org/packages/03/3e/dc5c793b62c60d0ca0b7e58f1fdd84d5aaa9f8df23e7589b39cc9ce20a03/pytz-2022.7.1.tar.gz"
             }
           ],
           "project_name": "pytz",
           "requires_dists": [],
           "requires_python": null,
-          "version": "2022.6"
+          "version": "2022.7.1"
         },
         {
           "artifacts": [
@@ -7695,29 +8151,29 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "ba75ec55f46c9e17db961d26485b033deb20758b1731e8e208e1e8a387fcf70c",
-              "url": "https://files.pythonhosted.org/packages/89/e9/906c2c02f6ea6aa6d25b9f10d93b610bd5e924177ec348c29d3aaf6ed76f/pywinpty-2.0.9-cp39-none-win_amd64.whl"
+              "hash": "3c46aef80dd50979aff93de199e4a00a8ee033ba7a03cadf0a91fed45f0c39d7",
+              "url": "https://files.pythonhosted.org/packages/ac/09/103cdc5913a8b89099ef8129dfc8f0e0cfdd900e764e3e5d9401256442c5/pywinpty-2.0.10-cp39-none-win_amd64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "30a7b371446a694a6ce5ef906d70ac04e569de5308c42a2bdc9c3bc9275ec51f",
-              "url": "https://files.pythonhosted.org/packages/16/b2/72d66d56daebf87f4d27adb528c97d013a378017053f0fc9f8f83a577cff/pywinpty-2.0.9-cp310-none-win_amd64.whl"
+              "hash": "7ffbd66310b83e42028fc9df7746118978d94fba8c1ebf15a7c1275fdd80b28a",
+              "url": "https://files.pythonhosted.org/packages/98/3f/eedff7d7f4bc2bb828fa4ea137528f04941bfe6805d13f594c96624a2f93/pywinpty-2.0.10-cp311-none-win_amd64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "01b6400dd79212f50a2f01af1c65b781290ff39610853db99bf03962eb9a615f",
-              "url": "https://files.pythonhosted.org/packages/22/77/59645ee028f410ef1d582fc2923d2cb61016ed38e6ae5022f405227ca2ad/pywinpty-2.0.9.tar.gz"
+              "hash": "4c7d06ad10f6e92bc850a467f26d98f4f30e73d2fe5926536308c6ae0566bc16",
+              "url": "https://files.pythonhosted.org/packages/a4/2e/7aabef8a774819d4851112388b6646bd65782adfcec6fbbf2e309ddb07fb/pywinpty-2.0.10-cp310-none-win_amd64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "d78ef6f4bd7a6c6f94dc1a39ba8fb028540cc39f5cb593e756506db17843125f",
-              "url": "https://files.pythonhosted.org/packages/f0/59/3d939a508718405b86c239895be80436b7a996a04e5ecd250add6945f97c/pywinpty-2.0.9-cp311-none-win_amd64.whl"
+              "hash": "cdbb5694cf8c7242c2ecfaca35c545d31fa5d5814c3d67a4e628f803f680ebea",
+              "url": "https://files.pythonhosted.org/packages/d3/89/2b9113eabacfe3bbebcdf95c24772e2267c7b6b9fed6e35bffba2080a4c1/pywinpty-2.0.10.tar.gz"
             }
           ],
           "project_name": "pywinpty",
           "requires_dists": [],
           "requires_python": ">=3.7",
-          "version": "2.0.9"
+          "version": "2.0.10"
         },
         {
           "artifacts": [
@@ -7841,192 +8297,206 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "687700f8371643916a1d2c61f3fdaa630407dd205c38afff936545d7b7466066",
-              "url": "https://files.pythonhosted.org/packages/5b/f3/94ba43f87f212bed83dd797d55331d132ebb74465007237baa5deb908d88/pyzmq-24.0.1-pp39-pypy39_pp73-win_amd64.whl"
+              "hash": "866eabf7c1315ef2e93e34230db7cbf672e0d7c626b37c11f7e870c8612c3dcc",
+              "url": "https://files.pythonhosted.org/packages/0c/85/32a5d18f6ffea367538c70127eb9bc2e5122db6ec65b5b5c81584bc5457c/pyzmq-25.0.0-pp39-pypy39_pp73-win_amd64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "7abddb2bd5489d30ffeb4b93a428130886c171b4d355ccd226e83254fcb6b9ef",
-              "url": "https://files.pythonhosted.org/packages/0c/5e/d6966d962f9dfe8c98fd1b182e63cc5379c89a586fc83387bece3eeef5e0/pyzmq-24.0.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+              "hash": "656281d496aaf9ca4fd4cea84e6d893e3361057c4707bd38618f7e811759103c",
+              "url": "https://files.pythonhosted.org/packages/00/b2/b83067a8af05bd8ebd9613046a0be15e7728219079cf0fbf17ec0fff0a40/pyzmq-25.0.0-cp311-cp311-musllinux_1_1_i686.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "5bd3d7dfd9cd058eb68d9a905dec854f86649f64d4ddf21f3ec289341386c44b",
-              "url": "https://files.pythonhosted.org/packages/25/99/71e7caf8b7d6193e233ffcf9b7342c61236958ecd7f269130f27a9d8bcaa/pyzmq-24.0.1-cp39-cp39-manylinux_2_12_x86_64.manylinux2010_x86_64.whl"
+              "hash": "9ca6db34b26c4d3e9b0728841ec9aa39484eee272caa97972ec8c8e231b20c7e",
+              "url": "https://files.pythonhosted.org/packages/02/5e/dae3cfb179ee0149c8b00f6400cd372fc6b738705f51db3e0f5b7384399a/pyzmq-25.0.0-cp39-cp39-manylinux_2_12_i686.manylinux2010_i686.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "624321120f7e60336be8ec74a172ae7fba5c3ed5bf787cc85f7e9986c9e0ebc2",
-              "url": "https://files.pythonhosted.org/packages/37/bc/b06363931ea30e29d96b108f711e77740f9d599f6494604c544e9169fe98/pyzmq-24.0.1-cp311-cp311-win32.whl"
+              "hash": "62b9e80890c0d2408eb42d5d7e1fc62a5ce71be3288684788f74cf3e59ffd6e2",
+              "url": "https://files.pythonhosted.org/packages/08/d7/6aec451d335d8f691993d63105009f508e4011bad0414ab4e6255b31798e/pyzmq-25.0.0-cp39-cp39-macosx_10_15_universal2.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "216f5d7dbb67166759e59b0479bca82b8acf9bed6015b526b8eb10143fb08e77",
-              "url": "https://files.pythonhosted.org/packages/46/0d/b06cf99a64d4187632f4ac9ddf6be99cd35de06fe72d75140496a8e0eef5/pyzmq-24.0.1.tar.gz"
+              "hash": "4d3d604fe0a67afd1aff906e54da557a5203368a99dcc50a70eef374f1d2abef",
+              "url": "https://files.pythonhosted.org/packages/13/51/16b0b03dcd26e4613f458a2523d3803a65e26972f89fb91296b091870794/pyzmq-25.0.0-cp39-cp39-musllinux_1_1_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "ccb94342d13e3bf3ffa6e62f95b5e3f0bc6bfa94558cb37f4b3d09d6feb536ff",
-              "url": "https://files.pythonhosted.org/packages/47/68/3d75e48e898034e878ba99729715f4e92c6b82d2f36fe5c033c60c7ac9b0/pyzmq-24.0.1-cp311-cp311-musllinux_1_1_aarch64.whl"
+              "hash": "3594c0ff604e685d7e907860b61d0e10e46c74a9ffca168f6e9e50ea934ee440",
+              "url": "https://files.pythonhosted.org/packages/1f/32/29071fa17e17636636dfb7e7c6ee941790bcad5f7281561a68baea5c2bdb/pyzmq-25.0.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "c31805d2c8ade9b11feca4674eee2b9cce1fec3e8ddb7bbdd961a09dc76a80ea",
-              "url": "https://files.pythonhosted.org/packages/49/7d/cf3096cef25e4bf8072dd22948de11e5d4e4c03c7b8b4617b75c0b01fa45/pyzmq-24.0.1-cp39-cp39-musllinux_1_1_aarch64.whl"
+              "hash": "01d53958c787cfea34091fcb8ef36003dbb7913b8e9f8f62a0715234ebc98b70",
+              "url": "https://files.pythonhosted.org/packages/23/54/83f2f9c86749ac10d17f37d51d29d1e80f83cd20b095e4283646ff36afc9/pyzmq-25.0.0-cp310-cp310-win32.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "abb756147314430bee5d10919b8493c0ccb109ddb7f5dfd2fcd7441266a25b75",
-              "url": "https://files.pythonhosted.org/packages/4a/d8/106a80d93fa7c09000c7f8e9ba8e0e7aec13cf85461d66311331185bd382/pyzmq-24.0.1-pp39-pypy39_pp73-manylinux_2_17_i686.manylinux2014_i686.whl"
+              "hash": "85456f0d8f3268eecd63dede3b99d5bd8d3b306310c37d4c15141111d22baeaf",
+              "url": "https://files.pythonhosted.org/packages/32/d1/802e9e4243cf54399541baa3279bf2b2c08cbe911928c531fc7cd0aee7b2/pyzmq-25.0.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "3104f4b084ad5d9c0cb87445cc8cfd96bba710bef4a66c2674910127044df209",
-              "url": "https://files.pythonhosted.org/packages/4d/c1/3d12cd5edf82800bf8581a1e511df883084ab9de531dac442a0dfeca88e1/pyzmq-24.0.1-cp39-cp39-musllinux_1_1_i686.whl"
+              "hash": "2d05d904f03ddf1e0d83d97341354dfe52244a619b5a1440a5f47a5b3451e84e",
+              "url": "https://files.pythonhosted.org/packages/3f/fa/55c6f991e6eda6b79e4f7b3d940660ba47579fe9db5c966d92adf1b2110b/pyzmq-25.0.0-cp310-cp310-macosx_10_15_universal2.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "8242543c522d84d033fe79be04cb559b80d7eb98ad81b137ff7e0a9020f00ace",
-              "url": "https://files.pythonhosted.org/packages/52/c5/ca38e710e645de5bec3425706d37be6fb9c977f604d81526276b2418c08b/pyzmq-24.0.1-cp311-cp311-manylinux_2_28_x86_64.whl"
+              "hash": "484c2c4ee02c1edc07039f42130bd16e804b1fe81c4f428e0042e03967f40c20",
+              "url": "https://files.pythonhosted.org/packages/41/a5/3fa528007e7f54fa4a6c76397ed994d7b82958bc1d641a7a1f692a0ff499/pyzmq-25.0.0-cp39-cp39-macosx_10_9_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "87f7ac99b15270db8d53f28c3c7b968612993a90a5cf359da354efe96f5372b4",
-              "url": "https://files.pythonhosted.org/packages/60/3b/6a332c236ec14cc25f95eac98a299cb91fe531d38c4fa2ecd0a0b8df11d2/pyzmq-24.0.1-cp310-cp310-manylinux_2_17_i686.manylinux2014_i686.whl"
+              "hash": "8539216173135e9e89f6b1cc392e74e6b935b91e8c76106cf50e7a02ab02efe5",
+              "url": "https://files.pythonhosted.org/packages/42/a8/14ef1a6526e709f81fb06aced32ba894098cf8037d21d5c243eb1aca95b5/pyzmq-25.0.0-cp310-cp310-musllinux_1_1_aarch64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "52afb0ac962963fff30cf1be775bc51ae083ef4c1e354266ab20e5382057dd62",
-              "url": "https://files.pythonhosted.org/packages/64/64/efacd16de5429f8b5a9df23bae15ae4d8977f24c58742c86156627e049de/pyzmq-24.0.1-cp39-cp39-macosx_10_15_universal2.whl"
+              "hash": "c48f257da280b3be6c94e05bd575eddb1373419dbb1a72c3ce64e88f29d1cd6d",
+              "url": "https://files.pythonhosted.org/packages/4b/c6/100d104d2924b20c906e358ab8253ec1cc8bf00a76e1c87e06c5fd5f7dd6/pyzmq-25.0.0-pp39-pypy39_pp73-manylinux_2_28_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "8c78bfe20d4c890cb5580a3b9290f700c570e167d4cdcc55feec07030297a5e3",
-              "url": "https://files.pythonhosted.org/packages/68/6f/1484e78d791844778e5f7b89d15238b27d6b7abf5ddfdf33c6c5c5e6a4e8/pyzmq-24.0.1-cp310-cp310-musllinux_1_1_aarch64.whl"
+              "hash": "0282bba9aee6e0346aa27d6c69b5f7df72b5a964c91958fc9e0c62dcae5fdcdc",
+              "url": "https://files.pythonhosted.org/packages/55/7b/78a39bfcece02f6768952a951f013af60b42af525ebe1eef3d149af9d1e3/pyzmq-25.0.0-cp311-cp311-win32.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "80093b595921eed1a2cead546a683b9e2ae7f4a4592bb2ab22f70d30174f003a",
-              "url": "https://files.pythonhosted.org/packages/69/81/243d866eb6497a4d6fce9317946126941a496821a2e32029cbe0d825bc4a/pyzmq-24.0.1-pp39-pypy39_pp73-macosx_10_9_x86_64.whl"
+              "hash": "3670e8c5644768f214a3b598fe46378a4a6f096d5fb82a67dfd3440028460565",
+              "url": "https://files.pythonhosted.org/packages/5f/38/2665a604c359a779f6a4a091095ce57cd615b094c7d738c9dcad6df7b0ad/pyzmq-25.0.0-cp39-cp39-win32.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "838812c65ed5f7c2bd11f7b098d2e5d01685a3f6d1f82849423b570bae698c00",
-              "url": "https://files.pythonhosted.org/packages/73/49/6d80a45d8ff25a7e30752c49a4a73a0642341b2364aa993473b5a0f4e003/pyzmq-24.0.1-cp311-cp311-macosx_10_15_universal2.whl"
+              "hash": "af1fbfb7ad6ac0009ccee33c90a1d303431c7fb594335eb97760988727a37577",
+              "url": "https://files.pythonhosted.org/packages/67/ee/2319050b463e7e8dee5a2384a405816fbc51a558c88f11a3a436f079ad8a/pyzmq-25.0.0-cp311-cp311-macosx_10_9_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "8f3f3154fde2b1ff3aa7b4f9326347ebc89c8ef425ca1db8f665175e6d3bd42f",
-              "url": "https://files.pythonhosted.org/packages/7c/84/1af73087551ea376609140643e10b7526647a4a4c313211b5a45296fc343/pyzmq-24.0.1-pp39-pypy39_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+              "hash": "4e295f7928a31ae0f657e848c5045ba6d693fe8921205f408ca3804b1b236968",
+              "url": "https://files.pythonhosted.org/packages/6c/1a/cd15043bf811ba492f512e481f8dcf223cb5bd6542cc5c10083c5ffd0a08/pyzmq-25.0.0-cp311-cp311-manylinux_2_28_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "9dca7c3956b03b7663fac4d150f5e6d4f6f38b2462c1e9afd83bcf7019f17913",
-              "url": "https://files.pythonhosted.org/packages/81/62/b8cd92a54671b76bfe166c31bb25a48a9628b3be3f7efc7b1063445296d4/pyzmq-24.0.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+              "hash": "00c94fd4c9dd3c95aace0c629a7fa713627a5c80c1819326b642adf6c4b8e2a2",
+              "url": "https://files.pythonhosted.org/packages/74/7a/31d3b68d6dd7769736ee42d0558f901de6274c939d05425b71ee43a29490/pyzmq-25.0.0-pp39-pypy39_pp73-macosx_10_9_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "ae61446166983c663cee42c852ed63899e43e484abf080089f771df4b9d272ef",
-              "url": "https://files.pythonhosted.org/packages/83/00/d4197ff8c892a26e15222051e774e09510f8d4bf89d343488874c3b0f19f/pyzmq-24.0.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+              "hash": "e4bba04ea779a3d7ef25a821bb63fd0939142c88e7813e5bd9c6265a20c523a2",
+              "url": "https://files.pythonhosted.org/packages/7d/4d/65212414b17abbbd4a12110a5d32e64e9633700bae34e3b81e2ea17b2b0f/pyzmq-25.0.0-cp311-cp311-macosx_10_15_universal2.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "94010bd61bc168c103a5b3b0f56ed3b616688192db7cd5b1d626e49f28ff51b3",
-              "url": "https://files.pythonhosted.org/packages/8e/3e/f27100244e96d78c9cfafa1cb457be760f756abd700ac6790f97a6eef271/pyzmq-24.0.1-cp311-cp311-manylinux_2_17_i686.manylinux2014_i686.whl"
+              "hash": "75243e422e85a62f0ab7953dc315452a56b2c6a7e7d1a3c3109ac3cc57ed6b47",
+              "url": "https://files.pythonhosted.org/packages/80/40/044fb4342b613ad45882dd3a1b7f34565885f5f12b833e9fb726e9cf55b4/pyzmq-25.0.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "dfb992dbcd88d8254471760879d48fb20836d91baa90f181c957122f9592b3dc",
-              "url": "https://files.pythonhosted.org/packages/93/03/edb302ae50adfbed34570c8d3c251fe71c57f9d42a4fc086152f1a390415/pyzmq-24.0.1-cp311-cp311-macosx_10_9_x86_64.whl"
+              "hash": "1f6116991568aac48b94d6d8aaed6157d407942ea385335a6ed313692777fb9d",
+              "url": "https://files.pythonhosted.org/packages/87/da/96d981dc99ea4278d95642139ef25b08900a4db819b66b4ae3f9dd95cc3b/pyzmq-25.0.0-cp311-cp311-musllinux_1_1_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "bcbebd369493d68162cddb74a9c1fcebd139dfbb7ddb23d8f8e43e6c87bac3a6",
-              "url": "https://files.pythonhosted.org/packages/9b/7d/d43ed00a8de7b9938025275a2db4370822ed0d1b1fbe0137f0cbb17ac8f3/pyzmq-24.0.1-cp310-cp310-macosx_10_9_x86_64.whl"
+              "hash": "9f72ea279b2941a5203e935a4588b9ba8a48aeb9a926d9dfa1986278bd362cb8",
+              "url": "https://files.pythonhosted.org/packages/8a/e5/96bfb6c6a630a4dfefb9a9a4de0b6339a124ff074d53b65d8ad7898ee14c/pyzmq-25.0.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "a435ef8a3bd95c8a2d316d6e0ff70d0db524f6037411652803e118871d703333",
-              "url": "https://files.pythonhosted.org/packages/a4/0a/88793e882ded0818713d09cbad0bc11a9244653668b8fc06d97f578a14bd/pyzmq-24.0.1-cp39-cp39-win32.whl"
+              "hash": "0645b5a2d2a06fd8eb738018490c514907f7488bf9359c6ee9d92f62e844b76f",
+              "url": "https://files.pythonhosted.org/packages/a6/19/0dad3c7298fd9085b699efeeeaedcf6d3b05f52eb01fac033b7d747e3a7a/pyzmq-25.0.0-cp311-cp311-manylinux_2_17_i686.manylinux2014_i686.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "6640f83df0ae4ae1104d4c62b77e9ef39be85ebe53f636388707d532bee2b7b8",
-              "url": "https://files.pythonhosted.org/packages/a8/bc/1d5ffcba5f33ddb321645add42f76bfdb66e529797cad05c551186a81362/pyzmq-24.0.1-cp311-cp311-musllinux_1_1_i686.whl"
+              "hash": "2754fa68da08a854f4816e05160137fa938a2347276471103d31e04bcee5365c",
+              "url": "https://files.pythonhosted.org/packages/b0/42/b4515c34658a0fc172edaf68982aa39b213c3677de7f56c2bc2a194d57ab/pyzmq-25.0.0-cp310-cp310-musllinux_1_1_i686.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "28b119ba97129d3001673a697b7cce47fe6de1f7255d104c2f01108a5179a066",
-              "url": "https://files.pythonhosted.org/packages/aa/01/329cf8e192acb018dd51916ae4cd868a3c0650441a07ffd90eeb2a70aacc/pyzmq-24.0.1-cp310-cp310-macosx_10_15_universal2.whl"
+              "hash": "4725412e27612f0d7d7c2f794d89807ad0227c2fc01dd6146b39ada49c748ef9",
+              "url": "https://files.pythonhosted.org/packages/b4/05/2e9aeb882648498c574d1a25a047acd03dc23b60016bb80085cbe78429e5/pyzmq-25.0.0-cp39-cp39-musllinux_1_1_i686.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "df0841f94928f8af9c7a1f0aaaffba1fb74607af023a152f59379c01c53aee58",
-              "url": "https://files.pythonhosted.org/packages/b8/9c/905d90c2b0a34e4dbff619843a90352ae24823089016a8d555ae41cefff1/pyzmq-24.0.1-cp39-cp39-musllinux_1_1_x86_64.whl"
+              "hash": "e99629a976809fe102ef73e856cf4b2660acd82a412a51e80ba2215e523dfd0a",
+              "url": "https://files.pythonhosted.org/packages/ba/0c/74ec9bd576d77adca6027fd7fb50f6bfad35ac1f72ca4bedfed2ac0bf69d/pyzmq-25.0.0-cp39-cp39-win_amd64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "1724117bae69e091309ffb8255412c4651d3f6355560d9af312d547f6c5bc8b8",
-              "url": "https://files.pythonhosted.org/packages/be/23/0a0534008de7b1e12e17077a465626405a53c5d66f2e6af2c8da0d9c5471/pyzmq-24.0.1-cp311-cp311-win_amd64.whl"
+              "hash": "58fc3ad5e1cfd2e6d24741fbb1e216b388115d31b0ca6670f894187f280b6ba6",
+              "url": "https://files.pythonhosted.org/packages/ba/75/6d49e003a07722166076764f6b9a6444a653a72a44912d93f14c21e8c09c/pyzmq-25.0.0-cp310-cp310-win_amd64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "3e6192dbcefaaa52ed81be88525a54a445f4b4fe2fffcae7fe40ebb58bd06bfd",
-              "url": "https://files.pythonhosted.org/packages/c3/9c/e4c3378e09dce355465a40d7fb128ba5011dd555ee912b8a824b308dc4bb/pyzmq-24.0.1-cp310-cp310-win32.whl"
+              "hash": "4cbb885f347eba7ab7681c450dee5b14aed9f153eec224ec0c3f299273d9241f",
+              "url": "https://files.pythonhosted.org/packages/c1/c5/531db8fdec6804a29bc6eaa914cc250d5f1f629f2db2b324fbccab03a348/pyzmq-25.0.0-pp39-pypy39_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "dabf1a05318d95b1537fd61d9330ef4313ea1216eea128a17615038859da3b3b",
-              "url": "https://files.pythonhosted.org/packages/c5/1b/bca275b85c4634699136928fd86b68c3e068da198b9c959bb5c22ea61fd0/pyzmq-24.0.1-cp39-cp39-manylinux_2_12_i686.manylinux2010_i686.whl"
+              "hash": "ac97e7d647d5519bcef48dd8d3d331f72975afa5c4496c95f6e854686f45e2d9",
+              "url": "https://files.pythonhosted.org/packages/cf/75/3221b3999808566064bc94190678dc0058af651747279ed3eca159df550e/pyzmq-25.0.0-cp311-cp311-musllinux_1_1_aarch64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "a180dbd5ea5d47c2d3b716d5c19cc3fb162d1c8db93b21a1295d69585bfddac1",
-              "url": "https://files.pythonhosted.org/packages/cb/e1/6441995e97a3fdd7cb9c85791d95a4f902b328fe5ef295f9fb3b039facdf/pyzmq-24.0.1-cp311-cp311-musllinux_1_1_x86_64.whl"
+              "hash": "f330a1a2c7f89fd4b0aa4dcb7bf50243bf1c8da9a2f1efc31daf57a2046b31f2",
+              "url": "https://files.pythonhosted.org/packages/cf/89/9dbc5bc589a06e94d493b551177a0ebbe70f08b5ebdd49dddf212df869ff/pyzmq-25.0.0.tar.gz"
             },
             {
               "algorithm": "sha256",
-              "hash": "2032d9cb994ce3b4cba2b8dfae08c7e25bc14ba484c770d4d3be33c27de8c45b",
-              "url": "https://files.pythonhosted.org/packages/cc/f9/b5cfc590c5a33a58367ae0ccf22da3256572e742473a6666b69127a55b63/pyzmq-24.0.1-cp39-cp39-win_amd64.whl"
+              "hash": "4a1bc30f0c18444d51e9b0d0dd39e3a4e7c53ee74190bebef238cd58de577ea9",
+              "url": "https://files.pythonhosted.org/packages/d4/9b/61d6cf04113855041cc22c1b66977657e7a323718eb89f4af54f4077212e/pyzmq-25.0.0-cp310-cp310-musllinux_1_1_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "afe1f3bc486d0ce40abb0a0c9adb39aed3bbac36ebdc596487b0cceba55c21c1",
-              "url": "https://files.pythonhosted.org/packages/d6/ad/496e868334493cd9d0e50367ed3349378195c475f9ea43c68a243debc8d7/pyzmq-24.0.1-cp310-cp310-musllinux_1_1_x86_64.whl"
+              "hash": "31e523d067ce44a04e876bed3ff9ea1ff8d1b6636d16e5fcace9d22f8c564369",
+              "url": "https://files.pythonhosted.org/packages/da/3c/71ca87cf890ea30ea10862ea10db31838e054c296e775df2c8a50b6fd18d/pyzmq-25.0.0-cp310-cp310-manylinux_2_28_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "8bad8210ad4df68c44ff3685cca3cda448ee46e20d13edcff8909eba6ec01ca4",
-              "url": "https://files.pythonhosted.org/packages/de/85/72bd31a71d3055cf7b62339c7aa133f26c2fc160f16bdaaff0b9264a4f63/pyzmq-24.0.1-cp39-cp39-macosx_10_9_x86_64.whl"
+              "hash": "b6f75b4b8574f3a8a0d6b4b52606fc75b82cb4391471be48ab0b8677c82f9ed4",
+              "url": "https://files.pythonhosted.org/packages/dd/f2/f3d56e4da8dbeff1aba3cb6a4ac694bcd3aae80af2b7df0fddc066a0590a/pyzmq-25.0.0-pp39-pypy39_pp73-manylinux_2_17_i686.manylinux2014_i686.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "44e706bac34e9f50779cb8c39f10b53a4d15aebb97235643d3112ac20bd577b4",
-              "url": "https://files.pythonhosted.org/packages/e0/1b/84bd305a203c9df58264f2df908a554129f8c2b682a5ddf2e370c80778cc/pyzmq-24.0.1-pp39-pypy39_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+              "hash": "2e7b87638ee30ab13230e37ce5331b3e730b1e0dda30120b9eeec3540ed292c8",
+              "url": "https://files.pythonhosted.org/packages/eb/30/07fab0f1344cd32c739e3fa0e3f1a266350317e2f77e945f8eada47eae24/pyzmq-25.0.0-cp310-cp310-manylinux_2_17_i686.manylinux2014_i686.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "86de64468cad9c6d269f32a6390e210ca5ada568c7a55de8e681ca3b897bb340",
-              "url": "https://files.pythonhosted.org/packages/e3/5f/3587e6e0c9f4d52c3569d0be6799a57429785e1413993303ed74b16d686d/pyzmq-24.0.1-cp310-cp310-win_amd64.whl"
+              "hash": "526f884a27e8bba62fe1f4e07c62be2cfe492b6d432a8fdc4210397f8cf15331",
+              "url": "https://files.pythonhosted.org/packages/f7/a2/17fa06423627a5e5e9902b7c77880824296c6fd479bbf4182ebcf10fd279/pyzmq-25.0.0-cp311-cp311-win_amd64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "e8012bce6836d3f20a6c9599f81dfa945f433dab4dbd0c4917a6fb1f998ab33d",
-              "url": "https://files.pythonhosted.org/packages/ec/d4/28ab3b669cee6a35bbcdc107c9521a28d8b285793118ad675058d5c7ecb5/pyzmq-24.0.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+              "hash": "487305c2a011fdcf3db1f24e8814bb76d23bc4d2f46e145bc80316a59a9aa07d",
+              "url": "https://files.pythonhosted.org/packages/f8/a2/85b36d137ef3b4f9806f6f21552c57c3dab592d540980fa8fd615a43f623/pyzmq-25.0.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "48f721f070726cd2a6e44f3c33f8ee4b24188e4b816e6dd8ba542c8c3bb5b246",
-              "url": "https://files.pythonhosted.org/packages/ec/e2/5fe1af54543b82b1a011d99a390e8a835bd112120657ca4d7a3d8966370e/pyzmq-24.0.1-cp310-cp310-musllinux_1_1_i686.whl"
+              "hash": "20638121b0bdc80777ce0ec8c1f14f1ffec0697a1f88f0b564fa4a23078791c4",
+              "url": "https://files.pythonhosted.org/packages/f9/23/25dcac691eaf807e14bba4f3ba6a7777b2bba079bb6a1158c38614d2a801/pyzmq-25.0.0-pp39-pypy39_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "0a154ef810d44f9d28868be04641f837374a64e7449df98d9208e76c260c7ef1",
+              "url": "https://files.pythonhosted.org/packages/f9/51/9515efb57e6e46650d4dd78726fd1e5347e2b014ce94f482a12c1157d2d5/pyzmq-25.0.0-cp310-cp310-macosx_10_9_x86_64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "c21a5f4e54a807df5afdef52b6d24ec1580153a6bcf0607f70a6e1d9fa74c5c3",
+              "url": "https://files.pythonhosted.org/packages/f9/85/7a7b13f38287accea5bfdaf3e91daf8b017d6f2ed55ae17b7cfb3203293c/pyzmq-25.0.0-cp39-cp39-musllinux_1_1_aarch64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "610d2d112acd4e5501fac31010064a6c6efd716ceb968e443cae0059eb7b86de",
+              "url": "https://files.pythonhosted.org/packages/fe/32/45d41f2e2316e534c004aea758500e17687afc36ec91e20137d8909538e1/pyzmq-25.0.0-cp39-cp39-manylinux_2_12_x86_64.manylinux2010_x86_64.whl"
             }
           ],
           "project_name": "pyzmq",
           "requires_dists": [
-            "cffi; implementation_name == \"pypy\"",
-            "py; implementation_name == \"pypy\""
+            "cffi; implementation_name == \"pypy\""
           ],
           "requires_python": ">=3.6",
-          "version": "24.0.1"
+          "version": "25"
         },
         {
           "artifacts": [
@@ -8265,13 +8735,13 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "8fefa2a1a1365bf5520aac41836fbee479da67864514bdb821f31ce07ce65349",
-              "url": "https://files.pythonhosted.org/packages/ca/91/6d9b8ccacd0412c08820f72cebaa4f0c0441b5cda699c90f618b6f8a1b42/requests-2.28.1-py3-none-any.whl"
+              "hash": "64299f4909223da747622c030b781c0d7811e359c37124b4bd368fb8c6518baa",
+              "url": "https://files.pythonhosted.org/packages/d2/f4/274d1dbe96b41cf4e0efb70cbced278ffd61b5c7bb70338b62af94ccb25b/requests-2.28.2-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "7c5599b102feddaa661c826c56ab4fee28bfd17f5abca1ebbe3e7f19d7c97983",
-              "url": "https://files.pythonhosted.org/packages/a5/61/a867851fd5ab77277495a8709ddda0861b28163c4613b011bc00228cc724/requests-2.28.1.tar.gz"
+              "hash": "98b1b2782e3c6c4904938b84c0eb932721069dfdb9134313beff7c83c2df24bf",
+              "url": "https://files.pythonhosted.org/packages/9d/ee/391076f5937f0a8cdf5e53b701ffc91753e87b07d66bae4a09aa671897bf/requests-2.28.2.tar.gz"
             }
           ],
           "project_name": "requests",
@@ -8279,12 +8749,12 @@
             "PySocks!=1.5.7,>=1.5.6; extra == \"socks\"",
             "certifi>=2017.4.17",
             "chardet<6,>=3.0.2; extra == \"use_chardet_on_py3\"",
-            "charset-normalizer<3,>=2",
+            "charset-normalizer<4,>=2",
             "idna<4,>=2.5",
             "urllib3<1.27,>=1.21.1"
           ],
           "requires_python": "<4,>=3.7",
-          "version": "2.28.1"
+          "version": "2.28.2"
         },
         {
           "artifacts": [
@@ -8325,6 +8795,26 @@
           "artifacts": [
             {
               "algorithm": "sha256",
+              "hash": "24f6ec1eda14ef823da9e36ec7113124b39c04d50a4d3d3a3c2859577e7791fa",
+              "url": "https://files.pythonhosted.org/packages/7b/44/4e421b96b67b2daff264473f7465db72fbdf36a07e05494f50300cc7b0c6/rfc3339_validator-0.1.4-py2.py3-none-any.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "138a2abdf93304ad60530167e51d2dfb9549521a836871b88d7f4695d0022f6b",
+              "url": "https://files.pythonhosted.org/packages/28/ea/a9387748e2d111c3c2b275ba970b735e04e15cdb1eb30693b6b5708c4dbd/rfc3339_validator-0.1.4.tar.gz"
+            }
+          ],
+          "project_name": "rfc3339-validator",
+          "requires_dists": [
+            "six"
+          ],
+          "requires_python": "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,>=2.7",
+          "version": "0.1.4"
+        },
+        {
+          "artifacts": [
+            {
+              "algorithm": "sha256",
               "hash": "a86d6e1f5b1dc238b218b012df0aa79409667bb209e58da56d0b94704e712a97",
               "url": "https://files.pythonhosted.org/packages/c4/e5/63ca2c4edf4e00657584608bee1001302bbf8c5f569340b78304f2f446cb/rfc3986-1.5.0-py2.py3-none-any.whl"
             },
@@ -8340,6 +8830,24 @@
           ],
           "requires_python": null,
           "version": "1.5"
+        },
+        {
+          "artifacts": [
+            {
+              "algorithm": "sha256",
+              "hash": "2f235c432ef459970b4306369336b9d5dbdda31b510ca1e327636e01f528bfa9",
+              "url": "https://files.pythonhosted.org/packages/9e/51/17023c0f8f1869d8806b979a2bffa3f861f26a3f1a66b094288323fba52f/rfc3986_validator-0.1.1-py2.py3-none-any.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "3d44bde7921b3b9ec3ae4e3adca370438eccebc676456449b145d533b240d055",
+              "url": "https://files.pythonhosted.org/packages/da/88/f270de456dd7d11dcc808abfa291ecdd3f45ff44e3b549ffa01b126464d0/rfc3986_validator-0.1.1.tar.gz"
+            }
+          ],
+          "project_name": "rfc3986-validator",
+          "requires_dists": [],
+          "requires_python": "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,>=2.7",
+          "version": "0.1.1"
         },
         {
           "artifacts": [
@@ -8389,6 +8897,11 @@
               "algorithm": "sha256",
               "hash": "184faeaec61dbaa3cace407cffc5819f7b977e75360e8d5ca19461cd851a5fc5",
               "url": "https://files.pythonhosted.org/packages/4b/34/a74dac5cce1efd0d3cc11a30b1eb997b53ec76b8bf18160692820b697a4c/ruamel.yaml.clib-0.2.7-cp39-cp39-win_amd64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "41d0f1fa4c6830176eef5b276af04c89320ea616655d01327d5ce65e50575c94",
+              "url": "https://files.pythonhosted.org/packages/11/50/b4ebeac05e40ab40d85659ec8629f9af54ed09f07b3269e17cbfb0fbecd6/ruamel.yaml.clib-0.2.7-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_24_x86_64.whl"
             },
             {
               "algorithm": "sha256",
@@ -8491,109 +9004,114 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "5b88e6d91ad9d59478fafe92a7c757d00c59e3bdc3331be8ada76a4f8d683f58",
-              "url": "https://files.pythonhosted.org/packages/d0/96/4f6eac3fea18f836a0e403539556b1684e6f3361fa39aa5d5797dedecd75/scipy-1.9.3-cp39-cp39-win_amd64.whl"
+              "hash": "954ff69d2d1bf666b794c1d7216e0a746c9d9289096a64ab3355a17c7c59db54",
+              "url": "https://files.pythonhosted.org/packages/b5/16/6261fb37606565833f7437692e57edd1f29f3e9dd3f3873720a2d25558b0/scipy-1.10.0-cp39-cp39-win_amd64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "fbc5c05c85c1a02be77b1ff591087c83bc44579c6d2bd9fb798bb64ea5e1a027",
-              "url": "https://files.pythonhosted.org/packages/0a/2e/44795c6398e24e45fa0bb61c3e98de1cfea567b1b51efd3751e2f7ff9720/scipy-1.9.3.tar.gz"
+              "hash": "6e4497e5142f325a5423ff5fda2fff5b5d953da028637ff7c704378c8c284ea7",
+              "url": "https://files.pythonhosted.org/packages/2b/54/7536dbfcbea26ca2c11d3c55b0c2d806d4349b5852318e12b98ffee27bd8/scipy-1.10.0-cp39-cp39-macosx_12_0_arm64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "83b89e9586c62e787f5012e8475fbb12185bafb996a03257e9675cd73d3736dd",
-              "url": "https://files.pythonhosted.org/packages/40/0e/3ff193b6ba6a0a6f13f8d367e8976370232e769bd609c8c11d86e0353adf/scipy-1.9.3-cp310-cp310-macosx_12_0_arm64.whl"
+              "hash": "0490dc499fe23e4be35b8b6dd1e60a4a34f0c4adb30ac671e6332446b3cbbb5a",
+              "url": "https://files.pythonhosted.org/packages/30/71/bb9e677e30c52f938ff71ba528915c579e794ac0f59804e06bfed3596dff/scipy-1.10.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "06d2e1b4c491dc7d8eacea139a1b0b295f74e1a1a0f704c375028f8320d16e31",
-              "url": "https://files.pythonhosted.org/packages/42/81/0a64d2204c3b261380ac96c6d61f018528108b62c0e21e6153a58cebf4f6/scipy-1.9.3-cp311-cp311-win_amd64.whl"
+              "hash": "b901b423c91281a974f6cd1c36f5c6c523e665b5a6d5e80fcb2334e14670eefd",
+              "url": "https://files.pythonhosted.org/packages/45/4e/250f55436fe2cec3db808ca6befa16d294935a21ed2b9dc03d0238ead769/scipy-1.10.0-cp310-cp310-macosx_10_15_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "d01e1dd7b15bd2449c8bfc6b7cc67d630700ed655654f0dfcf121600bad205c9",
-              "url": "https://files.pythonhosted.org/packages/59/0b/8a9acfc5c36bbf6e18d02f3a08db5b83bebba510be2df3230f53852c74a4/scipy-1.9.3-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+              "hash": "16ba05d3d1b9f2141004f3f36888e05894a525960b07f4c2bfc0456b955a00be",
+              "url": "https://files.pythonhosted.org/packages/5e/e3/ac8daa4adf427ef0f9913350e74b985ecd838ad32eafc3aa844f0760e839/scipy-1.10.0-cp310-cp310-macosx_12_0_arm64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "d644a64e174c16cb4b2e41dfea6af722053e83d066da7343f333a54dae9bc31c",
-              "url": "https://files.pythonhosted.org/packages/59/ef/d54d17c36b46a9b8f6e1d4bf039b7f7ad236504cfb13cf1872caec9cbeaa/scipy-1.9.3-cp39-cp39-macosx_10_9_x86_64.whl"
+              "hash": "151f066fe7d6653c3ffefd489497b8fa66d7316e3e0d0c0f7ff6acca1b802809",
+              "url": "https://files.pythonhosted.org/packages/5f/12/1f00e9b92ae6feb2da0d0ef1d1c5672903fc7f18e1c53123b69ebd65ecef/scipy-1.10.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "abaf921531b5aeaafced90157db505e10345e45038c39e5d9b6c7922d68085cb",
-              "url": "https://files.pythonhosted.org/packages/92/f9/7ae2c1ae200212bc84b5a8369a10d644aa8b588140fe292d59db3b4a2545/scipy-1.9.3-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+              "hash": "2f9ea0a37aca111a407cb98aa4e8dfde6e5d9333bae06dfa5d938d14c80bb5c3",
+              "url": "https://files.pythonhosted.org/packages/76/22/287d06df9b359ba6df3f986e83267f240132379e4181c43cead3c5d41227/scipy-1.10.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "4db5b30849606a95dcf519763dd3ab6fe9bd91df49eba517359e450a7d80ce2e",
-              "url": "https://files.pythonhosted.org/packages/b5/67/c5451465ec94e654e6315cd5136961d267ae94a0f799b85d26eb9efe4c9f/scipy-1.9.3-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+              "hash": "42ab8b9e7dc1ebe248e55f54eea5307b6ab15011a7883367af48dd781d1312e4",
+              "url": "https://files.pythonhosted.org/packages/7a/23/13579b64ab458782a43e11e1ad095488458b8df099063ae07773666adada/scipy-1.10.0-cp311-cp311-macosx_10_15_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "c68db6b290cbd4049012990d7fe71a2abd9ffbe82c0056ebe0f01df8be5436b0",
-              "url": "https://files.pythonhosted.org/packages/bb/b7/380c9e4cd71263f03d16f8a92c0e44c9bdef38777e1a7dde1f47ba996bac/scipy-1.9.3-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+              "hash": "3afcbddb4488ac950ce1147e7580178b333a29cd43524c689b2e3543a080a2c8",
+              "url": "https://files.pythonhosted.org/packages/9f/31/c78e7c54a62bd986051c76e18ca38dc962fdf4e4078485d4307d61339dc7/scipy-1.10.0-cp39-cp39-macosx_10_15_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "90453d2b93ea82a9f434e4e1cba043e779ff67b92f7a0e85d05d286a3625df3c",
-              "url": "https://files.pythonhosted.org/packages/c3/3e/e40c52775a5d19abd43b1c245fbc5dee283a29acc45c830bc73bfad9468b/scipy-1.9.3-cp311-cp311-macosx_12_0_arm64.whl"
+              "hash": "6faf86ef7717891195ae0537e48da7524d30bc3b828b30c9b115d04ea42f076f",
+              "url": "https://files.pythonhosted.org/packages/c3/c4/8efe05b8ee86c7276448ef54f71ddb194416b881bc7a0d3c353279eea6aa/scipy-1.10.0-cp311-cp311-win_amd64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "da8245491d73ed0a994ed9c2e380fd058ce2fa8a18da204681f2fe1f57f98f95",
-              "url": "https://files.pythonhosted.org/packages/c8/0f/d9f8c50be8670b7ba6f002679e84cd18f46a23faf62c1590f4d1bbec0c8c/scipy-1.9.3-cp39-cp39-macosx_12_0_arm64.whl"
+              "hash": "4df25a28bd22c990b22129d3c637fd5c3be4b7c94f975dca909d8bab3309b694",
+              "url": "https://files.pythonhosted.org/packages/d5/80/b23382de9c50509afd151d6876dca33cafef2237a36f74ac7f3bfc327fc2/scipy-1.10.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "1a72d885fa44247f92743fc20732ae55564ff2a519e8302fb7e18717c5355a8b",
-              "url": "https://files.pythonhosted.org/packages/ce/28/635391e72e24bd3f4a91e374f4a186a5e4ecc95f23d8a55c9b0d25777cf7/scipy-1.9.3-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+              "hash": "c8b3cbc636a87a89b770c6afc999baa6bcbb01691b5ccbbc1b1791c7c0a07540",
+              "url": "https://files.pythonhosted.org/packages/d6/bd/2d13a273d95f7b7d9903c906c486040b0aebb85e008f93a5dd0891f21f1f/scipy-1.10.0.tar.gz"
             },
             {
               "algorithm": "sha256",
-              "hash": "68239b6aa6f9c593da8be1509a05cb7f9efe98b80f43a5861cd24c7557e98523",
-              "url": "https://files.pythonhosted.org/packages/cf/0e/3f1685c1fcb5dfe35ec027a5fc7a29e8818c61b2cc7fa207b4fc7b959f52/scipy-1.9.3-cp310-cp310-win_amd64.whl"
+              "hash": "2ad449db4e0820e4b42baccefc98ec772ad7818dcbc9e28b85aa05a536b0f1a2",
+              "url": "https://files.pythonhosted.org/packages/da/b8/03dae1cd4fa687d84cd60513aef17efecf7c277bc771bb96a1d8780dd734/scipy-1.10.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "b41bc822679ad1c9a5f023bc93f6d0543129ca0f37c1ce294dd9d386f0a21096",
-              "url": "https://files.pythonhosted.org/packages/df/75/c0254dc58d1f1b00f9d3dbda029743b71b815dd512461ed20d9b7f459e37/scipy-1.9.3-cp311-cp311-macosx_10_9_x86_64.whl"
+              "hash": "27e548276b5a88b51212b61f6dda49a24acf5d770dff940bd372b3f7ced8c6c2",
+              "url": "https://files.pythonhosted.org/packages/ec/97/719e7c5b5081524b056652eec1e31c08a54f262f00dae62089094bde66b3/scipy-1.10.0-cp310-cp310-win_amd64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "83c06e62a390a9167da60bedd4575a14c1f58ca9dfde59830fc42e5197283dab",
-              "url": "https://files.pythonhosted.org/packages/f9/37/5cd44af74d7178a44452b17ea162bc93996d5555b4a978877d2efd56fe84/scipy-1.9.3-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+              "hash": "441cab2166607c82e6d7a8683779cb89ba0f475b983c7e4ab88f3668e268c143",
+              "url": "https://files.pythonhosted.org/packages/f3/c7/16537a3e7178a08329d455d7b1c6f43177034e708a0c2517f9e308560019/scipy-1.10.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "1884b66a54887e21addf9c16fb588720a8309a57b2e258ae1c7986d4444d3bc0",
-              "url": "https://files.pythonhosted.org/packages/fb/ba/1733dbbc19f2aa07d100cfa220bcc83a3977bc5c9f0a5ad262dae1f3ab90/scipy-1.9.3-cp310-cp310-macosx_10_9_x86_64.whl"
+              "hash": "e096b062d2efdea57f972d232358cb068413dc54eec4f24158bcbb5cb8bddfd8",
+              "url": "https://files.pythonhosted.org/packages/fc/c9/a58b6c6ade3e80f76b134632fad491438b78c844ee54e590c7b842cb9de3/scipy-1.10.0-cp311-cp311-macosx_12_0_arm64.whl"
             }
           ],
           "project_name": "scipy",
           "requires_dists": [
             "asv; extra == \"test\"",
+            "click; extra == \"dev\"",
+            "doit>=0.36.0; extra == \"dev\"",
             "flake8; extra == \"dev\"",
             "gmpy2; extra == \"test\"",
             "matplotlib>2; extra == \"doc\"",
             "mpmath; extra == \"test\"",
             "mypy; extra == \"dev\"",
-            "numpy<1.26.0,>=1.18.5",
+            "numpy<1.27.0,>=1.19.5",
             "numpydoc; extra == \"doc\"",
+            "pooch; extra == \"test\"",
             "pycodestyle; extra == \"dev\"",
             "pydata-sphinx-theme==0.9.0; extra == \"doc\"",
+            "pydevtool; extra == \"dev\"",
             "pytest-cov; extra == \"test\"",
+            "pytest-timeout; extra == \"test\"",
             "pytest-xdist; extra == \"test\"",
             "pytest; extra == \"test\"",
+            "rich-click; extra == \"dev\"",
             "scikit-umfpack; extra == \"test\"",
             "sphinx!=4.1.0; extra == \"doc\"",
-            "sphinx-panels>=0.5.2; extra == \"doc\"",
-            "sphinx-tabs; extra == \"doc\"",
+            "sphinx-design>=0.2.0; extra == \"doc\"",
             "threadpoolctl; extra == \"test\"",
             "typing_extensions; extra == \"dev\""
           ],
-          "requires_python": ">=3.8",
-          "version": "1.9.3"
+          "requires_python": "<3.12,>=3.8",
+          "version": "1.10"
         },
         {
           "artifacts": [
@@ -8643,13 +9161,13 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "57f6f22bde4e042978bcd50176fdb381d7c21a9efa4041202288d3737a0c6a54",
-              "url": "https://files.pythonhosted.org/packages/ef/e3/29d6e1a07e8d90ace4a522d9689d03e833b67b50d1588e693eec15f26251/setuptools-65.6.3-py3-none-any.whl"
+              "hash": "8ab4f1dbf2b4a65f7eec5ad0c620e84c34111a68d3349833494b9088212214dd",
+              "url": "https://files.pythonhosted.org/packages/ff/97/9dc902414912192d68364cc01cf17e826d259ef9753504b7ae1a256f2e35/setuptools-65.7.0-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "a7620757bf984b58deaf32fc8a4577a9bbc0850cf92c20e1ce41c38c19e5fb75",
-              "url": "https://files.pythonhosted.org/packages/b6/21/cb9a8d0b2c8597c83fce8e9c02884bce3d4951e41e807fc35791c6b23d9a/setuptools-65.6.3.tar.gz"
+              "hash": "4d3c92fac8f1118bb77a22181355e29c239cabfe2b9effdaa665c66b711136d7",
+              "url": "https://files.pythonhosted.org/packages/a1/29/f2ad3b78b9ebd24afa282eed9add27b47ef52b37291198021154b4b65166/setuptools-65.7.0.tar.gz"
             }
           ],
           "project_name": "setuptools",
@@ -8676,7 +9194,7 @@
             "pytest-cov; platform_python_implementation != \"PyPy\" and extra == \"testing\"",
             "pytest-enabler; extra == \"testing-integration\"",
             "pytest-enabler>=1.3; extra == \"testing\"",
-            "pytest-flake8; extra == \"testing\"",
+            "pytest-flake8; python_version < \"3.12\" and extra == \"testing\"",
             "pytest-mypy>=0.9.1; platform_python_implementation != \"PyPy\" and extra == \"testing\"",
             "pytest-perf; extra == \"testing\"",
             "pytest-timeout; extra == \"testing\"",
@@ -8688,6 +9206,7 @@
             "sphinx-favicon; extra == \"docs\"",
             "sphinx-hoverxref<2; extra == \"docs\"",
             "sphinx-inline-tabs; extra == \"docs\"",
+            "sphinx-lint; extra == \"docs\"",
             "sphinx-notfound-page==0.8.3; extra == \"docs\"",
             "sphinx-reredirects; extra == \"docs\"",
             "sphinx>=3.5; extra == \"docs\"",
@@ -8700,25 +9219,25 @@
             "wheel; extra == \"testing-integration\""
           ],
           "requires_python": ">=3.7",
-          "version": "65.6.3"
+          "version": "65.7"
         },
         {
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "a8f02ba61b69baaa13facdba62908ca8690a94b8119b69f5ec5873ea85f7391b",
-              "url": "https://files.pythonhosted.org/packages/3d/1a/d31fce69c119df1fddab3706b63c53d363982c55d841d9c3839b12f15327/shellingham-1.5.0-py2.py3-none-any.whl"
+              "hash": "368bf8c00754fd4f55afb7bbb86e272df77e4dc76ac29dbcbb81a59e9fc15744",
+              "url": "https://files.pythonhosted.org/packages/ae/2a/7ad62b2c56e71c6330fc35cfd5813376e788146ef7c884cc2fdf5fe77696/shellingham-1.5.0.post1-py2.py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "72fb7f5c63103ca2cb91b23dee0c71fe8ad6fbfd46418ef17dbe40db51592dad",
-              "url": "https://files.pythonhosted.org/packages/bd/e6/fdf53ebbf08016dba98f2b047d4db95790157f0e2eed3b14bb5754271475/shellingham-1.5.0.tar.gz"
+              "hash": "823bc5fb5c34d60f285b624e7264f4dda254bc803a3774a147bf99c0e3004a28",
+              "url": "https://files.pythonhosted.org/packages/1f/13/fab0a3f512478bc387b66c51557ee715ede8e9811c77ce952f9b9a4d8ac1/shellingham-1.5.0.post1.tar.gz"
             }
           ],
           "project_name": "shellingham",
           "requires_dists": [],
-          "requires_python": ">=3.4",
-          "version": "1.5"
+          "requires_python": ">=3.7",
+          "version": "1.5.post1"
         },
         {
           "artifacts": [
@@ -8816,93 +9335,93 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "d3b6d4588994da73567bb00af9d7224a16c8027865a8aab53ae9be83f9b7cbd1",
-              "url": "https://files.pythonhosted.org/packages/e4/e6/d6adeec3da2ed6b808d6fd6531d3bde14de5a04807563736555f33d1fa1d/SQLAlchemy-1.4.44-cp39-cp39-win_amd64.whl"
+              "hash": "315676344e3558f1f80d02535f410e80ea4e8fddba31ec78fe390eff5fb8f466",
+              "url": "https://files.pythonhosted.org/packages/5d/8d/e80ccbb290db8de2faccceb1e121886b45ea1463253dabb3e88a6195c276/SQLAlchemy-1.4.46-cp39-cp39-win_amd64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "6f0ea4d7348feb5e5d0bf317aace92e28398fa9a6e38b7be9ec1f31aad4a8039",
-              "url": "https://files.pythonhosted.org/packages/1e/23/0a0b26a7b94e4c268fa0dfbb9eb834628e4f27dbd421ec81483a74cda9b7/SQLAlchemy-1.4.44-cp310-cp310-win_amd64.whl"
+              "hash": "7f8267682eb41a0584cf66d8a697fef64b53281d01c93a503e1344197f2e01fe",
+              "url": "https://files.pythonhosted.org/packages/00/ef/3d1f7491eb4782dcd5e0494c650b4e52d02b17436db06510e5707fdee2be/SQLAlchemy-1.4.46-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "80ead36fb1d676cc019586ffdc21c7e906ce4bf243fe4021e4973dae332b6038",
-              "url": "https://files.pythonhosted.org/packages/2c/b2/7bbd111b546f853f19c0994d9b43023f3b42fba325eeef4a9efe5c141250/SQLAlchemy-1.4.44-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl"
+              "hash": "887865924c3d6e9a473dc82b70977395301533b3030d0f020c38fd9eba5419f2",
+              "url": "https://files.pythonhosted.org/packages/18/b4/6b635a822da6e69ad193a3963c5d4417ec07446bc5dfd7fded7aeac7e2ba/SQLAlchemy-1.4.46-cp311-cp311-win32.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "237067ba0ef45a518b64606e1807f7229969ad568288b110ed5f0ca714a3ed3a",
-              "url": "https://files.pythonhosted.org/packages/32/90/dc2454e34129f18dc0ed44f23311d474f5a1dbd520e78a8b08b1fd187cad/SQLAlchemy-1.4.44-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+              "hash": "a3714e5b33226131ac0da60d18995a102a17dddd42368b7bdd206737297823ad",
+              "url": "https://files.pythonhosted.org/packages/38/28/621616b6d80cead1efd6a50913a83bb263caed2c532e0084f7ff09c80b3d/SQLAlchemy-1.4.46-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "c46322354c58d4dc039a2c982d28284330f8919f31206894281f4b595b9d8dbe",
-              "url": "https://files.pythonhosted.org/packages/40/96/08c3b770e680683a00d25dbe5766bfa00b586fd6bbde79b30471a02084bf/SQLAlchemy-1.4.44-cp311-cp311-win32.whl"
+              "hash": "b7f4b6aa6e87991ec7ce0e769689a977776db6704947e562102431474799a857",
+              "url": "https://files.pythonhosted.org/packages/6a/4c/34ee83616714e6194980e0429a8d58746f011848ea766cd61083a6ae5535/SQLAlchemy-1.4.46-cp310-cp310-macosx_11_0_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "7313e4acebb9ae88dbde14a8a177467a7625b7449306c03a3f9f309b30e163d0",
-              "url": "https://files.pythonhosted.org/packages/56/5a/7122b55c6380b204af3ee12a732966003c06f193b7aee158bacf46acc7d6/SQLAlchemy-1.4.44-cp311-cp311-win_amd64.whl"
+              "hash": "955162ad1a931fe416eded6bb144ba891ccbf9b2e49dc7ded39274dd9c5affc5",
+              "url": "https://files.pythonhosted.org/packages/6c/d9/b1718d3a189d34fc018ace5caeb965370b509f760e7b661b12f2238a21ca/SQLAlchemy-1.4.46-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "7cf7c7adbf4417e3f46fc5a2dbf8395a5a69698217337086888f79700a12e93a",
-              "url": "https://files.pythonhosted.org/packages/63/83/e383d7ff99871e747a2e3641ad8034eb31ce7ae762883c8daed70fcfd56f/SQLAlchemy-1.4.44-cp39-cp39-win32.whl"
+              "hash": "b6e4cb5c63f705c9d546a054c60d326cbde7421421e2d2565ce3e2eee4e1a01f",
+              "url": "https://files.pythonhosted.org/packages/73/3e/b82293fc17612488ff068c5235e743ebfe05310301984ca0467f88237572/SQLAlchemy-1.4.46-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "65a0ad931944fcb0be12a8e0ac322dbd3ecf17c53f088bc10b6da8f0caac287b",
-              "url": "https://files.pythonhosted.org/packages/6d/86/e4ed32f9bbaa26944d0455695d185ac4b3d8300d78e1920d29795635f92e/SQLAlchemy-1.4.44-cp310-cp310-macosx_10_15_x86_64.whl"
+              "hash": "d68e1762997bfebf9e5cf2a9fd0bcf9ca2fdd8136ce7b24bbd3bbfa4328f3e4a",
+              "url": "https://files.pythonhosted.org/packages/82/77/2e514172a644f8c579a47f4d3125b057a5895ac9afc67971c5a33fed9550/SQLAlchemy-1.4.46-cp311-cp311-macosx_10_9_universal2.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "94c0093678001f5d79f2dcbf3104c54d6c89e41ab50d619494c503a4d3f1aef2",
-              "url": "https://files.pythonhosted.org/packages/8d/2c/56564b36ea9ac88b90563fa26d51602792b07ef4a324b1c63bca9b97e984/SQLAlchemy-1.4.44-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+              "hash": "31de1e2c45e67a5ec1ecca6ec26aefc299dd5151e355eb5199cd9516b57340be",
+              "url": "https://files.pythonhosted.org/packages/88/b5/47f5c394b2ff2a0997c05d4cc999537a576e6c2fd8298c996fa7deea6991/SQLAlchemy-1.4.46-cp310-cp310-win_amd64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "f5e8ed9cde48b76318ab989deeddc48f833d2a6a7b7c393c49b704f67dedf01d",
-              "url": "https://files.pythonhosted.org/packages/90/c0/960e58e7599cc379b082314212aa1af610a2f9e1c4c9909bee24a1fa0b92/SQLAlchemy-1.4.44-cp311-cp311-macosx_10_9_universal2.whl"
+              "hash": "51e1ba2884c6a2b8e19109dc08c71c49530006c1084156ecadfaadf5f9b8b053",
+              "url": "https://files.pythonhosted.org/packages/93/d5/343f29c27892d34ce774afc421d6174d71586915ebf6bdcc0b4f2b0e946c/SQLAlchemy-1.4.46-cp39-cp39-win32.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "6d7e1b28342b45f19e3dea7873a9479e4a57e15095a575afca902e517fb89652",
-              "url": "https://files.pythonhosted.org/packages/9f/a1/91dcc218089e94ba5b1d0ec81880993c115c10f3ba958b7850c5e1fd7d20/SQLAlchemy-1.4.44-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl"
+              "hash": "5dbf17ac9a61e7a3f1c7ca47237aac93cabd7f08ad92ac5b96d6f8dea4287fc1",
+              "url": "https://files.pythonhosted.org/packages/a4/6e/c1d1c8c675630d267363b2d42592c57e7a6fba618787bd9af9761f67b3b5/SQLAlchemy-1.4.46-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "595b185041a4dc5c685283ea98c2f67bbfa47bb28e4a4f5b27ebf40684e7a9f8",
-              "url": "https://files.pythonhosted.org/packages/ae/ae/a367beae48e34a318de390580675e231960e051b04c482e61f2149963652/SQLAlchemy-1.4.44-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+              "hash": "1b1e5e96e2789d89f023d080bee432e2fef64d95857969e70d3cadec80bd26f0",
+              "url": "https://files.pythonhosted.org/packages/a6/81/6ffe04515b539f001168b3d63ff5305fdc2db90696d18ba1be7ab340cde2/SQLAlchemy-1.4.46-cp39-cp39-macosx_11_0_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "9c857676d810ca196be73c98eb839125d6fa849bfa3589be06201a6517f9961c",
-              "url": "https://files.pythonhosted.org/packages/c5/01/968a65de5f249a2943ed14adfef8b59cfeb73747d678d1d8ee70c0b7d806/SQLAlchemy-1.4.44-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+              "hash": "6913b8247d8a292ef8315162a51931e2b40ce91681f1b6f18f697045200c4a30",
+              "url": "https://files.pythonhosted.org/packages/af/ae/8d8e67f2691f0fdb845df90013d68c12a9127e009b4dedc34a3228f4e5ad/SQLAlchemy-1.4.46.tar.gz"
             },
             {
               "algorithm": "sha256",
-              "hash": "c9aa372b295a36771cffc226b6517df3011a7d146ac22d19fa6a75f1cdf9d7e6",
-              "url": "https://files.pythonhosted.org/packages/d6/d7/58fb086d0cf343407f857f5a41ed3453ad94e6c94655f5d6b8626e593ca6/SQLAlchemy-1.4.44-cp39-cp39-macosx_10_15_x86_64.whl"
+              "hash": "984ee13543a346324319a1fb72b698e521506f6f22dc37d7752a329e9cd00a32",
+              "url": "https://files.pythonhosted.org/packages/bd/2d/db768a164efcd36c8ec1accf559dd89bda60fbaec33913207fc78d2043cf/SQLAlchemy-1.4.46-cp311-cp311-win_amd64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "ae1ed1ebc407d2f66c6f0ec44ef7d56e3f455859df5494680e2cf89dad8e3ae0",
-              "url": "https://files.pythonhosted.org/packages/e7/68/b0018977adf60718de3fbb7201e907bc6b9ee8549dd2f363be1016a7dbab/SQLAlchemy-1.4.44-cp310-cp310-win32.whl"
+              "hash": "69fac0a7054d86b997af12dc23f581cf0b25fb1c7d1fed43257dee3af32d3d6d",
+              "url": "https://files.pythonhosted.org/packages/cd/29/19c2455deb2fcaa5aa951eda2c8a878aba5c7211e73d9201303441c63ccc/SQLAlchemy-1.4.46-cp311-cp311-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "4c56e6899fa6e767e4be5d106941804a4201c5cb9620a409c0b80448ec70b656",
-              "url": "https://files.pythonhosted.org/packages/e9/29/2e92e729da5f3bb3c7daba5949865dcae7d7afe763ce267119f6ac2f3525/SQLAlchemy-1.4.44-cp311-cp311-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+              "hash": "4d112b0f3c1bc5ff70554a97344625ef621c1bfe02a73c5d97cac91f8cd7a41e",
+              "url": "https://files.pythonhosted.org/packages/e0/c9/21d0e10bff602b673f21ed99cc641e8883fef54983b23b09d5216fca3872/SQLAlchemy-1.4.46-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "2dda5f96719ae89b3ec0f1b79698d86eb9aecb1d54e990abb3fdd92c04b46a90",
-              "url": "https://files.pythonhosted.org/packages/eb/71/f5f512914b86bd007bf842d9b95dba78eedb899d46025ab86b197b22ae62/SQLAlchemy-1.4.44.tar.gz"
+              "hash": "5f752676fc126edc1c4af0ec2e4d2adca48ddfae5de46bb40adbd3f903eb2120",
+              "url": "https://files.pythonhosted.org/packages/e1/7e/92a4c30859e7950c8f4f5de0388b953b4b7e560e8d48a50f503d1d8e3980/SQLAlchemy-1.4.46-cp310-cp310-win32.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "68e0cd5d32a32c4395168d42f2fefbb03b817ead3a8f3704b8bd5697c0b26c24",
-              "url": "https://files.pythonhosted.org/packages/fc/3f/9789b0ed62202e3d0f3aeb9415c572fb97aaa8be10b2a941874b5ff8096b/SQLAlchemy-1.4.44-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+              "hash": "64cb0ad8a190bc22d2112001cfecdec45baffdf41871de777239da6a28ed74b6",
+              "url": "https://files.pythonhosted.org/packages/eb/8d/1b52215b53a4a7f3bc0e532c7491cd48fd30a9c2c76470c505db1229a8c8/SQLAlchemy-1.4.46-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
             }
           ],
           "project_name": "sqlalchemy",
@@ -8939,19 +9458,19 @@
             "typing-extensions!=3.10.0.1; extra == \"aiosqlite\""
           ],
           "requires_python": "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,>=2.7",
-          "version": "1.4.44"
+          "version": "1.4.46"
         },
         {
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "e23dc5f709e16e7a9788f9f65c65f9ac8b9b564bb4437c4971d673969a99b0bd",
-              "url": "https://files.pythonhosted.org/packages/79/05/4d40060b18b7c0275c76f456815f192ab69b59ba9212ec2d4f138a924899/sqlfluff-1.4.2-py3-none-any.whl"
+              "hash": "10b193ee009046f8fe3af9d1895f767b691635653cccc8698bc01eee2ccb69df",
+              "url": "https://files.pythonhosted.org/packages/78/31/695198c42d3943679aa1ef8e0688bbe3345d9dac6f0da155588983a3014b/sqlfluff-1.4.5-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "6182c8523b46b133bd4826462070fdcf72349e45906ad755813fb5b0f6cdcb4b",
-              "url": "https://files.pythonhosted.org/packages/d4/97/b89f0067ec68790efd3c17407f573f5ad4d05a953984049689f1f51c8fbb/sqlfluff-1.4.2.tar.gz"
+              "hash": "68a8abde2fa22b76a20d908e22087e2e12b0e4a2085be2ea955ff6305b0fea30",
+              "url": "https://files.pythonhosted.org/packages/2b/65/9c015ce3bb1b75b6ccd52aaefe1fec8f40688cc47ba8e4792e6d60dea348/sqlfluff-1.4.5.tar.gz"
             }
           ],
           "project_name": "sqlfluff",
@@ -8974,7 +9493,7 @@
             "typing-extensions"
           ],
           "requires_python": ">=3.7",
-          "version": "1.4.2"
+          "version": "1.4.5"
         },
         {
           "artifacts": [
@@ -9025,13 +9544,13 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "b5eda991ad5f0ee5d8ce4c4540202a573bb6691ecd0c712262d0bc85cf8f2c50",
-              "url": "https://files.pythonhosted.org/packages/1d/4e/30eda84159d5b3ad7fe663c40c49b16dd17436abe838f10a56c34bee44e8/starlette-0.22.0-py3-none-any.whl"
+              "hash": "ec69736c90be8dbfc6ec6800ba6feb79c8c44f9b1706c0b2bb27f936bcf362cc",
+              "url": "https://files.pythonhosted.org/packages/a3/1d/b23984c05e39ddab35bbba33a3828dc4f896250220dcbd946c0fcad1e934/starlette-0.23.1-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "b092cbc365bea34dd6840b42861bdabb2f507f8671e642e8272d2442e08ea4ff",
-              "url": "https://files.pythonhosted.org/packages/f7/ff/64bd3362f80e81402f21e0f1ba55f8801cd899ad3f2a1bcc4a94d284c786/starlette-0.22.0.tar.gz"
+              "hash": "8510e5b3d670326326c5c1d4cb657cc66832193fe5d5b7015a51c7b1e1b1bf42",
+              "url": "https://files.pythonhosted.org/packages/0c/d2/a2898deb36d12e40e84e83b7728628a04013cb0cfc545932c4605185bf2d/starlette-0.23.1.tar.gz"
             }
           ],
           "project_name": "starlette",
@@ -9045,7 +9564,7 @@
             "typing-extensions>=3.10.0; python_version < \"3.10\""
           ],
           "requires_python": ">=3.7",
-          "version": "0.22"
+          "version": "0.23.1"
         },
         {
           "artifacts": [
@@ -9109,17 +9628,18 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "bf6fe52accd06d0661d7611cc73202121ec6ee51e46d8185d489ac074ca457c2",
-              "url": "https://files.pythonhosted.org/packages/4c/27/3ddec4ed8f8312d9c4774ae0a62469d29637176df8a5a6321070aa0edc97/terminado-0.17.0-py3-none-any.whl"
+              "hash": "8650d44334eba354dd591129ca3124a6ba42c3d5b70df5051b6921d506fdaeae",
+              "url": "https://files.pythonhosted.org/packages/84/a7/c7628d79651b8c8c775d27b374315a825141b5783512e82026fb210dd639/terminado-0.17.1-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "520feaa3aeab8ad64a69ca779be54be9234edb2d0d6567e76c93c2c9a4e6e43f",
-              "url": "https://files.pythonhosted.org/packages/b6/17/557926e8c2842133454fe406ea79752a951c4602f2065d3cc6587a130289/terminado-0.17.0.tar.gz"
+              "hash": "6ccbbcd3a4f8a25a5ec04991f39a0b8db52dfcd487ea0e578d977e6752380333",
+              "url": "https://files.pythonhosted.org/packages/55/be/748034192602b9fd69ba94544c1675ff18b039ed8f346ad783478e31144f/terminado-0.17.1.tar.gz"
             }
           ],
           "project_name": "terminado",
           "requires_dists": [
+            "myst-parser; extra == \"docs\"",
             "pre-commit; extra == \"test\"",
             "ptyprocess; os_name != \"nt\"",
             "pydata-sphinx-theme; extra == \"docs\"",
@@ -9130,7 +9650,7 @@
             "tornado>=6.1.0"
           ],
           "requires_python": ">=3.7",
-          "version": "0.17"
+          "version": "0.17.1"
         },
         {
           "artifacts": [
@@ -9251,19 +9771,19 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "8ed8e109e96ae30bf66da2d2155e4eb9989d9c5c743c837e37d9774a4eddd804",
-              "url": "https://files.pythonhosted.org/packages/0b/d1/dfbff7af958d31a0132ecffe5333ffb5ebb315cdff4a22b4f754bc888aad/toposort-1.7-py2.py3-none-any.whl"
+              "hash": "9f434c815e1bd2f9ad05152b6b0071b1f56e288c107869708f2463ec932e2637",
+              "url": "https://files.pythonhosted.org/packages/ba/d8/494820a2dc0c03ea8594011b9dac352125c0bd26d5d9db5852fb1663d4b1/toposort-1.9-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "ddc2182c42912a440511bd7ff5d3e6a1cabc3accbc674a3258c8c41cbfbb2125",
-              "url": "https://files.pythonhosted.org/packages/b2/be/67bec9a73041616dd359f06e997d56c9c99d252460a3f035411d97c96c48/toposort-1.7.tar.gz"
+              "hash": "f41a34490d44934b533a7bdaff979ee8a47203fd2d8a746db83f2d5ab12458b9",
+              "url": "https://files.pythonhosted.org/packages/8d/c3/44e51b42160145e4ebeb7d86ab93bd933fa9498f94e183ef8a47c6de8b2f/toposort-1.9.tar.gz"
             }
           ],
           "project_name": "toposort",
           "requires_dists": [],
           "requires_python": null,
-          "version": "1.7"
+          "version": "1.9"
         },
         {
           "artifacts": [
@@ -9359,44 +9879,49 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "1410755385d778aed847d68deb99b3ba30fbbf489e17a1e8cbb753060d5cce73",
-              "url": "https://files.pythonhosted.org/packages/6b/8c/61bbbb51be65d26adc979db4862da9cd3eb24b753f1966fc1c7f44be19df/traitlets-5.6.0-py3-none-any.whl"
+              "hash": "a1ca5df6414f8b5760f7c5f256e326ee21b581742114545b462b35ffe3f04861",
+              "url": "https://files.pythonhosted.org/packages/76/fa/bd160e08ac7f656d818a0e40ff88e1a302b07ad2384864fb288db3c812fa/traitlets-5.8.1-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "10b6ed1c9cedee83e795db70a8b9c2db157bb3778ec4587a349ecb7ef3b1033b",
-              "url": "https://files.pythonhosted.org/packages/ed/98/43976cc847e7f2a79770af0a92cbb3cbf0e568ba0b3daa88699b4c746ae9/traitlets-5.6.0.tar.gz"
+              "hash": "32500888f5ff7bbf3b9267ea31748fa657aaf34d56d85e60f91dda7dc7f5785b",
+              "url": "https://files.pythonhosted.org/packages/be/58/2d930cfab2caca22c827229ca61aabd8102423f7e817805cba706dce1598/traitlets-5.8.1.tar.gz"
             }
           ],
           "project_name": "traitlets",
           "requires_dists": [
+            "argcomplete>=2.0; extra == \"test\"",
             "myst-parser; extra == \"docs\"",
             "pre-commit; extra == \"test\"",
             "pydata-sphinx-theme; extra == \"docs\"",
+            "pytest-mock; extra == \"test\"",
             "pytest; extra == \"test\"",
             "sphinx; extra == \"docs\""
           ],
           "requires_python": ">=3.7",
-          "version": "5.6"
+          "version": "5.8.1"
         },
         {
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "45b6d7432bc4f6c4a36a0224ecb3cc1814011df69bb734a407ed26c08c89c32b",
-              "url": "https://files.pythonhosted.org/packages/5d/68/48789e7ca7b3458d508aaf867304468869a0c72d8884eee2d800d4ae77e4/trino-0.318.0-py3-none-any.whl"
+              "hash": "44e07da121a655da9f9eb92a0670bad8b4d769f7e42537281bd101ab7b7de3ee",
+              "url": "https://files.pythonhosted.org/packages/c0/19/f4c98ef9e4ea3f38f78c1fce860fb9342d17ff3abdaa65e851532c05c549/trino-0.319.0-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "ca1bfed9ce9462f4a408a7be041c74ef6a36f621c91edf0792c63f483e00c104",
-              "url": "https://files.pythonhosted.org/packages/cb/42/c99d1132c9fc1db76ce997cc7058b82513e4d4736712c30cbd4d1dca6f17/trino-0.318.0.tar.gz"
+              "hash": "d5a01258ff48b4e6dbed9cdbb070e2bf5afdbec90c933b19f1acad6db2947f32",
+              "url": "https://files.pythonhosted.org/packages/b1/64/65ee4d85392a349b61582ad8b40807dec5937971ee723152aaae065047b9/trino-0.319.0.tar.gz"
             }
           ],
           "project_name": "trino",
           "requires_dists": [
+            "black; extra == \"tests\"",
             "click; extra == \"tests\"",
             "httpretty<1.1; extra == \"tests\"",
+            "isort; extra == \"tests\"",
             "keyring; extra == \"external-authentication-token-cache\"",
+            "pre-commit; extra == \"tests\"",
             "pytest-runner; extra == \"tests\"",
             "pytest; extra == \"tests\"",
             "pytz",
@@ -9404,32 +9929,13 @@
             "requests-kerberos; extra == \"all\"",
             "requests-kerberos; extra == \"kerberos\"",
             "requests-kerberos; extra == \"tests\"",
+            "sqlalchemy-utils; extra == \"tests\"",
             "sqlalchemy~=1.3; extra == \"all\"",
             "sqlalchemy~=1.3; extra == \"sqlalchemy\"",
             "sqlalchemy~=1.3; extra == \"tests\""
           ],
           "requires_python": ">=3.7",
-          "version": "0.318"
-        },
-        {
-          "artifacts": [
-            {
-              "algorithm": "sha256",
-              "hash": "a8b94eb34c95982fbd34b8daa46fd78c43db33c075b98c79b6e1d77e8f7dd4d5",
-              "url": "https://files.pythonhosted.org/packages/ca/38/837105d59d0b72eebf843dee6eda0c084aba4b6b4f64dd0251435eb86930/typing_compat-0.1.0-py2.py3-none-any.whl"
-            },
-            {
-              "algorithm": "sha256",
-              "hash": "a7159db80406de342bc128ab315fae3afe1ddc87cbc2df7a023763090fdfe5d2",
-              "url": "https://files.pythonhosted.org/packages/c8/f3/47e8f5d02b190aa1d47ad0311f55873121b7a0728c30423ce56bf790232c/typing-compat-0.1.0.tar.gz"
-            }
-          ],
-          "project_name": "typing-compat",
-          "requires_dists": [
-            "typing; python_version < \"3.5\""
-          ],
-          "requires_python": "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,>=2.7",
-          "version": "0.1"
+          "version": "0.319"
         },
         {
           "artifacts": [
@@ -9453,19 +9959,19 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "04a680bdc5b15750c39c12a448885a51134a27ec9af83667663f0b3a1bf3f342",
-              "url": "https://files.pythonhosted.org/packages/61/1e/3c4bf37f8d6ceba07ae357e70eedd21bd15a032b460bab6b12a58c0fce9d/tzdata-2022.6-py2.py3-none-any.whl"
+              "hash": "2b88858b0e3120792a3c0635c23daf36a7d7eeeca657c323da299d2094402a0d",
+              "url": "https://files.pythonhosted.org/packages/fa/5e/f99a7df3ae2079211d31ec23b1d34380c7870c26e99159f6e422dcbab538/tzdata-2022.7-py2.py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "91f11db4503385928c15598c98573e3af07e7229181bee5375bd30f1695ddcae",
-              "url": "https://files.pythonhosted.org/packages/5e/9f/63f7187ffd6d01dd5b5255b8c0b1c4f05ecfe79d940e0a243a6198071832/tzdata-2022.6.tar.gz"
+              "hash": "fe5f866eddd8b96e9fcba978f8e503c909b19ea7efda11e52e39494bad3a7bfa",
+              "url": "https://files.pythonhosted.org/packages/5b/30/b7abfb11be6642d26de1c1840d25e8d90333513350ad0ebc03101d55e13b/tzdata-2022.7.tar.gz"
             }
           ],
           "project_name": "tzdata",
           "requires_dists": [],
           "requires_python": ">=2",
-          "version": "2022.6"
+          "version": "2022.7"
         },
         {
           "artifacts": [
@@ -9551,13 +10057,13 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "47cc05d99aaa09c9e72ed5809b60e7ba354e64b59c9c173ac3018642d8bb41fc",
-              "url": "https://files.pythonhosted.org/packages/65/0c/cc6644eaa594585e5875f46f3c83ee8762b647b51fc5b0fb253a242df2dc/urllib3-1.26.13-py2.py3-none-any.whl"
+              "hash": "75edcdc2f7d85b137124a6c3c9fc3933cdeaa12ecb9a6a959f22797a0feca7e1",
+              "url": "https://files.pythonhosted.org/packages/fe/ca/466766e20b767ddb9b951202542310cba37ea5f2d792dae7589f1741af58/urllib3-1.26.14-py2.py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "c083dd0dce68dbfbe1129d5271cb90f9447dea7d52097c6e0126120c521ddea8",
-              "url": "https://files.pythonhosted.org/packages/c2/51/32da03cf19d17d46cce5c731967bf58de9bd71db3a379932f53b094deda4/urllib3-1.26.13.tar.gz"
+              "hash": "076907bf8fd355cde77728471316625a4d2f7e713c125f51953bb5b3eecf4f72",
+              "url": "https://files.pythonhosted.org/packages/c5/52/fe421fb7364aa738b3506a2d99e4f3a56e079c0a798e9f4fa5e14c60922f/urllib3-1.26.14.tar.gz"
             }
           ],
           "project_name": "urllib3",
@@ -9574,7 +10080,7 @@
             "urllib3-secure-extra; extra == \"secure\""
           ],
           "requires_python": "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,>=2.7",
-          "version": "1.26.13"
+          "version": "1.26.14"
         },
         {
           "artifacts": [
@@ -9734,13 +10240,13 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "40a7e06a98728fd5769e1af6fd1a706005b4bb7e16176a272ed4292473180389",
-              "url": "https://files.pythonhosted.org/packages/4c/5a/43d00dcd60392a249472638199c0fd7d023160194b35455fbbaae43eda20/virtualenv-20.17.0-py3-none-any.whl"
+              "hash": "ce3b1684d6e1a20a3e5ed36795a97dfc6af29bc3970ca8dab93e11ac6094b3c4",
+              "url": "https://files.pythonhosted.org/packages/18/a2/7931d40ecb02b5236a34ac53770f2f6931e3082b7a7dafe915d892d749d6/virtualenv-20.17.1-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "7d6a8d55b2f73b617f684ee40fd85740f062e1f2e379412cb1879c7136f05902",
-              "url": "https://files.pythonhosted.org/packages/ac/c0/a0a0fb1433e4c3d8d9e2d6c990812e328913c64adcfbcfcae1974af0521c/virtualenv-20.17.0.tar.gz"
+              "hash": "f8b927684efc6f1cc206c9db297a570ab9ad0e51c16fa9e45487d36d1905c058",
+              "url": "https://files.pythonhosted.org/packages/7b/19/65f13cff26c8cc11fdfcb0499cd8f13388dd7b35a79a376755f152b42d86/virtualenv-20.17.1.tar.gz"
             }
           ],
           "project_name": "virtualenv",
@@ -9767,99 +10273,114 @@
             "towncrier>=22.8; extra == \"docs\""
           ],
           "requires_python": ">=3.6",
-          "version": "20.17"
+          "version": "20.17.1"
         },
         {
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "ad576a565260d8f99d97f2e64b0f97a48228317095908568a9d5c786c829d428",
-              "url": "https://files.pythonhosted.org/packages/eb/15/e1a0c11f137fe05f593288fe735f8cd28c9b2f398e0c08623977dce81921/watchdog-2.1.9-py3-none-win_ia64.whl"
+              "hash": "195ab1d9d611a4c1e5311cbf42273bc541e18ea8c32712f2fb703cfc6ff006f9",
+              "url": "https://files.pythonhosted.org/packages/56/3e/2e21594c93a4dd8c8ffc7ea4276adab7cb027f836e8bbf293bec640020e0/watchdog-2.2.1-py3-none-win_ia64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "97f9752208f5154e9e7b76acc8c4f5a58801b338de2af14e7e181ee3b28a5d39",
-              "url": "https://files.pythonhosted.org/packages/1b/73/034d5eeed680829769485e1cccbd094991599801647954c0f7b91cff81e0/watchdog-2.1.9-cp39-cp39-macosx_10_9_universal2.whl"
+              "hash": "cdcc23c9528601a8a293eb4369cbd14f6b4f34f07ae8769421252e9c22718b6f",
+              "url": "https://files.pythonhosted.org/packages/11/6f/0396d373e039b89c60e23a1a9025edc6dd203121fe0af7d1427e85d5ec98/watchdog-2.2.1.tar.gz"
             },
             {
               "algorithm": "sha256",
-              "hash": "43ce20ebb36a51f21fa376f76d1d4692452b2527ccd601950d69ed36b9e21609",
-              "url": "https://files.pythonhosted.org/packages/42/f7/da8e889f8626786eac9454e8d2718fc79359ed517be20cdd50c647167d39/watchdog-2.1.9.tar.gz"
+              "hash": "5100eae58133355d3ca6c1083a33b81355c4f452afa474c2633bd2fbbba398b3",
+              "url": "https://files.pythonhosted.org/packages/17/c9/8c97c8f2ce646087d7c952af74985a3cc2b39bde9723c81fc17c01b861c0/watchdog-2.2.1-cp310-cp310-macosx_10_9_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "d3dda00aca282b26194bdd0adec21e4c21e916956d972369359ba63ade616153",
-              "url": "https://files.pythonhosted.org/packages/53/e0/4427a6c25d3a399bf30b9ab7a8d9aa438df4c460f5a094413c2dbd9ddb89/watchdog-2.1.9-py3-none-manylinux2014_i686.whl"
+              "hash": "cece1aa596027ff56369f0b50a9de209920e1df9ac6d02c7f9e5d8162eb4f02b",
+              "url": "https://files.pythonhosted.org/packages/23/7a/436bca74f15d70c16f9db13cbf449f41af65b59e9897b6ffb453c4a91db2/watchdog-2.2.1-py3-none-manylinux2014_ppc64le.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "7a833211f49143c3d336729b0020ffd1274078e94b0ae42e22f596999f50279c",
-              "url": "https://files.pythonhosted.org/packages/61/3f/a2fc9452b8161862a78674fda583d8e1addbbecf57a1e172b4a7a96e8087/watchdog-2.1.9-py3-none-win_amd64.whl"
+              "hash": "748ca797ff59962e83cc8e4b233f87113f3cf247c23e6be58b8a2885c7337aa3",
+              "url": "https://files.pythonhosted.org/packages/2b/b3/2ba384d62be9928ea3477cd1247e5254d90f9e985c6a1fb4a69d9462463f/watchdog-2.2.1-cp311-cp311-macosx_10_9_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "ee3e38a6cc050a8830089f79cbec8a3878ec2fe5160cdb2dc8ccb6def8552658",
-              "url": "https://files.pythonhosted.org/packages/72/68/7da5b686038f00feadd411187b8ab17ea71c392bc400a4232502d9d341e9/watchdog-2.1.9-cp310-cp310-macosx_11_0_arm64.whl"
+              "hash": "d6b87477752bd86ac5392ecb9eeed92b416898c30bd40c7e2dd03c3146105646",
+              "url": "https://files.pythonhosted.org/packages/2c/9c/bd6427901e99cd659f4e40092cee2fd668e1d367c5b23059f7128f90fa9c/watchdog-2.2.1-py3-none-manylinux2014_ppc64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "b530ae007a5f5d50b7fbba96634c7ee21abec70dc3e7f0233339c81943848dc1",
-              "url": "https://files.pythonhosted.org/packages/78/10/31420ab66c13fc3de8f7f1d0e0e7736715a09242f280c66bf994f1fd1ed2/watchdog-2.1.9-py3-none-manylinux2014_s390x.whl"
+              "hash": "e618a4863726bc7a3c64f95c218437f3349fb9d909eb9ea3a1ed3b567417c661",
+              "url": "https://files.pythonhosted.org/packages/34/a6/f21c909a8dbf295bf7715da9ef6cbbd4eba41253325c81cb22121a539b1b/watchdog-2.2.1-cp310-cp310-macosx_11_0_arm64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "a735a990a1095f75ca4f36ea2ef2752c99e6ee997c46b0de507ba40a09bf7330",
-              "url": "https://files.pythonhosted.org/packages/7e/72/d042345ee9c36edb4fb92a8d1760b114729f9c86c704c7cf513b9e1269d8/watchdog-2.1.9-cp310-cp310-macosx_10_9_universal2.whl"
+              "hash": "6ccd8d84b9490a82b51b230740468116b8205822ea5fdc700a553d92661253a3",
+              "url": "https://files.pythonhosted.org/packages/50/c3/eea5d31079b436ec89522ca03d3a8e9fa616389b0ee173892dfbd23f5166/watchdog-2.2.1-cp311-cp311-macosx_11_0_arm64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "226b3c6c468ce72051a4c15a4cc2ef317c32590d82ba0b330403cafd98a62cfd",
-              "url": "https://files.pythonhosted.org/packages/83/36/782ce92660031999f5c4dea12fa4ead53006f6569d00b253c38eb06742e3/watchdog-2.1.9-cp39-cp39-macosx_11_0_arm64.whl"
+              "hash": "8c28c23972ec9c524967895ccb1954bc6f6d4a557d36e681a36e84368660c4ce",
+              "url": "https://files.pythonhosted.org/packages/5d/c2/cabcca89b050ee704785365a30586e07de3fe101cba6276ca3aba145e0eb/watchdog-2.2.1-py3-none-manylinux2014_armv7l.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "083171652584e1b8829581f965b9b7723ca5f9a2cd7e20271edf264cfd7c1412",
-              "url": "https://files.pythonhosted.org/packages/88/1d/3f98cb264a3ec592a170e381acb27eeea5ad9c1dd0d881a3f853be27bd40/watchdog-2.1.9-py3-none-manylinux2014_ppc64le.whl"
+              "hash": "17f1708f7410af92ddf591e94ae71a27a13974559e72f7e9fde3ec174b26ba2e",
+              "url": "https://files.pythonhosted.org/packages/6d/7f/8deebfbec704ab40e2fe9064c1b157a9a7cd7061f64f7164fe5f902ce0fc/watchdog-2.2.1-py3-none-win_amd64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "9f05a5f7c12452f6a27203f76779ae3f46fa30f1dd833037ea8cbc2887c60213",
-              "url": "https://files.pythonhosted.org/packages/97/b3/bb38d1606b0e9a112afc6323d833cedd95610dcf913ace7f77c673a971f5/watchdog-2.1.9-py3-none-manylinux2014_aarch64.whl"
+              "hash": "e038be858425c4f621900b8ff1a3a1330d9edcfeaa1c0468aeb7e330fb87693e",
+              "url": "https://files.pythonhosted.org/packages/6f/94/b777029fdc7b1353e24ddc9f9f9bc0fe7788e684d036db20ded1a1b07aa6/watchdog-2.2.1-py3-none-manylinux2014_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "6b17d302850c8d412784d9246cfe8d7e3af6bcd45f958abb2d08a6f8bedf695d",
-              "url": "https://files.pythonhosted.org/packages/a1/ba/98ebdd44865c8dcb85d078e634f4f0b4ad1de021678f9707e1d04189b7a1/watchdog-2.1.9-cp310-cp310-macosx_10_9_x86_64.whl"
+              "hash": "8b5cde14e5c72b2df5d074774bdff69e9b55da77e102a91f36ef26ca35f9819c",
+              "url": "https://files.pythonhosted.org/packages/77/d0/455f2942c23283a0a9e759f289fabd33dc091d8c31bf507ba6cbfc77b266/watchdog-2.2.1-py3-none-manylinux2014_s390x.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "186f6c55abc5e03872ae14c2f294a153ec7292f807af99f57611acc8caa75306",
-              "url": "https://files.pythonhosted.org/packages/b8/11/62bfa298f40d93b9846df38281a01ddc61c3567423c14c0a8eda6bf149df/watchdog-2.1.9-py3-none-manylinux2014_ppc64.whl"
+              "hash": "978a1aed55de0b807913b7482d09943b23a2d634040b112bdf31811a422f6344",
+              "url": "https://files.pythonhosted.org/packages/88/d2/351134b5ff88b4e1a6b578cd4a83a8fe2abd4599190560d36da11c1127d4/watchdog-2.2.1-py3-none-manylinux2014_aarch64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "255bb5758f7e89b1a13c05a5bceccec2219f8995a3a4c4d6968fe1de6a3b2892",
-              "url": "https://files.pythonhosted.org/packages/c2/83/a0f418e4106dc8f9bcb0eeb31d0a929607ae7274bc88d7ebf76767229a73/watchdog-2.1.9-py3-none-manylinux2014_armv7l.whl"
+              "hash": "967636031fa4c4955f0f3f22da3c5c418aa65d50908d31b73b3b3ffd66d60640",
+              "url": "https://files.pythonhosted.org/packages/93/97/9d7cb281adcae6cb1085fd298df595bbc122b3b4e282c55187ba3d5817d3/watchdog-2.2.1-cp39-cp39-macosx_10_9_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "247dcf1df956daa24828bfea5a138d0e7a7c98b1a47cf1fa5b0c3c16241fcbb7",
-              "url": "https://files.pythonhosted.org/packages/d5/5f/3a81d3cf23731f643f494a0a61d0b8392964bc6c3a8be9e7fb83dd727916/watchdog-2.1.9-cp39-cp39-macosx_10_9_x86_64.whl"
+              "hash": "bc43c1b24d2f86b6e1cc15f68635a959388219426109233e606517ff7d0a5a73",
+              "url": "https://files.pythonhosted.org/packages/97/98/706978058d61948868d42a42135b5a8caaecf40513711fa6a7734db8d60f/watchdog-2.2.1-py3-none-win32.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "5952135968519e2447a01875a6f5fc8c03190b24d14ee52b0f4b1682259520b1",
-              "url": "https://files.pythonhosted.org/packages/dd/d2/3470040cbf4abb86c173f60fe73f4b568cc4d37ea3d60d51795dd631afbb/watchdog-2.1.9-py3-none-win32.whl"
+              "hash": "96cbeb494e6cbe3ae6aacc430e678ce4b4dd3ae5125035f72b6eb4e5e9eb4f4e",
+              "url": "https://files.pythonhosted.org/packages/9a/c7/2e730960a11b1161304ca7f9f9c3c7dd0ba230ad7378cdff76750a52ebcf/watchdog-2.2.1-cp39-cp39-macosx_11_0_arm64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "ed80a1628cee19f5cfc6bb74e173f1b4189eb532e705e2a13e3250312a62e0c9",
-              "url": "https://files.pythonhosted.org/packages/f8/50/d5501772dfb710618540842bfd927ba8e643834129101db279b3b388f2cb/watchdog-2.1.9-pp39-pypy39_pp73-macosx_10_9_x86_64.whl"
+              "hash": "102a60093090fc3ff76c983367b19849b7cc24ec414a43c0333680106e62aae1",
+              "url": "https://files.pythonhosted.org/packages/c2/47/065694b16c4e227b5a9b058f904c765a9a0d174c36db7bb34c915a37e324/watchdog-2.2.1-cp311-cp311-macosx_10_9_universal2.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "4f4e1c4aa54fb86316a62a87b3378c025e228178d55481d30d857c6c438897d6",
-              "url": "https://files.pythonhosted.org/packages/ff/e0/dad09238e32d161e332c2e94b367d2aaa5f2ffe3e240b49b70473979fd61/watchdog-2.1.9-py3-none-manylinux2014_x86_64.whl"
+              "hash": "c27d8c1535fd4474e40a4b5e01f4ba6720bac58e6751c667895cbc5c8a7af33c",
+              "url": "https://files.pythonhosted.org/packages/cb/3f/e9b10c8693d2e3a4d94a6ed7ae42391cf169d23523f9165b94151f321d88/watchdog-2.2.1-py3-none-manylinux2014_i686.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "d0f29fd9f3f149a5277929de33b4f121a04cf84bb494634707cfa8ea8ae106a8",
+              "url": "https://files.pythonhosted.org/packages/d0/ce/9cadf2b2ccb10dd3b96e036e79e497270fc1568af6b991dc55462df65ff6/watchdog-2.2.1-cp39-cp39-macosx_10_9_universal2.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "a480d122740debf0afac4ddd583c6c0bb519c24f817b42ed6f850e2f6f9d64a8",
+              "url": "https://files.pythonhosted.org/packages/f4/20/f02d47f27d2e395eca01a96438411ed343be76855481da95e18e2d6c6546/watchdog-2.2.1-pp39-pypy39_pp73-macosx_10_9_x86_64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "a09483249d25cbdb4c268e020cb861c51baab2d1affd9a6affc68ffe6a231260",
+              "url": "https://files.pythonhosted.org/packages/f8/35/98996332b9ae5a805ae8f7bad4834f51c0c8b070c223e7417163820732c5/watchdog-2.2.1-cp310-cp310-macosx_10_9_universal2.whl"
             }
           ],
           "project_name": "watchdog",
@@ -9867,7 +10388,7 @@
             "PyYAML>=3.10; extra == \"watchmedo\""
           ],
           "requires_python": ">=3.6",
-          "version": "2.1.9"
+          "version": "2.2.1"
         },
         {
           "artifacts": [
@@ -9958,13 +10479,13 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "beb4802a9cebb9144e99086eff703a642a13d6a0052920003a230f3294bbe784",
-              "url": "https://files.pythonhosted.org/packages/59/7c/e39aca596badaf1b78e8f547c807b04dae603a433d3e7a7e04d67f2ef3e5/wcwidth-0.2.5-py2.py3-none-any.whl"
+              "hash": "795b138f6875577cd91bba52baf9e445cd5118fd32723b460e30a0af30ea230e",
+              "url": "https://files.pythonhosted.org/packages/20/f4/c0584a25144ce20bfcf1aecd041768b8c762c1eb0aa77502a3f0baa83f11/wcwidth-0.2.6-py2.py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "c4d647b99872929fdb7bdcaa4fbe7f01413ed3d98077df798530e5b04f116c83",
-              "url": "https://files.pythonhosted.org/packages/89/38/459b727c381504f361832b9e5ace19966de1a235d73cdbdea91c771a1155/wcwidth-0.2.5.tar.gz"
+              "hash": "a5220780a404dbe3353789870978e472cfe477761f06ee55077256e509b156d0",
+              "url": "https://files.pythonhosted.org/packages/5e/5f/1e4bd82a9cc1f17b2c2361a2d876d4c38973a997003ba5eb400e8a932b6c/wcwidth-0.2.6.tar.gz"
             }
           ],
           "project_name": "wcwidth",
@@ -9972,7 +10493,7 @@
             "backports.functools-lru-cache>=1.2.1; python_version < \"3.2\""
           ],
           "requires_python": null,
-          "version": "0.2.5"
+          "version": "0.2.6"
         },
         {
           "artifacts": [
@@ -10223,7 +10744,7 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "3970c3d9cfcf08f38bf27ad9982f74f8cecbf4ef55e14fc286b240ee81636f73",
+              "hash": "9ca3ed9e533dfd5af3421651171e86d257f82f039fb6665ff816b822efbb73b5",
               "url": "git+https://github.com/wemake-services/wemake-python-styleguide"
             }
           ],
@@ -10278,176 +10799,251 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "7f3b0de8fda692d31ef03743b598620e31c2668b835edbd3962d080ccecf31eb",
-              "url": "https://files.pythonhosted.org/packages/d7/ae/ee70b20dc836d935a9a6483339854c09d8752e55a8104668e2426cf3baf3/widgetsnbextension-4.0.3-py3-none-any.whl"
+              "hash": "eaaaf434fb9b08bd197b2a14ffe45ddb5ac3897593d43c69287091e5f3147bf7",
+              "url": "https://files.pythonhosted.org/packages/c2/1a/73574f7194184c8670b804171d7f43f56c586e5f8142a41f7a53f0998b6b/widgetsnbextension-4.0.5-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "34824864c062b0b3030ad78210db5ae6a3960dfb61d5b27562d6631774de0286",
-              "url": "https://files.pythonhosted.org/packages/18/21/bb36c3760ec170c11d2bb7449ec3a3f9e6c5561949a80ef4fab799dda221/widgetsnbextension-4.0.3.tar.gz"
+              "hash": "003f716d930d385be3fd9de42dd9bf008e30053f73bddde235d14fbeaeff19af",
+              "url": "https://files.pythonhosted.org/packages/46/d0/ef509e5b74d96821b4ec170b7785449e25a89ef0e781e80562e515f84678/widgetsnbextension-4.0.5.tar.gz"
             }
           ],
           "project_name": "widgetsnbextension",
           "requires_dists": [],
           "requires_python": ">=3.7",
-          "version": "4.0.3"
+          "version": "4.0.5"
         },
         {
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "de49d77e968de6626ba7ef4472323f9d2e5a56c1d85b7c0e2a190b2173d3b9be",
-              "url": "https://files.pythonhosted.org/packages/02/df/0d3ae329942cb26c96ac5a4e9164a1d440ffd067331c6886b5ce0729b17a/yarl-1.8.1-cp39-cp39-win_amd64.whl"
+              "hash": "6604711362f2dbf7160df21c416f81fac0de6dbcf0b5445a2ef25478ecc4c778",
+              "url": "https://files.pythonhosted.org/packages/99/4f/e756d7569e3999bd7493be53a66b2e59caa97c70fec4f6fd17ea3315c0ef/yarl-1.8.2-cp39-cp39-win_amd64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "1e4808f996ca39a6463f45182e2af2fae55e2560be586d447ce8016f389f626f",
-              "url": "https://files.pythonhosted.org/packages/14/3c/3aaabeaf84b2b05243cb0995dbf76595dd4901470173f4000c23e6fb2a7b/yarl-1.8.1-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl"
+              "hash": "2a1fca9588f360036242f379bfea2b8b44cae2721859b1c56d033adfd5893634",
+              "url": "https://files.pythonhosted.org/packages/02/51/c33498373d2e0ff5d7f3e76038b7057003927d481405780d22f140906b24/yarl-1.8.2-cp311-cp311-macosx_10_9_universal2.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "07b21e274de4c637f3e3b7104694e53260b5fc10d51fb3ec5fed1da8e0f754e3",
-              "url": "https://files.pythonhosted.org/packages/17/72/8720b7fe90b35f7e75caa22bba1dd679ef2e0374e6907d4d584c939e20a0/yarl-1.8.1-cp310-cp310-macosx_10_9_x86_64.whl"
+              "hash": "cfa2bbca929aa742b5084fd4663dd4b87c191c844326fcb21c3afd2d11497f80",
+              "url": "https://files.pythonhosted.org/packages/06/04/add788ffdf590fd8d7aa93bd0add24d369fbf864548adf80bab8c8587bd3/yarl-1.8.2-cp310-cp310-musllinux_1_1_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "2d800b9c2eaf0684c08be5f50e52bfa2aa920e7163c2ea43f4f431e829b4f0fd",
-              "url": "https://files.pythonhosted.org/packages/1c/6f/314fef68b9973b445d469b0890f2d5a872f65f4e18477e0e56bc68dc1a69/yarl-1.8.1-cp310-cp310-musllinux_1_1_aarch64.whl"
+              "hash": "3fc056e35fa6fba63248d93ff6e672c096f95f7836938241ebc8260e062832fe",
+              "url": "https://files.pythonhosted.org/packages/0d/88/90457ba43e9d4424ee58a1adfa04c717569ab31456480958576ac3e8cfff/yarl-1.8.2-cp310-cp310-macosx_11_0_arm64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "4a88510731cd8d4befaba5fbd734a7dd914de5ab8132a5b3dde0bbd6c9476c64",
-              "url": "https://files.pythonhosted.org/packages/1e/7d/97972e1238f710cf157ddbb92f52af5dce684862137443b81d0f821a25ba/yarl-1.8.1-cp39-cp39-musllinux_1_1_aarch64.whl"
+              "hash": "fb742dcdd5eec9f26b61224c23baea46c9055cf16f62475e11b9b15dfd5c117b",
+              "url": "https://files.pythonhosted.org/packages/11/ea/c5487522577f3b029a39da71bbe81d7b13303894bde26c88046b2a180e79/yarl-1.8.2-cp311-cp311-win32.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "20df6ff4089bc86e4a66e3b1380460f864df3dd9dccaf88d6b3385d24405893b",
-              "url": "https://files.pythonhosted.org/packages/23/fa/30da7a36cf5199781002acfe602105bcce1adcb14afb324f7090ddd1e76d/yarl-1.8.1-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl"
+              "hash": "cb6d48d80a41f68de41212f3dfd1a9d9898d7841c8f7ce6696cf2fd9cb57ef83",
+              "url": "https://files.pythonhosted.org/packages/14/9c/80ccfc199679bea8fa6982a49c88ac54a1ec0c8c033bede70fa84fcd13ca/yarl-1.8.2-cp39-cp39-win32.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "6628d750041550c5d9da50bb40b5cf28a2e63b9388bac10fedd4f19236ef4957",
-              "url": "https://files.pythonhosted.org/packages/25/8f/8e534ed3093c2fe4d4a2fe5f42cf569904b1f56e07aafafd488e6e9c915b/yarl-1.8.1-cp310-cp310-musllinux_1_1_i686.whl"
+              "hash": "0978f29222e649c351b173da2b9b4665ad1feb8d1daa9d971eb90df08702668a",
+              "url": "https://files.pythonhosted.org/packages/20/23/9ed12660f860962f179bca719b1d8a895c572c5dbb75098d35d074d35703/yarl-1.8.2-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "fae37373155f5ef9b403ab48af5136ae9851151f7aacd9926251ab26b953118b",
-              "url": "https://files.pythonhosted.org/packages/28/c9/b4cc0b0841fc171ac830e27237da036a5085691f47135122481824bc9c5d/yarl-1.8.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+              "hash": "da65c3f263729e47351261351b8679c6429151ef9649bba08ef2528ff2c423b2",
+              "url": "https://files.pythonhosted.org/packages/21/47/47ef6563db61f6ecf9b23ac1b76682ec92b94cdd41fe645525411c127608/yarl-1.8.2-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "99449cd5366fe4608e7226c6cae80873296dfa0cde45d9b498fefa1de315a09e",
-              "url": "https://files.pythonhosted.org/packages/39/91/d8073e858f887f0574894cb514206502c8ceb8544d5821ba5baf871bfed2/yarl-1.8.1-cp39-cp39-musllinux_1_1_x86_64.whl"
+              "hash": "f8ca8ad414c85bbc50f49c0a106f951613dfa5f948ab69c10ce9b128d368baf8",
+              "url": "https://files.pythonhosted.org/packages/21/9c/d3b5976d5de5ece14e50a8452d573ac1746fa377346f1bb099fcc3900c61/yarl-1.8.2-cp39-cp39-macosx_10_9_universal2.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "21ac44b763e0eec15746a3d440f5e09ad2ecc8b5f6dcd3ea8cb4773d6d4703e3",
-              "url": "https://files.pythonhosted.org/packages/53/33/2b672d8793f875f6096fbb178be5e4456fffbe3bb48fd592e00f0869ef57/yarl-1.8.1-cp39-cp39-musllinux_1_1_ppc64le.whl"
+              "hash": "b05df9ea7496df11b710081bd90ecc3a3db6adb4fee36f6a411e7bc91a18aa42",
+              "url": "https://files.pythonhosted.org/packages/3e/da/942a19605c385e887a0ed784429d95a608a54cd0aa8dc9b44396bc8b57f5/yarl-1.8.2-cp310-cp310-win32.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "ed19b74e81b10b592084a5ad1e70f845f0aacb57577018d31de064e71ffa267a",
-              "url": "https://files.pythonhosted.org/packages/56/e8/e3a8a499eafd892b4fa2cd665aff51192c8f43475a33cc3c708b7f82adb9/yarl-1.8.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+              "hash": "47d49ac96156f0928f002e2424299b2c91d9db73e08c4cd6742923a086f1c863",
+              "url": "https://files.pythonhosted.org/packages/42/37/d8eae7ce26f39d0115375e3b654714c550933ffefa4d07104f85d0d37b41/yarl-1.8.2-cp310-cp310-macosx_10_9_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "9130ddf1ae9978abe63808b6b60a897e41fccb834408cde79522feb37fb72fb0",
-              "url": "https://files.pythonhosted.org/packages/59/4d/5d2cd47d05bd6928ead354feb78f22b73a18dc2b3aa97e09425274cd8fd5/yarl-1.8.1-cp310-cp310-win_amd64.whl"
+              "hash": "bcd7bb1e5c45274af9a1dd7494d3c52b2be5e6bd8d7e49c612705fd45420b12d",
+              "url": "https://files.pythonhosted.org/packages/4c/8a/4ebd7bbee5fc9a77a2d382ef8c6d1d6bff77362df4fbd0efe4c810c3a155/yarl-1.8.2-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "abc06b97407868ef38f3d172762f4069323de52f2b70d133d096a48d72215d28",
-              "url": "https://files.pythonhosted.org/packages/5b/6a/80a42dbdd433f9856ebda43963af6f4c671f2f565535991d13dffedeeec7/yarl-1.8.1-cp310-cp310-macosx_10_9_universal2.whl"
+              "hash": "4d04acba75c72e6eb90745447d69f84e6c9056390f7a9724605ca9c56b4afcc6",
+              "url": "https://files.pythonhosted.org/packages/52/e4/7bcabff7bc7b8421bef266bc955367f586d48667eb0a6ae812852feb51e8/yarl-1.8.2-cp311-cp311-musllinux_1_1_i686.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "4c322cbaa4ed78a8aac89b2174a6df398faf50e5fc12c4c191c40c59d5e28357",
-              "url": "https://files.pythonhosted.org/packages/5e/6b/012f4874880fb40f09c794f62b79fc32291837797a5929914832ced2cdb3/yarl-1.8.1-cp39-cp39-macosx_11_0_arm64.whl"
+              "hash": "0ef8fb25e52663a1c85d608f6dd72e19bd390e2ecaf29c17fb08f730226e3a08",
+              "url": "https://files.pythonhosted.org/packages/53/4a/379701b5373a47b49d2a590fd2a7f8502fb4f7da79eb187ee3f25e8fd84c/yarl-1.8.2-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "9de955d98e02fab288c7718662afb33aab64212ecb368c5dc866d9a57bf48880",
-              "url": "https://files.pythonhosted.org/packages/5f/fb/edeb230634491f9222dd494687ee05910f7f26add9bb049b640a7ae2727d/yarl-1.8.1-cp310-cp310-macosx_11_0_arm64.whl"
+              "hash": "e59399dda559688461762800d7fb34d9e8a6a7444fd76ec33220a926c8be1516",
+              "url": "https://files.pythonhosted.org/packages/5c/2c/8a41574a0afd95f4b4e8eb3477361ec3515ca8daddba441b49c2be70b7d5/yarl-1.8.2-cp39-cp39-musllinux_1_1_s390x.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "5999c4662631cb798496535afbd837a102859568adc67d75d2045e31ec3ac497",
-              "url": "https://files.pythonhosted.org/packages/67/29/52d35348cfcc38251d64fe5e8c75d2d7096fc10d15467e7ca308367b3965/yarl-1.8.1-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl"
+              "hash": "24ad1d10c9db1953291f56b5fe76203977f1ed05f82d09ec97acb623a7976574",
+              "url": "https://files.pythonhosted.org/packages/5e/81/6691d7dd1c6ca607a4d6804557e6e0bf43dd52ad8ae2bf8bdca2e5cce54d/yarl-1.8.2-cp310-cp310-win_amd64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "7ec362167e2c9fd178f82f252b6d97669d7245695dc057ee182118042026da40",
-              "url": "https://files.pythonhosted.org/packages/72/5e/96610128f06a47090b93708978ce96029f02291a62ddc63c786f4de45ed4/yarl-1.8.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+              "hash": "75c16b2a900b3536dfc7014905a128a2bea8fb01f9ee26d2d7d8db0a08e7cb2c",
+              "url": "https://files.pythonhosted.org/packages/5f/3c/59d045a4094f11dea659b69bfca8338803f6cb161da5b039d35cb415a84d/yarl-1.8.2-cp311-cp311-musllinux_1_1_s390x.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "3d1a50e461615747dd93c099f297c1994d472b0f4d2db8a64e55b1edf704ec1c",
-              "url": "https://files.pythonhosted.org/packages/87/27/f99c22607862ae77d76b31e2fcf72f88c5c97aa342beaac12963844b9f34/yarl-1.8.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+              "hash": "3edac5d74bb3209c418805bda77f973117836e1de7c000e9755e572c1f7850d0",
+              "url": "https://files.pythonhosted.org/packages/6f/3e/a9fc9c32ba8788758af0bb95edc0e75853561259dabd47920a6ef820c242/yarl-1.8.2-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "7de89c8456525650ffa2bb56a3eee6af891e98f498babd43ae307bd42dca98f6",
-              "url": "https://files.pythonhosted.org/packages/90/fc/5fb6ad9196322efddc7e3779e00ecab01b3073f90852906fb44118e5e82b/yarl-1.8.1-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl"
+              "hash": "42430ff511571940d51e75cf42f1e4dbdded477e71c1b7a17f4da76c1da8ea76",
+              "url": "https://files.pythonhosted.org/packages/7c/9a/6f2039a5578f2af2d36f22173abf22c957970e908617b90e12552f7dfc9a/yarl-1.8.2-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "e80ed5a9939ceb6fda42811542f31c8602be336b1fb977bccb012e83da7e4936",
-              "url": "https://files.pythonhosted.org/packages/b4/f8/d807818f2648c85c29abc7ccdc63c8ca5b136f03a2bb7828086f6fd4929d/yarl-1.8.1-cp39-cp39-macosx_10_9_universal2.whl"
+              "hash": "6d88056a04860a98341a0cf53e950e3ac9f4e51d1b6f61a53b0609df342cc8b2",
+              "url": "https://files.pythonhosted.org/packages/7f/13/a4b6ffff8f3278c020d6b7c42fee53133f6165d347db94bdd9ae394ba4f8/yarl-1.8.2-cp311-cp311-musllinux_1_1_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "0c03f456522d1ec815893d85fccb5def01ffaa74c1b16ff30f8aaa03eb21e453",
-              "url": "https://files.pythonhosted.org/packages/bc/2b/9dd8299ef8d57a78295d5f2f9d14dc3e29dafcc306507de7a4bf0b24a301/yarl-1.8.1-cp310-cp310-musllinux_1_1_x86_64.whl"
+              "hash": "8c46d3d89902c393a1d1e243ac847e0442d0196bbd81aecc94fcebbc2fd5857c",
+              "url": "https://files.pythonhosted.org/packages/88/59/fd28cddd2fe1806cde775c61b43dfe824b672bef1d214383fd86ead3db93/yarl-1.8.2-cp311-cp311-win_amd64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "5395da939ffa959974577eff2cbfc24b004a2fb6c346918f39966a5786874e54",
-              "url": "https://files.pythonhosted.org/packages/c1/01/6e6f4100b4bc20935bc9e1d22225be43e0d299fb8a08a33c999a55b43309/yarl-1.8.1-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl"
+              "hash": "bb81f753c815f6b8e2ddd2eef3c855cf7da193b82396ac013c661aaa6cc6b0a5",
+              "url": "https://files.pythonhosted.org/packages/88/6f/6ed536b68a754fe337f6d8b7686d6c28d7474c5326087eb76dd1a9975675/yarl-1.8.2-cp310-cp310-macosx_10_9_universal2.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "6afb336e23a793cd3b6476c30f030a0d4c7539cd81649683b5e0c1b0ab0bf350",
-              "url": "https://files.pythonhosted.org/packages/c8/a7/1a92f1049acd7f8fe122b5c78bd135b1a606414109b6cd43de696a5c4dfc/yarl-1.8.1-cp39-cp39-macosx_10_9_x86_64.whl"
+              "hash": "418857f837347e8aaef682679f41e36c24250097f9e2f315d39bae3a99a34cbf",
+              "url": "https://files.pythonhosted.org/packages/8b/cc/340f4cbea79da7462c5033108b674b42b7e0c1bcf7b0177da839e27a4afb/yarl-1.8.2-cp39-cp39-macosx_10_9_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "ea30a42dc94d42f2ba4d0f7c0ffb4f4f9baa1b23045910c0c32df9c9902cb272",
-              "url": "https://files.pythonhosted.org/packages/ce/54/7527c4d474fbc36af1b2e1977ae1d5d0150563e72e360fa82ba0b12e31d4/yarl-1.8.1-cp310-cp310-win32.whl"
+              "hash": "44ceac0450e648de86da8e42674f9b7077d763ea80c8ceb9d1c3e41f0f0a9951",
+              "url": "https://files.pythonhosted.org/packages/97/bb/c03ef39330f6d302863746c80094f566e5ff9949bc267062d4dcdc8e2264/yarl-1.8.2-cp39-cp39-musllinux_1_1_aarch64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "af887845b8c2e060eb5605ff72b6f2dd2aab7a761379373fd89d314f4752abbf",
-              "url": "https://files.pythonhosted.org/packages/d6/04/255c68974ec47fa754564c4abba8f61f9ed68b869bbbb854198d6259c4f7/yarl-1.8.1.tar.gz"
+              "hash": "c15163b6125db87c8f53c98baa5e785782078fbd2dbeaa04c6141935eb6dab7a",
+              "url": "https://files.pythonhosted.org/packages/9b/d2/7813ebb6fe192e568c78ba56658f7a26caeceff6302a96808512f5ee40fd/yarl-1.8.2-cp311-cp311-musllinux_1_1_aarch64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "076eede537ab978b605f41db79a56cad2e7efeea2aa6e0fa8f05a26c24a034fb",
-              "url": "https://files.pythonhosted.org/packages/e6/e0/1e778d018d5c5540b6cc7f77917102687bf23b850a9ab6236df1f558f1c0/yarl-1.8.1-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl"
+              "hash": "ae0eec05ab49e91a78700761777f284c2df119376e391db42c38ab46fd662b77",
+              "url": "https://files.pythonhosted.org/packages/b2/73/78372b24715d2b34348445ef501430d9d60ab11dcc2e20fd94cf2d086fcc/yarl-1.8.2-cp39-cp39-macosx_11_0_arm64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "76577f13333b4fe345c3704811ac7509b31499132ff0181f25ee26619de2c843",
-              "url": "https://files.pythonhosted.org/packages/ec/ce/3dd8b79342c789d169cfb953f720213b9180163f6eb7fa254b0a2f702e2d/yarl-1.8.1-cp310-cp310-musllinux_1_1_s390x.whl"
+              "hash": "6c4fcfa71e2c6a3cb568cf81aadc12768b9995323186a10827beccf5fa23d4f8",
+              "url": "https://files.pythonhosted.org/packages/b5/e0/6ea3832faed10de6a06cd407c660e6978d5538fe7489e934fb9967c8bb8b/yarl-1.8.2-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "f5af52738e225fcc526ae64071b7e5342abe03f42e0e8918227b38c9aa711e28",
-              "url": "https://files.pythonhosted.org/packages/f9/6d/66b56ab2b8db30a5a24ec9a38684dec1c962741d8f0a0e6123c0fb2dc455/yarl-1.8.1-cp310-cp310-musllinux_1_1_ppc64le.whl"
+              "hash": "48dd18adcf98ea9cd721a25313aef49d70d413a999d7d89df44f469edfb38a06",
+              "url": "https://files.pythonhosted.org/packages/b8/53/ceec5140e3cb51c904bb87fca5cf6a3ba5d98b0ea13991dd21833d90662e/yarl-1.8.2-cp39-cp39-musllinux_1_1_ppc64le.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "8b0af1cf36b93cee99a31a545fe91d08223e64390c5ecc5e94c39511832a4bb6",
-              "url": "https://files.pythonhosted.org/packages/fd/d0/9a3cd7b15bfa9f7b37f30364b16c654b01cccb222b34fbc93055bbca1fd3/yarl-1.8.1-cp39-cp39-win32.whl"
+              "hash": "ae4d7ff1049f36accde9e1ef7301912a751e5bae0a9d142459646114c70ecba6",
+              "url": "https://files.pythonhosted.org/packages/b9/bd/42b39f09ed7b26ed810900f513cd579d5918e3ca39de22f5c5f401a7c102/yarl-1.8.2-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "d0272228fabe78ce00a3365ffffd6f643f57a91043e119c289aaba202f4095b0",
-              "url": "https://files.pythonhosted.org/packages/fe/cb/ae0def686041d2da7dd631934f9f961123b597f9aa99c09917f67810cf6f/yarl-1.8.1-cp39-cp39-musllinux_1_1_s390x.whl"
+              "hash": "3150078118f62371375e1e69b13b48288e44f6691c1069340081c3fd12c94d5b",
+              "url": "https://files.pythonhosted.org/packages/ba/85/f9e3350daa31161d1f4dfb10e195951df4ac22d8f201603cf894b37510c8/yarl-1.8.2-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "2d93a049d29df172f48bcb09acf9226318e712ce67374f893b460b42cc1380ae",
-              "url": "https://files.pythonhosted.org/packages/ff/c0/ddcd9c883887a67c2d241fc807111fc2be840dcc5513067ddd59abfed933/yarl-1.8.1-cp39-cp39-musllinux_1_1_i686.whl"
+              "hash": "74dece2bfc60f0f70907c34b857ee98f2c6dd0f75185db133770cd67300d505f",
+              "url": "https://files.pythonhosted.org/packages/ba/c2/8760e6df148cb9d092894decfd9fcf07593bfff26f6716f992d5a1ca7a5c/yarl-1.8.2-cp310-cp310-musllinux_1_1_i686.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "58a3c13d1c3005dbbac5c9f0d3210b60220a65a999b1833aa46bd6677c69b08e",
+              "url": "https://files.pythonhosted.org/packages/be/d8/fcf074e9c246a0d22241f94d474794c876c073a3191d1608a64492d7ea4f/yarl-1.8.2-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "388a45dc77198b2460eac0aca1efd6a7c09e976ee768b0d5109173e521a19daf",
+              "url": "https://files.pythonhosted.org/packages/c0/fd/2f7a640dc157cc2d111114106e3036a69ba3408460d38580f681377c122d/yarl-1.8.2-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "97209cc91189b48e7cfe777237c04af8e7cc51eb369004e061809bcdf4e55220",
+              "url": "https://files.pythonhosted.org/packages/c2/4d/2d0cd4867b4699291479f329c8cfd3943edafe5ba7c250c31f7a65af2196/yarl-1.8.2-cp39-cp39-musllinux_1_1_i686.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "49d43402c6e3013ad0978602bf6bf5328535c48d192304b91b97a3c6790b1562",
+              "url": "https://files.pythonhosted.org/packages/c4/1e/1b204050c601d5cd82b45d5c8f439cb6f744a2ce0c0a6f83be0ddf0dc7b2/yarl-1.8.2.tar.gz"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "e7fd20d6576c10306dea2d6a5765f46f0ac5d6f53436217913e952d19237efc4",
+              "url": "https://files.pythonhosted.org/packages/c6/1c/4a992306ad86a8ae5a1fb4745bd76c590e7bcdb01ce2203dfd38dc830dfe/yarl-1.8.2-cp311-cp311-musllinux_1_1_ppc64le.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "bf071f797aec5b96abfc735ab97da9fd8f8768b43ce2abd85356a3127909d146",
+              "url": "https://files.pythonhosted.org/packages/c6/dc/50fe7fdcf3d27828a5922aaa1c4cbdf2d03827cd5ca6ace2757289e5ee18/yarl-1.8.2-cp310-cp310-musllinux_1_1_aarch64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "d617c241c8c3ad5c4e78a08429fa49e4b04bedfc507b34b4d8dceb83b4af3588",
+              "url": "https://files.pythonhosted.org/packages/c8/29/388508ba25f7cf777fac774c01cfb4ebf805efa3a567c4e2da570983e13a/yarl-1.8.2-cp39-cp39-musllinux_1_1_x86_64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "f37db05c6051eff17bc832914fe46869f8849de5b92dc4a3466cd63095d23dfd",
+              "url": "https://files.pythonhosted.org/packages/ca/f3/2ef9870409b3ea57a5890e4e49b6bfd6e347a45fe92f6b2e9567abfefb59/yarl-1.8.2-cp311-cp311-macosx_10_9_x86_64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "2305517e332a862ef75be8fad3606ea10108662bc6fe08509d5ca99503ac2aee",
+              "url": "https://files.pythonhosted.org/packages/cb/82/91f74496b653ac9a6220ee499510377c03a4ff768c5bd945f6759b23ebb8/yarl-1.8.2-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "10b08293cda921157f1e7c2790999d903b3fd28cd5c208cf8826b3b508026996",
+              "url": "https://files.pythonhosted.org/packages/cf/4c/4d0d1a5c50fab50ae368b9a8af1e1e6437fe1dc28ff8a04a06a90136af63/yarl-1.8.2-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "df60a94d332158b444301c7f569659c926168e4d4aad2cfbf4bce0e8fb8be826",
+              "url": "https://files.pythonhosted.org/packages/d3/50/a9a7e280bb94def4a7497d27dd0c9fc87c6feb2ef9cf7639df15b2d0a1e1/yarl-1.8.2-cp310-cp310-musllinux_1_1_ppc64le.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "63243b21c6e28ec2375f932a10ce7eda65139b5b854c0f6b82ed945ba526bff3",
+              "url": "https://files.pythonhosted.org/packages/de/c2/bdfaa94701e9f1dbd0dfd0454bcb56cf49669ba4591361161fbc5a5ef455/yarl-1.8.2-cp310-cp310-musllinux_1_1_s390x.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "de986979bbd87272fe557e0a8fcb66fd40ae2ddfe28a8b1ce4eae22681728fef",
+              "url": "https://files.pythonhosted.org/packages/df/8e/6163228567a53797d5468d39ec6d9133fa78aeb3490ff6a979730e056209/yarl-1.8.2-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "77e913b846a6b9c5f767b14dc1e759e5aff05502fe73079f6f4176359d832581",
+              "url": "https://files.pythonhosted.org/packages/e6/d3/5f5b39db2c8c09f6923418c9329a04fe6f68825f27d2cb9776871d75ddc3/yarl-1.8.2-cp311-cp311-macosx_11_0_arm64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "009a028127e0a1755c38b03244c0bea9d5565630db9c4cf9572496e947137a87",
+              "url": "https://files.pythonhosted.org/packages/f1/e1/e76a76353444f895a1f0b52e71c28d27a25c4657e51ed30666ef7bb7ff74/yarl-1.8.2-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
             }
           ],
           "project_name": "yarl",
@@ -10457,7 +11053,7 @@
             "typing-extensions>=3.7.4; python_version < \"3.8\""
           ],
           "requires_python": ">=3.7",
-          "version": "1.8.1"
+          "version": "1.8.2"
         },
         {
           "artifacts": [
@@ -10497,8 +11093,8 @@
         }
       ],
       "platform_tag": [
-        "cp39",
-        "cp39",
+        "cp310",
+        "cp310",
         "manylinux_2_36_x86_64"
       ]
     }

--- a/dockerfiles/orchestrate/BUILD
+++ b/dockerfiles/orchestrate/BUILD
@@ -6,7 +6,7 @@ pex_binary(
         "//:requirements#dagster-aws",
     ],
     shebang="/usr/bin/env python",
-    entry_point="dagit.cli:main"
+    entry_point="dagit.cli:main",
 )
 
 pex_binary(
@@ -17,7 +17,7 @@ pex_binary(
         "//:requirements#dagster-aws",
     ],
     shebang="/usr/bin/env python",
-    entry_point="dagster.daemon.cli:main"
+    entry_point="dagster.daemon.cli:main",
 )
 
 docker_image(
@@ -43,5 +43,36 @@ docker_image(
     ],
     target_stage="dagster-daemon",
     tags=["docker_image"],
+    image_tags=["{build_args.DAGSTER_VERSION}", "latest"],
+)
+
+docker_image(
+    name="edx-gcs-courses-pipeline",
+    dependencies=["src/ol_orchestrate:pipeline-repositories"],
+    source="Dockerfile.basic_pipeline",
+    extra_build_args=["PACKAGE_NAME=edx-gcs-courses-pipelines"],
+    tags=["data_pipeline", "docker_image"],
+    image_tags=["{build_args.DAGSTER_VERSION}", "latest"],
+)
+
+
+docker_image(
+    name="edx-pipeline",
+    dependencies=["src/ol_orchestrate:pipeline-repositories"],
+    source="Dockerfile.edx_pipeline",
+    extra_build_args=["PACKAGE_NAME=open-edx-pipelines"],
+    tags=["data_pipeline", "docker_image"],
+    image_tags=["{build_args.DAGSTER_VERSION}", "latest"],
+)
+
+docker_image(
+    name="asset-materialization-pipeline",
+    dependencies=[
+        "src/ol_orchestrate:pipeline-repositories",
+        "src/ol_dbt:dbt_project"
+    ],
+    source="Dockerfile.dbt_pipeline",
+    extra_build_args=["PACKAGE_NAME=asset-materialization-pipelines"],
+    tags=["data_pipeline", "docker_image"],
     image_tags=["{build_args.DAGSTER_VERSION}", "latest"],
 )

--- a/dockerfiles/orchestrate/Dockerfile.basic_pipeline
+++ b/dockerfiles/orchestrate/Dockerfile.basic_pipeline
@@ -1,0 +1,15 @@
+from python:3.9-slim
+
+ENV DAGSTER_HOME=/opt/dagster/dagster_home/
+
+RUN mkdir -p /opt/dagster/dagster_home /opt/dagster/app /tmp/packages && \
+    useradd -s /bin/bash -d /opt/dagster/dagster_home/ dagster && \
+    chown -R dagster:dagster /opt/dagster/dagster_home /opt/dagster/app && \
+    apt-get update && \
+    apt-get install -y wget git && apt-get clean -y
+
+COPY *.whl /tmp/packages/
+RUN pip install --no-cache-dir /tmp/packages/* && rm -r /tmp/packages/
+WORKDIR /opt/dagster/dagster_home
+USER dagster
+ENTRYPOINT ["dagster", "api", "grpc", "-h", "0.0.0.0", "-p", "4000"]

--- a/dockerfiles/orchestrate/Dockerfile.dbt_pipeline
+++ b/dockerfiles/orchestrate/Dockerfile.dbt_pipeline
@@ -1,0 +1,16 @@
+from python:3.9-slim
+
+ENV DAGSTER_HOME=/opt/dagster/dagster_home/
+
+RUN mkdir -p /opt/dagster/dagster_home /opt/dagster/app /tmp/packages && \
+    useradd -s /bin/bash -d /opt/dagster/dagster_home/ dagster && \
+    chown -R dagster:dagster /opt/dagster/dagster_home /opt/dagster/app && \
+    apt-get update && \
+    apt-get install -y wget git && apt-get clean -y
+
+COPY *.whl /tmp/packages/
+RUN pip install --no-cache-dir /tmp/packages/* && rm -r /tmp/packages/
+COPY --chown=dagster:dagster src/ol_dbt /opt/dbt/
+WORKDIR /opt/dagster/dagster_home
+USER dagster
+ENTRYPOINT ["dagster", "api", "grpc", "-h", "0.0.0.0", "-p", "4000"]

--- a/dockerfiles/orchestrate/Dockerfile.edx_pipeline
+++ b/dockerfiles/orchestrate/Dockerfile.edx_pipeline
@@ -14,7 +14,6 @@ RUN mkdir -p /opt/dagster/dagster_home /opt/dagster/app /tmp/packages && \
 
 COPY *.whl /tmp/packages/
 RUN pip install --no-cache-dir /tmp/packages/* && rm -r /tmp/packages/
-COPY --chown=dagster:dagster src/ol_dbt /opt/dbt/
 WORKDIR /opt/dagster/dagster_home
 USER dagster
 ENTRYPOINT ["dagster", "api", "grpc", "-h", "0.0.0.0", "-p", "4000"]

--- a/pants.toml
+++ b/pants.toml
@@ -1,5 +1,5 @@
 [GLOBAL]
-pants_version = "2.12.0"
+pants_version = "2.14.1"
 backend_packages = [
   'pants.backend.docker',
   'pants.backend.docker.lint.hadolint',
@@ -13,9 +13,6 @@ backend_packages = [
   'pants.backend.shell.lint.shfmt',
 ]
 pants_ignore = ['copier_templates/*']
-
-[source]
-root_patterns = ["src/", "/",]
 
 [python]
 enable_resolves = true

--- a/src/ol_orchestrate/BUILD
+++ b/src/ol_orchestrate/BUILD
@@ -1,83 +1,18 @@
-python_sources()
+python_sources(name="ol-orchestrate")
 
-files(
-    name="project-config",
-    sources=["dagster.yaml", "workspace.yaml"]
-)
+files(name="project-config", sources=["dagster.yaml", "workspace.yaml"])
 
 python_distribution(
-    name="open-edx",
-    dependencies=[
-        "//:requirements#dagster-postgres",
-        "//:requirements#dagster-aws",
-        "./repositories/open_edx.py"
-    ],
-    provides=python_artifact(
-        name="dagster-pipeline",
-        version="0.5.3",
-    ),
-)
-
-docker_image(
-    name="edx-pipeline",
-    dependencies=[
-        ":open-edx",
-        "src/ol_dbt:dbt_project"
-    ],
-    source="../../dockerfiles/orchestrate/Dockerfile.user_pipeline",
-    extra_build_args=["PACKAGE_NAME=open-edx-pipelines"],
-    tags=["data_pipeline", "docker_image"],
-    image_tags=["{build_args.DAGSTER_VERSION}", "latest"],
-)
-
-python_distribution(
-    name="asset-materialization",
-    dependencies=[
-        "//:requirements#dagster-postgres",
-        "//:requirements#dagster-aws",
-        "//:requirements#dbt-trino",
-        "./repositories/asset_materialization.py"
-    ],
-    provides=python_artifact(
-        name="dagster-pipeline",
-        version="0.5.3",
-    ),
-)
-
-docker_image(
-    name="asset-materialization-pipeline",
-    dependencies=[
-        ":asset-materialization",
-        "src/ol_dbt:dbt_project"
-    ],
-    source="../../dockerfiles/orchestrate/Dockerfile.user_pipeline",
-    extra_build_args=["PACKAGE_NAME=asset-materialization-pipelines"],
-    tags=["data_pipeline", "docker_image"],
-    image_tags=["{build_args.DAGSTER_VERSION}", "latest"],
-)
-
-python_distribution(
-    name="edx-gcs-courses",
+    name="pipeline-repositories",
     dependencies=[
         "//:requirements#dagster-postgres",
         "//:requirements#dagster-aws",
         "//:requirements#dagster-gcp",
-        "./repositories/edx_gcs_courses.py"
+        "//:requirements#dbt-trino",
+        "./repositories",
     ],
     provides=python_artifact(
         name="dagster-pipeline",
         version="0.5.3",
     ),
-)
-
-docker_image(
-    name="edx-gcs-courses-pipeline",
-    dependencies=[
-        ":edx-gcs-courses",
-        "src/ol_dbt:dbt_project"
-    ],
-    source="../../dockerfiles/orchestrate/Dockerfile.user_pipeline",
-    extra_build_args=["PACKAGE_NAME=edx-gcs-courses-pipelines"],
-    tags=["data_pipeline", "docker_image"],
-    image_tags=["{build_args.DAGSTER_VERSION}", "latest"],
 )

--- a/src/ol_orchestrate/sensors/BUILD
+++ b/src/ol_orchestrate/sensors/BUILD
@@ -1,0 +1,1 @@
+python_sources()


### PR DESCRIPTION
This condenses the builds to a single package and relies on package imports in the docker-compose to run the proper pipelines at deploy time.

## Description
- Split the dockerfile definitions to be more specific to the runtime requirements of the pipelines
- Combine the Python distributions to a single definition for simplicity
- Update the Pants version in the repository

## Motivation and Context
The Pants build configuration was starting to become more complicated which led to conflicts of module ownership that were non-trivial to resolve and didn't provide any functional benefit. This was resulting in build failures during the CI/CD build.

## How Has This Been Tested?
The Pants package command was executed successfully on my local machine.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Enhancement (improves on existing behavior)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project. (Did you install and run the pre-commit hooks?)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
