### PR TITLE
fix edxorg course certificate and an old DEDP course enrollment issues

### DIFF
--- a/src/ol_dbt/models/intermediate/edxorg/int__edxorg__mitx_courserun_certificates.sql
+++ b/src/ol_dbt/models/intermediate/edxorg/int__edxorg__mitx_courserun_certificates.sql
@@ -127,7 +127,9 @@ with person_courses as (
         on certificates.courserun_readable_id = runs.courserun_readable_id
     left join micromasters_users
         on certificates.user_username = micromasters_users.user_edxorg_username
-    where runs.micromasters_program_id != {{ var("dedp_micromasters_program_id") }}
+    where
+        runs.micromasters_program_id != {{ var("dedp_micromasters_program_id") }}
+        or runs.micromasters_program_id is null
 )
 
 

--- a/src/ol_dbt/models/staging/edxorg/_stg__edxorg__models.yml
+++ b/src/ol_dbt/models/staging/edxorg/_stg__edxorg__models.yml
@@ -21,8 +21,8 @@ models:
   - name: courserun_url
     description: str, The url path of the course run
   - name: course_number
-    description: str, The MIT course number for this course e.g. SysEngx1 is the course
-      number for MITxPRO/SysEngx1/1T2018
+    description: str, The MIT course number, not necessary the same as number in course
+      ID. e.g. for MITx/14.74x/3T2015, course number is 14.740x
   - name: courserun_semester
     description: str, The semester during which the course was launched e.g Fall 2020
   - name: courserun_enrollment_start_date

--- a/src/ol_dbt/models/staging/edxorg/stg__edxorg__bigquery__mitx_courserun.sql
+++ b/src/ol_dbt/models/staging/edxorg/stg__edxorg__bigquery__mitx_courserun.sql
@@ -13,7 +13,7 @@ with source as (
 , renamed as (
 
     select
-        trim(course_number) as course_number
+        replace(trim(course_number), '14.74x', '14.740x') as course_number
         , course_title as courserun_title
         , semester as courserun_semester
         , url as courserun_url


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This fixes two issues:
- edxorg course certificate model that excludes any certificates that are not part of the MM program. It propagated into int__mitx__courserun_certificates
- `MITx/14.74x/3T2015` didn't count as DEDP enrollments in `int__micromasters__course_enrollments` due to course number mismatch between edX.org and MicroMasters (14.74x from edX.org source vs 14.740x from MM).  As discussed with @pdpinch, we match `MITx/14.74x/3T2015` with [course-v1:MITx+14.74x+3T2015](https://micromasters.mit.edu/admin/courses/courserun/32/change/) from MicroMasters, thus it should count as DEDP enrollments and certificates


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
https://github.com/mitodl/ol-data-platform/issues/695
While testing the first fix, discovered the second issue.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Ran dbt on `stg__edxorg__bigquery__mitx_courserun`, `intermediate.mitx`, `intermediate.micromasters`, and `intermediate.edxorg`

Confirmed that two issues are addressed 

```
   ---25
    select COUNT(*) from "ol_data_lake_production"."ol_warehouse_production_rlougee_intermediate"."int__mitx__courserun_certificates"
    where courserun_readable_id  ='MITx/0.SolveX/3T2020'

   ---14228
    select COUNT(*) from "ol_data_lake_production"."ol_warehouse_production_rlougee_intermediate"."int__micromasters__course_enrollments"
    where courserun_readable_id  ='MITx/14.74x/3T2015'

```
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Enhancement (improves on existing behavior)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project. (Did you install and run the pre-commit hooks?)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
