### PR TITLE
refactor: Migrate to use Ruff for linting

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,55 +27,26 @@ repos:
     - '80'
     - --preserve-quotes
 - repo: https://github.com/adrienverge/yamllint.git
-  rev: v1.28.0
+  rev: v1.29.0
   hooks:
   - id: yamllint
     args: [--format, parsable, -d, relaxed]
-- repo: https://github.com/asottile/pyupgrade
-  rev: v3.3.1
-  hooks:
-  - id: pyupgrade
-    args:
-    - --py39-plus
-- repo: https://github.com/myint/autoflake/
-  rev: v2.0.0
-  hooks:
-  - id: autoflake
-    args:
-    - --in-place
-    - --ignore-init-module-imports
-    - --expand-star-imports
-    - --remove-unused-variables
-    - --remove-all-unused-imports
 - repo: https://github.com/Yelp/detect-secrets
   rev: v1.4.0
   hooks:
   - id: detect-secrets
     args:
     - --exclude-files poetry.lock
-- repo: https://github.com/PyCQA/isort
-  rev: 5.11.4
-  hooks:
-  - id: isort
-- repo: https://github.com/asottile/yesqa
-  rev: v1.4.0
-  hooks:
-  - id: yesqa
-    additional_dependencies:
-    - git+https://github.com/wemake-services/wemake-python-styleguide#egg=wemake-python-styleguide
 - repo: https://github.com/psf/black
   rev: 22.12.0
   hooks:
   - id: black
-- repo: https://github.com/PyCQA/flake8
-  rev: 5.0.4
+- repo: https://github.com/charliermarsh/ruff-pre-commit
+  # Ruff version.
+  rev: 'v0.0.238'
   hooks:
-  - id: flake8
-    additional_dependencies:
-    - git+https://github.com/wemake-services/wemake-python-styleguide#egg=wemake-python-styleguide
-    args:
-    - --config=setup.cfg
-    - --extend-ignore=D1,D2,D4
+  - id: ruff
+    args: [--extend-ignore=D1, --fix]
 - repo: https://github.com/pre-commit/mirrors-mypy
   rev: v0.991
   hooks:
@@ -87,7 +58,7 @@ repos:
     - types-pymysql
     - types-requests
 - repo: https://github.com/sqlfluff/sqlfluff
-  rev: 2.0.0a1
+  rev: 2.0.0a4
   hooks:
   - id: sqlfluff-fix
       # Arbitrary arguments to show an example

--- a/poetry.lock
+++ b/poetry.lock
@@ -2,14 +2,14 @@
 
 [[package]]
 name = "agate"
-version = "1.6.3"
+version = "1.7.0"
 description = "A data analysis library that is optimized for humans instead of machines."
 category = "main"
 optional = false
 python-versions = "*"
 files = [
-    {file = "agate-1.6.3-py2.py3-none-any.whl", hash = "sha256:2d568fd68a8eb8b56c805a1299ba4bc30ca0434563be1bea309c9d1c1c8401f4"},
-    {file = "agate-1.6.3.tar.gz", hash = "sha256:e0f2f813f7e12311a4cdccc97d6ba0a6781e9c1aa8eca0ab00d5931c0113a308"},
+    {file = "agate-1.7.0-py2.py3-none-any.whl", hash = "sha256:ad529c80fe6943906ab3d3bc59c12307e1181d35993e6055db59fa72dc79a6bd"},
+    {file = "agate-1.7.0.tar.gz", hash = "sha256:a835a1069247b39b0c340e31eb56e1a95e79f679ad37512192118a5ea3336020"},
 ]
 
 [package.dependencies]
@@ -19,11 +19,10 @@ leather = ">=0.3.2"
 parsedatetime = ">=2.1,<2.5 || >2.5,<2.6 || >2.6"
 python-slugify = ">=1.2.1"
 pytimeparse = ">=1.1.5"
-six = ">=1.9.0"
 
 [package.extras]
 docs = ["Sphinx (>=1.2.2)", "sphinx-rtd-theme (>=0.1.6)"]
-test = ["PyICU (>=2.4.2)", "coverage (>=3.7.1)", "cssselect (>=0.9.1)", "lxml (>=3.6.0)", "mock (>=1.3.0)", "nose (>=1.1.2)", "pytz (>=2015.4)", "unittest2 (>=1.1.0)"]
+test = ["PyICU (>=2.4.2)", "coverage (>=3.7.1)", "cssselect (>=0.9.1)", "lxml (>=3.6.0)", "pytest", "pytest-cov", "pytz (>=2015.4)"]
 
 [[package]]
 name = "alembic"
@@ -186,18 +185,6 @@ dev = ["cogapp", "pre-commit", "pytest", "wheel"]
 tests = ["pytest"]
 
 [[package]]
-name = "astor"
-version = "0.8.1"
-description = "Read/rewrite/write Python ASTs"
-category = "dev"
-optional = false
-python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,>=2.7"
-files = [
-    {file = "astor-0.8.1-py2.py3-none-any.whl", hash = "sha256:070a54e890cefb5b3739d19f30f5a5ec840ffc9c50ffa7d23cc9fc1a38ebbfc5"},
-    {file = "astor-0.8.1.tar.gz", hash = "sha256:6a6effda93f4e1ce9f618779b2dd1d9d84f1e32812c23a29b3fff6fd7f63fa5e"},
-]
-
-[[package]]
 name = "asttokens"
 version = "2.2.1"
 description = "Annotate AST trees with source code positions"
@@ -274,38 +261,15 @@ files = [
 ]
 
 [[package]]
-name = "bandit"
-version = "1.7.4"
-description = "Security oriented static analyser for python code."
-category = "dev"
-optional = false
-python-versions = ">=3.7"
-files = [
-    {file = "bandit-1.7.4-py3-none-any.whl", hash = "sha256:412d3f259dab4077d0e7f0c11f50f650cc7d10db905d98f6520a95a18049658a"},
-    {file = "bandit-1.7.4.tar.gz", hash = "sha256:2d63a8c573417bae338962d4b9b06fbc6080f74ecd955a092849e1e65c717bd2"},
-]
-
-[package.dependencies]
-colorama = {version = ">=0.3.9", markers = "platform_system == \"Windows\""}
-GitPython = ">=1.0.1"
-PyYAML = ">=5.3.1"
-stevedore = ">=1.20.0"
-
-[package.extras]
-test = ["beautifulsoup4 (>=4.8.0)", "coverage (>=4.5.4)", "fixtures (>=3.0.0)", "flake8 (>=4.0.0)", "pylint (==1.9.4)", "stestr (>=2.5.0)", "testscenarios (>=0.5.0)", "testtools (>=2.3.0)", "toml"]
-toml = ["toml"]
-yaml = ["PyYAML"]
-
-[[package]]
 name = "beautifulsoup4"
-version = "4.11.1"
+version = "4.11.2"
 description = "Screen-scraping library"
 category = "main"
 optional = false
 python-versions = ">=3.6.0"
 files = [
-    {file = "beautifulsoup4-4.11.1-py3-none-any.whl", hash = "sha256:58d5c3d29f5a36ffeb94f02f0d786cd53014cf9b3b3951d42e0080d8a9498d30"},
-    {file = "beautifulsoup4-4.11.1.tar.gz", hash = "sha256:ad9aa55b65ef2808eb405f46cf74df7fcb7044d5cbc26487f96eb2ef2e436693"},
+    {file = "beautifulsoup4-4.11.2-py3-none-any.whl", hash = "sha256:0e79446b10b3ecb499c1556f7e228a53e64a2bfcebd455f370d8927cb5b59e39"},
+    {file = "beautifulsoup4-4.11.2.tar.gz", hash = "sha256:bc4bdda6717de5a2987436fb8d72f45dc90dd856bdfd512a1314ce90349a0106"},
 ]
 
 [package.dependencies]
@@ -314,6 +278,24 @@ soupsieve = ">1.2"
 [package.extras]
 html5lib = ["html5lib"]
 lxml = ["lxml"]
+
+[[package]]
+name = "betterproto"
+version = "1.2.5"
+description = "A better Protobuf / gRPC generator & library"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+files = [
+    {file = "betterproto-1.2.5.tar.gz", hash = "sha256:74a3ab34646054f674d236d1229ba8182dc2eae86feb249b8590ef496ce9803d"},
+]
+
+[package.dependencies]
+grpclib = "*"
+stringcase = "*"
+
+[package.extras]
+compiler = ["black", "jinja2", "protobuf"]
 
 [[package]]
 name = "black"
@@ -372,18 +354,18 @@ css = ["tinycss2 (>=1.1.0,<1.2)"]
 
 [[package]]
 name = "boto3"
-version = "1.26.59"
+version = "1.26.62"
 description = "The AWS SDK for Python"
 category = "main"
 optional = false
 python-versions = ">= 3.7"
 files = [
-    {file = "boto3-1.26.59-py3-none-any.whl", hash = "sha256:34ee771a5cc84c16e75d4b9ef4672f51c2bafdce66ec457bbaac630b37d9cd5e"},
-    {file = "boto3-1.26.59.tar.gz", hash = "sha256:7d9cebb507fc96e6eb429621ccb2e731b75e7bbb8d6d9f0cf0c08089ee3c1ab7"},
+    {file = "boto3-1.26.62-py3-none-any.whl", hash = "sha256:0a0171c648da81916e6f5badebfefdbd15280118f69462eb9425f7bff4c1323f"},
+    {file = "boto3-1.26.62.tar.gz", hash = "sha256:0271e05cf962de53deb4ee5c6e37433c8284584a26f45275cf43de3f99410aa4"},
 ]
 
 [package.dependencies]
-botocore = ">=1.29.59,<1.30.0"
+botocore = ">=1.29.62,<1.30.0"
 jmespath = ">=0.7.1,<2.0.0"
 s3transfer = ">=0.6.0,<0.7.0"
 
@@ -392,14 +374,14 @@ crt = ["botocore[crt] (>=1.21.0,<2.0a0)"]
 
 [[package]]
 name = "botocore"
-version = "1.29.59"
+version = "1.29.62"
 description = "Low-level, data-driven core of boto 3."
 category = "main"
 optional = false
 python-versions = ">= 3.7"
 files = [
-    {file = "botocore-1.29.59-py3-none-any.whl", hash = "sha256:5533644ddefaccfaa98460a63eb73e61a46aad019771226d103b1054b0df6103"},
-    {file = "botocore-1.29.59.tar.gz", hash = "sha256:bc75d41c5eecf624a2f9875483135aa78088a50c8d29847793f92756697cfed5"},
+    {file = "botocore-1.29.62-py3-none-any.whl", hash = "sha256:11730086c8acc33372f438dd9ae3e960e6fc1c0dfa2801768b0585c8c874977e"},
+    {file = "botocore-1.29.62.tar.gz", hash = "sha256:8c7fdc6b14d9ef48ee8d1070700ab4204c121bc04ee57874e8419a9cdbe51144"},
 ]
 
 [package.dependencies]
@@ -421,24 +403,6 @@ files = [
     {file = "cachetools-5.3.0-py3-none-any.whl", hash = "sha256:429e1a1e845c008ea6c85aa35d4b98b65d6a9763eeef3e37e92728a12d1de9d4"},
     {file = "cachetools-5.3.0.tar.gz", hash = "sha256:13dfddc7b8df938c21a940dfa6557ce6e94a2f1cdfa58eb90c805721d58f2c14"},
 ]
-
-[[package]]
-name = "cachy"
-version = "0.1.1"
-description = "Cachy provides a simple yet effective caching library."
-category = "dev"
-optional = false
-python-versions = "*"
-files = [
-    {file = "cachy-0.1.1-py2.py3-none-any.whl", hash = "sha256:e52fade6799c16a7ebec481b83a857920c4d51dc1b40a63c82ce1af61766bc88"},
-    {file = "cachy-0.1.1.tar.gz", hash = "sha256:40b3ca1c57d0254c7d6d37920baadbb32a7e7cb7585e94f50764ad52ac016822"},
-]
-
-[package.extras]
-memcached = ["python-memcached"]
-memcachedc = ["pylibmc"]
-memcachedpy3 = ["python3-memcached"]
-redis = ["redis"]
 
 [[package]]
 name = "certifi"
@@ -652,22 +616,6 @@ files = [
 ]
 
 [[package]]
-name = "cleo"
-version = "0.6.8"
-description = "Cleo allows you to create beautiful and testable command-line interfaces."
-category = "dev"
-optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
-files = [
-    {file = "cleo-0.6.8-py2.py3-none-any.whl", hash = "sha256:9b7f79f1aa470a025c0d28c76aa225ee9e65028d32f80032e871aa3500df61b8"},
-    {file = "cleo-0.6.8.tar.gz", hash = "sha256:85a63076b72ca376fb06668be1fc7758dc16740b394783d5cc65200c4b32f71b"},
-]
-
-[package.dependencies]
-pastel = ">=0.1.0,<0.2.0"
-pylev = ">=1.3,<2.0"
-
-[[package]]
 name = "click"
 version = "8.1.3"
 description = "Composable command line interface toolkit"
@@ -684,14 +632,14 @@ colorama = {version = "*", markers = "platform_system == \"Windows\""}
 
 [[package]]
 name = "colorama"
-version = "0.4.5"
+version = "0.4.6"
 description = "Cross-platform colored terminal text."
 category = "main"
 optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,!=3.6.*,>=2.7"
 files = [
-    {file = "colorama-0.4.5-py2.py3-none-any.whl", hash = "sha256:854bf444933e37f5824ae7bfc1e98d5bce2ebe4160d46b5edf346a89358e99da"},
-    {file = "colorama-0.4.5.tar.gz", hash = "sha256:e6c6b4334fc50988a639d9b98aa429a0b57da6e17b9a44f0451f930b6967b7a4"},
+    {file = "colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6"},
+    {file = "colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44"},
 ]
 
 [[package]]
@@ -806,20 +754,20 @@ test = ["hypothesis (>=1.11.4,!=3.79.2)", "iso8601", "pretend", "pytest (>=6.2.0
 
 [[package]]
 name = "dagit"
-version = "1.1.14"
+version = "1.1.13"
 description = "Web UI for dagster."
 category = "main"
 optional = false
 python-versions = "*"
 files = [
-    {file = "dagit-1.1.14-py3-none-any.whl", hash = "sha256:72d0a4b351748db406aed1c131b6f4ac705a90fdc6f28c068ca8797bf547aa62"},
-    {file = "dagit-1.1.14.tar.gz", hash = "sha256:cb21598b3143cedfd6e7338ac4ccaa30cac879dca5fa2c4940e5340591e278b0"},
+    {file = "dagit-1.1.13-py3-none-any.whl", hash = "sha256:a87a25ea9c014cc634b1000d24c859439725a46d935d73514ebfaad081472ef1"},
+    {file = "dagit-1.1.13.tar.gz", hash = "sha256:877b3ae69bc3f16fd3400dd14f825310e708268d9e1338bc4e770d98602e7d27"},
 ]
 
 [package.dependencies]
 click = ">=7.0,<9.0"
-dagster = "1.1.14"
-dagster-graphql = "1.1.14"
+dagster = "1.1.13"
+dagster-graphql = "1.1.13"
 starlette = "*"
 uvicorn = {version = "*", extras = ["standard"]}
 
@@ -829,14 +777,14 @@ test = ["starlette[full]"]
 
 [[package]]
 name = "dagster"
-version = "1.1.14"
+version = "1.1.13"
 description = "The data orchestration platform built for productivity."
 category = "main"
 optional = false
 python-versions = "*"
 files = [
-    {file = "dagster-1.1.14-py3-none-any.whl", hash = "sha256:cc96bb17e81c1f9015da2cd1da4610cc1e362c2d034517d0b199cebee1154716"},
-    {file = "dagster-1.1.14.tar.gz", hash = "sha256:26ce119811880d1546792053bb5fe2c2b404d93378c51da7a085460dbc52b561"},
+    {file = "dagster-1.1.13-py3-none-any.whl", hash = "sha256:7355d1d972956753e249f58515b055e53fb7d1b2b0a55466e72f4cb63fdfd50f"},
+    {file = "dagster-1.1.13.tar.gz", hash = "sha256:4cbb9bea488dacfa05cd7d0ba1ff41036a710868ea685a6cfc515a00fe624442"},
 ]
 
 [package.dependencies]
@@ -860,7 +808,7 @@ pywin32 = {version = "!=226", markers = "platform_system == \"Windows\""}
 PyYAML = ">=5.1"
 requests = "*"
 setuptools = "*"
-sqlalchemy = ">=1.0,<2.0.0"
+sqlalchemy = ">=1.0"
 tabulate = "*"
 tomli = "*"
 toposort = ">=1.0"
@@ -878,18 +826,18 @@ test = ["buildkite-test-collector", "docker", "grpcio-tools (>=1.32.0,<1.44.0)",
 
 [[package]]
 name = "dagster-airbyte"
-version = "0.17.14"
+version = "0.17.13"
 description = "Package for integrating Airbyte with Dagster."
 category = "main"
 optional = false
 python-versions = "*"
 files = [
-    {file = "dagster-airbyte-0.17.14.tar.gz", hash = "sha256:d9216c634c656ac85689c8b5efeb47b380d923e6db35e7faeb5e1ed5c5489578"},
-    {file = "dagster_airbyte-0.17.14-py3-none-any.whl", hash = "sha256:41456c4e9c2232b0d496641eea0edaef1c272679a5a4c6b97201dea1fc351696"},
+    {file = "dagster-airbyte-0.17.13.tar.gz", hash = "sha256:0829562b270e8a88f03f9a25ca78d631121058671f19d493e72c11fb294b3982"},
+    {file = "dagster_airbyte-0.17.13-py3-none-any.whl", hash = "sha256:87432cdd128cffd795bc3f1ab7fe567a4853a98403908f746a1a390b59ebd569"},
 ]
 
 [package.dependencies]
-dagster = "1.1.14"
+dagster = "1.1.13"
 requests = "*"
 
 [package.extras]
@@ -897,19 +845,19 @@ test = ["requests-mock"]
 
 [[package]]
 name = "dagster-aws"
-version = "0.17.14"
+version = "0.17.13"
 description = "Package for AWS-specific Dagster framework solid and resource components."
 category = "main"
 optional = false
 python-versions = "*"
 files = [
-    {file = "dagster-aws-0.17.14.tar.gz", hash = "sha256:095ba7de0d44a1e16751e38314a6378ac436c2d6c6d8fcaf9b0f120cc63f2234"},
-    {file = "dagster_aws-0.17.14-py3-none-any.whl", hash = "sha256:a1efc29b36f2bda552186016cf178993ece10c6b4a99b3b19fa5a0e741e2def5"},
+    {file = "dagster-aws-0.17.13.tar.gz", hash = "sha256:83106ded47739e5139d60471fc0f865e2238014136e75d203a8073f269b4fc97"},
+    {file = "dagster_aws-0.17.13-py3-none-any.whl", hash = "sha256:a3babb80f0375dd8a010bde3c0d27cacd7e6bb478dbfead2d734166a4f6fb4a3"},
 ]
 
 [package.dependencies]
 boto3 = "*"
-dagster = "1.1.14"
+dagster = "1.1.13"
 packaging = "*"
 requests = "*"
 
@@ -920,19 +868,19 @@ test = ["moto (>=2.2.8)", "requests-mock", "xmltodict (==0.12.0)"]
 
 [[package]]
 name = "dagster-dbt"
-version = "0.17.14"
+version = "0.17.13"
 description = "A Dagster integration for dbt"
 category = "main"
 optional = false
 python-versions = "*"
 files = [
-    {file = "dagster-dbt-0.17.14.tar.gz", hash = "sha256:e5aa48807a921064f8d0fda4d09ff7430fc676a12b4918a846e2b3c116a9c996"},
-    {file = "dagster_dbt-0.17.14-py3-none-any.whl", hash = "sha256:295ea78ba123f50e159d3b5ec6a8be1a0c26f12a92c29ffe4718637e8ac32f5c"},
+    {file = "dagster-dbt-0.17.13.tar.gz", hash = "sha256:3157fd74d307bc4f394018b99b8d1ea70061c02fd5fbea5f25976e0660c3d537"},
+    {file = "dagster_dbt-0.17.13-py3-none-any.whl", hash = "sha256:70908dbb34125435ff0adbd4a6b25083d3a0f89fc08ea775506c3761cf635e53"},
 ]
 
 [package.dependencies]
-dagster = "1.1.14"
-dbt-core = "<1.4.0"
+dagster = "1.1.13"
+dbt-core = "*"
 requests = "*"
 typer = {version = "*", extras = ["all"]}
 
@@ -941,36 +889,36 @@ test = ["Jinja2", "dbt-postgres", "dbt-rpc (<0.3.0)"]
 
 [[package]]
 name = "dagster-docker"
-version = "0.17.14"
+version = "0.17.13"
 description = "A Dagster integration for docker"
 category = "main"
 optional = false
 python-versions = "*"
 files = [
-    {file = "dagster-docker-0.17.14.tar.gz", hash = "sha256:c9b44dc3ed966a27cff50139adb77791fc60a171530b8505a087dd3d9f3f1506"},
-    {file = "dagster_docker-0.17.14-py3-none-any.whl", hash = "sha256:b4329db279878bdd34ee9c3c4eed76d318e5508a08da98e501080453d1d2397d"},
+    {file = "dagster-docker-0.17.13.tar.gz", hash = "sha256:2555ae340e2e62ad49dded1d2b285a756640df5b86a172c1bd2e1fbaf4db6e5f"},
+    {file = "dagster_docker-0.17.13-py3-none-any.whl", hash = "sha256:54611d930701ae29cebe9516334fde27c4cd7c4e8357cd493ea0ff1380492931"},
 ]
 
 [package.dependencies]
-dagster = "1.1.14"
+dagster = "1.1.13"
 docker = "*"
 docker-image-py = "*"
 
 [[package]]
 name = "dagster-gcp"
-version = "0.17.14"
+version = "0.17.13"
 description = "Package for GCP-specific Dagster framework op and resource components."
 category = "main"
 optional = false
 python-versions = "*"
 files = [
-    {file = "dagster-gcp-0.17.14.tar.gz", hash = "sha256:cca8281325fed6e4ea7ec75827ef7fcb0345fd9d302aaa78e28c38dd292a9381"},
-    {file = "dagster_gcp-0.17.14-py3-none-any.whl", hash = "sha256:1454bc556367d4ce24ee46bd8815c2217936efd21c244abd114ffc704373d745"},
+    {file = "dagster-gcp-0.17.13.tar.gz", hash = "sha256:e3ca66c86d00a68dc092eba8e052b09d79414b9142d20e0c08d4d8f738606957"},
+    {file = "dagster_gcp-0.17.13-py3-none-any.whl", hash = "sha256:20c8cd2156830a19805e5a85c9899b17dad27c8fd44439f18ecca4ce6faa5adc"},
 ]
 
 [package.dependencies]
-dagster = "1.1.14"
-dagster-pandas = "0.17.14"
+dagster = "1.1.13"
+dagster-pandas = "0.17.13"
 db-dtypes = "*"
 google-api-python-client = "*"
 google-cloud-bigquery = "*"
@@ -982,36 +930,36 @@ pyarrow = ["pyarrow"]
 
 [[package]]
 name = "dagster-ge"
-version = "0.17.14"
+version = "0.17.13"
 description = "Package for GE-specific Dagster framework op and resource components."
 category = "main"
 optional = false
 python-versions = "*"
 files = [
-    {file = "dagster-ge-0.17.14.tar.gz", hash = "sha256:b43263d8b619e20d3ab643d7014ba11b2886ed34676021318f5ac45641eeccac"},
-    {file = "dagster_ge-0.17.14-py3-none-any.whl", hash = "sha256:a0ccc50047ba5ac59e1bfe1aabd4720e04eb1ba44fc043ba856d13d447214b56"},
+    {file = "dagster-ge-0.17.13.tar.gz", hash = "sha256:6d81c3ef3deff47ca04fbeb0e481a58bdbf67167db743368c521a3a8c019941c"},
+    {file = "dagster_ge-0.17.13-py3-none-any.whl", hash = "sha256:ccce66f5161d870c7b204c2196e23269a376867d94be75d80cc6ed07f39000fa"},
 ]
 
 [package.dependencies]
-dagster = "1.1.14"
-dagster-pandas = "0.17.14"
+dagster = "1.1.13"
+dagster-pandas = "0.17.13"
 great-expectations = ">=0.11.9,<0.12.8 || >0.12.8,<0.13.17 || >0.13.17,<0.13.27 || >0.13.27"
 pandas = "*"
 
 [[package]]
 name = "dagster-graphql"
-version = "1.1.14"
+version = "1.1.13"
 description = "The GraphQL frontend to python dagster."
 category = "main"
 optional = false
 python-versions = "*"
 files = [
-    {file = "dagster-graphql-1.1.14.tar.gz", hash = "sha256:df0562e48853718c7fd2459905017a618f6c39a579789eb05d59f24b70aee1e0"},
-    {file = "dagster_graphql-1.1.14-py3-none-any.whl", hash = "sha256:f1f4d1761f23e7d2f51fefe572e5efda2649b5c5dcd9a77fb56f83163cc88745"},
+    {file = "dagster-graphql-1.1.13.tar.gz", hash = "sha256:ca6c7abe329511b45ac4f69cf83b2d790dd9c47ef84b9dbe7628e3ebd0d3cda4"},
+    {file = "dagster_graphql-1.1.13-py3-none-any.whl", hash = "sha256:659cde033e0ed159d32c638f69818e2a1576a1ee03e4ed8688240aa22e9cdfae"},
 ]
 
 [package.dependencies]
-dagster = "1.1.14"
+dagster = "1.1.13"
 gql = {version = ">=3.0.0", extras = ["requests"]}
 graphene = ">=3"
 requests = "*"
@@ -1019,65 +967,53 @@ starlette = "*"
 
 [[package]]
 name = "dagster-pandas"
-version = "0.17.14"
+version = "0.17.13"
 description = "Utilities and examples for working with pandas and dagster, an opinionated framework for expressing data pipelines"
 category = "main"
 optional = false
 python-versions = "*"
 files = [
-    {file = "dagster-pandas-0.17.14.tar.gz", hash = "sha256:0d684f5dfdf5e3bcdb6feb932620f2e193f43d7cbe893f6214dbc048b000cd7c"},
-    {file = "dagster_pandas-0.17.14-py3-none-any.whl", hash = "sha256:074f4a7449d320d01c6fd542c9809a536ed8e3e37ec466630edb260f593df676"},
+    {file = "dagster-pandas-0.17.13.tar.gz", hash = "sha256:3085e74a32b32d0980e62a569681667ae3996e1b9e0e3070febf88115fd2b0eb"},
+    {file = "dagster_pandas-0.17.13-py3-none-any.whl", hash = "sha256:b96eff44b847b2432a3ac0263e42dd726a396b8c0936f8f1216188d5fb71d76d"},
 ]
 
 [package.dependencies]
-dagster = "1.1.14"
+dagster = "1.1.13"
 pandas = "*"
 
 [[package]]
 name = "dagster-postgres"
-version = "0.17.14"
+version = "0.17.13"
 description = "A Dagster integration for postgres"
 category = "main"
 optional = false
 python-versions = "*"
 files = [
-    {file = "dagster-postgres-0.17.14.tar.gz", hash = "sha256:9624a3cbbccf3afa0db55e2b4ed240da7d831b828a464bf138dea1de66c1d1ed"},
-    {file = "dagster_postgres-0.17.14-py3-none-any.whl", hash = "sha256:bef009dc269d14b3860e674556fc1e25e8c33190a435c233878891ef298bccea"},
+    {file = "dagster-postgres-0.17.13.tar.gz", hash = "sha256:0509e56fa35d4d652e9bc4efc4f7fa762a4ab2d720fec7490069f413dbbf1b91"},
+    {file = "dagster_postgres-0.17.13-py3-none-any.whl", hash = "sha256:f6db35e53391a2909eb96d3452b7cf5bf9c1c765642f82d780195bd50c217846"},
 ]
 
 [package.dependencies]
-dagster = "1.1.14"
+dagster = "1.1.13"
 psycopg2-binary = "*"
 
 [[package]]
 name = "dagster-shell"
-version = "0.17.14"
+version = "0.17.13"
 description = "Package for Dagster shell ops."
 category = "main"
 optional = false
 python-versions = "*"
 files = [
-    {file = "dagster-shell-0.17.14.tar.gz", hash = "sha256:3839109316e4b6f68ae5e2c09081d46b1c288e713b3dad90a08b4625d34c071e"},
-    {file = "dagster_shell-0.17.14-py3-none-any.whl", hash = "sha256:691dcb07e2181f2e7b81ee8f83c90a97a988a1c3c8a91ab8ca6e1fc21ff62f92"},
+    {file = "dagster-shell-0.17.13.tar.gz", hash = "sha256:6007883af4172113844c010a3038e746b7eb30667f585e20d827807f6ff77583"},
+    {file = "dagster_shell-0.17.13-py3-none-any.whl", hash = "sha256:cab86be51b9860d6490f226b6902cc9a4520c942d62b39c783dcf777367819b8"},
 ]
 
 [package.dependencies]
-dagster = "1.1.14"
+dagster = "1.1.13"
 
 [package.extras]
 test = ["psutil"]
-
-[[package]]
-name = "darglint"
-version = "1.8.1"
-description = "A utility for ensuring Google-style docstrings stay up to date with the source code."
-category = "dev"
-optional = false
-python-versions = ">=3.6,<4.0"
-files = [
-    {file = "darglint-1.8.1-py3-none-any.whl", hash = "sha256:5ae11c259c17b0701618a20c3da343a3eb98b3bc4b5a83d31cdd94f5ebdced8d"},
-    {file = "darglint-1.8.1.tar.gz", hash = "sha256:080d5106df149b199822e7ee7deb9c012b49891538f14a11be681044f0bb20da"},
-]
 
 [[package]]
 name = "db-dtypes"
@@ -1099,32 +1035,33 @@ pyarrow = ">=3.0.0"
 
 [[package]]
 name = "dbt-core"
-version = "1.3.2"
+version = "1.4.1"
 description = "With dbt, data analysts and engineers can build analytics the way engineers build applications."
 category = "main"
 optional = false
 python-versions = ">=3.7.2"
 files = [
-    {file = "dbt-core-1.3.2.tar.gz", hash = "sha256:029168f6f92350e2bc534eca59bc9d9e2cfc5a974046240a8549a50c8de81388"},
-    {file = "dbt_core-1.3.2-py3-none-any.whl", hash = "sha256:22caa8a68732b3fdf7d10fc94bce22ab01fb08bbb5b522a60c960cdf88a26b6a"},
+    {file = "dbt-core-1.4.1.tar.gz", hash = "sha256:ef67fd94260cb6a9d293ef8923fb39965687844d0b6937e5eabd9378d7611cf3"},
+    {file = "dbt_core-1.4.1-py3-none-any.whl", hash = "sha256:40fbc42484accb75bb59dd8cabb018da4f3a022f08cfa4f490a0c8759b25a9d9"},
 ]
 
 [package.dependencies]
-agate = ">=1.6,<1.6.4"
+agate = ">=1.6,<1.7.1"
+betterproto = "1.2.5"
 cffi = ">=1.9,<2.0.0"
 click = ">=7.0,<9"
-colorama = ">=0.3.9,<0.4.6"
+colorama = ">=0.3.9,<0.4.7"
 dbt-extractor = ">=0.4.1,<0.5.0"
 hologram = ">=0.0.14,<=0.0.15"
 idna = ">=2.5,<4"
 isodate = ">=0.6,<0.7"
 Jinja2 = "3.1.2"
 logbook = ">=1.5,<1.6"
-mashumaro = {version = "3.0.4", extras = ["msgpack"]}
+mashumaro = {version = "3.3.1", extras = ["msgpack"]}
 minimal-snowplow-tracker = "0.0.2"
 networkx = {version = ">=2.3,<3", markers = "python_version >= \"3.8\""}
 packaging = ">=20.9,<22.0"
-pathspec = ">=0.9.0,<0.10.0"
+pathspec = ">=0.9,<0.11"
 pyyaml = ">=6.0"
 requests = "<3.0.0"
 sqlparse = ">=0.2.3,<0.5"
@@ -1159,19 +1096,19 @@ files = [
 
 [[package]]
 name = "dbt-trino"
-version = "1.3.2"
+version = "1.4.0"
 description = "The trino adapter plugin for dbt (data build tool)"
 category = "main"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "dbt-trino-1.3.2.tar.gz", hash = "sha256:7c67b947cdd46a2792fc16b0d4d94f9f93ba058345fa921c39ebfda6d535ef91"},
-    {file = "dbt_trino-1.3.2-py3-none-any.whl", hash = "sha256:47d9aa1d7fa0d75eb137266b34fd5066d3d22833240b098712f2e666d86bbfd2"},
+    {file = "dbt-trino-1.4.0.tar.gz", hash = "sha256:88f92952048c04e93e88987990104266d5e653ef9b2b8c04931814c28ea15d86"},
+    {file = "dbt_trino-1.4.0-py3-none-any.whl", hash = "sha256:cf6ee739297008fbc3940e7efe16c15aec17f98c3eb5ed5fbaac0ef29ffcae3a"},
 ]
 
 [package.dependencies]
-dbt-core = ">=1.3.0,<1.4.0"
-trino = "0.319.0"
+dbt-core = ">=1.4.0,<1.5.0"
+trino = "0.321.0"
 
 [[package]]
 name = "debugpy"
@@ -1193,7 +1130,6 @@ files = [
     {file = "debugpy-1.6.6-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9b5d1b13d7c7bf5d7cf700e33c0b8ddb7baf030fcf502f76fc061ddd9405d16c"},
     {file = "debugpy-1.6.6-cp38-cp38-win32.whl", hash = "sha256:70ab53918fd907a3ade01909b3ed783287ede362c80c75f41e79596d5ccacd32"},
     {file = "debugpy-1.6.6-cp38-cp38-win_amd64.whl", hash = "sha256:c05349890804d846eca32ce0623ab66c06f8800db881af7a876dc073ac1c2225"},
-    {file = "debugpy-1.6.6-cp39-cp39-macosx_11_0_x86_64.whl", hash = "sha256:11a0f3a106f69901e4a9a5683ce943a7a5605696024134b522aa1bfda25b5fec"},
     {file = "debugpy-1.6.6-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a771739902b1ae22a120dbbb6bd91b2cae6696c0e318b5007c5348519a4211c6"},
     {file = "debugpy-1.6.6-cp39-cp39-win32.whl", hash = "sha256:549ae0cb2d34fc09d1675f9b01942499751d174381b6082279cf19cdb3c47cbe"},
     {file = "debugpy-1.6.6-cp39-cp39-win_amd64.whl", hash = "sha256:de4a045fbf388e120bb6ec66501458d3134f4729faed26ff95de52a754abddb1"},
@@ -1308,18 +1244,6 @@ files = [
 ]
 
 [[package]]
-name = "docutils"
-version = "0.19"
-description = "Docutils -- Python Documentation Utilities"
-category = "dev"
-optional = false
-python-versions = ">=3.7"
-files = [
-    {file = "docutils-0.19-py3-none-any.whl", hash = "sha256:5e1de4d849fee02c63b040a4a3fd567f4ab104defd8a5511fbbc24a8a017efbc"},
-    {file = "docutils-0.19.tar.gz", hash = "sha256:33995a6753c30b7f577febfc2c50411fec6aac7f7ffeb7c4cfe5991072dcf9e6"},
-]
-
-[[package]]
 name = "dynaconf"
 version = "3.1.11"
 description = "The dynamic configurator for your Python Project"
@@ -1351,18 +1275,6 @@ python-versions = ">=3.6"
 files = [
     {file = "entrypoints-0.4-py3-none-any.whl", hash = "sha256:f174b5ff827504fd3cd97cc3f8649f3693f51538c7e4bdf3ef002c8429d42f9f"},
     {file = "entrypoints-0.4.tar.gz", hash = "sha256:b706eddaa9218a19ebcd67b56818f05bb27589b1ca9e8d797b74affad4ccacd4"},
-]
-
-[[package]]
-name = "eradicate"
-version = "2.1.0"
-description = "Removes commented-out code."
-category = "dev"
-optional = false
-python-versions = "*"
-files = [
-    {file = "eradicate-2.1.0-py3-none-any.whl", hash = "sha256:8bfaca181db9227dc88bdbce4d051a9627604c2243e7d85324f6d6ce0fd08bb2"},
-    {file = "eradicate-2.1.0.tar.gz", hash = "sha256:aac7384ab25b1bf21c4c012de9b4bf8398945a14c98c911545b2ea50ab558014"},
 ]
 
 [[package]]
@@ -1427,232 +1339,6 @@ docs = ["furo (>=2022.12.7)", "sphinx (>=5.3)", "sphinx-autodoc-typehints (>=1.1
 testing = ["covdefaults (>=2.2.2)", "coverage (>=7.0.1)", "pytest (>=7.2)", "pytest-cov (>=4)", "pytest-timeout (>=2.1)"]
 
 [[package]]
-name = "first"
-version = "2.0.2"
-description = "Return the first true value of an iterable."
-category = "dev"
-optional = false
-python-versions = "*"
-files = [
-    {file = "first-2.0.2-py2.py3-none-any.whl", hash = "sha256:8d8e46e115ea8ac652c76123c0865e3ff18372aef6f03c22809ceefcea9dec86"},
-    {file = "first-2.0.2.tar.gz", hash = "sha256:ff285b08c55f8c97ce4ea7012743af2495c9f1291785f163722bd36f6af6d3bf"},
-]
-
-[[package]]
-name = "flake8"
-version = "5.0.4"
-description = "the modular source code checker: pep8 pyflakes and co"
-category = "dev"
-optional = false
-python-versions = ">=3.6.1"
-files = [
-    {file = "flake8-5.0.4-py2.py3-none-any.whl", hash = "sha256:7a1cf6b73744f5806ab95e526f6f0d8c01c66d7bbe349562d22dfca20610b248"},
-    {file = "flake8-5.0.4.tar.gz", hash = "sha256:6fbe320aad8d6b95cec8b8e47bc933004678dc63095be98528b7bdd2a9f510db"},
-]
-
-[package.dependencies]
-mccabe = ">=0.7.0,<0.8.0"
-pycodestyle = ">=2.9.0,<2.10.0"
-pyflakes = ">=2.5.0,<2.6.0"
-
-[[package]]
-name = "flake8-bandit"
-version = "4.1.1"
-description = "Automated security testing with bandit and flake8."
-category = "dev"
-optional = false
-python-versions = ">=3.6"
-files = [
-    {file = "flake8_bandit-4.1.1-py3-none-any.whl", hash = "sha256:4c8a53eb48f23d4ef1e59293657181a3c989d0077c9952717e98a0eace43e06d"},
-    {file = "flake8_bandit-4.1.1.tar.gz", hash = "sha256:068e09287189cbfd7f986e92605adea2067630b75380c6b5733dab7d87f9a84e"},
-]
-
-[package.dependencies]
-bandit = ">=1.7.3"
-flake8 = ">=5.0.0"
-
-[[package]]
-name = "flake8-broken-line"
-version = "0.6.0"
-description = "Flake8 plugin to forbid backslashes for line breaks"
-category = "dev"
-optional = false
-python-versions = ">=3.7,<4.0"
-files = [
-    {file = "flake8-broken-line-0.6.0.tar.gz", hash = "sha256:a02268f11a18837c83c59013a36cc00fee9e17a042745cc0c9895f1c9f6acc16"},
-    {file = "flake8_broken_line-0.6.0-py3-none-any.whl", hash = "sha256:c0ab336ff7de228dbffbe56d67b3615bb21fb15f3ed0604fa7bdf9feb72d7d88"},
-]
-
-[package.dependencies]
-flake8 = ">=3.5,<6"
-
-[[package]]
-name = "flake8-bugbear"
-version = "22.12.6"
-description = "A plugin for flake8 finding likely bugs and design problems in your program. Contains warnings that don't belong in pyflakes and pycodestyle."
-category = "dev"
-optional = false
-python-versions = ">=3.7"
-files = [
-    {file = "flake8-bugbear-22.12.6.tar.gz", hash = "sha256:4cdb2c06e229971104443ae293e75e64c6107798229202fbe4f4091427a30ac0"},
-    {file = "flake8_bugbear-22.12.6-py3-none-any.whl", hash = "sha256:b69a510634f8a9c298dfda2b18a8036455e6b19ecac4fe582e4d7a0abfa50a30"},
-]
-
-[package.dependencies]
-attrs = ">=19.2.0"
-flake8 = ">=3.0.0"
-
-[package.extras]
-dev = ["coverage", "hypothesis", "hypothesmith (>=0.2)", "pre-commit", "tox"]
-
-[[package]]
-name = "flake8-commas"
-version = "2.1.0"
-description = "Flake8 lint for trailing commas."
-category = "dev"
-optional = false
-python-versions = "*"
-files = [
-    {file = "flake8-commas-2.1.0.tar.gz", hash = "sha256:940441ab8ee544df564ae3b3f49f20462d75d5c7cac2463e0b27436e2050f263"},
-    {file = "flake8_commas-2.1.0-py2.py3-none-any.whl", hash = "sha256:ebb96c31e01d0ef1d0685a21f3f0e2f8153a0381430e748bf0bbbb5d5b453d54"},
-]
-
-[package.dependencies]
-flake8 = ">=2"
-
-[[package]]
-name = "flake8-comprehensions"
-version = "3.10.1"
-description = "A flake8 plugin to help you write better list/set/dict comprehensions."
-category = "dev"
-optional = false
-python-versions = ">=3.7"
-files = [
-    {file = "flake8-comprehensions-3.10.1.tar.gz", hash = "sha256:412052ac4a947f36b891143430fef4859705af11b2572fbb689f90d372cf26ab"},
-    {file = "flake8_comprehensions-3.10.1-py3-none-any.whl", hash = "sha256:d763de3c74bc18a79c039a7ec732e0a1985b0c79309ceb51e56401ad0a2cd44e"},
-]
-
-[package.dependencies]
-flake8 = ">=3.0,<3.2.0 || >3.2.0"
-
-[[package]]
-name = "flake8-debugger"
-version = "4.1.2"
-description = "ipdb/pdb statement checker plugin for flake8"
-category = "dev"
-optional = false
-python-versions = ">=3.7"
-files = [
-    {file = "flake8-debugger-4.1.2.tar.gz", hash = "sha256:52b002560941e36d9bf806fca2523dc7fb8560a295d5f1a6e15ac2ded7a73840"},
-    {file = "flake8_debugger-4.1.2-py3-none-any.whl", hash = "sha256:0a5e55aeddcc81da631ad9c8c366e7318998f83ff00985a49e6b3ecf61e571bf"},
-]
-
-[package.dependencies]
-flake8 = ">=3.0"
-pycodestyle = "*"
-
-[[package]]
-name = "flake8-docstrings"
-version = "1.7.0"
-description = "Extension for flake8 which uses pydocstyle to check docstrings"
-category = "dev"
-optional = false
-python-versions = ">=3.7"
-files = [
-    {file = "flake8_docstrings-1.7.0-py2.py3-none-any.whl", hash = "sha256:51f2344026da083fc084166a9353f5082b01f72901df422f74b4d953ae88ac75"},
-    {file = "flake8_docstrings-1.7.0.tar.gz", hash = "sha256:4c8cc748dc16e6869728699e5d0d685da9a10b0ea718e090b1ba088e67a941af"},
-]
-
-[package.dependencies]
-flake8 = ">=3"
-pydocstyle = ">=2.1"
-
-[[package]]
-name = "flake8-eradicate"
-version = "1.4.0"
-description = "Flake8 plugin to find commented out code"
-category = "dev"
-optional = false
-python-versions = ">=3.7,<4.0"
-files = [
-    {file = "flake8-eradicate-1.4.0.tar.gz", hash = "sha256:3088cfd6717d1c9c6c3ac45ef2e5f5b6c7267f7504d5a74b781500e95cb9c7e1"},
-    {file = "flake8_eradicate-1.4.0-py3-none-any.whl", hash = "sha256:e3bbd0871be358e908053c1ab728903c114f062ba596b4d40c852fd18f473d56"},
-]
-
-[package.dependencies]
-attrs = "*"
-eradicate = ">=2.0,<3.0"
-flake8 = ">=3.5,<6"
-
-[[package]]
-name = "flake8-isort"
-version = "5.0.3"
-description = "flake8 plugin that integrates isort ."
-category = "dev"
-optional = false
-python-versions = ">=3.7"
-files = [
-    {file = "flake8-isort-5.0.3.tar.gz", hash = "sha256:0951398c343c67f4933407adbbfb495d4df7c038650c5d05753a006efcfeb390"},
-    {file = "flake8_isort-5.0.3-py3-none-any.whl", hash = "sha256:8c4ab431d87780d0c8336e9614e50ef11201bc848ef64ca017532dec39d4bf49"},
-]
-
-[package.dependencies]
-flake8 = "*"
-isort = ">=4.3.5,<6"
-
-[package.extras]
-test = ["pytest"]
-
-[[package]]
-name = "flake8-quotes"
-version = "3.3.2"
-description = "Flake8 lint for quotes."
-category = "dev"
-optional = false
-python-versions = "*"
-files = [
-    {file = "flake8-quotes-3.3.2.tar.gz", hash = "sha256:6e26892b632dacba517bf27219c459a8396dcfac0f5e8204904c5a4ba9b480e1"},
-]
-
-[package.dependencies]
-flake8 = "*"
-
-[[package]]
-name = "flake8-rst-docstrings"
-version = "0.3.0"
-description = "Python docstring reStructuredText (RST) validator for flake8"
-category = "dev"
-optional = false
-python-versions = ">=3.7"
-files = [
-    {file = "flake8-rst-docstrings-0.3.0.tar.gz", hash = "sha256:d1ce22b4bd37b73cd86b8d980e946ef198cfcc18ed82fedb674ceaa2f8d1afa4"},
-    {file = "flake8_rst_docstrings-0.3.0-py3-none-any.whl", hash = "sha256:f8c3c6892ff402292651c31983a38da082480ad3ba253743de52989bdc84ca1c"},
-]
-
-[package.dependencies]
-flake8 = ">=3"
-pygments = "*"
-restructuredtext-lint = "*"
-
-[package.extras]
-develop = ["build", "twine"]
-
-[[package]]
-name = "flake8-string-format"
-version = "0.3.0"
-description = "string format checker, plugin for flake8"
-category = "dev"
-optional = false
-python-versions = "*"
-files = [
-    {file = "flake8-string-format-0.3.0.tar.gz", hash = "sha256:65f3da786a1461ef77fca3780b314edb2853c377f2e35069723348c8917deaa2"},
-    {file = "flake8_string_format-0.3.0-py2.py3-none-any.whl", hash = "sha256:812ff431f10576a74c89be4e85b8e075a705be39bc40c4b4278b5b13e2afa9af"},
-]
-
-[package.dependencies]
-flake8 = "*"
-
-[[package]]
 name = "fsspec"
 version = "2023.1.0"
 description = "File-system specification"
@@ -1699,36 +1385,6 @@ files = [
 ]
 
 [[package]]
-name = "gitdb"
-version = "4.0.10"
-description = "Git Object Database"
-category = "dev"
-optional = false
-python-versions = ">=3.7"
-files = [
-    {file = "gitdb-4.0.10-py3-none-any.whl", hash = "sha256:c286cf298426064079ed96a9e4a9d39e7f3e9bf15ba60701e95f5492f28415c7"},
-    {file = "gitdb-4.0.10.tar.gz", hash = "sha256:6eb990b69df4e15bad899ea868dc46572c3f75339735663b81de79b06f17eb9a"},
-]
-
-[package.dependencies]
-smmap = ">=3.0.1,<6"
-
-[[package]]
-name = "gitpython"
-version = "3.1.30"
-description = "GitPython is a python library used to interact with Git repositories"
-category = "dev"
-optional = false
-python-versions = ">=3.7"
-files = [
-    {file = "GitPython-3.1.30-py3-none-any.whl", hash = "sha256:cd455b0000615c60e286208ba540271af9fe531fa6a87cc590a7298785ab2882"},
-    {file = "GitPython-3.1.30.tar.gz", hash = "sha256:769c2d83e13f5d938b7688479da374c4e3d49f71549aaf462b646db9602ea6f8"},
-]
-
-[package.dependencies]
-gitdb = ">=4.0.1,<5"
-
-[[package]]
 name = "google-api-core"
 version = "2.11.0"
 description = "Google API client core library"
@@ -1755,14 +1411,14 @@ grpcio-gcp = ["grpcio-gcp (>=0.2.2,<1.0dev)"]
 
 [[package]]
 name = "google-api-python-client"
-version = "2.74.0"
+version = "2.75.0"
 description = "Google API Client Library for Python"
 category = "main"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "google-api-python-client-2.74.0.tar.gz", hash = "sha256:22c9565b6d4343e35a6d614f2c075e765888a81e11444a27c570e0865631a3f9"},
-    {file = "google_api_python_client-2.74.0-py2.py3-none-any.whl", hash = "sha256:679669b709450a12dacf28612adf0538afc858566b6ee01628e4013a2073dffc"},
+    {file = "google-api-python-client-2.75.0.tar.gz", hash = "sha256:0f109a2b71f14c9a7b48231fecfcdd3ab95861ea9abf54f060ac45c204fadc3d"},
+    {file = "google_api_python_client-2.75.0-py2.py3-none-any.whl", hash = "sha256:010fb49fdef85db9c622a3cb2ab89df48bea82d235794f66292aba2e1ee117a0"},
 ]
 
 [package.dependencies]
@@ -1816,14 +1472,14 @@ six = "*"
 
 [[package]]
 name = "google-cloud-bigquery"
-version = "3.4.2"
+version = "3.5.0"
 description = "Google BigQuery API client library"
 category = "main"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "google-cloud-bigquery-3.4.2.tar.gz", hash = "sha256:224dc329bc5ad09d614db765c95f0bb8b24f0881b3d2a4854062ca346f8896f0"},
-    {file = "google_cloud_bigquery-3.4.2-py2.py3-none-any.whl", hash = "sha256:2d9f59f4e23cb796877ed89cb626013eae437457dc5b268b67072f3bdc6255cb"},
+    {file = "google-cloud-bigquery-3.5.0.tar.gz", hash = "sha256:dd3ca84e5be6fa9e0570fb21665a902cc5651cbd045842fb714164c99a2639c4"},
+    {file = "google_cloud_bigquery-3.5.0-py2.py3-none-any.whl", hash = "sha256:358f54c473938b2d022335118b4e56cdcdaf22a5a112fa0cfeb888fd8814ba62"},
 ]
 
 [package.dependencies]
@@ -2112,9 +1768,15 @@ marshmallow = ">=3.7.1,<4.0.0"
 mistune = ">=0.8.4"
 nbformat = ">=5.0"
 notebook = ">=6.4.10"
-numpy = {version = ">=1.19.5", markers = "python_version == \"3.8\" or python_version == \"3.9\""}
+numpy = [
+    {version = ">=1.19.5", markers = "python_version == \"3.8\" or python_version == \"3.9\""},
+    {version = ">=1.23.0", markers = "python_version >= \"3.10\""},
+]
 packaging = "*"
-pandas = {version = ">=1.1.3", markers = "python_version == \"3.9\""}
+pandas = [
+    {version = ">=1.1.3", markers = "python_version == \"3.9\""},
+    {version = ">=1.4.0", markers = "python_version >= \"3.10\""},
+]
 pydantic = ">=1.0,<2.0"
 pyparsing = ">=2.4"
 python-dateutil = ">=2.8.1"
@@ -2323,6 +1985,24 @@ grpcio = ">=1.47.2"
 protobuf = ">=3.12.0"
 
 [[package]]
+name = "grpclib"
+version = "0.4.3"
+description = "Pure-Python gRPC implementation for asyncio"
+category = "main"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "grpclib-0.4.3.tar.gz", hash = "sha256:eadf2002fc5a25158b707c0338a6c0b96dd7fbdc6df66f7e515e7f041d56a940"},
+]
+
+[package.dependencies]
+h2 = ">=3.1.0,<5"
+multidict = "*"
+
+[package.extras]
+protobuf = ["protobuf (>=3.15.0)"]
+
+[[package]]
 name = "h11"
 version = "0.14.0"
 description = "A pure-Python, bring-your-own-I/O implementation of HTTP/1.1"
@@ -2333,6 +2013,22 @@ files = [
     {file = "h11-0.14.0-py3-none-any.whl", hash = "sha256:e3fe4ac4b851c468cc8363d500db52c2ead036020723024a109d37346efaa761"},
     {file = "h11-0.14.0.tar.gz", hash = "sha256:8f19fbbe99e72420ff35c00b27a34cb9937e902a8b810e2c88300c6f0a3b699d"},
 ]
+
+[[package]]
+name = "h2"
+version = "4.1.0"
+description = "HTTP/2 State-Machine based protocol implementation"
+category = "main"
+optional = false
+python-versions = ">=3.6.1"
+files = [
+    {file = "h2-4.1.0-py3-none-any.whl", hash = "sha256:03a46bcf682256c95b5fd9e9a99c1323584c3eec6440d379b9903d709476bc6d"},
+    {file = "h2-4.1.0.tar.gz", hash = "sha256:a83aca08fbe7aacb79fec788c9c0bac936343560ed9ec18b82a13a12c28d2abb"},
+]
+
+[package.dependencies]
+hpack = ">=4.0,<5"
+hyperframe = ">=6.0,<7"
 
 [[package]]
 name = "hologram"
@@ -2349,6 +2045,18 @@ files = [
 [package.dependencies]
 jsonschema = ">=3.0,<4.0"
 python-dateutil = ">=2.8,<2.9"
+
+[[package]]
+name = "hpack"
+version = "4.0.0"
+description = "Pure-Python HPACK header compression"
+category = "main"
+optional = false
+python-versions = ">=3.6.1"
+files = [
+    {file = "hpack-4.0.0-py3-none-any.whl", hash = "sha256:84a076fad3dc9a9f8063ccb8041ef100867b1878b25ef0ee63847a5d53818a6c"},
+    {file = "hpack-4.0.0.tar.gz", hash = "sha256:fc41de0c63e687ebffde81187a948221294896f6bdc0ae2312708df339430095"},
+]
 
 [[package]]
 name = "httpcore"
@@ -2497,15 +2205,27 @@ pyhcl = ">=0.4.4,<0.5.0"
 requests = ">=2.27.1,<3.0.0"
 
 [[package]]
+name = "hyperframe"
+version = "6.0.1"
+description = "HTTP/2 framing layer for Python"
+category = "main"
+optional = false
+python-versions = ">=3.6.1"
+files = [
+    {file = "hyperframe-6.0.1-py3-none-any.whl", hash = "sha256:0ec6bafd80d8ad2195c4f03aacba3a8265e57bc4cff261e802bf39970ed02a15"},
+    {file = "hyperframe-6.0.1.tar.gz", hash = "sha256:ae510046231dc8e9ecb1a6586f63d2347bf4c8905914aa84ba585ae85f28a914"},
+]
+
+[[package]]
 name = "identify"
-version = "2.5.16"
+version = "2.5.17"
 description = "File identification library for Python"
 category = "dev"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "identify-2.5.16-py2.py3-none-any.whl", hash = "sha256:832832a58ecc1b8f33d5e8cb4f7d3db2f5c7fbe922dfee5f958b48fed691501a"},
-    {file = "identify-2.5.16.tar.gz", hash = "sha256:c47acedfe6495b1c603ed7e93469b26e839cab38db4155113f36f718f8b3dc47"},
+    {file = "identify-2.5.17-py2.py3-none-any.whl", hash = "sha256:7d526dd1283555aafcc91539acc061d8f6f59adb0a7bba462735b0a318bff7ed"},
+    {file = "identify-2.5.17.tar.gz", hash = "sha256:93cc61a861052de9d4c541a7acb7e3dcc9c11b398a2144f6e52ae5285f5f4f06"},
 ]
 
 [package.extras]
@@ -2677,24 +2397,6 @@ files = [
 six = "*"
 
 [[package]]
-name = "isort"
-version = "5.12.0"
-description = "A Python utility / library to sort Python imports."
-category = "dev"
-optional = false
-python-versions = ">=3.8.0"
-files = [
-    {file = "isort-5.12.0-py3-none-any.whl", hash = "sha256:f84c2818376e66cf843d497486ea8fed8700b340f308f076c6fb1229dff318b6"},
-    {file = "isort-5.12.0.tar.gz", hash = "sha256:8bef7dde241278824a6d83f44a544709b065191b95b6e50894bdc722fcba0504"},
-]
-
-[package.extras]
-colors = ["colorama (>=0.4.3)"]
-pipfile-deprecated-finder = ["pip-shims (>=0.5.2)", "pipreqs", "requirementslib"]
-plugins = ["setuptools"]
-requirements-deprecated-finder = ["pip-api", "pipreqs"]
-
-[[package]]
 name = "jedi"
 version = "0.18.2"
 description = "An autocompletion tool for Python that can be used for text editors."
@@ -2800,14 +2502,14 @@ format-nongpl = ["idna", "jsonpointer (>1.13)", "rfc3339-validator", "rfc3986-va
 
 [[package]]
 name = "jupyter-client"
-version = "8.0.1"
+version = "8.0.2"
 description = "Jupyter protocol implementation and client libraries"
 category = "main"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "jupyter_client-8.0.1-py3-none-any.whl", hash = "sha256:6016b874fd1111d721bc5bee30624399e876e79e6f395d1a559e6dce9fb2e1ba"},
-    {file = "jupyter_client-8.0.1.tar.gz", hash = "sha256:3f67b1c8b7687e6db09bef10ff97669932b5e6ef6f5a8ee56d444b89022c5007"},
+    {file = "jupyter_client-8.0.2-py3-none-any.whl", hash = "sha256:c53731eb590b68839b0ce04bf46ff8c4f03278f5d9fe5c3b0f268a57cc2bd97e"},
+    {file = "jupyter_client-8.0.2.tar.gz", hash = "sha256:47ac9f586dbcff4d79387ec264faf0fdeb5f14845fa7345fd7d1e378f8096011"},
 ]
 
 [package.dependencies]
@@ -2824,14 +2526,14 @@ test = ["codecov", "coverage", "ipykernel (>=6.14)", "mypy", "paramiko", "pre-co
 
 [[package]]
 name = "jupyter-core"
-version = "5.1.5"
+version = "5.2.0"
 description = "Jupyter core package. A base package on which Jupyter projects rely."
 category = "main"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "jupyter_core-5.1.5-py3-none-any.whl", hash = "sha256:83064d61bb2a9bc874e8184331c117b3778c2a7e1851f60cb00d273ceb3285ae"},
-    {file = "jupyter_core-5.1.5.tar.gz", hash = "sha256:8e54c48cde1e0c8345f64bcf9658b78044ddf02b273726cea9d9f59be4b02130"},
+    {file = "jupyter_core-5.2.0-py3-none-any.whl", hash = "sha256:4bdc2928c37f6917130c667d8b8708f20aee539d8283c6be72aabd2a4b4c83b0"},
+    {file = "jupyter_core-5.2.0.tar.gz", hash = "sha256:1407cdb4c79ee467696c04b76633fc1884015fa109323365a6372c8e890cc83f"},
 ]
 
 [package.dependencies]
@@ -2870,14 +2572,14 @@ test = ["click", "coverage", "pre-commit", "pytest (>=7.0)", "pytest-asyncio (>=
 
 [[package]]
 name = "jupyter-server"
-version = "2.1.0"
+version = "2.2.0"
 description = "The backend—i.e. core services, APIs, and REST endpoints—to Jupyter web applications."
 category = "main"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "jupyter_server-2.1.0-py3-none-any.whl", hash = "sha256:90cd6f2bd0581ddd9b2dbe82026a0f4c228a1d95c86e22460efbfdfc931fcf56"},
-    {file = "jupyter_server-2.1.0.tar.gz", hash = "sha256:efaae5e4f0d5f22c7f2f2dc848635036ee74a2df02abed52d30d9d95121ad382"},
+    {file = "jupyter_server-2.2.0-py3-none-any.whl", hash = "sha256:9c79b7227a7e3974856265908da40715ab49b7014ac39478d80b07e164b5a70e"},
+    {file = "jupyter_server-2.2.0.tar.gz", hash = "sha256:f901efcb4adce2370c64dc5942be587bd181119644660a1eb123435c3cd01f95"},
 ]
 
 [package.dependencies]
@@ -3108,22 +2810,24 @@ tests = ["pytest", "pytz", "simplejson"]
 
 [[package]]
 name = "mashumaro"
-version = "3.0.4"
+version = "3.3.1"
 description = "Fast serialization framework on top of dataclasses"
 category = "main"
 optional = false
-python-versions = ">=3.6"
+python-versions = ">=3.7"
 files = [
-    {file = "mashumaro-3.0.4-py3-none-any.whl", hash = "sha256:72b97b7660b7a4de1df2466a52543e6439f968cd081ce55aae899bc375b1f53d"},
-    {file = "mashumaro-3.0.4.tar.gz", hash = "sha256:6d221e09df2d884afda19325d5412dc9b1274be9ba1c3e57c12a8977320c7e07"},
+    {file = "mashumaro-3.3.1-py3-none-any.whl", hash = "sha256:74ae7704e4ac8813ff701909aa8d96a405156dc2e1e3fd34ac07db7f0823a54a"},
+    {file = "mashumaro-3.3.1.tar.gz", hash = "sha256:997ed0a4ce64967b96ff65f5ca76b8e5e459a4ec7a6a0f73625a067004a801c9"},
 ]
 
 [package.dependencies]
 msgpack = {version = ">=0.5.6", optional = true, markers = "extra == \"msgpack\""}
-typing-extensions = "*"
+typing-extensions = ">=4.1.0"
 
 [package.extras]
 msgpack = ["msgpack (>=0.5.6)"]
+orjson = ["orjson"]
+toml = ["tomli (>=1.1.0)", "tomli-w (>=1.0)"]
 yaml = ["pyyaml (>=3.13)"]
 
 [[package]]
@@ -3140,18 +2844,6 @@ files = [
 
 [package.dependencies]
 traitlets = "*"
-
-[[package]]
-name = "mccabe"
-version = "0.7.0"
-description = "McCabe checker, plugin for flake8"
-category = "dev"
-optional = false
-python-versions = ">=3.6"
-files = [
-    {file = "mccabe-0.7.0-py2.py3-none-any.whl", hash = "sha256:6c2d30ab6be0e4a46919781807b4f0d834ebdd6c6e3dca0bda5a15f863427b6e"},
-    {file = "mccabe-0.7.0.tar.gz", hash = "sha256:348e0240c33b60bbdf4e523192ef919f28cb2c3d7d5c7794f74009290f236325"},
-]
 
 [[package]]
 name = "minimal-snowplow-tracker"
@@ -3718,7 +3410,10 @@ files = [
 ]
 
 [package.dependencies]
-numpy = {version = ">=1.20.3", markers = "python_version < \"3.10\""}
+numpy = [
+    {version = ">=1.20.3", markers = "python_version < \"3.10\""},
+    {version = ">=1.21.0", markers = "python_version >= \"3.10\""},
+]
 python-dateutil = ">=2.8.1"
 pytz = ">=2020.1"
 
@@ -3769,39 +3464,15 @@ qa = ["flake8 (==3.8.3)", "mypy (==0.782)"]
 testing = ["docopt", "pytest (<6.0.0)"]
 
 [[package]]
-name = "pastel"
-version = "0.1.1"
-description = "Bring colors to your terminal."
-category = "dev"
-optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
-files = [
-    {file = "pastel-0.1.1-py2.py3-none-any.whl", hash = "sha256:a904e1659512cc9880a028f66de77cc813a4c32f7ceb68725cbc8afad57ef7ef"},
-    {file = "pastel-0.1.1.tar.gz", hash = "sha256:bf3b1901b2442ea0d8ab9a390594e5b0c9584709d543a3113506fe8b28cbace3"},
-]
-
-[[package]]
 name = "pathspec"
-version = "0.9.0"
+version = "0.10.3"
 description = "Utility library for gitignore style pattern matching of file paths."
 category = "main"
 optional = false
-python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,>=2.7"
+python-versions = ">=3.7"
 files = [
-    {file = "pathspec-0.9.0-py2.py3-none-any.whl", hash = "sha256:7d15c4ddb0b5c802d161efc417ec1a2558ea2653c2e8ad9c19098201dc1c993a"},
-    {file = "pathspec-0.9.0.tar.gz", hash = "sha256:e564499435a2673d586f6b2130bb5b95f04a3ba06f81b8f895b651a3c76aabb1"},
-]
-
-[[package]]
-name = "pbr"
-version = "5.11.1"
-description = "Python Build Reasonableness"
-category = "dev"
-optional = false
-python-versions = ">=2.6"
-files = [
-    {file = "pbr-5.11.1-py2.py3-none-any.whl", hash = "sha256:567f09558bae2b3ab53cb3c1e2e33e726ff3338e7bae3db5dc954b3a44eef12b"},
-    {file = "pbr-5.11.1.tar.gz", hash = "sha256:aefc51675b0b533d56bb5fd1c8c6c0522fe31896679882e1c4c63d5e4a0fccb3"},
+    {file = "pathspec-0.10.3-py3-none-any.whl", hash = "sha256:3c95343af8b756205e2aba76e843ba9520a24dd84f68c22b9f93251507509dd6"},
+    {file = "pathspec-0.10.3.tar.gz", hash = "sha256:56200de4077d9d0791465aa9095a01d421861e405b5096955051deefd697d6f6"},
 ]
 
 [[package]]
@@ -3840,21 +3511,6 @@ python-dateutil = ">=2.6,<3.0"
 pytzdata = ">=2020.1"
 
 [[package]]
-name = "pep8-naming"
-version = "0.13.3"
-description = "Check PEP-8 naming conventions, plugin for flake8"
-category = "dev"
-optional = false
-python-versions = ">=3.7"
-files = [
-    {file = "pep8-naming-0.13.3.tar.gz", hash = "sha256:1705f046dfcd851378aac3be1cd1551c7c1e5ff363bacad707d43007877fa971"},
-    {file = "pep8_naming-0.13.3-py3-none-any.whl", hash = "sha256:1a86b8c71a03337c97181917e2b472f0f5e4ccb06844a0d6f0a33522549e7a80"},
-]
-
-[package.dependencies]
-flake8 = ">=5.0.0"
-
-[[package]]
 name = "pexpect"
 version = "4.8.0"
 description = "Pexpect allows easy control of interactive console applications."
@@ -3880,24 +3536,6 @@ files = [
     {file = "pickleshare-0.7.5-py2.py3-none-any.whl", hash = "sha256:9649af414d74d4df115d5d718f82acb59c9d418196b7b4290ed47a12ce62df56"},
     {file = "pickleshare-0.7.5.tar.gz", hash = "sha256:87683d47965c1da65cdacaf31c8441d12b8044cdec9aca500cd78fc2c683afca"},
 ]
-
-[[package]]
-name = "pip-tools"
-version = "1.11.0"
-description = "pip-tools keeps your pinned dependencies fresh."
-category = "dev"
-optional = false
-python-versions = "*"
-files = [
-    {file = "pip-tools-1.11.0.tar.gz", hash = "sha256:ba427b68443466c389e3b0b0ef55f537ab39344190ea980dfebb333d0e6a50a3"},
-    {file = "pip_tools-1.11.0-py2.py3-none-any.whl", hash = "sha256:50288eb066ce66dbef5401a21530712a93c659fe480c7d8d34e2379300555fa1"},
-]
-
-[package.dependencies]
-click = ">=6"
-first = "*"
-setuptools = "*"
-six = "*"
 
 [[package]]
 name = "platformdirs"
@@ -3930,25 +3568,6 @@ files = [
 [package.extras]
 dev = ["pre-commit", "tox"]
 testing = ["pytest", "pytest-benchmark"]
-
-[[package]]
-name = "poetry"
-version = "0.3.0"
-description = "Python dependency management and packaging made easy."
-category = "dev"
-optional = false
-python-versions = ">=3.6.0"
-files = [
-    {file = "poetry-0.3.0-py3-none-any.whl", hash = "sha256:d174c094f885d97b2dde521e5eb8b1ef1519f813d338e53799bec0de8d0bf315"},
-    {file = "poetry-0.3.0.tar.gz", hash = "sha256:787acbdaa07dbd1d091256f5a9300bd8dad0f3d8767c003b6f8acd9bb515ed26"},
-]
-
-[package.dependencies]
-cachy = ">=0.1.0,<0.2.0"
-cleo = ">=0.6.1,<0.7.0"
-pip-tools = ">=1.11.0,<2.0.0"
-requests = ">=2.18.0,<3.0.0"
-toml = ">=0.9.4,<0.10.0"
 
 [[package]]
 name = "pre-commit"
@@ -4250,18 +3869,6 @@ files = [
 pyasn1 = ">=0.4.6,<0.5.0"
 
 [[package]]
-name = "pycodestyle"
-version = "2.9.1"
-description = "Python style guide checker"
-category = "dev"
-optional = false
-python-versions = ">=3.6"
-files = [
-    {file = "pycodestyle-2.9.1-py2.py3-none-any.whl", hash = "sha256:d1735fc58b418fd7c5f658d28d943854f8a849b01a5d0a1e6f3f3fdd0166804b"},
-    {file = "pycodestyle-2.9.1.tar.gz", hash = "sha256:2c9607871d58c76354b697b42f5d57e1ada7d261c261efac224b664affdc5785"},
-]
-
-[[package]]
 name = "pycparser"
 version = "2.21"
 description = "C parser in Python"
@@ -4327,36 +3934,6 @@ dotenv = ["python-dotenv (>=0.10.4)"]
 email = ["email-validator (>=1.0.3)"]
 
 [[package]]
-name = "pydocstyle"
-version = "6.3.0"
-description = "Python docstring style checker"
-category = "dev"
-optional = false
-python-versions = ">=3.6"
-files = [
-    {file = "pydocstyle-6.3.0-py3-none-any.whl", hash = "sha256:118762d452a49d6b05e194ef344a55822987a462831ade91ec5c06fd2169d019"},
-    {file = "pydocstyle-6.3.0.tar.gz", hash = "sha256:7ce43f0c0ac87b07494eb9c0b462c0b73e6ff276807f204d6b53edc72b7e44e1"},
-]
-
-[package.dependencies]
-snowballstemmer = ">=2.2.0"
-
-[package.extras]
-toml = ["tomli (>=1.2.3)"]
-
-[[package]]
-name = "pyflakes"
-version = "2.5.0"
-description = "passive checker of Python programs"
-category = "dev"
-optional = false
-python-versions = ">=3.6"
-files = [
-    {file = "pyflakes-2.5.0-py2.py3-none-any.whl", hash = "sha256:4579f67d887f804e67edb544428f264b7b24f435b263c4614f384135cea553d2"},
-    {file = "pyflakes-2.5.0.tar.gz", hash = "sha256:491feb020dca48ccc562a8c0cbe8df07ee13078df59813b83959cbdada312ea3"},
-]
-
-[[package]]
 name = "pygments"
 version = "2.14.0"
 description = "Pygments is a syntax highlighting package written in Python."
@@ -4380,18 +3957,6 @@ optional = false
 python-versions = "*"
 files = [
     {file = "pyhcl-0.4.4.tar.gz", hash = "sha256:2d9b9dcdf1023d812bfed561ba72c99104c5b3f52e558d595130a44ce081b003"},
-]
-
-[[package]]
-name = "pylev"
-version = "1.4.0"
-description = "A pure Python Levenshtein implementation that's not freaking GPL'd."
-category = "dev"
-optional = false
-python-versions = "*"
-files = [
-    {file = "pylev-1.4.0-py2.py3-none-any.whl", hash = "sha256:7b2e2aa7b00e05bb3f7650eb506fc89f474f70493271a35c242d9a92188ad3dd"},
-    {file = "pylev-1.4.0.tar.gz", hash = "sha256:9e77e941042ad3a4cc305dcdf2b2dec1aec2fbe3dd9015d2698ad02b173006d1"},
 ]
 
 [[package]]
@@ -4936,20 +4501,6 @@ files = [
 requests = ">=2.0.1,<3.0.0"
 
 [[package]]
-name = "restructuredtext-lint"
-version = "1.4.0"
-description = "reStructuredText linter"
-category = "dev"
-optional = false
-python-versions = "*"
-files = [
-    {file = "restructuredtext_lint-1.4.0.tar.gz", hash = "sha256:1b235c0c922341ab6c530390892eb9e92f90b9b75046063e047cacfb0f050c45"},
-]
-
-[package.dependencies]
-docutils = ">=0.11,<1.0"
-
-[[package]]
 name = "rfc3339-validator"
 version = "0.1.4"
 description = "A pure python RFC3339 validator"
@@ -5063,7 +4614,6 @@ files = [
     {file = "ruamel.yaml.clib-0.2.7-cp310-cp310-win_amd64.whl", hash = "sha256:d000f258cf42fec2b1bbf2863c61d7b8918d31ffee905da62dede869254d3b8a"},
     {file = "ruamel.yaml.clib-0.2.7-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:045e0626baf1c52e5527bd5db361bc83180faaba2ff586e763d3d5982a876a9e"},
     {file = "ruamel.yaml.clib-0.2.7-cp311-cp311-macosx_12_6_arm64.whl", hash = "sha256:721bc4ba4525f53f6a611ec0967bdcee61b31df5a56801281027a3a6d1c2daf5"},
-    {file = "ruamel.yaml.clib-0.2.7-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_24_x86_64.whl", hash = "sha256:41d0f1fa4c6830176eef5b276af04c89320ea616655d01327d5ce65e50575c94"},
     {file = "ruamel.yaml.clib-0.2.7-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:4b3a93bb9bc662fc1f99c5c3ea8e623d8b23ad22f861eb6fce9377ac07ad6072"},
     {file = "ruamel.yaml.clib-0.2.7-cp36-cp36m-macosx_12_0_arm64.whl", hash = "sha256:a234a20ae07e8469da311e182e70ef6b199d0fbeb6c6cc2901204dd87fb867e8"},
     {file = "ruamel.yaml.clib-0.2.7-cp36-cp36m-manylinux2014_aarch64.whl", hash = "sha256:15910ef4f3e537eea7fe45f8a5d19997479940d9196f357152a09031c5be59f3"},
@@ -5089,6 +4639,32 @@ files = [
     {file = "ruamel.yaml.clib-0.2.7-cp39-cp39-win32.whl", hash = "sha256:d5e51e2901ec2366b79f16c2299a03e74ba4531ddcfacc1416639c557aef0ad8"},
     {file = "ruamel.yaml.clib-0.2.7-cp39-cp39-win_amd64.whl", hash = "sha256:184faeaec61dbaa3cace407cffc5819f7b977e75360e8d5ca19461cd851a5fc5"},
     {file = "ruamel.yaml.clib-0.2.7.tar.gz", hash = "sha256:1f08fd5a2bea9c4180db71678e850b995d2a5f4537be0e94557668cf0f5f9497"},
+]
+
+[[package]]
+name = "ruff"
+version = "0.0.239"
+description = "An extremely fast Python linter, written in Rust."
+category = "dev"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "ruff-0.0.239-py3-none-macosx_10_7_x86_64.whl", hash = "sha256:de9830cfcca81c5d25233bf4be6f2f95deb58a7eaf2295f91280de97a54240d7"},
+    {file = "ruff-0.0.239-py3-none-macosx_10_9_x86_64.macosx_11_0_arm64.macosx_10_9_universal2.whl", hash = "sha256:71c05f627fb9efb0859af248fe00f61391266d14e9406c10236dec7db1b1bfe5"},
+    {file = "ruff-0.0.239-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3b1caea095c22067abc685b8452be5a9079ca27b88bffd80730f9e4ca8f81e7c"},
+    {file = "ruff-0.0.239-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:97293bae6da5bd82672473f6d43421de7dd27fe8a8b1b3c79ffeda37bcb492b4"},
+    {file = "ruff-0.0.239-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:25c3a84f8db9281385685041e98b67afd4a0bb5a872e897331af8229eb28b965"},
+    {file = "ruff-0.0.239-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:0056b7e1975a3ad7ef7eb9df4ca9f905661caf924c6843ecbe4e10719cd6cd0b"},
+    {file = "ruff-0.0.239-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:b38916c62eb2587743d2ec8e1f03a43eb5889cf4a56cb55f5eb3bffee5260e32"},
+    {file = "ruff-0.0.239-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:7afe3bc50339b916b75a587ed299859fae9c1056ed73d35531c0af610dbe67f6"},
+    {file = "ruff-0.0.239-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:daac673996ecbef77bccf8cd03189c60302568b7aec669e352aa2d8925b074b2"},
+    {file = "ruff-0.0.239-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:d3e4bb03333b0c8012ad7d27246a7a95dba3d6ec8796c172af055a179a86b61c"},
+    {file = "ruff-0.0.239-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:801a209887f777811caf9fd4513eec9b505e139d1b0844e1eacd1b4683b0eba2"},
+    {file = "ruff-0.0.239-py3-none-musllinux_1_2_i686.whl", hash = "sha256:216592db3bd93c260cc329d3237548f17fea1f43f87673ab5cdeb04d548fbea9"},
+    {file = "ruff-0.0.239-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:1e523edf92c5e888d93a145ef20ad548fca4da7cbd7a8321b3539967a03b7caf"},
+    {file = "ruff-0.0.239-py3-none-win32.whl", hash = "sha256:e54233e7d97d5b705582f673dc3184c7b16c42f7eac3be707c0adf716e457293"},
+    {file = "ruff-0.0.239-py3-none-win_amd64.whl", hash = "sha256:a1bdd3b5ea60b160d3ceb2f8fef4d88af58b7932d4ed46c85c586ef2f277b71d"},
+    {file = "ruff-0.0.239.tar.gz", hash = "sha256:bbb1fe64d4641ce7e5855bbebd9e81f6a596501bcb67842600186b3aa9b950cf"},
 ]
 
 [[package]]
@@ -5167,14 +4743,14 @@ win32 = ["pywin32"]
 
 [[package]]
 name = "setuptools"
-version = "67.0.0"
+version = "67.1.0"
 description = "Easily download, build, install, upgrade, and uninstall Python packages"
 category = "main"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "setuptools-67.0.0-py3-none-any.whl", hash = "sha256:9d790961ba6219e9ff7d9557622d2fe136816a264dd01d5997cfc057d804853d"},
-    {file = "setuptools-67.0.0.tar.gz", hash = "sha256:883131c5b6efa70b9101c7ef30b2b7b780a4283d5fc1616383cdf22c83cbefe6"},
+    {file = "setuptools-67.1.0-py3-none-any.whl", hash = "sha256:a7687c12b444eaac951ea87a9627c4f904ac757e7abdc5aac32833234af90378"},
+    {file = "setuptools-67.1.0.tar.gz", hash = "sha256:e261cdf010c11a41cb5cb5f1bf3338a7433832029f559a6a7614bd42a967c300"},
 ]
 
 [package.extras]
@@ -5207,18 +4783,6 @@ files = [
 ]
 
 [[package]]
-name = "smmap"
-version = "5.0.0"
-description = "A pure Python implementation of a sliding window memory map manager"
-category = "dev"
-optional = false
-python-versions = ">=3.6"
-files = [
-    {file = "smmap-5.0.0-py3-none-any.whl", hash = "sha256:2aba19d6a040e78d8b09de5c57e96207b09ed71d8e55ce0959eeee6c8e190d94"},
-    {file = "smmap-5.0.0.tar.gz", hash = "sha256:c840e62059cd3be204b0c9c9f74be2c09d5648eddd4580d9314c3ecde0b30936"},
-]
-
-[[package]]
 name = "sniffio"
 version = "1.3.0"
 description = "Sniff out which async library your code is running under"
@@ -5228,18 +4792,6 @@ python-versions = ">=3.7"
 files = [
     {file = "sniffio-1.3.0-py3-none-any.whl", hash = "sha256:eecefdce1e5bbfb7ad2eeaabf7c1eeb404d7757c379bd1f7e5cce9d8bf425384"},
     {file = "sniffio-1.3.0.tar.gz", hash = "sha256:e60305c5e5d314f5389259b7f22aaa33d8f7dee49763119234af3755c55b9101"},
-]
-
-[[package]]
-name = "snowballstemmer"
-version = "2.2.0"
-description = "This package provides 29 stemmers for 28 languages generated from Snowball algorithms."
-category = "dev"
-optional = false
-python-versions = "*"
-files = [
-    {file = "snowballstemmer-2.2.0-py2.py3-none-any.whl", hash = "sha256:c8e1716e83cc398ae16824e5572ae04e0d9fc2c6b985fb0f900f5f0c96ecba1a"},
-    {file = "snowballstemmer-2.2.0.tar.gz", hash = "sha256:09b16deb8547d3412ad7b590689584cd0fe25ec8db3be37788be3810cbf19cb1"},
 ]
 
 [[package]]
@@ -5256,77 +4808,70 @@ files = [
 
 [[package]]
 name = "sqlalchemy"
-version = "1.4.46"
+version = "2.0.1"
 description = "Database Abstraction Library"
 category = "main"
 optional = false
-python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,>=2.7"
+python-versions = ">=3.7"
 files = [
-    {file = "SQLAlchemy-1.4.46-cp27-cp27m-macosx_10_14_x86_64.whl", hash = "sha256:7001f16a9a8e06488c3c7154827c48455d1c1507d7228d43e781afbc8ceccf6d"},
-    {file = "SQLAlchemy-1.4.46-cp27-cp27m-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:c7a46639ba058d320c9f53a81db38119a74b8a7a1884df44d09fbe807d028aaf"},
-    {file = "SQLAlchemy-1.4.46-cp27-cp27m-win32.whl", hash = "sha256:c04144a24103135ea0315d459431ac196fe96f55d3213bfd6d39d0247775c854"},
-    {file = "SQLAlchemy-1.4.46-cp27-cp27m-win_amd64.whl", hash = "sha256:7b81b1030c42b003fc10ddd17825571603117f848814a344d305262d370e7c34"},
-    {file = "SQLAlchemy-1.4.46-cp27-cp27mu-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:939f9a018d2ad04036746e15d119c0428b1e557470361aa798e6e7d7f5875be0"},
-    {file = "SQLAlchemy-1.4.46-cp310-cp310-macosx_11_0_x86_64.whl", hash = "sha256:b7f4b6aa6e87991ec7ce0e769689a977776db6704947e562102431474799a857"},
-    {file = "SQLAlchemy-1.4.46-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5dbf17ac9a61e7a3f1c7ca47237aac93cabd7f08ad92ac5b96d6f8dea4287fc1"},
-    {file = "SQLAlchemy-1.4.46-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:7f8267682eb41a0584cf66d8a697fef64b53281d01c93a503e1344197f2e01fe"},
-    {file = "SQLAlchemy-1.4.46-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:64cb0ad8a190bc22d2112001cfecdec45baffdf41871de777239da6a28ed74b6"},
-    {file = "SQLAlchemy-1.4.46-cp310-cp310-win32.whl", hash = "sha256:5f752676fc126edc1c4af0ec2e4d2adca48ddfae5de46bb40adbd3f903eb2120"},
-    {file = "SQLAlchemy-1.4.46-cp310-cp310-win_amd64.whl", hash = "sha256:31de1e2c45e67a5ec1ecca6ec26aefc299dd5151e355eb5199cd9516b57340be"},
-    {file = "SQLAlchemy-1.4.46-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:d68e1762997bfebf9e5cf2a9fd0bcf9ca2fdd8136ce7b24bbd3bbfa4328f3e4a"},
-    {file = "SQLAlchemy-1.4.46-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4d112b0f3c1bc5ff70554a97344625ef621c1bfe02a73c5d97cac91f8cd7a41e"},
-    {file = "SQLAlchemy-1.4.46-cp311-cp311-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:69fac0a7054d86b997af12dc23f581cf0b25fb1c7d1fed43257dee3af32d3d6d"},
-    {file = "SQLAlchemy-1.4.46-cp311-cp311-win32.whl", hash = "sha256:887865924c3d6e9a473dc82b70977395301533b3030d0f020c38fd9eba5419f2"},
-    {file = "SQLAlchemy-1.4.46-cp311-cp311-win_amd64.whl", hash = "sha256:984ee13543a346324319a1fb72b698e521506f6f22dc37d7752a329e9cd00a32"},
-    {file = "SQLAlchemy-1.4.46-cp36-cp36m-macosx_10_14_x86_64.whl", hash = "sha256:9167d4227b56591a4cc5524f1b79ccd7ea994f36e4c648ab42ca995d28ebbb96"},
-    {file = "SQLAlchemy-1.4.46-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d61e9ecc849d8d44d7f80894ecff4abe347136e9d926560b818f6243409f3c86"},
-    {file = "SQLAlchemy-1.4.46-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:3ec187acf85984263299a3f15c34a6c0671f83565d86d10f43ace49881a82718"},
-    {file = "SQLAlchemy-1.4.46-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9883f5fae4fd8e3f875adc2add69f8b945625811689a6c65866a35ee9c0aea23"},
-    {file = "SQLAlchemy-1.4.46-cp36-cp36m-win32.whl", hash = "sha256:535377e9b10aff5a045e3d9ada8a62d02058b422c0504ebdcf07930599890eb0"},
-    {file = "SQLAlchemy-1.4.46-cp36-cp36m-win_amd64.whl", hash = "sha256:18cafdb27834fa03569d29f571df7115812a0e59fd6a3a03ccb0d33678ec8420"},
-    {file = "SQLAlchemy-1.4.46-cp37-cp37m-macosx_10_15_x86_64.whl", hash = "sha256:a1ad90c97029cc3ab4ffd57443a20fac21d2ec3c89532b084b073b3feb5abff3"},
-    {file = "SQLAlchemy-1.4.46-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4847f4b1d822754e35707db913396a29d874ee77b9c3c3ef3f04d5a9a6209618"},
-    {file = "SQLAlchemy-1.4.46-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:c5a99282848b6cae0056b85da17392a26b2d39178394fc25700bcf967e06e97a"},
-    {file = "SQLAlchemy-1.4.46-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d4b1cc7835b39835c75cf7c20c926b42e97d074147c902a9ebb7cf2c840dc4e2"},
-    {file = "SQLAlchemy-1.4.46-cp37-cp37m-win32.whl", hash = "sha256:c522e496f9b9b70296a7675272ec21937ccfc15da664b74b9f58d98a641ce1b6"},
-    {file = "SQLAlchemy-1.4.46-cp37-cp37m-win_amd64.whl", hash = "sha256:ae067ab639fa499f67ded52f5bc8e084f045d10b5ac7bb928ae4ca2b6c0429a5"},
-    {file = "SQLAlchemy-1.4.46-cp38-cp38-macosx_10_15_x86_64.whl", hash = "sha256:e3c1808008124850115a3f7e793a975cfa5c8a26ceeeb9ff9cbb4485cac556df"},
-    {file = "SQLAlchemy-1.4.46-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d4d164df3d83d204c69f840da30b292ac7dc54285096c6171245b8d7807185aa"},
-    {file = "SQLAlchemy-1.4.46-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:b33ffbdbbf5446cf36cd4cc530c9d9905d3c2fe56ed09e25c22c850cdb9fac92"},
-    {file = "SQLAlchemy-1.4.46-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3d94682732d1a0def5672471ba42a29ff5e21bb0aae0afa00bb10796fc1e28dd"},
-    {file = "SQLAlchemy-1.4.46-cp38-cp38-win32.whl", hash = "sha256:f8cb80fe8d14307e4124f6fad64dfd87ab749c9d275f82b8b4ec84c84ecebdbe"},
-    {file = "SQLAlchemy-1.4.46-cp38-cp38-win_amd64.whl", hash = "sha256:07e48cbcdda6b8bc7a59d6728bd3f5f574ffe03f2c9fb384239f3789c2d95c2e"},
-    {file = "SQLAlchemy-1.4.46-cp39-cp39-macosx_11_0_x86_64.whl", hash = "sha256:1b1e5e96e2789d89f023d080bee432e2fef64d95857969e70d3cadec80bd26f0"},
-    {file = "SQLAlchemy-1.4.46-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a3714e5b33226131ac0da60d18995a102a17dddd42368b7bdd206737297823ad"},
-    {file = "SQLAlchemy-1.4.46-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:955162ad1a931fe416eded6bb144ba891ccbf9b2e49dc7ded39274dd9c5affc5"},
-    {file = "SQLAlchemy-1.4.46-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b6e4cb5c63f705c9d546a054c60d326cbde7421421e2d2565ce3e2eee4e1a01f"},
-    {file = "SQLAlchemy-1.4.46-cp39-cp39-win32.whl", hash = "sha256:51e1ba2884c6a2b8e19109dc08c71c49530006c1084156ecadfaadf5f9b8b053"},
-    {file = "SQLAlchemy-1.4.46-cp39-cp39-win_amd64.whl", hash = "sha256:315676344e3558f1f80d02535f410e80ea4e8fddba31ec78fe390eff5fb8f466"},
-    {file = "SQLAlchemy-1.4.46.tar.gz", hash = "sha256:6913b8247d8a292ef8315162a51931e2b40ce91681f1b6f18f697045200c4a30"},
+    {file = "SQLAlchemy-2.0.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:3997238968fa495fac4b17fa18b36616c41a6e6759f323dfb3f83cbcf1d3b1bb"},
+    {file = "SQLAlchemy-2.0.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:d1588f6ba25dbb2d6eb1531e56f419e02cdc9ec06d9f082195877c5148f6f6ab"},
+    {file = "SQLAlchemy-2.0.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e60bec8fdd753212aa8cec012bbb3060e9c2227496fa935ca8918744a34c864d"},
+    {file = "SQLAlchemy-2.0.1-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:20b9e36f0219285c580dc5e98cadb59b751e259f3829460bc58d45e7a770dd36"},
+    {file = "SQLAlchemy-2.0.1-cp310-cp310-win32.whl", hash = "sha256:0186b970fd4561def531b582a86819d8f8af65c8b1a78cf015ee47e526f4cfb6"},
+    {file = "SQLAlchemy-2.0.1-cp310-cp310-win_amd64.whl", hash = "sha256:664a21613d7eff895de9ef731632575cfca773ddbac9b7f7adad288ab971bcbd"},
+    {file = "SQLAlchemy-2.0.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:1f504779e6e68d0cb7043825958125abd7742c7c73ce9c6b652d20c6b5f17022"},
+    {file = "SQLAlchemy-2.0.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:8f9085bedb9e2f2bf714cfd86be6deaa7050f998843a3a0e595ec3eb0d25c743"},
+    {file = "SQLAlchemy-2.0.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a97c4b5527ea563867ccbee031af93932d9699c6c73f1ea70adcbc935c80379e"},
+    {file = "SQLAlchemy-2.0.1-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:3846d36c1ca113a7fa078abb5e69a8c3d1c7642baf12267dcd9a0d660cf1bdeb"},
+    {file = "SQLAlchemy-2.0.1-cp311-cp311-win32.whl", hash = "sha256:aeb49e1436d6558d31c006b385a5071e802be6db257ce36940e66cefce92aa72"},
+    {file = "SQLAlchemy-2.0.1-cp311-cp311-win_amd64.whl", hash = "sha256:9efb27e899cf7d43cf42c0852ef772a8b568c39dc7b55768a5a80c67bb64dfc2"},
+    {file = "SQLAlchemy-2.0.1-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:7e23205506a437476dce8193357ce47254cce7c94018b1b4856476ad2e74f1ae"},
+    {file = "SQLAlchemy-2.0.1-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ca2ce5f3125cb6e043c90dd901446b74878f35eb6660e0e58d7ef02832f7d332"},
+    {file = "SQLAlchemy-2.0.1-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:476bd377f430b1871f058332696ef61c42dfa8ad242ebb8bcf212c3d4127ea8a"},
+    {file = "SQLAlchemy-2.0.1-cp37-cp37m-win32.whl", hash = "sha256:101df3fa8f207ade1124d7729f6c9eab28a2560baa31b3e131e76a599d884b33"},
+    {file = "SQLAlchemy-2.0.1-cp37-cp37m-win_amd64.whl", hash = "sha256:05b81afdc25d1ce43cb59647c9992559dc7487b1670ccab0426fc8b8f859e933"},
+    {file = "SQLAlchemy-2.0.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:7b07b83789997cf83ce9a5e7156a2b9a6cb54a4137add8ad95eff32f6746279b"},
+    {file = "SQLAlchemy-2.0.1-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:e49e9aefffe9c598a6ccf8d2dbb4556f4d93d0ae346b9d199b3712d24af0ce75"},
+    {file = "SQLAlchemy-2.0.1-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:db3e4db26c1a771d7b23a1031eaf351cfcaaa96d463ae900bb56c6a6f0585fbf"},
+    {file = "SQLAlchemy-2.0.1-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:664ec164bc01ab66dfd19062ca7982a9ea12274596e17732908eb78621adc147"},
+    {file = "SQLAlchemy-2.0.1-cp38-cp38-win32.whl", hash = "sha256:6dd8405bd1ffcbf11fda0e6b172e7e90044610de16325295efe92367551f666d"},
+    {file = "SQLAlchemy-2.0.1-cp38-cp38-win_amd64.whl", hash = "sha256:5bc451ee18776dcb6b2ac8c154db0536f75a2535f5da055179734f5e7f2e7b72"},
+    {file = "SQLAlchemy-2.0.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:655e93fabd11bf53e6af44cee152b608d49ece4b4d9cc29328dd476faaa47c0c"},
+    {file = "SQLAlchemy-2.0.1-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:a5e1826a1ebbbbc26285a0304d7cafff4ec63cdae83fde89d5f2ec67f4444a44"},
+    {file = "SQLAlchemy-2.0.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:08c9169692722df8a2ef6c6ff1055e11563c990e9c74df9af62139a0c6397b8c"},
+    {file = "SQLAlchemy-2.0.1-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:31d019c60f4817b24c484d3110c7754cd2b8f7070057eddef5822994bf16da5a"},
+    {file = "SQLAlchemy-2.0.1-cp39-cp39-win32.whl", hash = "sha256:c681d0f59c8ed12fd3f68d08d423354b1cc501220ddabc7a20b9ca8ed52b8f70"},
+    {file = "SQLAlchemy-2.0.1-cp39-cp39-win_amd64.whl", hash = "sha256:619784c399f5c4240b002e4dba30cfba15696274614da77846b69b2c9a74066b"},
+    {file = "SQLAlchemy-2.0.1-py3-none-any.whl", hash = "sha256:f44c37e03cb941dd0db371a9f391cfb586c9966f436bf18b5492ee26f5ac6a5b"},
+    {file = "SQLAlchemy-2.0.1.tar.gz", hash = "sha256:70d38432d75f6c95973f9713b30881e40a4e8d8ccfe8bbeb55466d8c737acc79"},
 ]
 
 [package.dependencies]
-greenlet = {version = "!=0.4.17", markers = "python_version >= \"3\" and (platform_machine == \"aarch64\" or platform_machine == \"ppc64le\" or platform_machine == \"x86_64\" or platform_machine == \"amd64\" or platform_machine == \"AMD64\" or platform_machine == \"win32\" or platform_machine == \"WIN32\")"}
+greenlet = {version = "!=0.4.17", markers = "platform_machine == \"aarch64\" or platform_machine == \"ppc64le\" or platform_machine == \"x86_64\" or platform_machine == \"amd64\" or platform_machine == \"AMD64\" or platform_machine == \"win32\" or platform_machine == \"WIN32\""}
+typing-extensions = ">=4.2.0"
 
 [package.extras]
 aiomysql = ["aiomysql", "greenlet (!=0.4.17)"]
 aiosqlite = ["aiosqlite", "greenlet (!=0.4.17)", "typing-extensions (!=3.10.0.1)"]
 asyncio = ["greenlet (!=0.4.17)"]
-asyncmy = ["asyncmy (>=0.2.3,!=0.2.4)", "greenlet (!=0.4.17)"]
-mariadb-connector = ["mariadb (>=1.0.1,!=1.1.2)"]
+asyncmy = ["asyncmy (>=0.2.3,!=0.2.4,!=0.2.6)", "greenlet (!=0.4.17)"]
+mariadb-connector = ["mariadb (>=1.0.1,!=1.1.2,!=1.1.5)"]
 mssql = ["pyodbc"]
 mssql-pymssql = ["pymssql"]
 mssql-pyodbc = ["pyodbc"]
-mypy = ["mypy (>=0.910)", "sqlalchemy2-stubs"]
-mysql = ["mysqlclient (>=1.4.0)", "mysqlclient (>=1.4.0,<2)"]
+mypy = ["mypy (>=0.910)"]
+mysql = ["mysqlclient (>=1.4.0)"]
 mysql-connector = ["mysql-connector-python"]
-oracle = ["cx-oracle (>=7)", "cx-oracle (>=7,<8)"]
+oracle = ["cx-oracle (>=7)"]
+oracle-oracledb = ["oracledb (>=1.0.1)"]
 postgresql = ["psycopg2 (>=2.7)"]
 postgresql-asyncpg = ["asyncpg", "greenlet (!=0.4.17)"]
-postgresql-pg8000 = ["pg8000 (>=1.16.6,!=1.29.0)"]
+postgresql-pg8000 = ["pg8000 (>=1.29.1)"]
+postgresql-psycopg = ["psycopg (>=3.0.7)"]
 postgresql-psycopg2binary = ["psycopg2-binary"]
 postgresql-psycopg2cffi = ["psycopg2cffi"]
-pymysql = ["pymysql", "pymysql (<1)"]
+pymysql = ["pymysql"]
 sqlcipher = ["sqlcipher3-binary"]
 
 [[package]]
@@ -5409,19 +4954,15 @@ typing-extensions = {version = ">=3.10.0", markers = "python_version < \"3.10\""
 full = ["httpx (>=0.22.0)", "itsdangerous", "jinja2", "python-multipart", "pyyaml"]
 
 [[package]]
-name = "stevedore"
-version = "4.1.1"
-description = "Manage dynamic plugins for Python applications"
-category = "dev"
+name = "stringcase"
+version = "1.2.0"
+description = "String case converter."
+category = "main"
 optional = false
-python-versions = ">=3.8"
+python-versions = "*"
 files = [
-    {file = "stevedore-4.1.1-py3-none-any.whl", hash = "sha256:aa6436565c069b2946fe4ebff07f5041e0c8bf18c7376dd29edf80cf7d524e4e"},
-    {file = "stevedore-4.1.1.tar.gz", hash = "sha256:7f8aeb6e3f90f96832c301bff21a7eb5eefbe894c88c506483d355565d88cc1a"},
+    {file = "stringcase-1.2.0.tar.gz", hash = "sha256:48a06980661908efe8d9d34eab2b6c13aefa2163b3ced26972902e3bdfd87008"},
 ]
-
-[package.dependencies]
-pbr = ">=2.0.0,<2.1.0 || >2.1.0"
 
 [[package]]
 name = "tabulate"
@@ -5504,14 +5045,14 @@ test = ["flake8", "isort", "pytest"]
 
 [[package]]
 name = "toml"
-version = "0.9.6"
+version = "0.10.2"
 description = "Python Library for Tom's Obvious, Minimal Language"
 category = "dev"
 optional = false
-python-versions = "*"
+python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*"
 files = [
-    {file = "toml-0.9.6-py2.py3-none-any.whl", hash = "sha256:a7901919d3e4f92ffba7ff40a9d697e35bbbc8a8049fe8da742f34c83606d957"},
-    {file = "toml-0.9.6.tar.gz", hash = "sha256:380178cde50a6a79f9d2cf6f42a62a5174febe5eea4126fe4038785f1d888d42"},
+    {file = "toml-0.10.2-py2.py3-none-any.whl", hash = "sha256:806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b"},
+    {file = "toml-0.10.2.tar.gz", hash = "sha256:b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f"},
 ]
 
 [[package]]
@@ -5594,14 +5135,14 @@ telegram = ["requests"]
 
 [[package]]
 name = "traitlets"
-version = "5.8.1"
+version = "5.9.0"
 description = "Traitlets Python configuration system"
 category = "main"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "traitlets-5.8.1-py3-none-any.whl", hash = "sha256:a1ca5df6414f8b5760f7c5f256e326ee21b581742114545b462b35ffe3f04861"},
-    {file = "traitlets-5.8.1.tar.gz", hash = "sha256:32500888f5ff7bbf3b9267ea31748fa657aaf34d56d85e60f91dda7dc7f5785b"},
+    {file = "traitlets-5.9.0-py3-none-any.whl", hash = "sha256:9e6ec080259b9a5940c797d58b613b5e31441c2257b87c2e795c5228ae80d2d8"},
+    {file = "traitlets-5.9.0.tar.gz", hash = "sha256:f6cde21a9c68cf756af02035f72d5a723bf607e862e7be33ece505abf4a3bad9"},
 ]
 
 [package.extras]
@@ -5610,26 +5151,27 @@ test = ["argcomplete (>=2.0)", "pre-commit", "pytest", "pytest-mock"]
 
 [[package]]
 name = "trino"
-version = "0.319.0"
+version = "0.321.0"
 description = "Client for the Trino distributed SQL Engine"
 category = "main"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "trino-0.319.0-py3-none-any.whl", hash = "sha256:44e07da121a655da9f9eb92a0670bad8b4d769f7e42537281bd101ab7b7de3ee"},
-    {file = "trino-0.319.0.tar.gz", hash = "sha256:d5a01258ff48b4e6dbed9cdbb070e2bf5afdbec90c933b19f1acad6db2947f32"},
+    {file = "trino-0.321.0-py3-none-any.whl", hash = "sha256:d713e0d37015860d428bf6601dc430b5cd80c574081ab28d634e38250a050fb4"},
+    {file = "trino-0.321.0.tar.gz", hash = "sha256:6642a57dff253f8c13787e5ec832de43304ab6f1d8109bc51a17b1150a529dfa"},
 ]
 
 [package.dependencies]
 pytz = "*"
 requests = "*"
+tzlocal = "*"
 
 [package.extras]
-all = ["requests-kerberos", "sqlalchemy (>=1.3,<2.0)"]
+all = ["requests-kerberos", "sqlalchemy (>=1.3)"]
 external-authentication-token-cache = ["keyring"]
 kerberos = ["requests-kerberos"]
-sqlalchemy = ["sqlalchemy (>=1.3,<2.0)"]
-tests = ["black", "click", "httpretty (<1.1)", "isort", "pre-commit", "pytest", "pytest-runner", "requests-kerberos", "sqlalchemy (>=1.3,<2.0)", "sqlalchemy-utils"]
+sqlalchemy = ["sqlalchemy (>=1.3)"]
+tests = ["black", "click", "httpretty (<1.1)", "isort", "pre-commit", "pytest", "pytest-runner", "requests-kerberos", "sqlalchemy (>=1.3)"]
 
 [[package]]
 name = "typer"
@@ -6043,43 +5585,6 @@ files = [
 ]
 
 [[package]]
-name = "wemake-python-styleguide"
-version = "0.17.0"
-description = "The strictest and most opinionated python linter ever"
-category = "dev"
-optional = false
-python-versions = "^3.7"
-files = []
-develop = false
-
-[package.dependencies]
-astor = "^0.8"
-attrs = "*"
-darglint = "^1.2"
-flake8 = "^5.0"
-flake8-bandit = "^4.1"
-flake8-broken-line = "^0.6"
-flake8-bugbear = "^22.9"
-flake8-commas = "^2.0"
-flake8-comprehensions = "^3.1"
-flake8-debugger = "^4.0"
-flake8-docstrings = "^1.3"
-flake8-eradicate = "^1.0"
-flake8-isort = ">=4,<6"
-flake8-quotes = "^3.0"
-flake8-rst-docstrings = ">=0.2,<0.4"
-flake8-string-format = "^0.3"
-pep8-naming = "^0.13"
-pygments = "^2.4"
-typing_extensions = ">=4.0,<5.0"
-
-[package.source]
-type = "git"
-url = "https://github.com/wemake-services/wemake-python-styleguide"
-reference = "HEAD"
-resolved_reference = "f23a4b6e10a7a14bf265fd8c0eb430906bbc4a60"
-
-[[package]]
 name = "werkzeug"
 version = "2.2.2"
 description = "The comprehensive WSGI web application library."
@@ -6215,5 +5720,5 @@ testing = ["flake8 (<5)", "func-timeout", "jaraco.functools", "jaraco.itertools"
 
 [metadata]
 lock-version = "2.0"
-python-versions = ">=3.9,<3.10"
-content-hash = "924159724fc448f145ba76335682edf3e145510d035e453d287373246a26eede"
+python-versions = ">=3.9,<3.11"
+content-hash = "6dda58dccbf5f2e32ea84734705b8fcb6208d3b10daa1e74b2a82c7b45f58124"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ packages = [
 ]
 
 [tool.poetry.dependencies]
-python = ">=3.9,<3.10"
+python = ">=3.9,<3.11"
 PyPika = "^0.48.9"
 dagit = "^1.0"
 dagster = "^1.0"
@@ -40,13 +40,11 @@ dynaconf = "^3.1.11"
 
 [tool.poetry.dev-dependencies]
 black = "*"
-isort = "*"
 mypy = "*"
-poetry = "*"
 pre-commit = "^3"
 pytest = "^7.1.2"
 sqlfluff = "^1.4.1"
-wemake-python-styleguide = {git = "https://github.com/wemake-services/wemake-python-styleguide"}
+ruff = "^0.0.239"
 
 [tool.black]
 target-version = ["py39"]
@@ -80,3 +78,82 @@ target = "qa"
 [tool.sqlfluff.layout.type.comma]
 # Use leading commas for cleaner diffs
 line_position = "leading"
+
+[tool.ruff]
+target-version = "py39"
+line-length = 88
+select = [
+    "A",      # flake8-builtins
+    # "ARG",  # flake8-unused-arguments
+    # "ANN",  # flake8-annotations
+    "B",      # flake8-bugbear
+    # "BLE",  # flake8-blind-except
+    # "C4",   # flake8-comprehensions
+    # "COM",  # flake8-commas
+    "DTZ",    # flake8-datetimez
+    "D",      # pydocstyle
+    "E",      # pydocstyle
+    "ERA",  # eradicate
+    # "EM",   # flake8-errmsg
+    "EXE",    # flake8-executable
+    "F",      # flake8
+    "G",      # flake8-logging-format
+    "ICN",    # flake8-import-conventions
+    # "INP",    # flake8-no-pep420
+    "ISC",    # flake8-implicit-str-concat
+    "N",      # pep8-naming
+    # "PD",   # pandas-vet
+    "PIE",    # flake8-pie
+    # "PGH",  # pygrep-hooks                [Enable]
+    # "PT",   # flake8-pytest-style         [Enable]
+    "PTH",  # flake8-use-pathlib
+    "PLR",    # Refactor
+    "Q",      # flake8-quotes
+    "RET",    # flake8-return
+    "S",      # flake8-bandit
+    "SIM",    # flake8-simplify
+    "T10",    # flake8-debugger
+    "T20",    # flake8-print
+    "TCH",  # flake8-type-checking
+    "TID",    # flake8-tidy-imports
+    "UP",     # pyupgrade
+    "W",      # pydocstyle
+    "YTT",     # flake8-2020
+    "RUF"
+]
+ignore = [
+    "B008",
+    "B905",
+    "D104",
+    "D200",
+    "D202",
+    "D205",
+    "D301",
+    "D400",
+    "N801",
+    "N802",
+    "N803",
+    "N806",
+    "N813",
+    "N815",
+    "N816",
+    "PIE804",
+    "RET504",
+    "RET505",
+    "RET506",
+    "RET507",
+    "RET508",
+    "UP007"
+
+]
+typing-modules = ["colour.hints"]
+fixable = ["I", "D", "B", "E", "F", "UP", "C4", "Q", "RET", "PIE", "SIM","UP", "W", "RUF"]
+
+[tool.ruff.pydocstyle]
+convention = "pep257"
+
+[tool.ruff.flake8-quotes]
+inline-quotes = "double"
+
+[tool.ruff.per-file-ignores]
+"test_*.py" = ["S101"]

--- a/src/ol_dbt/models/marts/micromasters/marts__micromasters_program_certificates.sql
+++ b/src/ol_dbt/models/marts/micromasters/marts__micromasters_program_certificates.sql
@@ -60,7 +60,8 @@ with edx_course_certificates as (
         -- functions and we don't want to count the same course against the program requirements multiple times
         , row_number() over (
             partition by edx_course_certificates.user_id, micromasters_courses.course_id
-            order by edx_course_certificates.courseruncertificate_created_on asc) as user_course_certificate_number
+            order by edx_course_certificates.courseruncertificate_created_on asc
+        ) as user_course_certificate_number
     from edx_course_certificates
     inner join
         micromasters_courses

--- a/src/ol_orchestrate/jobs/open_edx.py
+++ b/src/ol_orchestrate/jobs/open_edx.py
@@ -7,7 +7,7 @@ from ol_orchestrate.lib.hooks import (
     notify_healthchecks_io_on_success,
 )
 from ol_orchestrate.lib.yaml_config_helper import load_yaml_config
-from ol_orchestrate.ops.open_edx import (  # noqa: WPS235
+from ol_orchestrate.ops.open_edx import (
     course_enrollments,
     course_roles,
     enrolled_users,
@@ -52,7 +52,10 @@ def edx_course_pipeline():
         export_edx_forum_database(),
     )
     export_edx_courses.with_hooks(
-        {notify_healthchecks_io_on_success, notify_healthchecks_io_on_failure}
+        {
+            notify_healthchecks_io_on_success,
+            notify_healthchecks_io_on_failure,
+        }
     )(course_list, extracts_upload)
 
 

--- a/src/ol_orchestrate/lib/arrow_helper.py
+++ b/src/ol_orchestrate/lib/arrow_helper.py
@@ -24,7 +24,7 @@ def write_parquet_file(file_system, output_folder, arrow_table, file_name):
     if file_system.type_name == "local":
         file_system.create_dir(output_folder)
 
-    with file_system.open_output_stream(file_path) as parquet_file:
+    with file_system.open_output_stream(file_path) as parquet_file:  # noqa: SIM117
         with parquet.ParquetWriter(
             parquet_file, arrow_table.schema, use_deprecated_int96_timestamps=True
         ) as writer:

--- a/src/ol_orchestrate/lib/dagster_types/files.py
+++ b/src/ol_orchestrate/lib/dagster_types/files.py
@@ -5,4 +5,4 @@ from dagster import usable_as_dagster_type
 
 @usable_as_dagster_type
 class DagsterPath(PosixPath):
-    pass  # noqa: WPS420, WPS604
+    pass

--- a/src/ol_orchestrate/lib/edx_api_client.py
+++ b/src/ol_orchestrate/lib/edx_api_client.py
@@ -1,13 +1,16 @@
 import time
-from collections.abc import Generator
+from collections.abc import Generator  # noqa: TCH003
 
 import httpx
 
 TOO_MANY_REQUESTS = 429
 
 
-def get_access_token(  # noqa: S107
-    client_id: str, client_secret: str, edx_url: str, token_type: str = "jwt"
+def get_access_token(
+    client_id: str,
+    client_secret: str,
+    edx_url: str,
+    token_type: str = "jwt",  # noqa: S107
 ) -> str:
     """Retrieve an access token from an Open edX site via OAUTH2 credentials.
 
@@ -69,7 +72,7 @@ def _fetch_with_auth(
 
 def get_edx_course_ids(
     edx_url: str, access_token: str, page_size: int = 100
-) -> Generator[list[dict], None, None]:  # noqa: DAR301
+) -> Generator[list[dict], None, None]:
     """Retrieve all items from the edX courses REST API including pagination.
 
     :param edx_url: Base URL of edX instance being queried, including protocol.  e.g.

--- a/src/ol_orchestrate/lib/file_rendering.py
+++ b/src/ol_orchestrate/lib/file_rendering.py
@@ -1,5 +1,5 @@
 import csv
-from pathlib import Path
+from pathlib import Path  # noqa: TCH003
 
 
 def write_csv(

--- a/src/ol_orchestrate/ops/edx_gcs_courses.py
+++ b/src/ol_orchestrate/ops/edx_gcs_courses.py
@@ -34,7 +34,7 @@ def download_edx_gcs_course_data(context):
     edx_course_tarball_path = context.resources.results_dir.path.joinpath(
         context.op_config["edx_gcs_course_tarballs"]
     )
-    os.makedirs(edx_course_tarball_path, exist_ok=True)
+    os.makedirs(edx_course_tarball_path, exist_ok=True)  # noqa: PTH103
     blobs = storage_client.list_blobs(bucket)
     for blob in blobs:
         blob.download_to_filename(f"{edx_course_tarball_path}/{blob.name}")
@@ -101,12 +101,12 @@ def upload_edx_gcs_course_data_to_s3(
         description="Daily export directory for edX export pipeline",
         metadata_entries=[
             MetadataEntry.fspath(
-                f"s3://{results_bucket}/{context.resources.results_dir.path.name}"  # noqa: E501, WPS237
+                f"s3://{results_bucket}/{context.resources.results_dir.path.name}"  # noqa: E501
             ),
         ],
     )
     context.resources.results_dir.clean_dir()
     yield Output(
-        f"{results_bucket}/{context.resources.results_dir.path.name}",  # noqa: WPS237
+        f"{results_bucket}/{context.resources.results_dir.path.name}",
         "edx_s3_course_tarball_directory",
     )

--- a/src/ol_orchestrate/ops/open_edx.py
+++ b/src/ol_orchestrate/ops/open_edx.py
@@ -1,7 +1,7 @@
 import time
 from datetime import timedelta
 
-from dagster import (  # noqa: WPS235
+from dagster import (
     AssetMaterialization,
     ExpectationResult,
     Failure,
@@ -530,7 +530,7 @@ def export_edx_forum_database(  # type: ignore
         ),
     },
 )
-def export_edx_courses(  # noqa: WPS210
+def export_edx_courses(
     context: OpExecutionContext, edx_course_ids: List[str], daily_extracts_dir: str
 ) -> None:
     access_token = get_access_token(
@@ -547,7 +547,7 @@ def export_edx_courses(  # noqa: WPS210
     successful_exports: set[str] = set()
     failed_exports: set[str] = set()
     tasks = exported_courses["upload_task_ids"]
-    context.log.info("Exporting %s tasks from Open edX", len(tasks))  # noqa: WPS323
+    context.log.info("Exporting %s tasks from Open edX", len(tasks))
     # Possible status values found here:
     # https://github.com/openedx/django-user-tasks/blob/master/user_tasks/models.py
     while len(successful_exports.union(failed_exports)) < len(tasks):
@@ -563,10 +563,8 @@ def export_edx_courses(  # noqa: WPS210
                 successful_exports.add(course_id)
             if task_status["state"] in {"Failed", "Canceled", "Retrying"}:
                 failed_exports.add(course_id)
-    for course_id in successful_exports:  # noqa: WPS440
-        context.log.info(
-            "Moving course %s to %s", course_id, daily_extracts_dir  # noqa: WPS323
-        )
+    for course_id in successful_exports:
+        context.log.info("Moving course %s to %s", course_id, daily_extracts_dir)
         course_file = f"{course_id}.tar.gz"
         source_object = {
             "Bucket": context.op_config["edx_course_bucket"],
@@ -627,7 +625,7 @@ def write_course_list_csv(context: OpExecutionContext, edx_course_ids: list[str]
     },
     out={"edx_daily_extracts_directory": Out(dagster_type=String)},
 )
-def upload_extracted_data(  # noqa: WPS211
+def upload_extracted_data(  # noqa: PLR0913
     context: OpExecutionContext,
     edx_course_ids_csv: DagsterPath,
     edx_course_roles: DagsterPath,
@@ -693,12 +691,12 @@ def upload_extracted_data(  # noqa: WPS211
         description="Daily export directory for edX export pipeline",
         metadata_entries=[
             MetadataEntry.fspath(
-                f"s3://{results_bucket}/{context.resources.results_dir.path.name}"  # noqa: E501, WPS237
+                f"s3://{results_bucket}/{context.resources.results_dir.path.name}"  # noqa: E501
             ),
         ],
     )
     context.resources.results_dir.clean_dir()
     yield Output(
-        f"{results_bucket}/{context.resources.results_dir.path.name}",  # noqa: WPS237
+        f"{results_bucket}/{context.resources.results_dir.path.name}",
         "edx_daily_extracts_directory",
     )

--- a/src/ol_orchestrate/repositories/edx_gcs_courses.py
+++ b/src/ol_orchestrate/repositories/edx_gcs_courses.py
@@ -32,7 +32,7 @@ edx_gcs_courses = Definitions(
     sensors=[
         SensorDefinition(
             evaluation_fn=check_new_gcs_assets_sensor,
-            minimum_interval_seconds=86400,  # noqa: WPS432 - 1 day
+            minimum_interval_seconds=86400,
             job=gcs_sync_job,
             default_status=DefaultSensorStatus.RUNNING,
         )

--- a/src/ol_orchestrate/resources/athena_db.py
+++ b/src/ol_orchestrate/resources/athena_db.py
@@ -5,11 +5,11 @@ from typing import Optional
 import pyathena
 from dagster import Field, InitResourceContext, Noneable, String, resource
 from pyathena.cursor import DictCursor
-from pypika import Query
+from pypika import Query  # noqa: TCH002
 
 
 class AthenaClient:
-    def __init__(  # noqa: WPS211
+    def __init__(  # noqa: PLR0913
         self,
         work_group: str,
         schema_name: str,

--- a/src/ol_orchestrate/resources/healthchecks.py
+++ b/src/ol_orchestrate/resources/healthchecks.py
@@ -1,4 +1,4 @@
-import urllib.parse  # noqa: WPS301
+import urllib.parse
 from typing import Literal, Optional
 
 import httpx

--- a/src/ol_orchestrate/resources/mysql_db.py
+++ b/src/ol_orchestrate/resources/mysql_db.py
@@ -3,13 +3,13 @@ from typing import Optional
 import pymysql
 from dagster import Field, InitResourceContext, Int, String, resource
 from pymysql.cursors import DictCursor
-from pypika import Query
+from pypika import Query  # noqa: TCH002
 
 DEFAULT_MYSQL_PORT = 3306
 
 
 class MySQLClient:
-    def __init__(  # noqa: WPS211
+    def __init__(  # noqa: PLR0913
         self,
         hostname: str,
         username: str,

--- a/src/ol_orchestrate/resources/outputs.py
+++ b/src/ol_orchestrate/resources/outputs.py
@@ -1,6 +1,6 @@
 import os
 import shutil
-from collections.abc import Generator
+from collections.abc import Generator  # noqa: TCH003
 from datetime import datetime
 from typing import Optional
 
@@ -12,14 +12,14 @@ from ol_orchestrate.lib.dagster_types.files import DagsterPath
 class ResultsDir:
     def __init__(self, root_dir: Optional[str] = None):
         if root_dir is None:
-            self.root_dir = DagsterPath(os.getcwd())
+            self.root_dir = DagsterPath(os.getcwd())  # noqa: PTH109
         else:
             self.root_dir = DagsterPath(root_dir)
         self.dir_name = "results"
 
     def create_dir(self):
         try:
-            os.makedirs(self.path)
+            os.makedirs(self.path)  # noqa: PTH103
         except FileExistsError:
             return
 
@@ -28,7 +28,7 @@ class ResultsDir:
 
     @property
     def path(self) -> DagsterPath:
-        return DagsterPath(os.path.join(self.root_dir, self.dir_name))
+        return DagsterPath(os.path.join(self.root_dir, self.dir_name))  # noqa: PTH118
 
     @property
     def absolute_path(self) -> str:
@@ -39,7 +39,7 @@ class DailyResultsDir(ResultsDir):
     def __init__(
         self,
         root_dir: Optional[str] = None,
-        date_format: str = "%Y-%m-%d",  # noqa: WPS323
+        date_format: str = "%Y-%m-%d",
         date_override: Optional[str] = None,
     ):
         """Instantiate a results directory that defaults to being named according to the current date.  # noqa: E501
@@ -53,12 +53,12 @@ class DailyResultsDir(ResultsDir):
         :param date_override: A string representing an override of the date to be used for the generated directory.  # noqa: E501
             Primarily used for cases where a backfill process needs to occur.
         :type date_override: str
-        """
+        """  # noqa: E501
         super().__init__(root_dir)
         if date_override:
-            dir_date = datetime.strptime(date_override, date_format)
+            dir_date = datetime.strptime(date_override, date_format)  # noqa: DTZ007
         else:
-            dir_date = datetime.utcnow()
+            dir_date = datetime.utcnow()  # noqa: DTZ003
         self.dir_name = dir_date.strftime(date_format)
 
 
@@ -75,7 +75,7 @@ class DailyResultsDir(ResultsDir):
         ),
         "outputs_directory_date_format": Field(
             String,
-            default_value="%Y-%m-%d",  # noqa: WPS323
+            default_value="%Y-%m-%d",
             is_required=False,
             description="Format string for structuring the name of the daily outputs directory",  # noqa: E501
         ),
@@ -100,8 +100,9 @@ def daily_dir(
 
     :yield: An instance of a daily results directory
     """
-    run_dir = os.path.join(
-        os.getcwd() or resource_context.resource_config["outputs_root_dir"],
+    run_dir = os.path.join(  # noqa: PTH118
+        os.getcwd()  # noqa: PTH109
+        or resource_context.resource_config["outputs_root_dir"],
         resource_context.dagster_run.run_id,
     )
     results_dir = DailyResultsDir(

--- a/src/ol_orchestrate/resources/postgres_db.py
+++ b/src/ol_orchestrate/resources/postgres_db.py
@@ -1,17 +1,17 @@
 """Resource for connection to a postgres db."""
 
-import pandas
+import pandas  # noqa: ICN001
 import psycopg2
-import pyarrow
+import pyarrow  # noqa: ICN001
 from dagster import Field, InitResourceContext, Int, String, resource
-from pypika import Query
+from pypika import Query  # noqa: TCH002
 
 DEFAULT_POSTGRES_PORT = 5432
 DEFAULT_POSTGRES_QUERY_CHUNKSIZE = 5000
 
 
 class PostgresClient:
-    def __init__(  # noqa: WPS211
+    def __init__(  # noqa: PLR0913
         self,
         hostname: str,
         username: str,
@@ -60,7 +60,7 @@ class PostgresClient:
 
         :rtype: Table
         """
-        for chunk in pandas.read_sql_query(  # noqa: WPS352
+        for chunk in pandas.read_sql_query(
             str(query),
             self.connection,
             chunksize=chunksize,

--- a/src/ol_orchestrate/resources/sqlite_db.py
+++ b/src/ol_orchestrate/resources/sqlite_db.py
@@ -1,7 +1,7 @@
 import sqlite3
 
 from dagster import Field, InitResourceContext, String, resource
-from pypika import Query
+from pypika import Query  # noqa: TCH002
 
 DEFAULT_MYSQL_PORT = 3306
 

--- a/src/ol_orchestrate/sensors/sync_gcs_to_s3.py
+++ b/src/ol_orchestrate/sensors/sync_gcs_to_s3.py
@@ -15,4 +15,3 @@ def check_new_gcs_assets_sensor(context: SensorEvaluationContext):
             )
         else:
             yield SkipReason("No new files in GCS bucket")
-            return


### PR DESCRIPTION
## Description
Replaces our use of wemake-python-styleguide, isort, autoflake, and pyupgrade with [Ruff](https://github.com/charliermarsh/ruff)

## Motivation and Context
The wemake-python-styleguide project appears to be inactive and has an unpredictable future. In its current state it is incompatible with the newest Flake8 version, which prevents us from upgrading our pre-commit hooks. Ruff is a tool that subsumes a number of our other pre-commit checks and does it much faster, while providing a substantial rule set that largely matches our previous rules.

## How Has This Been Tested?
Ran `pre-commit run --all-files` and ensured it passed.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Enhancement (improves on existing behavior)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project. (Did you install and run the pre-commit hooks?)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
