### PR TITLE
add secondary sorting to MM course certificates and grades

### DIFF
--- a/src/ol_dbt/models/intermediate/micromasters/subqueries/__micromasters_course_certificates_dedp_from_micromasters.sql
+++ b/src/ol_dbt/models/intermediate/micromasters/subqueries/__micromasters_course_certificates_dedp_from_micromasters.sql
@@ -1,5 +1,7 @@
---- Unlike other platforms, DEDP course certificate from MM is based on course not run, we try to match it with
---- course run from learner's highest grades
+--- Unlike other platforms, MicroMasters DEDP course certificates are based on course not run, we try to find the run
+--- with highest grade for the course. If there are multiple runs with the highest grade, pick the latest grade from
+--  runs before DEDP course certificates were generated
+
 with dedp_course_certificates as (
     select * from {{ ref('stg__micromasters__app__postgres__grades_coursecertificate') }}
 )
@@ -20,10 +22,17 @@ with dedp_course_certificates as (
         , courseruns.course_id
         , row_number() over (
             partition by courserun_grades.user_id, courseruns.course_id
-            order by courserun_grades.courserungrade_grade desc
+            --- in case of multiple highest grades, use secondary sorting to ensure the consistent result
+            order by courserun_grades.courserungrade_grade desc, courserun_grades.coursegrade_created_on desc
         ) as row_num
     from courserun_grades
     inner join courseruns on courseruns.courserun_id = courserun_grades.courserun_id
+    inner join dedp_course_certificates
+        on
+            dedp_course_certificates.user_id = courserun_grades.user_id
+            and dedp_course_certificates.course_id = courseruns.course_id
+            and dedp_course_certificates.coursecertificate_created_on > courseruns.courserun_start_on
+
 )
 
 


### PR DESCRIPTION
# What are the relevant tickets?
N/A
I noticed this issue when testing DEDP course certificates

# Description (What does it do?)
This PR adds a secondary sorting to the subqueries in the MM DEDP course certificate/grade models to ensure that if learners get the highest grade from different runs within the same DEDP course, the query would then pick the latest grade from these runs but this run needs to be before the DEDP course certificates were generated. This logic only applies to DEDP course certificates/grades from MicroMasters

In MM, DEDP course certificates were generated based on courses not runs, so we have to populate runs with their highest grade.

e.g Let's say a learner gets the highest grade for both `course-v1:MITxT+JPAL102x+3T2021` and `course-v1:MITx+JPAL102x+3T2020` with 0.94, and the DEDP course certificate was generated on 2022-02-01, we would choose  `course-v1:MITxT+JPAL102x+3T2021` for the DEDP course certificate

# How can this be tested?
dbt build on +int__micromasters__course_certificates/grades
dbt tests passed

