### PR TITLE
create MITx program certificates and dedup DEDP certificates

### DIFF
--- a/src/ol_dbt/models/intermediate/micromasters/_int_micromasters__models.yml
+++ b/src/ol_dbt/models/intermediate/micromasters/_int_micromasters__models.yml
@@ -116,12 +116,18 @@ models:
     description: str, The username of the learner on the edX platform. For users who
       got DEDP certificates on MITx Online, this could be blank if they don't have
       their edxorg account linked on MicroMasters.
+  - name: user_mitxonline_username
+    description: str, username on MITx Online
   - name: user_email
     description: str, The email address of the learner on the edX platform
     tests:
     - not_null
   - name: program_title
     description: str, title of the program
+    tests:
+    - not_null
+  - name: micromasters_program_id
+    description: int, sequential ID representing a program in MicroMasters
     tests:
     - not_null
   - name: user_edxorg_id
@@ -157,6 +163,9 @@ models:
   - name: user_address_state_or_territory
     description: str,  state or territory where user lives in from the profile in
       the micromasters database
+  tests:
+  - dbt_expectations.expect_compound_columns_to_be_unique:
+      column_list: ["user_email", "program_title"]
 
 - name: int__micromasters__course_certificates
   description: course certificates earned for MicroMasters programs. This include

--- a/src/ol_dbt/models/intermediate/micromasters/_int_micromasters__models.yml
+++ b/src/ol_dbt/models/intermediate/micromasters/_int_micromasters__models.yml
@@ -165,7 +165,7 @@ models:
       the micromasters database
   tests:
   - dbt_expectations.expect_compound_columns_to_be_unique:
-      column_list: ["user_email", "program_title"]
+      column_list: ["user_email", "micromasters_program_id"]
 
 - name: int__micromasters__course_certificates
   description: course certificates earned for MicroMasters programs. This include

--- a/src/ol_dbt/models/intermediate/micromasters/int__micromasters__program_certificates.sql
+++ b/src/ol_dbt/models/intermediate/micromasters/int__micromasters__program_certificates.sql
@@ -22,8 +22,10 @@ with program_certificates_dedp_from_micromasters as (
 , report as (
     select
         user_edxorg_username
+        , user_mitxonline_username
         , user_email
         , program_title
+        , micromasters_program_id
         , user_edxorg_id
         , program_completion_timestamp
         , user_gender
@@ -43,8 +45,10 @@ with program_certificates_dedp_from_micromasters as (
 
     select
         user_edxorg_username
+        , user_mitxonline_username
         , user_email
         , program_title
+        , micromasters_program_id
         , user_edxorg_id
         , program_completion_timestamp
         , user_gender
@@ -64,8 +68,10 @@ with program_certificates_dedp_from_micromasters as (
 
     select
         user_edxorg_username
+        , user_mitxonline_username
         , user_email
         , program_title
+        , micromasters_program_id
         , user_edxorg_id
         , program_completion_timestamp
         , user_gender
@@ -84,8 +90,10 @@ with program_certificates_dedp_from_micromasters as (
 
 select
     user_edxorg_username
+    , user_mitxonline_username
     , user_email
     , program_title
+    , micromasters_program_id
     , user_edxorg_id
     , program_completion_timestamp
     , user_gender

--- a/src/ol_dbt/models/intermediate/micromasters/subqueries/__int_micromasters_subqueries__models.yml
+++ b/src/ol_dbt/models/intermediate/micromasters/subqueries/__int_micromasters_subqueries__models.yml
@@ -153,6 +153,8 @@ models:
     description: str, The username of the learner on the edX platform
     tests:
     - not_null
+  - name: user_mitxonline_username
+    description: str, username on MITx Online
   - name: user_email
     description: str, The email address of the learner on the edX platform
     tests:
@@ -206,6 +208,10 @@ models:
   columns:
   - name: user_edxorg_username
     description: str, The username of the learner on the edX platform
+  - name: user_mitxonline_username
+    description: str, username on MITx Online
+    tests:
+    - not_null
   - name: user_email
     description: str, The email address of the learner on the edX platform
     tests:
@@ -262,6 +268,8 @@ models:
     description: str, The username of the learner on the edX platform
     tests:
     - not_null
+  - name: user_mitxonline_username
+    description: str, username on MITx Online
   - name: user_email
     description: str, The email address of the learner on the edX platform
     tests:

--- a/src/ol_dbt/models/intermediate/micromasters/subqueries/__micromasters_program_certificates_dedp_from_micromasters.sql
+++ b/src/ol_dbt/models/intermediate/micromasters/subqueries/__micromasters_program_certificates_dedp_from_micromasters.sql
@@ -23,6 +23,7 @@ with mm_program_certificates as (
 
 select
     micromasters_users.user_edxorg_username as user_edxorg_username
+    , micromasters_users.user_mitxonline_username
     , micromasters_users.user_email
     , micromasters_programs.program_id as micromasters_program_id
     , micromasters_programs.program_title

--- a/src/ol_dbt/models/intermediate/micromasters/subqueries/__micromasters_program_certificates_dedp_from_mitxonline.sql
+++ b/src/ol_dbt/models/intermediate/micromasters/subqueries/__micromasters_program_certificates_dedp_from_mitxonline.sql
@@ -28,6 +28,7 @@ with mitxonline_program_certificates as (
 
 select
     micromasters_users.user_edxorg_username as user_edxorg_username
+    , mitxonline_users.user_username as user_mitxonline_username
     , micromasters_users.user_email
     , micromasters_programs.program_id as micromasters_program_id
     , micromasters_programs.program_title

--- a/src/ol_dbt/models/intermediate/micromasters/subqueries/__micromasters_program_certificates_non_dedp.sql
+++ b/src/ol_dbt/models/intermediate/micromasters/subqueries/__micromasters_program_certificates_non_dedp.sql
@@ -13,6 +13,7 @@ with edx_course_certificates as (
 , micromasters_program_requirements as (
     select *
     from {{ ref('int__micromasters__program_requirements') }}
+    where program_id != {{ var("dedp_micromasters_program_id") }}
 )
 
 , micromasters_users as (
@@ -24,6 +25,7 @@ with edx_course_certificates as (
 , micromasters_programs as (
     select *
     from {{ ref('int__micromasters__programs') }}
+    where program_id != {{ var("dedp_micromasters_program_id") }}
 )
 
 , program_certificates_override_list as (
@@ -122,6 +124,7 @@ with edx_course_certificates as (
 , non_dedp_certificates as (
     select
         edx_users.user_username as user_edxorg_username
+        , micromasters_users.user_mitxonline_username
         , edx_users.user_email
         , micromasters_programs.program_id as micromasters_program_id
         , micromasters_programs.program_title
@@ -157,6 +160,7 @@ with edx_course_certificates as (
 , non_dedp_overides as (
     select
         edx_users.user_username as user_edxorg_username
+        , micromasters_users.user_mitxonline_username
         , edx_users.user_email
         , micromasters_programs.program_id as micromasters_program_id
         , micromasters_programs.program_title

--- a/src/ol_dbt/models/intermediate/mitx/_int_mitx__models.yml
+++ b/src/ol_dbt/models/intermediate/mitx/_int_mitx__models.yml
@@ -288,3 +288,32 @@ models:
   tests:
   - dbt_expectations.expect_compound_columns_to_be_unique:
       column_list: ["user_email", "courserun_readable_id"]
+
+- name: int__mitx__program_certificates
+  description: MITx program certificates combined from MicroMasters and MITx Online
+  columns:
+  - name: program_title
+    description: str, title of the program
+    tests:
+    - not_null
+  - name: mitxonline_program_id
+    description: int, primary key representing the program in the MITx Online database
+  - name: micromasters_program_id
+    description: int, primary key representing the program in the MicroMasters database
+  - name: user_edxorg_username
+    description: str, username on edX.org
+  - name: user_mitxonline_username
+    description: str, username on MITx Online
+  - name: user_email
+    description: str, user email from either MITx Online or MicroMasters
+    tests:
+    - not_null
+  - name: user_full_name
+    description: str, The full name of the user taken from either MITx Online or edX.org
+  - name: program_completion_timestamp
+    description: timestamp, For MicroMasters Non DEDP programs, this is timestamp
+      of the course certificate that completed the program. For other programs, this
+      is timestamp for when program certificates were initially created
+  tests:
+  - dbt_expectations.expect_compound_columns_to_be_unique:
+      column_list: ["user_email", "program_title"]

--- a/src/ol_dbt/models/intermediate/mitx/int__mitx__program_certificates.sql
+++ b/src/ol_dbt/models/intermediate/mitx/int__mitx__program_certificates.sql
@@ -1,0 +1,47 @@
+{{ config(materialized='view') }}
+
+with micromasters_program_certificates as (
+    select * from {{ ref('int__micromasters__program_certificates') }}
+)
+
+, mitxonline_program_certificates as (
+    select * from {{ ref('int__mitxonline__program_certificates') }}
+    --- dedp is handled in micromasters_program_certificates
+    where program_id != {{ var("dedp_mitxonline_program_id") }}
+)
+
+, mitx_programs as (
+    select * from {{ ref('int__mitx__programs') }}
+)
+
+, mitx_program_certificates as (
+    select
+        micromasters_program_certificates.program_title
+        , micromasters_program_certificates.micromasters_program_id
+        , mitx_programs.mitxonline_program_id
+        , micromasters_program_certificates.program_completion_timestamp
+        , micromasters_program_certificates.user_mitxonline_username
+        , micromasters_program_certificates.user_edxorg_username
+        , micromasters_program_certificates.user_email
+        , micromasters_program_certificates.user_full_name
+    from micromasters_program_certificates
+    left join mitx_programs
+        on micromasters_program_certificates.micromasters_program_id = mitx_programs.micromasters_program_id
+
+    union all
+
+    select
+        mitxonline_program_certificates.program_title
+        , mitx_programs.micromasters_program_id
+        , mitxonline_program_certificates.program_id as mitxonline_program_id
+        , mitxonline_program_certificates.programcertificate_created_on as program_completion_timestamp
+        , mitxonline_program_certificates.user_username as user_mitxonline_username
+        , mitxonline_program_certificates.user_edxorg_username
+        , mitxonline_program_certificates.user_email
+        , mitxonline_program_certificates.user_full_name
+    from mitxonline_program_certificates
+    left join mitx_programs
+        on mitxonline_program_certificates.program_id = mitx_programs.mitxonline_program_id
+)
+
+select * from mitx_program_certificates

--- a/src/ol_dbt/models/intermediate/mitxonline/_int_mitxonline__models.yml
+++ b/src/ol_dbt/models/intermediate/mitxonline/_int_mitxonline__models.yml
@@ -1044,11 +1044,17 @@ models:
     tests:
     - not_null
   - name: user_username
-    description: string, username
+    description: str, username on MITx Online
     tests:
     - not_null
+  - name: user_edxorg_username
+    description: str, username on edX.org
   - name: user_email
-    description: string, email
+    description: str, user email on MITx Online
+    tests:
+    - not_null
+  - name: user_full_name
+    description: str, user full name on MITx Online
     tests:
     - not_null
   tests:

--- a/src/ol_dbt/models/intermediate/mitxonline/int__mitxonline__program_certificates.sql
+++ b/src/ol_dbt/models/intermediate/mitxonline/int__mitxonline__program_certificates.sql
@@ -9,7 +9,7 @@ with certificates as (
 )
 
 , users as (
-    select * from {{ ref('stg__mitxonline__app__postgres__users_user') }}
+    select * from {{ ref('int__mitxonline__users') }}
 )
 
 , program_certificates as (
@@ -24,6 +24,8 @@ with certificates as (
         , certificates.programcertificate_updated_on
         , certificates.user_id
         , users.user_username
+        , users.user_edxorg_username
+        , users.user_full_name
         , users.user_email
     from certificates
     inner join programs on certificates.program_id = programs.program_id


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
   - Removing 678 double-counted DEDP certificates in `int__micromasters__program_certificates`, which will decrease the number in the MM summary report
   - Adding the combined `int__mitx__program_certificates`

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
https://github.com/mitodl/ol-data-platform/issues/668

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Ran dbt build on `int__mitxonline__program_certificates`, `intermediate.micromasters` and `int__mitx__program_certificates`

