### PR TITLE
fix dbt test failures for duplicate certificates and grades in MITx intermeidate

### DIFF
--- a/src/ol_dbt/models/intermediate/mitx/_int_mitx__models.yml
+++ b/src/ol_dbt/models/intermediate/mitx/_int_mitx__models.yml
@@ -19,9 +19,8 @@ models:
     tests:
     - unique
   - name: program_description
-    description: str, description of the program
-    tests:
-    - not_null
+    description: str, description of the program. blank for MITx Online programs as
+      this field is only applicable for MicroMasters programs
 
 - name: int__mitx__courses
   description: Intermediate model for combined MITxOnline and edxorg courses

--- a/src/ol_dbt/models/intermediate/mitx/int__mitx__courserun_certificates.sql
+++ b/src/ol_dbt/models/intermediate/mitx/int__mitx__courserun_certificates.sql
@@ -19,13 +19,6 @@ with mitxonline_certificates as (
     where program_id = {{ var("dedp_mitxonline_program_id") }}
 )
 
-, mitxonline_non_dedp_course_certificates as (
-    select mitxonline_certificates.*
-    from mitxonline_certificates
-    left join mitxonline_dedp_courses on mitxonline_certificates.course_id = mitxonline_dedp_courses.course_id
-    where mitxonline_dedp_courses.course_id is null
-)
-
 , edxorg_non_program_course_certificates as (
     select * from {{ ref('int__edxorg__mitx_courserun_certificates') }}
     where micromasters_program_id is null
@@ -33,6 +26,19 @@ with mitxonline_certificates as (
 
 , program_course_certificates as (
     select * from {{ ref('int__micromasters__course_certificates') }}
+)
+
+, mitxonline_non_dedp_course_certificates as (
+    select mitxonline_certificates.*
+    from mitxonline_certificates
+    left join mitxonline_dedp_courses on mitxonline_certificates.course_id = mitxonline_dedp_courses.course_id
+    left join program_course_certificates
+        on
+            mitxonline_certificates.courserun_readable_id = program_course_certificates.courserun_readable_id
+            and mitxonline_certificates.user_username = program_course_certificates.user_mitxonline_username
+    where
+        mitxonline_dedp_courses.course_id is null
+        and program_course_certificates.courserun_readable_id is null
 )
 
 , mitx_certificates as (

--- a/src/ol_dbt/models/intermediate/mitx/int__mitx__courserun_grades.sql
+++ b/src/ol_dbt/models/intermediate/mitx/int__mitx__courserun_grades.sql
@@ -13,13 +13,6 @@ with mitxonline_grades as (
     where program_id = {{ var("dedp_mitxonline_program_id") }}
 )
 
-, mitxonline_non_dedp_course_grades as (
-    select mitxonline_grades.*
-    from mitxonline_grades
-    left join mitxonline_dedp_courses on mitxonline_grades.course_id = mitxonline_dedp_courses.course_id
-    where mitxonline_dedp_courses.course_id is null
-)
-
 , edxorg_non_program_course_grades as (
     select * from {{ ref('int__edxorg__mitx_courserun_grades') }}
     where micromasters_program_id is null
@@ -27,6 +20,17 @@ with mitxonline_grades as (
 
 , all_program_course_grades as (
     select * from {{ ref('int__micromasters__course_grades') }}
+)
+
+, mitxonline_non_dedp_course_grades as (
+    select mitxonline_grades.*
+    from mitxonline_grades
+    left join mitxonline_dedp_courses on mitxonline_grades.course_id = mitxonline_dedp_courses.course_id
+    left join all_program_course_grades
+        on
+            mitxonline_grades.courserun_readable_id = all_program_course_grades.courserun_readable_id
+            and mitxonline_grades.user_username = all_program_course_grades.user_mitxonline_username
+    where mitxonline_dedp_courses.course_id is null and all_program_course_grades.courserun_readable_id is null
 )
 
 , mitx_grades as (


### PR DESCRIPTION

# What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
N/A 

# Description (What does it do?)
<!--- Describe your changes in detail -->
This is to address dbt test failure and warning
```
Failure in test dbt_expectations_expect_compound_columns_to_be_unique_int__mitx__courserun_grades_user_mitxonline_username__user_edxorg_username__courserun_readable_id (models/intermediate/mitx/_int_mitx__models.yml)
Got 91 results, configured to fail if >10
```
```
Warning in test not_null_int__mitx__programs_program_description (models/intermediate/mitx/_int_mitx__models.yml)
Got 2 results, configured to warn if != 0
```

# How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->
Run dbt build on `int__mitx__courserun_certificates` and `int__mitx__courserun_grades` including upsteam models
The test should pass to ensure there are no dups in these two tables

# Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->


<!--- Uncomment and add steps to be completed before merging this PR if necessary
## Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
