### PR TITLE
add user and discount info to MITxOnline flexiblepriceapplication

### DIFF
--- a/src/ol_dbt/models/intermediate/mitxonline/_int_mitxonline__models.yml
+++ b/src/ol_dbt/models/intermediate/mitxonline/_int_mitxonline__models.yml
@@ -103,6 +103,20 @@ models:
       flexible pricing
     tests:
     - not_null
+  - name: user_username
+    description: string, username of the user requesting flexible pricing
+    tests:
+    - not_null
+  - name: user_full_name
+    description: string, full name of the user requesting flexible pricing
+    tests:
+    - not_null
+  - name: user_email
+    description: string, email of the user requesting flexible pricing
+    tests:
+    - not_null
+  - name: user_address_country
+    description: string, country code of the user requesting flexible pricing
   - name: courseware_type
     description: string, type of courseware that the user is applying for a discount
       for. May be either 'course' or 'program'
@@ -114,6 +128,22 @@ models:
   - name: flexiblepricetier_id
     description: int, primary key in flexiblepricing_flexiblepricetier of the price
       tier the user applied for
+  - name: discount_id
+    description: int, id of ecommerce_discount associated with the flexible price
+      tier
+    tests:
+    - not_null
+  - name: discount_amount
+    description: numeric, discount amount. May be a percent or dollar amount
+    tests:
+    - not_null
+  - name: discount_type
+    description: string, specify if discount amount refers to a percent of, a dollar
+      amount off, or a discounted price
+    tests:
+    - not_null
+    - accepted_values:
+        values: ["percent-off", "dollars-off", "fixed-price"]
   - name: course_id
     description: int, primary key in either the courses_course table courseware_type
       is "course"
@@ -293,7 +323,7 @@ models:
   - name: discount_updated_on
     description: timestamp, specifying when the discount was most recently updated
   - name: discount_amount
-    description: numeric, discount amount. May be a precent or dollar amount
+    description: numeric, discount amount. May be a percent or dollar amount
     tests:
     - not_null
   - name: discount_type

--- a/src/ol_dbt/models/intermediate/mitxonline/int__mitxonline__flexiblepricing_flexiblepriceapplication.sql
+++ b/src/ol_dbt/models/intermediate/mitxonline/int__mitxonline__flexiblepricing_flexiblepriceapplication.sql
@@ -2,6 +2,18 @@ with flexiblepriceapplication as (
     select * from {{ ref('stg__mitxonline__app__postgres__flexiblepricing_flexiblepriceapplication') }}
 )
 
+, flexiblepricetier as (
+    select * from {{ ref('stg__mitxonline__app__postgres__flexiblepricing_flexiblepricetier') }}
+)
+
+, discount as (
+    select * from {{ ref('stg__mitxonline__app__postgres__ecommerce_discount') }}
+)
+
+, users as (
+    select * from {{ ref('int__mitxonline__users') }}
+)
+
 , contenttypes as (
     select *
     from {{ ref('stg__mitxonline__app__postgres__django_contenttype') }}
@@ -11,7 +23,14 @@ select
     flexiblepriceapplication.flexiblepriceapplication_id
     , flexiblepriceapplication.flexiblepriceapplication_status
     , flexiblepriceapplication.flexiblepricetier_id
+    , flexiblepricetier.discount_id
+    , discount.discount_type
+    , discount.discount_amount
     , flexiblepriceapplication.user_id
+    , users.user_username
+    , users.user_full_name
+    , users.user_email
+    , users.user_address_country
     , flexiblepriceapplication.flexiblepriceapplication_created_on
     , flexiblepriceapplication.flexiblepriceapplication_income_usd
     , flexiblepriceapplication.flexiblepriceapplication_updated_on
@@ -37,3 +56,6 @@ select
     end as courseware_type
 from flexiblepriceapplication
 inner join contenttypes on flexiblepriceapplication.contenttype_id = contenttypes.contenttype_id
+inner join users on users.user_id = flexiblepriceapplication.user_id
+inner join flexiblepricetier on flexiblepriceapplication.flexiblepricetier_id = flexiblepricetier.flexiblepricetier_id
+inner join discount on flexiblepricetier.discount_id = discount.discount_id


### PR DESCRIPTION
# What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
https://github.com/mitodl/hq/issues/1074
close https://github.com/mitodl/ol-data-platform/issues/577

# Description (What does it do?)
<!--- Describe your changes in detail -->
It adds username, full name, country, and discount amount/type to `int__mitxonline__flexiblepricing_flexiblepriceapplication` to simplify reports


# How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->
Run dbt build on `int__mitxonline__flexiblepricing_flexiblepriceapplication`, and ensure that tests are passed