### PR TITLE
fix dbt test for mitx enrollments and grades

### DIFF
--- a/src/ol_dbt/models/intermediate/edxorg/_int_edxorg__models.yml
+++ b/src/ol_dbt/models/intermediate/edxorg/_int_edxorg__models.yml
@@ -71,7 +71,9 @@ models:
   - name: user_mitxonline_username
     description: str, username on MITx Online
   - name: user_email
-    description: str, The email address of the learner on edx.org
+    description: str, The current email address of the learner on edx.org. Learners
+      can update their emails on edx.org, so this is not necessary the same email
+      as when learner earned certificate for the course.
     tests:
     - not_null
   - name: user_full_name
@@ -128,11 +130,13 @@ models:
     tests:
     - not_null
   - name: user_username
-    description: str, username of a learner on the edX platform (some blank from source)
+    description: str, username of a learner on the edX platform
     tests:
     - not_null
   - name: user_email
-    description: str, The email address of the learner on edx.org
+    description: str, The current email address of the learner on edx.org. Learners
+      can update their emails on edx.org, so this is not necessary the same email
+      as when learner enrolled for the course.
     tests:
     - not_null
   - name: user_full_name
@@ -242,7 +246,9 @@ models:
   - name: user_mitxonline_username
     description: str, username on MITx Online
   - name: user_email
-    description: str, The email address of the learner on edx.org
+    description: str, The current email address of the learner on edx.org. Learners
+      can update their emails on edx.org, so this is not necessary the same email
+      as when learner enrolled for the course.
     tests:
     - not_null
   - name: courserungrade_passing_grade
@@ -293,7 +299,9 @@ models:
     tests:
     - not_null
   - name: user_email
-    description: str, The email address of the learner on edx.org
+    description: str, The current email address of the learner on edx.org. Learners
+      can update their emails on edx.org, so this is not necessary the same email
+      as when learner enrolled for the course.
     tests:
     - not_null
   - name: courseactivitiy_visited_once

--- a/src/ol_dbt/models/intermediate/mitx/_int_mitx__models.yml
+++ b/src/ol_dbt/models/intermediate/mitx/_int_mitx__models.yml
@@ -195,7 +195,9 @@ models:
   - name: courserun_title
     description: str, title of the course run, maybe blank for some edX.org runs
   - name: user_email
-    description: str, user email associated with their account
+    description: str, current user email on edX.org or MITxOnline. For edx.org, learners
+      can update their emails, so this is not necessary the same email as when learner
+      enrolled for the course
     tests:
     - not_null
   - name: user_username
@@ -219,7 +221,7 @@ models:
     description: str, country code provided by the user from MITx Online or edX.org
   tests:
   - dbt_expectations.expect_compound_columns_to_be_unique:
-      column_list: ["user_email", "courserun_readable_id"]
+      column_list: ["user_mitxonline_username", "user_edxorg_username", "courserun_readable_id"]
 
 - name: int__mitx__courserun_certificates
   description: MITx course certificates combined from MITx Online and edX.org. It
@@ -247,7 +249,9 @@ models:
   - name: user_mitxonline_username
     description: str, username on MITxOnline
   - name: user_email
-    description: str, user email on edX.org or MITxOnline
+    description: str, current user email on edX.org or MITxOnline. For edx.org, learners
+      can update their emails, so this is not necessary the same email as when learner
+      earned certificate for the course
     tests:
     - not_null
   - name: courseruncertificate_url
@@ -261,7 +265,7 @@ models:
     - not_null
   tests:
   - dbt_expectations.expect_compound_columns_to_be_unique:
-      column_list: ["user_email", "courserun_readable_id"]
+      column_list: ["user_mitxonline_username", "user_edxorg_username", "courserun_readable_id"]
 
 - name: int__mitx__courserun_grades
   description: MITx course grades combined from MITx Online and edX.org
@@ -287,7 +291,9 @@ models:
   - name: user_mitxonline_username
     description: str, username on MITxOnline
   - name: user_email
-    description: str, user email on edX.org or MITxOnline
+    description: str, current user email on edX.org or MITxOnline. Learners can update
+      their emails on edx.org, so this is not necessary the same email as when learner
+      enrolled for the course
     tests:
     - not_null
   - name: user_full_name
@@ -305,7 +311,7 @@ models:
     - not_null
   tests:
   - dbt_expectations.expect_compound_columns_to_be_unique:
-      column_list: ["user_email", "courserun_readable_id"]
+      column_list: ["user_mitxonline_username", "user_edxorg_username", "courserun_readable_id"]
 
 - name: int__mitx__program_certificates
   description: MITx program certificates combined from MicroMasters and MITx Online


### PR DESCRIPTION
# What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
N/A

# Description (What does it do?)
<!--- Describe your changes in detail -->
This addresses two dbt warnings on production.
```
Warning in test dbt_expectations_expect_compound_columns_to_be_unique_int__mitx__courserun_enrollments_user_email__courserun_readable_id (models/intermediate/mitx/_int_mitx__models.yml)
Got 1 result, configured to warn if != 0

compiled Code at target/compiled/open_learning/models/intermediate/mitx/_int_mitx__models.yml/dbt_expectations_expect_compou_d1f5f8705e44746678b29192ff4ebc7b.sql

Warning in test dbt_expectations_expect_compound_columns_to_be_unique_int__mitx__courserun_grades_user_email__courserun_readable_id (models/intermediate/mitx/_int_mitx__models.yml)
Got 1 result, configured to warn if != 0

compiled Code at target/compiled/open_learning/models/intermediate/mitx/_int_mitx__models.yml/dbt_expectations_expect_compou_4d74168b457d1cdeb4a4a29e0c0c958f.sql
```

Reviewed the data and found that a user from edX.org updated his email a couple of weeks ago and that same email is now linked to two accounts. But because these two accounts were enrolled for the same course, our test - unique on user_email and courserun_readable_id failed on that user. Since it's possible that user can update their email on edx.org, I updated the test to account for that 

# How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->
`dbt test --select intermediate.mitx --target production` should be successful without warnings
