### PR TITLE
568 update edxorg intermediate models

### DIFF
--- a/src/ol_dbt/macros/translate_course_id_to_platform.sql
+++ b/src/ol_dbt/macros/translate_course_id_to_platform.sql
@@ -1,0 +1,8 @@
+{% macro translate_course_id_to_platform(course_id) %}
+        case
+            when {{ course_id }} like 'MITxT%' then '{{ var("mitxonline") }}'
+            when {{ course_id }} like 'xPRO%' then '{{ var("mitxpro") }}'
+            when {{ course_id }} is null then null
+            else '{{ var("edxorg") }}'
+        end
+{% endmacro %}

--- a/src/ol_dbt/models/intermediate/edxorg/_int_edxorg__models.yml
+++ b/src/ol_dbt/models/intermediate/edxorg/_int_edxorg__models.yml
@@ -3,7 +3,7 @@ version: 2
 
 models:
 - name: int__edxorg__mitx_courseruns
-  description: Intermediate model for MITx course runs from edx.org
+  description: Intermediate model for MITx course runs on edx.org
   columns:
   - name: courserun_readable_id
     description: str, The canonical ID of the course run in the format as {org}/{course}/{run}
@@ -11,7 +11,7 @@ models:
     - unique
     - not_null
   - name: courserun_title
-    description: str, The title of the course run
+    description: str, The title of the course run on edx.org
     tests:
     - not_null
   - name: courserun_url
@@ -45,20 +45,17 @@ models:
     - relationships:
         to: ref('stg__micromasters__app__postgres__courses_course')
         field: course_id
-  tests:
-  - dbt_expectations.expect_table_row_count_to_equal_other_table:
-      compare_model: ref('stg__edxorg__bigquery__mitx_courserun')
 
 - name: int__edxorg__mitx_courserun_certificates
   description: Intermediate model for course run certificates from edx.org
   columns:
   - name: courseruncertificate_id
-    description: int, sequential ID of the certificate
+    description: int, sequential ID of the certificate on edx.org
     tests:
     - not_null
     - unique
   - name: user_id
-    description: int, Numerical user ID of a learner on the edX platform
+    description: int, Numerical user ID of a learner on edx.org
     tests:
     - not_null
     - relationships:
@@ -71,11 +68,11 @@ models:
     tests:
     - not_null
   - name: user_username
-    description: str, The username of the learner on the edX platform
+    description: str, The username of the learner on edx.org
     tests:
     - not_null
   - name: user_email
-    description: str, The email address of the learner on the edX platform
+    description: str, The email address of the learner on edx.org
     tests:
     - not_null
   - name: courseruncertificate_created_on
@@ -110,10 +107,10 @@ models:
       column_list: ["user_id", "courserun_readable_id"]
 
 - name: int__edxorg__mitx_courserun_enrollments
-  description: Intermediate model for course run enrollments from edx.org
+  description: Intermediate model for course run enrollments on edx.org
   columns:
   - name: user_id
-    description: int, Numerical user ID of a learner on the edX platform
+    description: int, Numerical user ID of a learner on edx.org
     tests:
     - not_null
     - relationships:
@@ -130,7 +127,7 @@ models:
     tests:
     - not_null
   - name: user_email
-    description: str, The email address of the learner on the edX platform
+    description: str, The email address of the learner on edx.org
     tests:
     - not_null
   - name: courserunenrollment_created_on
@@ -150,12 +147,12 @@ models:
     data
   columns:
   - name: user_id
-    description: int, Numerical user ID on the edX platform
+    description: int, Numerical user ID on edx.org
     tests:
     - not_null
     - unique
   - name: user_username
-    description: str, The unique username of the user on the edX platform
+    description: str, The unique username of the user on edx.org
     tests:
     - not_null
     - unique
@@ -165,9 +162,9 @@ models:
     tests:
     - not_null
   - name: user_full_name
-    description: str, The full name of the user on the edX platform
+    description: str, The full name of the user on edx.org
   - name: user_country
-    description: str, Country provided by the user on the edX platform
+    description: str, Country provided by the user on edx.org
   - name: user_joined_on
     description: timestamp, timestamp that the user's account was created.
   - name: user_gender
@@ -181,7 +178,7 @@ models:
   description: Intermediate model for course run grades from edx.org
   columns:
   - name: user_id
-    description: int, Numerical user ID of a learner on the edX platform
+    description: int, Numerical user ID of a learner on edx.org
     tests:
     - not_null
     - relationships:
@@ -192,11 +189,11 @@ models:
     tests:
     - not_null
   - name: user_username
-    description: str, The username of the learner on the edX platform
+    description: str, The username of the learner on edx.org
     tests:
     - not_null
   - name: user_email
-    description: str, The email address of the learner on the edX platform
+    description: str, The email address of the learner on edx.org
     tests:
     - not_null
   - name: courserungrade_passing_grade
@@ -219,7 +216,7 @@ models:
     from tracking events
   columns:
   - name: user_id
-    description: int, Numerical user ID of a learner on the edX platform
+    description: int, Numerical user ID of a learner on edx.org
     tests:
     - dbt_expectations.expect_column_to_exist
     - not_null
@@ -232,12 +229,12 @@ models:
     - dbt_expectations.expect_column_to_exist
     - not_null
   - name: user_username
-    description: str, The username of the learner on the edX platform
+    description: str, The username of the learner on edx.org
     tests:
     - dbt_expectations.expect_column_to_exist
     - not_null
   - name: user_email
-    description: str, The email address of the learner on the edX platform
+    description: str, The email address of the learner on edx.org
     tests:
     - dbt_expectations.expect_column_to_exist
     - not_null

--- a/src/ol_dbt/models/intermediate/edxorg/int__edxorg__mitx_courserun_certificates.sql
+++ b/src/ol_dbt/models/intermediate/edxorg/int__edxorg__mitx_courserun_certificates.sql
@@ -3,13 +3,17 @@
 with person_courses as (
     select *
     from {{ ref('stg__edxorg__bigquery__mitx_person_course') }}
-    where courseruncertificate_is_earned = true
+    where
+        courserun_platform = '{{ var("edxorg") }}'
+        and courseruncertificate_is_earned = true
 )
 
 , user_info_combo as (
     select *
     from {{ ref('stg__edxorg__bigquery__mitx_user_info_combo') }}
-    where courseruncertificate_id is not null
+    where
+        courserun_platform = '{{ var("edxorg") }}'
+        and courseruncertificate_id is not null
 )
 
 , certificates as (

--- a/src/ol_dbt/models/intermediate/edxorg/int__edxorg__mitx_courserun_enrollments.sql
+++ b/src/ol_dbt/models/intermediate/edxorg/int__edxorg__mitx_courserun_enrollments.sql
@@ -1,4 +1,4 @@
--- Course Run Enrollment information for edx.org
+-- Course Run Enrollment information from edx.org
 
 with enrollments as (
     select
@@ -9,6 +9,7 @@ with enrollments as (
         , courserunenrollment_enrollment_mode
         , courserunenrollment_is_active
     from {{ ref('stg__edxorg__bigquery__mitx_person_course') }}
+    where courserun_platform = '{{ var("edxorg") }}'
 )
 
 , runs as (

--- a/src/ol_dbt/models/intermediate/edxorg/int__edxorg__mitx_courserun_grades.sql
+++ b/src/ol_dbt/models/intermediate/edxorg/int__edxorg__mitx_courserun_grades.sql
@@ -1,4 +1,4 @@
--- Course Run Grades information for edx.org
+-- Course Run Grades information from edx.org
 
 with grades as (
     select
@@ -8,6 +8,7 @@ with grades as (
         , courserungrade_user_grade
         , courserungrade_is_passing
     from {{ ref('stg__edxorg__bigquery__mitx_person_course') }}
+    where courserun_platform = '{{ var("edxorg") }}'
 )
 
 , runs as (

--- a/src/ol_dbt/models/intermediate/edxorg/int__edxorg__mitx_courseruns.sql
+++ b/src/ol_dbt/models/intermediate/edxorg/int__edxorg__mitx_courseruns.sql
@@ -1,9 +1,10 @@
--- MITx Course Runs information for edx.org
+-- MITx Course Runs from edx.org
 ---It also adds a field micromaster_program_id so that we could use it to get program requirements from MicroMaster
 
 
 with runs as (
     select * from {{ ref('stg__edxorg__bigquery__mitx_courserun') }}
+    where courserun_platform = '{{ var("edxorg") }}'
 )
 
 --- MicroMasters's course_edx_key can either be {org}+{course_number} or course-v1:{org}+{course_number}, so it

--- a/src/ol_dbt/models/intermediate/edxorg/int__edxorg__mitx_user_courseactivities.sql
+++ b/src/ol_dbt/models/intermediate/edxorg/int__edxorg__mitx_user_courseactivities.sql
@@ -1,5 +1,6 @@
 with person_courses as (
     select * from {{ ref('stg__edxorg__bigquery__mitx_person_course') }}
+    where courserun_platform = '{{ var("edxorg") }}'
 )
 
 , runs as (

--- a/src/ol_dbt/models/intermediate/edxorg/int__edxorg__mitx_users.sql
+++ b/src/ol_dbt/models/intermediate/edxorg/int__edxorg__mitx_users.sql
@@ -1,4 +1,4 @@
----Intermediate MITx users for edx.org
+---Intermediate MITx users from edx.org
 ---user data is mostly in user_info_combo but email or username could be blank in user_info_combo in some older courses,
 ---to get the most recent user data, we combine user_info_combo and email_opt_in here to always use username
 -- and email from email_opt_in and the rest profile fields from user_info_combo
@@ -6,6 +6,7 @@
 
 with user_info_combo as (
     select * from {{ ref('stg__edxorg__bigquery__mitx_user_info_combo') }}
+    where courserun_platform = '{{ var("edxorg") }}'
 )
 
 --- email_opt_in is one row per course_id with the same user_* data, use window function to pick one per user_id
@@ -17,6 +18,7 @@ with user_info_combo as (
         , user_full_name
         , row_number() over (partition by user_id order by user_email_opt_in_updated_on desc) as row_num
     from {{ ref('stg__edxorg__bigquery__mitx_user_email_opt_in') }}
+    where courserun_platform = '{{ var("edxorg") }}'
 )
 
 , most_recent_user_info as (

--- a/src/ol_dbt/models/staging/edxorg/_edxorg_sources.yml
+++ b/src/ol_dbt/models/staging/edxorg/_edxorg_sources.yml
@@ -91,7 +91,8 @@ sources:
         number}/{semester}. Note that this is old format as IR converts any new format
         (course-v1:{org}+{course}+{run}) into old ones
     - name: user_id
-      description: int, Numerical user ID of a learner on the edX platform
+      description: int, Numerical user ID of a learner on a specific edX platform
+        - MITx Online/xPro open edx or edx.org
     - name: username
       description: str, username of a learner on the edX platform
     - name: registered
@@ -312,7 +313,8 @@ sources:
       is not always populated.
     columns:
     - name: user_id
-      description: int, Numerical user ID of a learner on the edX platform (not unique)
+      description: int, Numerical user ID of a learner on a specific edX platform
+        - MITx Online/xPro open edx or edx.org
     - name: username
       description: str, The username of the learner on the edX platform (not unique)
     - name: email
@@ -436,7 +438,8 @@ sources:
     - name: course_id
       description: str, The canonical ID of the course in the format as {org}/{course}/{run}.
     - name: user_id
-      description: int, Numerical user ID of a learner on the edX platform
+      description: int, Numerical user ID of a learner on a specific edX platform
+        - MITx Online/xPro open edx or edx.org
     - name: username
       description: str, username of a learner on the edX platform
     - name: email

--- a/src/ol_dbt/models/staging/edxorg/_stg__edxorg__models.yml
+++ b/src/ol_dbt/models/staging/edxorg/_stg__edxorg__models.yml
@@ -11,6 +11,13 @@ models:
     tests:
     - unique
     - not_null
+  - name: courserun_platform
+    description: str, indicating what platform the course is from, MITx Online/xPro
+      open edx or edx.org
+    tests:
+    - not_null
+    - accepted_values:
+        values: '{{ var("platforms") }}'
   - name: courserun_title
     description: str, The title of the course run
     tests:
@@ -39,7 +46,8 @@ models:
 - name: stg__edxorg__bigquery__mitx_person_course
   columns:
   - name: user_id
-    description: int, Numerical user ID of a learner on the edX platform
+    description: int, Numerical user ID of a learner on a specific edX platform -
+      MITx Online/xPro open edx or edx.org
     tests:
     - not_null
   - name: courserun_readable_id
@@ -48,6 +56,13 @@ models:
       that use new format
     tests:
     - not_null
+  - name: courserun_platform
+    description: str, indicating what platform the data is from, MITx Online/xPro
+      open edx or edx.org
+    tests:
+    - not_null
+    - accepted_values:
+        values: '{{ var("platforms") }}'
   - name: user_username
     description: str, username of a learner on the edX platform (some blank from source)
   - name: user_gender
@@ -165,9 +180,13 @@ models:
     in a course from IRx BigQuery.
   columns:
   - name: user_id
-    description: int, Numerical user ID of a learner on the edX platform
+    description: int, Numerical user ID of a learner on a specific edX platform -
+      MITx Online/xPro open edx or edx.org
     tests:
     - not_null
+  - name: courserun_platform
+    description: str, indicating what platform the data is from, MITx Online/xPro
+      open edx or edx.org. It could be null in this table
   - name: user_username
     description: str, The username of the learner on the edX platform
   - name: user_full_name
@@ -260,16 +279,37 @@ models:
     this table are the most recent data
   columns:
   - name: user_id
-    description: int, Numerical user ID of a learner on the edX platform
+    description: int, Numerical user ID of a learner on a specific edX platform -
+      MITx Online/xPro open edx or edx.org
+    tests:
+    - not_null
   - name: user_username
     description: str, The username of the user on the edX platform
+    tests:
+    - not_null
   - name: user_email
     description: str, The email address of the user on the edX platform
+    tests:
+    - not_null
   - name: user_full_name
     description: str, The full name of the user on the edX platform
+  - name: courserun_readable_id
+    description: str, The course ID formatted as {org}/{course}/{run}
+    tests:
+    - not_null
+  - name: courserun_platform
+    description: str, indicating what platform the data is from, MITx Online/xPro
+      open edx or edx.org
+    tests:
+    - not_null
+    - accepted_values:
+        values: '{{ var("platforms") }}'
   - name: user_is_opted_in_for_email
     description: boolean, indicating if the learner has opted to receive marketing
       emails
   - name: user_email_opt_in_updated_on
     description: timestamp, specifying when email opt in preference was most recently
       updated
+  tests:
+  - dbt_expectations.expect_compound_columns_to_be_unique:
+      column_list: ["user_id", "courserun_readable_id"]

--- a/src/ol_dbt/models/staging/edxorg/stg__edxorg__bigquery__mitx_courserun.sql
+++ b/src/ol_dbt/models/staging/edxorg/stg__edxorg__bigquery__mitx_courserun.sql
@@ -26,6 +26,7 @@ with source as (
             else institution
         end as courserun_institution
         , replace(course_id, 'ESD.SCM1x', 'CTL.SC1x') as courserun_readable_id
+        , {{ translate_course_id_to_platform('course_id') }} as courserun_platform
         , coalesce(self_paced = 1, false) as courserun_is_self_paced
     from source
 

--- a/src/ol_dbt/models/staging/edxorg/stg__edxorg__bigquery__mitx_person_course.sql
+++ b/src/ol_dbt/models/staging/edxorg/stg__edxorg__bigquery__mitx_person_course.sql
@@ -12,6 +12,7 @@ with source as (
     select
         user_id
         , course_id as courserun_readable_id
+        , {{ translate_course_id_to_platform('course_id') }} as courserun_platform
 
         --- users
         , username as user_username

--- a/src/ol_dbt/models/staging/edxorg/stg__edxorg__bigquery__mitx_user_email_opt_in.sql
+++ b/src/ol_dbt/models/staging/edxorg/stg__edxorg__bigquery__mitx_user_email_opt_in.sql
@@ -11,6 +11,8 @@ with source as (
         , username as user_username
         , full_name as user_full_name
         , is_opted_in_for_email as user_is_opted_in_for_email
+        , course_id as courserun_readable_id
+        , {{ translate_course_id_to_platform('course_id') }} as courserun_platform
         , {{ cast_timestamp_to_iso8601('preference_set_datetime') }} as user_email_opt_in_updated_on
     from source
 

--- a/src/ol_dbt/models/staging/edxorg/stg__edxorg__bigquery__mitx_user_info_combo.sql
+++ b/src/ol_dbt/models/staging/edxorg/stg__edxorg__bigquery__mitx_user_info_combo.sql
@@ -10,6 +10,7 @@ with source as (
 
     select
         user_id
+        , {{ translate_course_id_to_platform('enrollment_course_id') }} as courserun_platform
         , email as user_email
         , username as user_username
         , id_map_hash_id as user_map_hash_id


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This PR adds platform fields to edx staging models based on course_id and fixes all the edxorg intermediate models to use the correct data from edxorg, not conflict with our open edx data (open edx data is incomplete in `raw__irx__edxorg__bigquery__mitx_person_course` and `raw__irx__edxorg__bigquery__mitx_user_info_combo` at the moment, see issue description)
This should not affect the MicroMasters logic since MM data are still in edxorg
We will create separate MITx models to combine from different sources.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
https://github.com/mitodl/ol-data-platform/issues/568

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I ran `dbt build --select staging.edxorg` and `dbt build --select intermediate.edxorg`

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Enhancement (improves on existing behavior)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project. (Did you install and run the pre-commit hooks?)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
