### PR TITLE
implement MITx course enrollments and add verified DEDP enrollments

### DIFF
--- a/src/ol_dbt/models/intermediate/edxorg/_int_edxorg__models.yml
+++ b/src/ol_dbt/models/intermediate/edxorg/_int_edxorg__models.yml
@@ -131,7 +131,8 @@ models:
   - name: courserunenrollment_created_on
     description: timestamp, timestamp of user's enrollment in the course
   - name: courserunenrollment_enrollment_mode
-    description: str, enrollment mode, e.g. honor, audit, verified
+    description: str, enrollment mode, e.g. honor, audit, verified. For edx.org DEDP
+      courses, enrollments are verified in MicroMasters orders
   - name: courserunenrollment_is_active
     description: boolean, indicating if enrollment is active or not
   - name: courserun_title
@@ -196,6 +197,9 @@ models:
   - name: user_last_login
     description: timestamp, Timestamp indicating the last time the user logged into
       the edX platform
+  - name: user_mitxonline_username
+    description: str, username on MITx Online if user's account is linked on MicroMasters
+      portal
 
 - name: int__edxorg__mitx_courserun_grades
   description: Intermediate model for course run grades from edx.org

--- a/src/ol_dbt/models/intermediate/mitx/_int_mitx__models.yml
+++ b/src/ol_dbt/models/intermediate/mitx/_int_mitx__models.yml
@@ -37,3 +37,61 @@ models:
   tests:
   - dbt_expectations.expect_compound_columns_to_be_unique:
       column_list: ["user_id", "platform"]
+
+- name: int__mitx__courserun_enrollments
+  description: MITx courserun enrollments combined from MITx Online and edX.org
+  columns:
+  - name: platform
+    description: string, indicating application where the data is from. It's either
+      MITx Online or edX.org
+    tests:
+    - not_null
+    - accepted_values:
+        values: ["MITx Online", "edX.org"]
+  - name: courserunenrollment_is_active
+    description: boolean, indicating whether the user is still enrolled in the run
+    tests:
+    - not_null
+  - name: courserunenrollment_created_on
+    description: timestamp, specifying when an enrollment was initially created
+    tests:
+    - not_null
+  - name: courserunenrollment_enrollment_mode
+    description: str, enrollment mode for MITx courses. DEDP enrollments are verified
+      in either MITx Online or MicroMasters orders. For DEDP runs on edX.org or DEDP
+      runs on MITx Online in '3T2021', '1T2022', '2T2022', these are paid and verified
+      in MicroMasters. For other DEDP courses that run on MITx Online, they are paid
+      and verified in MITx Online
+    tests:
+    - not_null
+  - name: courserunenrollment_enrollment_status
+    description: str, enrollment status for users whose enrollment changed. Only applicable
+      for MITx Online, In MITx Online options are 'deferred', 'transferred', 'refunded',
+      'enrolled', 'unenrolled', maybe blank
+    tests:
+    - accepted_values:
+        values: ['deferred', 'transferred', 'refunded', 'unenrolled']
+  - name: user_id
+    description: int, user ID on the corresponding platform - MITx Online or edX.org
+    tests:
+    - not_null
+  - name: courserun_readable_id
+    description: str, course run ID on edX.org or MITxOnline. Open edX Course ID formatted
+      as course-v1:{org}+{course code}+{run_tag}
+    tests:
+    - not_null
+  - name: courserun_title
+    description: str, title of the course run, maybe blank for some edX.org runs
+  - name: user_email
+    description: str, user email associated with their account
+    tests:
+    - not_null
+  - name: user_mitxonline_username
+    description: str, username on MITx Online if user's account is linked on MicroMasters
+      portal
+  - name: user_edxorg_username
+    description: str, username in edx.org. For the very small number of users with
+      multiple edx usernames, this is the username with the latest logins
+  tests:
+  - dbt_expectations.expect_compound_columns_to_be_unique:
+      column_list: ["user_email", "courserun_readable_id"]

--- a/src/ol_dbt/models/intermediate/mitx/int__mitx__courserun_enrollments.sql
+++ b/src/ol_dbt/models/intermediate/mitx/int__mitx__courserun_enrollments.sql
@@ -1,0 +1,50 @@
+--- MITx course enrollments from MITx Online and edX.org with no duplication
+--- For DEDP courses, verified enrollments are already handled in MITx Online
+--  and edX.org enrollment intermediate models
+
+{{ config(materialized='view') }}
+
+with mitxonline_enrollments as (
+    select *
+    from {{ ref('int__mitxonline__courserunenrollments') }}
+    --- to dedup, filter out migrated DEDP course enrollments for courses that run on edX.org
+    where courserunenrollment_platform = '{{ var("mitxonline") }}'
+)
+
+, edxorg_enrollments as (
+    select * from {{ ref('int__edxorg__mitx_courserun_enrollments') }}
+)
+
+, mitx_enrollments as (
+    select
+        '{{ var("mitxonline") }}' as platform
+        , courserunenrollment_is_active
+        , courserunenrollment_created_on
+        , courserunenrollment_enrollment_mode
+        , courserunenrollment_enrollment_status
+        , courserun_title
+        , courserun_readable_id
+        , user_id
+        , user_email
+        , user_edxorg_username
+        , user_username as user_mitxonline_username
+    from mitxonline_enrollments
+
+    union all
+
+    select
+        '{{ var("edxorg") }}' as platform
+        , courserunenrollment_is_active
+        , courserunenrollment_created_on
+        , courserunenrollment_enrollment_mode
+        , null as courserunenrollment_enrollment_status
+        , courserun_title
+        , courserun_readable_id
+        , user_id
+        , user_email
+        , user_username as user_edxorg_username
+        , user_mitxonline_username
+    from edxorg_enrollments
+)
+
+select * from mitx_enrollments

--- a/src/ol_dbt/models/intermediate/mitxonline/_int_mitxonline__models.yml
+++ b/src/ol_dbt/models/intermediate/mitxonline/_int_mitxonline__models.yml
@@ -518,14 +518,28 @@ models:
     tests:
     - not_null
   - name: courserunenrollment_enrollment_mode
-    description: str, enrollment mode for user
+    description: str, enrollment mode for enrolled courses in MITx Online database.
+      DEDP enrollments for MITx Online courses are verified in either MITx Online
+      or MicroMasters orders. For DEDP runs on MITx Online in '3T2021', '1T2022',
+      '2T2022', these are paid and verified in MicroMasters. For other DEDP courses
+      that run on MITx Online, they are paid and verified in MITx Online
+    tests:
+    - not_null
+    - accepted_values:
+        values: ['verified', 'audit', 'honor']
   - name: courserunenrollment_enrollment_status
     description: str, enrollment status for users whose enrollment changed. Options
-      are 'deferred', 'transferred', 'refunded', 'enrolled', 'unenrolled'
+      are 'deferred', 'transferred', 'refunded', 'unenrolled', maybe null
     tests:
     - accepted_values:
-        values: ['deferred', 'transferred', 'refunded', 'enrolled', 'unenrolled',
-          '']
+        values: ['deferred', 'transferred', 'refunded', 'unenrolled']
+  - name: courserunenrollment_platform
+    description: str, indicating what platform user enrolled in the course run as
+      some of edx.org enrollments were migrated from MicroMasters
+    tests:
+    - not_null
+    - accepted_values:
+        values: ["MITx Online", "edX.org"]
   - name: courserun_title
     description: str, title of the course run
     tests:
@@ -542,6 +556,9 @@ models:
     description: str, user email associated with their account
     tests:
     - not_null
+  - name: user_edxorg_username
+    description: str, username in edx.org. For the very small number of users with
+      multiple edx usernames, this is the username with the latest logins
   tests:
   - dbt_expectations.expect_table_row_count_to_equal_other_table:
       compare_model: ref('stg__mitxonline__app__postgres__courses_courserunenrollment')
@@ -666,6 +683,10 @@ models:
       course
     tests:
     - not_null
+  - name: course_number
+    description: str, unique string for the course e.g. 14.009x
+    tests:
+    - not_null
   - name: courserun_title
     description: str, title of the course run
     tests:
@@ -681,6 +702,13 @@ models:
     tests:
     - unique
     - not_null
+  - name: courserun_platform
+    description: str, indicating whether the course runs on MITx Online or edX.org,
+      those edx.org DEDP courses were migrated from MicroMasters
+    tests:
+    - not_null
+    - accepted_values:
+        values: ["MITx Online", "edX.org"]
   - name: courserun_tag
     description: str, string that identifies a single run in a course E.g. 1T2022
     tests:
@@ -1025,6 +1053,9 @@ models:
     description: boolean, indicating if user is active or not
   - name: user_micromasters_profile_id
     description: int, foreign key to profiles_profile in MicroMasters
+  - name: user_edxorg_username
+    description: str, username in edx.org. For the very small number of users with
+      multiple edx usernames, this is the username with the latest logins
   - name: user_first_name
     description: str, first name
   - name: user_last_name

--- a/src/ol_dbt/models/intermediate/mitxonline/int__mitxonline__course_runs.sql
+++ b/src/ol_dbt/models/intermediate/mitxonline/int__mitxonline__course_runs.sql
@@ -5,19 +5,27 @@ with runs as (
     from {{ ref('stg__mitxonline__app__postgres__courses_courserun') }}
 )
 
+, courses as (
+    select * from {{ ref('stg__mitxonline__app__postgres__courses_course') }}
+)
+
+
 select
-    courserun_id
-    , course_id
-    , courserun_title
-    , courserun_readable_id
-    , courserun_edx_readable_id
-    , courserun_tag
-    , courserun_url
-    , courserun_start_on
-    , courserun_end_on
-    , courserun_enrollment_start_on
-    , courserun_enrollment_end_on
-    , courserun_upgrade_deadline
-    , courserun_is_self_paced
-    , courserun_is_live
+    runs.courserun_id
+    , runs.course_id
+    , courses.course_number
+    , runs.courserun_title
+    , runs.courserun_readable_id
+    , runs.courserun_edx_readable_id
+    , runs.courserun_tag
+    , runs.courserun_url
+    , runs.courserun_start_on
+    , runs.courserun_end_on
+    , runs.courserun_enrollment_start_on
+    , runs.courserun_enrollment_end_on
+    , runs.courserun_upgrade_deadline
+    , runs.courserun_is_self_paced
+    , runs.courserun_is_live
+    , runs.courserun_platform
 from runs
+inner join courses on runs.course_id = courses.course_id

--- a/src/ol_dbt/models/intermediate/mitxonline/int__mitxonline__courserunenrollments.sql
+++ b/src/ol_dbt/models/intermediate/mitxonline/int__mitxonline__courserunenrollments.sql
@@ -1,19 +1,92 @@
 -- Enrollment information for MITx Online
+-- For DEDP courses that run on MITx Online, enrollments are verified via their purchased orders either in MITx Online
+-- or MicroMasters. We migrated some DEDP orders from MicroMasters for those who have accounts on MITx Online, but due
+-- to migration timing issue (orders could be modified on MM after migration), we should use MM orders to verify
+-- enrollments for DEDP runs in '3T2021', '1T2022', '2T2022'
 
 with enrollments as (
     select * from {{ ref('stg__mitxonline__app__postgres__courses_courserunenrollment') }}
 )
 
-, runs as (
-    select * from {{ ref('stg__mitxonline__app__postgres__courses_courserun') }}
+, mitxonline_users as (
+    select * from {{ ref('int__mitxonline__users') }}
 )
 
-, users as (
+, mitxonline_runs as (
+    select * from {{ ref('int__mitxonline__course_runs') }}
+)
+
+, mitxonline_programs as (
+    select * from {{ ref('int__mitxonline__program_to_courses') }}
+)
+
+, mitxonline_orders as (
+    select * from {{ ref('int__mitxonline__ecommerce_order') }}
+)
+
+, micromasters_orders as (
+    select * from {{ ref('stg__micromasters__app__postgres__ecommerce_order') }}
+)
+
+, micromasters_lines as (
+    select * from {{ ref('stg__micromasters__app__postgres__ecommerce_line') }}
+)
+
+, micromasters_users as (
+    select * from {{ ref('__micromasters__users') }}
+)
+
+, dedp_enrollments_verified_in_micromasters as (
+    select
+        enrollments.user_id
+        , enrollments.courserun_id
+    from enrollments
+    inner join mitxonline_runs on enrollments.courserun_id = mitxonline_runs.courserun_id
+    inner join mitxonline_programs on mitxonline_programs.course_id = mitxonline_runs.course_id
+    inner join mitxonline_users on enrollments.user_id = mitxonline_users.user_id
+    inner join micromasters_users
+        on mitxonline_users.user_micromasters_profile_id = micromasters_users.user_profile_id
+    inner join micromasters_orders on micromasters_users.user_id = micromasters_orders.user_id
+    inner join micromasters_lines
+        on
+            mitxonline_runs.courserun_readable_id = micromasters_lines.courserun_readable_id
+            and micromasters_orders.order_id = micromasters_lines.order_id
+    where
+        mitxonline_runs.courserun_tag in ('2T2022', '1T2022', '3T2021')
+        and mitxonline_programs.program_id = {{ var("dedp_mitxonline_program_id") }}
+        and micromasters_orders.order_state = 'fulfilled'
+)
+
+, dedp_enrollments_verified_in_mitxonline as (
+    select
+        enrollments.user_id
+        , enrollments.courserun_id
+    from enrollments
+    inner join mitxonline_orders
+        on
+            mitxonline_orders.user_id = enrollments.user_id
+            and mitxonline_orders.courserun_id = enrollments.courserun_id
+    inner join mitxonline_runs on enrollments.courserun_id = mitxonline_runs.courserun_id
+    inner join mitxonline_programs on mitxonline_programs.course_id = mitxonline_runs.course_id
+    where
+        mitxonline_runs.courserun_tag not in ('2T2022', '1T2022', '3T2021')
+        and mitxonline_programs.program_id = {{ var("dedp_mitxonline_program_id") }}
+        and mitxonline_orders.order_state = 'fulfilled'
+
+)
+
+, dedp_enrollments_verified as (
     select
         user_id
-        , user_username
-        , user_email
-    from {{ ref('stg__mitxonline__app__postgres__users_user') }}
+        , courserun_id
+    from dedp_enrollments_verified_in_micromasters
+
+    union distinct
+
+    select
+        user_id
+        , courserun_id
+    from dedp_enrollments_verified_in_mitxonline
 )
 
 , mitxonline_enrollments as (
@@ -23,15 +96,27 @@ with enrollments as (
         , enrollments.user_id
         , enrollments.courserun_id
         , enrollments.courserunenrollment_created_on
-        , enrollments.courserunenrollment_enrollment_mode
         , enrollments.courserunenrollment_enrollment_status
-        , runs.courserun_title
-        , runs.courserun_readable_id
-        , users.user_username
-        , users.user_email
+        , mitxonline_runs.courserun_platform as courserunenrollment_platform
+        , mitxonline_runs.courserun_title
+        , mitxonline_runs.courserun_readable_id
+        , mitxonline_users.user_username
+        , mitxonline_users.user_email
+        , mitxonline_users.user_edxorg_username
+        , case
+            when
+                dedp_enrollments_verified.user_id is not null
+                and dedp_enrollments_verified.courserun_id is not null then 'verified'
+            else enrollments.courserunenrollment_enrollment_mode
+        end as courserunenrollment_enrollment_mode
     from enrollments
-    inner join runs on enrollments.courserun_id = runs.courserun_id
-    inner join users on enrollments.user_id = users.user_id
+    inner join mitxonline_runs on enrollments.courserun_id = mitxonline_runs.courserun_id
+    inner join mitxonline_users on enrollments.user_id = mitxonline_users.user_id
+    left join dedp_enrollments_verified
+        on
+            enrollments.user_id = dedp_enrollments_verified.user_id
+            and enrollments.courserun_id = dedp_enrollments_verified.courserun_id
+
 )
 
 select * from mitxonline_enrollments

--- a/src/ol_dbt/models/intermediate/mitxonline/int__mitxonline__users.sql
+++ b/src/ol_dbt/models/intermediate/mitxonline/int__mitxonline__users.sql
@@ -32,6 +32,10 @@ with users as (
     inner join micromasters_auth on micromasters_auth.user_id = micromasters_profiles.user_id
 )
 
+, micromasters_users as (
+    select * from {{ ref('__micromasters__users') }}
+)
+
 select
     users.user_id
     , users.user_username
@@ -59,7 +63,10 @@ select
     , users_profile.user_type_is_educator
     , users_profile.user_type_is_other
     , micromasters_profile.user_profile_id as user_micromasters_profile_id
+    , micromasters_users.user_edxorg_username
 from users
 left join users_legaladdress on users_legaladdress.user_id = users.user_id
 left join users_profile on users_profile.user_id = users.user_id
 left join micromasters_profile on micromasters_profile.user_username = users.user_username
+left join micromasters_users
+    on micromasters_profile.user_profile_id = micromasters_users.user_profile_id

--- a/src/ol_dbt/models/staging/micromasters/_stg_micromasters__models.yml
+++ b/src/ol_dbt/models/staging/micromasters/_stg_micromasters__models.yml
@@ -62,10 +62,13 @@ models:
     description: timestamp, specifying when the line was most recently updated
     tests:
     - not_null
-  - name: courserun_edx_readable_id
-    description: string, edx_course_key from courses_courserun
+  - name: courserun_readable_id
+    description: string, courserun_readable_id from courses_courserun
     tests:
     - not_null
+  - name: courserun_edxorg_readable_id
+    description: str, courserun_readable_id formatted as {org}/{course code}/{run_tag}
+      to match course in edxorg
   - name: line_price
     description: numeric, price paid for the course run
     tests:
@@ -636,6 +639,8 @@ models:
   - name: courserun_readable_id
     description: str, Open edX Course ID formatted as course-v1:{org}+{course code}+{run_tag},
       maybe blank
+  - name: courserun_tag
+    description: str, string that identifies a single run in a course E.g. 1T2022
   - name: courserun_enrollment_url
     description: str, url to enroll in the course run
   - name: courserun_is_discontinued

--- a/src/ol_dbt/models/staging/micromasters/stg__micromasters__app__postgres__courses_courserun.sql
+++ b/src/ol_dbt/models/staging/micromasters/stg__micromasters__app__postgres__courses_courserun.sql
@@ -11,6 +11,10 @@ with source as (
         , title as courserun_title
         , edx_course_key as courserun_readable_id
         , case
+            when edx_course_key like 'MITx/%' then split(edx_course_key, '/')[3]
+            when edx_course_key like 'course-v1:%' then split(edx_course_key, '+')[3]
+        end as courserun_tag
+        , case
             when courseware_backend = 'mitxonline' then '{{ var("mitxonline") }}'
             when courseware_backend = 'edxorg' then '{{ var("edxorg") }}'
             else courseware_backend

--- a/src/ol_dbt/models/staging/micromasters/stg__micromasters__app__postgres__ecommerce_line.sql
+++ b/src/ol_dbt/models/staging/micromasters/stg__micromasters__app__postgres__ecommerce_line.sql
@@ -8,7 +8,8 @@ with source as (
 
     select
         id as line_id
-        , course_key as courserun_edx_readable_id
+        , course_key as courserun_readable_id
+        , replace(replace(course_key, 'course-v1:', ''), '+', '/') as courserun_edxorg_readable_id
         , price as line_price
         , description as line_description
         , {{ cast_timestamp_to_iso8601('created_at') }} as line_created_on

--- a/src/ol_dbt/models/staging/mitxonline/_stg_mitxonline__models.yml
+++ b/src/ol_dbt/models/staging/mitxonline/_stg_mitxonline__models.yml
@@ -19,7 +19,10 @@ models:
     - not_null
   - name: courserunenrollment_enrollment_status
     description: str, enrollment status for users whose enrollment is no longer active.
-      Options are 'deferred', 'transferred', 'refunded', 'unenrolled'
+      Options are 'deferred', 'transferred', 'refunded', 'unenrolled', maybe blank
+    tests:
+    - accepted_values:
+        values: ['deferred', 'transferred', 'refunded', 'unenrolled']
   - name: courserunenrollment_is_active
     description: boolean, indicating whether the user is still enrolled in the run
     tests:
@@ -892,6 +895,13 @@ models:
     tests:
     - unique
     - not_null
+  - name: courserun_platform
+    description: str, indicating whether this course runs on MITx Online or edX.org.
+      Some of edx.org data were migrated from MicroMasters
+    tests:
+    - not_null
+    - accepted_values:
+        values: ["MITx Online", "edX.org"]
   - name: courserun_url
     description: str, url location for the course run in MITx Online
   - name: courserun_is_self_paced

--- a/src/ol_dbt/models/staging/mitxonline/stg__mitxonline__app__postgres__courses_courserun.sql
+++ b/src/ol_dbt/models/staging/mitxonline/stg__mitxonline__app__postgres__courses_courserun.sql
@@ -14,6 +14,10 @@ with source as (
         , courseware_url_path as courserun_url
         , run_tag as courserun_tag
         , is_self_paced as courserun_is_self_paced
+        , case
+            when courseware_id like 'course-v1:MITxT+%' then '{{ var("mitxonline") }}'
+            else '{{ var("edxorg") }}'
+        end as courserun_platform
         , replace(replace(courseware_id, 'course-v1:', ''), '+', '/') as courserun_edx_readable_id
         , {{ cast_timestamp_to_iso8601('start_date') }} as courserun_start_on
         , {{ cast_timestamp_to_iso8601('end_date') }} as courserun_end_on

--- a/src/ol_dbt/models/staging/mitxonline/stg__mitxonline__app__postgres__courses_courserunenrollment.sql
+++ b/src/ol_dbt/models/staging/mitxonline/stg__mitxonline__app__postgres__courses_courserunenrollment.sql
@@ -7,13 +7,17 @@ with source as (
 , cleaned as (
     select
         id as courserunenrollment_id
-        , change_status as courserunenrollment_enrollment_status
+        ---since raw data has both empty string and null, convert them to null for consistency
         , active as courserunenrollment_is_active
         , edx_enrolled as courserunenrollment_is_edx_enrolled
         , run_id as courserun_id
         , user_id
         , enrollment_mode as courserunenrollment_enrollment_mode
         , edx_emails_subscription as courserunenrollment_has_edx_email_subscription
+        , case
+            when change_status = '' then null
+            else change_status
+        end as courserunenrollment_enrollment_status
         , {{ cast_timestamp_to_iso8601('created_on') }} as courserunenrollment_created_on
         , {{ cast_timestamp_to_iso8601('updated_on') }} as courserunenrollment_updated_on
     from source


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
-  Update enrollment mode to `verified` in `int__mitxonline__courserunenrollments` if learners have paid on MITx Online or MM for MITx Online DEDP courses
   - For DEDP 3T2021, 2T2022, and 1T2022 runs, purchases were made on MM, so we use MM orders to verify these enrollments, even though we migrated these MM orders to MITx Online
   - For DEDP runs after 2T2022 (not 3T2021, 2T2022, and 1T2022), we check MITx Online orders to verify their enrollments 
- Update enrollment mode to `verified` in `int__edxorg__mitx_courserun_enrollments` if learners have paid on MM for edX.org DEDP courses
- Add MITx course enrollment model `int__mitx__courserun_enrollments` with no dups
- Some small improvements and changes like adding user_edxorg_username to MITxOnline users, user_mitxonline_username to edX.org users if applicable

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
https://github.com/mitodl/ol-data-platform/issues/628
and two mentioned in https://github.com/mitodl/hq/issues/1090
DEDP verified enrollments in MITx Online 
DEDP verified enrollments in edX.org

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
dbt run and test passed
```
dbt run --select +int__mitx__courserun_enrollments --full-refresh --var 'schema_suffix: rlougee' --target dev_production

rachellougee@Rachels-MacBook-Pro ol_dbt % dbt test --select +int__mitx__courserun_enrollments  --var 'schema_suffix: rlougee' --target dev_production              
20:26:05  Running with dbt=1.2.2
20:26:05  Found 224 models, 1671 tests, 0 snapshots, 0 analyses, 759 macros, 0 operations, 0 seed files, 119 sources, 0 exposures, 0 metrics
20:26:05  
20:26:07  Concurrency: 4 threads (target='dev_production')
20:26:07  

20:28:44  Finished running 300 tests in 0 hours 2 minutes and 39.13 seconds (159.13s).
20:28:45  
20:28:45  Completed successfully
20:28:45  
20:28:45  Done. PASS=300 WARN=0 ERROR=0 SKIP=0 TOTAL=300

```
I also checked that there are verified enrollments for 3T2021, 2T2022, and 1T2022. e.g.
```
SELECT COUNT(*) FROM "ol_data_lake_production"."ol_warehouse_production_rlougee_intermediate"."int__mitx__courserun_enrollments" 
WHERE courserun_readable_id = 'MITx/14.310x/3T2021' and courserunenrollment_enrollment_mode ='verified'
```
And make sure the MM program courses enrollments numbers don't go down when compared with https://bi.odl.mit.edu/queries/1258/source


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Enhancement (improves on existing behavior)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project. (Did you install and run the pre-commit hooks?)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
