### PR TITLE
Add employment and education from MicroMasters

### DIFF
--- a/src/ol_dbt/models/intermediate/micromasters/_int_micromasters__models.yml
+++ b/src/ol_dbt/models/intermediate/micromasters/_int_micromasters__models.yml
@@ -263,3 +263,97 @@ models:
   tests:
   - dbt_expectations.expect_compound_columns_to_be_unique:
       column_list: ["user_email", "courserun_readable_id"]
+
+- name: int__micromasters__users
+  description: MicroMasters users
+  columns:
+  - name: user_id
+    description: int, sequential ID representing a user in MicroMasters
+    tests:
+    - unique
+    - not_null
+  - name: user_profile_id
+    description: int, foreign key to profiles_profile
+    tests:
+    - unique
+    - not_null
+  - name: user_username
+    description: str, unique string to identify user in MicroMasters
+    tests:
+    - unique
+    - not_null
+  - name: user_mitxonline_username
+    description: str, username in MITx Online
+  - name: user_edxorg_username
+    description: str, username in edX.org. For the very small number of users with
+      multiple edx usernames, this is the username with the latest logins
+  - name: user_email
+    description: str, user email associated with user account (not unique)
+    tests:
+    - not_null
+  - name: user_joined_on
+    description: timestamp, specifying when a user account was initially created
+  - name: user_last_login
+    description: timestamp, specifying when a user last logged in
+  - name: user_is_active
+    description: boolean, indicating if user is active or not
+  - name: user_preferred_language
+    description: str, user's preferred language
+  - name: user_mailing_address
+    description: str, user's mailing address on edx.org
+  - name: user_bio
+    description: str, user's biography on edx.org
+  - name: user_about_me
+    description: str, about me in user profile
+  - name: user_edx_name
+    description: str, user's full name on edx.org
+  - name: user_edx_goals
+    description: str, user's personal goal on edx.org
+  - name: user_full_name
+    description: str, user's full name
+  - name: user_first_name
+    description: str, first name on user profile
+  - name: user_last_name
+    description: str, last name on user profile
+  - name: user_preferred_name
+    description: str, user's Nickname / Preferred name
+  - name: user_nationality
+    description: str, user's nationality (stored as country code)
+  - name: user_address_country
+    description: str, country where user lives in
+  - name: user_address_city
+    description: str, city where user lives in
+  - name: user_address_state_or_territory
+    description: str,  state or territory where user lives in
+  - name: user_address_postal_code
+    description: str, postal code where user lives in
+  - name: user_street_address
+    description: str, street address where user lives in
+  - name: user_gender
+    description: str, user gender (could be blank)
+    tests:
+    - accepted_values:
+        values: ['Male', 'Female', 'Other/Prefer Not to Say']
+  - name: user_highest_education
+    description: str, user highest education pulled from users education history in
+      MicroMasters database or level of education reported on edx if former doesn't
+      exist
+    tests:
+    - accepted_values:
+        values: ["Doctorate", "Master''s or professional degree", "Bachelor''s degree",
+          "Associate degree", "Secondary/high school", "Junior secondary/junior high/middle\
+            \ school", "Elementary/primary school", "No formal education", "Other\
+            \ education", "Doctorate in science or engineering", "Doctorate in another\
+            \ field"]
+  - name: user_company_name
+    description: str, this is the most recent company this user works for, pulled
+      from users employment history in MicroMasters database
+  - name: user_job_position
+    description: str, user's job title in the most recent employment, pulled from
+      users employment history in MicroMasters database
+  - name: user_company_industry
+    description: str, industry of the most recent company this user works for, pulled
+      from users employment history in MicroMasters database
+  tests:
+  - dbt_expectations.expect_table_row_count_to_equal_other_table:
+      compare_model: ref('__micromasters__users')

--- a/src/ol_dbt/models/intermediate/micromasters/int__micromasters__users.sql
+++ b/src/ol_dbt/models/intermediate/micromasters/int__micromasters__users.sql
@@ -1,0 +1,77 @@
+with users as (
+    select * from {{ ref('__micromasters__users') }}
+)
+
+, education as (
+    select
+        user_profile_id
+        , user_education_degree
+        , user_graduation_date
+        , row_number() over (partition by user_profile_id order by user_graduation_date desc) as row_num
+    from {{ ref('stg__micromasters__app__postgres__profiles_education') }}
+)
+
+, highest_education as (
+    select
+        user_profile_id
+        , user_education_degree
+    from education
+    where row_num = 1
+)
+
+, employment as (
+    select
+        user_profile_id
+        , user_company_name
+        , user_job_position
+        , user_company_industry
+        , row_number() over (partition by user_profile_id order by user_start_date desc) as row_num
+    from {{ ref('stg__micromasters__app__postgres__profiles_employment') }}
+)
+
+, most_recent_employment as (
+    select
+        user_profile_id
+        , user_company_name
+        , user_job_position
+        , user_company_industry
+    from employment
+    where row_num = 1
+)
+
+select
+    users.user_id
+    , users.user_username
+    , users.user_email
+    , users.user_joined_on
+    , users.user_last_login
+    , users.user_is_active
+    , users.user_profile_id
+    , users.user_full_name
+    , users.user_first_name
+    , users.user_last_name
+    , users.user_address_country
+    , users.user_address_city
+    , users.user_address_state_or_territory
+    , users.user_address_postal_code
+    , users.user_street_address
+    , users.user_mailing_address
+    , users.user_preferred_name
+    , users.user_preferred_language
+    , users.user_nationality
+    , users.user_phone_number
+    , users.user_bio
+    , users.user_about_me
+    , users.user_edx_name
+    , users.user_edx_goals
+    , users.user_birth_date
+    , users.user_gender
+    , users.user_mitxonline_username
+    , users.user_edxorg_username
+    , most_recent_employment.user_company_name
+    , most_recent_employment.user_company_industry
+    , most_recent_employment.user_job_position
+    , coalesce(highest_education.user_education_degree, users.user_highest_education) as user_highest_education
+from users
+left join highest_education on highest_education.user_profile_id = users.user_profile_id
+left join most_recent_employment on most_recent_employment.user_profile_id = users.user_profile_id

--- a/src/ol_dbt/models/staging/micromasters/_micromasters__sources.yml
+++ b/src/ol_dbt/models/staging/micromasters/_micromasters__sources.yml
@@ -506,3 +506,56 @@ sources:
       description: int, foreign key to courses_electivesset
     - name: course_id
       description: int, foreign key to courses_course
+
+  - name: raw__micromasters__app__postgres__profiles_education
+    columns:
+    - name: id
+      description: int, primary key representing a user education record
+    - name: profile_id
+      description: int, foreign key to profiles_profile
+    - name: degree_name
+      description: >
+        str, user degree choice are:
+        "p" - "Doctorate"
+        "m" - "Master's or professional degree"
+        "b" - "Bachelor's degree"
+        "a" - "Associate degree"
+        "hs" - "Secondary/high school"
+        "other" - "Other education"
+    - name: field_of_study
+      description: str, field of study for this education degree
+    - name: online_degree
+      description: boolean, indicating if it's online education degree
+    - name: school_name
+      description: str, name of school for this education
+    - name: school_city
+      description: str, city where school is located
+    - name: school_state_or_territory
+      description: str, state or territory where school is located
+    - name: school_country
+      description: str, country code where school is located
+    - name: graduation_date
+      description: date, graduation date for this education
+
+  - name: raw__micromasters__app__postgres__profiles_employment
+    columns:
+    - name: id
+      description: int, primary key representing a user employment record
+    - name: profile_id
+      description: int, foreign key to profiles_profile
+    - name: company_name
+      description: str, name of the company for this employment
+    - name: position
+      description: str, user's position in this company
+    - name: industry
+      description: str, industry of this company
+    - name: city
+      description: str, city where this company is located
+    - name: state_or_territory
+      description: str, state or territory where this company is located
+    - name: country
+      description: str, country code where this company is located
+    - name: start_date
+      description: date, start date for this employment
+    - name: end_date
+      description: date, end date for this employment

--- a/src/ol_dbt/models/staging/micromasters/_stg_micromasters__models.yml
+++ b/src/ol_dbt/models/staging/micromasters/_stg_micromasters__models.yml
@@ -477,7 +477,7 @@ models:
   - name: user_street_address
     description: str, street address where user lives in
   - name: user_highest_education
-    description: str, user's level of education
+    description: str, user's level of education reported on edx
     tests:
     - accepted_values:
         values: ["Doctorate", "Master''s or professional degree", "Bachelor''s degree",
@@ -758,3 +758,77 @@ models:
   tests:
   - dbt_expectations.expect_compound_columns_to_be_unique:
       column_list: ["course_id", "electiveset_id"]
+
+
+- name: stg__micromasters__app__postgres__profiles_education
+  columns:
+  - name: user_education_id
+    description: int, primary key representing a user education record
+    tests:
+    - not_null
+    - unique
+  - name: user_profile_id
+    description: int, foreign key to profiles_profile
+    tests:
+    - not_null
+    - relationships:
+        to: ref('stg__micromasters__app__postgres__profiles_profile')
+        field: user_profile_id
+  - name: user_education_degree
+    description: str, user education degree
+    tests:
+    - accepted_values:
+        values: ["Doctorate", "Master''s or professional degree", "Bachelor''s degree",
+          "Associate degree", "Secondary/high school", "Other education"]
+  - name: user_field_of_study
+    description: str, field of study for this education degree
+  - name: user_education_is_online_degree
+    description: boolean, indicating if it's online education degree
+    tests:
+    - not_null
+  - name: user_school_name
+    description: str, name of school for this education
+    tests:
+    - not_null
+  - name: user_school_city
+    description: str, city where school is located
+  - name: user_school_state
+    description: str, state or territory where school is located
+  - name: user_school_country
+    description: str, country code where school is located
+  - name: user_graduation_date
+    description: date, graduation date for this education
+    tests:
+    - not_null
+
+- name: stg__micromasters__app__postgres__profiles_employment
+  columns:
+  - name: user_employment_id
+    description: int, primary key representing a user employment record
+  - name: user_profile_id
+    description: int, foreign key to profiles_profile
+    tests:
+    - not_null
+    - relationships:
+        to: ref('stg__micromasters__app__postgres__profiles_profile')
+        field: user_profile_id
+  - name: user_company_name
+    description: str, name of the company for this employment
+    tests:
+    - not_null
+  - name: user_job_position
+    description: str, user's job position in this company
+  - name: user_company_industry
+    description: str, industry of this company
+  - name: user_company_city
+    description: str, city where this company is located
+  - name: user_company_state
+    description: str, state or territory where this company is located
+  - name: user_company_country
+    description: str, country code where this company is located
+  - name: user_start_date
+    description: date, start date for this employment
+    tests:
+    - not_null
+  - name: user_end_date
+    description: date, end date for this employment

--- a/src/ol_dbt/models/staging/micromasters/stg__micromasters__app__postgres__profiles_education.sql
+++ b/src/ol_dbt/models/staging/micromasters/stg__micromasters__app__postgres__profiles_education.sql
@@ -1,0 +1,22 @@
+-- MicroMasters User Educations Information
+
+with source as (
+    select * from {{ source('ol_warehouse_raw_data','raw__micromasters__app__postgres__profiles_education') }}
+)
+
+, cleaned as (
+    select
+        id as user_education_id
+        , profile_id as user_profile_id
+        , field_of_study as user_field_of_study
+        , online_degree as user_education_is_online_degree
+        , school_city as user_school_city
+        , school_country as user_school_country
+        , school_name as user_school_name
+        , school_state_or_territory as user_school_state
+        , {{ transform_education_value('degree_name') }} as user_education_degree
+        , {{ cast_date_to_iso8601('graduation_date') }} as user_graduation_date
+    from source
+)
+
+select * from cleaned

--- a/src/ol_dbt/models/staging/micromasters/stg__micromasters__app__postgres__profiles_employment.sql
+++ b/src/ol_dbt/models/staging/micromasters/stg__micromasters__app__postgres__profiles_employment.sql
@@ -1,0 +1,22 @@
+-- MicroMasters User Employment Information
+
+with source as (
+    select * from {{ source('ol_warehouse_raw_data','raw__micromasters__app__postgres__profiles_employment') }}
+)
+
+, cleaned as (
+    select
+        id as user_employment_id
+        , profile_id as user_profile_id
+        , position as user_job_position
+        , industry as user_company_industry
+        , company_name as user_company_name
+        , city as user_company_city
+        , state_or_territory as user_company_state
+        , country as user_company_country
+        , {{ cast_date_to_iso8601('start_date') }} as user_start_date
+        , {{ cast_date_to_iso8601('end_date') }} as user_end_date
+    from source
+)
+
+select * from cleaned


### PR DESCRIPTION
# Description 
<!--- Describe your changes in detail -->
Add the following models
stg__micromasters__app__postgres__profiles_employment
stg__micromasters__app__postgres__profiles_education
int__micromasters__users (with most recent employment and highest education)

To re-create https://bi.odl.mit.edu/queries/1073/source with data lake, it needs these tables

# How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->
dbt build on 3 new models