### PR TITLE
Add macro to cast timestamp to iso8601

### DIFF
--- a/src/ol_dbt/macros/cast_timestamp_to_iso8601.sql
+++ b/src/ol_dbt/macros/cast_timestamp_to_iso8601.sql
@@ -1,0 +1,3 @@
+{% macro cast_timestamp_to_iso8601(column_name) %}
+    to_iso8601(from_iso8601_timestamp({{ column_name }}))
+{% endmacro %}

--- a/src/ol_dbt/models/staging/bootcamps/stg__bootcamps__app__postgres__auth_user.sql
+++ b/src/ol_dbt/models/staging/bootcamps/stg__bootcamps__app__postgres__auth_user.sql
@@ -9,8 +9,8 @@ with source as (
         , username as user_username
         , email as user_email
         , is_active as user_is_active
-        , to_iso8601(from_iso8601_timestamp(date_joined)) as user_joined_on
-        , to_iso8601(from_iso8601_timestamp(last_login)) as user_last_login
+        , {{ cast_timestamp_to_iso8601('date_joined') }} as user_joined_on
+        , {{ cast_timestamp_to_iso8601('last_login') }} as user_last_login
     from source
 )
 

--- a/src/ol_dbt/models/staging/bootcamps/stg__bootcamps__app__postgres__courserunenrollment.sql
+++ b/src/ol_dbt/models/staging/bootcamps/stg__bootcamps__app__postgres__courserunenrollment.sql
@@ -12,9 +12,9 @@ with source as (
         , bootcamp_run_id as courserun_id
         , change_status as courserunenrollment_enrollment_status
         , user_certificate_is_blocked as courserunenrollment_is_certificate_blocked
-        , to_iso8601(from_iso8601_timestamp(created_on)) as courserunenrollment_created_on
-        , to_iso8601(from_iso8601_timestamp(updated_on)) as courserunenrollment_updated_on
-        , to_iso8601(from_iso8601_timestamp(novoed_sync_date)) as courserunenrollment_novoed_sync_on
+        , {{ cast_timestamp_to_iso8601('created_on') }} as courserunenrollment_created_on
+        , {{ cast_timestamp_to_iso8601('updated_on') }} as courserunenrollment_updated_on
+        , {{ cast_timestamp_to_iso8601('novoed_sync_date') }} as courserunenrollment_novoed_sync_on
     from source
 )
 

--- a/src/ol_dbt/models/staging/bootcamps/stg__bootcamps__app__postgres__courses_courserun.sql
+++ b/src/ol_dbt/models/staging/bootcamps/stg__bootcamps__app__postgres__courses_courserun.sql
@@ -10,8 +10,8 @@ with source as (
         , bootcamp_id as course_id
         , title as courserun_title
         , bootcamp_run_id as courserun_readable_id
-        , to_iso8601(from_iso8601_timestamp(start_date)) as courserun_start_on
-        , to_iso8601(from_iso8601_timestamp(end_date)) as courserun_end_on
+        , {{ cast_timestamp_to_iso8601('start_date') }} as courserun_start_on
+        , {{ cast_timestamp_to_iso8601('end_date') }} as courserun_end_on
     from source
 )
 

--- a/src/ol_dbt/models/staging/bootcamps/stg__bootcamps__app__postgres__courses_courseruncertificate.sql
+++ b/src/ol_dbt/models/staging/bootcamps/stg__bootcamps__app__postgres__courses_courseruncertificate.sql
@@ -11,8 +11,8 @@ with source as (
         , bootcamp_run_id as courserun_id
         , user_id
         , is_revoked as courseruncertificate_is_revoked
-        , to_iso8601(from_iso8601_timestamp(created_on)) as courseruncertificate_created_on
-        , to_iso8601(from_iso8601_timestamp(updated_on)) as courseruncertificate_updated_on
+        , {{ cast_timestamp_to_iso8601('created_on') }} as courseruncertificate_created_on
+        , {{ cast_timestamp_to_iso8601('updated_on') }} as courseruncertificate_updated_on
     from source
 )
 

--- a/src/ol_dbt/models/staging/edxorg/stg__edxorg__bigquery__mitx_person_course.sql
+++ b/src/ol_dbt/models/staging/edxorg/stg__edxorg__bigquery__mitx_person_course.sql
@@ -29,12 +29,12 @@ with source as (
         , {{ transform_gender_value('gender') }} as user_gender
         , {{ transform_education_value('loe') }} as user_highest_education
 
-        , to_iso8601(from_iso8601_timestamp(start_time)) as courserunenrollment_created_on
-        , to_iso8601(from_iso8601_timestamp(verified_enroll_time)) as courserunenrollment_enrolled_on
+        , {{ cast_timestamp_to_iso8601('start_time') }} as courserunenrollment_created_on
+        , {{ cast_timestamp_to_iso8601('verified_enroll_time') }} as courserunenrollment_enrolled_on
 
-        , to_iso8601(from_iso8601_timestamp(verified_unenroll_time)) as courserunenrollment_unenrolled_on
-        , to_iso8601(from_iso8601_timestamp(cert_created_date)) as courseruncertificate_created_on
-        , to_iso8601(from_iso8601_timestamp(cert_modified_date)) as courseruncertificate_updated_on
+        , {{ cast_timestamp_to_iso8601('verified_unenroll_time') }} as courserunenrollment_unenrolled_on
+        , {{ cast_timestamp_to_iso8601('cert_created_date') }} as courseruncertificate_created_on
+        , {{ cast_timestamp_to_iso8601('cert_modified_date') }} as courseruncertificate_updated_on
     from source
     where user_id is not null --- temporary fix to filter the bad data
 

--- a/src/ol_dbt/models/staging/edxorg/stg__edxorg__bigquery__mitx_user_email_opt_in.sql
+++ b/src/ol_dbt/models/staging/edxorg/stg__edxorg__bigquery__mitx_user_email_opt_in.sql
@@ -11,7 +11,7 @@ with source as (
         , username as user_username
         , full_name as user_full_name
         , is_opted_in_for_email as user_is_opted_in_for_email
-        , to_iso8601(from_iso8601_timestamp(preference_set_datetime)) as user_email_opt_in_updated_on
+        , {{ cast_timestamp_to_iso8601('preference_set_datetime') }} as user_email_opt_in_updated_on
     from source
 
 )

--- a/src/ol_dbt/models/staging/edxorg/stg__edxorg__bigquery__mitx_user_info_combo.sql
+++ b/src/ol_dbt/models/staging/edxorg/stg__edxorg__bigquery__mitx_user_info_combo.sql
@@ -36,11 +36,11 @@ with source as (
         , certificate_status as courseruncertificate_status
         , {{ transform_gender_value('profile_gender') }} as user_gender
         , {{ transform_education_value('profile_level_of_education') }} as user_highest_education
-        , to_iso8601(from_iso8601_timestamp(date_joined)) as user_joined_on
-        , to_iso8601(from_iso8601_timestamp(last_login)) as user_last_login
-        , to_iso8601(from_iso8601_timestamp(enrollment_created)) as courserunenrollment_created_on
-        , to_iso8601(from_iso8601_timestamp(certificate_created_date)) as courseruncertificate_created_on
-        , to_iso8601(from_iso8601_timestamp(certificate_modified_date)) as courseruncertificate_updated_on
+        , {{ cast_timestamp_to_iso8601('date_joined') }} as user_joined_on
+        , {{ cast_timestamp_to_iso8601('last_login') }} as user_last_login
+        , {{ cast_timestamp_to_iso8601('enrollment_created') }} as courserunenrollment_created_on
+        , {{ cast_timestamp_to_iso8601('certificate_created_date') }} as courseruncertificate_created_on
+        , {{ cast_timestamp_to_iso8601('certificate_modified_date') }} as courseruncertificate_updated_on
     from source
     --- user_id could be blank due to parsing error on edx data so filter out these
     where user_id is not null

--- a/src/ol_dbt/models/staging/micromasters/stg__micromasters__app__postgres__auth_user.sql
+++ b/src/ol_dbt/models/staging/micromasters/stg__micromasters__app__postgres__auth_user.sql
@@ -11,8 +11,8 @@ with source as (
         , username as user_username
         , email as user_email
         , is_active as user_is_active
-        , to_iso8601(from_iso8601_timestamp(date_joined)) as user_joined_on
-        , to_iso8601(from_iso8601_timestamp(last_login)) as user_last_login
+        , {{ cast_timestamp_to_iso8601('date_joined') }} as user_joined_on
+        , {{ cast_timestamp_to_iso8601('last_login') }} as user_last_login
     from source
 )
 

--- a/src/ol_dbt/models/staging/micromasters/stg__micromasters__app__postgres__courses_program.sql
+++ b/src/ol_dbt/models/staging/micromasters/stg__micromasters__app__postgres__courses_program.sql
@@ -14,8 +14,8 @@ with source as (
         , num_required_courses as program_num_required_courses
         , ga_tracking_id as program_ga_tracking_id
         , financial_aid_availability as program_is_financial_aid_available
-        , to_iso8601(from_iso8601_timestamp(created_on)) as program_created_on
-        , to_iso8601(from_iso8601_timestamp(updated_on)) as program_updated_on
+        , {{ cast_timestamp_to_iso8601('created_on') }} as program_created_on
+        , {{ cast_timestamp_to_iso8601('updated_on') }} as program_updated_on
     from source
 )
 

--- a/src/ol_dbt/models/staging/micromasters/stg__micromasters__app__postgres__profiles_profile.sql
+++ b/src/ol_dbt/models/staging/micromasters/stg__micromasters__app__postgres__profiles_profile.sql
@@ -55,8 +55,8 @@ with source as (
             when account_privacy = 'private' then 'Private'
             else account_privacy
         end as user_account_privacy
-        , to_iso8601(from_iso8601_timestamp(date_joined_micromasters)) as user_joined_on
-        , to_iso8601(from_iso8601_timestamp(updated_on)) as user_profile_updated_on
+        , {{ cast_timestamp_to_iso8601('date_joined_micromasters') }} as user_joined_on
+        , {{ cast_timestamp_to_iso8601('updated_on') }} as user_profile_updated_on
     from source
 )
 

--- a/src/ol_dbt/models/staging/mitxonline/stg__mitxonline__app__postgres__courses_blockedcountry.sql
+++ b/src/ol_dbt/models/staging/mitxonline/stg__mitxonline__app__postgres__courses_blockedcountry.sql
@@ -9,8 +9,8 @@ with source as (
         id as blockedcountry_id
         , country as blockedcountry_code
         , course_id
-        , to_iso8601(from_iso8601_timestamp(created_on)) as blockedcountry_created_on
-        , to_iso8601(from_iso8601_timestamp(updated_on)) as blockedcountry_updated_on
+        , {{ cast_timestamp_to_iso8601('created_on') }} as blockedcountry_created_on
+        , {{ cast_timestamp_to_iso8601('updated_on') }} as blockedcountry_updated_on
     from source
 )
 

--- a/src/ol_dbt/models/staging/mitxonline/stg__mitxonline__app__postgres__courses_course.sql
+++ b/src/ol_dbt/models/staging/mitxonline/stg__mitxonline__app__postgres__courses_course.sql
@@ -10,8 +10,8 @@ with source as (
         , live as course_is_live
         , title as course_title
         , readable_id as course_readable_id
-        , to_iso8601(from_iso8601_timestamp(created_on)) as course_created_on
-        , to_iso8601(from_iso8601_timestamp(updated_on)) as course_updated_on
+        , {{ cast_timestamp_to_iso8601('created_on') }} as course_created_on
+        , {{ cast_timestamp_to_iso8601('updated_on') }} as course_updated_on
     from source
 )
 

--- a/src/ol_dbt/models/staging/mitxonline/stg__mitxonline__app__postgres__courses_courserun.sql
+++ b/src/ol_dbt/models/staging/mitxonline/stg__mitxonline__app__postgres__courses_courserun.sql
@@ -14,14 +14,14 @@ with source as (
         , courseware_url_path as courserun_url
         , run_tag as courserun_tag
         , is_self_paced as courserun_is_self_paced
-        , to_iso8601(from_iso8601_timestamp(start_date)) as courserun_start_on
-        , to_iso8601(from_iso8601_timestamp(end_date)) as courserun_end_on
-        , to_iso8601(from_iso8601_timestamp(enrollment_start)) as courserun_enrollment_start_on
-        , to_iso8601(from_iso8601_timestamp(enrollment_end)) as courserun_enrollment_end_on
-        , to_iso8601(from_iso8601_timestamp(expiration_date)) as courserun_expired_on
-        , to_iso8601(from_iso8601_timestamp(upgrade_deadline)) as courserun_upgrade_deadline
-        , to_iso8601(from_iso8601_timestamp(created_on)) as courserun_created_on
-        , to_iso8601(from_iso8601_timestamp(updated_on)) as courserun_updated_on
+        , {{ cast_timestamp_to_iso8601('start_date') }} as courserun_start_on
+        , {{ cast_timestamp_to_iso8601('end_date') }} as courserun_end_on
+        , {{ cast_timestamp_to_iso8601('enrollment_start') }} as courserun_enrollment_start_on
+        , {{ cast_timestamp_to_iso8601('enrollment_end') }} as courserun_enrollment_end_on
+        , {{ cast_timestamp_to_iso8601('expiration_date') }} as courserun_expired_on
+        , {{ cast_timestamp_to_iso8601('upgrade_deadline') }} as courserun_upgrade_deadline
+        , {{ cast_timestamp_to_iso8601('created_on') }} as courserun_created_on
+        , {{ cast_timestamp_to_iso8601('updated_on') }} as courserun_updated_on
     from source
 )
 

--- a/src/ol_dbt/models/staging/mitxonline/stg__mitxonline__app__postgres__courses_courseruncertificate.sql
+++ b/src/ol_dbt/models/staging/mitxonline/stg__mitxonline__app__postgres__courses_courseruncertificate.sql
@@ -12,8 +12,8 @@ with source as (
         , user_id
         , certificate_page_revision_id  --- rename it after the referenced model is created
         , is_revoked as courseruncertificate_is_revoked
-        , to_iso8601(from_iso8601_timestamp(created_on)) as courseruncertificate_created_on
-        , to_iso8601(from_iso8601_timestamp(updated_on)) as courseruncertificate_updated_on
+        , {{ cast_timestamp_to_iso8601('created_on') }} as courseruncertificate_created_on
+        , {{ cast_timestamp_to_iso8601('updated_on') }} as courseruncertificate_updated_on
     from source
 )
 

--- a/src/ol_dbt/models/staging/mitxonline/stg__mitxonline__app__postgres__courses_courserunenrollment.sql
+++ b/src/ol_dbt/models/staging/mitxonline/stg__mitxonline__app__postgres__courses_courserunenrollment.sql
@@ -14,8 +14,8 @@ with source as (
         , user_id
         , enrollment_mode as courserunenrollment_enrollment_mode
         , edx_emails_subscription as courserunenrollment_has_edx_email_subscription
-        , to_iso8601(from_iso8601_timestamp(created_on)) as courserunenrollment_created_on
-        , to_iso8601(from_iso8601_timestamp(updated_on)) as courserunenrollment_updated_on
+        , {{ cast_timestamp_to_iso8601('created_on') }} as courserunenrollment_created_on
+        , {{ cast_timestamp_to_iso8601('updated_on') }} as courserunenrollment_updated_on
     from source
 )
 

--- a/src/ol_dbt/models/staging/mitxonline/stg__mitxonline__app__postgres__courses_courserungrade.sql
+++ b/src/ol_dbt/models/staging/mitxonline/stg__mitxonline__app__postgres__courses_courserungrade.sql
@@ -13,8 +13,8 @@ with source as (
         , letter_grade as courserungrade_letter_grade
         , set_by_admin as courserungrade_is_set_by_admin
         , passed as courserungrade_is_passing
-        , to_iso8601(from_iso8601_timestamp(created_on)) as courserungrade_created_on
-        , to_iso8601(from_iso8601_timestamp(updated_on)) as courserungrade_updated_on
+        , {{ cast_timestamp_to_iso8601('created_on') }} as courserungrade_created_on
+        , {{ cast_timestamp_to_iso8601('updated_on') }} as courserungrade_updated_on
     from source
 )
 

--- a/src/ol_dbt/models/staging/mitxonline/stg__mitxonline__app__postgres__courses_coursetopic.sql
+++ b/src/ol_dbt/models/staging/mitxonline/stg__mitxonline__app__postgres__courses_coursetopic.sql
@@ -8,8 +8,8 @@ with source as (
     select
         id as coursetopic_id
         , name as coursetopic_name
-        , to_iso8601(from_iso8601_timestamp(created_on)) as coursetopic_created_on
-        , to_iso8601(from_iso8601_timestamp(updated_on)) as coursetopic_updated_on
+        , {{ cast_timestamp_to_iso8601('created_on') }} as coursetopic_created_on
+        , {{ cast_timestamp_to_iso8601('updated_on') }} as coursetopic_updated_on
     from source
 )
 

--- a/src/ol_dbt/models/staging/mitxonline/stg__mitxonline__app__postgres__courses_program.sql
+++ b/src/ol_dbt/models/staging/mitxonline/stg__mitxonline__app__postgres__courses_program.sql
@@ -10,8 +10,8 @@ with source as (
         , live as program_is_live
         , title as program_title
         , readable_id as program_readable_id
-        , to_iso8601(from_iso8601_timestamp(created_on)) as program_created_on
-        , to_iso8601(from_iso8601_timestamp(updated_on)) as program_updated_on
+        , {{ cast_timestamp_to_iso8601('created_on') }} as program_created_on
+        , {{ cast_timestamp_to_iso8601('updated_on') }} as program_updated_on
     from source
 )
 

--- a/src/ol_dbt/models/staging/mitxonline/stg__mitxonline__app__postgres__courses_programcertificate.sql
+++ b/src/ol_dbt/models/staging/mitxonline/stg__mitxonline__app__postgres__courses_programcertificate.sql
@@ -12,8 +12,8 @@ with source as (
         , user_id
         , certificate_page_revision_id  --- rename it after the referenced model is created
         , is_revoked as programcertificate_is_revoked
-        , to_iso8601(from_iso8601_timestamp(created_on)) as programcertificate_created_on
-        , to_iso8601(from_iso8601_timestamp(updated_on)) as programcertificate_updated_on
+        , {{ cast_timestamp_to_iso8601('created_on') }} as programcertificate_created_on
+        , {{ cast_timestamp_to_iso8601('updated_on') }} as programcertificate_updated_on
     from source
 )
 

--- a/src/ol_dbt/models/staging/mitxonline/stg__mitxonline__app__postgres__courses_programenrollment.sql
+++ b/src/ol_dbt/models/staging/mitxonline/stg__mitxonline__app__postgres__courses_programenrollment.sql
@@ -12,8 +12,8 @@ with source as (
         , program_id
         , user_id
         , enrollment_mode as programenrollment_enrollment_mode
-        , to_iso8601(from_iso8601_timestamp(created_on)) as programenrollment_created_on
-        , to_iso8601(from_iso8601_timestamp(updated_on)) as programenrollment_updated_on
+        , {{ cast_timestamp_to_iso8601('created_on') }} as programenrollment_created_on
+        , {{ cast_timestamp_to_iso8601('updated_on') }} as programenrollment_updated_on
     from source
 )
 

--- a/src/ol_dbt/models/staging/mitxonline/stg__mitxonline__app__postgres__courses_programrun.sql
+++ b/src/ol_dbt/models/staging/mitxonline/stg__mitxonline__app__postgres__courses_programrun.sql
@@ -8,10 +8,10 @@ with source as (
         id as programrun_id
         , run_tag as programrun_tag
         , program_id
-        , to_iso8601(from_iso8601_timestamp(start_date)) as programrun_start_on
-        , to_iso8601(from_iso8601_timestamp(end_date)) as programrun_end_on
-        , to_iso8601(from_iso8601_timestamp(updated_on)) as programrun_updated_on
-        , to_iso8601(from_iso8601_timestamp(created_on)) as programrun_created_on
+        , {{ cast_timestamp_to_iso8601('start_date') }} as programrun_start_on
+        , {{ cast_timestamp_to_iso8601('end_date') }} as programrun_end_on
+        , {{ cast_timestamp_to_iso8601('updated_on') }} as programrun_updated_on
+        , {{ cast_timestamp_to_iso8601('created_on') }} as programrun_created_on
     from source
 
 )

--- a/src/ol_dbt/models/staging/mitxonline/stg__mitxonline__app__postgres__ecommerce_basket.sql
+++ b/src/ol_dbt/models/staging/mitxonline/stg__mitxonline__app__postgres__ecommerce_basket.sql
@@ -9,8 +9,8 @@ with source as (
     select
         id as basket_id
         , user_id
-        , to_iso8601(from_iso8601_timestamp(created_on)) as basket_created_on
-        , to_iso8601(from_iso8601_timestamp(updated_on)) as basket_updated_on
+        , {{ cast_timestamp_to_iso8601('created_on') }} as basket_created_on
+        , {{ cast_timestamp_to_iso8601('updated_on') }} as basket_updated_on
 
     from source
 

--- a/src/ol_dbt/models/staging/mitxonline/stg__mitxonline__app__postgres__ecommerce_basketdiscount.sql
+++ b/src/ol_dbt/models/staging/mitxonline/stg__mitxonline__app__postgres__ecommerce_basketdiscount.sql
@@ -11,9 +11,9 @@ with source as (
         , redeemed_by_id as user_id
         , redeemed_basket_id as basket_id
         , redeemed_discount_id as discount_id
-        , to_iso8601(from_iso8601_timestamp(redemption_date)) as basketdiscount_applied_on
-        , to_iso8601(from_iso8601_timestamp(created_on)) as basketdiscount_created_on
-        , to_iso8601(from_iso8601_timestamp(updated_on)) as basketdiscount_updated_on
+        , {{ cast_timestamp_to_iso8601('redemption_date') }} as basketdiscount_applied_on
+        , {{ cast_timestamp_to_iso8601('created_on') }} as basketdiscount_created_on
+        , {{ cast_timestamp_to_iso8601('updated_on') }} as basketdiscount_updated_on
 
     from source
 

--- a/src/ol_dbt/models/staging/mitxonline/stg__mitxonline__app__postgres__ecommerce_basketitem.sql
+++ b/src/ol_dbt/models/staging/mitxonline/stg__mitxonline__app__postgres__ecommerce_basketitem.sql
@@ -11,8 +11,8 @@ with source as (
         , quantity as basketitem_quantity
         , basket_id
         , product_id
-        , to_iso8601(from_iso8601_timestamp(created_on)) as basketitem_created_on
-        , to_iso8601(from_iso8601_timestamp(updated_on)) as basketitem_updated_on
+        , {{ cast_timestamp_to_iso8601('created_on') }} as basketitem_created_on
+        , {{ cast_timestamp_to_iso8601('updated_on') }} as basketitem_updated_on
 
     from source
 

--- a/src/ol_dbt/models/staging/mitxonline/stg__mitxonline__app__postgres__ecommerce_discount.sql
+++ b/src/ol_dbt/models/staging/mitxonline/stg__mitxonline__app__postgres__ecommerce_discount.sql
@@ -14,10 +14,10 @@ with source as (
         , max_redemptions as discount_max_redemptions
         , redemption_type as discount_redemption_type
         , for_flexible_pricing as discount_is_for_flexible_pricing
-        , to_iso8601(from_iso8601_timestamp(created_on)) as discount_created_on
-        , to_iso8601(from_iso8601_timestamp(updated_on)) as discount_updated_on
-        , to_iso8601(from_iso8601_timestamp(activation_date)) as discount_activated_on
-        , to_iso8601(from_iso8601_timestamp(expiration_date)) as discount_expires_on
+        , {{ cast_timestamp_to_iso8601('created_on') }} as discount_created_on
+        , {{ cast_timestamp_to_iso8601('updated_on') }} as discount_updated_on
+        , {{ cast_timestamp_to_iso8601('activation_date') }} as discount_activated_on
+        , {{ cast_timestamp_to_iso8601('expiration_date') }} as discount_expires_on
 
     from source
 

--- a/src/ol_dbt/models/staging/mitxonline/stg__mitxonline__app__postgres__ecommerce_discountproduct.sql
+++ b/src/ol_dbt/models/staging/mitxonline/stg__mitxonline__app__postgres__ecommerce_discountproduct.sql
@@ -10,8 +10,8 @@ with source as (
         id as discountproduct_id
         , product_id
         , discount_id
-        , to_iso8601(from_iso8601_timestamp(created_on)) as discountproduct_created_on
-        , to_iso8601(from_iso8601_timestamp(updated_on)) as discountproduct_updated_on
+        , {{ cast_timestamp_to_iso8601('created_on') }} as discountproduct_created_on
+        , {{ cast_timestamp_to_iso8601('updated_on') }} as discountproduct_updated_on
 
     from source
 

--- a/src/ol_dbt/models/staging/mitxonline/stg__mitxonline__app__postgres__ecommerce_discountredemption.sql
+++ b/src/ol_dbt/models/staging/mitxonline/stg__mitxonline__app__postgres__ecommerce_discountredemption.sql
@@ -11,7 +11,7 @@ with source as (
         , redeemed_by_id as user_id
         , redeemed_order_id as order_id
         , redeemed_discount_id as discount_id
-        , to_iso8601(from_iso8601_timestamp(redemption_date)) as discountredemption_timestamp
+        , {{ cast_timestamp_to_iso8601('redemption_date') }} as discountredemption_timestamp
 
     from source
 

--- a/src/ol_dbt/models/staging/mitxonline/stg__mitxonline__app__postgres__ecommerce_line.sql
+++ b/src/ol_dbt/models/staging/mitxonline/stg__mitxonline__app__postgres__ecommerce_line.sql
@@ -12,8 +12,8 @@ with source as (
         , product_version_id
         , purchased_object_id as product_object_id
         , purchased_content_type_id as contenttype_id
-        , to_iso8601(from_iso8601_timestamp(created_on)) as line_created_on
-        , to_iso8601(from_iso8601_timestamp(updated_on)) as line_updated_on
+        , {{ cast_timestamp_to_iso8601('created_on') }} as line_created_on
+        , {{ cast_timestamp_to_iso8601('updated_on') }} as line_updated_on
     from source
 
 )

--- a/src/ol_dbt/models/staging/mitxonline/stg__mitxonline__app__postgres__ecommerce_order.sql
+++ b/src/ol_dbt/models/staging/mitxonline/stg__mitxonline__app__postgres__ecommerce_order.sql
@@ -12,8 +12,8 @@ with source as (
         , purchaser_id as order_purchaser_user_id
         , reference_number as order_reference_number
         , total_price_paid as order_total_price_paid
-        , to_iso8601(from_iso8601_timestamp(created_on)) as order_created_on
-        , to_iso8601(from_iso8601_timestamp(updated_on)) as order_updated_on
+        , {{ cast_timestamp_to_iso8601('created_on') }} as order_created_on
+        , {{ cast_timestamp_to_iso8601('updated_on') }} as order_updated_on
     from source
 
 )

--- a/src/ol_dbt/models/staging/mitxonline/stg__mitxonline__app__postgres__ecommerce_product.sql
+++ b/src/ol_dbt/models/staging/mitxonline/stg__mitxonline__app__postgres__ecommerce_product.sql
@@ -13,8 +13,8 @@ with source as (
         , object_id as product_object_id
         , description as product_description
         , content_type_id as contenttype_id
-        , to_iso8601(from_iso8601_timestamp(created_on)) as product_created_on
-        , to_iso8601(from_iso8601_timestamp(updated_on)) as product_updated_on
+        , {{ cast_timestamp_to_iso8601('created_on') }} as product_created_on
+        , {{ cast_timestamp_to_iso8601('updated_on') }} as product_updated_on
     from source
 )
 

--- a/src/ol_dbt/models/staging/mitxonline/stg__mitxonline__app__postgres__ecommerce_transaction.sql
+++ b/src/ol_dbt/models/staging/mitxonline/stg__mitxonline__app__postgres__ecommerce_transaction.sql
@@ -13,8 +13,8 @@ with source as (
         , order_id
         , transaction_id as transaction_readable_identifier
         , transaction_type as transaction_type
-        , to_iso8601(from_iso8601_timestamp(created_on)) as transaction_created_on
-        , to_iso8601(from_iso8601_timestamp(updated_on)) as transaction_updated_on
+        , {{ cast_timestamp_to_iso8601('created_on') }} as transaction_created_on
+        , {{ cast_timestamp_to_iso8601('updated_on') }} as transaction_updated_on
     from source
 
 )

--- a/src/ol_dbt/models/staging/mitxonline/stg__mitxonline__app__postgres__ecommerce_userdiscount.sql
+++ b/src/ol_dbt/models/staging/mitxonline/stg__mitxonline__app__postgres__ecommerce_userdiscount.sql
@@ -10,8 +10,8 @@ with source as (
         id as userdiscount_id
         , user_id
         , discount_id
-        , to_iso8601(from_iso8601_timestamp(created_on)) as userdiscount_created_on
-        , to_iso8601(from_iso8601_timestamp(updated_on)) as userdiscount_updated_on
+        , {{ cast_timestamp_to_iso8601('created_on') }} as userdiscount_created_on
+        , {{ cast_timestamp_to_iso8601('updated_on') }} as userdiscount_updated_on
     from source
 
 )

--- a/src/ol_dbt/models/staging/mitxonline/stg__mitxonline__app__postgres__flexiblepricing_countryincomethreshold.sql
+++ b/src/ol_dbt/models/staging/mitxonline/stg__mitxonline__app__postgres__flexiblepricing_countryincomethreshold.sql
@@ -11,8 +11,8 @@ with source as (
         id as countryincomethreshold_id
         , country_code as countryincomethreshold_country_code
         , income_threshold as countryincomethreshold_income_threshold
-        , to_iso8601(from_iso8601_timestamp(created_on)) as countryincomethreshold_created_on
-        , to_iso8601(from_iso8601_timestamp(updated_on)) as countryincomethreshold_updated_on
+        , {{ cast_timestamp_to_iso8601('created_on') }} as countryincomethreshold_created_on
+        , {{ cast_timestamp_to_iso8601('updated_on') }} as countryincomethreshold_updated_on
 
     from source
 

--- a/src/ol_dbt/models/staging/mitxonline/stg__mitxonline__app__postgres__flexiblepricing_currencyexchangerate.sql
+++ b/src/ol_dbt/models/staging/mitxonline/stg__mitxonline__app__postgres__flexiblepricing_currencyexchangerate.sql
@@ -12,8 +12,8 @@ with source as (
         , description as currencyexchangerate_description
         , currency_code as currencyexchangerate_currency_code
         , exchange_rate as currencyexchangerate_exchange_rate
-        , to_iso8601(from_iso8601_timestamp(created_on)) as currencyexchangerate_created_on
-        , to_iso8601(from_iso8601_timestamp(updated_on)) as currencyexchangerate_updated_on
+        , {{ cast_timestamp_to_iso8601('created_on') }} as currencyexchangerate_created_on
+        , {{ cast_timestamp_to_iso8601('updated_on') }} as currencyexchangerate_updated_on
 
     from source
 

--- a/src/ol_dbt/models/staging/mitxonline/stg__mitxonline__app__postgres__flexiblepricing_flexiblepriceapplication.sql
+++ b/src/ol_dbt/models/staging/mitxonline/stg__mitxonline__app__postgres__flexiblepricing_flexiblepriceapplication.sql
@@ -20,10 +20,10 @@ with source as (
         , country_of_residence as flexiblepriceapplication_country_of_residence
         , courseware_object_id
         , courseware_content_type_id as contenttype_id
-        , to_iso8601(from_iso8601_timestamp(date_exchange_rate)) as flexiblepriceapplication_exchange_rate_timestamp
-        , to_iso8601(from_iso8601_timestamp(date_documents_sent)) as flexiblepriceapplication_date_documents_sent
-        , to_iso8601(from_iso8601_timestamp(created_on)) as flexiblepriceapplication_created_on
-        , to_iso8601(from_iso8601_timestamp(updated_on)) as flexiblepriceapplication_updated_on
+        , {{ cast_timestamp_to_iso8601('date_exchange_rate') }} as flexiblepriceapplication_exchange_rate_timestamp
+        , {{ cast_timestamp_to_iso8601('date_documents_sent') }} as flexiblepriceapplication_date_documents_sent
+        , {{ cast_timestamp_to_iso8601('created_on') }} as flexiblepriceapplication_created_on
+        , {{ cast_timestamp_to_iso8601('updated_on') }} as flexiblepriceapplication_updated_on
 
     from source
 

--- a/src/ol_dbt/models/staging/mitxonline/stg__mitxonline__app__postgres__flexiblepricing_flexiblepricetier.sql
+++ b/src/ol_dbt/models/staging/mitxonline/stg__mitxonline__app__postgres__flexiblepricing_flexiblepricetier.sql
@@ -11,8 +11,8 @@ with source as (
         , source.courseware_object_id
         , source.income_threshold_usd as flexiblepricetier_income_threshold_usd
         , source.courseware_content_type_id as contenttype_id
-        , to_iso8601(from_iso8601_timestamp(source.created_on)) as flexiblepricetier_created_on
-        , to_iso8601(from_iso8601_timestamp(source.updated_on)) as flexiblepricetier_updated_on
+        , {{ cast_timestamp_to_iso8601('source.created_on') }} as flexiblepricetier_created_on
+        , {{ cast_timestamp_to_iso8601('source.updated_on') }} as flexiblepricetier_updated_on
 
     from source
 )

--- a/src/ol_dbt/models/staging/mitxonline/stg__mitxonline__app__postgres__reversion_revision.sql
+++ b/src/ol_dbt/models/staging/mitxonline/stg__mitxonline__app__postgres__reversion_revision.sql
@@ -10,7 +10,7 @@ with source as (
         id as revision_id
         , comment as revision_comment
         , user_id
-        , to_iso8601(from_iso8601_timestamp(date_created)) as revision_date_created
+        , {{ cast_timestamp_to_iso8601('date_created') }} as revision_date_created
 
     from source
 

--- a/src/ol_dbt/models/staging/mitxonline/stg__mitxonline__app__postgres__users_user.sql
+++ b/src/ol_dbt/models/staging/mitxonline/stg__mitxonline__app__postgres__users_user.sql
@@ -12,8 +12,8 @@ with source as (
         , email as user_email
         , is_active as user_is_active
         , name as user_full_name
-        , to_iso8601(from_iso8601_timestamp(created_on)) as user_joined_on
-        , to_iso8601(from_iso8601_timestamp(last_login)) as user_last_login
+        , {{ cast_timestamp_to_iso8601('created_on') }} as user_joined_on
+        , {{ cast_timestamp_to_iso8601('last_login') }} as user_last_login
     from source
 )
 

--- a/src/ol_dbt/models/staging/mitxpro/stg__mitxpro__app__postgres__b2becommerce_b2bcoupon.sql
+++ b/src/ol_dbt/models/staging/mitxpro/stg__mitxpro__app__postgres__b2becommerce_b2bcoupon.sql
@@ -15,10 +15,10 @@ with source as (
         , name as b2bcoupon_name
         , reusable as b2bcoupon_is_reusable
         , coupon_code as b2bcoupon_coupon_code
-        , to_iso8601(from_iso8601_timestamp(updated_on)) as b2bcoupon_updated_on
-        , to_iso8601(from_iso8601_timestamp(created_on)) as b2bcoupon_created_on
-        , to_iso8601(from_iso8601_timestamp(expiration_date)) as b2bcoupon_expires_on
-        , to_iso8601(from_iso8601_timestamp(activation_date)) as b2bcoupon_activated_on
+        , {{ cast_timestamp_to_iso8601('updated_on') }} as b2bcoupon_updated_on
+        , {{ cast_timestamp_to_iso8601('created_on') }} as b2bcoupon_created_on
+        , {{ cast_timestamp_to_iso8601('expiration_date') }} as b2bcoupon_expires_on
+        , {{ cast_timestamp_to_iso8601('activation_date') }} as b2bcoupon_activated_on
     from source
 )
 

--- a/src/ol_dbt/models/staging/mitxpro/stg__mitxpro__app__postgres__b2becommerce_b2bcouponaudit.sql
+++ b/src/ol_dbt/models/staging/mitxpro/stg__mitxpro__app__postgres__b2becommerce_b2bcouponaudit.sql
@@ -12,8 +12,8 @@ with source as (
         , acting_user_id as b2bcouponaudit_acting_user_id
         , data_before as b2bcouponaudit_data_before
         , data_after as b2bcouponaudit_data_after
-        , to_iso8601(from_iso8601_timestamp(created_on)) as b2bcouponaudit_created_on
-        , to_iso8601(from_iso8601_timestamp(updated_on)) as b2bcouponaudit_updated_on
+        , {{ cast_timestamp_to_iso8601('created_on') }} as b2bcouponaudit_created_on
+        , {{ cast_timestamp_to_iso8601('updated_on') }} as b2bcouponaudit_updated_on
     from source
 
 )

--- a/src/ol_dbt/models/staging/mitxpro/stg__mitxpro__app__postgres__b2becommerce_b2border.sql
+++ b/src/ol_dbt/models/staging/mitxpro/stg__mitxpro__app__postgres__b2becommerce_b2border.sql
@@ -20,8 +20,8 @@ with source as (
         , discount as b2border_discount
         , program_run_id as programrun_id
         , email as b2border_email
-        , to_iso8601(from_iso8601_timestamp(updated_on)) as b2border_updated_on
-        , to_iso8601(from_iso8601_timestamp(created_on)) as b2border_created_on
+        , {{ cast_timestamp_to_iso8601('updated_on') }} as b2border_updated_on
+        , {{ cast_timestamp_to_iso8601('created_on') }} as b2border_created_on
     from source
 
 )

--- a/src/ol_dbt/models/staging/mitxpro/stg__mitxpro__app__postgres__b2becommerce_b2borderaudit.sql
+++ b/src/ol_dbt/models/staging/mitxpro/stg__mitxpro__app__postgres__b2becommerce_b2borderaudit.sql
@@ -12,8 +12,8 @@ with source as (
         , acting_user_id as b2borderaudit_acting_user_id
         , data_before as b2borderaudit_data_before
         , data_after as b2borderaudit_data_after
-        , to_iso8601(from_iso8601_timestamp(created_on)) as b2borderaudit_created_on
-        , to_iso8601(from_iso8601_timestamp(updated_on)) as b2borderaudit_updated_on
+        , {{ cast_timestamp_to_iso8601('created_on') }} as b2borderaudit_created_on
+        , {{ cast_timestamp_to_iso8601('updated_on') }} as b2borderaudit_updated_on
     from source
 
 )

--- a/src/ol_dbt/models/staging/mitxpro/stg__mitxpro__app__postgres__b2becommerce_b2breceipt.sql
+++ b/src/ol_dbt/models/staging/mitxpro/stg__mitxpro__app__postgres__b2becommerce_b2breceipt.sql
@@ -10,8 +10,8 @@ with source as (
         id as b2breceipt_id
         , order_id as b2border_id
         , data as b2breceipt_data
-        , to_iso8601(from_iso8601_timestamp(created_on)) as b2breceipt_created_on
-        , to_iso8601(from_iso8601_timestamp(updated_on)) as b2breceipt_updated_on
+        , {{ cast_timestamp_to_iso8601('created_on') }} as b2breceipt_created_on
+        , {{ cast_timestamp_to_iso8601('updated_on') }} as b2breceipt_updated_on
     from source
 
 )

--- a/src/ol_dbt/models/staging/mitxpro/stg__mitxpro__app__postgres__courses_course.sql
+++ b/src/ol_dbt/models/staging/mitxpro/stg__mitxpro__app__postgres__courses_course.sql
@@ -12,8 +12,8 @@ with source as (
         , program_id
         , readable_id as course_readable_id
         , position_in_program
-        , to_iso8601(from_iso8601_timestamp(created_on)) as course_created_on
-        , to_iso8601(from_iso8601_timestamp(updated_on)) as course_updated_on
+        , {{ cast_timestamp_to_iso8601('created_on') }} as course_created_on
+        , {{ cast_timestamp_to_iso8601('updated_on') }} as course_updated_on
     from source
 )
 

--- a/src/ol_dbt/models/staging/mitxpro/stg__mitxpro__app__postgres__courses_courserun.sql
+++ b/src/ol_dbt/models/staging/mitxpro/stg__mitxpro__app__postgres__courses_courserun.sql
@@ -13,13 +13,13 @@ with source as (
         , courseware_id as courserun_readable_id
         , courseware_url_path as courserun_url
         , run_tag as courserun_tag
-        , to_iso8601(from_iso8601_timestamp(start_date)) as courserun_start_on
-        , to_iso8601(from_iso8601_timestamp(end_date)) as courserun_end_on
-        , to_iso8601(from_iso8601_timestamp(enrollment_start)) as courserun_enrollment_start_on
-        , to_iso8601(from_iso8601_timestamp(enrollment_end)) as courserun_enrollment_end_on
-        , to_iso8601(from_iso8601_timestamp(expiration_date)) as courserun_expired_on
-        , to_iso8601(from_iso8601_timestamp(created_on)) as courserun_created_on
-        , to_iso8601(from_iso8601_timestamp(updated_on)) as courserun_updated_on
+        , {{ cast_timestamp_to_iso8601('start_date') }} as courserun_start_on
+        , {{ cast_timestamp_to_iso8601('end_date') }} as courserun_end_on
+        , {{ cast_timestamp_to_iso8601('enrollment_start') }} as courserun_enrollment_start_on
+        , {{ cast_timestamp_to_iso8601('enrollment_end') }} as courserun_enrollment_end_on
+        , {{ cast_timestamp_to_iso8601('expiration_date') }} as courserun_expired_on
+        , {{ cast_timestamp_to_iso8601('created_on') }} as courserun_created_on
+        , {{ cast_timestamp_to_iso8601('updated_on') }} as courserun_updated_on
     from source
 )
 

--- a/src/ol_dbt/models/staging/mitxpro/stg__mitxpro__app__postgres__courses_courseruncertificate.sql
+++ b/src/ol_dbt/models/staging/mitxpro/stg__mitxpro__app__postgres__courses_courseruncertificate.sql
@@ -12,8 +12,8 @@ with source as (
         , user_id
         , certificate_page_revision_id  --- rename it after the referenced model is created
         , is_revoked as courseruncertificate_is_revoked
-        , to_iso8601(from_iso8601_timestamp(created_on)) as courseruncertificate_created_on
-        , to_iso8601(from_iso8601_timestamp(updated_on)) as courseruncertificate_updated_on
+        , {{ cast_timestamp_to_iso8601('created_on') }} as courseruncertificate_created_on
+        , {{ cast_timestamp_to_iso8601('updated_on') }} as courseruncertificate_updated_on
     from source
 )
 

--- a/src/ol_dbt/models/staging/mitxpro/stg__mitxpro__app__postgres__courses_courserunenrollment.sql
+++ b/src/ol_dbt/models/staging/mitxpro/stg__mitxpro__app__postgres__courses_courserunenrollment.sql
@@ -14,8 +14,8 @@ with source as (
         , user_id
         , company_id as ecommerce_company_id
         , order_id as ecommerce_order_id
-        , to_iso8601(from_iso8601_timestamp(created_on)) as courserunenrollment_created_on
-        , to_iso8601(from_iso8601_timestamp(updated_on)) as courserunenrollment_updated_on
+        , {{ cast_timestamp_to_iso8601('created_on') }} as courserunenrollment_created_on
+        , {{ cast_timestamp_to_iso8601('updated_on') }} as courserunenrollment_updated_on
     from source
 )
 

--- a/src/ol_dbt/models/staging/mitxpro/stg__mitxpro__app__postgres__courses_courserungrade.sql
+++ b/src/ol_dbt/models/staging/mitxpro/stg__mitxpro__app__postgres__courses_courserungrade.sql
@@ -13,8 +13,8 @@ with source as (
         , letter_grade as courserungrade_letter_grade
         , set_by_admin as courserungrade_is_set_by_admin
         , passed as courserungrade_is_passing
-        , to_iso8601(from_iso8601_timestamp(created_on)) as courserungrade_created_on
-        , to_iso8601(from_iso8601_timestamp(updated_on)) as courserungrade_updated_on
+        , {{ cast_timestamp_to_iso8601('created_on') }} as courserungrade_created_on
+        , {{ cast_timestamp_to_iso8601('updated_on') }} as courserungrade_updated_on
     from source
 )
 

--- a/src/ol_dbt/models/staging/mitxpro/stg__mitxpro__app__postgres__courses_coursetopic.sql
+++ b/src/ol_dbt/models/staging/mitxpro/stg__mitxpro__app__postgres__courses_coursetopic.sql
@@ -8,8 +8,8 @@ with source as (
     select
         id as coursetopic_id
         , name as coursetopic_name
-        , to_iso8601(from_iso8601_timestamp(created_on)) as coursetopic_created_on
-        , to_iso8601(from_iso8601_timestamp(updated_on)) as coursetopic_updated_on
+        , {{ cast_timestamp_to_iso8601('created_on') }} as coursetopic_created_on
+        , {{ cast_timestamp_to_iso8601('updated_on') }} as coursetopic_updated_on
     from source
 )
 

--- a/src/ol_dbt/models/staging/mitxpro/stg__mitxpro__app__postgres__courses_program.sql
+++ b/src/ol_dbt/models/staging/mitxpro/stg__mitxpro__app__postgres__courses_program.sql
@@ -10,8 +10,8 @@ with source as (
         , live as program_is_live
         , title as program_title
         , readable_id as program_readable_id
-        , to_iso8601(from_iso8601_timestamp(created_on)) as program_created_on
-        , to_iso8601(from_iso8601_timestamp(updated_on)) as program_updated_on
+        , {{ cast_timestamp_to_iso8601('created_on') }} as program_created_on
+        , {{ cast_timestamp_to_iso8601('updated_on') }} as program_updated_on
     from source
 )
 

--- a/src/ol_dbt/models/staging/mitxpro/stg__mitxpro__app__postgres__courses_programcertificate.sql
+++ b/src/ol_dbt/models/staging/mitxpro/stg__mitxpro__app__postgres__courses_programcertificate.sql
@@ -12,8 +12,8 @@ with source as (
         , user_id
         , certificate_page_revision_id  --- rename it after the referenced model is created
         , is_revoked as programcertificate_is_revoked
-        , to_iso8601(from_iso8601_timestamp(created_on)) as programcertificate_created_on
-        , to_iso8601(from_iso8601_timestamp(updated_on)) as programcertificate_updated_on
+        , {{ cast_timestamp_to_iso8601('created_on') }} as programcertificate_created_on
+        , {{ cast_timestamp_to_iso8601('updated_on') }} as programcertificate_updated_on
     from source
 )
 

--- a/src/ol_dbt/models/staging/mitxpro/stg__mitxpro__app__postgres__courses_programenrollment.sql
+++ b/src/ol_dbt/models/staging/mitxpro/stg__mitxpro__app__postgres__courses_programenrollment.sql
@@ -13,8 +13,8 @@ with source as (
         , user_id
         , company_id as ecommerce_company_id
         , order_id as ecommerce_order_id
-        , to_iso8601(from_iso8601_timestamp(created_on)) as programenrollment_created_on
-        , to_iso8601(from_iso8601_timestamp(updated_on)) as programenrollment_updated_on
+        , {{ cast_timestamp_to_iso8601('created_on') }} as programenrollment_created_on
+        , {{ cast_timestamp_to_iso8601('updated_on') }} as programenrollment_updated_on
     from source
 )
 

--- a/src/ol_dbt/models/staging/mitxpro/stg__mitxpro__app__postgres__courses_programrun.sql
+++ b/src/ol_dbt/models/staging/mitxpro/stg__mitxpro__app__postgres__courses_programrun.sql
@@ -9,10 +9,10 @@ with source as (
         id as programrun_id
         , program_id
         , run_tag as programrun_tag
-        , to_iso8601(from_iso8601_timestamp(start_date)) as programrun_start_on
-        , to_iso8601(from_iso8601_timestamp(end_date)) as programrun_end_on
-        , to_iso8601(from_iso8601_timestamp(created_on)) as programrun_created_on
-        , to_iso8601(from_iso8601_timestamp(updated_on)) as programrun_updated_on
+        , {{ cast_timestamp_to_iso8601('start_date') }} as programrun_start_on
+        , {{ cast_timestamp_to_iso8601('end_date') }} as programrun_end_on
+        , {{ cast_timestamp_to_iso8601('created_on') }} as programrun_created_on
+        , {{ cast_timestamp_to_iso8601('updated_on') }} as programrun_updated_on
     from source
 )
 

--- a/src/ol_dbt/models/staging/mitxpro/stg__mitxpro__app__postgres__ecommerce_basket.sql
+++ b/src/ol_dbt/models/staging/mitxpro/stg__mitxpro__app__postgres__ecommerce_basket.sql
@@ -9,8 +9,8 @@ with source as (
     select
         id as basket_id
         , user_id
-        , to_iso8601(from_iso8601_timestamp(created_on)) as basket_created_on
-        , to_iso8601(from_iso8601_timestamp(updated_on)) as basket_updated_on
+        , {{ cast_timestamp_to_iso8601('created_on') }} as basket_created_on
+        , {{ cast_timestamp_to_iso8601('updated_on') }} as basket_updated_on
 
     from source
 

--- a/src/ol_dbt/models/staging/mitxpro/stg__mitxpro__app__postgres__ecommerce_basketitem.sql
+++ b/src/ol_dbt/models/staging/mitxpro/stg__mitxpro__app__postgres__ecommerce_basketitem.sql
@@ -12,8 +12,8 @@ with source as (
         , basket_id
         , product_id
         , program_run_id as programrun_id
-        , to_iso8601(from_iso8601_timestamp(created_on)) as basketitem_created_on
-        , to_iso8601(from_iso8601_timestamp(updated_on)) as basketitem_updated_on
+        , {{ cast_timestamp_to_iso8601('created_on') }} as basketitem_created_on
+        , {{ cast_timestamp_to_iso8601('updated_on') }} as basketitem_updated_on
     from source
 
 )

--- a/src/ol_dbt/models/staging/mitxpro/stg__mitxpro__app__postgres__ecommerce_basketrunselection.sql
+++ b/src/ol_dbt/models/staging/mitxpro/stg__mitxpro__app__postgres__ecommerce_basketrunselection.sql
@@ -10,8 +10,8 @@ with source as (
         id as basketrunselection_id
         , basket_id
         , run_id as courserun_id
-        , to_iso8601(from_iso8601_timestamp(created_on)) as basketrunselection_created_on
-        , to_iso8601(from_iso8601_timestamp(updated_on)) as basketrunselection_updated_on
+        , {{ cast_timestamp_to_iso8601('created_on') }} as basketrunselection_created_on
+        , {{ cast_timestamp_to_iso8601('updated_on') }} as basketrunselection_updated_on
     from source
 
 )

--- a/src/ol_dbt/models/staging/mitxpro/stg__mitxpro__app__postgres__ecommerce_bulkcouponassignment.sql
+++ b/src/ol_dbt/models/staging/mitxpro/stg__mitxpro__app__postgres__ecommerce_bulkcouponassignment.sql
@@ -9,14 +9,13 @@ with source as (
     select
         assignment_sheet_id as bulkcouponassignment_assignment_sheet_id
         , id as bulkcouponassignment_id
-        , to_iso8601(from_iso8601_timestamp(assignments_started_date)) as bulkcouponassignment_assignments_started_on
-        , to_iso8601(from_iso8601_timestamp(last_assignment_date)) as bulkcouponassignment_last_assignment_on
-        , to_iso8601(
-            from_iso8601_timestamp(message_delivery_completed_date)
-        ) as bulkcouponassignment_message_delivery_completed_on
-        , to_iso8601(from_iso8601_timestamp(sheet_last_modified_date)) as bulkcouponassignment_sheet_last_modified_on
-        , to_iso8601(from_iso8601_timestamp(updated_on)) as bulkcouponassignment_updated_on
-        , to_iso8601(from_iso8601_timestamp(created_on)) as bulkcouponassignment_created_on
+        , {{ cast_timestamp_to_iso8601('assignments_started_date') }} as bulkcouponassignment_assignments_started_on
+        , {{ cast_timestamp_to_iso8601('last_assignment_date') }} as bulkcouponassignment_last_assignment_on
+        , {{ cast_timestamp_to_iso8601('message_delivery_completed_date') }}
+        as bulkcouponassignment_message_delivery_completed_on
+        , {{ cast_timestamp_to_iso8601('sheet_last_modified_date') }} as bulkcouponassignment_sheet_last_modified_on
+        , {{ cast_timestamp_to_iso8601('updated_on') }} as bulkcouponassignment_updated_on
+        , {{ cast_timestamp_to_iso8601('created_on') }} as bulkcouponassignment_created_on
 
     from source
 

--- a/src/ol_dbt/models/staging/mitxpro/stg__mitxpro__app__postgres__ecommerce_company.sql
+++ b/src/ol_dbt/models/staging/mitxpro/stg__mitxpro__app__postgres__ecommerce_company.sql
@@ -8,8 +8,8 @@ with source as (
     select
         id as company_id
         , name as company_name
-        , to_iso8601(from_iso8601_timestamp(updated_on)) as company_updated_on
-        , to_iso8601(from_iso8601_timestamp(created_on)) as company_created_on
+        , {{ cast_timestamp_to_iso8601('updated_on') }} as company_updated_on
+        , {{ cast_timestamp_to_iso8601('created_on') }} as company_created_on
     from source
 )
 

--- a/src/ol_dbt/models/staging/mitxpro/stg__mitxpro__app__postgres__ecommerce_coupon.sql
+++ b/src/ol_dbt/models/staging/mitxpro/stg__mitxpro__app__postgres__ecommerce_coupon.sql
@@ -12,8 +12,8 @@ with source as (
         , enabled as coupon_is_active
         , include_future_runs as coupon_applies_to_future_runs
         , is_global as coupon_is_global
-        , to_iso8601(from_iso8601_timestamp(updated_on)) as coupon_updated_on
-        , to_iso8601(from_iso8601_timestamp(created_on)) as coupon_created_on
+        , {{ cast_timestamp_to_iso8601('updated_on') }} as coupon_updated_on
+        , {{ cast_timestamp_to_iso8601('created_on') }} as coupon_created_on
     from source
 )
 

--- a/src/ol_dbt/models/staging/mitxpro/stg__mitxpro__app__postgres__ecommerce_couponbasket.sql
+++ b/src/ol_dbt/models/staging/mitxpro/stg__mitxpro__app__postgres__ecommerce_couponbasket.sql
@@ -10,8 +10,8 @@ with source as (
         id as couponbasket_id
         , basket_id
         , coupon_id
-        , to_iso8601(from_iso8601_timestamp(created_on)) as couponbasket_created_on
-        , to_iso8601(from_iso8601_timestamp(updated_on)) as couponbasket_updated_on
+        , {{ cast_timestamp_to_iso8601('created_on') }} as couponbasket_created_on
+        , {{ cast_timestamp_to_iso8601('updated_on') }} as couponbasket_updated_on
     from source
 
 )

--- a/src/ol_dbt/models/staging/mitxpro/stg__mitxpro__app__postgres__ecommerce_couponpayment.sql
+++ b/src/ol_dbt/models/staging/mitxpro/stg__mitxpro__app__postgres__ecommerce_couponpayment.sql
@@ -8,8 +8,8 @@ with source as (
     select
         id as couponpayment_id
         , name as couponpayment_name
-        , to_iso8601(from_iso8601_timestamp(updated_on)) as couponpayment_updated_on
-        , to_iso8601(from_iso8601_timestamp(created_on)) as couponpayment_created_on
+        , {{ cast_timestamp_to_iso8601('updated_on') }} as couponpayment_updated_on
+        , {{ cast_timestamp_to_iso8601('created_on') }} as couponpayment_created_on
     from source
 )
 

--- a/src/ol_dbt/models/staging/mitxpro/stg__mitxpro__app__postgres__ecommerce_couponpaymentversion.sql
+++ b/src/ol_dbt/models/staging/mitxpro/stg__mitxpro__app__postgres__ecommerce_couponpaymentversion.sql
@@ -20,10 +20,10 @@ with source as (
         , tag as couponpaymentversion_tag
         , discount_type as couponpaymentversion_discount_type
         , max_redemptions as couponpaymentversion_max_redemptions
-        , to_iso8601(from_iso8601_timestamp(expiration_date)) as couponpaymentversion_expires_on
-        , to_iso8601(from_iso8601_timestamp(activation_date)) as couponpaymentversion_activated_on
-        , to_iso8601(from_iso8601_timestamp(created_on)) as couponpaymentversion_created_on
-        , to_iso8601(from_iso8601_timestamp(updated_on)) as couponpaymentversion_updated_on
+        , {{ cast_timestamp_to_iso8601('expiration_date') }} as couponpaymentversion_expires_on
+        , {{ cast_timestamp_to_iso8601('activation_date') }} as couponpaymentversion_activated_on
+        , {{ cast_timestamp_to_iso8601('created_on') }} as couponpaymentversion_created_on
+        , {{ cast_timestamp_to_iso8601('updated_on') }} as couponpaymentversion_updated_on
 
     from source
 

--- a/src/ol_dbt/models/staging/mitxpro/stg__mitxpro__app__postgres__ecommerce_couponproduct.sql
+++ b/src/ol_dbt/models/staging/mitxpro/stg__mitxpro__app__postgres__ecommerce_couponproduct.sql
@@ -11,8 +11,8 @@ with source as (
         , product_id
         , coupon_id
         , program_run_id as programrun_id
-        , to_iso8601(from_iso8601_timestamp(created_on)) as couponproduct_created_on
-        , to_iso8601(from_iso8601_timestamp(updated_on)) as couponproduct_updated_on
+        , {{ cast_timestamp_to_iso8601('created_on') }} as couponproduct_created_on
+        , {{ cast_timestamp_to_iso8601('updated_on') }} as couponproduct_updated_on
     from source
 
 )

--- a/src/ol_dbt/models/staging/mitxpro/stg__mitxpro__app__postgres__ecommerce_couponredemption.sql
+++ b/src/ol_dbt/models/staging/mitxpro/stg__mitxpro__app__postgres__ecommerce_couponredemption.sql
@@ -10,8 +10,8 @@ with source as (
         id as couponredemption_id
         , order_id
         , coupon_version_id as couponversion_id
-        , to_iso8601(from_iso8601_timestamp(created_on)) as couponredemption_created_on
-        , to_iso8601(from_iso8601_timestamp(updated_on)) as couponredemption_updated_on
+        , {{ cast_timestamp_to_iso8601('created_on') }} as couponredemption_created_on
+        , {{ cast_timestamp_to_iso8601('updated_on') }} as couponredemption_updated_on
     from source
 
 )

--- a/src/ol_dbt/models/staging/mitxpro/stg__mitxpro__app__postgres__ecommerce_couponversion.sql
+++ b/src/ol_dbt/models/staging/mitxpro/stg__mitxpro__app__postgres__ecommerce_couponversion.sql
@@ -9,8 +9,8 @@ with source as (
         id as couponversion_id
         , coupon_id
         , payment_version_id as couponpaymentversion_id
-        , to_iso8601(from_iso8601_timestamp(updated_on)) as couponversion_updated_on
-        , to_iso8601(from_iso8601_timestamp(created_on)) as couponversion_created_on
+        , {{ cast_timestamp_to_iso8601('updated_on') }} as couponversion_updated_on
+        , {{ cast_timestamp_to_iso8601('created_on') }} as couponversion_created_on
     from source
 )
 

--- a/src/ol_dbt/models/staging/mitxpro/stg__mitxpro__app__postgres__ecommerce_line.sql
+++ b/src/ol_dbt/models/staging/mitxpro/stg__mitxpro__app__postgres__ecommerce_line.sql
@@ -10,8 +10,8 @@ with source as (
         id as line_id
         , order_id
         , product_version_id as productversion_id
-        , to_iso8601(from_iso8601_timestamp(created_on)) as line_created_on
-        , to_iso8601(from_iso8601_timestamp(updated_on)) as line_updated_on
+        , {{ cast_timestamp_to_iso8601('created_on') }} as line_created_on
+        , {{ cast_timestamp_to_iso8601('updated_on') }} as line_updated_on
     from source
 
 )

--- a/src/ol_dbt/models/staging/mitxpro/stg__mitxpro__app__postgres__ecommerce_linerunselection.sql
+++ b/src/ol_dbt/models/staging/mitxpro/stg__mitxpro__app__postgres__ecommerce_linerunselection.sql
@@ -10,8 +10,8 @@ with source as (
         id as linerunselection_id
         , line_id
         , run_id as courserun_id
-        , to_iso8601(from_iso8601_timestamp(created_on)) as linerunselection_created_on
-        , to_iso8601(from_iso8601_timestamp(updated_on)) as linerunselection_updated_on
+        , {{ cast_timestamp_to_iso8601('created_on') }} as linerunselection_created_on
+        , {{ cast_timestamp_to_iso8601('updated_on') }} as linerunselection_updated_on
     from source
 
 )

--- a/src/ol_dbt/models/staging/mitxpro/stg__mitxpro__app__postgres__ecommerce_order.sql
+++ b/src/ol_dbt/models/staging/mitxpro/stg__mitxpro__app__postgres__ecommerce_order.sql
@@ -10,8 +10,8 @@ with source as (
         , status as order_state
         , total_price_paid as order_total_price_paid
         , purchaser_id as order_purchaser_user_id
-        , to_iso8601(from_iso8601_timestamp(updated_on)) as order_updated_on
-        , to_iso8601(from_iso8601_timestamp(created_on)) as order_created_on
+        , {{ cast_timestamp_to_iso8601('updated_on') }} as order_updated_on
+        , {{ cast_timestamp_to_iso8601('created_on') }} as order_created_on
     from source
 )
 

--- a/src/ol_dbt/models/staging/mitxpro/stg__mitxpro__app__postgres__ecommerce_orderaudit.sql
+++ b/src/ol_dbt/models/staging/mitxpro/stg__mitxpro__app__postgres__ecommerce_orderaudit.sql
@@ -12,8 +12,8 @@ with source as (
         , acting_user_id as orderaudit_acting_user_id
         , data_before as orderaudit_data_before
         , data_after as orderaudit_data_after
-        , to_iso8601(from_iso8601_timestamp(created_on)) as orderaudit_created_on
-        , to_iso8601(from_iso8601_timestamp(updated_on)) as orderaudit_updated_on
+        , {{ cast_timestamp_to_iso8601('created_on') }} as orderaudit_created_on
+        , {{ cast_timestamp_to_iso8601('updated_on') }} as orderaudit_updated_on
     from source
 
 )

--- a/src/ol_dbt/models/staging/mitxpro/stg__mitxpro__app__postgres__ecommerce_product.sql
+++ b/src/ol_dbt/models/staging/mitxpro/stg__mitxpro__app__postgres__ecommerce_product.sql
@@ -12,8 +12,8 @@ with source as (
         , object_id as product_object_id
         , visible_in_bulk_form as product_is_visible_in_bulk_form
         , content_type_id as contenttype_id
-        , to_iso8601(from_iso8601_timestamp(updated_on)) as product_updated_on
-        , to_iso8601(from_iso8601_timestamp(created_on)) as product_created_on
+        , {{ cast_timestamp_to_iso8601('updated_on') }} as product_updated_on
+        , {{ cast_timestamp_to_iso8601('created_on') }} as product_created_on
     from source
 
 )

--- a/src/ol_dbt/models/staging/mitxpro/stg__mitxpro__app__postgres__ecommerce_productcouponassignment.sql
+++ b/src/ol_dbt/models/staging/mitxpro/stg__mitxpro__app__postgres__ecommerce_productcouponassignment.sql
@@ -14,9 +14,9 @@ with source as (
         , message_status as productcouponassignment_message_status
         , email as productcouponassignment_email
         , original_email as productcouponassignment_original_email
-        , to_iso8601(from_iso8601_timestamp(message_status_date)) as productcouponassignment_message_status_updated_on
-        , to_iso8601(from_iso8601_timestamp(created_on)) as productcouponassignment_created_on
-        , to_iso8601(from_iso8601_timestamp(updated_on)) as productcouponassignment_updated_on
+        , {{ cast_timestamp_to_iso8601('message_status_date') }} as productcouponassignment_message_status_updated_on
+        , {{ cast_timestamp_to_iso8601('created_on') }} as productcouponassignment_created_on
+        , {{ cast_timestamp_to_iso8601('updated_on') }} as productcouponassignment_updated_on
 
     from source
 

--- a/src/ol_dbt/models/staging/mitxpro/stg__mitxpro__app__postgres__ecommerce_productversion.sql
+++ b/src/ol_dbt/models/staging/mitxpro/stg__mitxpro__app__postgres__ecommerce_productversion.sql
@@ -13,8 +13,8 @@ with source as (
         , description as productversion_description
         , product_id
         , requires_enrollment_code as productversion_requires_enrollment_code
-        , to_iso8601(from_iso8601_timestamp(updated_on)) as productversion_updated_on
-        , to_iso8601(from_iso8601_timestamp(created_on)) as productversion_created_on
+        , {{ cast_timestamp_to_iso8601('updated_on') }} as productversion_updated_on
+        , {{ cast_timestamp_to_iso8601('created_on') }} as productversion_created_on
     from source
 
 )

--- a/src/ol_dbt/models/staging/mitxpro/stg__mitxpro__app__postgres__ecommerce_programrunline.sql
+++ b/src/ol_dbt/models/staging/mitxpro/stg__mitxpro__app__postgres__ecommerce_programrunline.sql
@@ -10,8 +10,8 @@ with source as (
         id as programrunline_id
         , line_id
         , program_run_id as programrun_id
-        , to_iso8601(from_iso8601_timestamp(created_on)) as programrunline_created_on
-        , to_iso8601(from_iso8601_timestamp(updated_on)) as programrunline_updated_on
+        , {{ cast_timestamp_to_iso8601('created_on') }} as programrunline_created_on
+        , {{ cast_timestamp_to_iso8601('updated_on') }} as programrunline_updated_on
     from source
 
 )

--- a/src/ol_dbt/models/staging/mitxpro/stg__mitxpro__app__postgres__ecommerce_receipt.sql
+++ b/src/ol_dbt/models/staging/mitxpro/stg__mitxpro__app__postgres__ecommerce_receipt.sql
@@ -10,8 +10,8 @@ with source as (
         id as receipt_id
         , order_id
         , data as receipt_data
-        , to_iso8601(from_iso8601_timestamp(created_on)) as receipt_created_on
-        , to_iso8601(from_iso8601_timestamp(updated_on)) as receipt_updated_on
+        , {{ cast_timestamp_to_iso8601('created_on') }} as receipt_created_on
+        , {{ cast_timestamp_to_iso8601('updated_on') }} as receipt_updated_on
     from source
 
 )

--- a/src/ol_dbt/models/staging/mitxpro/stg__mitxpro__app__postgres__users_user.sql
+++ b/src/ol_dbt/models/staging/mitxpro/stg__mitxpro__app__postgres__users_user.sql
@@ -11,8 +11,8 @@ with source as (
         , email as user_email
         , is_active as user_is_active
         , name as user_full_name
-        , to_iso8601(from_iso8601_timestamp(created_on)) as user_joined_on
-        , to_iso8601(from_iso8601_timestamp(last_login)) as user_last_login
+        , {{ cast_timestamp_to_iso8601('created_on') }} as user_joined_on
+        , {{ cast_timestamp_to_iso8601('last_login') }} as user_last_login
     from source
 )
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Add a macro to cast timestamp to iso 8601 format

## Motivation and Context
`to_iso8601(from_iso8601_timestamp())` is added to many models, by adding it to a macro it can be reused and easy to update later

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I've run `dbt run --select staging --full-refresh` to make sure all the models that use it are working fine

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Enhancement (improves on existing behavior)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project. (Did you install and run the pre-commit hooks?)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
