### PR TITLE
add a few missing fields to intermediate

### DIFF
--- a/src/ol_dbt/models/intermediate/edxorg/_int_edxorg__models.yml
+++ b/src/ol_dbt/models/intermediate/edxorg/_int_edxorg__models.yml
@@ -256,7 +256,6 @@ models:
   - name: user_id
     description: int, Numerical user ID of a learner on edx.org
     tests:
-    - dbt_expectations.expect_column_to_exist
     - not_null
     - relationships:
         to: ref('int__edxorg__mitx_users')
@@ -264,121 +263,72 @@ models:
   - name: courserun_readable_id
     description: str, The canonical ID of the course run in the format as {org}/{course}/{run}.
     tests:
-    - dbt_expectations.expect_column_to_exist
     - not_null
   - name: user_username
     description: str, The username of the learner on edx.org
     tests:
-    - dbt_expectations.expect_column_to_exist
     - not_null
   - name: user_email
     description: str, The email address of the learner on edx.org
     tests:
-    - dbt_expectations.expect_column_to_exist
     - not_null
   - name: courseactivitiy_visited_once
     description: boolean, indicating that the user visited the course at least once
-    tests:
-    - dbt_expectations.expect_column_to_exist
   - name: courseactivitiy_viewed_half
     description: boolean, indicating that the user viewed at least half of the chapters
       of the course
-    tests:
-    - dbt_expectations.expect_column_to_exist
   - name: courseactivitiy_num_events
     description: int, Number of tracking log events
-    tests:
-    - dbt_expectations.expect_column_to_exist
   - name: courseactivitiy_num_activity_days
     description: int, Number of days with activity from tracking logs
-    tests:
-    - dbt_expectations.expect_column_to_exist
   - name: courseactivitiy_num_progress_check
     description: int, Number of progress check events from tracking logs
-    tests:
-    - dbt_expectations.expect_column_to_exist
   - name: courseactivitiy_num_problem_check
     description: int, Number of problem_check interaction events from tracking logs
-    tests:
-    - dbt_expectations.expect_column_to_exist
   - name: courseactivitiy_num_show_answer
     description: int, Number of show_answer events from tracking logs
-    tests:
-    - dbt_expectations.expect_column_to_exist
   - name: courseactivitiy_num_show_transcript
     description: int, Number of show_transcript video interaction events from tracking
       logs
-    tests:
-    - dbt_expectations.expect_column_to_exist
   - name: courseactivitiy_num_seq_goto
     description: int, Number of sequence_goto navigational events from tracking logs
-    tests:
-    - dbt_expectations.expect_column_to_exist
   - name: courseactivitiy_num_play_video
     description: int, Number of play_video video interaction events from tracking
       logs
-    tests:
-    - dbt_expectations.expect_column_to_exist
   - name: courseactivitiy_num_seek_video
     description: int, Number of seek_video video interaction events from tracking
       logs
-    tests:
-    - dbt_expectations.expect_column_to_exist
   - name: courseactivitiy_num_pause_video
     description: int, Number of pause_video video interaction events from tracking
       logs
-    tests:
-    - dbt_expectations.expect_column_to_exist
   - name: courseactivitiy_num_video_interactions
     description: int, Number of all the video interaction events from tracking log
-    tests:
-    - dbt_expectations.expect_column_to_exist
   - name: courseactivitiy_num_unique_videos_viewed
     description: int, Number of Unique Videos viewed per user within a course
-    tests:
-    - dbt_expectations.expect_column_to_exist
   - name: courseactivitiy_percentage_total_videos_watched
     description: int, Total number of all videos watched per user within a course
-    tests:
-    - dbt_expectations.expect_column_to_exist
   - name: courseactivitiy_average_time_diff_in_sec
     description: float, Average time difference in seconds between consecutive events
       from tracking logs
-    tests:
-    - dbt_expectations.expect_column_to_exist
   - name: courseactivitiy_standard_deviation_in_sec
     description: float, Standard deviation of difference in seconds between consecutive
       events from tracking logs
-    tests:
-    - dbt_expectations.expect_column_to_exist
   - name: courseactivitiy_max_diff_in_sec
     description: float, Maximum difference in seconds between consecutive events from
       tracking logs
-    tests:
-    - dbt_expectations.expect_column_to_exist
   - name: courseactivitiy_num_consecutive_events_used
     description: int, Number of consecutive events used in time difference computations,
       from tracking logs
-    tests:
-    - dbt_expectations.expect_column_to_exist
   - name: courseactivitiy_total_elapsed_time_in_sec
     description: int, Total elapsed time (in seconds) spent by user on this course,
       based on time difference of consecutive events, with 5 min max cutoff, from
       tracking logs
-    tests:
-    - dbt_expectations.expect_column_to_exist
   - name: courseactivitiy_first_event_timestamp
     description: timestamp, timestamp of first event of user from tracking logs
-    tests:
-    - dbt_expectations.expect_column_to_exist
   - name: courseactivitiy_last_event_timestamp
     description: timestamp, timestamp of last event of user from tracking logs
-    tests:
-    - dbt_expectations.expect_column_to_exist
   - name: courserun_title
     description: str, The title of the course run
-    tests:
-    - dbt_expectations.expect_column_to_exist
   tests:
   - dbt_expectations.expect_compound_columns_to_be_unique:
       column_list: ["user_id", "courserun_readable_id"]

--- a/src/ol_dbt/models/intermediate/mitxonline/_int_mitxonline__models.yml
+++ b/src/ol_dbt/models/intermediate/mitxonline/_int_mitxonline__models.yml
@@ -352,6 +352,10 @@ models:
     tests:
     - unique
     - not_null
+  - name: transaction_data
+    description: json, data returned from cybersource when the transaction is fulfilled
+    tests:
+    - not_null
   - name: transaction_amount
     description: numeric, transaction ammount
     tests:
@@ -533,6 +537,10 @@ models:
     tests:
     - accepted_values:
         values: ['deferred', 'transferred', 'refunded', 'unenrolled']
+  - name: courserunenrollment_is_edx_enrolled
+    description: boolean, indicating whether the user is enrolled on edx
+    tests:
+    - not_null
   - name: courserunenrollment_platform
     description: str, indicating what platform user enrolled in the course run as
       some of edx.org enrollments were migrated from MicroMasters

--- a/src/ol_dbt/models/intermediate/mitxonline/int__mitxonline__courserunenrollments.sql
+++ b/src/ol_dbt/models/intermediate/mitxonline/int__mitxonline__courserunenrollments.sql
@@ -97,6 +97,7 @@ with enrollments as (
         , enrollments.courserun_id
         , enrollments.courserunenrollment_created_on
         , enrollments.courserunenrollment_enrollment_status
+        , enrollments.courserunenrollment_is_edx_enrolled
         , mitxonline_runs.courserun_platform as courserunenrollment_platform
         , mitxonline_runs.courserun_title
         , mitxonline_runs.courserun_readable_id

--- a/src/ol_dbt/models/intermediate/mitxonline/int__mitxonline__ecommerce_transaction.sql
+++ b/src/ol_dbt/models/intermediate/mitxonline/int__mitxonline__ecommerce_transaction.sql
@@ -5,6 +5,7 @@ with transactions as (
 
 select
     transactions.transaction_id
+    , transaction_data
     , transactions.transaction_amount
     , transactions.order_id
     , transactions.transaction_created_on

--- a/src/ol_dbt/models/intermediate/mitxpro/_int_mitxpro__models.yml
+++ b/src/ol_dbt/models/intermediate/mitxpro/_int_mitxpro__models.yml
@@ -707,6 +707,10 @@ models:
     - accepted_values:
         values: ['deferred', 'transferred', 'refunded', 'enrolled', 'unenrolled',
           '', null]
+  - name: courserunenrollment_is_edx_enrolled
+    description: boolean, indicating whether the user is enrolled on edx
+    tests:
+    - not_null
   - name: courserun_title
     description: str, title of the course run
     tests:

--- a/src/ol_dbt/models/intermediate/mitxpro/int__mitxpro__courserunenrollments.sql
+++ b/src/ol_dbt/models/intermediate/mitxpro/int__mitxpro__courserunenrollments.sql
@@ -24,6 +24,7 @@ with enrollments as (
         , enrollments.courserun_id
         , enrollments.courserunenrollment_created_on
         , enrollments.courserunenrollment_enrollment_status
+        , enrollments.courserunenrollment_is_edx_enrolled
         , runs.courserun_readable_id
         , runs.courserun_title
         , users.user_username

--- a/src/ol_dbt/models/staging/bootcamps/_stg_bootcamps__models.yml
+++ b/src/ol_dbt/models/staging/bootcamps/_stg_bootcamps__models.yml
@@ -189,7 +189,7 @@ models:
     description: boolean, indicates that new cretificates shouldn't be created for
       the enrollment
     tests:
-    - dbt_expectations.expect_column_to_exist - not_null
+    - not_null
   tests:
   - dbt_expectations.expect_compound_columns_to_be_unique:
       column_list: ["user_id", "courserun_id"]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Adds `courserunenrollment_is_edx_enrolled` and `transaction_data` that is used in Customer Report - MITx Online 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
No issue created

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
dbt run and test

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Enhancement (improves on existing behavior)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project. (Did you install and run the pre-commit hooks?)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
