### PR TITLE
bootcamp ecommerce

### DIFF
--- a/src/ol_dbt/models/intermediate/bootcamps/_int_bootcamps__models.yml
+++ b/src/ol_dbt/models/intermediate/bootcamps/_int_bootcamps__models.yml
@@ -2,6 +2,144 @@
 version: 2
 
 models:
+- name: int__bootcamps__ecommerce_wiretransferreceipt
+  description: Data about a wire transfer used to pay for an order
+  columns:
+  - name: wiretransferreceipt_id
+    description: int, primary key representing a wire transfer receipt
+    tests:
+    - dbt_expectations.expect_column_to_exist
+    - not_null
+    - unique
+  - name: wiretransferreceipt_created_on
+    description: timestamp, specifying when the wire transfer receipt was initially
+      created
+    tests:
+    - dbt_expectations.expect_column_to_exist
+    - not_null
+  - name: wiretransferreceipt_updated_on
+    description: timestamp, specifying when the wire transfer receipt was most recently
+      updated
+    tests:
+    - dbt_expectations.expect_column_to_exist
+    - not_null
+  - name: wiretransferreceipt_data
+    description: json, wire transfer data for a payment
+    tests:
+    - dbt_expectations.expect_column_to_exist
+    - not_null
+  - name: order_id
+    description: int, primary key in ecommerce_order
+    tests:
+    - dbt_expectations.expect_column_to_exist
+  tests:
+  - dbt_expectations.expect_table_column_count_to_equal:
+      value: 5
+  - dbt_expectations.expect_table_row_count_to_equal_other_table:
+      compare_model: ref('stg__bootcamps__app__postgres__ecommerce_wiretransferreceipt')
+- name: int__bootcamps__ecommerce_receipt
+  description: Data returned from cybersource when a user pays for an order with cybersource
+  columns:
+  - name: receipt_id
+    description: int, primary key representing a receipt
+    tests:
+    - dbt_expectations.expect_column_to_exist
+    - not_null
+    - unique
+  - name: receipt_created_on
+    description: timestamp, specifying when the receipt was initially created
+    tests:
+    - dbt_expectations.expect_column_to_exist
+    - not_null
+  - name: receipt_updated_on
+    description: timestamp, specifying when the receipt was most recently updated
+    tests:
+    - dbt_expectations.expect_column_to_exist
+    - not_null
+  - name: receipt_data
+    description: json, cybersource data for a payment
+    tests:
+    - dbt_expectations.expect_column_to_exist
+    - not_null
+  - name: order_id
+    description: int, primary key in ecommerce_order
+    tests:
+    - dbt_expectations.expect_column_to_exist
+  tests:
+  - dbt_expectations.expect_table_column_count_to_equal:
+      value: 5
+  - dbt_expectations.expect_table_row_count_to_equal_other_table:
+      compare_model: ref('stg__bootcamps__app__postgres__ecommerce_receipt')
+- name: int__bootcamps__order
+  columns:
+  - name: order_id
+    description: int, primary key representing a single bootcamps order
+    tests:
+    - dbt_expectations.expect_column_to_exist
+    - unique
+    - not_null
+  - name: order_created_on
+    description: timestamp, specifying when the order was initially created
+    tests:
+    - dbt_expectations.expect_column_to_exist
+    - not_null
+  - name: order_updated_on
+    description: timestamp, specifying when the order was most recently updated
+    tests:
+    - dbt_expectations.expect_column_to_exist
+    - not_null
+  - name: order_state
+    description: string, order state. Options are "fulfilled", "failed", "created",
+      "refunded"
+    tests:
+    - dbt_expectations.expect_column_to_exist
+    - not_null
+    - accepted_values:
+        values: ['fulfilled', 'failed', 'created', 'refunded']
+  - name: order_total_price_paid
+    description: number, total order amount
+    tests:
+    - dbt_expectations.expect_column_to_exist
+    - not_null
+  - name: order_purchaser_user_id
+    description: int, primary key in auth_user for the purchaser
+    tests:
+    - dbt_expectations.expect_column_to_exist
+    - not_null
+  - name: order_payment_type
+    description: string, payment type for the order. One of "cybersource", "wiretransfer",
+      "refund"
+    tests:
+    - dbt_expectations.expect_column_to_exist
+    - not_null
+  - name: application_id
+    description: int, primary key in applications_bootcampapplication for the application
+      the order is associated with
+    tests:
+    - dbt_expectations.expect_column_to_exist
+  - name: line_id
+    description: int, primary key representing an ecommerce line
+    tests:
+    - dbt_expectations.expect_column_to_exist
+    - unique
+    - not_null
+  - name: line_description
+    description: string, description of the purchased bootcamp run
+    tests:
+    - dbt_expectations.expect_column_to_exist
+    - not_null
+  - name: courserun_id
+    description: int, foreign key in courses_courserun of the purchased run
+    tests:
+    - dbt_expectations.expect_column_to_exist
+    - not_null
+  tests:
+  - dbt_expectations.expect_table_column_count_to_equal:
+      value: 11
+  - dbt_expectations.expect_table_row_count_to_equal_other_table:
+      compare_model: ref('stg__bootcamps__app__postgres__ecommerce_order')
+  - dbt_expectations.expect_table_row_count_to_equal_other_table:
+      compare_model: ref('stg__bootcamps__app__postgres__line')
 - name: int__bootcamps__courserunenrollments
   description: Intermediate model for enrollments in bootcamps
   columns:

--- a/src/ol_dbt/models/intermediate/bootcamps/int__bootcamps__ecommerce_order.sql
+++ b/src/ol_dbt/models/intermediate/bootcamps/int__bootcamps__ecommerce_order.sql
@@ -1,0 +1,24 @@
+with orders as (
+    select *
+    from {{ ref('stg__bootcamps__app__postgres__ecommerce_order') }}
+)
+
+, lines as (
+    select *
+    from {{ ref('stg__bootcamps__app__postgres__ecommerce_line') }}
+)
+
+select
+    orders.order_id
+    , orders.order_state
+    , orders.order_purchaser_user_id
+    , orders.application_id
+    , orders.order_payment_type
+    , orders.order_total_price_paid
+    , orders.order_created_on
+    , orders.order_updated_on
+    , lines.line_id
+    , lines.line_description
+    , lines.courserun_id
+from lines
+inner join orders on orders.order_id = lines.order_id

--- a/src/ol_dbt/models/intermediate/bootcamps/int__bootcamps__ecommerce_receipt.sql
+++ b/src/ol_dbt/models/intermediate/bootcamps/int__bootcamps__ecommerce_receipt.sql
@@ -1,0 +1,12 @@
+with receipts as (
+    select *
+    from {{ ref('stg__bootcamps__app__postgres__ecommerce_receipt') }}
+)
+
+select
+    receipt_id
+    , receipt_created_on
+    , receipt_updated_on
+    , receipt_data
+    , order_id
+from receipts

--- a/src/ol_dbt/models/intermediate/bootcamps/int__bootcamps__ecommerce_wiretransferreceipt.sql
+++ b/src/ol_dbt/models/intermediate/bootcamps/int__bootcamps__ecommerce_wiretransferreceipt.sql
@@ -1,0 +1,12 @@
+with receipts as (
+    select *
+    from {{ ref('stg__bootcamps__app__postgres__ecommerce_wiretransferreceipt') }}
+)
+
+select
+    wiretransferreceipt_id
+    , wiretransferreceipt_created_on
+    , wiretransferreceipt_updated_on
+    , wiretransferreceipt_data
+    , order_id
+from receipts

--- a/src/ol_dbt/models/staging/bootcamps/_bootcamps__sources.yml
+++ b/src/ol_dbt/models/staging/bootcamps/_bootcamps__sources.yml
@@ -7,6 +7,172 @@ sources:
   database: 'ol_data_lake_{{ target.name }}'
   schema: 'ol_warehouse_{{ target.name }}_raw'
   tables:
+  - name: raw__bootcamps__app__postgres__ecommerce_wiretransferreceipt
+    description: Data about a wire transfer
+    columns:
+    - name: id
+      description: int, primary key representing a  wire transfer receipt
+      tests:
+      - dbt_expectations.expect_column_to_exist
+    - name: created_on
+      description: timestamp, specifying when the wire transfer receipt was initially
+        created
+      tests:
+      - dbt_expectations.expect_column_to_exist
+    - name: updated_on
+      description: timestamp, specifying when the wire transfer receipt was most recently
+        updated
+      tests:
+      - dbt_expectations.expect_column_to_exist
+    - name: data
+      description: json, data for a payment
+      tests:
+      - dbt_expectations.expect_column_to_exist
+    - name: order_id
+      description: int, primary key in ecommerce_order
+      tests:
+      - dbt_expectations.expect_column_to_exist
+    - name: wire_transfer_id
+      description: int, unique id used to identify the wire transfer in the spreadsheet
+        we use to import wire transfer data
+      tests:
+      - dbt_expectations.expect_column_to_exist
+    tests:
+    - dbt_expectations.expect_table_column_count_to_equal:
+        value: 6
+  - name: raw__bootcamps__app__postgres__ecommerce_receipt
+    description: Data returned from cybersource when a user pays for an order through
+      cybersource
+    columns:
+    - name: id
+      description: int, primary key representing a receipt
+      tests:
+      - dbt_expectations.expect_column_to_exist
+    - name: created_on
+      description: timestamp, specifying when the receipt was initially created
+      tests:
+      - dbt_expectations.expect_column_to_exist
+    - name: updated_on
+      description: timestamp, specifying when the receipt was most recently updated
+      tests:
+      - dbt_expectations.expect_column_to_exist
+    - name: data
+      description: json, cybersource data for a payment
+      tests:
+      - dbt_expectations.expect_column_to_exist
+    - name: order_id
+      description: int, primary key in ecommerce_order
+      tests:
+      - dbt_expectations.expect_column_to_exist
+    tests:
+    - dbt_expectations.expect_table_column_count_to_equal:
+        value: 5
+  - name: raw__bootcamps__app__postgres__ecommerce_line
+    columns:
+    - name: id
+      description: int, primary key representing an ecommerce line
+      tests:
+      - dbt_expectations.expect_column_to_exist
+    - name: created_on
+      description: timestamp, specifying when the line was initially created
+      tests:
+      - dbt_expectations.expect_column_to_exist
+    - name: updated_on
+      description: timestamp, specifying when the line was most recently updated
+      tests:
+      - dbt_expectations.expect_column_to_exist
+    - name: price
+      description: numeric, price paid for the bootcamp run
+      tests:
+      - dbt_expectations.expect_column_to_exist
+    - name: description
+      description: string, description of the purchased bootcamp run
+      tests:
+      - dbt_expectations.expect_column_to_exist
+    - name: order_id
+      description: int, foreign key for the order this line belongs to
+      tests:
+      - dbt_expectations.expect_column_to_exist
+    - name: bootcamp_run_id
+      description: int, foreign key in courses_courserun of the purchased run
+      tests:
+      - dbt_expectations.expect_column_to_exist
+    tests:
+    - dbt_expectations.expect_table_column_count_to_equal:
+        value: 7
+  - name: raw__bootcamps__app__postgres__ecommerce_orderaudit
+    columns:
+    - name: id
+      description: int, primary key representing a change to the orders table
+      tests:
+      - dbt_expectations.expect_column_to_exist
+    - name: created_on
+      description: timestamp, specifying when the order audit was initially created
+      tests:
+      - dbt_expectations.expect_column_to_exist
+    - name: updated_on
+      description: timestamp, specifying when the order audit was most recently updated
+      tests:
+      - dbt_expectations.expect_column_to_exist
+    - name: data_before
+      description: json, jsonified order object before the change
+      tests:
+      - dbt_expectations.expect_column_to_exist
+    - name: data_after
+      description: json, jsonified order object after the change
+      tests:
+      - dbt_expectations.expect_column_to_exist
+    - name: acting_user_id
+      description: int, reference to auth_user table, the user who made the change
+      tests:
+      - dbt_expectations.expect_column_to_exist
+    - name: order_id
+      description: int, reference to ecommerce_order
+      tests:
+      - dbt_expectations.expect_column_to_exist
+    tests:
+    - dbt_expectations.expect_table_column_count_to_equal:
+        value: 7
+  - name: raw__bootcamps__app__postgres__ecommerce_order
+    columns:
+    - name: id
+      description: int, primary key representing a single bootcamps order
+      tests:
+      - dbt_expectations.expect_column_to_exist
+    - name: created_on
+      description: timestamp, specifying when the order was initially created
+      tests:
+      - dbt_expectations.expect_column_to_exist
+    - name: updated_on
+      description: timestamp, specifying when the order was most recently updated
+      tests:
+      - dbt_expectations.expect_column_to_exist
+    - name: status
+      description: string, order state. Options are "fulfilled", "failed" "created",
+        "refunded"
+      tests:
+      - dbt_expectations.expect_column_to_exist
+    - name: total_price_paid
+      description: number, total order amount
+      tests:
+      - dbt_expectations.expect_column_to_exist
+    - name: user_id
+      description: int, primary key in auth_user for the purchaser
+      tests:
+      - dbt_expectations.expect_column_to_exist
+    - name: payment_type
+      description: string, payment type for the order. One of "cybersource", "wiretransfer",
+        "refund"
+      tests:
+      - dbt_expectations.expect_column_to_exist
+    - name: application_id
+      description: int, primary key in applications_bootcampapplication for the application
+        the order is associated with
+      tests:
+      - dbt_expectations.expect_column_to_exist
+    tests:
+    - dbt_expectations.expect_table_column_count_to_equal:
+        value: 8
   - name: raw__bootcamps__app__postgres__klasses_bootcamprunenrollment
     description: ""
     columns:

--- a/src/ol_dbt/models/staging/bootcamps/_stg_bootcamps__models.yml
+++ b/src/ol_dbt/models/staging/bootcamps/_stg_bootcamps__models.yml
@@ -2,6 +2,205 @@
 version: 2
 
 models:
+- name: stg__bootcamps__app__postgres__ecommerce_wiretransferreceipt
+  description: Data about a wire transfer
+  columns:
+  - name: wiretransferreceipt_id
+    description: int, primary key representing a  wire transfer receipt
+    tests:
+    - dbt_expectations.expect_column_to_exist
+    - unique
+    - not_null
+  - name: wiretransferreceipt_created_on
+    description: timestamp, specifying when the wire transfer receipt was initially
+      created
+    tests:
+    - dbt_expectations.expect_column_to_exist
+    - not_null
+  - name: wiretransferreceipt_updated_on
+    description: timestamp, specifying when the wire transfer receipt was most recently
+      updated
+    tests:
+    - dbt_expectations.expect_column_to_exist
+    - not_null
+  - name: wiretransferreceipt_data
+    description: json, data for a payment
+    tests:
+    - dbt_expectations.expect_column_to_exist
+    - not_null
+  - name: order_id
+    description: int, primary key in ecommerce_order
+    tests:
+    - dbt_expectations.expect_column_to_exist
+  - name: wiretransferreceipt_import_id
+    description: int, unique id used to identify the wire transfer in the spreadsheet
+      we use to import wire transfer data
+    tests:
+    - dbt_expectations.expect_column_to_exist
+    - not_null
+  tests:
+  - dbt_expectations.expect_table_column_count_to_equal:
+      value: 6
+- name: stg__bootcamps__app__postgres__ecommerce_receipt
+  description: Data returned from cybersource when a user pays for an order through
+    cybersource
+  columns:
+  - name: receipt_id
+    description: int, primary key representing a receipt
+    tests:
+    - dbt_expectations.expect_column_to_exist
+    - not_null
+    - unique
+  - name: receipt_created_on
+    description: timestamp, specifying when the receipt was initially created
+    tests:
+    - dbt_expectations.expect_column_to_exist
+    - not_null
+  - name: receipt_updated_on
+    description: timestamp, specifying when the receipt was most recently updated
+    tests:
+    - dbt_expectations.expect_column_to_exist
+    - not_null
+  - name: receipt_data
+    description: json, cybersource data for a payment
+    tests:
+    - dbt_expectations.expect_column_to_exist
+    - not_null
+  - name: order_id
+    description: int, primary key in ecommerce_order
+    tests:
+    - dbt_expectations.expect_column_to_exist
+  tests:
+  - dbt_expectations.expect_table_column_count_to_equal:
+      value: 5
+- name: stg__bootcamps__app__postgres__ecommerce_line
+  columns:
+  - name: line_id
+    description: int, primary key representing an ecommerce line
+    tests:
+    - dbt_expectations.expect_column_to_exist
+    - unique
+    - not_null
+  - name: line_created_on
+    description: timestamp, specifying when the line was initially created
+    tests:
+    - dbt_expectations.expect_column_to_exist
+    - not_null
+  - name: line_updated_on
+    description: timestamp, specifying when the line was most recently updated
+    tests:
+    - dbt_expectations.expect_column_to_exist
+    - not_null
+  - name: line_price
+    description: numeric, price paid for the bootcamp run
+    tests:
+    - dbt_expectations.expect_column_to_exist
+  - name: line_description
+    description: string, description of the purchased bootcamp run
+    tests:
+    - dbt_expectations.expect_column_to_exist
+    - not_null
+  - name: order_id
+    description: int, foreign key for the order this line belongs to
+    tests:
+    - dbt_expectations.expect_column_to_exist
+    - not_null
+    - unique
+  - name: courserun_id
+    description: int, foreign key in courses_courserun of the purchased run
+    tests:
+    - dbt_expectations.expect_column_to_exist
+    - not_null
+  tests:
+  - dbt_expectations.expect_table_column_count_to_equal:
+      value: 7
+- name: stg__bootcamps__app__postgres__ecommerce_orderaudit
+  columns:
+  - name: orderaudit_id
+    description: int, primary key representing a change to the orders table
+    tests:
+    - dbt_expectations.expect_column_to_exist
+    - unique
+    - not_null
+  - name: orderaudit_created_on
+    description: timestamp, specifying when the order audit was initially created
+    tests:
+    - dbt_expectations.expect_column_to_exist
+    - not_null
+  - name: orderaudit_updated_on
+    description: timestamp, specifying when the order audit was most recently updated
+    tests:
+    - dbt_expectations.expect_column_to_exist
+    - not_null
+  - name: orderaudit_data_before
+    description: json, jsonified order object before the change
+    tests:
+    - dbt_expectations.expect_column_to_exist
+  - name: orderaudit_data_after
+    description: json, jsonified order object after the change
+    tests:
+    - dbt_expectations.expect_column_to_exist
+  - name: orderaudit_acting_user_id
+    description: int, reference to users_user table, the user who made the change
+    tests:
+    - dbt_expectations.expect_column_to_exist
+  - name: order_id
+    description: int, reference to ecommerce_order
+    tests:
+    - dbt_expectations.expect_column_to_exist
+  tests:
+  - dbt_expectations.expect_table_column_count_to_equal:
+      value: 7
+- name: stg__bootcamps__app__postgres__ecommerce_order
+  columns:
+  - name: order_id
+    description: int, primary key representing a single bootcamps order
+    tests:
+    - dbt_expectations.expect_column_to_exist
+    - unique
+    - not_null
+  - name: order_created_on
+    description: timestamp, specifying when the order was initially created
+    tests:
+    - dbt_expectations.expect_column_to_exist
+    - not_null
+  - name: order_updated_on
+    description: timestamp, specifying when the order was most recently updated
+    tests:
+    - dbt_expectations.expect_column_to_exist
+    - not_null
+  - name: order_state
+    description: string, order state. Options are "fulfilled", "failed", "created",
+      "refunded"
+    tests:
+    - dbt_expectations.expect_column_to_exist
+    - not_null
+    - accepted_values:
+        values: ['fulfilled', 'failed', 'created', 'refunded']
+  - name: order_total_price_paid
+    description: number, total order amount
+    tests:
+    - dbt_expectations.expect_column_to_exist
+    - not_null
+  - name: order_purchaser_user_id
+    description: int, primary key in auth_user for the purchaser
+    tests:
+    - dbt_expectations.expect_column_to_exist
+    - not_null
+  - name: order_payment_type
+    description: string, payment type for the order. One of "cybersource", "wiretransfer",
+      "refund"
+    tests:
+    - dbt_expectations.expect_column_to_exist
+    - not_null
+  - name: application_id
+    description: int, primary key in applications_bootcampapplication for the application
+      the order is associated with
+    tests:
+    - dbt_expectations.expect_column_to_exist
+  tests:
+  - dbt_expectations.expect_table_column_count_to_equal:
+      value: 8
 - name: stg__bootcamps__app__postgres__courserunenrollment
   columns:
   - name: courserunenrollment_id

--- a/src/ol_dbt/models/staging/bootcamps/stg__bootcamps__app__postgres__ecommerce_line.sql
+++ b/src/ol_dbt/models/staging/bootcamps/stg__bootcamps__app__postgres__ecommerce_line.sql
@@ -1,0 +1,20 @@
+with source as (
+
+    select * from {{ source('ol_warehouse_raw_data', 'raw__bootcamps__app__postgres__ecommerce_line') }}
+
+)
+
+, renamed as (
+    select
+        id as line_id
+        , price as line_price
+        , description as line_description
+        , order_id
+        , bootcamp_run_id as courserun_id
+        , {{ cast_timestamp_to_iso8601('created_on') }} as line_created_on
+        , {{ cast_timestamp_to_iso8601('updated_on') }} as line_updated_on
+    from source
+
+)
+
+select * from renamed

--- a/src/ol_dbt/models/staging/bootcamps/stg__bootcamps__app__postgres__ecommerce_order.sql
+++ b/src/ol_dbt/models/staging/bootcamps/stg__bootcamps__app__postgres__ecommerce_order.sql
@@ -1,0 +1,21 @@
+with source as (
+
+    select * from {{ source('ol_warehouse_raw_data', 'raw__bootcamps__app__postgres__ecommerce_order') }}
+
+)
+
+, renamed as (
+    select
+        id as order_id
+        , status as order_state
+        , user_id as order_purchaser_user_id
+        , application_id as application_id
+        , payment_type as order_payment_type
+        , total_price_paid as order_total_price_paid
+        , {{ cast_timestamp_to_iso8601('created_on') }} as order_created_on
+        , {{ cast_timestamp_to_iso8601('updated_on') }} as order_updated_on
+    from source
+
+)
+
+select * from renamed

--- a/src/ol_dbt/models/staging/bootcamps/stg__bootcamps__app__postgres__ecommerce_orderaudit.sql
+++ b/src/ol_dbt/models/staging/bootcamps/stg__bootcamps__app__postgres__ecommerce_orderaudit.sql
@@ -1,0 +1,20 @@
+with source as (
+
+    select * from {{ source('ol_warehouse_raw_data', 'raw__bootcamps__app__postgres__ecommerce_orderaudit') }}
+
+)
+
+, renamed as (
+    select
+        id as orderaudit_id
+        , order_id
+        , acting_user_id as orderaudit_acting_user_id
+        , data_before as orderaudit_data_before
+        , data_after as orderaudit_data_after
+        , {{ cast_timestamp_to_iso8601('created_on') }} as orderaudit_created_on
+        , {{ cast_timestamp_to_iso8601('updated_on') }} as orderaudit_updated_on
+    from source
+
+)
+
+select * from renamed

--- a/src/ol_dbt/models/staging/bootcamps/stg__bootcamps__app__postgres__ecommerce_receipt.sql
+++ b/src/ol_dbt/models/staging/bootcamps/stg__bootcamps__app__postgres__ecommerce_receipt.sql
@@ -1,0 +1,18 @@
+with source as (
+
+    select * from {{ source('ol_warehouse_raw_data', 'raw__bootcamps__app__postgres__ecommerce_receipt') }}
+
+)
+
+, renamed as (
+    select
+        id as receipt_id
+        , order_id
+        , data as receipt_data
+        , {{ cast_timestamp_to_iso8601('created_on') }} as receipt_created_on
+        , {{ cast_timestamp_to_iso8601('updated_on') }} as receipt_updated_on
+    from source
+
+)
+
+select * from renamed

--- a/src/ol_dbt/models/staging/bootcamps/stg__bootcamps__app__postgres__ecommerce_wiretransferreceipt.sql
+++ b/src/ol_dbt/models/staging/bootcamps/stg__bootcamps__app__postgres__ecommerce_wiretransferreceipt.sql
@@ -1,0 +1,19 @@
+with source as (
+
+    select * from {{ source('ol_warehouse_raw_data', 'raw__bootcamps__app__postgres__ecommerce_wiretransferreceipt') }}
+
+)
+
+, renamed as (
+    select
+        id as wiretransferreceipt_id
+        , order_id
+        , data as wiretransferreceipt_data
+        , {{ cast_timestamp_to_iso8601('created_on') }} as wiretransferreceipt_created_on
+        , {{ cast_timestamp_to_iso8601('updated_on') }} as wiretransferreceipt_updated_on
+        , wire_transfer_id as wiretransferreceipt_import_id
+    from source
+
+)
+
+select * from renamed


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
closes https://github.com/mitodl/ol-data-platform/issues/540

## Motivation and Context
Adds
int__bootcamps__ecommerce_wiretransferreceipt
int__bootcamps__ecommerce_receipt
int__bootcamps__order

stg__bootcamps__app__postgres__ecommerce_wiretransferreceipt
stg__bootcamps__app__postgres__ecommerce_receipt
stg__bootcamps__app__postgres__ecommerce_line
stg__bootcamps__app__postgres__ecommerce_orderaudit
stg__bootcamps__app__postgres__ecommerce_order

## How Has This Been Tested?
dbt run
dbt test

