### PR TITLE
micromasters mart fixes

### DIFF
--- a/src/ol_dbt/models/intermediate/micromasters/mart_components/_int_micromasters_mart_component__models.yml
+++ b/src/ol_dbt/models/intermediate/micromasters/mart_components/_int_micromasters_mart_component__models.yml
@@ -5,7 +5,7 @@ models:
 - name: mart_components__micromasters_program_certificates_dedp_from_micromasters
   description: DEDP program certificate earners according to the micromasters database
   columns:
-  - name: user_username
+  - name: user_edxorg_username
     description: str, The username of the learner on the edX platform
     tests:
     - not_null
@@ -60,10 +60,8 @@ models:
 - name: mart_components__micromasters_program_certificates_dedp_from_mitxonline
   description: DEDP program certificate earners according to the mitxonline database
   columns:
-  - name: user_username
+  - name: user_edxorg_username
     description: str, The username of the learner on the edX platform
-    tests:
-    - not_null
   - name: user_email
     description: str, The email address of the learner on the edX platform
     tests:
@@ -78,8 +76,6 @@ models:
     - not_null
   - name: user_edxorg_id
     description: int, Numerical user ID of a learner on the edX platform
-    tests:
-    - not_null
   - name: user_gender
     description: str, user's gender from edxorg - blank means user did not specify
       a gender. Null means this student signed up before this information was collected
@@ -118,7 +114,7 @@ models:
   description: Non DEDP program certificate earners. Calculated from joining edxorg
     course certificate records to the program requirements from the micromasters database
   columns:
-  - name: user_username
+  - name: user_edxorg_username
     description: str, The username of the learner on the edX platform
     tests:
     - not_null

--- a/src/ol_dbt/models/intermediate/micromasters/mart_components/mart_components__micromasters_program_certificates_dedp_from_micromasters.sql
+++ b/src/ol_dbt/models/intermediate/micromasters/mart_components/mart_components__micromasters_program_certificates_dedp_from_micromasters.sql
@@ -27,7 +27,7 @@ with mm_program_certificates as (
 )
 
 select
-    micromasters_users.user_edxorg_username as user_username
+    micromasters_users.user_edxorg_username as user_edxorg_username
     , micromasters_users.user_email
     , micromasters_programs.program_id as micromasters_program_id
     , micromasters_programs.program_title

--- a/src/ol_dbt/models/intermediate/micromasters/mart_components/mart_components__micromasters_program_certificates_dedp_from_mitxonline.sql
+++ b/src/ol_dbt/models/intermediate/micromasters/mart_components/mart_components__micromasters_program_certificates_dedp_from_mitxonline.sql
@@ -30,22 +30,22 @@ with mitxonline_program_certificates as (
 )
 
 select
-    micromasters_users.user_edxorg_username as user_username
+    micromasters_users.user_edxorg_username as user_edxorg_username
     , micromasters_users.user_email
     , micromasters_programs.program_id as micromasters_program_id
     , micromasters_programs.program_title
     , edx_users.user_id as user_edxorg_id
     , edx_users.user_gender
-    , edx_users.user_country
     , micromasters_profiles.user_address_city
     , micromasters_profiles.user_first_name
     , micromasters_profiles.user_last_name
     , micromasters_profiles.user_address_postal_code
     , micromasters_profiles.user_street_address
     , micromasters_profiles.user_address_state_or_territory
-    , edx_users.user_full_name
     , mitxonline_program_certificates.programcertificate_created_on as program_completion_timestamp
     , micromasters_profiles.user_id as micromasters_user_id
+    , coalesce(edx_users.user_country, mitxonline_users.user_address_country) as user_country
+    , coalesce(edx_users.user_full_name, mitxonline_users.user_full_name) as user_full_name
     , substring(micromasters_profiles.user_birth_date, 1, 4) as user_year_of_birth
 from mitxonline_program_certificates
 left join mitxonline_users on mitxonline_users.user_id = mitxonline_program_certificates.user_id

--- a/src/ol_dbt/models/intermediate/micromasters/mart_components/mart_components__micromasters_program_certificates_non_dedp.sql
+++ b/src/ol_dbt/models/intermediate/micromasters/mart_components/mart_components__micromasters_program_certificates_non_dedp.sql
@@ -124,7 +124,7 @@ with edx_course_certificates as (
 
 , non_dedp_certificates as (
     select
-        edx_users.user_username
+        edx_users.user_username as user_edxorg_username
         , edx_users.user_email
         , micromasters_programs.program_id as micromasters_program_id
         , micromasters_programs.program_title
@@ -161,7 +161,7 @@ with edx_course_certificates as (
 
 , non_dedp_overides as (
     select
-        edx_users.user_username
+        edx_users.user_username as user_edxorg_username
         , edx_users.user_email
         , micromasters_programs.program_id as micromasters_program_id
         , micromasters_programs.program_title
@@ -192,7 +192,7 @@ with edx_course_certificates as (
             non_dedp_certificates.user_edxorg_id
             = program_certificates_override_list.user_edxorg_id and non_dedp_certificates.micromasters_program_id
             = program_certificates_override_list.micromasters_program_id
-    where non_dedp_certificates.user_username is null
+    where non_dedp_certificates.user_edxorg_username is null
 )
 
 select *

--- a/src/ol_dbt/models/marts/micromasters/_marts_micromasters__models.yml
+++ b/src/ol_dbt/models/marts/micromasters/_marts_micromasters__models.yml
@@ -5,16 +5,12 @@ models:
 - name: marts__micromasters_program_certificates
   description: MicroMasters program certificate earners
   columns:
-  - name: user_username
+  - name: user_edxorg_username
     description: str, The username of the learner on the edX platform
     tests:
     - not_null
   - name: user_email
     description: str, The email address of the learner on the edX platform
-    tests:
-    - not_null
-  - name: micromasters_program_id
-    description: int, sequential ID representing a program in MicroMasters
     tests:
     - not_null
   - name: program_title
@@ -23,22 +19,29 @@ models:
     - not_null
   - name: user_edxorg_id
     description: int, Numerical user ID of a learner on the edX platform
+  - name: program_completion_timestamp
+    description: timestamp, timestamp of the course certificate that completed the
+      program
   - name: user_gender
     description: str, user's gender from edxorg - blank means user did not specify
       a gender. Null means this student signed up before this information was collected
     tests:
     - accepted_values:
         values: ['Male', 'Female', 'Other/Prefer Not to Say', '', null]
-  - name: user_country
-    description: str, Country provided by the user on the edX platform
   - name: user_address_city
     description: str, city where user lives in, collected from the micromasters database
   - name: user_first_name
     description: str, first from the micromasters profile
   - name: user_last_name
     description: str, last name from the micromasters profile
+  - name: user_full_name
+    description: str, The full name of the user. Taken from either the edX database
+      or the mitxonline database
   - name: user_year_of_birth
     description: str, user's birth year from the profile in the micromasters database
+  - name: user_country
+    description: str, Country provided by the user either on the edX platform or the
+      mitxonline platform
   - name: user_address_postal_code
     description: str, postal code where user lives in from the profile in micromasters
   - name: user_street_address
@@ -47,10 +50,3 @@ models:
   - name: user_address_state_or_territory
     description: str,  state or territory where user lives in from the profile in
       the micromasters database
-  - name: user_full_name
-    description: str, The full name of the user on the edX platform
-  - name: program_completion_timestamp
-    description: timestamp, timestamp of the course certificate that completed the
-      program
-  - name: micromasters_user_id
-    description: str, user id in the micromasters database

--- a/src/ol_dbt/models/marts/micromasters/marts__micromasters_program_certificates.sql
+++ b/src/ol_dbt/models/marts/micromasters/marts__micromasters_program_certificates.sql
@@ -36,6 +36,21 @@ with program_certificates_dedp_from_micromasters as (
 )
 
 
-select *
+select
+    user_edxorg_username
+    , user_email
+    , program_title
+    , user_edxorg_id
+    , program_completion_timestamp
+    , user_gender
+    , user_address_city
+    , user_first_name
+    , user_last_name
+    , user_full_name
+    , user_year_of_birth
+    , user_country
+    , user_address_postal_code
+    , user_street_address
+    , user_address_state_or_territory
 from report
 order by program_completion_timestamp desc

--- a/src/ol_dbt/models/staging/edxorg/stg__edxorg__bigquery__mitx_person_course.sql
+++ b/src/ol_dbt/models/staging/edxorg/stg__edxorg__bigquery__mitx_person_course.sql
@@ -11,7 +11,7 @@ with source as (
 
     select
         user_id
-        , course_id as courserun_readable_id
+        , replace(course_id, 'ESD.SCM1x', 'CTL.SC1x') as courserun_readable_id
         , {{ translate_course_id_to_platform('course_id') }} as courserun_platform
 
         --- users


### PR DESCRIPTION

## Description
closes https://github.com/mitodl/ol-data-platform/issues/563

This makes the following updates
1) We replace ESD.SCM1x' with 'CTL.SC1x' in the courserun_readable_ids in stg__edxorg__bigquery__mitx_user_info_combo so that that course matches the course id in micromasters and the course id naming scheme for other courses. We need to also do this in stg__edxorg__bigquery__mitx_person_course or the certificates earned in that course are missing from int__edxorg__mitx_courserun_certificates
2) Some mitxonline DEDP learners don't have a edx account (or we can't match them to edx user info) we should get country and full name for those users from the mitxonline user data
3) Peter asked for a specific column order in the final mart