### PR TITLE
add edx course readable_id to mitxonline/xpro

### DIFF
--- a/src/ol_dbt/models/intermediate/mitxonline/_int_mitxonline__models.yml
+++ b/src/ol_dbt/models/intermediate/mitxonline/_int_mitxonline__models.yml
@@ -670,6 +670,12 @@ models:
     tests:
     - unique
     - not_null
+  - name: courserun_edx_readable_id
+    description: str, The edx course ID of the course run in the format as {org}/{course}/{run}.
+      it can be used to match courserun_readable_id in int__edxorg__mitx_courseruns
+    tests:
+    - unique
+    - not_null
   - name: courserun_tag
     description: str, string that identifies a single run in a course E.g. 1T2022
     tests:

--- a/src/ol_dbt/models/intermediate/mitxonline/int__mitxonline__course_runs.sql
+++ b/src/ol_dbt/models/intermediate/mitxonline/int__mitxonline__course_runs.sql
@@ -10,6 +10,7 @@ select
     , course_id
     , courserun_title
     , courserun_readable_id
+    , courserun_edx_readable_id
     , courserun_tag
     , courserun_url
     , courserun_start_on

--- a/src/ol_dbt/models/intermediate/mitxpro/_int_mitxpro__models.yml
+++ b/src/ol_dbt/models/intermediate/mitxpro/_int_mitxpro__models.yml
@@ -894,6 +894,12 @@ models:
     tests:
     - unique
     - not_null
+  - name: courserun_edx_readable_id
+    description: str, The edx course ID of the course run in the format as {org}/{course}/{run}.
+      it can be used to match courserun_readable_id in int__edxorg__mitx_courseruns
+    tests:
+    - unique
+    - not_null
   - name: courserun_url
     description: str, url location for the course run on MITxPro website
   - name: courserun_start_on

--- a/src/ol_dbt/models/intermediate/mitxpro/int__mitxpro__course_runs.sql
+++ b/src/ol_dbt/models/intermediate/mitxpro/int__mitxpro__course_runs.sql
@@ -9,6 +9,7 @@ select
     , course_id
     , courserun_title
     , courserun_readable_id
+    , courserun_edx_readable_id
     , courserun_tag
     , courserun_url
     , courserun_start_on

--- a/src/ol_dbt/models/staging/mitxonline/_stg_mitxonline__models.yml
+++ b/src/ol_dbt/models/staging/mitxonline/_stg_mitxonline__models.yml
@@ -45,6 +45,7 @@ models:
   tests:
   - dbt_expectations.expect_compound_columns_to_be_unique:
       column_list: ["courserun_id", "user_id"]
+
 - name: stg__mitxonline__app__postgres__courses_programenrollment
   columns:
   - name: programenrollment_id
@@ -80,6 +81,7 @@ models:
   tests:
   - dbt_expectations.expect_compound_columns_to_be_unique:
       column_list: ["program_id", "user_id"]
+
 - name: stg__mitxonline__app__postgres__ecommerce_basketdiscount
   columns:
   - name: basketdiscount_id
@@ -686,6 +688,11 @@ models:
     tests:
     - unique
     - not_null
+  - name: course_edx_readable_id
+    description: str, The edx course ID of the course in the format as {org}/{course}
+    tests:
+    - unique
+    - not_null
   - name: course_created_on
     description: timestamp, specifying when a course was initially created
   - name: course_updated_on
@@ -798,6 +805,12 @@ models:
         field: course_id
   - name: courserun_readable_id
     description: str, Open edX Course ID formatted as course-v1:{org}+{course code}+{run_tag}
+    tests:
+    - unique
+    - not_null
+  - name: courserun_edx_readable_id
+    description: str, The edx course ID of the course run in the format as {org}/{course}/{run}.
+      it can be used to match courserun_readable_id in stg__edxorg__bigquery__mitx_courserun
     tests:
     - unique
     - not_null

--- a/src/ol_dbt/models/staging/mitxonline/stg__mitxonline__app__postgres__courses_course.sql
+++ b/src/ol_dbt/models/staging/mitxonline/stg__mitxonline__app__postgres__courses_course.sql
@@ -10,6 +10,7 @@ with source as (
         , live as course_is_live
         , title as course_title
         , readable_id as course_readable_id
+        , replace(replace(readable_id, 'course-v1:', ''), '+', '/') as course_edx_readable_id
         , {{ cast_timestamp_to_iso8601('created_on') }} as course_created_on
         , {{ cast_timestamp_to_iso8601('updated_on') }} as course_updated_on
     from source

--- a/src/ol_dbt/models/staging/mitxonline/stg__mitxonline__app__postgres__courses_courserun.sql
+++ b/src/ol_dbt/models/staging/mitxonline/stg__mitxonline__app__postgres__courses_courserun.sql
@@ -14,6 +14,7 @@ with source as (
         , courseware_url_path as courserun_url
         , run_tag as courserun_tag
         , is_self_paced as courserun_is_self_paced
+        , replace(replace(courseware_id, 'course-v1:', ''), '+', '/') as courserun_edx_readable_id
         , {{ cast_timestamp_to_iso8601('start_date') }} as courserun_start_on
         , {{ cast_timestamp_to_iso8601('end_date') }} as courserun_end_on
         , {{ cast_timestamp_to_iso8601('enrollment_start') }} as courserun_enrollment_start_on

--- a/src/ol_dbt/models/staging/mitxpro/_stg_mitxpro__models.yml
+++ b/src/ol_dbt/models/staging/mitxpro/_stg_mitxpro__models.yml
@@ -1042,6 +1042,11 @@ models:
     tests:
     - unique
     - not_null
+  - name: course_edx_readable_id
+    description: str, The edx course ID of the course in the format as {org}/{course}
+    tests:
+    - unique
+    - not_null
   - name: position_in_program
     description: int, sequential number indicating the course display order in a program
       on MITxPro website
@@ -1076,6 +1081,12 @@ models:
   - name: courserun_readable_id
     description: str, Open edX Course ID formatted as course-v1:{org}+{course code}+{run_tag}
       e.g. course-v1:xPRO+MLx1+R0
+    tests:
+    - unique
+    - not_null
+  - name: courserun_edx_readable_id
+    description: str, The edx course ID of the course run in the format as {org}/{course}/{run}.
+      it can be used to match courserun_readable_id in stg__edxorg__bigquery__mitx_courserun
     tests:
     - unique
     - not_null

--- a/src/ol_dbt/models/staging/mitxpro/stg__mitxpro__app__postgres__courses_course.sql
+++ b/src/ol_dbt/models/staging/mitxpro/stg__mitxpro__app__postgres__courses_course.sql
@@ -12,6 +12,7 @@ with source as (
         , program_id
         , readable_id as course_readable_id
         , position_in_program
+        , replace(replace(readable_id, 'course-v1:', ''), '+', '/') as course_edx_readable_id
         , {{ cast_timestamp_to_iso8601('created_on') }} as course_created_on
         , {{ cast_timestamp_to_iso8601('updated_on') }} as course_updated_on
     from source

--- a/src/ol_dbt/models/staging/mitxpro/stg__mitxpro__app__postgres__courses_courserun.sql
+++ b/src/ol_dbt/models/staging/mitxpro/stg__mitxpro__app__postgres__courses_courserun.sql
@@ -13,6 +13,7 @@ with source as (
         , courseware_id as courserun_readable_id
         , courseware_url_path as courserun_url
         , run_tag as courserun_tag
+        , replace(replace(courseware_id, 'course-v1:', ''), '+', '/') as courserun_edx_readable_id
         , {{ cast_timestamp_to_iso8601('start_date') }} as courserun_start_on
         , {{ cast_timestamp_to_iso8601('end_date') }} as courserun_end_on
         , {{ cast_timestamp_to_iso8601('enrollment_start') }} as courserun_enrollment_start_on


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This PR adds course_edx_readable_id to staging and intermediate models, these can be used to link courses between edx and MITxOnlin/xPro
int__mitxpro__course_runs
stg__mitxpro__app__postgres__courses_courserun
int__mitxonline__course_runs
stg__mitxonline__app__postgres__courses_courserun

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
https://github.com/mitodl/ol-data-platform/issues/552

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
ran `dbt run` and `dbt test` on affected models

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Enhancement (improves on existing behavior)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project. (Did you install and run the pre-commit hooks?)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
