### PR TITLE
Add new MITXPRO tables to int & mart

### DIFF
--- a/src/ol_dbt/models/intermediate/mitxpro/_int_mitxpro__models.yml
+++ b/src/ol_dbt/models/intermediate/mitxpro/_int_mitxpro__models.yml
@@ -22,19 +22,19 @@ models:
   - name: couponpayment_name
     description: string, human readable name for the coupon payment
   - name: b2border_contract_number
-    description: string, contract number used to identify the order
+    description: string, contract number used to identify the order  
   - name: product_id
-    description: int, foreign key in ecommerce_product
+    description: int, foreign key in ecommerce_product 
   - name: couponpaymentversion_payment_transaction
     description: string, string that identifies the payment invoice for coupon purchases
-      by companies
+      by companies 
   - name: req_reference_number
     description: b2b receipt req reference number for a payment
   - name: programrun_readable_id
     description: str, unique program run ID formatted as program-v1:{org}+{program
       code}+{run_tag} e.g. program-v1:xPRO+MLx+R1
   - name: program_title
-    description: str, title of the course run
+    description: str, title of the course run   
   - name: courserun_readable_id
     description: str, Open edX Course ID formatted as course-v1:{org}+{course code}+{run_tag}
       e.g. course-v1:xPRO+MLx1+R0
@@ -60,7 +60,7 @@ models:
       "refunded" all associated with the coupon
   tests:
   - dbt_expectations.expect_compound_columns_to_be_unique:
-      column_list: ["coupon_id", "order_ids", "product_id"]
+      column_list: ["coupon_id", "order_ids", "product_id", "couponpaymentversion_payment_transaction"]
 - name: int__mitxpro__ecommerce_couponversion
   description: A version of a coupon linked to a specific couponpaymentversion record
   columns:

--- a/src/ol_dbt/models/intermediate/mitxpro/_int_mitxpro__models.yml
+++ b/src/ol_dbt/models/intermediate/mitxpro/_int_mitxpro__models.yml
@@ -22,19 +22,19 @@ models:
   - name: couponpayment_name
     description: string, human readable name for the coupon payment
   - name: b2border_contract_number
-    description: string, contract number used to identify the order  
+    description: string, contract number used to identify the order
   - name: product_id
-    description: int, foreign key in ecommerce_product 
+    description: int, foreign key in ecommerce_product
   - name: couponpaymentversion_payment_transaction
     description: string, string that identifies the payment invoice for coupon purchases
-      by companies 
+      by companies
   - name: req_reference_number
     description: b2b receipt req reference number for a payment
   - name: programrun_readable_id
     description: str, unique program run ID formatted as program-v1:{org}+{program
       code}+{run_tag} e.g. program-v1:xPRO+MLx+R1
   - name: program_title
-    description: str, title of the course run   
+    description: str, title of the course run
   - name: courserun_readable_id
     description: str, Open edX Course ID formatted as course-v1:{org}+{course code}+{run_tag}
       e.g. course-v1:xPRO+MLx1+R0

--- a/src/ol_dbt/models/intermediate/mitxpro/_int_mitxpro__models.yml
+++ b/src/ol_dbt/models/intermediate/mitxpro/_int_mitxpro__models.yml
@@ -11,24 +11,26 @@ models:
     description: string, coupon code for the coupon
   - name: coupon_id
     description: int, foreign key referencing ecommerce_coupon
+  - name: couponversion_updated_on
+    description: timestamp, specifying when the coupon version was most recently updated
   - name: coupon_created_on
     description: timestamp, specifying when the coupon was initially created
   - name: couponpayment_name
     description: string, human readable name for the coupon payment
   - name: b2border_contract_number
-    description: string, contract number used to identify the order
+    description: string, contract number used to identify the order  
   - name: product_id
-    description: int, foreign key in ecommerce_product
+    description: int, foreign key in ecommerce_product 
   - name: couponpaymentversion_payment_transaction
     description: string, string that identifies the payment invoice for coupon purchases
-      by companies
+      by companies 
   - name: req_reference_number
     description: b2b receipt req reference number for a payment
   - name: programrun_readable_id
     description: str, unique program run ID formatted as program-v1:{org}+{program
       code}+{run_tag} e.g. program-v1:xPRO+MLx+R1
   - name: program_title
-    description: str, title of the course run
+    description: str, title of the course run   
   - name: courserun_readable_id
     description: str, Open edX Course ID formatted as course-v1:{org}+{course code}+{run_tag}
       e.g. course-v1:xPRO+MLx1+R0
@@ -36,9 +38,9 @@ models:
     description: str, title of the course
   - name: productversion_readable_id
     description: string, the readable_id field from the product object
-  - name: combinedcoupon_table_source
-    description: string, Describes whether the data on the combioned coupon table
-      is coming from b2b or elsewhere
+  - name: combinedcoupon_table_source   
+    description:  string, Describes whether the data on the combioned coupon table is 
+      coming from b2b or elsewhere
   - name: couponpaymentversion_coupon_type
     description: string, one of 'single-use' or 'promo'. Promo coupon codes can be
       used multiple times

--- a/src/ol_dbt/models/intermediate/mitxpro/_int_mitxpro__models.yml
+++ b/src/ol_dbt/models/intermediate/mitxpro/_int_mitxpro__models.yml
@@ -18,19 +18,19 @@ models:
   - name: couponpayment_name
     description: string, human readable name for the coupon payment
   - name: b2border_contract_number
-    description: string, contract number used to identify the order  
+    description: string, contract number used to identify the order
   - name: product_id
-    description: int, foreign key in ecommerce_product 
+    description: int, foreign key in ecommerce_product
   - name: couponpaymentversion_payment_transaction
     description: string, string that identifies the payment invoice for coupon purchases
-      by companies 
+      by companies
   - name: req_reference_number
     description: b2b receipt req reference number for a payment
   - name: programrun_readable_id
     description: str, unique program run ID formatted as program-v1:{org}+{program
       code}+{run_tag} e.g. program-v1:xPRO+MLx+R1
   - name: program_title
-    description: str, title of the course run   
+    description: str, title of the course run
   - name: courserun_readable_id
     description: str, Open edX Course ID formatted as course-v1:{org}+{course code}+{run_tag}
       e.g. course-v1:xPRO+MLx1+R0
@@ -38,9 +38,9 @@ models:
     description: str, title of the course
   - name: productversion_readable_id
     description: string, the readable_id field from the product object
-  - name: combinedcoupon_table_source   
-    description:  string, Describes whether the data on the combioned coupon table is 
-      coming from b2b or elsewhere
+  - name: combinedcoupon_table_source
+    description: string, Describes whether the data on the combioned coupon table
+      is coming from b2b or elsewhere
   - name: couponpaymentversion_coupon_type
     description: string, one of 'single-use' or 'promo'. Promo coupon codes can be
       used multiple times

--- a/src/ol_dbt/models/intermediate/mitxpro/_int_mitxpro__models.yml
+++ b/src/ol_dbt/models/intermediate/mitxpro/_int_mitxpro__models.yml
@@ -9,28 +9,32 @@ models:
     description: string, email associated to the coupon
   - name: coupon_code
     description: string, coupon code for the coupon
+    tests:
+    - not_null
   - name: coupon_id
     description: int, foreign key referencing ecommerce_coupon
-  - name: couponversion_updated_on
-    description: timestamp, specifying when the coupon version was most recently updated
+    tests:
+    - not_null
   - name: coupon_created_on
     description: timestamp, specifying when the coupon was initially created
+    tests:
+    - not_null
   - name: couponpayment_name
     description: string, human readable name for the coupon payment
   - name: b2border_contract_number
-    description: string, contract number used to identify the order
+    description: string, contract number used to identify the order  
   - name: product_id
-    description: int, foreign key in ecommerce_product
+    description: int, foreign key in ecommerce_product 
   - name: couponpaymentversion_payment_transaction
     description: string, string that identifies the payment invoice for coupon purchases
-      by companies
+      by companies 
   - name: req_reference_number
     description: b2b receipt req reference number for a payment
   - name: programrun_readable_id
     description: str, unique program run ID formatted as program-v1:{org}+{program
       code}+{run_tag} e.g. program-v1:xPRO+MLx+R1
   - name: program_title
-    description: str, title of the course run
+    description: str, title of the course run   
   - name: courserun_readable_id
     description: str, Open edX Course ID formatted as course-v1:{org}+{course code}+{run_tag}
       e.g. course-v1:xPRO+MLx1+R0
@@ -38,9 +42,6 @@ models:
     description: str, title of the course
   - name: productversion_readable_id
     description: string, the readable_id field from the product object
-  - name: combinedcoupon_table_source
-    description: string, Describes whether the data on the combioned coupon table
-      is coming from b2b or elsewhere
   - name: couponpaymentversion_coupon_type
     description: string, one of 'single-use' or 'promo'. Promo coupon codes can be
       used multiple times

--- a/src/ol_dbt/models/intermediate/mitxpro/_int_mitxpro__models.yml
+++ b/src/ol_dbt/models/intermediate/mitxpro/_int_mitxpro__models.yml
@@ -16,19 +16,19 @@ models:
   - name: couponpayment_name
     description: string, human readable name for the coupon payment
   - name: b2border_contract_number
-    description: string, contract number used to identify the order  
+    description: string, contract number used to identify the order
   - name: product_id
-    description: int, foreign key in ecommerce_product 
+    description: int, foreign key in ecommerce_product
   - name: couponpaymentversion_payment_transaction
     description: string, string that identifies the payment invoice for coupon purchases
-      by companies 
+      by companies
   - name: req_reference_number
     description: b2b receipt req reference number for a payment
   - name: programrun_readable_id
     description: str, unique program run ID formatted as program-v1:{org}+{program
       code}+{run_tag} e.g. program-v1:xPRO+MLx+R1
   - name: program_title
-    description: str, title of the course run   
+    description: str, title of the course run
   - name: courserun_readable_id
     description: str, Open edX Course ID formatted as course-v1:{org}+{course code}+{run_tag}
       e.g. course-v1:xPRO+MLx1+R0
@@ -36,9 +36,9 @@ models:
     description: str, title of the course
   - name: productversion_readable_id
     description: string, the readable_id field from the product object
-  - name: combinedcoupon_table_source   
-    description:  string, Describes whether the data on the combioned coupon table is 
-      coming from b2b or elsewhere
+  - name: combinedcoupon_table_source
+    description: string, Describes whether the data on the combioned coupon table
+      is coming from b2b or elsewhere
   - name: couponpaymentversion_coupon_type
     description: string, one of 'single-use' or 'promo'. Promo coupon codes can be
       used multiple times

--- a/src/ol_dbt/models/intermediate/mitxpro/_int_mitxpro__models.yml
+++ b/src/ol_dbt/models/intermediate/mitxpro/_int_mitxpro__models.yml
@@ -22,19 +22,19 @@ models:
   - name: couponpayment_name
     description: string, human readable name for the coupon payment
   - name: b2border_contract_number
-    description: string, contract number used to identify the order
+    description: string, contract number used to identify the order  
   - name: product_id
-    description: int, foreign key in ecommerce_product
+    description: int, foreign key in ecommerce_product 
   - name: couponpaymentversion_payment_transaction
     description: string, string that identifies the payment invoice for coupon purchases
-      by companies
+      by companies 
   - name: req_reference_number
     description: b2b receipt req reference number for a payment
   - name: programrun_readable_id
     description: str, unique program run ID formatted as program-v1:{org}+{program
       code}+{run_tag} e.g. program-v1:xPRO+MLx+R1
   - name: program_title
-    description: str, title of the course run
+    description: str, title of the course run   
   - name: courserun_readable_id
     description: str, Open edX Course ID formatted as course-v1:{org}+{course code}+{run_tag}
       e.g. course-v1:xPRO+MLx1+R0
@@ -60,7 +60,7 @@ models:
       "refunded" all associated with the coupon
   tests:
   - dbt_expectations.expect_compound_columns_to_be_unique:
-      column_list: ["coupon_id", "order_ids"]
+      column_list: ["coupon_id", "order_ids", "product_id"]
 - name: int__mitxpro__ecommerce_couponversion
   description: A version of a coupon linked to a specific couponpaymentversion record
   columns:

--- a/src/ol_dbt/models/intermediate/mitxpro/_int_mitxpro__models.yml
+++ b/src/ol_dbt/models/intermediate/mitxpro/_int_mitxpro__models.yml
@@ -22,19 +22,19 @@ models:
   - name: couponpayment_name
     description: string, human readable name for the coupon payment
   - name: b2border_contract_number
-    description: string, contract number used to identify the order
+    description: string, contract number used to identify the order  
   - name: product_id
-    description: int, foreign key in ecommerce_product
+    description: int, foreign key in ecommerce_product 
   - name: couponpaymentversion_payment_transaction
     description: string, string that identifies the payment invoice for coupon purchases
-      by companies
+      by companies 
   - name: req_reference_number
     description: b2b receipt req reference number for a payment
   - name: programrun_readable_id
     description: str, unique program run ID formatted as program-v1:{org}+{program
       code}+{run_tag} e.g. program-v1:xPRO+MLx+R1
   - name: program_title
-    description: str, title of the course run
+    description: str, title of the course run   
   - name: courserun_readable_id
     description: str, Open edX Course ID formatted as course-v1:{org}+{course code}+{run_tag}
       e.g. course-v1:xPRO+MLx1+R0
@@ -58,6 +58,9 @@ models:
   - name: combined_order_state
     description: string, order state. Options are "fulfilled", "failed", "created"
       "refunded" all associated with the coupon
+  tests:
+  - dbt_expectations.expect_compound_columns_to_be_unique:
+      column_list: ["coupon_id", "order_ids"]
 - name: int__mitxpro__ecommerce_couponversion
   description: A version of a coupon linked to a specific couponpaymentversion record
   columns:

--- a/src/ol_dbt/models/intermediate/mitxpro/_int_mitxpro__models.yml
+++ b/src/ol_dbt/models/intermediate/mitxpro/_int_mitxpro__models.yml
@@ -9,24 +9,26 @@ models:
     description: string, email associated to the coupon
   - name: coupon_code
     description: string, coupon code for the coupon
+  - name: coupon_id
+    description: int, foreign key referencing ecommerce_coupon
   - name: coupon_created_on
     description: timestamp, specifying when the coupon was initially created
   - name: couponpayment_name
     description: string, human readable name for the coupon payment
   - name: b2border_contract_number
-    description: string, contract number used to identify the order
+    description: string, contract number used to identify the order  
   - name: product_id
-    description: int, foreign key in ecommerce_product
+    description: int, foreign key in ecommerce_product 
   - name: couponpaymentversion_payment_transaction
     description: string, string that identifies the payment invoice for coupon purchases
-      by companies
+      by companies 
   - name: req_reference_number
     description: b2b receipt req reference number for a payment
   - name: programrun_readable_id
     description: str, unique program run ID formatted as program-v1:{org}+{program
       code}+{run_tag} e.g. program-v1:xPRO+MLx+R1
   - name: program_title
-    description: str, title of the course run
+    description: str, title of the course run   
   - name: courserun_readable_id
     description: str, Open edX Course ID formatted as course-v1:{org}+{course code}+{run_tag}
       e.g. course-v1:xPRO+MLx1+R0
@@ -34,9 +36,9 @@ models:
     description: str, title of the course
   - name: productversion_readable_id
     description: string, the readable_id field from the product object
-  - name: combinedcoupon_table_source
-    description: string, Describes whether the data on the combioned coupon table
-      is coming from b2b or elsewhere
+  - name: combinedcoupon_table_source   
+    description:  string, Describes whether the data on the combioned coupon table is 
+      coming from b2b or elsewhere
   - name: couponpaymentversion_coupon_type
     description: string, one of 'single-use' or 'promo'. Promo coupon codes can be
       used multiple times
@@ -49,10 +51,10 @@ models:
   - name: user_address_countries
     description: str, country codes for the user(s)
   - name: order_ids
-    description: int, foreign key for ecommerce_orders
+    description: int, foreign key for ecommerce_orders all associated with the coupon
   - name: combined_order_state
     description: string, order state. Options are "fulfilled", "failed", "created"
-      "refunded"
+      "refunded" all associated with the coupon
 - name: int__mitxpro__ecommerce_couponversion
   description: A version of a coupon linked to a specific couponpaymentversion record
   columns:

--- a/src/ol_dbt/models/intermediate/mitxpro/_int_mitxpro__models.yml
+++ b/src/ol_dbt/models/intermediate/mitxpro/_int_mitxpro__models.yml
@@ -22,19 +22,19 @@ models:
   - name: couponpayment_name
     description: string, human readable name for the coupon payment
   - name: b2border_contract_number
-    description: string, contract number used to identify the order
+    description: string, contract number used to identify the order  
   - name: product_id
-    description: int, foreign key in ecommerce_product
+    description: int, foreign key in ecommerce_product 
   - name: couponpaymentversion_payment_transaction
     description: string, string that identifies the payment invoice for coupon purchases
-      by companies
+      by companies 
   - name: req_reference_number
     description: b2b receipt req reference number for a payment
   - name: programrun_readable_id
     description: str, unique program run ID formatted as program-v1:{org}+{program
       code}+{run_tag} e.g. program-v1:xPRO+MLx+R1
   - name: program_title
-    description: str, title of the course run
+    description: str, title of the course run   
   - name: courserun_readable_id
     description: str, Open edX Course ID formatted as course-v1:{org}+{course code}+{run_tag}
       e.g. course-v1:xPRO+MLx1+R0

--- a/src/ol_dbt/models/intermediate/mitxpro/int__mitxpro__ecommerce_combinedcoupons.sql
+++ b/src/ol_dbt/models/intermediate/mitxpro/int__mitxpro__ecommerce_combinedcoupons.sql
@@ -69,17 +69,17 @@ with coupon as (
 )
 
 , payment_transactions as (
-    select distinct 
+    select distinct
         ecommerce_couponversion.coupon_id
         , ecommerce_couponpaymentversion.couponpaymentversion_payment_transaction
     from ecommerce_couponpaymentversion
-    inner join ecommerce_couponversion 
+    inner join ecommerce_couponversion
         on ecommerce_couponpaymentversion.couponpaymentversion_id = ecommerce_couponversion.couponpaymentversion_id
     where ecommerce_couponpaymentversion.couponpaymentversion_payment_transaction is not null
 )
 
 , latest_couponversion as (
-    select 
+    select
         coupon_id
         , max(couponversion_updated_on) as max_couponversion_updated_on
     from ecommerce_couponversion
@@ -87,38 +87,38 @@ with coupon as (
 )
 
 , reg_coupon_summary as (
-    select 
+    select
         coupon.coupon_id
-        , cast(array_join(array_distinct(array_agg(program_runs.programrun_readable_id)), ', ') as varchar) 
+        , cast(array_join(array_distinct(array_agg(program_runs.programrun_readable_id)), ', ') as varchar)
             as programrun_readable_id
         , cast(array_join(array_distinct(array_agg(program_runs.program_title)), ', ') as varchar) as program_title
-        , cast(array_join(array_distinct(array_agg(course_runs.courserun_readable_id)), ', ') as varchar) 
+        , cast(array_join(array_distinct(array_agg(course_runs.courserun_readable_id)), ', ') as varchar)
             as courserun_readable_id
         , cast(array_join(array_distinct(array_agg(courses.course_title)), ', ') as varchar) as course_title
-        , cast(array_join(array_distinct(array_agg(productversion.productversion_readable_id)), ', ') as varchar) 
+        , cast(array_join(array_distinct(array_agg(productversion.productversion_readable_id)), ', ') as varchar)
             as productversion_readable_id
         , cast(array_join(array_distinct(array_agg(users_user.user_email)), ', ') as varchar) as combined_user_emails
-        , cast(array_join(array_distinct(array_agg(users_user.user_address_country)), ', ') as varchar) 
+        , cast(array_join(array_distinct(array_agg(users_user.user_address_country)), ', ') as varchar)
             as user_address_countries
         , cast(array_join(array_distinct(array_agg(ecommerce_order.order_id)), ', ') as varchar) as order_ids
-        , cast(array_join(array_distinct(array_agg(ecommerce_order.order_state)), ', ') as varchar) 
+        , cast(array_join(array_distinct(array_agg(ecommerce_order.order_state)), ', ') as varchar)
             as combined_order_state
         , case when (count(couponredemption.couponredemption_id) >= 1) then 'true' else 'false' end as coupon_redeemed
-        
+
     from coupon
     left join latest_couponversion
         on coupon.coupon_id = latest_couponversion.coupon_id
-    left join ecommerce_couponversion 
-        on 
-            latest_couponversion.coupon_id = ecommerce_couponversion.coupon_id 
+    left join ecommerce_couponversion
+        on
+            latest_couponversion.coupon_id = ecommerce_couponversion.coupon_id
             and ecommerce_couponversion.couponversion_updated_on = latest_couponversion.max_couponversion_updated_on
     left join couponredemption
         on ecommerce_couponversion.couponversion_id = couponredemption.couponversion_id
-    left join ecommerce_couponpaymentversion 
+    left join ecommerce_couponpaymentversion
         on ecommerce_couponpaymentversion.couponpaymentversion_id = ecommerce_couponversion.couponpaymentversion_id
     left join ecommerce_order
         on ecommerce_order.order_id = couponredemption.order_id
-    left join ecommerce_line 
+    left join ecommerce_line
         on ecommerce_line.order_id = ecommerce_order.order_id
     left join program_runs
         on ecommerce_line.programrun_id = program_runs.programrun_id
@@ -128,22 +128,22 @@ with coupon as (
         on course_runs.course_id = courses.course_id
     left join productversion
         on productversion.productversion_id = ecommerce_line.productversion_id
-    left join users_user    
+    left join users_user
         on ecommerce_order.order_purchaser_user_id = users_user.user_id
     where ecommerce_order.order_state = 'fulfilled' or ecommerce_order.order_state = 'refunded'
-    group by 
+    group by
         coupon.coupon_id
 )
 
 , reg_coupon_fields as (
-    select 
+    select
         productcouponassignment.productcouponassignment_email as coupon_email
         , coupon.coupon_code
         , coupon.coupon_id
         , coupon.coupon_created_on
         , coupon.couponpayment_name
         , productcouponassignment.product_id
-        , payment_transactions.couponpaymentversion_payment_transaction 
+        , payment_transactions.couponpaymentversion_payment_transaction
         , productcouponassignment.productcouponassignment_is_redeemed
     from coupon
     left join productcouponassignment
@@ -153,13 +153,13 @@ with coupon as (
 )
 
 , unassigned_enrollment_codes as (
-    select 
+    select
         coupon.coupon_code
         , coupon.coupon_id
         , coupon.coupon_created_on as coupon_created_on
         , coupon.couponpayment_name
         , b2b_ecommerce_b2border.b2border_contract_number
-        , payment_transactions.couponpaymentversion_payment_transaction  
+        , payment_transactions.couponpaymentversion_payment_transaction
         , program_runs.programrun_readable_id
         , program_runs.program_title
         , course_runs.courserun_readable_id
@@ -177,22 +177,22 @@ with coupon as (
     inner join latest_couponversion
         on coupon.coupon_id = latest_couponversion.coupon_id
     inner join ecommerce_couponversion
-        on 
-            latest_couponversion.coupon_id = ecommerce_couponversion.coupon_id 
+        on
+            latest_couponversion.coupon_id = ecommerce_couponversion.coupon_id
             and ecommerce_couponversion.couponversion_updated_on = latest_couponversion.max_couponversion_updated_on
     inner join ecommerce_couponpaymentversion
-        on ecommerce_couponpaymentversion.couponpaymentversion_id = ecommerce_couponversion.couponpaymentversion_id 
-    left join b2b_ecommerce_b2border 
+        on ecommerce_couponpaymentversion.couponpaymentversion_id = ecommerce_couponversion.couponpaymentversion_id
+    left join b2b_ecommerce_b2border
         on ecommerce_couponpaymentversion.couponpaymentversion_id = b2b_ecommerce_b2border.couponpaymentversion_id
-    left join payment_transactions 
-        on payment_transactions.coupon_id = coupon.coupon_id   
+    left join payment_transactions
+        on payment_transactions.coupon_id = coupon.coupon_id
     left join couponredemption
         on couponredemption.couponversion_id = ecommerce_couponversion.couponversion_id
-    left join ecommerce_order 
+    left join ecommerce_order
         on couponredemption.order_id = ecommerce_order.order_id
-    left join users_user 
-        on users_user.user_id = ecommerce_order.order_purchaser_user_id 
-    left join ecommerce_line 
+    left join users_user
+        on users_user.user_id = ecommerce_order.order_purchaser_user_id
+    left join ecommerce_line
         on ecommerce_line.order_id = ecommerce_order.order_id
     left join program_runs
         on ecommerce_line.programrun_id = program_runs.programrun_id
@@ -202,19 +202,19 @@ with coupon as (
         on course_runs.course_id = courses.course_id
     left join productversion
         on productversion.productversion_id = ecommerce_line.productversion_id
-    where 
-        ecommerce_couponpaymentversion.couponpaymentversion_coupon_type = 'single-use' 
-        and ecommerce_couponpaymentversion.couponpaymentversion_discount_amount = 1.0000 
+    where
+        ecommerce_couponpaymentversion.couponpaymentversion_coupon_type = 'single-use'
+        and ecommerce_couponpaymentversion.couponpaymentversion_discount_amount = 1.0000
         and coupon.coupon_id not in (
             select coupon_id
-            from ecommerce_productcouponassignment 
+            from ecommerce_productcouponassignment
         )
         and not exists (
             select b2b_ecommerce_b2border.couponpaymentversion_id
             from b2b_ecommerce_b2border
-            where 
+            where
                 b2b_ecommerce_b2border.couponpaymentversion_id = ecommerce_couponpaymentversion.couponpaymentversion_id
-        ) 
+        )
 )
 
 , b2b_coupon_fields as (
@@ -226,7 +226,7 @@ with coupon as (
         , coupon.couponpayment_name
         , b2b_ecommerce_b2border.b2border_contract_number
         , b2b_ecommerce_b2border.product_id
-        , ecommerce_couponpaymentversion.couponpaymentversion_payment_transaction 
+        , ecommerce_couponpaymentversion.couponpaymentversion_payment_transaction
         , program_runs.programrun_readable_id
         , program_runs.program_title
         , course_runs.courserun_readable_id
@@ -243,25 +243,25 @@ with coupon as (
                 as varchar
             ), '"', ''
         ) as req_reference_number
-        , case 
+        , case
             when couponredemption.couponredemption_id is not null
-                then 'true' 
-            else 'false' 
+                then 'true'
+            else 'false'
         end as coupon_redeemed
-    from b2b_ecommerce_b2border 
-    inner join ecommerce_couponpaymentversion 
+    from b2b_ecommerce_b2border
+    inner join ecommerce_couponpaymentversion
         on ecommerce_couponpaymentversion.couponpaymentversion_id = b2b_ecommerce_b2border.couponpaymentversion_id
-    inner join ecommerce_couponversion 
+    inner join ecommerce_couponversion
         on ecommerce_couponversion.couponpaymentversion_id = ecommerce_couponpaymentversion.couponpaymentversion_id
-    inner join coupon 
+    inner join coupon
         on coupon.coupon_id = ecommerce_couponversion.coupon_id
-    left join couponredemption 
+    left join couponredemption
         on couponredemption.couponversion_id = ecommerce_couponversion.couponversion_id
-    left join ecommerce_order 
+    left join ecommerce_order
         on ecommerce_order.order_id = couponredemption.order_id
-    left join b2b_ecommerce_b2breceipt 
+    left join b2b_ecommerce_b2breceipt
         on b2b_ecommerce_b2breceipt.b2border_id = b2b_ecommerce_b2border.b2border_id
-    left join ecommerce_line 
+    left join ecommerce_line
         on ecommerce_line.order_id = ecommerce_order.order_id
     left join program_runs
         on ecommerce_line.programrun_id = program_runs.programrun_id
@@ -271,12 +271,12 @@ with coupon as (
         on course_runs.course_id = courses.course_id
     left join productversion
         on productversion.productversion_id = b2b_ecommerce_b2border.productversion_id
-    left join users_user    
+    left join users_user
         on ecommerce_order.order_purchaser_user_id = users_user.user_id
 )
 
 
-select 
+select
     reg_coupon_fields.coupon_email
     , reg_coupon_fields.coupon_code
     , reg_coupon_fields.coupon_id
@@ -303,7 +303,7 @@ where reg_coupon_fields.coupon_id not in (select coupon_id from b2b_coupon_field
 
 union distinct
 
-select 
+select
     b2b_coupon_fields.b2border_email as coupon_email
     , b2b_coupon_fields.coupon_code
     , b2b_coupon_fields.coupon_id
@@ -327,7 +327,7 @@ from b2b_coupon_fields
 
 union distinct
 
-select 
+select
     coupon_email
     , coupon_code
     , coupon_id
@@ -335,7 +335,7 @@ select
     , couponpayment_name
     , b2border_contract_number
     , product_id
-    , couponpaymentversion_payment_transaction  
+    , couponpaymentversion_payment_transaction
     , req_reference_number
     , programrun_readable_id
     , program_title

--- a/src/ol_dbt/models/intermediate/mitxpro/int__mitxpro__ecommerce_combinedcoupons.sql
+++ b/src/ol_dbt/models/intermediate/mitxpro/int__mitxpro__ecommerce_combinedcoupons.sql
@@ -69,17 +69,17 @@ with coupon as (
 )
 
 , payment_transactions as (
-    select distinct
+    select distinct 
         ecommerce_couponversion.coupon_id
         , ecommerce_couponpaymentversion.couponpaymentversion_payment_transaction
     from ecommerce_couponpaymentversion
-    inner join ecommerce_couponversion
+    inner join ecommerce_couponversion 
         on ecommerce_couponpaymentversion.couponpaymentversion_id = ecommerce_couponversion.couponpaymentversion_id
     where ecommerce_couponpaymentversion.couponpaymentversion_payment_transaction is not null
 )
 
 , reg_coupon_summary as (
-    select
+    select 
         coupon.coupon_id
         , ecommerce_couponversion.couponversion_updated_on
         , program_runs.programrun_readable_id
@@ -95,15 +95,15 @@ with coupon as (
         , array_join(array_distinct(array_agg(ecommerce_order.order_id)), ', ') as order_ids
         , array_join(array_distinct(array_agg(ecommerce_order.order_state)), ', ') as combined_order_state
     from coupon
-    left join ecommerce_couponversion
+    left join ecommerce_couponversion 
         on coupon.coupon_id = ecommerce_couponversion.coupon_id
     left join couponredemption
         on ecommerce_couponversion.couponversion_id = couponredemption.couponversion_id
-    left join ecommerce_couponpaymentversion
+    left join ecommerce_couponpaymentversion 
         on ecommerce_couponpaymentversion.couponpaymentversion_id = ecommerce_couponversion.couponpaymentversion_id
     left join ecommerce_order
         on ecommerce_order.order_id = couponredemption.order_id
-    left join ecommerce_line
+    left join ecommerce_line 
         on ecommerce_line.order_id = ecommerce_order.order_id
     left join program_runs
         on ecommerce_line.programrun_id = program_runs.programrun_id
@@ -113,9 +113,9 @@ with coupon as (
         on course_runs.course_id = courses.course_id
     left join productversion
         on productversion.productversion_id = ecommerce_line.productversion_id
-    left join users_user
+    left join users_user    
         on ecommerce_order.order_purchaser_user_id = users_user.user_id
-    group by
+    group by 
         coupon.coupon_id
         , ecommerce_couponversion.couponversion_updated_on
         , program_runs.programrun_readable_id
@@ -128,14 +128,14 @@ with coupon as (
 )
 
 , reg_coupon_fields as (
-    select
+    select 
         productcouponassignment.productcouponassignment_email as coupon_email
         , coupon.coupon_code
         , coupon.coupon_id
         , coupon.coupon_created_on
         , coupon.couponpayment_name
         , productcouponassignment.product_id
-        , payment_transactions.couponpaymentversion_payment_transaction
+        , payment_transactions.couponpaymentversion_payment_transaction 
         , productcouponassignment.productcouponassignment_is_redeemed
     from coupon
     left join productcouponassignment
@@ -154,7 +154,7 @@ with coupon as (
         , coupon.couponpayment_name
         , b2b_ecommerce_b2border.b2border_contract_number
         , b2b_ecommerce_b2border.product_id
-        , ecommerce_couponpaymentversion.couponpaymentversion_payment_transaction
+        , ecommerce_couponpaymentversion.couponpaymentversion_payment_transaction 
         , program_runs.programrun_readable_id
         , program_runs.program_title
         , course_runs.courserun_readable_id
@@ -173,25 +173,25 @@ with coupon as (
                 as varchar
             ), '"', ''
         ) as req_reference_number
-        , case
+        , case 
             when couponredemption.couponredemption_id is not null
-                then 'true'
-            else 'false'
+                then 'true' 
+            else 'false' 
         end as coupon_redeemed
-    from b2b_ecommerce_b2border
-    inner join ecommerce_couponpaymentversion
+    from b2b_ecommerce_b2border 
+    inner join ecommerce_couponpaymentversion 
         on ecommerce_couponpaymentversion.couponpaymentversion_id = b2b_ecommerce_b2border.couponpaymentversion_id
-    inner join ecommerce_couponversion
+    inner join ecommerce_couponversion 
         on ecommerce_couponversion.couponpaymentversion_id = ecommerce_couponpaymentversion.couponpaymentversion_id
-    inner join coupon
+    inner join coupon 
         on coupon.coupon_id = ecommerce_couponversion.coupon_id
-    left join couponredemption
+    left join couponredemption 
         on couponredemption.couponversion_id = ecommerce_couponversion.couponversion_id
-    left join ecommerce_order
+    left join ecommerce_order 
         on ecommerce_order.order_id = couponredemption.order_id
-    left join b2b_ecommerce_b2breceipt
+    left join b2b_ecommerce_b2breceipt 
         on b2b_ecommerce_b2breceipt.b2border_id = b2b_ecommerce_b2border.b2border_id
-    left join ecommerce_line
+    left join ecommerce_line 
         on ecommerce_line.order_id = ecommerce_order.order_id
     left join program_runs
         on ecommerce_line.programrun_id = program_runs.programrun_id
@@ -201,12 +201,12 @@ with coupon as (
         on course_runs.course_id = courses.course_id
     left join productversion
         on productversion.productversion_id = b2b_ecommerce_b2border.productversion_id
-    left join users_user
+    left join users_user    
         on ecommerce_order.order_purchaser_user_id = users_user.user_id
 )
 
 
-select
+select 
     reg_coupon_fields.coupon_email
     , reg_coupon_fields.coupon_code
     , reg_coupon_fields.coupon_id
@@ -226,10 +226,10 @@ select
     , reg_coupon_summary.couponpaymentversion_coupon_type
     , reg_coupon_summary.couponpaymentversion_discount_amount
     , reg_coupon_summary.coupon_redeemed
-    , reg_coupon_summary.combined_user_emails
-    , reg_coupon_summary.user_address_countries
-    , reg_coupon_summary.order_ids
-    , reg_coupon_summary.combined_order_state
+    , cast(reg_coupon_summary.combined_user_emails as bigint) as combined_user_emails
+    , cast(reg_coupon_summary.user_address_countries as bigint) as user_address_countries
+    , cast(reg_coupon_summary.order_ids as bigint) as order_ids
+    , cast(reg_coupon_summary.combined_order_state as bigint) as combined_order_state
 from reg_coupon_fields
 inner join reg_coupon_summary
     on reg_coupon_fields.coupon_id = reg_coupon_summary.coupon_id
@@ -237,7 +237,7 @@ where reg_coupon_fields.coupon_id not in (select coupon_id from b2b_coupon_field
 
 union distinct
 
-select
+select 
     b2b_coupon_fields.b2border_email as coupon_email
     , b2b_coupon_fields.coupon_code
     , b2b_coupon_fields.coupon_id
@@ -257,8 +257,8 @@ select
     , b2b_coupon_fields.couponpaymentversion_coupon_type
     , b2b_coupon_fields.couponpaymentversion_discount_amount
     , b2b_coupon_fields.coupon_redeemed
-    , b2b_coupon_fields.combined_user_emails
-    , b2b_coupon_fields.user_address_countries
-    , b2b_coupon_fields.order_ids
-    , b2b_coupon_fields.combined_order_state
+    , cast(b2b_coupon_fields.combined_user_emails as bigint) as combined_user_emails
+    , cast(b2b_coupon_fields.user_address_countries as bigint) as user_address_countries
+    , cast(b2b_coupon_fields.order_ids as bigint) as order_ids
+    , cast(b2b_coupon_fields.combined_order_state as bigint) as combined_order_state
 from b2b_coupon_fields

--- a/src/ol_dbt/models/intermediate/mitxpro/int__mitxpro__ecommerce_combinedcoupons.sql
+++ b/src/ol_dbt/models/intermediate/mitxpro/int__mitxpro__ecommerce_combinedcoupons.sql
@@ -69,17 +69,17 @@ with coupon as (
 )
 
 , payment_transactions as (
-    select distinct
+    select distinct 
         ecommerce_couponversion.coupon_id
         , ecommerce_couponpaymentversion.couponpaymentversion_payment_transaction
     from ecommerce_couponpaymentversion
-    inner join ecommerce_couponversion
+    inner join ecommerce_couponversion 
         on ecommerce_couponpaymentversion.couponpaymentversion_id = ecommerce_couponversion.couponpaymentversion_id
     where ecommerce_couponpaymentversion.couponpaymentversion_payment_transaction is not null
 )
 
 
-select
+select 
     productcouponassignment.productcouponassignment_email as coupon_email
     , coupon.coupon_code
     , coupon.coupon_id
@@ -87,7 +87,7 @@ select
     , coupon.couponpayment_name
     , null as b2border_contract_number
     , productcouponassignment.product_id
-    , payment_transactions.couponpaymentversion_payment_transaction
+    , payment_transactions.couponpaymentversion_payment_transaction 
     , null as req_reference_number
     , program_runs.programrun_readable_id
     , program_runs.program_title
@@ -97,7 +97,7 @@ select
     , 'regular coupon' as combinedcoupon_table_source
     , ecommerce_couponpaymentversion.couponpaymentversion_coupon_type
     , ecommerce_couponpaymentversion.couponpaymentversion_discount_amount
-    , coalesce ((count(couponredemption.couponredemption_id) >= 1), false) as coupon_redeemed
+    , case when (count(couponredemption.couponredemption_id) >= 1) then 'true' else 'false' end as coupon_redeemed
     , array_join(array_distinct(array_agg(users_user.user_email)), ', ') as combined_user_emails
     , array_join(array_distinct(array_agg(users_user.user_address_country)), ', ') as user_address_countries
     , array_join(array_distinct(array_agg(ecommerce_order.order_id)), ', ') as order_ids
@@ -105,19 +105,19 @@ select
 from coupon
 left join productcouponassignment
     on productcouponassignment.coupon_id = coupon.coupon_id
-left join ecommerce_couponversion
+left join ecommerce_couponversion 
     on coupon.coupon_id = ecommerce_couponversion.coupon_id
-left join ecommerce_couponpaymentversion
+left join ecommerce_couponpaymentversion 
     on ecommerce_couponpaymentversion.couponpaymentversion_id = ecommerce_couponversion.couponpaymentversion_id
 left join couponredemption
     on ecommerce_couponversion.couponversion_id = couponredemption.couponversion_id
 left join ecommerce_order
     on ecommerce_order.order_id = couponredemption.order_id
-left join users_user
+left join users_user    
     on ecommerce_order.order_purchaser_user_id = users_user.user_id
 left join payment_transactions
     on coupon.coupon_id = payment_transactions.coupon_id
-left join ecommerce_line
+left join ecommerce_line 
     on ecommerce_line.order_id = ecommerce_order.order_id
 left join program_runs
     on ecommerce_line.programrun_id = program_runs.programrun_id
@@ -127,14 +127,14 @@ left join courses
     on course_runs.course_id = courses.course_id
 left join productversion
     on productversion.productversion_id = ecommerce_line.productversion_id
-group by
-    productcouponassignment.productcouponassignment_email
+group by 
+    productcouponassignment.productcouponassignment_email 
     , coupon.coupon_code
     , coupon.coupon_id
     , coupon.coupon_created_on
     , coupon.couponpayment_name
     , productcouponassignment.product_id
-    , payment_transactions.couponpaymentversion_payment_transaction
+    , payment_transactions.couponpaymentversion_payment_transaction 
     , program_runs.programrun_readable_id
     , program_runs.program_title
     , course_runs.courserun_readable_id
@@ -145,7 +145,7 @@ group by
 
 union distinct
 
-select
+select 
     b2b_ecommerce_b2border.b2border_email as coupon_email
     , coupon.coupon_code
     , coupon.coupon_id
@@ -153,7 +153,7 @@ select
     , coupon.couponpayment_name
     , b2b_ecommerce_b2border.b2border_contract_number
     , b2b_ecommerce_b2border.product_id
-    , ecommerce_couponpaymentversion.couponpaymentversion_payment_transaction
+    , ecommerce_couponpaymentversion.couponpaymentversion_payment_transaction 
     , replace(
         cast(
             json_extract(b2b_ecommerce_b2breceipt.b2breceipt_data, '$.req_reference_number'
@@ -169,27 +169,31 @@ select
     , 'b2b coupon' as combinedcoupon_table_source
     , ecommerce_couponpaymentversion.couponpaymentversion_coupon_type
     , ecommerce_couponpaymentversion.couponpaymentversion_discount_amount
-    , coalesce ((count(couponredemption.couponredemption_id) >= 1), false) as coupon_redeemed
+    , case 
+        when (count(couponredemption.couponredemption_id) >= 1) 
+            then 'true' 
+        else 'false' 
+    end as coupon_redeemed
     , array_join(array_distinct(array_agg(users_user.user_email)), ', ') as combined_user_emails
     , array_join(array_distinct(array_agg(users_user.user_address_country)), ', ') as user_address_countries
     , array_join(array_distinct(array_agg(ecommerce_order.order_id)), ', ') as order_ids
     , array_join(array_distinct(array_agg(ecommerce_order.order_state)), ', ') as combined_order_state
-from b2b_ecommerce_b2border
-left join ecommerce_couponpaymentversion
+from b2b_ecommerce_b2border 
+left join ecommerce_couponpaymentversion 
     on ecommerce_couponpaymentversion.couponpaymentversion_id = b2b_ecommerce_b2border.couponpaymentversion_id
-left join coupon
-    on coupon.coupon_id = b2b_ecommerce_b2border.b2bcoupon_id
-left join ecommerce_couponversion
+left join coupon 
+    on coupon.coupon_id = b2b_ecommerce_b2border.b2bcoupon_id 
+left join ecommerce_couponversion 
     on ecommerce_couponversion.coupon_id = coupon.coupon_id
-left join couponredemption
+left join couponredemption 
     on couponredemption.couponversion_id = ecommerce_couponversion.couponversion_id
-left join ecommerce_order
+left join ecommerce_order 
     on ecommerce_order.order_id = couponredemption.order_id
-left join users_user
+left join users_user    
     on ecommerce_order.order_purchaser_user_id = users_user.user_id
-left join b2b_ecommerce_b2breceipt
+left join b2b_ecommerce_b2breceipt 
     on b2b_ecommerce_b2breceipt.b2border_id = b2b_ecommerce_b2border.b2border_id
-left join ecommerce_line
+left join ecommerce_line 
     on ecommerce_line.order_id = ecommerce_order.order_id
 left join program_runs
     on ecommerce_line.programrun_id = program_runs.programrun_id
@@ -199,21 +203,21 @@ left join courses
     on course_runs.course_id = courses.course_id
 left join productversion
     on productversion.productversion_id = b2b_ecommerce_b2border.productversion_id
-group by
-    b2b_ecommerce_b2border.b2border_email
+group by 
+    b2b_ecommerce_b2border.b2border_email 
     , coupon.coupon_code
     , coupon.coupon_id
     , coupon.coupon_created_on
     , coupon.couponpayment_name
     , b2b_ecommerce_b2border.b2border_contract_number
     , b2b_ecommerce_b2border.product_id
-    , ecommerce_couponpaymentversion.couponpaymentversion_payment_transaction
+    , ecommerce_couponpaymentversion.couponpaymentversion_payment_transaction 
     , replace(
         cast(
             json_extract(b2b_ecommerce_b2breceipt.b2breceipt_data, '$.req_reference_number')
             as varchar
         ), '"', ''
-    )
+    ) 
     , program_runs.programrun_readable_id
     , program_runs.program_title
     , course_runs.courserun_readable_id

--- a/src/ol_dbt/models/intermediate/mitxpro/int__mitxpro__ecommerce_combinedcoupons.sql
+++ b/src/ol_dbt/models/intermediate/mitxpro/int__mitxpro__ecommerce_combinedcoupons.sql
@@ -69,17 +69,17 @@ with coupon as (
 )
 
 , payment_transactions as (
-    select distinct 
+    select distinct
         ecommerce_couponversion.coupon_id
         , ecommerce_couponpaymentversion.couponpaymentversion_payment_transaction
     from ecommerce_couponpaymentversion
-    inner join ecommerce_couponversion 
+    inner join ecommerce_couponversion
         on ecommerce_couponpaymentversion.couponpaymentversion_id = ecommerce_couponversion.couponpaymentversion_id
     where ecommerce_couponpaymentversion.couponpaymentversion_payment_transaction is not null
 )
 
 , reg_coupon_summary as (
-    select 
+    select
         coupon.coupon_id
         , ecommerce_couponversion.couponversion_updated_on
         , program_runs.programrun_readable_id
@@ -95,15 +95,15 @@ with coupon as (
         , array_join(array_distinct(array_agg(ecommerce_order.order_id)), ', ') as order_ids
         , array_join(array_distinct(array_agg(ecommerce_order.order_state)), ', ') as combined_order_state
     from coupon
-    left join ecommerce_couponversion 
+    left join ecommerce_couponversion
         on coupon.coupon_id = ecommerce_couponversion.coupon_id
     left join couponredemption
         on ecommerce_couponversion.couponversion_id = couponredemption.couponversion_id
-    left join ecommerce_couponpaymentversion 
+    left join ecommerce_couponpaymentversion
         on ecommerce_couponpaymentversion.couponpaymentversion_id = ecommerce_couponversion.couponpaymentversion_id
     left join ecommerce_order
         on ecommerce_order.order_id = couponredemption.order_id
-    left join ecommerce_line 
+    left join ecommerce_line
         on ecommerce_line.order_id = ecommerce_order.order_id
     left join program_runs
         on ecommerce_line.programrun_id = program_runs.programrun_id
@@ -113,9 +113,9 @@ with coupon as (
         on course_runs.course_id = courses.course_id
     left join productversion
         on productversion.productversion_id = ecommerce_line.productversion_id
-    left join users_user    
+    left join users_user
         on ecommerce_order.order_purchaser_user_id = users_user.user_id
-    group by 
+    group by
         coupon.coupon_id
         , ecommerce_couponversion.couponversion_updated_on
         , program_runs.programrun_readable_id
@@ -128,14 +128,14 @@ with coupon as (
 )
 
 , reg_coupon_fields as (
-    select 
+    select
         productcouponassignment.productcouponassignment_email as coupon_email
         , coupon.coupon_code
         , coupon.coupon_id
         , coupon.coupon_created_on
         , coupon.couponpayment_name
         , productcouponassignment.product_id
-        , payment_transactions.couponpaymentversion_payment_transaction 
+        , payment_transactions.couponpaymentversion_payment_transaction
         , productcouponassignment.productcouponassignment_is_redeemed
     from coupon
     left join productcouponassignment
@@ -154,7 +154,7 @@ with coupon as (
         , coupon.couponpayment_name
         , b2b_ecommerce_b2border.b2border_contract_number
         , b2b_ecommerce_b2border.product_id
-        , ecommerce_couponpaymentversion.couponpaymentversion_payment_transaction 
+        , ecommerce_couponpaymentversion.couponpaymentversion_payment_transaction
         , program_runs.programrun_readable_id
         , program_runs.program_title
         , course_runs.courserun_readable_id
@@ -162,36 +162,36 @@ with coupon as (
         , productversion.productversion_readable_id
         , ecommerce_couponpaymentversion.couponpaymentversion_coupon_type
         , ecommerce_couponpaymentversion.couponpaymentversion_discount_amount
-        , TRY_CAST(users_user.user_email as BigInt) combined_user_emails 
-        , TRY_CAST(users_user.user_address_country as BigInt) user_address_countries 
-        , TRY_CAST(ecommerce_order.order_id as BigInt) as order_ids
-        , TRY_CAST(ecommerce_order.order_state as BigInt) as combined_order_state
+        , try_cast(users_user.user_email as BigInt) as combined_user_emails
+        , try_cast(users_user.user_address_country as BigInt) as user_address_countries
+        , try_cast(ecommerce_order.order_id as BigInt) as order_ids
+        , try_cast(ecommerce_order.order_state as BigInt) as combined_order_state
         , replace(
             cast(
                 json_extract(b2b_ecommerce_b2breceipt.b2breceipt_data, '$.req_reference_number'
                 )
-                as varchar
+                as Varchar
             ), '"', ''
         ) as req_reference_number
-        , case 
+        , case
             when couponredemption.couponredemption_id is not null
-                then 'true' 
-            else 'false' 
+                then 'true'
+            else 'false'
         end as coupon_redeemed
-    from b2b_ecommerce_b2border 
-    inner join ecommerce_couponpaymentversion 
+    from b2b_ecommerce_b2border
+    inner join ecommerce_couponpaymentversion
         on ecommerce_couponpaymentversion.couponpaymentversion_id = b2b_ecommerce_b2border.couponpaymentversion_id
-    inner join ecommerce_couponversion 
+    inner join ecommerce_couponversion
         on ecommerce_couponversion.couponpaymentversion_id = ecommerce_couponpaymentversion.couponpaymentversion_id
-    inner join coupon 
+    inner join coupon
         on coupon.coupon_id = ecommerce_couponversion.coupon_id
-    left join couponredemption 
+    left join couponredemption
         on couponredemption.couponversion_id = ecommerce_couponversion.couponversion_id
-    left join ecommerce_order 
+    left join ecommerce_order
         on ecommerce_order.order_id = couponredemption.order_id
-    left join b2b_ecommerce_b2breceipt 
+    left join b2b_ecommerce_b2breceipt
         on b2b_ecommerce_b2breceipt.b2border_id = b2b_ecommerce_b2border.b2border_id
-    left join ecommerce_line 
+    left join ecommerce_line
         on ecommerce_line.order_id = ecommerce_order.order_id
     left join program_runs
         on ecommerce_line.programrun_id = program_runs.programrun_id
@@ -201,12 +201,12 @@ with coupon as (
         on course_runs.course_id = courses.course_id
     left join productversion
         on productversion.productversion_id = b2b_ecommerce_b2border.productversion_id
-    left join users_user    
+    left join users_user
         on ecommerce_order.order_purchaser_user_id = users_user.user_id
 )
 
 
-select 
+select
     reg_coupon_fields.coupon_email
     , reg_coupon_fields.coupon_code
     , reg_coupon_fields.coupon_id
@@ -226,10 +226,10 @@ select
     , reg_coupon_summary.couponpaymentversion_coupon_type
     , reg_coupon_summary.couponpaymentversion_discount_amount
     , reg_coupon_summary.coupon_redeemed
-    , TRY_CAST(reg_coupon_summary.combined_user_emails as BigInt) as combined_user_emails
-    , TRY_CAST(reg_coupon_summary.user_address_countries as BigInt) as user_address_countries
-    , TRY_CAST(reg_coupon_summary.order_ids as BigInt) as order_ids
-    , TRY_CAST(reg_coupon_summary.combined_order_state as BigInt) as combined_order_state
+    , try_cast(reg_coupon_summary.combined_user_emails as BigInt) as combined_user_emails
+    , try_cast(reg_coupon_summary.user_address_countries as BigInt) as user_address_countries
+    , try_cast(reg_coupon_summary.order_ids as BigInt) as order_ids
+    , try_cast(reg_coupon_summary.combined_order_state as BigInt) as combined_order_state
 from reg_coupon_fields
 inner join reg_coupon_summary
     on reg_coupon_fields.coupon_id = reg_coupon_summary.coupon_id
@@ -237,7 +237,7 @@ where reg_coupon_fields.coupon_id not in (select coupon_id from b2b_coupon_field
 
 union distinct
 
-select 
+select
     b2b_coupon_fields.b2border_email as coupon_email
     , b2b_coupon_fields.coupon_code
     , b2b_coupon_fields.coupon_id

--- a/src/ol_dbt/models/intermediate/mitxpro/int__mitxpro__ecommerce_combinedcoupons.sql
+++ b/src/ol_dbt/models/intermediate/mitxpro/int__mitxpro__ecommerce_combinedcoupons.sql
@@ -69,17 +69,17 @@ with coupon as (
 )
 
 , payment_transactions as (
-    select distinct 
+    select distinct
         ecommerce_couponversion.coupon_id
         , ecommerce_couponpaymentversion.couponpaymentversion_payment_transaction
     from ecommerce_couponpaymentversion
-    inner join ecommerce_couponversion 
+    inner join ecommerce_couponversion
         on ecommerce_couponpaymentversion.couponpaymentversion_id = ecommerce_couponversion.couponpaymentversion_id
     where ecommerce_couponpaymentversion.couponpaymentversion_payment_transaction is not null
 )
 
 , reg_coupon_summary as (
-    select 
+    select
         coupon.coupon_id
         , ecommerce_couponversion.couponversion_updated_on
         , program_runs.programrun_readable_id
@@ -95,15 +95,15 @@ with coupon as (
         , array_join(array_distinct(array_agg(ecommerce_order.order_id)), ', ') as order_ids
         , array_join(array_distinct(array_agg(ecommerce_order.order_state)), ', ') as combined_order_state
     from coupon
-    left join ecommerce_couponversion 
+    left join ecommerce_couponversion
         on coupon.coupon_id = ecommerce_couponversion.coupon_id
     left join couponredemption
         on ecommerce_couponversion.couponversion_id = couponredemption.couponversion_id
-    left join ecommerce_couponpaymentversion 
+    left join ecommerce_couponpaymentversion
         on ecommerce_couponpaymentversion.couponpaymentversion_id = ecommerce_couponversion.couponpaymentversion_id
     left join ecommerce_order
         on ecommerce_order.order_id = couponredemption.order_id
-    left join ecommerce_line 
+    left join ecommerce_line
         on ecommerce_line.order_id = ecommerce_order.order_id
     left join program_runs
         on ecommerce_line.programrun_id = program_runs.programrun_id
@@ -113,9 +113,9 @@ with coupon as (
         on course_runs.course_id = courses.course_id
     left join productversion
         on productversion.productversion_id = ecommerce_line.productversion_id
-    left join users_user    
+    left join users_user
         on ecommerce_order.order_purchaser_user_id = users_user.user_id
-    group by 
+    group by
         coupon.coupon_id
         , ecommerce_couponversion.couponversion_updated_on
         , program_runs.programrun_readable_id
@@ -128,14 +128,14 @@ with coupon as (
 )
 
 , reg_coupon_fields as (
-    select 
+    select
         productcouponassignment.productcouponassignment_email as coupon_email
         , coupon.coupon_code
         , coupon.coupon_id
         , coupon.coupon_created_on
         , coupon.couponpayment_name
         , productcouponassignment.product_id
-        , payment_transactions.couponpaymentversion_payment_transaction 
+        , payment_transactions.couponpaymentversion_payment_transaction
         , productcouponassignment.productcouponassignment_is_redeemed
     from coupon
     left join productcouponassignment
@@ -154,7 +154,7 @@ with coupon as (
         , coupon.couponpayment_name
         , b2b_ecommerce_b2border.b2border_contract_number
         , b2b_ecommerce_b2border.product_id
-        , ecommerce_couponpaymentversion.couponpaymentversion_payment_transaction 
+        , ecommerce_couponpaymentversion.couponpaymentversion_payment_transaction
         , program_runs.programrun_readable_id
         , program_runs.program_title
         , course_runs.courserun_readable_id
@@ -173,25 +173,25 @@ with coupon as (
                 as varchar
             ), '"', ''
         ) as req_reference_number
-        , case 
+        , case
             when couponredemption.couponredemption_id is not null
-                then 'true' 
-            else 'false' 
+                then 'true'
+            else 'false'
         end as coupon_redeemed
-    from b2b_ecommerce_b2border 
-    inner join ecommerce_couponpaymentversion 
+    from b2b_ecommerce_b2border
+    inner join ecommerce_couponpaymentversion
         on ecommerce_couponpaymentversion.couponpaymentversion_id = b2b_ecommerce_b2border.couponpaymentversion_id
-    inner join ecommerce_couponversion 
+    inner join ecommerce_couponversion
         on ecommerce_couponversion.couponpaymentversion_id = ecommerce_couponpaymentversion.couponpaymentversion_id
-    inner join coupon 
+    inner join coupon
         on coupon.coupon_id = ecommerce_couponversion.coupon_id
-    left join couponredemption 
+    left join couponredemption
         on couponredemption.couponversion_id = ecommerce_couponversion.couponversion_id
-    left join ecommerce_order 
+    left join ecommerce_order
         on ecommerce_order.order_id = couponredemption.order_id
-    left join b2b_ecommerce_b2breceipt 
+    left join b2b_ecommerce_b2breceipt
         on b2b_ecommerce_b2breceipt.b2border_id = b2b_ecommerce_b2border.b2border_id
-    left join ecommerce_line 
+    left join ecommerce_line
         on ecommerce_line.order_id = ecommerce_order.order_id
     left join program_runs
         on ecommerce_line.programrun_id = program_runs.programrun_id
@@ -201,12 +201,12 @@ with coupon as (
         on course_runs.course_id = courses.course_id
     left join productversion
         on productversion.productversion_id = b2b_ecommerce_b2border.productversion_id
-    left join users_user    
+    left join users_user
         on ecommerce_order.order_purchaser_user_id = users_user.user_id
 )
 
 
-select 
+select
     reg_coupon_fields.coupon_email
     , reg_coupon_fields.coupon_code
     , reg_coupon_fields.coupon_id
@@ -237,7 +237,7 @@ where reg_coupon_fields.coupon_id not in (select coupon_id from b2b_coupon_field
 
 union distinct
 
-select 
+select
     b2b_coupon_fields.b2border_email as coupon_email
     , b2b_coupon_fields.coupon_code
     , b2b_coupon_fields.coupon_id

--- a/src/ol_dbt/models/intermediate/mitxpro/int__mitxpro__ecommerce_combinedcoupons.sql
+++ b/src/ol_dbt/models/intermediate/mitxpro/int__mitxpro__ecommerce_combinedcoupons.sql
@@ -69,17 +69,17 @@ with coupon as (
 )
 
 , payment_transactions as (
-    select distinct
+    select distinct 
         ecommerce_couponversion.coupon_id
         , ecommerce_couponpaymentversion.couponpaymentversion_payment_transaction
     from ecommerce_couponpaymentversion
-    inner join ecommerce_couponversion
+    inner join ecommerce_couponversion 
         on ecommerce_couponpaymentversion.couponpaymentversion_id = ecommerce_couponversion.couponpaymentversion_id
     where ecommerce_couponpaymentversion.couponpaymentversion_payment_transaction is not null
 )
 
 , reg_coupon_summary as (
-    select
+    select 
         coupon.coupon_id
         , ecommerce_couponversion.couponversion_updated_on
         , program_runs.programrun_readable_id
@@ -95,15 +95,15 @@ with coupon as (
         , array_join(array_distinct(array_agg(ecommerce_order.order_id)), ', ') as order_ids
         , array_join(array_distinct(array_agg(ecommerce_order.order_state)), ', ') as combined_order_state
     from coupon
-    left join ecommerce_couponversion
+    left join ecommerce_couponversion 
         on coupon.coupon_id = ecommerce_couponversion.coupon_id
     left join couponredemption
         on ecommerce_couponversion.couponversion_id = couponredemption.couponversion_id
-    left join ecommerce_couponpaymentversion
+    left join ecommerce_couponpaymentversion 
         on ecommerce_couponpaymentversion.couponpaymentversion_id = ecommerce_couponversion.couponpaymentversion_id
     left join ecommerce_order
         on ecommerce_order.order_id = couponredemption.order_id
-    left join ecommerce_line
+    left join ecommerce_line 
         on ecommerce_line.order_id = ecommerce_order.order_id
     left join program_runs
         on ecommerce_line.programrun_id = program_runs.programrun_id
@@ -113,9 +113,9 @@ with coupon as (
         on course_runs.course_id = courses.course_id
     left join productversion
         on productversion.productversion_id = ecommerce_line.productversion_id
-    left join users_user
+    left join users_user    
         on ecommerce_order.order_purchaser_user_id = users_user.user_id
-    group by
+    group by 
         coupon.coupon_id
         , ecommerce_couponversion.couponversion_updated_on
         , program_runs.programrun_readable_id
@@ -128,14 +128,14 @@ with coupon as (
 )
 
 , reg_coupon_fields as (
-    select
+    select 
         productcouponassignment.productcouponassignment_email as coupon_email
         , coupon.coupon_code
         , coupon.coupon_id
         , coupon.coupon_created_on
         , coupon.couponpayment_name
         , productcouponassignment.product_id
-        , payment_transactions.couponpaymentversion_payment_transaction
+        , payment_transactions.couponpaymentversion_payment_transaction 
         , productcouponassignment.productcouponassignment_is_redeemed
     from coupon
     left join productcouponassignment
@@ -154,7 +154,7 @@ with coupon as (
         , coupon.couponpayment_name
         , b2b_ecommerce_b2border.b2border_contract_number
         , b2b_ecommerce_b2border.product_id
-        , ecommerce_couponpaymentversion.couponpaymentversion_payment_transaction
+        , ecommerce_couponpaymentversion.couponpaymentversion_payment_transaction 
         , program_runs.programrun_readable_id
         , program_runs.program_title
         , course_runs.courserun_readable_id
@@ -173,25 +173,25 @@ with coupon as (
                 as varchar
             ), '"', ''
         ) as req_reference_number
-        , case
+        , case 
             when couponredemption.couponredemption_id is not null
-                then 'true'
-            else 'false'
+                then 'true' 
+            else 'false' 
         end as coupon_redeemed
-    from b2b_ecommerce_b2border
-    inner join ecommerce_couponpaymentversion
+    from b2b_ecommerce_b2border 
+    inner join ecommerce_couponpaymentversion 
         on ecommerce_couponpaymentversion.couponpaymentversion_id = b2b_ecommerce_b2border.couponpaymentversion_id
-    inner join ecommerce_couponversion
+    inner join ecommerce_couponversion 
         on ecommerce_couponversion.couponpaymentversion_id = ecommerce_couponpaymentversion.couponpaymentversion_id
-    inner join coupon
+    inner join coupon 
         on coupon.coupon_id = ecommerce_couponversion.coupon_id
-    left join couponredemption
+    left join couponredemption 
         on couponredemption.couponversion_id = ecommerce_couponversion.couponversion_id
-    left join ecommerce_order
+    left join ecommerce_order 
         on ecommerce_order.order_id = couponredemption.order_id
-    left join b2b_ecommerce_b2breceipt
+    left join b2b_ecommerce_b2breceipt 
         on b2b_ecommerce_b2breceipt.b2border_id = b2b_ecommerce_b2border.b2border_id
-    left join ecommerce_line
+    left join ecommerce_line 
         on ecommerce_line.order_id = ecommerce_order.order_id
     left join program_runs
         on ecommerce_line.programrun_id = program_runs.programrun_id
@@ -201,12 +201,12 @@ with coupon as (
         on course_runs.course_id = courses.course_id
     left join productversion
         on productversion.productversion_id = b2b_ecommerce_b2border.productversion_id
-    left join users_user
+    left join users_user    
         on ecommerce_order.order_purchaser_user_id = users_user.user_id
 )
 
 
-select
+select 
     reg_coupon_fields.coupon_email
     , reg_coupon_fields.coupon_code
     , reg_coupon_fields.coupon_id
@@ -237,7 +237,7 @@ where reg_coupon_fields.coupon_id not in (select coupon_id from b2b_coupon_field
 
 union distinct
 
-select
+select 
     b2b_coupon_fields.b2border_email as coupon_email
     , b2b_coupon_fields.coupon_code
     , b2b_coupon_fields.coupon_id
@@ -256,9 +256,9 @@ select
     , 'b2b coupon' as combinedcoupon_table_source
     , b2b_coupon_fields.couponpaymentversion_coupon_type
     , b2b_coupon_fields.couponpaymentversion_discount_amount
-    , b2b_coupon_summary.coupon_redeemed
-    , b2b_coupon_summary.combined_user_emails
-    , b2b_coupon_summary.user_address_countries
-    , b2b_coupon_summary.order_ids
-    , b2b_coupon_summary.combined_order_state
+    , b2b_coupon_fields.coupon_redeemed
+    , b2b_coupon_fields.combined_user_emails
+    , b2b_coupon_fields.user_address_countries
+    , b2b_coupon_fields.order_ids
+    , b2b_coupon_fields.combined_order_state
 from b2b_coupon_fields

--- a/src/ol_dbt/models/intermediate/mitxpro/int__mitxpro__ecommerce_combinedcoupons.sql
+++ b/src/ol_dbt/models/intermediate/mitxpro/int__mitxpro__ecommerce_combinedcoupons.sql
@@ -69,17 +69,17 @@ with coupon as (
 )
 
 , payment_transactions as (
-    select distinct
+    select distinct 
         ecommerce_couponversion.coupon_id
         , ecommerce_couponpaymentversion.couponpaymentversion_payment_transaction
     from ecommerce_couponpaymentversion
-    inner join ecommerce_couponversion
+    inner join ecommerce_couponversion 
         on ecommerce_couponpaymentversion.couponpaymentversion_id = ecommerce_couponversion.couponpaymentversion_id
     where ecommerce_couponpaymentversion.couponpaymentversion_payment_transaction is not null
 )
 
 , latest_couponversion as (
-    select
+    select 
         coupon_id
         , max(couponversion_updated_on) as max_couponversion_updated_on
     from ecommerce_couponversion
@@ -87,38 +87,38 @@ with coupon as (
 )
 
 , reg_coupon_summary as (
-    select
+    select 
         coupon.coupon_id
-        , cast(array_join(array_distinct(array_agg(program_runs.programrun_readable_id)), ', ') as varchar)
+        , cast(array_join(array_distinct(array_agg(program_runs.programrun_readable_id)), ', ') as varchar) 
             as programrun_readable_id
         , cast(array_join(array_distinct(array_agg(program_runs.program_title)), ', ') as varchar) as program_title
-        , cast(array_join(array_distinct(array_agg(course_runs.courserun_readable_id)), ', ') as varchar)
+        , cast(array_join(array_distinct(array_agg(course_runs.courserun_readable_id)), ', ') as varchar) 
             as courserun_readable_id
         , cast(array_join(array_distinct(array_agg(courses.course_title)), ', ') as varchar) as course_title
-        , cast(array_join(array_distinct(array_agg(productversion.productversion_readable_id)), ', ') as varchar)
+        , cast(array_join(array_distinct(array_agg(productversion.productversion_readable_id)), ', ') as varchar) 
             as productversion_readable_id
         , cast(array_join(array_distinct(array_agg(users_user.user_email)), ', ') as varchar) as combined_user_emails
-        , cast(array_join(array_distinct(array_agg(users_user.user_address_country)), ', ') as varchar)
+        , cast(array_join(array_distinct(array_agg(users_user.user_address_country)), ', ') as varchar) 
             as user_address_countries
         , cast(array_join(array_distinct(array_agg(ecommerce_order.order_id)), ', ') as varchar) as order_ids
-        , cast(array_join(array_distinct(array_agg(ecommerce_order.order_state)), ', ') as varchar)
+        , cast(array_join(array_distinct(array_agg(ecommerce_order.order_state)), ', ') as varchar) 
             as combined_order_state
         , case when (count(couponredemption.couponredemption_id) >= 1) then 'true' else 'false' end as coupon_redeemed
-
+        
     from coupon
     left join latest_couponversion
         on coupon.coupon_id = latest_couponversion.coupon_id
-    left join ecommerce_couponversion
-        on
-            latest_couponversion.coupon_id = ecommerce_couponversion.coupon_id
+    left join ecommerce_couponversion 
+        on 
+            latest_couponversion.coupon_id = ecommerce_couponversion.coupon_id 
             and ecommerce_couponversion.couponversion_updated_on = latest_couponversion.max_couponversion_updated_on
     left join couponredemption
         on ecommerce_couponversion.couponversion_id = couponredemption.couponversion_id
-    left join ecommerce_couponpaymentversion
+    left join ecommerce_couponpaymentversion 
         on ecommerce_couponpaymentversion.couponpaymentversion_id = ecommerce_couponversion.couponpaymentversion_id
     left join ecommerce_order
         on ecommerce_order.order_id = couponredemption.order_id
-    left join ecommerce_line
+    left join ecommerce_line 
         on ecommerce_line.order_id = ecommerce_order.order_id
     left join program_runs
         on ecommerce_line.programrun_id = program_runs.programrun_id
@@ -128,22 +128,22 @@ with coupon as (
         on course_runs.course_id = courses.course_id
     left join productversion
         on productversion.productversion_id = ecommerce_line.productversion_id
-    left join users_user
+    left join users_user    
         on ecommerce_order.order_purchaser_user_id = users_user.user_id
     where ecommerce_order.order_state = 'fulfilled' or ecommerce_order.order_state = 'refunded'
-    group by
+    group by 
         coupon.coupon_id
 )
 
 , reg_coupon_fields as (
-    select
+    select 
         productcouponassignment.productcouponassignment_email as coupon_email
         , coupon.coupon_code
         , coupon.coupon_id
         , coupon.coupon_created_on
         , coupon.couponpayment_name
         , productcouponassignment.product_id
-        , payment_transactions.couponpaymentversion_payment_transaction
+        , payment_transactions.couponpaymentversion_payment_transaction 
         , productcouponassignment.productcouponassignment_is_redeemed
     from coupon
     left join productcouponassignment
@@ -153,13 +153,13 @@ with coupon as (
 )
 
 , unassigned_enrollment_codes as (
-    select
+    select 
         coupon.coupon_code
         , coupon.coupon_id
         , coupon.coupon_created_on as coupon_created_on
         , coupon.couponpayment_name
         , b2b_ecommerce_b2border.b2border_contract_number
-        , payment_transactions.couponpaymentversion_payment_transaction
+        , payment_transactions.couponpaymentversion_payment_transaction  
         , program_runs.programrun_readable_id
         , program_runs.program_title
         , course_runs.courserun_readable_id
@@ -177,22 +177,22 @@ with coupon as (
     inner join latest_couponversion
         on coupon.coupon_id = latest_couponversion.coupon_id
     inner join ecommerce_couponversion
-        on
-            latest_couponversion.coupon_id = ecommerce_couponversion.coupon_id
+        on 
+            latest_couponversion.coupon_id = ecommerce_couponversion.coupon_id 
             and ecommerce_couponversion.couponversion_updated_on = latest_couponversion.max_couponversion_updated_on
     inner join ecommerce_couponpaymentversion
-        on ecommerce_couponpaymentversion.couponpaymentversion_id = ecommerce_couponversion.couponpaymentversion_id
-    left join b2b_ecommerce_b2border
+        on ecommerce_couponpaymentversion.couponpaymentversion_id = ecommerce_couponversion.couponpaymentversion_id 
+    left join b2b_ecommerce_b2border 
         on ecommerce_couponpaymentversion.couponpaymentversion_id = b2b_ecommerce_b2border.couponpaymentversion_id
-    left join payment_transactions
-        on payment_transactions.coupon_id = coupon.coupon_id
+    left join payment_transactions 
+        on payment_transactions.coupon_id = coupon.coupon_id   
     left join couponredemption
         on couponredemption.couponversion_id = ecommerce_couponversion.couponversion_id
-    left join ecommerce_order
+    left join ecommerce_order 
         on couponredemption.order_id = ecommerce_order.order_id
-    left join users_user
-        on users_user.user_id = ecommerce_order.order_purchaser_user_id
-    left join ecommerce_line
+    left join users_user 
+        on users_user.user_id = ecommerce_order.order_purchaser_user_id 
+    left join ecommerce_line 
         on ecommerce_line.order_id = ecommerce_order.order_id
     left join program_runs
         on ecommerce_line.programrun_id = program_runs.programrun_id
@@ -202,19 +202,19 @@ with coupon as (
         on course_runs.course_id = courses.course_id
     left join productversion
         on productversion.productversion_id = ecommerce_line.productversion_id
-    where
-        ecommerce_couponpaymentversion.couponpaymentversion_coupon_type = 'single-use'
-        and ecommerce_couponpaymentversion.couponpaymentversion_discount_amount = 1.0000
+    where 
+        ecommerce_couponpaymentversion.couponpaymentversion_coupon_type = 'single-use' 
+        and ecommerce_couponpaymentversion.couponpaymentversion_discount_amount = 1.0000 
         and coupon.coupon_id not in (
             select coupon_id
-            from productcouponassignment
+            from productcouponassignment 
         )
         and not exists (
             select b2b_ecommerce_b2border.couponpaymentversion_id
             from b2b_ecommerce_b2border
-            where
+            where 
                 b2b_ecommerce_b2border.couponpaymentversion_id = ecommerce_couponpaymentversion.couponpaymentversion_id
-        )
+        ) 
 )
 
 , b2b_coupon_fields as (
@@ -226,7 +226,7 @@ with coupon as (
         , coupon.couponpayment_name
         , b2b_ecommerce_b2border.b2border_contract_number
         , b2b_ecommerce_b2border.product_id
-        , ecommerce_couponpaymentversion.couponpaymentversion_payment_transaction
+        , ecommerce_couponpaymentversion.couponpaymentversion_payment_transaction 
         , program_runs.programrun_readable_id
         , program_runs.program_title
         , course_runs.courserun_readable_id
@@ -234,7 +234,7 @@ with coupon as (
         , productversion.productversion_readable_id
         , users_user.user_email as combined_user_emails
         , users_user.user_address_country as user_address_countries
-        , ecommerce_order.order_id as order_ids
+        , cast(ecommerce_order.order_id as varchar) as order_ids
         , ecommerce_order.order_state as combined_order_state
         , replace(
             cast(
@@ -243,25 +243,25 @@ with coupon as (
                 as varchar
             ), '"', ''
         ) as req_reference_number
-        , case
+        , case 
             when couponredemption.couponredemption_id is not null
-                then 'true'
-            else 'false'
+                then 'true' 
+            else 'false' 
         end as coupon_redeemed
-    from b2b_ecommerce_b2border
-    inner join ecommerce_couponpaymentversion
+    from b2b_ecommerce_b2border 
+    inner join ecommerce_couponpaymentversion 
         on ecommerce_couponpaymentversion.couponpaymentversion_id = b2b_ecommerce_b2border.couponpaymentversion_id
-    inner join ecommerce_couponversion
+    inner join ecommerce_couponversion 
         on ecommerce_couponversion.couponpaymentversion_id = ecommerce_couponpaymentversion.couponpaymentversion_id
-    inner join coupon
+    inner join coupon 
         on coupon.coupon_id = ecommerce_couponversion.coupon_id
-    left join couponredemption
+    left join couponredemption 
         on couponredemption.couponversion_id = ecommerce_couponversion.couponversion_id
-    left join ecommerce_order
+    left join ecommerce_order 
         on ecommerce_order.order_id = couponredemption.order_id
-    left join b2b_ecommerce_b2breceipt
+    left join b2b_ecommerce_b2breceipt 
         on b2b_ecommerce_b2breceipt.b2border_id = b2b_ecommerce_b2border.b2border_id
-    left join ecommerce_line
+    left join ecommerce_line 
         on ecommerce_line.order_id = ecommerce_order.order_id
     left join program_runs
         on ecommerce_line.programrun_id = program_runs.programrun_id
@@ -271,12 +271,12 @@ with coupon as (
         on course_runs.course_id = courses.course_id
     left join productversion
         on productversion.productversion_id = b2b_ecommerce_b2border.productversion_id
-    left join users_user
+    left join users_user    
         on ecommerce_order.order_purchaser_user_id = users_user.user_id
 )
 
 
-select
+select 
     reg_coupon_fields.coupon_email
     , reg_coupon_fields.coupon_code
     , reg_coupon_fields.coupon_id
@@ -303,7 +303,7 @@ where reg_coupon_fields.coupon_id not in (select coupon_id from b2b_coupon_field
 
 union distinct
 
-select
+select 
     b2b_coupon_fields.b2border_email as coupon_email
     , b2b_coupon_fields.coupon_code
     , b2b_coupon_fields.coupon_id
@@ -321,13 +321,13 @@ select
     , b2b_coupon_fields.coupon_redeemed
     , b2b_coupon_fields.combined_user_emails
     , b2b_coupon_fields.user_address_countries
-    , cast(b2b_coupon_fields.order_ids as varchar) as order_ids
+    , b2b_coupon_fields.order_ids
     , b2b_coupon_fields.combined_order_state
 from b2b_coupon_fields
 
 union distinct
 
-select
+select 
     coupon_email
     , coupon_code
     , coupon_id
@@ -335,7 +335,7 @@ select
     , couponpayment_name
     , b2border_contract_number
     , product_id
-    , couponpaymentversion_payment_transaction
+    , couponpaymentversion_payment_transaction  
     , req_reference_number
     , programrun_readable_id
     , program_title
@@ -345,6 +345,6 @@ select
     , redeemed as coupon_redeemed
     , combined_user_emails
     , user_address_countries
-    , order_ids
+    , cast(order_ids as varchar) as order_ids
     , combined_order_state
 from unassigned_enrollment_codes

--- a/src/ol_dbt/models/intermediate/mitxpro/int__mitxpro__ecommerce_combinedcoupons.sql
+++ b/src/ol_dbt/models/intermediate/mitxpro/int__mitxpro__ecommerce_combinedcoupons.sql
@@ -69,45 +69,19 @@ with coupon as (
 )
 
 , payment_transactions as (
-    select distinct
+    select distinct 
         ecommerce_couponversion.coupon_id
         , ecommerce_couponpaymentversion.couponpaymentversion_payment_transaction
     from ecommerce_couponpaymentversion
-    inner join ecommerce_couponversion
+    inner join ecommerce_couponversion 
         on ecommerce_couponpaymentversion.couponpaymentversion_id = ecommerce_couponversion.couponpaymentversion_id
     where ecommerce_couponpaymentversion.couponpaymentversion_payment_transaction is not null
 )
 
 , reg_coupon_summary as (
-    select
+    select 
         coupon.coupon_id
-        , case when (count(couponredemption.couponredemption_id) >= 1) then 'true' else 'false' end as coupon_redeemed
-        , array_join(array_distinct(array_agg(users_user.user_email)), ', ') as combined_user_emails
-        , array_join(array_distinct(array_agg(users_user.user_address_country)), ', ') as user_address_countries
-        , array_join(array_distinct(array_agg(ecommerce_order.order_id)), ', ') as order_ids
-        , array_join(array_distinct(array_agg(ecommerce_order.order_state)), ', ') as combined_order_state
-    from coupon
-    left join ecommerce_couponversion
-        on coupon.coupon_id = ecommerce_couponversion.coupon_id
-    left join couponredemption
-        on ecommerce_couponversion.couponversion_id = couponredemption.couponversion_id
-    left join ecommerce_order
-        on ecommerce_order.order_id = couponredemption.order_id
-    left join users_user
-        on ecommerce_order.order_purchaser_user_id = users_user.user_id
-    group by
-        coupon.coupon_id
-)
-
-, reg_coupon_fields as (
-    select
-        productcouponassignment.productcouponassignment_email as coupon_email
-        , coupon.coupon_code
-        , coupon.coupon_id
-        , coupon.coupon_created_on
-        , coupon.couponpayment_name
-        , productcouponassignment.product_id
-        , payment_transactions.couponpaymentversion_payment_transaction
+        , ecommerce_couponversion.couponversion_updated_on
         , program_runs.programrun_readable_id
         , program_runs.program_title
         , course_runs.courserun_readable_id
@@ -115,20 +89,21 @@ with coupon as (
         , productversion.productversion_readable_id
         , ecommerce_couponpaymentversion.couponpaymentversion_coupon_type
         , ecommerce_couponpaymentversion.couponpaymentversion_discount_amount
+        , case when (count(couponredemption.couponredemption_id) >= 1) then 'true' else 'false' end as coupon_redeemed
+        , array_join(array_distinct(array_agg(users_user.user_email)), ', ') as combined_user_emails
+        , array_join(array_distinct(array_agg(users_user.user_address_country)), ', ') as user_address_countries
+        , array_join(array_distinct(array_agg(ecommerce_order.order_id)), ', ') as order_ids
+        , array_join(array_distinct(array_agg(ecommerce_order.order_state)), ', ') as combined_order_state
     from coupon
-    left join productcouponassignment
-        on productcouponassignment.coupon_id = coupon.coupon_id
-    left join ecommerce_couponversion
+    left join ecommerce_couponversion 
         on coupon.coupon_id = ecommerce_couponversion.coupon_id
-    left join ecommerce_couponpaymentversion
-        on ecommerce_couponpaymentversion.couponpaymentversion_id = ecommerce_couponversion.couponpaymentversion_id
     left join couponredemption
         on ecommerce_couponversion.couponversion_id = couponredemption.couponversion_id
+    left join ecommerce_couponpaymentversion 
+        on ecommerce_couponpaymentversion.couponpaymentversion_id = ecommerce_couponversion.couponpaymentversion_id
     left join ecommerce_order
         on ecommerce_order.order_id = couponredemption.order_id
-    left join payment_transactions
-        on coupon.coupon_id = payment_transactions.coupon_id
-    left join ecommerce_line
+    left join ecommerce_line 
         on ecommerce_line.order_id = ecommerce_order.order_id
     left join program_runs
         on ecommerce_line.programrun_id = program_runs.programrun_id
@@ -138,14 +113,11 @@ with coupon as (
         on course_runs.course_id = courses.course_id
     left join productversion
         on productversion.productversion_id = ecommerce_line.productversion_id
-    group by
-        productcouponassignment.productcouponassignment_email
-        , coupon.coupon_code
-        , coupon.coupon_id
-        , coupon.coupon_created_on
-        , coupon.couponpayment_name
-        , productcouponassignment.product_id
-        , payment_transactions.couponpaymentversion_payment_transaction
+    left join users_user    
+        on ecommerce_order.order_purchaser_user_id = users_user.user_id
+    group by 
+        coupon.coupon_id
+        , ecommerce_couponversion.couponversion_updated_on
         , program_runs.programrun_readable_id
         , program_runs.program_title
         , course_runs.courserun_readable_id
@@ -155,45 +127,34 @@ with coupon as (
         , ecommerce_couponpaymentversion.couponpaymentversion_discount_amount
 )
 
-, b2b_coupon_summary as (
-    select
-        coupon.coupon_id
-        , case
-            when (count(couponredemption.couponredemption_id) >= 1)
-                then 'true'
-            else 'false'
-        end as coupon_redeemed
-        , array_join(array_distinct(array_agg(users_user.user_email)), ', ') as combined_user_emails
-        , array_join(array_distinct(array_agg(users_user.user_address_country)), ', ') as user_address_countries
-        , array_join(array_distinct(array_agg(ecommerce_order.order_id)), ', ') as order_ids
-        , array_join(array_distinct(array_agg(ecommerce_order.order_state)), ', ') as combined_order_state
-    from b2b_ecommerce_b2border
-    inner join ecommerce_couponpaymentversion
-        on ecommerce_couponpaymentversion.couponpaymentversion_id = b2b_ecommerce_b2border.couponpaymentversion_id
-    inner join ecommerce_couponversion
-        on ecommerce_couponversion.couponpaymentversion_id = ecommerce_couponpaymentversion.couponpaymentversion_id
-    inner join coupon
-        on coupon.coupon_id = ecommerce_couponversion.coupon_id
-    left join couponredemption
-        on couponredemption.couponversion_id = ecommerce_couponversion.couponversion_id
-    left join ecommerce_order
-        on ecommerce_order.order_id = couponredemption.order_id
-    left join users_user
-        on ecommerce_order.order_purchaser_user_id = users_user.user_id
-    group by
-        coupon.coupon_id
+, reg_coupon_fields as (
+    select 
+        productcouponassignment.productcouponassignment_email as coupon_email
+        , coupon.coupon_code
+        , coupon.coupon_id
+        , coupon.coupon_created_on
+        , coupon.couponpayment_name
+        , productcouponassignment.product_id
+        , payment_transactions.couponpaymentversion_payment_transaction 
+        , productcouponassignment.productcouponassignment_is_redeemed
+    from coupon
+    left join productcouponassignment
+        on productcouponassignment.coupon_id = coupon.coupon_id
+    left join payment_transactions
+        on coupon.coupon_id = payment_transactions.coupon_id
 )
 
 , b2b_coupon_fields as (
     select
         b2b_ecommerce_b2border.b2border_email
+        , ecommerce_couponversion.couponversion_updated_on
         , coupon.coupon_code
         , coupon.coupon_id
         , coupon.coupon_created_on
         , coupon.couponpayment_name
         , b2b_ecommerce_b2border.b2border_contract_number
         , b2b_ecommerce_b2border.product_id
-        , ecommerce_couponpaymentversion.couponpaymentversion_payment_transaction
+        , ecommerce_couponpaymentversion.couponpaymentversion_payment_transaction 
         , program_runs.programrun_readable_id
         , program_runs.program_title
         , course_runs.courserun_readable_id
@@ -201,6 +162,10 @@ with coupon as (
         , productversion.productversion_readable_id
         , ecommerce_couponpaymentversion.couponpaymentversion_coupon_type
         , ecommerce_couponpaymentversion.couponpaymentversion_discount_amount
+        , users_user.user_email as combined_user_emails
+        , users_user.user_address_country as user_address_countries
+        , ecommerce_order.order_id as order_ids
+        , ecommerce_order.order_state as combined_order_state
         , replace(
             cast(
                 json_extract(b2b_ecommerce_b2breceipt.b2breceipt_data, '$.req_reference_number'
@@ -208,20 +173,25 @@ with coupon as (
                 as varchar
             ), '"', ''
         ) as req_reference_number
-    from b2b_ecommerce_b2border
-    inner join ecommerce_couponpaymentversion
+        , case 
+            when couponredemption.couponredemption_id is not null
+                then 'true' 
+            else 'false' 
+        end as coupon_redeemed
+    from b2b_ecommerce_b2border 
+    inner join ecommerce_couponpaymentversion 
         on ecommerce_couponpaymentversion.couponpaymentversion_id = b2b_ecommerce_b2border.couponpaymentversion_id
-    inner join ecommerce_couponversion
+    inner join ecommerce_couponversion 
         on ecommerce_couponversion.couponpaymentversion_id = ecommerce_couponpaymentversion.couponpaymentversion_id
-    inner join coupon
+    inner join coupon 
         on coupon.coupon_id = ecommerce_couponversion.coupon_id
-    left join couponredemption
+    left join couponredemption 
         on couponredemption.couponversion_id = ecommerce_couponversion.couponversion_id
-    left join ecommerce_order
+    left join ecommerce_order 
         on ecommerce_order.order_id = couponredemption.order_id
-    left join b2b_ecommerce_b2breceipt
+    left join b2b_ecommerce_b2breceipt 
         on b2b_ecommerce_b2breceipt.b2border_id = b2b_ecommerce_b2border.b2border_id
-    left join ecommerce_line
+    left join ecommerce_line 
         on ecommerce_line.order_id = ecommerce_order.order_id
     left join program_runs
         on ecommerce_line.programrun_id = program_runs.programrun_id
@@ -231,35 +201,16 @@ with coupon as (
         on course_runs.course_id = courses.course_id
     left join productversion
         on productversion.productversion_id = b2b_ecommerce_b2border.productversion_id
-    group by
-        b2b_ecommerce_b2border.b2border_email
-        , coupon.coupon_code
-        , coupon.coupon_id
-        , coupon.coupon_created_on
-        , coupon.couponpayment_name
-        , b2b_ecommerce_b2border.b2border_contract_number
-        , b2b_ecommerce_b2border.product_id
-        , ecommerce_couponpaymentversion.couponpaymentversion_payment_transaction
-        , program_runs.programrun_readable_id
-        , program_runs.program_title
-        , course_runs.courserun_readable_id
-        , courses.course_title
-        , productversion.productversion_readable_id
-        , ecommerce_couponpaymentversion.couponpaymentversion_coupon_type
-        , ecommerce_couponpaymentversion.couponpaymentversion_discount_amount
-        , replace(
-            cast(
-                json_extract(b2b_ecommerce_b2breceipt.b2breceipt_data, '$.req_reference_number')
-                as varchar
-            ), '"', ''
-        )
+    left join users_user    
+        on ecommerce_order.order_purchaser_user_id = users_user.user_id
 )
 
 
-select
+select 
     reg_coupon_fields.coupon_email
     , reg_coupon_fields.coupon_code
     , reg_coupon_fields.coupon_id
+    , reg_coupon_fields.couponversion_updated_on
     , reg_coupon_fields.coupon_created_on
     , reg_coupon_fields.couponpayment_name
     , null as b2border_contract_number
@@ -286,10 +237,11 @@ where reg_coupon_fields.coupon_id not in (select coupon_id from b2b_coupon_summa
 
 union distinct
 
-select
+select 
     b2b_coupon_fields.b2border_email as coupon_email
     , b2b_coupon_fields.coupon_code
     , b2b_coupon_fields.coupon_id
+    , b2b_coupon_fields.couponversion_updated_on
     , b2b_coupon_fields.coupon_created_on
     , b2b_coupon_fields.couponpayment_name
     , b2b_coupon_fields.b2border_contract_number
@@ -310,5 +262,3 @@ select
     , b2b_coupon_summary.order_ids
     , b2b_coupon_summary.combined_order_state
 from b2b_coupon_fields
-inner join b2b_coupon_summary
-    on b2b_coupon_fields.coupon_id = b2b_coupon_summary.coupon_id

--- a/src/ol_dbt/models/intermediate/mitxpro/int__mitxpro__ecommerce_combinedcoupons.sql
+++ b/src/ol_dbt/models/intermediate/mitxpro/int__mitxpro__ecommerce_combinedcoupons.sql
@@ -71,17 +71,17 @@ with coupon as (
 )
 
 , payment_transactions as (
-    select distinct 
+    select distinct
         ecommerce_couponversion.coupon_id
         , ecommerce_couponpaymentversion.couponpaymentversion_payment_transaction
     from ecommerce_couponpaymentversion
-    inner join ecommerce_couponversion 
+    inner join ecommerce_couponversion
         on ecommerce_couponpaymentversion.couponpaymentversion_id = ecommerce_couponversion.couponpaymentversion_id
     where ecommerce_couponpaymentversion.couponpaymentversion_payment_transaction is not null
 )
 
 , latest_couponversion as (
-    select 
+    select
         coupon_id
         , max(couponversion_updated_on) as max_couponversion_updated_on
     from ecommerce_couponversion
@@ -89,38 +89,38 @@ with coupon as (
 )
 
 , reg_coupon_summary as (
-    select 
+    select
         coupon.coupon_id
-        , cast(array_join(array_distinct(array_agg(program_runs.programrun_readable_id)), ', ') as varchar) 
+        , cast(array_join(array_distinct(array_agg(program_runs.programrun_readable_id)), ', ') as varchar)
             as programrun_readable_id
         , cast(array_join(array_distinct(array_agg(program_runs.program_title)), ', ') as varchar) as program_title
-        , cast(array_join(array_distinct(array_agg(course_runs.courserun_readable_id)), ', ') as varchar) 
+        , cast(array_join(array_distinct(array_agg(course_runs.courserun_readable_id)), ', ') as varchar)
             as courserun_readable_id
         , cast(array_join(array_distinct(array_agg(courses.course_title)), ', ') as varchar) as course_title
-        , cast(array_join(array_distinct(array_agg(productversion.productversion_readable_id)), ', ') as varchar) 
+        , cast(array_join(array_distinct(array_agg(productversion.productversion_readable_id)), ', ') as varchar)
             as productversion_readable_id
         , cast(array_join(array_distinct(array_agg(users_user.user_email)), ', ') as varchar) as combined_user_emails
-        , cast(array_join(array_distinct(array_agg(users_user.user_address_country)), ', ') as varchar) 
+        , cast(array_join(array_distinct(array_agg(users_user.user_address_country)), ', ') as varchar)
             as user_address_countries
         , cast(array_join(array_distinct(array_agg(ecommerce_order.order_id)), ', ') as varchar) as order_ids
-        , cast(array_join(array_distinct(array_agg(ecommerce_order.order_state)), ', ') as varchar) 
+        , cast(array_join(array_distinct(array_agg(ecommerce_order.order_state)), ', ') as varchar)
             as combined_order_state
         , case when (count(couponredemption.couponredemption_id) >= 1) then 'true' else 'false' end as coupon_redeemed
-        
+
     from coupon
     left join latest_couponversion
         on coupon.coupon_id = latest_couponversion.coupon_id
-    left join ecommerce_couponversion 
-        on 
-            latest_couponversion.coupon_id = ecommerce_couponversion.coupon_id 
+    left join ecommerce_couponversion
+        on
+            latest_couponversion.coupon_id = ecommerce_couponversion.coupon_id
             and ecommerce_couponversion.couponversion_updated_on = latest_couponversion.max_couponversion_updated_on
     left join couponredemption
         on ecommerce_couponversion.couponversion_id = couponredemption.couponversion_id
-    left join ecommerce_couponpaymentversion 
+    left join ecommerce_couponpaymentversion
         on ecommerce_couponpaymentversion.couponpaymentversion_id = ecommerce_couponversion.couponpaymentversion_id
     left join ecommerce_order
         on ecommerce_order.order_id = couponredemption.order_id
-    left join ecommerce_line 
+    left join ecommerce_line
         on ecommerce_line.order_id = ecommerce_order.order_id
     left join program_runs
         on ecommerce_line.programrun_id = program_runs.programrun_id
@@ -130,22 +130,22 @@ with coupon as (
         on course_runs.course_id = courses.course_id
     left join productversion
         on productversion.productversion_id = ecommerce_line.productversion_id
-    left join users_user    
+    left join users_user
         on ecommerce_order.order_purchaser_user_id = users_user.user_id
     where ecommerce_order.order_state = 'fulfilled' or ecommerce_order.order_state = 'refunded'
-    group by 
+    group by
         coupon.coupon_id
 )
 
 , reg_coupon_fields as (
-    select 
+    select
         productcouponassignment.productcouponassignment_email as coupon_email
         , coupon.coupon_code
         , coupon.coupon_id
         , coupon.coupon_created_on
         , coupon.couponpayment_name
         , productcouponassignment.product_id
-        , payment_transactions.couponpaymentversion_payment_transaction 
+        , payment_transactions.couponpaymentversion_payment_transaction
         , productcouponassignment.productcouponassignment_is_redeemed
     from coupon
     left join productcouponassignment
@@ -155,13 +155,13 @@ with coupon as (
 )
 
 , unassigned_enrollment_codes as (
-    select 
+    select
         coupon.coupon_code
         , coupon.coupon_id
         , coupon.coupon_created_on as coupon_created_on
         , coupon.couponpayment_name
         , b2b_ecommerce_b2border.b2border_contract_number
-        , payment_transactions.couponpaymentversion_payment_transaction  
+        , payment_transactions.couponpaymentversion_payment_transaction
         , program_runs.programrun_readable_id
         , program_runs.program_title
         , course_runs.courserun_readable_id
@@ -179,22 +179,22 @@ with coupon as (
     inner join latest_couponversion
         on coupon.coupon_id = latest_couponversion.coupon_id
     inner join ecommerce_couponversion
-        on 
-            latest_couponversion.coupon_id = ecommerce_couponversion.coupon_id 
+        on
+            latest_couponversion.coupon_id = ecommerce_couponversion.coupon_id
             and ecommerce_couponversion.couponversion_updated_on = latest_couponversion.max_couponversion_updated_on
     inner join ecommerce_couponpaymentversion
-        on ecommerce_couponpaymentversion.couponpaymentversion_id = ecommerce_couponversion.couponpaymentversion_id 
-    left join b2b_ecommerce_b2border 
+        on ecommerce_couponpaymentversion.couponpaymentversion_id = ecommerce_couponversion.couponpaymentversion_id
+    left join b2b_ecommerce_b2border
         on ecommerce_couponpaymentversion.couponpaymentversion_id = b2b_ecommerce_b2border.couponpaymentversion_id
-    left join payment_transactions 
-        on payment_transactions.coupon_id = coupon.coupon_id   
+    left join payment_transactions
+        on payment_transactions.coupon_id = coupon.coupon_id
     left join couponredemption
         on couponredemption.couponversion_id = ecommerce_couponversion.couponversion_id
-    left join ecommerce_order 
+    left join ecommerce_order
         on couponredemption.order_id = ecommerce_order.order_id
-    left join users_user 
-        on users_user.user_id = ecommerce_order.order_purchaser_user_id 
-    left join ecommerce_line 
+    left join users_user
+        on users_user.user_id = ecommerce_order.order_purchaser_user_id
+    left join ecommerce_line
         on ecommerce_line.order_id = ecommerce_order.order_id
     left join program_runs
         on ecommerce_line.programrun_id = program_runs.programrun_id
@@ -204,19 +204,19 @@ with coupon as (
         on course_runs.course_id = courses.course_id
     left join productversion
         on productversion.productversion_id = ecommerce_line.productversion_id
-    where 
-        ecommerce_couponpaymentversion.couponpaymentversion_coupon_type = 'single-use' 
-        and ecommerce_couponpaymentversion.couponpaymentversion_discount_amount = 1.0000 
+    where
+        ecommerce_couponpaymentversion.couponpaymentversion_coupon_type = 'single-use'
+        and ecommerce_couponpaymentversion.couponpaymentversion_discount_amount = 1.0000
         and coupon.coupon_id not in (
             select coupon_id
-            from productcouponassignment 
+            from productcouponassignment
         )
         and not exists (
             select b2b_ecommerce_b2border.couponpaymentversion_id
             from b2b_ecommerce_b2border
-            where 
+            where
                 b2b_ecommerce_b2border.couponpaymentversion_id = ecommerce_couponpaymentversion.couponpaymentversion_id
-        ) 
+        )
 )
 
 , b2b_coupon_fields as (
@@ -228,7 +228,7 @@ with coupon as (
         , coupon.couponpayment_name
         , b2b_ecommerce_b2border.b2border_contract_number
         , b2b_ecommerce_b2border.product_id
-        , ecommerce_couponpaymentversion.couponpaymentversion_payment_transaction 
+        , ecommerce_couponpaymentversion.couponpaymentversion_payment_transaction
         , program_runs.programrun_readable_id
         , program_runs.program_title
         , course_runs.courserun_readable_id
@@ -245,25 +245,25 @@ with coupon as (
                 as varchar
             ), '"', ''
         ) as req_reference_number
-        , case 
+        , case
             when couponredemption.couponredemption_id is not null
-                then 'true' 
-            else 'false' 
+                then 'true'
+            else 'false'
         end as coupon_redeemed
-    from b2b_ecommerce_b2border 
-    inner join ecommerce_couponpaymentversion 
+    from b2b_ecommerce_b2border
+    inner join ecommerce_couponpaymentversion
         on ecommerce_couponpaymentversion.couponpaymentversion_id = b2b_ecommerce_b2border.couponpaymentversion_id
-    inner join ecommerce_couponversion 
+    inner join ecommerce_couponversion
         on ecommerce_couponversion.couponpaymentversion_id = ecommerce_couponpaymentversion.couponpaymentversion_id
-    inner join coupon 
+    inner join coupon
         on coupon.coupon_id = ecommerce_couponversion.coupon_id
-    left join couponredemption 
+    left join couponredemption
         on couponredemption.couponversion_id = ecommerce_couponversion.couponversion_id
-    left join ecommerce_order 
+    left join ecommerce_order
         on ecommerce_order.order_id = couponredemption.order_id
-    left join b2b_ecommerce_b2breceipt 
+    left join b2b_ecommerce_b2breceipt
         on b2b_ecommerce_b2breceipt.b2border_id = b2b_ecommerce_b2border.b2border_id
-    left join ecommerce_line 
+    left join ecommerce_line
         on ecommerce_line.order_id = ecommerce_order.order_id
     left join program_runs
         on ecommerce_line.programrun_id = program_runs.programrun_id
@@ -273,12 +273,12 @@ with coupon as (
         on course_runs.course_id = courses.course_id
     left join productversion
         on productversion.productversion_id = b2b_ecommerce_b2border.productversion_id
-    left join users_user    
+    left join users_user
         on ecommerce_order.order_purchaser_user_id = users_user.user_id
 )
 
 
-select 
+select
     reg_coupon_fields.coupon_email
     , reg_coupon_fields.coupon_code
     , reg_coupon_fields.coupon_id
@@ -305,7 +305,7 @@ where reg_coupon_fields.coupon_id not in (select coupon_id from b2b_coupon_field
 
 union distinct
 
-select 
+select
     b2b_coupon_fields.b2border_email as coupon_email
     , b2b_coupon_fields.coupon_code
     , b2b_coupon_fields.coupon_id
@@ -329,7 +329,7 @@ from b2b_coupon_fields
 
 union distinct
 
-select 
+select
     coupon_email
     , coupon_code
     , coupon_id
@@ -337,7 +337,7 @@ select
     , couponpayment_name
     , b2border_contract_number
     , product_id
-    , couponpaymentversion_payment_transaction  
+    , couponpaymentversion_payment_transaction
     , req_reference_number
     , programrun_readable_id
     , program_title
@@ -350,5 +350,6 @@ select
     , cast(order_ids as varchar) as order_ids
     , combined_order_state
 from unassigned_enrollment_codes
-where coupon_id not in (select coupon_id from reg_coupon_fields)
-and coupon_id not in (select coupon_id from b2b_coupon_fields)
+where
+    coupon_id not in (select coupon_id from reg_coupon_fields)
+    and coupon_id not in (select coupon_id from b2b_coupon_fields)

--- a/src/ol_dbt/models/intermediate/mitxpro/int__mitxpro__ecommerce_combinedcoupons.sql
+++ b/src/ol_dbt/models/intermediate/mitxpro/int__mitxpro__ecommerce_combinedcoupons.sql
@@ -71,17 +71,17 @@ with coupon as (
 )
 
 , payment_transactions as (
-    select distinct
+    select distinct 
         ecommerce_couponversion.coupon_id
         , ecommerce_couponpaymentversion.couponpaymentversion_payment_transaction
     from ecommerce_couponpaymentversion
-    inner join ecommerce_couponversion
+    inner join ecommerce_couponversion 
         on ecommerce_couponpaymentversion.couponpaymentversion_id = ecommerce_couponversion.couponpaymentversion_id
     where ecommerce_couponpaymentversion.couponpaymentversion_payment_transaction is not null
 )
 
 , latest_couponversion as (
-    select
+    select 
         coupon_id
         , max(couponversion_updated_on) as max_couponversion_updated_on
     from ecommerce_couponversion
@@ -89,38 +89,38 @@ with coupon as (
 )
 
 , reg_coupon_summary as (
-    select
+    select 
         coupon.coupon_id
-        , cast(array_join(array_distinct(array_agg(program_runs.programrun_readable_id)), ', ') as varchar)
+        , cast(array_join(array_distinct(array_agg(program_runs.programrun_readable_id)), ', ') as varchar) 
             as programrun_readable_id
         , cast(array_join(array_distinct(array_agg(program_runs.program_title)), ', ') as varchar) as program_title
-        , cast(array_join(array_distinct(array_agg(course_runs.courserun_readable_id)), ', ') as varchar)
+        , cast(array_join(array_distinct(array_agg(course_runs.courserun_readable_id)), ', ') as varchar) 
             as courserun_readable_id
         , cast(array_join(array_distinct(array_agg(courses.course_title)), ', ') as varchar) as course_title
-        , cast(array_join(array_distinct(array_agg(productversion.productversion_readable_id)), ', ') as varchar)
+        , cast(array_join(array_distinct(array_agg(productversion.productversion_readable_id)), ', ') as varchar) 
             as productversion_readable_id
         , cast(array_join(array_distinct(array_agg(users_user.user_email)), ', ') as varchar) as combined_user_emails
-        , cast(array_join(array_distinct(array_agg(users_user.user_address_country)), ', ') as varchar)
+        , cast(array_join(array_distinct(array_agg(users_user.user_address_country)), ', ') as varchar) 
             as user_address_countries
         , cast(array_join(array_distinct(array_agg(ecommerce_order.order_id)), ', ') as varchar) as order_ids
-        , cast(array_join(array_distinct(array_agg(ecommerce_order.order_state)), ', ') as varchar)
+        , cast(array_join(array_distinct(array_agg(ecommerce_order.order_state)), ', ') as varchar) 
             as combined_order_state
         , case when (count(couponredemption.couponredemption_id) >= 1) then 'true' else 'false' end as coupon_redeemed
-
+        
     from coupon
     left join latest_couponversion
         on coupon.coupon_id = latest_couponversion.coupon_id
-    left join ecommerce_couponversion
-        on
-            latest_couponversion.coupon_id = ecommerce_couponversion.coupon_id
+    left join ecommerce_couponversion 
+        on 
+            latest_couponversion.coupon_id = ecommerce_couponversion.coupon_id 
             and ecommerce_couponversion.couponversion_updated_on = latest_couponversion.max_couponversion_updated_on
     left join couponredemption
         on ecommerce_couponversion.couponversion_id = couponredemption.couponversion_id
-    left join ecommerce_couponpaymentversion
+    left join ecommerce_couponpaymentversion 
         on ecommerce_couponpaymentversion.couponpaymentversion_id = ecommerce_couponversion.couponpaymentversion_id
     left join ecommerce_order
         on ecommerce_order.order_id = couponredemption.order_id
-    left join ecommerce_line
+    left join ecommerce_line 
         on ecommerce_line.order_id = ecommerce_order.order_id
     left join program_runs
         on ecommerce_line.programrun_id = program_runs.programrun_id
@@ -130,22 +130,22 @@ with coupon as (
         on course_runs.course_id = courses.course_id
     left join productversion
         on productversion.productversion_id = ecommerce_line.productversion_id
-    left join users_user
+    left join users_user    
         on ecommerce_order.order_purchaser_user_id = users_user.user_id
     where ecommerce_order.order_state = 'fulfilled' or ecommerce_order.order_state = 'refunded'
-    group by
+    group by 
         coupon.coupon_id
 )
 
 , reg_coupon_fields as (
-    select
+    select 
         productcouponassignment.productcouponassignment_email as coupon_email
         , coupon.coupon_code
         , coupon.coupon_id
         , coupon.coupon_created_on
         , coupon.couponpayment_name
         , productcouponassignment.product_id
-        , payment_transactions.couponpaymentversion_payment_transaction
+        , payment_transactions.couponpaymentversion_payment_transaction 
         , productcouponassignment.productcouponassignment_is_redeemed
     from coupon
     left join productcouponassignment
@@ -155,13 +155,13 @@ with coupon as (
 )
 
 , unassigned_enrollment_codes as (
-    select
+    select 
         coupon.coupon_code
         , coupon.coupon_id
         , coupon.coupon_created_on as coupon_created_on
         , coupon.couponpayment_name
         , b2b_ecommerce_b2border.b2border_contract_number
-        , payment_transactions.couponpaymentversion_payment_transaction
+        , payment_transactions.couponpaymentversion_payment_transaction  
         , program_runs.programrun_readable_id
         , program_runs.program_title
         , course_runs.courserun_readable_id
@@ -179,22 +179,22 @@ with coupon as (
     inner join latest_couponversion
         on coupon.coupon_id = latest_couponversion.coupon_id
     inner join ecommerce_couponversion
-        on
-            latest_couponversion.coupon_id = ecommerce_couponversion.coupon_id
+        on 
+            latest_couponversion.coupon_id = ecommerce_couponversion.coupon_id 
             and ecommerce_couponversion.couponversion_updated_on = latest_couponversion.max_couponversion_updated_on
     inner join ecommerce_couponpaymentversion
-        on ecommerce_couponpaymentversion.couponpaymentversion_id = ecommerce_couponversion.couponpaymentversion_id
-    left join b2b_ecommerce_b2border
+        on ecommerce_couponpaymentversion.couponpaymentversion_id = ecommerce_couponversion.couponpaymentversion_id 
+    left join b2b_ecommerce_b2border 
         on ecommerce_couponpaymentversion.couponpaymentversion_id = b2b_ecommerce_b2border.couponpaymentversion_id
-    left join payment_transactions
-        on payment_transactions.coupon_id = coupon.coupon_id
+    left join payment_transactions 
+        on payment_transactions.coupon_id = coupon.coupon_id   
     left join couponredemption
         on couponredemption.couponversion_id = ecommerce_couponversion.couponversion_id
-    left join ecommerce_order
+    left join ecommerce_order 
         on couponredemption.order_id = ecommerce_order.order_id
-    left join users_user
-        on users_user.user_id = ecommerce_order.order_purchaser_user_id
-    left join ecommerce_line
+    left join users_user 
+        on users_user.user_id = ecommerce_order.order_purchaser_user_id 
+    left join ecommerce_line 
         on ecommerce_line.order_id = ecommerce_order.order_id
     left join program_runs
         on ecommerce_line.programrun_id = program_runs.programrun_id
@@ -204,19 +204,19 @@ with coupon as (
         on course_runs.course_id = courses.course_id
     left join productversion
         on productversion.productversion_id = ecommerce_line.productversion_id
-    where
-        ecommerce_couponpaymentversion.couponpaymentversion_coupon_type = 'single-use'
-        and ecommerce_couponpaymentversion.couponpaymentversion_discount_amount = 1.0000
+    where 
+        ecommerce_couponpaymentversion.couponpaymentversion_coupon_type = 'single-use' 
+        and ecommerce_couponpaymentversion.couponpaymentversion_discount_amount = 1.0000 
         and coupon.coupon_id not in (
             select coupon_id
-            from productcouponassignment
+            from productcouponassignment 
         )
         and not exists (
             select b2b_ecommerce_b2border.couponpaymentversion_id
             from b2b_ecommerce_b2border
-            where
+            where 
                 b2b_ecommerce_b2border.couponpaymentversion_id = ecommerce_couponpaymentversion.couponpaymentversion_id
-        )
+        ) 
 )
 
 , b2b_coupon_fields as (
@@ -228,7 +228,7 @@ with coupon as (
         , coupon.couponpayment_name
         , b2b_ecommerce_b2border.b2border_contract_number
         , b2b_ecommerce_b2border.product_id
-        , ecommerce_couponpaymentversion.couponpaymentversion_payment_transaction
+        , ecommerce_couponpaymentversion.couponpaymentversion_payment_transaction 
         , program_runs.programrun_readable_id
         , program_runs.program_title
         , course_runs.courserun_readable_id
@@ -239,25 +239,25 @@ with coupon as (
         , cast(ecommerce_order.order_id as varchar) as order_ids
         , ecommerce_order.order_state as combined_order_state
         , req_reference_number
-        , case
+        , case 
             when couponredemption.couponredemption_id is not null
-                then 'true'
-            else 'false'
+                then 'true' 
+            else 'false' 
         end as coupon_redeemed
-    from b2b_ecommerce_b2border
-    inner join ecommerce_couponpaymentversion
+    from b2b_ecommerce_b2border 
+    inner join ecommerce_couponpaymentversion 
         on ecommerce_couponpaymentversion.couponpaymentversion_id = b2b_ecommerce_b2border.couponpaymentversion_id
-    inner join ecommerce_couponversion
+    inner join ecommerce_couponversion 
         on ecommerce_couponversion.couponpaymentversion_id = ecommerce_couponpaymentversion.couponpaymentversion_id
-    inner join coupon
+    inner join coupon 
         on coupon.coupon_id = ecommerce_couponversion.coupon_id
-    left join couponredemption
+    left join couponredemption 
         on couponredemption.couponversion_id = ecommerce_couponversion.couponversion_id
-    left join ecommerce_order
+    left join ecommerce_order 
         on ecommerce_order.order_id = couponredemption.order_id
-    left join b2b_ecommerce_b2breceipt
+    left join b2b_ecommerce_b2breceipt 
         on b2b_ecommerce_b2breceipt.b2border_id = b2b_ecommerce_b2border.b2border_id
-    left join ecommerce_line
+    left join ecommerce_line 
         on ecommerce_line.order_id = ecommerce_order.order_id
     left join program_runs
         on ecommerce_line.programrun_id = program_runs.programrun_id
@@ -267,12 +267,12 @@ with coupon as (
         on course_runs.course_id = courses.course_id
     left join productversion
         on productversion.productversion_id = b2b_ecommerce_b2border.productversion_id
-    left join users_user
+    left join users_user    
         on ecommerce_order.order_purchaser_user_id = users_user.user_id
 )
 
 
-select
+select 
     reg_coupon_fields.coupon_email
     , reg_coupon_fields.coupon_code
     , reg_coupon_fields.coupon_id
@@ -299,7 +299,7 @@ where reg_coupon_fields.coupon_id not in (select coupon_id from b2b_coupon_field
 
 union distinct
 
-select
+select 
     b2b_coupon_fields.b2border_email as coupon_email
     , b2b_coupon_fields.coupon_code
     , b2b_coupon_fields.coupon_id
@@ -323,7 +323,7 @@ from b2b_coupon_fields
 
 union distinct
 
-select
+select 
     coupon_email
     , coupon_code
     , coupon_id
@@ -331,7 +331,7 @@ select
     , couponpayment_name
     , b2border_contract_number
     , product_id
-    , couponpaymentversion_payment_transaction
+    , couponpaymentversion_payment_transaction  
     , req_reference_number
     , programrun_readable_id
     , program_title
@@ -344,6 +344,6 @@ select
     , cast(order_ids as varchar) as order_ids
     , combined_order_state
 from unassigned_enrollment_codes
-where
+where 
     coupon_id not in (select coupon_id from reg_coupon_fields)
     and coupon_id not in (select coupon_id from b2b_coupon_fields)

--- a/src/ol_dbt/models/intermediate/mitxpro/int__mitxpro__ecommerce_combinedcoupons.sql
+++ b/src/ol_dbt/models/intermediate/mitxpro/int__mitxpro__ecommerce_combinedcoupons.sql
@@ -69,17 +69,17 @@ with coupon as (
 )
 
 , payment_transactions as (
-    select distinct
+    select distinct 
         ecommerce_couponversion.coupon_id
         , ecommerce_couponpaymentversion.couponpaymentversion_payment_transaction
     from ecommerce_couponpaymentversion
-    inner join ecommerce_couponversion
+    inner join ecommerce_couponversion 
         on ecommerce_couponpaymentversion.couponpaymentversion_id = ecommerce_couponversion.couponpaymentversion_id
     where ecommerce_couponpaymentversion.couponpaymentversion_payment_transaction is not null
 )
 
 , reg_coupon_summary as (
-    select
+    select 
         coupon.coupon_id
         , case when (count(couponredemption.couponredemption_id) >= 1) then 'true' else 'false' end as coupon_redeemed
         , array_join(array_distinct(array_agg(users_user.user_email)), ', ') as combined_user_emails
@@ -87,27 +87,27 @@ with coupon as (
         , array_join(array_distinct(array_agg(ecommerce_order.order_id)), ', ') as order_ids
         , array_join(array_distinct(array_agg(ecommerce_order.order_state)), ', ') as combined_order_state
     from coupon
-    left join ecommerce_couponversion
+    left join ecommerce_couponversion 
         on coupon.coupon_id = ecommerce_couponversion.coupon_id
     left join couponredemption
         on ecommerce_couponversion.couponversion_id = couponredemption.couponversion_id
     left join ecommerce_order
         on ecommerce_order.order_id = couponredemption.order_id
-    left join users_user
+    left join users_user    
         on ecommerce_order.order_purchaser_user_id = users_user.user_id
-    group by
+    group by 
         coupon.coupon_id
 )
 
 , reg_coupon_fields as (
-    select
+    select 
         productcouponassignment.productcouponassignment_email as coupon_email
         , coupon.coupon_code
         , coupon.coupon_id
         , coupon.coupon_created_on
         , coupon.couponpayment_name
         , productcouponassignment.product_id
-        , payment_transactions.couponpaymentversion_payment_transaction
+        , payment_transactions.couponpaymentversion_payment_transaction 
         , program_runs.programrun_readable_id
         , program_runs.program_title
         , course_runs.courserun_readable_id
@@ -116,11 +116,11 @@ with coupon as (
         , ecommerce_couponpaymentversion.couponpaymentversion_coupon_type
         , ecommerce_couponpaymentversion.couponpaymentversion_discount_amount
     from coupon
-    inner join productcouponassignment
+    left join productcouponassignment
         on productcouponassignment.coupon_id = coupon.coupon_id
-    left join ecommerce_couponversion
+    left join ecommerce_couponversion 
         on coupon.coupon_id = ecommerce_couponversion.coupon_id
-    left join ecommerce_couponpaymentversion
+    left join ecommerce_couponpaymentversion 
         on ecommerce_couponpaymentversion.couponpaymentversion_id = ecommerce_couponversion.couponpaymentversion_id
     left join couponredemption
         on ecommerce_couponversion.couponversion_id = couponredemption.couponversion_id
@@ -128,7 +128,7 @@ with coupon as (
         on ecommerce_order.order_id = couponredemption.order_id
     left join payment_transactions
         on coupon.coupon_id = payment_transactions.coupon_id
-    left join ecommerce_line
+    left join ecommerce_line 
         on ecommerce_line.order_id = ecommerce_order.order_id
     left join program_runs
         on ecommerce_line.programrun_id = program_runs.programrun_id
@@ -138,14 +138,14 @@ with coupon as (
         on course_runs.course_id = courses.course_id
     left join productversion
         on productversion.productversion_id = ecommerce_line.productversion_id
-    group by
-        productcouponassignment.productcouponassignment_email
+    group by 
+        productcouponassignment.productcouponassignment_email 
         , coupon.coupon_code
         , coupon.coupon_id
         , coupon.coupon_created_on
         , coupon.couponpayment_name
         , productcouponassignment.product_id
-        , payment_transactions.couponpaymentversion_payment_transaction
+        , payment_transactions.couponpaymentversion_payment_transaction 
         , program_runs.programrun_readable_id
         , program_runs.program_title
         , course_runs.courserun_readable_id
@@ -156,32 +156,32 @@ with coupon as (
 )
 
 , b2b_coupon_summary as (
-    select
+    select 
         coupon.coupon_id
-        , case
-            when (count(couponredemption.couponredemption_id) >= 1)
-                then 'true'
-            else 'false'
+        , case 
+            when (count(couponredemption.couponredemption_id) >= 1) 
+                then 'true' 
+            else 'false' 
         end as coupon_redeemed
         , array_join(array_distinct(array_agg(users_user.user_email)), ', ') as combined_user_emails
         , array_join(array_distinct(array_agg(users_user.user_address_country)), ', ') as user_address_countries
         , array_join(array_distinct(array_agg(ecommerce_order.order_id)), ', ') as order_ids
         , array_join(array_distinct(array_agg(ecommerce_order.order_state)), ', ') as combined_order_state
-    from b2b_ecommerce_b2border
-    inner join ecommerce_couponpaymentversion
+    from b2b_ecommerce_b2border 
+    inner join ecommerce_couponpaymentversion 
         on ecommerce_couponpaymentversion.couponpaymentversion_id = b2b_ecommerce_b2border.couponpaymentversion_id
-    inner join ecommerce_couponversion
+    inner join ecommerce_couponversion 
         on ecommerce_couponversion.couponpaymentversion_id = ecommerce_couponpaymentversion.couponpaymentversion_id
-    inner join coupon
-        on coupon.coupon_id = ecommerce_couponversion.coupon_id
-    left join couponredemption
+    inner join coupon 
+        on coupon.coupon_id = ecommerce_couponversion.coupon_id 
+    left join couponredemption 
         on couponredemption.couponversion_id = ecommerce_couponversion.couponversion_id
-    left join ecommerce_order
+    left join ecommerce_order 
         on ecommerce_order.order_id = couponredemption.order_id
-    left join users_user
+    left join users_user    
         on ecommerce_order.order_purchaser_user_id = users_user.user_id
-    group by
-        coupon.coupon_id
+    group by 
+        coupon.coupon_id   
 )
 
 , b2b_coupon_fields as (
@@ -193,7 +193,7 @@ with coupon as (
         , coupon.couponpayment_name
         , b2b_ecommerce_b2border.b2border_contract_number
         , b2b_ecommerce_b2border.product_id
-        , ecommerce_couponpaymentversion.couponpaymentversion_payment_transaction
+        , ecommerce_couponpaymentversion.couponpaymentversion_payment_transaction 
         , program_runs.programrun_readable_id
         , program_runs.program_title
         , course_runs.courserun_readable_id
@@ -208,20 +208,20 @@ with coupon as (
                 as varchar
             ), '"', ''
         ) as req_reference_number
-    from b2b_ecommerce_b2border
-    inner join ecommerce_couponpaymentversion
+    from b2b_ecommerce_b2border 
+    inner join ecommerce_couponpaymentversion 
         on ecommerce_couponpaymentversion.couponpaymentversion_id = b2b_ecommerce_b2border.couponpaymentversion_id
-    inner join ecommerce_couponversion
+    inner join ecommerce_couponversion 
         on ecommerce_couponversion.couponpaymentversion_id = ecommerce_couponpaymentversion.couponpaymentversion_id
-    inner join coupon
+    inner join coupon 
         on coupon.coupon_id = ecommerce_couponversion.coupon_id
-    left join couponredemption
+    left join couponredemption 
         on couponredemption.couponversion_id = ecommerce_couponversion.couponversion_id
-    left join ecommerce_order
+    left join ecommerce_order 
         on ecommerce_order.order_id = couponredemption.order_id
-    left join b2b_ecommerce_b2breceipt
+    left join b2b_ecommerce_b2breceipt 
         on b2b_ecommerce_b2breceipt.b2border_id = b2b_ecommerce_b2border.b2border_id
-    left join ecommerce_line
+    left join ecommerce_line 
         on ecommerce_line.order_id = ecommerce_order.order_id
     left join program_runs
         on ecommerce_line.programrun_id = program_runs.programrun_id
@@ -231,15 +231,15 @@ with coupon as (
         on course_runs.course_id = courses.course_id
     left join productversion
         on productversion.productversion_id = b2b_ecommerce_b2border.productversion_id
-    group by
-        b2b_ecommerce_b2border.b2border_email
+    group by 
+        b2b_ecommerce_b2border.b2border_email 
         , coupon.coupon_code
         , coupon.coupon_id
         , coupon.coupon_created_on
         , coupon.couponpayment_name
         , b2b_ecommerce_b2border.b2border_contract_number
         , b2b_ecommerce_b2border.product_id
-        , ecommerce_couponpaymentversion.couponpaymentversion_payment_transaction
+        , ecommerce_couponpaymentversion.couponpaymentversion_payment_transaction 
         , program_runs.programrun_readable_id
         , program_runs.program_title
         , course_runs.courserun_readable_id
@@ -252,11 +252,11 @@ with coupon as (
                 json_extract(b2b_ecommerce_b2breceipt.b2breceipt_data, '$.req_reference_number')
                 as varchar
             ), '"', ''
-        )
+        ) 
 )
 
 
-select
+select 
     reg_coupon_fields.coupon_email
     , reg_coupon_fields.coupon_code
     , reg_coupon_fields.coupon_id
@@ -282,10 +282,11 @@ select
 from reg_coupon_fields
 inner join reg_coupon_summary
     on reg_coupon_fields.coupon_id = reg_coupon_summary.coupon_id
+where reg_coupon_fields.coupon_id not in (select coupon_id from b2b_coupon_summary)
 
 union distinct
 
-select
+select 
     b2b_coupon_fields.b2border_email as coupon_email
     , b2b_coupon_fields.coupon_code
     , b2b_coupon_fields.coupon_id

--- a/src/ol_dbt/models/intermediate/mitxpro/int__mitxpro__ecommerce_combinedcoupons.sql
+++ b/src/ol_dbt/models/intermediate/mitxpro/int__mitxpro__ecommerce_combinedcoupons.sql
@@ -69,17 +69,17 @@ with coupon as (
 )
 
 , payment_transactions as (
-    select distinct 
+    select distinct
         ecommerce_couponversion.coupon_id
         , ecommerce_couponpaymentversion.couponpaymentversion_payment_transaction
     from ecommerce_couponpaymentversion
-    inner join ecommerce_couponversion 
+    inner join ecommerce_couponversion
         on ecommerce_couponpaymentversion.couponpaymentversion_id = ecommerce_couponversion.couponpaymentversion_id
     where ecommerce_couponpaymentversion.couponpaymentversion_payment_transaction is not null
 )
 
 , reg_coupon_summary as (
-    select 
+    select
         coupon.coupon_id
         , case when (count(couponredemption.couponredemption_id) >= 1) then 'true' else 'false' end as coupon_redeemed
         , array_join(array_distinct(array_agg(users_user.user_email)), ', ') as combined_user_emails
@@ -87,27 +87,27 @@ with coupon as (
         , array_join(array_distinct(array_agg(ecommerce_order.order_id)), ', ') as order_ids
         , array_join(array_distinct(array_agg(ecommerce_order.order_state)), ', ') as combined_order_state
     from coupon
-    left join ecommerce_couponversion 
+    left join ecommerce_couponversion
         on coupon.coupon_id = ecommerce_couponversion.coupon_id
     left join couponredemption
         on ecommerce_couponversion.couponversion_id = couponredemption.couponversion_id
     left join ecommerce_order
         on ecommerce_order.order_id = couponredemption.order_id
-    left join users_user    
+    left join users_user
         on ecommerce_order.order_purchaser_user_id = users_user.user_id
-    group by 
+    group by
         coupon.coupon_id
 )
 
 , reg_coupon_fields as (
-    select 
+    select
         productcouponassignment.productcouponassignment_email as coupon_email
         , coupon.coupon_code
         , coupon.coupon_id
         , coupon.coupon_created_on
         , coupon.couponpayment_name
         , productcouponassignment.product_id
-        , payment_transactions.couponpaymentversion_payment_transaction 
+        , payment_transactions.couponpaymentversion_payment_transaction
         , program_runs.programrun_readable_id
         , program_runs.program_title
         , course_runs.courserun_readable_id
@@ -118,9 +118,9 @@ with coupon as (
     from coupon
     inner join productcouponassignment
         on productcouponassignment.coupon_id = coupon.coupon_id
-    left join ecommerce_couponversion 
+    left join ecommerce_couponversion
         on coupon.coupon_id = ecommerce_couponversion.coupon_id
-    left join ecommerce_couponpaymentversion 
+    left join ecommerce_couponpaymentversion
         on ecommerce_couponpaymentversion.couponpaymentversion_id = ecommerce_couponversion.couponpaymentversion_id
     left join couponredemption
         on ecommerce_couponversion.couponversion_id = couponredemption.couponversion_id
@@ -128,7 +128,7 @@ with coupon as (
         on ecommerce_order.order_id = couponredemption.order_id
     left join payment_transactions
         on coupon.coupon_id = payment_transactions.coupon_id
-    left join ecommerce_line 
+    left join ecommerce_line
         on ecommerce_line.order_id = ecommerce_order.order_id
     left join program_runs
         on ecommerce_line.programrun_id = program_runs.programrun_id
@@ -138,14 +138,14 @@ with coupon as (
         on course_runs.course_id = courses.course_id
     left join productversion
         on productversion.productversion_id = ecommerce_line.productversion_id
-    group by 
-        productcouponassignment.productcouponassignment_email 
+    group by
+        productcouponassignment.productcouponassignment_email
         , coupon.coupon_code
         , coupon.coupon_id
         , coupon.coupon_created_on
         , coupon.couponpayment_name
         , productcouponassignment.product_id
-        , payment_transactions.couponpaymentversion_payment_transaction 
+        , payment_transactions.couponpaymentversion_payment_transaction
         , program_runs.programrun_readable_id
         , program_runs.program_title
         , course_runs.courserun_readable_id
@@ -156,32 +156,32 @@ with coupon as (
 )
 
 , b2b_coupon_summary as (
-    select 
+    select
         coupon.coupon_id
-        , case 
-            when (count(couponredemption.couponredemption_id) >= 1) 
-                then 'true' 
-            else 'false' 
+        , case
+            when (count(couponredemption.couponredemption_id) >= 1)
+                then 'true'
+            else 'false'
         end as coupon_redeemed
         , array_join(array_distinct(array_agg(users_user.user_email)), ', ') as combined_user_emails
         , array_join(array_distinct(array_agg(users_user.user_address_country)), ', ') as user_address_countries
         , array_join(array_distinct(array_agg(ecommerce_order.order_id)), ', ') as order_ids
         , array_join(array_distinct(array_agg(ecommerce_order.order_state)), ', ') as combined_order_state
-    from b2b_ecommerce_b2border 
-    inner join ecommerce_couponpaymentversion 
+    from b2b_ecommerce_b2border
+    inner join ecommerce_couponpaymentversion
         on ecommerce_couponpaymentversion.couponpaymentversion_id = b2b_ecommerce_b2border.couponpaymentversion_id
-    inner join ecommerce_couponversion 
+    inner join ecommerce_couponversion
         on ecommerce_couponversion.couponpaymentversion_id = ecommerce_couponpaymentversion.couponpaymentversion_id
-    inner join coupon 
-        on coupon.coupon_id = ecommerce_couponversion.coupon_id 
-    left join couponredemption 
+    inner join coupon
+        on coupon.coupon_id = ecommerce_couponversion.coupon_id
+    left join couponredemption
         on couponredemption.couponversion_id = ecommerce_couponversion.couponversion_id
-    left join ecommerce_order 
+    left join ecommerce_order
         on ecommerce_order.order_id = couponredemption.order_id
-    left join users_user    
+    left join users_user
         on ecommerce_order.order_purchaser_user_id = users_user.user_id
-    group by 
-        coupon.coupon_id   
+    group by
+        coupon.coupon_id
 )
 
 , b2b_coupon_fields as (
@@ -193,7 +193,7 @@ with coupon as (
         , coupon.couponpayment_name
         , b2b_ecommerce_b2border.b2border_contract_number
         , b2b_ecommerce_b2border.product_id
-        , ecommerce_couponpaymentversion.couponpaymentversion_payment_transaction 
+        , ecommerce_couponpaymentversion.couponpaymentversion_payment_transaction
         , program_runs.programrun_readable_id
         , program_runs.program_title
         , course_runs.courserun_readable_id
@@ -208,20 +208,20 @@ with coupon as (
                 as varchar
             ), '"', ''
         ) as req_reference_number
-    from b2b_ecommerce_b2border 
-    inner join ecommerce_couponpaymentversion 
+    from b2b_ecommerce_b2border
+    inner join ecommerce_couponpaymentversion
         on ecommerce_couponpaymentversion.couponpaymentversion_id = b2b_ecommerce_b2border.couponpaymentversion_id
-    inner join ecommerce_couponversion 
+    inner join ecommerce_couponversion
         on ecommerce_couponversion.couponpaymentversion_id = ecommerce_couponpaymentversion.couponpaymentversion_id
-    inner join coupon 
+    inner join coupon
         on coupon.coupon_id = ecommerce_couponversion.coupon_id
-    left join couponredemption 
+    left join couponredemption
         on couponredemption.couponversion_id = ecommerce_couponversion.couponversion_id
-    left join ecommerce_order 
+    left join ecommerce_order
         on ecommerce_order.order_id = couponredemption.order_id
-    left join b2b_ecommerce_b2breceipt 
+    left join b2b_ecommerce_b2breceipt
         on b2b_ecommerce_b2breceipt.b2border_id = b2b_ecommerce_b2border.b2border_id
-    left join ecommerce_line 
+    left join ecommerce_line
         on ecommerce_line.order_id = ecommerce_order.order_id
     left join program_runs
         on ecommerce_line.programrun_id = program_runs.programrun_id
@@ -231,15 +231,15 @@ with coupon as (
         on course_runs.course_id = courses.course_id
     left join productversion
         on productversion.productversion_id = b2b_ecommerce_b2border.productversion_id
-    group by 
-        b2b_ecommerce_b2border.b2border_email 
+    group by
+        b2b_ecommerce_b2border.b2border_email
         , coupon.coupon_code
         , coupon.coupon_id
         , coupon.coupon_created_on
         , coupon.couponpayment_name
         , b2b_ecommerce_b2border.b2border_contract_number
         , b2b_ecommerce_b2border.product_id
-        , ecommerce_couponpaymentversion.couponpaymentversion_payment_transaction 
+        , ecommerce_couponpaymentversion.couponpaymentversion_payment_transaction
         , program_runs.programrun_readable_id
         , program_runs.program_title
         , course_runs.courserun_readable_id
@@ -252,11 +252,11 @@ with coupon as (
                 json_extract(b2b_ecommerce_b2breceipt.b2breceipt_data, '$.req_reference_number')
                 as varchar
             ), '"', ''
-        ) 
+        )
 )
 
 
-select 
+select
     reg_coupon_fields.coupon_email
     , reg_coupon_fields.coupon_code
     , reg_coupon_fields.coupon_id
@@ -285,7 +285,7 @@ inner join reg_coupon_summary
 
 union distinct
 
-select 
+select
     b2b_coupon_fields.b2border_email as coupon_email
     , b2b_coupon_fields.coupon_code
     , b2b_coupon_fields.coupon_id

--- a/src/ol_dbt/models/intermediate/mitxpro/int__mitxpro__ecommerce_combinedcoupons.sql
+++ b/src/ol_dbt/models/intermediate/mitxpro/int__mitxpro__ecommerce_combinedcoupons.sql
@@ -69,17 +69,17 @@ with coupon as (
 )
 
 , payment_transactions as (
-    select distinct
+    select distinct 
         ecommerce_couponversion.coupon_id
         , ecommerce_couponpaymentversion.couponpaymentversion_payment_transaction
     from ecommerce_couponpaymentversion
-    inner join ecommerce_couponversion
+    inner join ecommerce_couponversion 
         on ecommerce_couponpaymentversion.couponpaymentversion_id = ecommerce_couponversion.couponpaymentversion_id
     where ecommerce_couponpaymentversion.couponpaymentversion_payment_transaction is not null
 )
 
 , latest_couponversion as (
-    select
+    select 
         coupon_id
         , max(couponversion_updated_on) as max_couponversion_updated_on
     from ecommerce_couponversion
@@ -87,38 +87,38 @@ with coupon as (
 )
 
 , reg_coupon_summary as (
-    select
+    select 
         coupon.coupon_id
-        , cast(array_join(array_distinct(array_agg(program_runs.programrun_readable_id)), ', ') as varchar)
+        , cast(array_join(array_distinct(array_agg(program_runs.programrun_readable_id)), ', ') as varchar) 
             as programrun_readable_id
         , cast(array_join(array_distinct(array_agg(program_runs.program_title)), ', ') as varchar) as program_title
-        , cast(array_join(array_distinct(array_agg(course_runs.courserun_readable_id)), ', ') as varchar)
+        , cast(array_join(array_distinct(array_agg(course_runs.courserun_readable_id)), ', ') as varchar) 
             as courserun_readable_id
         , cast(array_join(array_distinct(array_agg(courses.course_title)), ', ') as varchar) as course_title
-        , cast(array_join(array_distinct(array_agg(productversion.productversion_readable_id)), ', ') as varchar)
+        , cast(array_join(array_distinct(array_agg(productversion.productversion_readable_id)), ', ') as varchar) 
             as productversion_readable_id
         , cast(array_join(array_distinct(array_agg(users_user.user_email)), ', ') as varchar) as combined_user_emails
-        , cast(array_join(array_distinct(array_agg(users_user.user_address_country)), ', ') as varchar)
+        , cast(array_join(array_distinct(array_agg(users_user.user_address_country)), ', ') as varchar) 
             as user_address_countries
         , cast(array_join(array_distinct(array_agg(ecommerce_order.order_id)), ', ') as varchar) as order_ids
-        , cast(array_join(array_distinct(array_agg(ecommerce_order.order_state)), ', ') as varchar)
+        , cast(array_join(array_distinct(array_agg(ecommerce_order.order_state)), ', ') as varchar) 
             as combined_order_state
         , case when (count(couponredemption.couponredemption_id) >= 1) then 'true' else 'false' end as coupon_redeemed
-
+        
     from coupon
     left join latest_couponversion
         on coupon.coupon_id = latest_couponversion.coupon_id
-    left join ecommerce_couponversion
-        on
-            latest_couponversion.coupon_id = ecommerce_couponversion.coupon_id
+    left join ecommerce_couponversion 
+        on 
+            latest_couponversion.coupon_id = ecommerce_couponversion.coupon_id 
             and ecommerce_couponversion.couponversion_updated_on = latest_couponversion.max_couponversion_updated_on
     left join couponredemption
         on ecommerce_couponversion.couponversion_id = couponredemption.couponversion_id
-    left join ecommerce_couponpaymentversion
+    left join ecommerce_couponpaymentversion 
         on ecommerce_couponpaymentversion.couponpaymentversion_id = ecommerce_couponversion.couponpaymentversion_id
     left join ecommerce_order
         on ecommerce_order.order_id = couponredemption.order_id
-    left join ecommerce_line
+    left join ecommerce_line 
         on ecommerce_line.order_id = ecommerce_order.order_id
     left join program_runs
         on ecommerce_line.programrun_id = program_runs.programrun_id
@@ -128,22 +128,22 @@ with coupon as (
         on course_runs.course_id = courses.course_id
     left join productversion
         on productversion.productversion_id = ecommerce_line.productversion_id
-    left join users_user
+    left join users_user    
         on ecommerce_order.order_purchaser_user_id = users_user.user_id
     where ecommerce_order.order_state = 'fulfilled' or ecommerce_order.order_state = 'refunded'
-    group by
+    group by 
         coupon.coupon_id
 )
 
 , reg_coupon_fields as (
-    select
+    select 
         productcouponassignment.productcouponassignment_email as coupon_email
         , coupon.coupon_code
         , coupon.coupon_id
         , coupon.coupon_created_on
         , coupon.couponpayment_name
         , productcouponassignment.product_id
-        , payment_transactions.couponpaymentversion_payment_transaction
+        , payment_transactions.couponpaymentversion_payment_transaction 
         , productcouponassignment.productcouponassignment_is_redeemed
     from coupon
     left join productcouponassignment
@@ -153,13 +153,13 @@ with coupon as (
 )
 
 , unassigned_enrollment_codes as (
-    select
+    select 
         coupon.coupon_code
         , coupon.coupon_id
         , coupon.coupon_created_on as coupon_created_on
         , coupon.couponpayment_name
         , b2b_ecommerce_b2border.b2border_contract_number
-        , payment_transactions.couponpaymentversion_payment_transaction
+        , payment_transactions.couponpaymentversion_payment_transaction  
         , program_runs.programrun_readable_id
         , program_runs.program_title
         , course_runs.courserun_readable_id
@@ -177,22 +177,22 @@ with coupon as (
     inner join latest_couponversion
         on coupon.coupon_id = latest_couponversion.coupon_id
     inner join ecommerce_couponversion
-        on
-            latest_couponversion.coupon_id = ecommerce_couponversion.coupon_id
+        on 
+            latest_couponversion.coupon_id = ecommerce_couponversion.coupon_id 
             and ecommerce_couponversion.couponversion_updated_on = latest_couponversion.max_couponversion_updated_on
     inner join ecommerce_couponpaymentversion
-        on ecommerce_couponpaymentversion.couponpaymentversion_id = ecommerce_couponversion.couponpaymentversion_id
-    left join b2b_ecommerce_b2border
+        on ecommerce_couponpaymentversion.couponpaymentversion_id = ecommerce_couponversion.couponpaymentversion_id 
+    left join b2b_ecommerce_b2border 
         on ecommerce_couponpaymentversion.couponpaymentversion_id = b2b_ecommerce_b2border.couponpaymentversion_id
-    left join payment_transactions
-        on payment_transactions.coupon_id = coupon.coupon_id
+    left join payment_transactions 
+        on payment_transactions.coupon_id = coupon.coupon_id   
     left join couponredemption
         on couponredemption.couponversion_id = ecommerce_couponversion.couponversion_id
-    left join ecommerce_order
+    left join ecommerce_order 
         on couponredemption.order_id = ecommerce_order.order_id
-    left join users_user
-        on users_user.user_id = ecommerce_order.order_purchaser_user_id
-    left join ecommerce_line
+    left join users_user 
+        on users_user.user_id = ecommerce_order.order_purchaser_user_id 
+    left join ecommerce_line 
         on ecommerce_line.order_id = ecommerce_order.order_id
     left join program_runs
         on ecommerce_line.programrun_id = program_runs.programrun_id
@@ -202,19 +202,19 @@ with coupon as (
         on course_runs.course_id = courses.course_id
     left join productversion
         on productversion.productversion_id = ecommerce_line.productversion_id
-    where
-        ecommerce_couponpaymentversion.couponpaymentversion_coupon_type = 'single-use'
-        and ecommerce_couponpaymentversion.couponpaymentversion_discount_amount = 1.0000
+    where 
+        ecommerce_couponpaymentversion.couponpaymentversion_coupon_type = 'single-use' 
+        and ecommerce_couponpaymentversion.couponpaymentversion_discount_amount = 1.0000 
         and coupon.coupon_id not in (
             select coupon_id
-            from ecommerce_productcouponassignment
+            from productcouponassignment 
         )
         and not exists (
             select b2b_ecommerce_b2border.couponpaymentversion_id
             from b2b_ecommerce_b2border
-            where
+            where 
                 b2b_ecommerce_b2border.couponpaymentversion_id = ecommerce_couponpaymentversion.couponpaymentversion_id
-        )
+        ) 
 )
 
 , b2b_coupon_fields as (
@@ -226,7 +226,7 @@ with coupon as (
         , coupon.couponpayment_name
         , b2b_ecommerce_b2border.b2border_contract_number
         , b2b_ecommerce_b2border.product_id
-        , ecommerce_couponpaymentversion.couponpaymentversion_payment_transaction
+        , ecommerce_couponpaymentversion.couponpaymentversion_payment_transaction 
         , program_runs.programrun_readable_id
         , program_runs.program_title
         , course_runs.courserun_readable_id
@@ -243,25 +243,25 @@ with coupon as (
                 as varchar
             ), '"', ''
         ) as req_reference_number
-        , case
+        , case 
             when couponredemption.couponredemption_id is not null
-                then 'true'
-            else 'false'
+                then 'true' 
+            else 'false' 
         end as coupon_redeemed
-    from b2b_ecommerce_b2border
-    inner join ecommerce_couponpaymentversion
+    from b2b_ecommerce_b2border 
+    inner join ecommerce_couponpaymentversion 
         on ecommerce_couponpaymentversion.couponpaymentversion_id = b2b_ecommerce_b2border.couponpaymentversion_id
-    inner join ecommerce_couponversion
+    inner join ecommerce_couponversion 
         on ecommerce_couponversion.couponpaymentversion_id = ecommerce_couponpaymentversion.couponpaymentversion_id
-    inner join coupon
+    inner join coupon 
         on coupon.coupon_id = ecommerce_couponversion.coupon_id
-    left join couponredemption
+    left join couponredemption 
         on couponredemption.couponversion_id = ecommerce_couponversion.couponversion_id
-    left join ecommerce_order
+    left join ecommerce_order 
         on ecommerce_order.order_id = couponredemption.order_id
-    left join b2b_ecommerce_b2breceipt
+    left join b2b_ecommerce_b2breceipt 
         on b2b_ecommerce_b2breceipt.b2border_id = b2b_ecommerce_b2border.b2border_id
-    left join ecommerce_line
+    left join ecommerce_line 
         on ecommerce_line.order_id = ecommerce_order.order_id
     left join program_runs
         on ecommerce_line.programrun_id = program_runs.programrun_id
@@ -271,12 +271,12 @@ with coupon as (
         on course_runs.course_id = courses.course_id
     left join productversion
         on productversion.productversion_id = b2b_ecommerce_b2border.productversion_id
-    left join users_user
+    left join users_user    
         on ecommerce_order.order_purchaser_user_id = users_user.user_id
 )
 
 
-select
+select 
     reg_coupon_fields.coupon_email
     , reg_coupon_fields.coupon_code
     , reg_coupon_fields.coupon_id
@@ -303,7 +303,7 @@ where reg_coupon_fields.coupon_id not in (select coupon_id from b2b_coupon_field
 
 union distinct
 
-select
+select 
     b2b_coupon_fields.b2border_email as coupon_email
     , b2b_coupon_fields.coupon_code
     , b2b_coupon_fields.coupon_id
@@ -327,7 +327,7 @@ from b2b_coupon_fields
 
 union distinct
 
-select
+select 
     coupon_email
     , coupon_code
     , coupon_id
@@ -335,7 +335,7 @@ select
     , couponpayment_name
     , b2border_contract_number
     , product_id
-    , couponpaymentversion_payment_transaction
+    , couponpaymentversion_payment_transaction  
     , req_reference_number
     , programrun_readable_id
     , program_title

--- a/src/ol_dbt/models/intermediate/mitxpro/int__mitxpro__ecommerce_combinedcoupons.sql
+++ b/src/ol_dbt/models/intermediate/mitxpro/int__mitxpro__ecommerce_combinedcoupons.sql
@@ -69,17 +69,17 @@ with coupon as (
 )
 
 , payment_transactions as (
-    select distinct 
+    select distinct
         ecommerce_couponversion.coupon_id
         , ecommerce_couponpaymentversion.couponpaymentversion_payment_transaction
     from ecommerce_couponpaymentversion
-    inner join ecommerce_couponversion 
+    inner join ecommerce_couponversion
         on ecommerce_couponpaymentversion.couponpaymentversion_id = ecommerce_couponversion.couponpaymentversion_id
     where ecommerce_couponpaymentversion.couponpaymentversion_payment_transaction is not null
 )
 
 , reg_coupon_summary as (
-    select 
+    select
         coupon.coupon_id
         , case when (count(couponredemption.couponredemption_id) >= 1) then 'true' else 'false' end as coupon_redeemed
         , array_join(array_distinct(array_agg(users_user.user_email)), ', ') as combined_user_emails
@@ -87,27 +87,27 @@ with coupon as (
         , array_join(array_distinct(array_agg(ecommerce_order.order_id)), ', ') as order_ids
         , array_join(array_distinct(array_agg(ecommerce_order.order_state)), ', ') as combined_order_state
     from coupon
-    left join ecommerce_couponversion 
+    left join ecommerce_couponversion
         on coupon.coupon_id = ecommerce_couponversion.coupon_id
     left join couponredemption
         on ecommerce_couponversion.couponversion_id = couponredemption.couponversion_id
     left join ecommerce_order
         on ecommerce_order.order_id = couponredemption.order_id
-    left join users_user    
+    left join users_user
         on ecommerce_order.order_purchaser_user_id = users_user.user_id
-    group by 
+    group by
         coupon.coupon_id
 )
 
 , reg_coupon_fields as (
-    select 
+    select
         productcouponassignment.productcouponassignment_email as coupon_email
         , coupon.coupon_code
         , coupon.coupon_id
         , coupon.coupon_created_on
         , coupon.couponpayment_name
         , productcouponassignment.product_id
-        , payment_transactions.couponpaymentversion_payment_transaction 
+        , payment_transactions.couponpaymentversion_payment_transaction
         , program_runs.programrun_readable_id
         , program_runs.program_title
         , course_runs.courserun_readable_id
@@ -118,9 +118,9 @@ with coupon as (
     from coupon
     left join productcouponassignment
         on productcouponassignment.coupon_id = coupon.coupon_id
-    left join ecommerce_couponversion 
+    left join ecommerce_couponversion
         on coupon.coupon_id = ecommerce_couponversion.coupon_id
-    left join ecommerce_couponpaymentversion 
+    left join ecommerce_couponpaymentversion
         on ecommerce_couponpaymentversion.couponpaymentversion_id = ecommerce_couponversion.couponpaymentversion_id
     left join couponredemption
         on ecommerce_couponversion.couponversion_id = couponredemption.couponversion_id
@@ -128,7 +128,7 @@ with coupon as (
         on ecommerce_order.order_id = couponredemption.order_id
     left join payment_transactions
         on coupon.coupon_id = payment_transactions.coupon_id
-    left join ecommerce_line 
+    left join ecommerce_line
         on ecommerce_line.order_id = ecommerce_order.order_id
     left join program_runs
         on ecommerce_line.programrun_id = program_runs.programrun_id
@@ -138,14 +138,14 @@ with coupon as (
         on course_runs.course_id = courses.course_id
     left join productversion
         on productversion.productversion_id = ecommerce_line.productversion_id
-    group by 
-        productcouponassignment.productcouponassignment_email 
+    group by
+        productcouponassignment.productcouponassignment_email
         , coupon.coupon_code
         , coupon.coupon_id
         , coupon.coupon_created_on
         , coupon.couponpayment_name
         , productcouponassignment.product_id
-        , payment_transactions.couponpaymentversion_payment_transaction 
+        , payment_transactions.couponpaymentversion_payment_transaction
         , program_runs.programrun_readable_id
         , program_runs.program_title
         , course_runs.courserun_readable_id
@@ -156,32 +156,32 @@ with coupon as (
 )
 
 , b2b_coupon_summary as (
-    select 
+    select
         coupon.coupon_id
-        , case 
-            when (count(couponredemption.couponredemption_id) >= 1) 
-                then 'true' 
-            else 'false' 
+        , case
+            when (count(couponredemption.couponredemption_id) >= 1)
+                then 'true'
+            else 'false'
         end as coupon_redeemed
         , array_join(array_distinct(array_agg(users_user.user_email)), ', ') as combined_user_emails
         , array_join(array_distinct(array_agg(users_user.user_address_country)), ', ') as user_address_countries
         , array_join(array_distinct(array_agg(ecommerce_order.order_id)), ', ') as order_ids
         , array_join(array_distinct(array_agg(ecommerce_order.order_state)), ', ') as combined_order_state
-    from b2b_ecommerce_b2border 
-    inner join ecommerce_couponpaymentversion 
+    from b2b_ecommerce_b2border
+    inner join ecommerce_couponpaymentversion
         on ecommerce_couponpaymentversion.couponpaymentversion_id = b2b_ecommerce_b2border.couponpaymentversion_id
-    inner join ecommerce_couponversion 
+    inner join ecommerce_couponversion
         on ecommerce_couponversion.couponpaymentversion_id = ecommerce_couponpaymentversion.couponpaymentversion_id
-    inner join coupon 
-        on coupon.coupon_id = ecommerce_couponversion.coupon_id 
-    left join couponredemption 
+    inner join coupon
+        on coupon.coupon_id = ecommerce_couponversion.coupon_id
+    left join couponredemption
         on couponredemption.couponversion_id = ecommerce_couponversion.couponversion_id
-    left join ecommerce_order 
+    left join ecommerce_order
         on ecommerce_order.order_id = couponredemption.order_id
-    left join users_user    
+    left join users_user
         on ecommerce_order.order_purchaser_user_id = users_user.user_id
-    group by 
-        coupon.coupon_id   
+    group by
+        coupon.coupon_id
 )
 
 , b2b_coupon_fields as (
@@ -193,7 +193,7 @@ with coupon as (
         , coupon.couponpayment_name
         , b2b_ecommerce_b2border.b2border_contract_number
         , b2b_ecommerce_b2border.product_id
-        , ecommerce_couponpaymentversion.couponpaymentversion_payment_transaction 
+        , ecommerce_couponpaymentversion.couponpaymentversion_payment_transaction
         , program_runs.programrun_readable_id
         , program_runs.program_title
         , course_runs.courserun_readable_id
@@ -208,20 +208,20 @@ with coupon as (
                 as varchar
             ), '"', ''
         ) as req_reference_number
-    from b2b_ecommerce_b2border 
-    inner join ecommerce_couponpaymentversion 
+    from b2b_ecommerce_b2border
+    inner join ecommerce_couponpaymentversion
         on ecommerce_couponpaymentversion.couponpaymentversion_id = b2b_ecommerce_b2border.couponpaymentversion_id
-    inner join ecommerce_couponversion 
+    inner join ecommerce_couponversion
         on ecommerce_couponversion.couponpaymentversion_id = ecommerce_couponpaymentversion.couponpaymentversion_id
-    inner join coupon 
+    inner join coupon
         on coupon.coupon_id = ecommerce_couponversion.coupon_id
-    left join couponredemption 
+    left join couponredemption
         on couponredemption.couponversion_id = ecommerce_couponversion.couponversion_id
-    left join ecommerce_order 
+    left join ecommerce_order
         on ecommerce_order.order_id = couponredemption.order_id
-    left join b2b_ecommerce_b2breceipt 
+    left join b2b_ecommerce_b2breceipt
         on b2b_ecommerce_b2breceipt.b2border_id = b2b_ecommerce_b2border.b2border_id
-    left join ecommerce_line 
+    left join ecommerce_line
         on ecommerce_line.order_id = ecommerce_order.order_id
     left join program_runs
         on ecommerce_line.programrun_id = program_runs.programrun_id
@@ -231,15 +231,15 @@ with coupon as (
         on course_runs.course_id = courses.course_id
     left join productversion
         on productversion.productversion_id = b2b_ecommerce_b2border.productversion_id
-    group by 
-        b2b_ecommerce_b2border.b2border_email 
+    group by
+        b2b_ecommerce_b2border.b2border_email
         , coupon.coupon_code
         , coupon.coupon_id
         , coupon.coupon_created_on
         , coupon.couponpayment_name
         , b2b_ecommerce_b2border.b2border_contract_number
         , b2b_ecommerce_b2border.product_id
-        , ecommerce_couponpaymentversion.couponpaymentversion_payment_transaction 
+        , ecommerce_couponpaymentversion.couponpaymentversion_payment_transaction
         , program_runs.programrun_readable_id
         , program_runs.program_title
         , course_runs.courserun_readable_id
@@ -252,11 +252,11 @@ with coupon as (
                 json_extract(b2b_ecommerce_b2breceipt.b2breceipt_data, '$.req_reference_number')
                 as varchar
             ), '"', ''
-        ) 
+        )
 )
 
 
-select 
+select
     reg_coupon_fields.coupon_email
     , reg_coupon_fields.coupon_code
     , reg_coupon_fields.coupon_id
@@ -285,7 +285,7 @@ inner join reg_coupon_summary
 
 union distinct
 
-select 
+select
     b2b_coupon_fields.b2border_email as coupon_email
     , b2b_coupon_fields.coupon_code
     , b2b_coupon_fields.coupon_id

--- a/src/ol_dbt/models/intermediate/mitxpro/int__mitxpro__ecommerce_combinedcoupons.sql
+++ b/src/ol_dbt/models/intermediate/mitxpro/int__mitxpro__ecommerce_combinedcoupons.sql
@@ -69,32 +69,25 @@ with coupon as (
 )
 
 , payment_transactions as (
-    select distinct
+    select distinct 
         ecommerce_couponversion.coupon_id
         , ecommerce_couponpaymentversion.couponpaymentversion_payment_transaction
-    from (
-        select
-            couponpayment_name
-            , max(couponpaymentversion_id) as couponpaymentversion_id
-        from ecommerce_couponpaymentversion
-        group by couponpayment_name
-    ) as max_couponpaymentversion
-    inner join ecommerce_couponpaymentversion
-        on max_couponpaymentversion.couponpaymentversion_id = ecommerce_couponpaymentversion.couponpaymentversion_id
-    inner join ecommerce_couponversion
+    from ecommerce_couponpaymentversion
+    inner join ecommerce_couponversion 
         on ecommerce_couponpaymentversion.couponpaymentversion_id = ecommerce_couponversion.couponpaymentversion_id
+    where ecommerce_couponpaymentversion.couponpaymentversion_payment_transaction is not null
 )
-/*the code above works because different couponpaymentversion records with the
-same payment_id always have the same couponpaymentversion_payment_transaction*/
 
-select
+
+select 
     productcouponassignment.productcouponassignment_email as coupon_email
     , coupon.coupon_code
+    , coupon.coupon_id
     , coupon.coupon_created_on
     , coupon.couponpayment_name
     , null as b2border_contract_number
     , productcouponassignment.product_id
-    , payment_transactions.couponpaymentversion_payment_transaction
+    , payment_transactions.couponpaymentversion_payment_transaction 
     , null as req_reference_number
     , program_runs.programrun_readable_id
     , program_runs.program_title
@@ -104,7 +97,7 @@ select
     , 'regular coupon' as combinedcoupon_table_source
     , ecommerce_couponpaymentversion.couponpaymentversion_coupon_type
     , ecommerce_couponpaymentversion.couponpaymentversion_discount_amount
-    , case when (count(couponredemption.couponredemption_id) >= 1) then 'True' else 'False' end as coupon_redeemed
+    , case when (count(couponredemption.couponredemption_id) >= 1) then true else false end as coupon_redeemed
     , array_join(array_distinct(array_agg(users_user.user_email)), ', ') as combined_user_emails
     , array_join(array_distinct(array_agg(users_user.user_address_country)), ', ') as user_address_countries
     , array_join(array_distinct(array_agg(ecommerce_order.order_id)), ', ') as order_ids
@@ -112,19 +105,19 @@ select
 from coupon
 left join productcouponassignment
     on productcouponassignment.coupon_id = coupon.coupon_id
-left join ecommerce_couponversion
+left join ecommerce_couponversion 
     on coupon.coupon_id = ecommerce_couponversion.coupon_id
-left join ecommerce_couponpaymentversion
+left join ecommerce_couponpaymentversion 
     on ecommerce_couponpaymentversion.couponpaymentversion_id = ecommerce_couponversion.couponpaymentversion_id
 left join couponredemption
     on ecommerce_couponversion.couponversion_id = couponredemption.couponversion_id
 left join ecommerce_order
     on ecommerce_order.order_id = couponredemption.order_id
-left join users_user
+left join users_user    
     on ecommerce_order.order_purchaser_user_id = users_user.user_id
 left join payment_transactions
     on coupon.coupon_id = payment_transactions.coupon_id
-left join ecommerce_line
+left join ecommerce_line 
     on ecommerce_line.order_id = ecommerce_order.order_id
 left join program_runs
     on ecommerce_line.programrun_id = program_runs.programrun_id
@@ -134,13 +127,14 @@ left join courses
     on course_runs.course_id = courses.course_id
 left join productversion
     on productversion.productversion_id = ecommerce_line.productversion_id
-group by
-    productcouponassignment.productcouponassignment_email
+group by 
+    productcouponassignment.productcouponassignment_email 
     , coupon.coupon_code
+    , coupon.coupon_id
     , coupon.coupon_created_on
     , coupon.couponpayment_name
     , productcouponassignment.product_id
-    , payment_transactions.couponpaymentversion_payment_transaction
+    , payment_transactions.couponpaymentversion_payment_transaction 
     , program_runs.programrun_readable_id
     , program_runs.program_title
     , course_runs.courserun_readable_id
@@ -151,14 +145,15 @@ group by
 
 union distinct
 
-select
+select 
     b2b_ecommerce_b2border.b2border_email as coupon_email
     , coupon.coupon_code
+    , coupon.coupon_id
     , coupon.coupon_created_on
     , coupon.couponpayment_name
     , b2b_ecommerce_b2border.b2border_contract_number
     , b2b_ecommerce_b2border.product_id
-    , ecommerce_couponpaymentversion.couponpaymentversion_payment_transaction
+    , ecommerce_couponpaymentversion.couponpaymentversion_payment_transaction 
     , replace(
         cast(
             json_extract(b2b_ecommerce_b2breceipt.b2breceipt_data, '$.req_reference_number'
@@ -174,31 +169,31 @@ select
     , 'b2b coupon' as combinedcoupon_table_source
     , ecommerce_couponpaymentversion.couponpaymentversion_coupon_type
     , ecommerce_couponpaymentversion.couponpaymentversion_discount_amount
-    , case
-        when (count(couponredemption.couponredemption_id) >= 1)
-            then 'True'
-        else 'False'
+    , case 
+        when (count(couponredemption.couponredemption_id) >= 1) 
+            then true 
+        else false 
     end as coupon_redeemed
     , array_join(array_distinct(array_agg(users_user.user_email)), ', ') as combined_user_emails
     , array_join(array_distinct(array_agg(users_user.user_address_country)), ', ') as user_address_countries
     , array_join(array_distinct(array_agg(ecommerce_order.order_id)), ', ') as order_ids
     , array_join(array_distinct(array_agg(ecommerce_order.order_state)), ', ') as combined_order_state
-from b2b_ecommerce_b2border
-inner join ecommerce_couponpaymentversion
+from b2b_ecommerce_b2border 
+left join ecommerce_couponpaymentversion 
     on ecommerce_couponpaymentversion.couponpaymentversion_id = b2b_ecommerce_b2border.couponpaymentversion_id
-inner join coupon
-    on coupon.coupon_id = b2b_ecommerce_b2border.b2bcoupon_id
-inner join ecommerce_couponversion
+left join coupon 
+    on coupon.coupon_id = b2b_ecommerce_b2border.b2bcoupon_id 
+left join ecommerce_couponversion 
     on ecommerce_couponversion.coupon_id = coupon.coupon_id
-left join couponredemption
+left join couponredemption 
     on couponredemption.couponversion_id = ecommerce_couponversion.couponversion_id
-left join ecommerce_order
+left join ecommerce_order 
     on ecommerce_order.order_id = couponredemption.order_id
-left join users_user
+left join users_user    
     on ecommerce_order.order_purchaser_user_id = users_user.user_id
-left join b2b_ecommerce_b2breceipt
+left join b2b_ecommerce_b2breceipt 
     on b2b_ecommerce_b2breceipt.b2border_id = b2b_ecommerce_b2border.b2border_id
-left join ecommerce_line
+left join ecommerce_line 
     on ecommerce_line.order_id = ecommerce_order.order_id
 left join program_runs
     on ecommerce_line.programrun_id = program_runs.programrun_id
@@ -208,20 +203,21 @@ left join courses
     on course_runs.course_id = courses.course_id
 left join productversion
     on productversion.productversion_id = b2b_ecommerce_b2border.productversion_id
-group by
-    b2b_ecommerce_b2border.b2border_email
+group by 
+    b2b_ecommerce_b2border.b2border_email 
     , coupon.coupon_code
+    , coupon.coupon_id
     , coupon.coupon_created_on
     , coupon.couponpayment_name
     , b2b_ecommerce_b2border.b2border_contract_number
     , b2b_ecommerce_b2border.product_id
-    , ecommerce_couponpaymentversion.couponpaymentversion_payment_transaction
+    , ecommerce_couponpaymentversion.couponpaymentversion_payment_transaction 
     , replace(
         cast(
             json_extract(b2b_ecommerce_b2breceipt.b2breceipt_data, '$.req_reference_number')
             as varchar
         ), '"', ''
-    )
+    ) 
     , program_runs.programrun_readable_id
     , program_runs.program_title
     , course_runs.courserun_readable_id

--- a/src/ol_dbt/models/intermediate/mitxpro/int__mitxpro__ecommerce_combinedcoupons.sql
+++ b/src/ol_dbt/models/intermediate/mitxpro/int__mitxpro__ecommerce_combinedcoupons.sql
@@ -69,17 +69,17 @@ with coupon as (
 )
 
 , payment_transactions as (
-    select distinct 
+    select distinct
         ecommerce_couponversion.coupon_id
         , ecommerce_couponpaymentversion.couponpaymentversion_payment_transaction
     from ecommerce_couponpaymentversion
-    inner join ecommerce_couponversion 
+    inner join ecommerce_couponversion
         on ecommerce_couponpaymentversion.couponpaymentversion_id = ecommerce_couponversion.couponpaymentversion_id
     where ecommerce_couponpaymentversion.couponpaymentversion_payment_transaction is not null
 )
 
 , reg_coupon_summary as (
-    select 
+    select
         coupon.coupon_id
         , case when (count(couponredemption.couponredemption_id) >= 1) then 'true' else 'false' end as coupon_redeemed
         , array_join(array_distinct(array_agg(users_user.user_email)), ', ') as combined_user_emails
@@ -87,27 +87,27 @@ with coupon as (
         , array_join(array_distinct(array_agg(ecommerce_order.order_id)), ', ') as order_ids
         , array_join(array_distinct(array_agg(ecommerce_order.order_state)), ', ') as combined_order_state
     from coupon
-    left join ecommerce_couponversion 
+    left join ecommerce_couponversion
         on coupon.coupon_id = ecommerce_couponversion.coupon_id
     left join couponredemption
         on ecommerce_couponversion.couponversion_id = couponredemption.couponversion_id
     left join ecommerce_order
         on ecommerce_order.order_id = couponredemption.order_id
-    left join users_user    
+    left join users_user
         on ecommerce_order.order_purchaser_user_id = users_user.user_id
-    group by 
+    group by
         coupon.coupon_id
 )
 
 , reg_coupon_fields as (
-    select 
+    select
         productcouponassignment.productcouponassignment_email as coupon_email
         , coupon.coupon_code
         , coupon.coupon_id
         , coupon.coupon_created_on
         , coupon.couponpayment_name
         , productcouponassignment.product_id
-        , payment_transactions.couponpaymentversion_payment_transaction 
+        , payment_transactions.couponpaymentversion_payment_transaction
         , program_runs.programrun_readable_id
         , program_runs.program_title
         , course_runs.courserun_readable_id
@@ -118,9 +118,9 @@ with coupon as (
     from coupon
     left join productcouponassignment
         on productcouponassignment.coupon_id = coupon.coupon_id
-    left join ecommerce_couponversion 
+    left join ecommerce_couponversion
         on coupon.coupon_id = ecommerce_couponversion.coupon_id
-    left join ecommerce_couponpaymentversion 
+    left join ecommerce_couponpaymentversion
         on ecommerce_couponpaymentversion.couponpaymentversion_id = ecommerce_couponversion.couponpaymentversion_id
     left join couponredemption
         on ecommerce_couponversion.couponversion_id = couponredemption.couponversion_id
@@ -128,7 +128,7 @@ with coupon as (
         on ecommerce_order.order_id = couponredemption.order_id
     left join payment_transactions
         on coupon.coupon_id = payment_transactions.coupon_id
-    left join ecommerce_line 
+    left join ecommerce_line
         on ecommerce_line.order_id = ecommerce_order.order_id
     left join program_runs
         on ecommerce_line.programrun_id = program_runs.programrun_id
@@ -138,14 +138,14 @@ with coupon as (
         on course_runs.course_id = courses.course_id
     left join productversion
         on productversion.productversion_id = ecommerce_line.productversion_id
-    group by 
-        productcouponassignment.productcouponassignment_email 
+    group by
+        productcouponassignment.productcouponassignment_email
         , coupon.coupon_code
         , coupon.coupon_id
         , coupon.coupon_created_on
         , coupon.couponpayment_name
         , productcouponassignment.product_id
-        , payment_transactions.couponpaymentversion_payment_transaction 
+        , payment_transactions.couponpaymentversion_payment_transaction
         , program_runs.programrun_readable_id
         , program_runs.program_title
         , course_runs.courserun_readable_id
@@ -156,32 +156,32 @@ with coupon as (
 )
 
 , b2b_coupon_summary as (
-    select 
+    select
         coupon.coupon_id
-        , case 
-            when (count(couponredemption.couponredemption_id) >= 1) 
-                then 'true' 
-            else 'false' 
+        , case
+            when (count(couponredemption.couponredemption_id) >= 1)
+                then 'true'
+            else 'false'
         end as coupon_redeemed
         , array_join(array_distinct(array_agg(users_user.user_email)), ', ') as combined_user_emails
         , array_join(array_distinct(array_agg(users_user.user_address_country)), ', ') as user_address_countries
         , array_join(array_distinct(array_agg(ecommerce_order.order_id)), ', ') as order_ids
         , array_join(array_distinct(array_agg(ecommerce_order.order_state)), ', ') as combined_order_state
-    from b2b_ecommerce_b2border 
-    inner join ecommerce_couponpaymentversion 
+    from b2b_ecommerce_b2border
+    inner join ecommerce_couponpaymentversion
         on ecommerce_couponpaymentversion.couponpaymentversion_id = b2b_ecommerce_b2border.couponpaymentversion_id
-    inner join ecommerce_couponversion 
+    inner join ecommerce_couponversion
         on ecommerce_couponversion.couponpaymentversion_id = ecommerce_couponpaymentversion.couponpaymentversion_id
-    inner join coupon 
-        on coupon.coupon_id = ecommerce_couponversion.coupon_id 
-    left join couponredemption 
+    inner join coupon
+        on coupon.coupon_id = ecommerce_couponversion.coupon_id
+    left join couponredemption
         on couponredemption.couponversion_id = ecommerce_couponversion.couponversion_id
-    left join ecommerce_order 
+    left join ecommerce_order
         on ecommerce_order.order_id = couponredemption.order_id
-    left join users_user    
+    left join users_user
         on ecommerce_order.order_purchaser_user_id = users_user.user_id
-    group by 
-        coupon.coupon_id   
+    group by
+        coupon.coupon_id
 )
 
 , b2b_coupon_fields as (
@@ -193,7 +193,7 @@ with coupon as (
         , coupon.couponpayment_name
         , b2b_ecommerce_b2border.b2border_contract_number
         , b2b_ecommerce_b2border.product_id
-        , ecommerce_couponpaymentversion.couponpaymentversion_payment_transaction 
+        , ecommerce_couponpaymentversion.couponpaymentversion_payment_transaction
         , program_runs.programrun_readable_id
         , program_runs.program_title
         , course_runs.courserun_readable_id
@@ -208,20 +208,20 @@ with coupon as (
                 as varchar
             ), '"', ''
         ) as req_reference_number
-    from b2b_ecommerce_b2border 
-    inner join ecommerce_couponpaymentversion 
+    from b2b_ecommerce_b2border
+    inner join ecommerce_couponpaymentversion
         on ecommerce_couponpaymentversion.couponpaymentversion_id = b2b_ecommerce_b2border.couponpaymentversion_id
-    inner join ecommerce_couponversion 
+    inner join ecommerce_couponversion
         on ecommerce_couponversion.couponpaymentversion_id = ecommerce_couponpaymentversion.couponpaymentversion_id
-    inner join coupon 
+    inner join coupon
         on coupon.coupon_id = ecommerce_couponversion.coupon_id
-    left join couponredemption 
+    left join couponredemption
         on couponredemption.couponversion_id = ecommerce_couponversion.couponversion_id
-    left join ecommerce_order 
+    left join ecommerce_order
         on ecommerce_order.order_id = couponredemption.order_id
-    left join b2b_ecommerce_b2breceipt 
+    left join b2b_ecommerce_b2breceipt
         on b2b_ecommerce_b2breceipt.b2border_id = b2b_ecommerce_b2border.b2border_id
-    left join ecommerce_line 
+    left join ecommerce_line
         on ecommerce_line.order_id = ecommerce_order.order_id
     left join program_runs
         on ecommerce_line.programrun_id = program_runs.programrun_id
@@ -231,15 +231,15 @@ with coupon as (
         on course_runs.course_id = courses.course_id
     left join productversion
         on productversion.productversion_id = b2b_ecommerce_b2border.productversion_id
-    group by 
-        b2b_ecommerce_b2border.b2border_email 
+    group by
+        b2b_ecommerce_b2border.b2border_email
         , coupon.coupon_code
         , coupon.coupon_id
         , coupon.coupon_created_on
         , coupon.couponpayment_name
         , b2b_ecommerce_b2border.b2border_contract_number
         , b2b_ecommerce_b2border.product_id
-        , ecommerce_couponpaymentversion.couponpaymentversion_payment_transaction 
+        , ecommerce_couponpaymentversion.couponpaymentversion_payment_transaction
         , program_runs.programrun_readable_id
         , program_runs.program_title
         , course_runs.courserun_readable_id
@@ -252,11 +252,11 @@ with coupon as (
                 json_extract(b2b_ecommerce_b2breceipt.b2breceipt_data, '$.req_reference_number')
                 as varchar
             ), '"', ''
-        ) 
+        )
 )
 
 
-select 
+select
     reg_coupon_fields.coupon_email
     , reg_coupon_fields.coupon_code
     , reg_coupon_fields.coupon_id
@@ -285,7 +285,7 @@ inner join reg_coupon_summary
 
 union distinct
 
-select 
+select
     b2b_coupon_fields.b2border_email as coupon_email
     , b2b_coupon_fields.coupon_code
     , b2b_coupon_fields.b2b_coupon_fields.coupon_id

--- a/src/ol_dbt/models/intermediate/mitxpro/int__mitxpro__ecommerce_combinedcoupons.sql
+++ b/src/ol_dbt/models/intermediate/mitxpro/int__mitxpro__ecommerce_combinedcoupons.sql
@@ -69,17 +69,17 @@ with coupon as (
 )
 
 , payment_transactions as (
-    select distinct
+    select distinct 
         ecommerce_couponversion.coupon_id
         , ecommerce_couponpaymentversion.couponpaymentversion_payment_transaction
     from ecommerce_couponpaymentversion
-    inner join ecommerce_couponversion
+    inner join ecommerce_couponversion 
         on ecommerce_couponpaymentversion.couponpaymentversion_id = ecommerce_couponversion.couponpaymentversion_id
     where ecommerce_couponpaymentversion.couponpaymentversion_payment_transaction is not null
 )
 
 , reg_coupon_summary as (
-    select
+    select 
         coupon.coupon_id
         , case when (count(couponredemption.couponredemption_id) >= 1) then 'true' else 'false' end as coupon_redeemed
         , array_join(array_distinct(array_agg(users_user.user_email)), ', ') as combined_user_emails
@@ -87,27 +87,27 @@ with coupon as (
         , array_join(array_distinct(array_agg(ecommerce_order.order_id)), ', ') as order_ids
         , array_join(array_distinct(array_agg(ecommerce_order.order_state)), ', ') as combined_order_state
     from coupon
-    left join ecommerce_couponversion
+    left join ecommerce_couponversion 
         on coupon.coupon_id = ecommerce_couponversion.coupon_id
     left join couponredemption
         on ecommerce_couponversion.couponversion_id = couponredemption.couponversion_id
     left join ecommerce_order
         on ecommerce_order.order_id = couponredemption.order_id
-    left join users_user
+    left join users_user    
         on ecommerce_order.order_purchaser_user_id = users_user.user_id
-    group by
+    group by 
         coupon.coupon_id
 )
 
 , reg_coupon_fields as (
-    select
+    select 
         productcouponassignment.productcouponassignment_email as coupon_email
         , coupon.coupon_code
         , coupon.coupon_id
         , coupon.coupon_created_on
         , coupon.couponpayment_name
         , productcouponassignment.product_id
-        , payment_transactions.couponpaymentversion_payment_transaction
+        , payment_transactions.couponpaymentversion_payment_transaction 
         , program_runs.programrun_readable_id
         , program_runs.program_title
         , course_runs.courserun_readable_id
@@ -118,9 +118,9 @@ with coupon as (
     from coupon
     left join productcouponassignment
         on productcouponassignment.coupon_id = coupon.coupon_id
-    left join ecommerce_couponversion
+    left join ecommerce_couponversion 
         on coupon.coupon_id = ecommerce_couponversion.coupon_id
-    left join ecommerce_couponpaymentversion
+    left join ecommerce_couponpaymentversion 
         on ecommerce_couponpaymentversion.couponpaymentversion_id = ecommerce_couponversion.couponpaymentversion_id
     left join couponredemption
         on ecommerce_couponversion.couponversion_id = couponredemption.couponversion_id
@@ -128,7 +128,7 @@ with coupon as (
         on ecommerce_order.order_id = couponredemption.order_id
     left join payment_transactions
         on coupon.coupon_id = payment_transactions.coupon_id
-    left join ecommerce_line
+    left join ecommerce_line 
         on ecommerce_line.order_id = ecommerce_order.order_id
     left join program_runs
         on ecommerce_line.programrun_id = program_runs.programrun_id
@@ -138,14 +138,14 @@ with coupon as (
         on course_runs.course_id = courses.course_id
     left join productversion
         on productversion.productversion_id = ecommerce_line.productversion_id
-    group by
-        productcouponassignment.productcouponassignment_email
+    group by 
+        productcouponassignment.productcouponassignment_email 
         , coupon.coupon_code
         , coupon.coupon_id
         , coupon.coupon_created_on
         , coupon.couponpayment_name
         , productcouponassignment.product_id
-        , payment_transactions.couponpaymentversion_payment_transaction
+        , payment_transactions.couponpaymentversion_payment_transaction 
         , program_runs.programrun_readable_id
         , program_runs.program_title
         , course_runs.courserun_readable_id
@@ -156,32 +156,32 @@ with coupon as (
 )
 
 , b2b_coupon_summary as (
-    select
+    select 
         coupon.coupon_id
-        , case
-            when (count(couponredemption.couponredemption_id) >= 1)
-                then 'true'
-            else 'false'
+        , case 
+            when (count(couponredemption.couponredemption_id) >= 1) 
+                then 'true' 
+            else 'false' 
         end as coupon_redeemed
         , array_join(array_distinct(array_agg(users_user.user_email)), ', ') as combined_user_emails
         , array_join(array_distinct(array_agg(users_user.user_address_country)), ', ') as user_address_countries
         , array_join(array_distinct(array_agg(ecommerce_order.order_id)), ', ') as order_ids
         , array_join(array_distinct(array_agg(ecommerce_order.order_state)), ', ') as combined_order_state
-    from b2b_ecommerce_b2border
-    inner join ecommerce_couponpaymentversion
+    from b2b_ecommerce_b2border 
+    inner join ecommerce_couponpaymentversion 
         on ecommerce_couponpaymentversion.couponpaymentversion_id = b2b_ecommerce_b2border.couponpaymentversion_id
-    inner join ecommerce_couponversion
+    inner join ecommerce_couponversion 
         on ecommerce_couponversion.couponpaymentversion_id = ecommerce_couponpaymentversion.couponpaymentversion_id
-    inner join coupon
-        on coupon.coupon_id = ecommerce_couponversion.coupon_id
-    left join couponredemption
+    inner join coupon 
+        on coupon.coupon_id = ecommerce_couponversion.coupon_id 
+    left join couponredemption 
         on couponredemption.couponversion_id = ecommerce_couponversion.couponversion_id
-    left join ecommerce_order
+    left join ecommerce_order 
         on ecommerce_order.order_id = couponredemption.order_id
-    left join users_user
+    left join users_user    
         on ecommerce_order.order_purchaser_user_id = users_user.user_id
-    group by
-        coupon.coupon_id
+    group by 
+        coupon.coupon_id   
 )
 
 , b2b_coupon_fields as (
@@ -193,7 +193,7 @@ with coupon as (
         , coupon.couponpayment_name
         , b2b_ecommerce_b2border.b2border_contract_number
         , b2b_ecommerce_b2border.product_id
-        , ecommerce_couponpaymentversion.couponpaymentversion_payment_transaction
+        , ecommerce_couponpaymentversion.couponpaymentversion_payment_transaction 
         , program_runs.programrun_readable_id
         , program_runs.program_title
         , course_runs.courserun_readable_id
@@ -208,20 +208,20 @@ with coupon as (
                 as varchar
             ), '"', ''
         ) as req_reference_number
-    from b2b_ecommerce_b2border
-    inner join ecommerce_couponpaymentversion
+    from b2b_ecommerce_b2border 
+    inner join ecommerce_couponpaymentversion 
         on ecommerce_couponpaymentversion.couponpaymentversion_id = b2b_ecommerce_b2border.couponpaymentversion_id
-    inner join ecommerce_couponversion
+    inner join ecommerce_couponversion 
         on ecommerce_couponversion.couponpaymentversion_id = ecommerce_couponpaymentversion.couponpaymentversion_id
-    inner join coupon
+    inner join coupon 
         on coupon.coupon_id = ecommerce_couponversion.coupon_id
-    left join couponredemption
+    left join couponredemption 
         on couponredemption.couponversion_id = ecommerce_couponversion.couponversion_id
-    left join ecommerce_order
+    left join ecommerce_order 
         on ecommerce_order.order_id = couponredemption.order_id
-    left join b2b_ecommerce_b2breceipt
+    left join b2b_ecommerce_b2breceipt 
         on b2b_ecommerce_b2breceipt.b2border_id = b2b_ecommerce_b2border.b2border_id
-    left join ecommerce_line
+    left join ecommerce_line 
         on ecommerce_line.order_id = ecommerce_order.order_id
     left join program_runs
         on ecommerce_line.programrun_id = program_runs.programrun_id
@@ -231,15 +231,15 @@ with coupon as (
         on course_runs.course_id = courses.course_id
     left join productversion
         on productversion.productversion_id = b2b_ecommerce_b2border.productversion_id
-    group by
-        b2b_ecommerce_b2border.b2border_email
+    group by 
+        b2b_ecommerce_b2border.b2border_email 
         , coupon.coupon_code
         , coupon.coupon_id
         , coupon.coupon_created_on
         , coupon.couponpayment_name
         , b2b_ecommerce_b2border.b2border_contract_number
         , b2b_ecommerce_b2border.product_id
-        , ecommerce_couponpaymentversion.couponpaymentversion_payment_transaction
+        , ecommerce_couponpaymentversion.couponpaymentversion_payment_transaction 
         , program_runs.programrun_readable_id
         , program_runs.program_title
         , course_runs.courserun_readable_id
@@ -252,11 +252,11 @@ with coupon as (
                 json_extract(b2b_ecommerce_b2breceipt.b2breceipt_data, '$.req_reference_number')
                 as varchar
             ), '"', ''
-        )
+        ) 
 )
 
 
-select
+select 
     reg_coupon_fields.coupon_email
     , reg_coupon_fields.coupon_code
     , reg_coupon_fields.coupon_id
@@ -285,10 +285,10 @@ inner join reg_coupon_summary
 
 union distinct
 
-select
+select 
     b2b_coupon_fields.b2border_email as coupon_email
     , b2b_coupon_fields.coupon_code
-    , b2b_coupon_fields.b2b_coupon_fields.coupon_id
+    , b2b_coupon_fields.coupon_id
     , b2b_coupon_fields.coupon_created_on
     , b2b_coupon_fields.couponpayment_name
     , b2b_coupon_fields.b2border_contract_number

--- a/src/ol_dbt/models/intermediate/mitxpro/int__mitxpro__ecommerce_combinedcoupons.sql
+++ b/src/ol_dbt/models/intermediate/mitxpro/int__mitxpro__ecommerce_combinedcoupons.sql
@@ -69,17 +69,17 @@ with coupon as (
 )
 
 , payment_transactions as (
-    select distinct
+    select distinct 
         ecommerce_couponversion.coupon_id
         , ecommerce_couponpaymentversion.couponpaymentversion_payment_transaction
     from ecommerce_couponpaymentversion
-    inner join ecommerce_couponversion
+    inner join ecommerce_couponversion 
         on ecommerce_couponpaymentversion.couponpaymentversion_id = ecommerce_couponversion.couponpaymentversion_id
     where ecommerce_couponpaymentversion.couponpaymentversion_payment_transaction is not null
 )
 
 , latest_couponversion as (
-    select
+    select 
         coupon_id
         , max(couponversion_updated_on) as max_couponversion_updated_on
     from ecommerce_couponversion
@@ -87,38 +87,38 @@ with coupon as (
 )
 
 , reg_coupon_summary as (
-    select
+    select 
         coupon.coupon_id
-        , cast(array_join(array_distinct(array_agg(program_runs.programrun_readable_id)), ', ') as varchar)
+        , cast(array_join(array_distinct(array_agg(program_runs.programrun_readable_id)), ', ') as varchar) 
             as programrun_readable_id
         , cast(array_join(array_distinct(array_agg(program_runs.program_title)), ', ') as varchar) as program_title
-        , cast(array_join(array_distinct(array_agg(course_runs.courserun_readable_id)), ', ') as varchar)
+        , cast(array_join(array_distinct(array_agg(course_runs.courserun_readable_id)), ', ') as varchar) 
             as courserun_readable_id
         , cast(array_join(array_distinct(array_agg(courses.course_title)), ', ') as varchar) as course_title
-        , cast(array_join(array_distinct(array_agg(productversion.productversion_readable_id)), ', ') as varchar)
+        , cast(array_join(array_distinct(array_agg(productversion.productversion_readable_id)), ', ') as varchar) 
             as productversion_readable_id
         , cast(array_join(array_distinct(array_agg(users_user.user_email)), ', ') as varchar) as combined_user_emails
-        , cast(array_join(array_distinct(array_agg(users_user.user_address_country)), ', ') as varchar)
+        , cast(array_join(array_distinct(array_agg(users_user.user_address_country)), ', ') as varchar) 
             as user_address_countries
         , cast(array_join(array_distinct(array_agg(ecommerce_order.order_id)), ', ') as varchar) as order_ids
-        , cast(array_join(array_distinct(array_agg(ecommerce_order.order_state)), ', ') as varchar)
+        , cast(array_join(array_distinct(array_agg(ecommerce_order.order_state)), ', ') as varchar) 
             as combined_order_state
         , case when (count(couponredemption.couponredemption_id) >= 1) then 'true' else 'false' end as coupon_redeemed
-
+        
     from coupon
     left join latest_couponversion
         on coupon.coupon_id = latest_couponversion.coupon_id
-    left join ecommerce_couponversion
-        on
-            latest_couponversion.coupon_id = ecommerce_couponversion.coupon_id
+    left join ecommerce_couponversion 
+        on 
+            latest_couponversion.coupon_id = ecommerce_couponversion.coupon_id 
             and ecommerce_couponversion.couponversion_updated_on = latest_couponversion.max_couponversion_updated_on
     left join couponredemption
         on ecommerce_couponversion.couponversion_id = couponredemption.couponversion_id
-    left join ecommerce_couponpaymentversion
+    left join ecommerce_couponpaymentversion 
         on ecommerce_couponpaymentversion.couponpaymentversion_id = ecommerce_couponversion.couponpaymentversion_id
     left join ecommerce_order
         on ecommerce_order.order_id = couponredemption.order_id
-    left join ecommerce_line
+    left join ecommerce_line 
         on ecommerce_line.order_id = ecommerce_order.order_id
     left join program_runs
         on ecommerce_line.programrun_id = program_runs.programrun_id
@@ -128,22 +128,22 @@ with coupon as (
         on course_runs.course_id = courses.course_id
     left join productversion
         on productversion.productversion_id = ecommerce_line.productversion_id
-    left join users_user
+    left join users_user    
         on ecommerce_order.order_purchaser_user_id = users_user.user_id
     where ecommerce_order.order_state = 'fulfilled' or ecommerce_order.order_state = 'refunded'
-    group by
+    group by 
         coupon.coupon_id
 )
 
 , reg_coupon_fields as (
-    select
+    select 
         productcouponassignment.productcouponassignment_email as coupon_email
         , coupon.coupon_code
         , coupon.coupon_id
         , coupon.coupon_created_on
         , coupon.couponpayment_name
         , productcouponassignment.product_id
-        , payment_transactions.couponpaymentversion_payment_transaction
+        , payment_transactions.couponpaymentversion_payment_transaction 
         , productcouponassignment.productcouponassignment_is_redeemed
     from coupon
     left join productcouponassignment
@@ -153,13 +153,13 @@ with coupon as (
 )
 
 , unassigned_enrollment_codes as (
-    select
+    select 
         coupon.coupon_code
         , coupon.coupon_id
         , coupon.coupon_created_on as coupon_created_on
         , coupon.couponpayment_name
         , b2b_ecommerce_b2border.b2border_contract_number
-        , payment_transactions.couponpaymentversion_payment_transaction
+        , payment_transactions.couponpaymentversion_payment_transaction  
         , program_runs.programrun_readable_id
         , program_runs.program_title
         , course_runs.courserun_readable_id
@@ -177,22 +177,22 @@ with coupon as (
     inner join latest_couponversion
         on coupon.coupon_id = latest_couponversion.coupon_id
     inner join ecommerce_couponversion
-        on
-            latest_couponversion.coupon_id = ecommerce_couponversion.coupon_id
+        on 
+            latest_couponversion.coupon_id = ecommerce_couponversion.coupon_id 
             and ecommerce_couponversion.couponversion_updated_on = latest_couponversion.max_couponversion_updated_on
     inner join ecommerce_couponpaymentversion
-        on ecommerce_couponpaymentversion.couponpaymentversion_id = ecommerce_couponversion.couponpaymentversion_id
-    left join b2b_ecommerce_b2border
+        on ecommerce_couponpaymentversion.couponpaymentversion_id = ecommerce_couponversion.couponpaymentversion_id 
+    left join b2b_ecommerce_b2border 
         on ecommerce_couponpaymentversion.couponpaymentversion_id = b2b_ecommerce_b2border.couponpaymentversion_id
-    left join payment_transactions
-        on payment_transactions.coupon_id = coupon.coupon_id
+    left join payment_transactions 
+        on payment_transactions.coupon_id = coupon.coupon_id   
     left join couponredemption
         on couponredemption.couponversion_id = ecommerce_couponversion.couponversion_id
-    left join ecommerce_order
+    left join ecommerce_order 
         on couponredemption.order_id = ecommerce_order.order_id
-    left join users_user
-        on users_user.user_id = ecommerce_order.order_purchaser_user_id
-    left join ecommerce_line
+    left join users_user 
+        on users_user.user_id = ecommerce_order.order_purchaser_user_id 
+    left join ecommerce_line 
         on ecommerce_line.order_id = ecommerce_order.order_id
     left join program_runs
         on ecommerce_line.programrun_id = program_runs.programrun_id
@@ -202,19 +202,19 @@ with coupon as (
         on course_runs.course_id = courses.course_id
     left join productversion
         on productversion.productversion_id = ecommerce_line.productversion_id
-    where
-        ecommerce_couponpaymentversion.couponpaymentversion_coupon_type = 'single-use'
-        and ecommerce_couponpaymentversion.couponpaymentversion_discount_amount = 1.0000
+    where 
+        ecommerce_couponpaymentversion.couponpaymentversion_coupon_type = 'single-use' 
+        and ecommerce_couponpaymentversion.couponpaymentversion_discount_amount = 1.0000 
         and coupon.coupon_id not in (
             select coupon_id
-            from productcouponassignment
+            from productcouponassignment 
         )
         and not exists (
             select b2b_ecommerce_b2border.couponpaymentversion_id
             from b2b_ecommerce_b2border
-            where
+            where 
                 b2b_ecommerce_b2border.couponpaymentversion_id = ecommerce_couponpaymentversion.couponpaymentversion_id
-        )
+        ) 
 )
 
 , b2b_coupon_fields as (
@@ -226,7 +226,7 @@ with coupon as (
         , coupon.couponpayment_name
         , b2b_ecommerce_b2border.b2border_contract_number
         , b2b_ecommerce_b2border.product_id
-        , ecommerce_couponpaymentversion.couponpaymentversion_payment_transaction
+        , ecommerce_couponpaymentversion.couponpaymentversion_payment_transaction 
         , program_runs.programrun_readable_id
         , program_runs.program_title
         , course_runs.courserun_readable_id
@@ -243,25 +243,25 @@ with coupon as (
                 as varchar
             ), '"', ''
         ) as req_reference_number
-        , case
+        , case 
             when couponredemption.couponredemption_id is not null
-                then 'true'
-            else 'false'
+                then 'true' 
+            else 'false' 
         end as coupon_redeemed
-    from b2b_ecommerce_b2border
-    inner join ecommerce_couponpaymentversion
+    from b2b_ecommerce_b2border 
+    inner join ecommerce_couponpaymentversion 
         on ecommerce_couponpaymentversion.couponpaymentversion_id = b2b_ecommerce_b2border.couponpaymentversion_id
-    inner join ecommerce_couponversion
+    inner join ecommerce_couponversion 
         on ecommerce_couponversion.couponpaymentversion_id = ecommerce_couponpaymentversion.couponpaymentversion_id
-    inner join coupon
+    inner join coupon 
         on coupon.coupon_id = ecommerce_couponversion.coupon_id
-    left join couponredemption
+    left join couponredemption 
         on couponredemption.couponversion_id = ecommerce_couponversion.couponversion_id
-    left join ecommerce_order
+    left join ecommerce_order 
         on ecommerce_order.order_id = couponredemption.order_id
-    left join b2b_ecommerce_b2breceipt
+    left join b2b_ecommerce_b2breceipt 
         on b2b_ecommerce_b2breceipt.b2border_id = b2b_ecommerce_b2border.b2border_id
-    left join ecommerce_line
+    left join ecommerce_line 
         on ecommerce_line.order_id = ecommerce_order.order_id
     left join program_runs
         on ecommerce_line.programrun_id = program_runs.programrun_id
@@ -271,12 +271,12 @@ with coupon as (
         on course_runs.course_id = courses.course_id
     left join productversion
         on productversion.productversion_id = b2b_ecommerce_b2border.productversion_id
-    left join users_user
+    left join users_user    
         on ecommerce_order.order_purchaser_user_id = users_user.user_id
 )
 
 
-select
+select 
     reg_coupon_fields.coupon_email
     , reg_coupon_fields.coupon_code
     , reg_coupon_fields.coupon_id
@@ -294,7 +294,7 @@ select
     , reg_coupon_summary.coupon_redeemed
     , reg_coupon_summary.combined_user_emails as combined_user_emails
     , reg_coupon_summary.user_address_countries as user_address_countries
-    , reg_coupon_summary.order_ids as order_ids
+    , cast(reg_coupon_summary.order_ids as varchar) as order_ids
     , reg_coupon_summary.combined_order_state as combined_order_state
 from reg_coupon_fields
 left join reg_coupon_summary
@@ -303,7 +303,7 @@ where reg_coupon_fields.coupon_id not in (select coupon_id from b2b_coupon_field
 
 union distinct
 
-select
+select 
     b2b_coupon_fields.b2border_email as coupon_email
     , b2b_coupon_fields.coupon_code
     , b2b_coupon_fields.coupon_id
@@ -321,13 +321,13 @@ select
     , b2b_coupon_fields.coupon_redeemed
     , b2b_coupon_fields.combined_user_emails
     , b2b_coupon_fields.user_address_countries
-    , b2b_coupon_fields.order_ids
+    , cast(b2b_coupon_fields.order_ids as varchar) as order_ids
     , b2b_coupon_fields.combined_order_state
 from b2b_coupon_fields
 
 union distinct
 
-select
+select 
     coupon_email
     , coupon_code
     , coupon_id
@@ -335,7 +335,7 @@ select
     , couponpayment_name
     , b2border_contract_number
     , product_id
-    , couponpaymentversion_payment_transaction
+    , couponpaymentversion_payment_transaction  
     , req_reference_number
     , programrun_readable_id
     , program_title

--- a/src/ol_dbt/models/intermediate/mitxpro/int__mitxpro__ecommerce_combinedcoupons.sql
+++ b/src/ol_dbt/models/intermediate/mitxpro/int__mitxpro__ecommerce_combinedcoupons.sql
@@ -71,17 +71,17 @@ with coupon as (
 )
 
 , payment_transactions as (
-    select distinct
+    select distinct 
         ecommerce_couponversion.coupon_id
         , ecommerce_couponpaymentversion.couponpaymentversion_payment_transaction
     from ecommerce_couponpaymentversion
-    inner join ecommerce_couponversion
+    inner join ecommerce_couponversion 
         on ecommerce_couponpaymentversion.couponpaymentversion_id = ecommerce_couponversion.couponpaymentversion_id
     where ecommerce_couponpaymentversion.couponpaymentversion_payment_transaction is not null
 )
 
 , latest_couponversion as (
-    select
+    select 
         coupon_id
         , max(couponversion_updated_on) as max_couponversion_updated_on
     from ecommerce_couponversion
@@ -89,38 +89,38 @@ with coupon as (
 )
 
 , reg_coupon_summary as (
-    select
+    select 
         coupon.coupon_id
-        , cast(array_join(array_distinct(array_agg(program_runs.programrun_readable_id)), ', ') as varchar)
+        , cast(array_join(array_distinct(array_agg(program_runs.programrun_readable_id)), ', ') as varchar) 
             as programrun_readable_id
         , cast(array_join(array_distinct(array_agg(program_runs.program_title)), ', ') as varchar) as program_title
-        , cast(array_join(array_distinct(array_agg(course_runs.courserun_readable_id)), ', ') as varchar)
+        , cast(array_join(array_distinct(array_agg(course_runs.courserun_readable_id)), ', ') as varchar) 
             as courserun_readable_id
         , cast(array_join(array_distinct(array_agg(courses.course_title)), ', ') as varchar) as course_title
-        , cast(array_join(array_distinct(array_agg(productversion.productversion_readable_id)), ', ') as varchar)
+        , cast(array_join(array_distinct(array_agg(productversion.productversion_readable_id)), ', ') as varchar) 
             as productversion_readable_id
         , cast(array_join(array_distinct(array_agg(users_user.user_email)), ', ') as varchar) as combined_user_emails
-        , cast(array_join(array_distinct(array_agg(users_user.user_address_country)), ', ') as varchar)
+        , cast(array_join(array_distinct(array_agg(users_user.user_address_country)), ', ') as varchar) 
             as user_address_countries
         , cast(array_join(array_distinct(array_agg(ecommerce_order.order_id)), ', ') as varchar) as order_ids
-        , cast(array_join(array_distinct(array_agg(ecommerce_order.order_state)), ', ') as varchar)
+        , cast(array_join(array_distinct(array_agg(ecommerce_order.order_state)), ', ') as varchar) 
             as combined_order_state
         , case when (count(couponredemption.couponredemption_id) >= 1) then 'true' else 'false' end as coupon_redeemed
-
+        
     from coupon
     left join latest_couponversion
         on coupon.coupon_id = latest_couponversion.coupon_id
-    left join ecommerce_couponversion
-        on
-            latest_couponversion.coupon_id = ecommerce_couponversion.coupon_id
+    left join ecommerce_couponversion 
+        on 
+            latest_couponversion.coupon_id = ecommerce_couponversion.coupon_id 
             and ecommerce_couponversion.couponversion_updated_on = latest_couponversion.max_couponversion_updated_on
     left join couponredemption
         on ecommerce_couponversion.couponversion_id = couponredemption.couponversion_id
-    left join ecommerce_couponpaymentversion
+    left join ecommerce_couponpaymentversion 
         on ecommerce_couponpaymentversion.couponpaymentversion_id = ecommerce_couponversion.couponpaymentversion_id
     left join ecommerce_order
         on ecommerce_order.order_id = couponredemption.order_id
-    left join ecommerce_line
+    left join ecommerce_line 
         on ecommerce_line.order_id = ecommerce_order.order_id
     left join program_runs
         on ecommerce_line.programrun_id = program_runs.programrun_id
@@ -130,22 +130,22 @@ with coupon as (
         on course_runs.course_id = courses.course_id
     left join productversion
         on productversion.productversion_id = ecommerce_line.productversion_id
-    left join users_user
+    left join users_user    
         on ecommerce_order.order_purchaser_user_id = users_user.user_id
     where ecommerce_order.order_state = 'fulfilled' or ecommerce_order.order_state = 'refunded'
-    group by
+    group by 
         coupon.coupon_id
 )
 
 , reg_coupon_fields as (
-    select
+    select 
         productcouponassignment.productcouponassignment_email as coupon_email
         , coupon.coupon_code
         , coupon.coupon_id
         , coupon.coupon_created_on
         , coupon.couponpayment_name
         , productcouponassignment.product_id
-        , payment_transactions.couponpaymentversion_payment_transaction
+        , payment_transactions.couponpaymentversion_payment_transaction 
         , productcouponassignment.productcouponassignment_is_redeemed
     from coupon
     left join productcouponassignment
@@ -155,13 +155,13 @@ with coupon as (
 )
 
 , unassigned_enrollment_codes as (
-    select
+    select 
         coupon.coupon_code
         , coupon.coupon_id
         , coupon.coupon_created_on as coupon_created_on
         , coupon.couponpayment_name
         , b2b_ecommerce_b2border.b2border_contract_number
-        , payment_transactions.couponpaymentversion_payment_transaction
+        , payment_transactions.couponpaymentversion_payment_transaction  
         , program_runs.programrun_readable_id
         , program_runs.program_title
         , course_runs.courserun_readable_id
@@ -179,22 +179,22 @@ with coupon as (
     inner join latest_couponversion
         on coupon.coupon_id = latest_couponversion.coupon_id
     inner join ecommerce_couponversion
-        on
-            latest_couponversion.coupon_id = ecommerce_couponversion.coupon_id
+        on 
+            latest_couponversion.coupon_id = ecommerce_couponversion.coupon_id 
             and ecommerce_couponversion.couponversion_updated_on = latest_couponversion.max_couponversion_updated_on
     inner join ecommerce_couponpaymentversion
-        on ecommerce_couponpaymentversion.couponpaymentversion_id = ecommerce_couponversion.couponpaymentversion_id
-    left join b2b_ecommerce_b2border
+        on ecommerce_couponpaymentversion.couponpaymentversion_id = ecommerce_couponversion.couponpaymentversion_id 
+    left join b2b_ecommerce_b2border 
         on ecommerce_couponpaymentversion.couponpaymentversion_id = b2b_ecommerce_b2border.couponpaymentversion_id
-    left join payment_transactions
-        on payment_transactions.coupon_id = coupon.coupon_id
+    left join payment_transactions 
+        on payment_transactions.coupon_id = coupon.coupon_id   
     left join couponredemption
         on couponredemption.couponversion_id = ecommerce_couponversion.couponversion_id
-    left join ecommerce_order
+    left join ecommerce_order 
         on couponredemption.order_id = ecommerce_order.order_id
-    left join users_user
-        on users_user.user_id = ecommerce_order.order_purchaser_user_id
-    left join ecommerce_line
+    left join users_user 
+        on users_user.user_id = ecommerce_order.order_purchaser_user_id 
+    left join ecommerce_line 
         on ecommerce_line.order_id = ecommerce_order.order_id
     left join program_runs
         on ecommerce_line.programrun_id = program_runs.programrun_id
@@ -204,19 +204,19 @@ with coupon as (
         on course_runs.course_id = courses.course_id
     left join productversion
         on productversion.productversion_id = ecommerce_line.productversion_id
-    where
-        ecommerce_couponpaymentversion.couponpaymentversion_coupon_type = 'single-use'
-        and ecommerce_couponpaymentversion.couponpaymentversion_discount_amount = 1.0000
+    where 
+        ecommerce_couponpaymentversion.couponpaymentversion_coupon_type = 'single-use' 
+        and ecommerce_couponpaymentversion.couponpaymentversion_discount_amount = 1.0000 
         and coupon.coupon_id not in (
             select coupon_id
-            from productcouponassignment
+            from productcouponassignment 
         )
         and not exists (
             select b2b_ecommerce_b2border.couponpaymentversion_id
             from b2b_ecommerce_b2border
-            where
+            where 
                 b2b_ecommerce_b2border.couponpaymentversion_id = ecommerce_couponpaymentversion.couponpaymentversion_id
-        )
+        ) 
 )
 
 , b2b_coupon_fields as (
@@ -228,7 +228,7 @@ with coupon as (
         , coupon.couponpayment_name
         , b2b_ecommerce_b2border.b2border_contract_number
         , b2b_ecommerce_b2border.product_id
-        , ecommerce_couponpaymentversion.couponpaymentversion_payment_transaction
+        , ecommerce_couponpaymentversion.couponpaymentversion_payment_transaction 
         , program_runs.programrun_readable_id
         , program_runs.program_title
         , course_runs.courserun_readable_id
@@ -238,26 +238,26 @@ with coupon as (
         , users_user.user_address_country as user_address_countries
         , cast(ecommerce_order.order_id as varchar) as order_ids
         , ecommerce_order.order_state as combined_order_state
-        , req_reference_number
-        , case
+        , b2b_ecommerce_b2breceipt.req_reference_number
+        , case 
             when couponredemption.couponredemption_id is not null
-                then 'true'
-            else 'false'
+                then 'true' 
+            else 'false' 
         end as coupon_redeemed
-    from b2b_ecommerce_b2border
-    inner join ecommerce_couponpaymentversion
+    from b2b_ecommerce_b2border 
+    inner join ecommerce_couponpaymentversion 
         on ecommerce_couponpaymentversion.couponpaymentversion_id = b2b_ecommerce_b2border.couponpaymentversion_id
-    inner join ecommerce_couponversion
+    inner join ecommerce_couponversion 
         on ecommerce_couponversion.couponpaymentversion_id = ecommerce_couponpaymentversion.couponpaymentversion_id
-    inner join coupon
+    inner join coupon 
         on coupon.coupon_id = ecommerce_couponversion.coupon_id
-    left join couponredemption
+    left join couponredemption 
         on couponredemption.couponversion_id = ecommerce_couponversion.couponversion_id
-    left join ecommerce_order
+    left join ecommerce_order 
         on ecommerce_order.order_id = couponredemption.order_id
-    left join b2b_ecommerce_b2breceipt
+    left join b2b_ecommerce_b2breceipt 
         on b2b_ecommerce_b2breceipt.b2border_id = b2b_ecommerce_b2border.b2border_id
-    left join ecommerce_line
+    left join ecommerce_line 
         on ecommerce_line.order_id = ecommerce_order.order_id
     left join program_runs
         on ecommerce_line.programrun_id = program_runs.programrun_id
@@ -267,12 +267,12 @@ with coupon as (
         on course_runs.course_id = courses.course_id
     left join productversion
         on productversion.productversion_id = b2b_ecommerce_b2border.productversion_id
-    left join users_user
+    left join users_user    
         on ecommerce_order.order_purchaser_user_id = users_user.user_id
 )
 
 
-select
+select 
     reg_coupon_fields.coupon_email
     , reg_coupon_fields.coupon_code
     , reg_coupon_fields.coupon_id
@@ -299,7 +299,7 @@ where reg_coupon_fields.coupon_id not in (select coupon_id from b2b_coupon_field
 
 union distinct
 
-select
+select 
     b2b_coupon_fields.b2border_email as coupon_email
     , b2b_coupon_fields.coupon_code
     , b2b_coupon_fields.coupon_id
@@ -323,7 +323,7 @@ from b2b_coupon_fields
 
 union distinct
 
-select
+select 
     coupon_email
     , coupon_code
     , coupon_id
@@ -331,7 +331,7 @@ select
     , couponpayment_name
     , b2border_contract_number
     , product_id
-    , couponpaymentversion_payment_transaction
+    , couponpaymentversion_payment_transaction  
     , req_reference_number
     , programrun_readable_id
     , program_title
@@ -344,6 +344,6 @@ select
     , cast(order_ids as varchar) as order_ids
     , combined_order_state
 from unassigned_enrollment_codes
-where
+where 
     coupon_id not in (select coupon_id from reg_coupon_fields)
     and coupon_id not in (select coupon_id from b2b_coupon_fields)

--- a/src/ol_dbt/models/intermediate/mitxpro/int__mitxpro__ecommerce_combinedcoupons.sql
+++ b/src/ol_dbt/models/intermediate/mitxpro/int__mitxpro__ecommerce_combinedcoupons.sql
@@ -69,17 +69,17 @@ with coupon as (
 )
 
 , payment_transactions as (
-    select distinct 
+    select distinct
         ecommerce_couponversion.coupon_id
         , ecommerce_couponpaymentversion.couponpaymentversion_payment_transaction
     from ecommerce_couponpaymentversion
-    inner join ecommerce_couponversion 
+    inner join ecommerce_couponversion
         on ecommerce_couponpaymentversion.couponpaymentversion_id = ecommerce_couponversion.couponpaymentversion_id
     where ecommerce_couponpaymentversion.couponpaymentversion_payment_transaction is not null
 )
 
 , latest_couponversion as (
-    select 
+    select
         coupon_id
         , max(couponversion_updated_on) as max_couponversion_updated_on
     from ecommerce_couponversion
@@ -87,38 +87,38 @@ with coupon as (
 )
 
 , reg_coupon_summary as (
-    select 
+    select
         coupon.coupon_id
-        , cast(array_join(array_distinct(array_agg(program_runs.programrun_readable_id)), ', ') as varchar) 
+        , cast(array_join(array_distinct(array_agg(program_runs.programrun_readable_id)), ', ') as varchar)
             as programrun_readable_id
         , cast(array_join(array_distinct(array_agg(program_runs.program_title)), ', ') as varchar) as program_title
-        , cast(array_join(array_distinct(array_agg(course_runs.courserun_readable_id)), ', ') as varchar) 
+        , cast(array_join(array_distinct(array_agg(course_runs.courserun_readable_id)), ', ') as varchar)
             as courserun_readable_id
         , cast(array_join(array_distinct(array_agg(courses.course_title)), ', ') as varchar) as course_title
-        , cast(array_join(array_distinct(array_agg(productversion.productversion_readable_id)), ', ') as varchar) 
+        , cast(array_join(array_distinct(array_agg(productversion.productversion_readable_id)), ', ') as varchar)
             as productversion_readable_id
         , cast(array_join(array_distinct(array_agg(users_user.user_email)), ', ') as varchar) as combined_user_emails
-        , cast(array_join(array_distinct(array_agg(users_user.user_address_country)), ', ') as varchar) 
+        , cast(array_join(array_distinct(array_agg(users_user.user_address_country)), ', ') as varchar)
             as user_address_countries
         , cast(array_join(array_distinct(array_agg(ecommerce_order.order_id)), ', ') as varchar) as order_ids
-        , cast(array_join(array_distinct(array_agg(ecommerce_order.order_state)), ', ') as varchar) 
+        , cast(array_join(array_distinct(array_agg(ecommerce_order.order_state)), ', ') as varchar)
             as combined_order_state
         , case when (count(couponredemption.couponredemption_id) >= 1) then 'true' else 'false' end as coupon_redeemed
-        
+
     from coupon
     left join latest_couponversion
         on coupon.coupon_id = latest_couponversion.coupon_id
-    left join ecommerce_couponversion 
-        on 
-            latest_couponversion.coupon_id = ecommerce_couponversion.coupon_id 
+    left join ecommerce_couponversion
+        on
+            latest_couponversion.coupon_id = ecommerce_couponversion.coupon_id
             and ecommerce_couponversion.couponversion_updated_on = latest_couponversion.max_couponversion_updated_on
     left join couponredemption
         on ecommerce_couponversion.couponversion_id = couponredemption.couponversion_id
-    left join ecommerce_couponpaymentversion 
+    left join ecommerce_couponpaymentversion
         on ecommerce_couponpaymentversion.couponpaymentversion_id = ecommerce_couponversion.couponpaymentversion_id
     left join ecommerce_order
         on ecommerce_order.order_id = couponredemption.order_id
-    left join ecommerce_line 
+    left join ecommerce_line
         on ecommerce_line.order_id = ecommerce_order.order_id
     left join program_runs
         on ecommerce_line.programrun_id = program_runs.programrun_id
@@ -128,22 +128,22 @@ with coupon as (
         on course_runs.course_id = courses.course_id
     left join productversion
         on productversion.productversion_id = ecommerce_line.productversion_id
-    left join users_user    
+    left join users_user
         on ecommerce_order.order_purchaser_user_id = users_user.user_id
     where ecommerce_order.order_state = 'fulfilled' or ecommerce_order.order_state = 'refunded'
-    group by 
+    group by
         coupon.coupon_id
 )
 
 , reg_coupon_fields as (
-    select 
+    select
         productcouponassignment.productcouponassignment_email as coupon_email
         , coupon.coupon_code
         , coupon.coupon_id
         , coupon.coupon_created_on
         , coupon.couponpayment_name
         , productcouponassignment.product_id
-        , payment_transactions.couponpaymentversion_payment_transaction 
+        , payment_transactions.couponpaymentversion_payment_transaction
         , productcouponassignment.productcouponassignment_is_redeemed
     from coupon
     left join productcouponassignment
@@ -153,13 +153,13 @@ with coupon as (
 )
 
 , unassigned_enrollment_codes as (
-    select 
+    select
         coupon.coupon_code
         , coupon.coupon_id
         , coupon.coupon_created_on as coupon_created_on
         , coupon.couponpayment_name
         , b2b_ecommerce_b2border.b2border_contract_number
-        , payment_transactions.couponpaymentversion_payment_transaction  
+        , payment_transactions.couponpaymentversion_payment_transaction
         , program_runs.programrun_readable_id
         , program_runs.program_title
         , course_runs.courserun_readable_id
@@ -177,22 +177,22 @@ with coupon as (
     inner join latest_couponversion
         on coupon.coupon_id = latest_couponversion.coupon_id
     inner join ecommerce_couponversion
-        on 
-            latest_couponversion.coupon_id = ecommerce_couponversion.coupon_id 
+        on
+            latest_couponversion.coupon_id = ecommerce_couponversion.coupon_id
             and ecommerce_couponversion.couponversion_updated_on = latest_couponversion.max_couponversion_updated_on
     inner join ecommerce_couponpaymentversion
-        on ecommerce_couponpaymentversion.couponpaymentversion_id = ecommerce_couponversion.couponpaymentversion_id 
-    left join b2b_ecommerce_b2border 
+        on ecommerce_couponpaymentversion.couponpaymentversion_id = ecommerce_couponversion.couponpaymentversion_id
+    left join b2b_ecommerce_b2border
         on ecommerce_couponpaymentversion.couponpaymentversion_id = b2b_ecommerce_b2border.couponpaymentversion_id
-    left join payment_transactions 
-        on payment_transactions.coupon_id = coupon.coupon_id   
+    left join payment_transactions
+        on payment_transactions.coupon_id = coupon.coupon_id
     left join couponredemption
         on couponredemption.couponversion_id = ecommerce_couponversion.couponversion_id
-    left join ecommerce_order 
+    left join ecommerce_order
         on couponredemption.order_id = ecommerce_order.order_id
-    left join users_user 
-        on users_user.user_id = ecommerce_order.order_purchaser_user_id 
-    left join ecommerce_line 
+    left join users_user
+        on users_user.user_id = ecommerce_order.order_purchaser_user_id
+    left join ecommerce_line
         on ecommerce_line.order_id = ecommerce_order.order_id
     left join program_runs
         on ecommerce_line.programrun_id = program_runs.programrun_id
@@ -202,19 +202,19 @@ with coupon as (
         on course_runs.course_id = courses.course_id
     left join productversion
         on productversion.productversion_id = ecommerce_line.productversion_id
-    where 
-        ecommerce_couponpaymentversion.couponpaymentversion_coupon_type = 'single-use' 
-        and ecommerce_couponpaymentversion.couponpaymentversion_discount_amount = 1.0000 
+    where
+        ecommerce_couponpaymentversion.couponpaymentversion_coupon_type = 'single-use'
+        and ecommerce_couponpaymentversion.couponpaymentversion_discount_amount = 1.0000
         and coupon.coupon_id not in (
             select coupon_id
-            from productcouponassignment 
+            from productcouponassignment
         )
         and not exists (
             select b2b_ecommerce_b2border.couponpaymentversion_id
             from b2b_ecommerce_b2border
-            where 
+            where
                 b2b_ecommerce_b2border.couponpaymentversion_id = ecommerce_couponpaymentversion.couponpaymentversion_id
-        ) 
+        )
 )
 
 , b2b_coupon_fields as (
@@ -226,7 +226,7 @@ with coupon as (
         , coupon.couponpayment_name
         , b2b_ecommerce_b2border.b2border_contract_number
         , b2b_ecommerce_b2border.product_id
-        , ecommerce_couponpaymentversion.couponpaymentversion_payment_transaction 
+        , ecommerce_couponpaymentversion.couponpaymentversion_payment_transaction
         , program_runs.programrun_readable_id
         , program_runs.program_title
         , course_runs.courserun_readable_id
@@ -243,25 +243,25 @@ with coupon as (
                 as varchar
             ), '"', ''
         ) as req_reference_number
-        , case 
+        , case
             when couponredemption.couponredemption_id is not null
-                then 'true' 
-            else 'false' 
+                then 'true'
+            else 'false'
         end as coupon_redeemed
-    from b2b_ecommerce_b2border 
-    inner join ecommerce_couponpaymentversion 
+    from b2b_ecommerce_b2border
+    inner join ecommerce_couponpaymentversion
         on ecommerce_couponpaymentversion.couponpaymentversion_id = b2b_ecommerce_b2border.couponpaymentversion_id
-    inner join ecommerce_couponversion 
+    inner join ecommerce_couponversion
         on ecommerce_couponversion.couponpaymentversion_id = ecommerce_couponpaymentversion.couponpaymentversion_id
-    inner join coupon 
+    inner join coupon
         on coupon.coupon_id = ecommerce_couponversion.coupon_id
-    left join couponredemption 
+    left join couponredemption
         on couponredemption.couponversion_id = ecommerce_couponversion.couponversion_id
-    left join ecommerce_order 
+    left join ecommerce_order
         on ecommerce_order.order_id = couponredemption.order_id
-    left join b2b_ecommerce_b2breceipt 
+    left join b2b_ecommerce_b2breceipt
         on b2b_ecommerce_b2breceipt.b2border_id = b2b_ecommerce_b2border.b2border_id
-    left join ecommerce_line 
+    left join ecommerce_line
         on ecommerce_line.order_id = ecommerce_order.order_id
     left join program_runs
         on ecommerce_line.programrun_id = program_runs.programrun_id
@@ -271,12 +271,12 @@ with coupon as (
         on course_runs.course_id = courses.course_id
     left join productversion
         on productversion.productversion_id = b2b_ecommerce_b2border.productversion_id
-    left join users_user    
+    left join users_user
         on ecommerce_order.order_purchaser_user_id = users_user.user_id
 )
 
 
-select 
+select
     reg_coupon_fields.coupon_email
     , reg_coupon_fields.coupon_code
     , reg_coupon_fields.coupon_id
@@ -303,7 +303,7 @@ where reg_coupon_fields.coupon_id not in (select coupon_id from b2b_coupon_field
 
 union distinct
 
-select 
+select
     b2b_coupon_fields.b2border_email as coupon_email
     , b2b_coupon_fields.coupon_code
     , b2b_coupon_fields.coupon_id
@@ -327,7 +327,7 @@ from b2b_coupon_fields
 
 union distinct
 
-select 
+select
     coupon_email
     , coupon_code
     , coupon_id
@@ -335,7 +335,7 @@ select
     , couponpayment_name
     , b2border_contract_number
     , product_id
-    , couponpaymentversion_payment_transaction  
+    , couponpaymentversion_payment_transaction
     , req_reference_number
     , programrun_readable_id
     , program_title

--- a/src/ol_dbt/models/intermediate/mitxpro/int__mitxpro__ecommerce_combinedcoupons.sql
+++ b/src/ol_dbt/models/intermediate/mitxpro/int__mitxpro__ecommerce_combinedcoupons.sql
@@ -71,17 +71,17 @@ with coupon as (
 )
 
 , payment_transactions as (
-    select distinct
+    select distinct 
         ecommerce_couponversion.coupon_id
         , ecommerce_couponpaymentversion.couponpaymentversion_payment_transaction
     from ecommerce_couponpaymentversion
-    inner join ecommerce_couponversion
+    inner join ecommerce_couponversion 
         on ecommerce_couponpaymentversion.couponpaymentversion_id = ecommerce_couponversion.couponpaymentversion_id
     where ecommerce_couponpaymentversion.couponpaymentversion_payment_transaction is not null
 )
 
 , latest_couponversion as (
-    select
+    select 
         coupon_id
         , max(couponversion_updated_on) as max_couponversion_updated_on
     from ecommerce_couponversion
@@ -89,38 +89,38 @@ with coupon as (
 )
 
 , reg_coupon_summary as (
-    select
+    select 
         coupon.coupon_id
-        , cast(array_join(array_distinct(array_agg(program_runs.programrun_readable_id)), ', ') as varchar)
+        , cast(array_join(array_distinct(array_agg(program_runs.programrun_readable_id)), ', ') as varchar) 
             as programrun_readable_id
         , cast(array_join(array_distinct(array_agg(program_runs.program_title)), ', ') as varchar) as program_title
-        , cast(array_join(array_distinct(array_agg(course_runs.courserun_readable_id)), ', ') as varchar)
+        , cast(array_join(array_distinct(array_agg(course_runs.courserun_readable_id)), ', ') as varchar) 
             as courserun_readable_id
         , cast(array_join(array_distinct(array_agg(courses.course_title)), ', ') as varchar) as course_title
-        , cast(array_join(array_distinct(array_agg(productversion.productversion_readable_id)), ', ') as varchar)
+        , cast(array_join(array_distinct(array_agg(productversion.productversion_readable_id)), ', ') as varchar) 
             as productversion_readable_id
         , cast(array_join(array_distinct(array_agg(users_user.user_email)), ', ') as varchar) as combined_user_emails
-        , cast(array_join(array_distinct(array_agg(users_user.user_address_country)), ', ') as varchar)
+        , cast(array_join(array_distinct(array_agg(users_user.user_address_country)), ', ') as varchar) 
             as user_address_countries
         , cast(array_join(array_distinct(array_agg(ecommerce_order.order_id)), ', ') as varchar) as order_ids
-        , cast(array_join(array_distinct(array_agg(ecommerce_order.order_state)), ', ') as varchar)
+        , cast(array_join(array_distinct(array_agg(ecommerce_order.order_state)), ', ') as varchar) 
             as combined_order_state
         , case when (count(couponredemption.couponredemption_id) >= 1) then 'true' else 'false' end as coupon_redeemed
-
+        
     from coupon
     left join latest_couponversion
         on coupon.coupon_id = latest_couponversion.coupon_id
-    left join ecommerce_couponversion
-        on
-            latest_couponversion.coupon_id = ecommerce_couponversion.coupon_id
+    left join ecommerce_couponversion 
+        on 
+            latest_couponversion.coupon_id = ecommerce_couponversion.coupon_id 
             and ecommerce_couponversion.couponversion_updated_on = latest_couponversion.max_couponversion_updated_on
     left join couponredemption
         on ecommerce_couponversion.couponversion_id = couponredemption.couponversion_id
-    left join ecommerce_couponpaymentversion
+    left join ecommerce_couponpaymentversion 
         on ecommerce_couponpaymentversion.couponpaymentversion_id = ecommerce_couponversion.couponpaymentversion_id
     left join ecommerce_order
         on ecommerce_order.order_id = couponredemption.order_id
-    left join ecommerce_line
+    left join ecommerce_line 
         on ecommerce_line.order_id = ecommerce_order.order_id
     left join program_runs
         on ecommerce_line.programrun_id = program_runs.programrun_id
@@ -130,22 +130,22 @@ with coupon as (
         on course_runs.course_id = courses.course_id
     left join productversion
         on productversion.productversion_id = ecommerce_line.productversion_id
-    left join users_user
+    left join users_user    
         on ecommerce_order.order_purchaser_user_id = users_user.user_id
     where ecommerce_order.order_state = 'fulfilled' or ecommerce_order.order_state = 'refunded'
-    group by
+    group by 
         coupon.coupon_id
 )
 
 , reg_coupon_fields as (
-    select
+    select 
         productcouponassignment.productcouponassignment_email as coupon_email
         , coupon.coupon_code
         , coupon.coupon_id
         , coupon.coupon_created_on
         , coupon.couponpayment_name
         , productcouponassignment.product_id
-        , payment_transactions.couponpaymentversion_payment_transaction
+        , payment_transactions.couponpaymentversion_payment_transaction 
         , productcouponassignment.productcouponassignment_is_redeemed
     from coupon
     left join productcouponassignment
@@ -155,13 +155,13 @@ with coupon as (
 )
 
 , unassigned_enrollment_codes as (
-    select
+    select 
         coupon.coupon_code
         , coupon.coupon_id
         , coupon.coupon_created_on as coupon_created_on
         , coupon.couponpayment_name
         , b2b_ecommerce_b2border.b2border_contract_number
-        , payment_transactions.couponpaymentversion_payment_transaction
+        , payment_transactions.couponpaymentversion_payment_transaction  
         , program_runs.programrun_readable_id
         , program_runs.program_title
         , course_runs.courserun_readable_id
@@ -179,22 +179,22 @@ with coupon as (
     inner join latest_couponversion
         on coupon.coupon_id = latest_couponversion.coupon_id
     inner join ecommerce_couponversion
-        on
-            latest_couponversion.coupon_id = ecommerce_couponversion.coupon_id
+        on 
+            latest_couponversion.coupon_id = ecommerce_couponversion.coupon_id 
             and ecommerce_couponversion.couponversion_updated_on = latest_couponversion.max_couponversion_updated_on
     inner join ecommerce_couponpaymentversion
-        on ecommerce_couponpaymentversion.couponpaymentversion_id = ecommerce_couponversion.couponpaymentversion_id
-    left join b2b_ecommerce_b2border
+        on ecommerce_couponpaymentversion.couponpaymentversion_id = ecommerce_couponversion.couponpaymentversion_id 
+    left join b2b_ecommerce_b2border 
         on ecommerce_couponpaymentversion.couponpaymentversion_id = b2b_ecommerce_b2border.couponpaymentversion_id
-    left join payment_transactions
-        on payment_transactions.coupon_id = coupon.coupon_id
+    left join payment_transactions 
+        on payment_transactions.coupon_id = coupon.coupon_id   
     left join couponredemption
         on couponredemption.couponversion_id = ecommerce_couponversion.couponversion_id
-    left join ecommerce_order
+    left join ecommerce_order 
         on couponredemption.order_id = ecommerce_order.order_id
-    left join users_user
-        on users_user.user_id = ecommerce_order.order_purchaser_user_id
-    left join ecommerce_line
+    left join users_user 
+        on users_user.user_id = ecommerce_order.order_purchaser_user_id 
+    left join ecommerce_line 
         on ecommerce_line.order_id = ecommerce_order.order_id
     left join program_runs
         on ecommerce_line.programrun_id = program_runs.programrun_id
@@ -204,19 +204,19 @@ with coupon as (
         on course_runs.course_id = courses.course_id
     left join productversion
         on productversion.productversion_id = ecommerce_line.productversion_id
-    where
-        ecommerce_couponpaymentversion.couponpaymentversion_coupon_type = 'single-use'
-        and ecommerce_couponpaymentversion.couponpaymentversion_discount_amount = 1.0000
+    where 
+        ecommerce_couponpaymentversion.couponpaymentversion_coupon_type = 'single-use' 
+        and ecommerce_couponpaymentversion.couponpaymentversion_discount_amount = 1.0000 
         and coupon.coupon_id not in (
             select coupon_id
-            from productcouponassignment
+            from productcouponassignment 
         )
         and not exists (
             select b2b_ecommerce_b2border.couponpaymentversion_id
             from b2b_ecommerce_b2border
-            where
+            where 
                 b2b_ecommerce_b2border.couponpaymentversion_id = ecommerce_couponpaymentversion.couponpaymentversion_id
-        )
+        ) 
 )
 
 , b2b_coupon_fields as (
@@ -228,7 +228,7 @@ with coupon as (
         , coupon.couponpayment_name
         , b2b_ecommerce_b2border.b2border_contract_number
         , b2b_ecommerce_b2border.product_id
-        , ecommerce_couponpaymentversion.couponpaymentversion_payment_transaction
+        , ecommerce_couponpaymentversion.couponpaymentversion_payment_transaction 
         , program_runs.programrun_readable_id
         , program_runs.program_title
         , course_runs.courserun_readable_id
@@ -238,32 +238,26 @@ with coupon as (
         , users_user.user_address_country as user_address_countries
         , cast(ecommerce_order.order_id as varchar) as order_ids
         , ecommerce_order.order_state as combined_order_state
-        , replace(
-            cast(
-                json_extract(b2b_ecommerce_b2breceipt.b2breceipt_data, '$.req_reference_number'
-                )
-                as varchar
-            ), '"', ''
-        ) as req_reference_number
-        , case
+        , req_reference_number
+        , case 
             when couponredemption.couponredemption_id is not null
-                then 'true'
-            else 'false'
+                then 'true' 
+            else 'false' 
         end as coupon_redeemed
-    from b2b_ecommerce_b2border
-    inner join ecommerce_couponpaymentversion
+    from b2b_ecommerce_b2border 
+    inner join ecommerce_couponpaymentversion 
         on ecommerce_couponpaymentversion.couponpaymentversion_id = b2b_ecommerce_b2border.couponpaymentversion_id
-    inner join ecommerce_couponversion
+    inner join ecommerce_couponversion 
         on ecommerce_couponversion.couponpaymentversion_id = ecommerce_couponpaymentversion.couponpaymentversion_id
-    inner join coupon
+    inner join coupon 
         on coupon.coupon_id = ecommerce_couponversion.coupon_id
-    left join couponredemption
+    left join couponredemption 
         on couponredemption.couponversion_id = ecommerce_couponversion.couponversion_id
-    left join ecommerce_order
+    left join ecommerce_order 
         on ecommerce_order.order_id = couponredemption.order_id
-    left join b2b_ecommerce_b2breceipt
+    left join b2b_ecommerce_b2breceipt 
         on b2b_ecommerce_b2breceipt.b2border_id = b2b_ecommerce_b2border.b2border_id
-    left join ecommerce_line
+    left join ecommerce_line 
         on ecommerce_line.order_id = ecommerce_order.order_id
     left join program_runs
         on ecommerce_line.programrun_id = program_runs.programrun_id
@@ -273,12 +267,12 @@ with coupon as (
         on course_runs.course_id = courses.course_id
     left join productversion
         on productversion.productversion_id = b2b_ecommerce_b2border.productversion_id
-    left join users_user
+    left join users_user    
         on ecommerce_order.order_purchaser_user_id = users_user.user_id
 )
 
 
-select
+select 
     reg_coupon_fields.coupon_email
     , reg_coupon_fields.coupon_code
     , reg_coupon_fields.coupon_id
@@ -305,7 +299,7 @@ where reg_coupon_fields.coupon_id not in (select coupon_id from b2b_coupon_field
 
 union distinct
 
-select
+select 
     b2b_coupon_fields.b2border_email as coupon_email
     , b2b_coupon_fields.coupon_code
     , b2b_coupon_fields.coupon_id
@@ -329,7 +323,7 @@ from b2b_coupon_fields
 
 union distinct
 
-select
+select 
     coupon_email
     , coupon_code
     , coupon_id
@@ -337,7 +331,7 @@ select
     , couponpayment_name
     , b2border_contract_number
     , product_id
-    , couponpaymentversion_payment_transaction
+    , couponpaymentversion_payment_transaction  
     , req_reference_number
     , programrun_readable_id
     , program_title
@@ -350,6 +344,5 @@ select
     , cast(order_ids as varchar) as order_ids
     , combined_order_state
 from unassigned_enrollment_codes
-where
-    coupon_id not in (select coupon_id from reg_coupon_fields)
-    and coupon_id not in (select coupon_id from b2b_coupon_fields)
+where coupon_id not in (select coupon_id from reg_coupon_fields)
+and coupon_id not in (select coupon_id from b2b_coupon_fields)

--- a/src/ol_dbt/models/intermediate/mitxpro/int__mitxpro__ecommerce_combinedcoupons.sql
+++ b/src/ol_dbt/models/intermediate/mitxpro/int__mitxpro__ecommerce_combinedcoupons.sql
@@ -69,17 +69,17 @@ with coupon as (
 )
 
 , payment_transactions as (
-    select distinct
+    select distinct 
         ecommerce_couponversion.coupon_id
         , ecommerce_couponpaymentversion.couponpaymentversion_payment_transaction
     from ecommerce_couponpaymentversion
-    inner join ecommerce_couponversion
+    inner join ecommerce_couponversion 
         on ecommerce_couponpaymentversion.couponpaymentversion_id = ecommerce_couponversion.couponpaymentversion_id
     where ecommerce_couponpaymentversion.couponpaymentversion_payment_transaction is not null
 )
 
 , reg_coupon_summary as (
-    select
+    select 
         coupon.coupon_id
         , ecommerce_couponversion.couponversion_updated_on
         , program_runs.programrun_readable_id
@@ -95,15 +95,15 @@ with coupon as (
         , array_join(array_distinct(array_agg(ecommerce_order.order_id)), ', ') as order_ids
         , array_join(array_distinct(array_agg(ecommerce_order.order_state)), ', ') as combined_order_state
     from coupon
-    left join ecommerce_couponversion
+    left join ecommerce_couponversion 
         on coupon.coupon_id = ecommerce_couponversion.coupon_id
     left join couponredemption
         on ecommerce_couponversion.couponversion_id = couponredemption.couponversion_id
-    left join ecommerce_couponpaymentversion
+    left join ecommerce_couponpaymentversion 
         on ecommerce_couponpaymentversion.couponpaymentversion_id = ecommerce_couponversion.couponpaymentversion_id
     left join ecommerce_order
         on ecommerce_order.order_id = couponredemption.order_id
-    left join ecommerce_line
+    left join ecommerce_line 
         on ecommerce_line.order_id = ecommerce_order.order_id
     left join program_runs
         on ecommerce_line.programrun_id = program_runs.programrun_id
@@ -113,9 +113,9 @@ with coupon as (
         on course_runs.course_id = courses.course_id
     left join productversion
         on productversion.productversion_id = ecommerce_line.productversion_id
-    left join users_user
+    left join users_user    
         on ecommerce_order.order_purchaser_user_id = users_user.user_id
-    group by
+    group by 
         coupon.coupon_id
         , ecommerce_couponversion.couponversion_updated_on
         , program_runs.programrun_readable_id
@@ -128,14 +128,14 @@ with coupon as (
 )
 
 , reg_coupon_fields as (
-    select
+    select 
         productcouponassignment.productcouponassignment_email as coupon_email
         , coupon.coupon_code
         , coupon.coupon_id
         , coupon.coupon_created_on
         , coupon.couponpayment_name
         , productcouponassignment.product_id
-        , payment_transactions.couponpaymentversion_payment_transaction
+        , payment_transactions.couponpaymentversion_payment_transaction 
         , productcouponassignment.productcouponassignment_is_redeemed
     from coupon
     left join productcouponassignment
@@ -154,7 +154,7 @@ with coupon as (
         , coupon.couponpayment_name
         , b2b_ecommerce_b2border.b2border_contract_number
         , b2b_ecommerce_b2border.product_id
-        , ecommerce_couponpaymentversion.couponpaymentversion_payment_transaction
+        , ecommerce_couponpaymentversion.couponpaymentversion_payment_transaction 
         , program_runs.programrun_readable_id
         , program_runs.program_title
         , course_runs.courserun_readable_id
@@ -173,25 +173,25 @@ with coupon as (
                 as varchar
             ), '"', ''
         ) as req_reference_number
-        , case
+        , case 
             when couponredemption.couponredemption_id is not null
-                then 'true'
-            else 'false'
+                then 'true' 
+            else 'false' 
         end as coupon_redeemed
-    from b2b_ecommerce_b2border
-    inner join ecommerce_couponpaymentversion
+    from b2b_ecommerce_b2border 
+    inner join ecommerce_couponpaymentversion 
         on ecommerce_couponpaymentversion.couponpaymentversion_id = b2b_ecommerce_b2border.couponpaymentversion_id
-    inner join ecommerce_couponversion
+    inner join ecommerce_couponversion 
         on ecommerce_couponversion.couponpaymentversion_id = ecommerce_couponpaymentversion.couponpaymentversion_id
-    inner join coupon
+    inner join coupon 
         on coupon.coupon_id = ecommerce_couponversion.coupon_id
-    left join couponredemption
+    left join couponredemption 
         on couponredemption.couponversion_id = ecommerce_couponversion.couponversion_id
-    left join ecommerce_order
+    left join ecommerce_order 
         on ecommerce_order.order_id = couponredemption.order_id
-    left join b2b_ecommerce_b2breceipt
+    left join b2b_ecommerce_b2breceipt 
         on b2b_ecommerce_b2breceipt.b2border_id = b2b_ecommerce_b2border.b2border_id
-    left join ecommerce_line
+    left join ecommerce_line 
         on ecommerce_line.order_id = ecommerce_order.order_id
     left join program_runs
         on ecommerce_line.programrun_id = program_runs.programrun_id
@@ -201,16 +201,16 @@ with coupon as (
         on course_runs.course_id = courses.course_id
     left join productversion
         on productversion.productversion_id = b2b_ecommerce_b2border.productversion_id
-    left join users_user
+    left join users_user    
         on ecommerce_order.order_purchaser_user_id = users_user.user_id
 )
 
 
-select
+select 
     reg_coupon_fields.coupon_email
     , reg_coupon_fields.coupon_code
     , reg_coupon_fields.coupon_id
-    , reg_coupon_fields.couponversion_updated_on
+    , reg_coupon_summary.couponversion_updated_on
     , reg_coupon_fields.coupon_created_on
     , reg_coupon_fields.couponpayment_name
     , null as b2border_contract_number
@@ -237,7 +237,7 @@ where reg_coupon_fields.coupon_id not in (select coupon_id from b2b_coupon_field
 
 union distinct
 
-select
+select 
     b2b_coupon_fields.b2border_email as coupon_email
     , b2b_coupon_fields.coupon_code
     , b2b_coupon_fields.coupon_id

--- a/src/ol_dbt/models/intermediate/mitxpro/int__mitxpro__ecommerce_combinedcoupons.sql
+++ b/src/ol_dbt/models/intermediate/mitxpro/int__mitxpro__ecommerce_combinedcoupons.sql
@@ -69,17 +69,17 @@ with coupon as (
 )
 
 , payment_transactions as (
-    select distinct 
+    select distinct
         ecommerce_couponversion.coupon_id
         , ecommerce_couponpaymentversion.couponpaymentversion_payment_transaction
     from ecommerce_couponpaymentversion
-    inner join ecommerce_couponversion 
+    inner join ecommerce_couponversion
         on ecommerce_couponpaymentversion.couponpaymentversion_id = ecommerce_couponversion.couponpaymentversion_id
     where ecommerce_couponpaymentversion.couponpaymentversion_payment_transaction is not null
 )
 
 , reg_coupon_summary as (
-    select 
+    select
         coupon.coupon_id
         , case when (count(couponredemption.couponredemption_id) >= 1) then 'true' else 'false' end as coupon_redeemed
         , array_join(array_distinct(array_agg(users_user.user_email)), ', ') as combined_user_emails
@@ -87,27 +87,27 @@ with coupon as (
         , array_join(array_distinct(array_agg(ecommerce_order.order_id)), ', ') as order_ids
         , array_join(array_distinct(array_agg(ecommerce_order.order_state)), ', ') as combined_order_state
     from coupon
-    left join ecommerce_couponversion 
+    left join ecommerce_couponversion
         on coupon.coupon_id = ecommerce_couponversion.coupon_id
     left join couponredemption
         on ecommerce_couponversion.couponversion_id = couponredemption.couponversion_id
     left join ecommerce_order
         on ecommerce_order.order_id = couponredemption.order_id
-    left join users_user    
+    left join users_user
         on ecommerce_order.order_purchaser_user_id = users_user.user_id
-    group by 
+    group by
         coupon.coupon_id
 )
 
 , reg_coupon_fields as (
-    select 
+    select
         productcouponassignment.productcouponassignment_email as coupon_email
         , coupon.coupon_code
         , coupon.coupon_id
         , coupon.coupon_created_on
         , coupon.couponpayment_name
         , productcouponassignment.product_id
-        , payment_transactions.couponpaymentversion_payment_transaction 
+        , payment_transactions.couponpaymentversion_payment_transaction
         , program_runs.programrun_readable_id
         , program_runs.program_title
         , course_runs.courserun_readable_id
@@ -118,9 +118,9 @@ with coupon as (
     from coupon
     left join productcouponassignment
         on productcouponassignment.coupon_id = coupon.coupon_id
-    left join ecommerce_couponversion 
+    left join ecommerce_couponversion
         on coupon.coupon_id = ecommerce_couponversion.coupon_id
-    left join ecommerce_couponpaymentversion 
+    left join ecommerce_couponpaymentversion
         on ecommerce_couponpaymentversion.couponpaymentversion_id = ecommerce_couponversion.couponpaymentversion_id
     left join couponredemption
         on ecommerce_couponversion.couponversion_id = couponredemption.couponversion_id
@@ -128,7 +128,7 @@ with coupon as (
         on ecommerce_order.order_id = couponredemption.order_id
     left join payment_transactions
         on coupon.coupon_id = payment_transactions.coupon_id
-    left join ecommerce_line 
+    left join ecommerce_line
         on ecommerce_line.order_id = ecommerce_order.order_id
     left join program_runs
         on ecommerce_line.programrun_id = program_runs.programrun_id
@@ -138,14 +138,14 @@ with coupon as (
         on course_runs.course_id = courses.course_id
     left join productversion
         on productversion.productversion_id = ecommerce_line.productversion_id
-    group by 
-        productcouponassignment.productcouponassignment_email 
+    group by
+        productcouponassignment.productcouponassignment_email
         , coupon.coupon_code
         , coupon.coupon_id
         , coupon.coupon_created_on
         , coupon.couponpayment_name
         , productcouponassignment.product_id
-        , payment_transactions.couponpaymentversion_payment_transaction 
+        , payment_transactions.couponpaymentversion_payment_transaction
         , program_runs.programrun_readable_id
         , program_runs.program_title
         , course_runs.courserun_readable_id
@@ -156,32 +156,32 @@ with coupon as (
 )
 
 , b2b_coupon_summary as (
-    select 
+    select
         coupon.coupon_id
-        , case 
-            when (count(couponredemption.couponredemption_id) >= 1) 
-                then 'true' 
-            else 'false' 
+        , case
+            when (count(couponredemption.couponredemption_id) >= 1)
+                then 'true'
+            else 'false'
         end as coupon_redeemed
         , array_join(array_distinct(array_agg(users_user.user_email)), ', ') as combined_user_emails
         , array_join(array_distinct(array_agg(users_user.user_address_country)), ', ') as user_address_countries
         , array_join(array_distinct(array_agg(ecommerce_order.order_id)), ', ') as order_ids
         , array_join(array_distinct(array_agg(ecommerce_order.order_state)), ', ') as combined_order_state
-    from b2b_ecommerce_b2border 
-    inner join ecommerce_couponpaymentversion 
+    from b2b_ecommerce_b2border
+    inner join ecommerce_couponpaymentversion
         on ecommerce_couponpaymentversion.couponpaymentversion_id = b2b_ecommerce_b2border.couponpaymentversion_id
-    inner join ecommerce_couponversion 
+    inner join ecommerce_couponversion
         on ecommerce_couponversion.couponpaymentversion_id = ecommerce_couponpaymentversion.couponpaymentversion_id
-    inner join coupon 
-        on coupon.coupon_id = ecommerce_couponversion.coupon_id 
-    left join couponredemption 
+    inner join coupon
+        on coupon.coupon_id = ecommerce_couponversion.coupon_id
+    left join couponredemption
         on couponredemption.couponversion_id = ecommerce_couponversion.couponversion_id
-    left join ecommerce_order 
+    left join ecommerce_order
         on ecommerce_order.order_id = couponredemption.order_id
-    left join users_user    
+    left join users_user
         on ecommerce_order.order_purchaser_user_id = users_user.user_id
-    group by 
-        coupon.coupon_id   
+    group by
+        coupon.coupon_id
 )
 
 , b2b_coupon_fields as (
@@ -193,7 +193,7 @@ with coupon as (
         , coupon.couponpayment_name
         , b2b_ecommerce_b2border.b2border_contract_number
         , b2b_ecommerce_b2border.product_id
-        , ecommerce_couponpaymentversion.couponpaymentversion_payment_transaction 
+        , ecommerce_couponpaymentversion.couponpaymentversion_payment_transaction
         , program_runs.programrun_readable_id
         , program_runs.program_title
         , course_runs.courserun_readable_id
@@ -208,20 +208,20 @@ with coupon as (
                 as varchar
             ), '"', ''
         ) as req_reference_number
-    from b2b_ecommerce_b2border 
-    inner join ecommerce_couponpaymentversion 
+    from b2b_ecommerce_b2border
+    inner join ecommerce_couponpaymentversion
         on ecommerce_couponpaymentversion.couponpaymentversion_id = b2b_ecommerce_b2border.couponpaymentversion_id
-    inner join ecommerce_couponversion 
+    inner join ecommerce_couponversion
         on ecommerce_couponversion.couponpaymentversion_id = ecommerce_couponpaymentversion.couponpaymentversion_id
-    inner join coupon 
+    inner join coupon
         on coupon.coupon_id = ecommerce_couponversion.coupon_id
-    left join couponredemption 
+    left join couponredemption
         on couponredemption.couponversion_id = ecommerce_couponversion.couponversion_id
-    left join ecommerce_order 
+    left join ecommerce_order
         on ecommerce_order.order_id = couponredemption.order_id
-    left join b2b_ecommerce_b2breceipt 
+    left join b2b_ecommerce_b2breceipt
         on b2b_ecommerce_b2breceipt.b2border_id = b2b_ecommerce_b2border.b2border_id
-    left join ecommerce_line 
+    left join ecommerce_line
         on ecommerce_line.order_id = ecommerce_order.order_id
     left join program_runs
         on ecommerce_line.programrun_id = program_runs.programrun_id
@@ -231,15 +231,15 @@ with coupon as (
         on course_runs.course_id = courses.course_id
     left join productversion
         on productversion.productversion_id = b2b_ecommerce_b2border.productversion_id
-    group by 
-        b2b_ecommerce_b2border.b2border_email 
+    group by
+        b2b_ecommerce_b2border.b2border_email
         , coupon.coupon_code
         , coupon.coupon_id
         , coupon.coupon_created_on
         , coupon.couponpayment_name
         , b2b_ecommerce_b2border.b2border_contract_number
         , b2b_ecommerce_b2border.product_id
-        , ecommerce_couponpaymentversion.couponpaymentversion_payment_transaction 
+        , ecommerce_couponpaymentversion.couponpaymentversion_payment_transaction
         , program_runs.programrun_readable_id
         , program_runs.program_title
         , course_runs.courserun_readable_id
@@ -252,11 +252,11 @@ with coupon as (
                 json_extract(b2b_ecommerce_b2breceipt.b2breceipt_data, '$.req_reference_number')
                 as varchar
             ), '"', ''
-        ) 
+        )
 )
 
 
-select 
+select
     reg_coupon_fields.coupon_email
     , reg_coupon_fields.coupon_code
     , reg_coupon_fields.coupon_id
@@ -286,7 +286,7 @@ where reg_coupon_fields.coupon_id not in (select coupon_id from b2b_coupon_summa
 
 union distinct
 
-select 
+select
     b2b_coupon_fields.b2border_email as coupon_email
     , b2b_coupon_fields.coupon_code
     , b2b_coupon_fields.coupon_id

--- a/src/ol_dbt/models/intermediate/mitxpro/int__mitxpro__ecommerce_combinedcoupons.sql
+++ b/src/ol_dbt/models/intermediate/mitxpro/int__mitxpro__ecommerce_combinedcoupons.sql
@@ -69,17 +69,17 @@ with coupon as (
 )
 
 , payment_transactions as (
-    select distinct
+    select distinct 
         ecommerce_couponversion.coupon_id
         , ecommerce_couponpaymentversion.couponpaymentversion_payment_transaction
     from ecommerce_couponpaymentversion
-    inner join ecommerce_couponversion
+    inner join ecommerce_couponversion 
         on ecommerce_couponpaymentversion.couponpaymentversion_id = ecommerce_couponversion.couponpaymentversion_id
     where ecommerce_couponpaymentversion.couponpaymentversion_payment_transaction is not null
 )
 
 , latest_couponversion as (
-    select
+    select 
         coupon_id
         , max(couponversion_updated_on) as max_couponversion_updated_on
     from ecommerce_couponversion
@@ -87,38 +87,38 @@ with coupon as (
 )
 
 , reg_coupon_summary as (
-    select
+    select 
         coupon.coupon_id
-        , cast(array_join(array_distinct(array_agg(program_runs.programrun_readable_id)), ', ') as varchar)
+        , cast(array_join(array_distinct(array_agg(program_runs.programrun_readable_id)), ', ') as varchar) 
             as programrun_readable_id
         , cast(array_join(array_distinct(array_agg(program_runs.program_title)), ', ') as varchar) as program_title
-        , cast(array_join(array_distinct(array_agg(course_runs.courserun_readable_id)), ', ') as varchar)
+        , cast(array_join(array_distinct(array_agg(course_runs.courserun_readable_id)), ', ') as varchar) 
             as courserun_readable_id
         , cast(array_join(array_distinct(array_agg(courses.course_title)), ', ') as varchar) as course_title
-        , cast(array_join(array_distinct(array_agg(productversion.productversion_readable_id)), ', ') as varchar)
+        , cast(array_join(array_distinct(array_agg(productversion.productversion_readable_id)), ', ') as varchar) 
             as productversion_readable_id
         , cast(array_join(array_distinct(array_agg(users_user.user_email)), ', ') as varchar) as combined_user_emails
-        , cast(array_join(array_distinct(array_agg(users_user.user_address_country)), ', ') as varchar)
+        , cast(array_join(array_distinct(array_agg(users_user.user_address_country)), ', ') as varchar) 
             as user_address_countries
         , cast(array_join(array_distinct(array_agg(ecommerce_order.order_id)), ', ') as varchar) as order_ids
-        , cast(array_join(array_distinct(array_agg(ecommerce_order.order_state)), ', ') as varchar)
+        , cast(array_join(array_distinct(array_agg(ecommerce_order.order_state)), ', ') as varchar) 
             as combined_order_state
         , case when (count(couponredemption.couponredemption_id) >= 1) then 'true' else 'false' end as coupon_redeemed
-
+        
     from coupon
     left join latest_couponversion
         on coupon.coupon_id = latest_couponversion.coupon_id
-    left join ecommerce_couponversion
-        on
-            latest_couponversion.coupon_id = ecommerce_couponversion.coupon_id
+    left join ecommerce_couponversion 
+        on 
+            latest_couponversion.coupon_id = ecommerce_couponversion.coupon_id 
             and ecommerce_couponversion.couponversion_updated_on = latest_couponversion.max_couponversion_updated_on
     left join couponredemption
         on ecommerce_couponversion.couponversion_id = couponredemption.couponversion_id
-    left join ecommerce_couponpaymentversion
+    left join ecommerce_couponpaymentversion 
         on ecommerce_couponpaymentversion.couponpaymentversion_id = ecommerce_couponversion.couponpaymentversion_id
     left join ecommerce_order
         on ecommerce_order.order_id = couponredemption.order_id
-    left join ecommerce_line
+    left join ecommerce_line 
         on ecommerce_line.order_id = ecommerce_order.order_id
     left join program_runs
         on ecommerce_line.programrun_id = program_runs.programrun_id
@@ -128,22 +128,22 @@ with coupon as (
         on course_runs.course_id = courses.course_id
     left join productversion
         on productversion.productversion_id = ecommerce_line.productversion_id
-    left join users_user
+    left join users_user    
         on ecommerce_order.order_purchaser_user_id = users_user.user_id
     where ecommerce_order.order_state = 'fulfilled' or ecommerce_order.order_state = 'refunded'
-    group by
+    group by 
         coupon.coupon_id
 )
 
 , reg_coupon_fields as (
-    select
+    select 
         productcouponassignment.productcouponassignment_email as coupon_email
         , coupon.coupon_code
         , coupon.coupon_id
         , coupon.coupon_created_on
         , coupon.couponpayment_name
         , productcouponassignment.product_id
-        , payment_transactions.couponpaymentversion_payment_transaction
+        , payment_transactions.couponpaymentversion_payment_transaction 
         , productcouponassignment.productcouponassignment_is_redeemed
     from coupon
     left join productcouponassignment
@@ -153,13 +153,13 @@ with coupon as (
 )
 
 , unassigned_enrollment_codes as (
-    select
+    select 
         coupon.coupon_code
         , coupon.coupon_id
         , coupon.coupon_created_on as coupon_created_on
         , coupon.couponpayment_name
         , b2b_ecommerce_b2border.b2border_contract_number
-        , payment_transactions.couponpaymentversion_payment_transaction
+        , payment_transactions.couponpaymentversion_payment_transaction  
         , program_runs.programrun_readable_id
         , program_runs.program_title
         , course_runs.courserun_readable_id
@@ -177,22 +177,22 @@ with coupon as (
     inner join latest_couponversion
         on coupon.coupon_id = latest_couponversion.coupon_id
     inner join ecommerce_couponversion
-        on
-            latest_couponversion.coupon_id = ecommerce_couponversion.coupon_id
+        on 
+            latest_couponversion.coupon_id = ecommerce_couponversion.coupon_id 
             and ecommerce_couponversion.couponversion_updated_on = latest_couponversion.max_couponversion_updated_on
     inner join ecommerce_couponpaymentversion
-        on ecommerce_couponpaymentversion.couponpaymentversion_id = ecommerce_couponversion.couponpaymentversion_id
-    left join b2b_ecommerce_b2border
+        on ecommerce_couponpaymentversion.couponpaymentversion_id = ecommerce_couponversion.couponpaymentversion_id 
+    left join b2b_ecommerce_b2border 
         on ecommerce_couponpaymentversion.couponpaymentversion_id = b2b_ecommerce_b2border.couponpaymentversion_id
-    left join payment_transactions
-        on payment_transactions.coupon_id = coupon.coupon_id
+    left join payment_transactions 
+        on payment_transactions.coupon_id = coupon.coupon_id   
     left join couponredemption
         on couponredemption.couponversion_id = ecommerce_couponversion.couponversion_id
-    left join ecommerce_order
+    left join ecommerce_order 
         on couponredemption.order_id = ecommerce_order.order_id
-    left join users_user
-        on users_user.user_id = ecommerce_order.order_purchaser_user_id
-    left join ecommerce_line
+    left join users_user 
+        on users_user.user_id = ecommerce_order.order_purchaser_user_id 
+    left join ecommerce_line 
         on ecommerce_line.order_id = ecommerce_order.order_id
     left join program_runs
         on ecommerce_line.programrun_id = program_runs.programrun_id
@@ -202,19 +202,19 @@ with coupon as (
         on course_runs.course_id = courses.course_id
     left join productversion
         on productversion.productversion_id = ecommerce_line.productversion_id
-    where
-        ecommerce_couponpaymentversion.couponpaymentversion_coupon_type = 'single-use'
-        and ecommerce_couponpaymentversion.couponpaymentversion_discount_amount = 1.0000
+    where 
+        ecommerce_couponpaymentversion.couponpaymentversion_coupon_type = 'single-use' 
+        and ecommerce_couponpaymentversion.couponpaymentversion_discount_amount = 1.0000 
         and coupon.coupon_id not in (
             select coupon_id
-            from productcouponassignment
+            from productcouponassignment 
         )
         and not exists (
             select b2b_ecommerce_b2border.couponpaymentversion_id
             from b2b_ecommerce_b2border
-            where
+            where 
                 b2b_ecommerce_b2border.couponpaymentversion_id = ecommerce_couponpaymentversion.couponpaymentversion_id
-        )
+        ) 
 )
 
 , b2b_coupon_fields as (
@@ -226,7 +226,7 @@ with coupon as (
         , coupon.couponpayment_name
         , b2b_ecommerce_b2border.b2border_contract_number
         , b2b_ecommerce_b2border.product_id
-        , ecommerce_couponpaymentversion.couponpaymentversion_payment_transaction
+        , ecommerce_couponpaymentversion.couponpaymentversion_payment_transaction 
         , program_runs.programrun_readable_id
         , program_runs.program_title
         , course_runs.courserun_readable_id
@@ -243,25 +243,25 @@ with coupon as (
                 as varchar
             ), '"', ''
         ) as req_reference_number
-        , case
+        , case 
             when couponredemption.couponredemption_id is not null
-                then 'true'
-            else 'false'
+                then 'true' 
+            else 'false' 
         end as coupon_redeemed
-    from b2b_ecommerce_b2border
-    inner join ecommerce_couponpaymentversion
+    from b2b_ecommerce_b2border 
+    inner join ecommerce_couponpaymentversion 
         on ecommerce_couponpaymentversion.couponpaymentversion_id = b2b_ecommerce_b2border.couponpaymentversion_id
-    inner join ecommerce_couponversion
+    inner join ecommerce_couponversion 
         on ecommerce_couponversion.couponpaymentversion_id = ecommerce_couponpaymentversion.couponpaymentversion_id
-    inner join coupon
+    inner join coupon 
         on coupon.coupon_id = ecommerce_couponversion.coupon_id
-    left join couponredemption
+    left join couponredemption 
         on couponredemption.couponversion_id = ecommerce_couponversion.couponversion_id
-    left join ecommerce_order
+    left join ecommerce_order 
         on ecommerce_order.order_id = couponredemption.order_id
-    left join b2b_ecommerce_b2breceipt
+    left join b2b_ecommerce_b2breceipt 
         on b2b_ecommerce_b2breceipt.b2border_id = b2b_ecommerce_b2border.b2border_id
-    left join ecommerce_line
+    left join ecommerce_line 
         on ecommerce_line.order_id = ecommerce_order.order_id
     left join program_runs
         on ecommerce_line.programrun_id = program_runs.programrun_id
@@ -271,12 +271,12 @@ with coupon as (
         on course_runs.course_id = courses.course_id
     left join productversion
         on productversion.productversion_id = b2b_ecommerce_b2border.productversion_id
-    left join users_user
+    left join users_user    
         on ecommerce_order.order_purchaser_user_id = users_user.user_id
 )
 
 
-select
+select 
     reg_coupon_fields.coupon_email
     , reg_coupon_fields.coupon_code
     , reg_coupon_fields.coupon_id
@@ -303,7 +303,7 @@ where reg_coupon_fields.coupon_id not in (select coupon_id from b2b_coupon_field
 
 union distinct
 
-select
+select 
     b2b_coupon_fields.b2border_email as coupon_email
     , b2b_coupon_fields.coupon_code
     , b2b_coupon_fields.coupon_id
@@ -327,7 +327,7 @@ from b2b_coupon_fields
 
 union distinct
 
-select
+select 
     coupon_email
     , coupon_code
     , coupon_id
@@ -335,7 +335,7 @@ select
     , couponpayment_name
     , b2border_contract_number
     , product_id
-    , couponpaymentversion_payment_transaction
+    , couponpaymentversion_payment_transaction  
     , req_reference_number
     , programrun_readable_id
     , program_title
@@ -348,3 +348,5 @@ select
     , cast(order_ids as varchar) as order_ids
     , combined_order_state
 from unassigned_enrollment_codes
+where coupon_id not in (select coupon_id from reg_coupon_fields)
+and coupon_id not in (select coupon_id from b2b_coupon_fields)

--- a/src/ol_dbt/models/intermediate/mitxpro/int__mitxpro__ecommerce_combinedcoupons.sql
+++ b/src/ol_dbt/models/intermediate/mitxpro/int__mitxpro__ecommerce_combinedcoupons.sql
@@ -69,17 +69,17 @@ with coupon as (
 )
 
 , payment_transactions as (
-    select distinct 
+    select distinct
         ecommerce_couponversion.coupon_id
         , ecommerce_couponpaymentversion.couponpaymentversion_payment_transaction
     from ecommerce_couponpaymentversion
-    inner join ecommerce_couponversion 
+    inner join ecommerce_couponversion
         on ecommerce_couponpaymentversion.couponpaymentversion_id = ecommerce_couponversion.couponpaymentversion_id
     where ecommerce_couponpaymentversion.couponpaymentversion_payment_transaction is not null
 )
 
 , reg_coupon_summary as (
-    select 
+    select
         coupon.coupon_id
         , ecommerce_couponversion.couponversion_updated_on
         , program_runs.programrun_readable_id
@@ -95,15 +95,15 @@ with coupon as (
         , array_join(array_distinct(array_agg(ecommerce_order.order_id)), ', ') as order_ids
         , array_join(array_distinct(array_agg(ecommerce_order.order_state)), ', ') as combined_order_state
     from coupon
-    left join ecommerce_couponversion 
+    left join ecommerce_couponversion
         on coupon.coupon_id = ecommerce_couponversion.coupon_id
     left join couponredemption
         on ecommerce_couponversion.couponversion_id = couponredemption.couponversion_id
-    left join ecommerce_couponpaymentversion 
+    left join ecommerce_couponpaymentversion
         on ecommerce_couponpaymentversion.couponpaymentversion_id = ecommerce_couponversion.couponpaymentversion_id
     left join ecommerce_order
         on ecommerce_order.order_id = couponredemption.order_id
-    left join ecommerce_line 
+    left join ecommerce_line
         on ecommerce_line.order_id = ecommerce_order.order_id
     left join program_runs
         on ecommerce_line.programrun_id = program_runs.programrun_id
@@ -113,9 +113,9 @@ with coupon as (
         on course_runs.course_id = courses.course_id
     left join productversion
         on productversion.productversion_id = ecommerce_line.productversion_id
-    left join users_user    
+    left join users_user
         on ecommerce_order.order_purchaser_user_id = users_user.user_id
-    group by 
+    group by
         coupon.coupon_id
         , ecommerce_couponversion.couponversion_updated_on
         , program_runs.programrun_readable_id
@@ -128,14 +128,14 @@ with coupon as (
 )
 
 , reg_coupon_fields as (
-    select 
+    select
         productcouponassignment.productcouponassignment_email as coupon_email
         , coupon.coupon_code
         , coupon.coupon_id
         , coupon.coupon_created_on
         , coupon.couponpayment_name
         , productcouponassignment.product_id
-        , payment_transactions.couponpaymentversion_payment_transaction 
+        , payment_transactions.couponpaymentversion_payment_transaction
         , productcouponassignment.productcouponassignment_is_redeemed
     from coupon
     left join productcouponassignment
@@ -154,7 +154,7 @@ with coupon as (
         , coupon.couponpayment_name
         , b2b_ecommerce_b2border.b2border_contract_number
         , b2b_ecommerce_b2border.product_id
-        , ecommerce_couponpaymentversion.couponpaymentversion_payment_transaction 
+        , ecommerce_couponpaymentversion.couponpaymentversion_payment_transaction
         , program_runs.programrun_readable_id
         , program_runs.program_title
         , course_runs.courserun_readable_id
@@ -162,36 +162,36 @@ with coupon as (
         , productversion.productversion_readable_id
         , ecommerce_couponpaymentversion.couponpaymentversion_coupon_type
         , ecommerce_couponpaymentversion.couponpaymentversion_discount_amount
-        , TRY_CAST(users_user.user_email as BigInt) combined_user_emails 
-        , TRY_CAST(users_user.user_address_country as BigInt) user_address_countries 
-        , TRY_CAST(ecommerce_order.order_id as BigInt) as order_ids
-        , TRY_CAST(ecommerce_order.order_state as BigInt) as combined_order_state
+        , try_cast(users_user.user_email as BigInt) as combined_user_emails
+        , try_cast(users_user.user_address_country as BigInt) as user_address_countries
+        , try_cast(ecommerce_order.order_id as BigInt) as order_ids
+        , try_cast(ecommerce_order.order_state as BigInt) as combined_order_state
         , replace(
             cast(
                 json_extract(b2b_ecommerce_b2breceipt.b2breceipt_data, '$.req_reference_number'
                 )
-                as varchar
+                as Varchar
             ), '"', ''
         ) as req_reference_number
-        , case 
+        , case
             when couponredemption.couponredemption_id is not null
-                then 'true' 
-            else 'false' 
+                then 'true'
+            else 'false'
         end as coupon_redeemed
-    from b2b_ecommerce_b2border 
-    inner join ecommerce_couponpaymentversion 
+    from b2b_ecommerce_b2border
+    inner join ecommerce_couponpaymentversion
         on ecommerce_couponpaymentversion.couponpaymentversion_id = b2b_ecommerce_b2border.couponpaymentversion_id
-    inner join ecommerce_couponversion 
+    inner join ecommerce_couponversion
         on ecommerce_couponversion.couponpaymentversion_id = ecommerce_couponpaymentversion.couponpaymentversion_id
-    inner join coupon 
+    inner join coupon
         on coupon.coupon_id = ecommerce_couponversion.coupon_id
-    left join couponredemption 
+    left join couponredemption
         on couponredemption.couponversion_id = ecommerce_couponversion.couponversion_id
-    left join ecommerce_order 
+    left join ecommerce_order
         on ecommerce_order.order_id = couponredemption.order_id
-    left join b2b_ecommerce_b2breceipt 
+    left join b2b_ecommerce_b2breceipt
         on b2b_ecommerce_b2breceipt.b2border_id = b2b_ecommerce_b2border.b2border_id
-    left join ecommerce_line 
+    left join ecommerce_line
         on ecommerce_line.order_id = ecommerce_order.order_id
     left join program_runs
         on ecommerce_line.programrun_id = program_runs.programrun_id
@@ -201,12 +201,12 @@ with coupon as (
         on course_runs.course_id = courses.course_id
     left join productversion
         on productversion.productversion_id = b2b_ecommerce_b2border.productversion_id
-    left join users_user    
+    left join users_user
         on ecommerce_order.order_purchaser_user_id = users_user.user_id
 )
 
 
-select 
+select
     reg_coupon_fields.coupon_email
     , reg_coupon_fields.coupon_code
     , reg_coupon_fields.coupon_id
@@ -226,10 +226,10 @@ select
     , reg_coupon_summary.couponpaymentversion_coupon_type
     , reg_coupon_summary.couponpaymentversion_discount_amount
     , reg_coupon_summary.coupon_redeemed
-    , cast(reg_coupon_summary.combined_user_emails as bigint) as combined_user_emails
-    , cast(reg_coupon_summary.user_address_countries as bigint) as user_address_countries
-    , cast(reg_coupon_summary.order_ids as bigint) as order_ids
-    , cast(reg_coupon_summary.combined_order_state as bigint) as combined_order_state
+    , cast(reg_coupon_summary.combined_user_emails as Bigint) as combined_user_emails
+    , cast(reg_coupon_summary.user_address_countries as Bigint) as user_address_countries
+    , cast(reg_coupon_summary.order_ids as Bigint) as order_ids
+    , cast(reg_coupon_summary.combined_order_state as Bigint) as combined_order_state
 from reg_coupon_fields
 inner join reg_coupon_summary
     on reg_coupon_fields.coupon_id = reg_coupon_summary.coupon_id
@@ -237,7 +237,7 @@ where reg_coupon_fields.coupon_id not in (select coupon_id from b2b_coupon_field
 
 union distinct
 
-select 
+select
     b2b_coupon_fields.b2border_email as coupon_email
     , b2b_coupon_fields.coupon_code
     , b2b_coupon_fields.coupon_id

--- a/src/ol_dbt/models/intermediate/mitxpro/int__mitxpro__ecommerce_combinedcoupons.sql
+++ b/src/ol_dbt/models/intermediate/mitxpro/int__mitxpro__ecommerce_combinedcoupons.sql
@@ -71,17 +71,17 @@ with coupon as (
 )
 
 , payment_transactions as (
-    select distinct 
+    select distinct
         ecommerce_couponversion.coupon_id
         , max(ecommerce_couponpaymentversion.couponpaymentversion_payment_transaction)
     from ecommerce_couponpaymentversion
-    inner join ecommerce_couponversion 
+    inner join ecommerce_couponversion
         on ecommerce_couponpaymentversion.couponpaymentversion_id = ecommerce_couponversion.couponpaymentversion_id
     where ecommerce_couponpaymentversion.couponpaymentversion_payment_transaction is not null
 )
 
 , latest_couponversion as (
-    select 
+    select
         coupon_id
         , max(couponversion_updated_on) as max_couponversion_updated_on
     from ecommerce_couponversion
@@ -89,38 +89,38 @@ with coupon as (
 )
 
 , reg_coupon_summary as (
-    select 
+    select
         coupon.coupon_id
-        , cast(array_join(array_distinct(array_agg(program_runs.programrun_readable_id)), ', ') as varchar) 
+        , cast(array_join(array_distinct(array_agg(program_runs.programrun_readable_id)), ', ') as varchar)
             as programrun_readable_id
         , cast(array_join(array_distinct(array_agg(program_runs.program_title)), ', ') as varchar) as program_title
-        , cast(array_join(array_distinct(array_agg(course_runs.courserun_readable_id)), ', ') as varchar) 
+        , cast(array_join(array_distinct(array_agg(course_runs.courserun_readable_id)), ', ') as varchar)
             as courserun_readable_id
         , cast(array_join(array_distinct(array_agg(courses.course_title)), ', ') as varchar) as course_title
-        , cast(array_join(array_distinct(array_agg(productversion.productversion_readable_id)), ', ') as varchar) 
+        , cast(array_join(array_distinct(array_agg(productversion.productversion_readable_id)), ', ') as varchar)
             as productversion_readable_id
         , cast(array_join(array_distinct(array_agg(users_user.user_email)), ', ') as varchar) as combined_user_emails
-        , cast(array_join(array_distinct(array_agg(users_user.user_address_country)), ', ') as varchar) 
+        , cast(array_join(array_distinct(array_agg(users_user.user_address_country)), ', ') as varchar)
             as user_address_countries
         , cast(array_join(array_distinct(array_agg(ecommerce_order.order_id)), ', ') as varchar) as order_ids
-        , cast(array_join(array_distinct(array_agg(ecommerce_order.order_state)), ', ') as varchar) 
+        , cast(array_join(array_distinct(array_agg(ecommerce_order.order_state)), ', ') as varchar)
             as combined_order_state
         , case when (count(couponredemption.couponredemption_id) >= 1) then 'true' else 'false' end as coupon_redeemed
-        
+
     from coupon
     left join latest_couponversion
         on coupon.coupon_id = latest_couponversion.coupon_id
-    left join ecommerce_couponversion 
-        on 
-            latest_couponversion.coupon_id = ecommerce_couponversion.coupon_id 
+    left join ecommerce_couponversion
+        on
+            latest_couponversion.coupon_id = ecommerce_couponversion.coupon_id
             and ecommerce_couponversion.couponversion_updated_on = latest_couponversion.max_couponversion_updated_on
     left join couponredemption
         on ecommerce_couponversion.couponversion_id = couponredemption.couponversion_id
-    left join ecommerce_couponpaymentversion 
+    left join ecommerce_couponpaymentversion
         on ecommerce_couponpaymentversion.couponpaymentversion_id = ecommerce_couponversion.couponpaymentversion_id
     left join ecommerce_order
         on ecommerce_order.order_id = couponredemption.order_id
-    left join ecommerce_line 
+    left join ecommerce_line
         on ecommerce_line.order_id = ecommerce_order.order_id
     left join program_runs
         on ecommerce_line.programrun_id = program_runs.programrun_id
@@ -130,22 +130,22 @@ with coupon as (
         on course_runs.course_id = courses.course_id
     left join productversion
         on productversion.productversion_id = ecommerce_line.productversion_id
-    left join users_user    
+    left join users_user
         on ecommerce_order.order_purchaser_user_id = users_user.user_id
     where ecommerce_order.order_state = 'fulfilled' or ecommerce_order.order_state = 'refunded'
-    group by 
+    group by
         coupon.coupon_id
 )
 
 , reg_coupon_fields as (
-    select 
+    select
         productcouponassignment.productcouponassignment_email as coupon_email
         , coupon.coupon_code
         , coupon.coupon_id
         , coupon.coupon_created_on
         , coupon.couponpayment_name
         , productcouponassignment.product_id
-        , payment_transactions.couponpaymentversion_payment_transaction 
+        , payment_transactions.couponpaymentversion_payment_transaction
         , productcouponassignment.productcouponassignment_is_redeemed
     from coupon
     left join productcouponassignment
@@ -155,13 +155,13 @@ with coupon as (
 )
 
 , unassigned_enrollment_codes as (
-    select 
+    select
         coupon.coupon_code
         , coupon.coupon_id
         , coupon.coupon_created_on as coupon_created_on
         , coupon.couponpayment_name
         , b2b_ecommerce_b2border.b2border_contract_number
-        , payment_transactions.couponpaymentversion_payment_transaction  
+        , payment_transactions.couponpaymentversion_payment_transaction
         , program_runs.programrun_readable_id
         , program_runs.program_title
         , course_runs.courserun_readable_id
@@ -179,22 +179,22 @@ with coupon as (
     inner join latest_couponversion
         on coupon.coupon_id = latest_couponversion.coupon_id
     inner join ecommerce_couponversion
-        on 
-            latest_couponversion.coupon_id = ecommerce_couponversion.coupon_id 
+        on
+            latest_couponversion.coupon_id = ecommerce_couponversion.coupon_id
             and ecommerce_couponversion.couponversion_updated_on = latest_couponversion.max_couponversion_updated_on
     inner join ecommerce_couponpaymentversion
-        on ecommerce_couponpaymentversion.couponpaymentversion_id = ecommerce_couponversion.couponpaymentversion_id 
-    left join b2b_ecommerce_b2border 
+        on ecommerce_couponpaymentversion.couponpaymentversion_id = ecommerce_couponversion.couponpaymentversion_id
+    left join b2b_ecommerce_b2border
         on ecommerce_couponpaymentversion.couponpaymentversion_id = b2b_ecommerce_b2border.couponpaymentversion_id
-    left join payment_transactions 
-        on payment_transactions.coupon_id = coupon.coupon_id   
+    left join payment_transactions
+        on payment_transactions.coupon_id = coupon.coupon_id
     left join couponredemption
         on couponredemption.couponversion_id = ecommerce_couponversion.couponversion_id
-    left join ecommerce_order 
+    left join ecommerce_order
         on couponredemption.order_id = ecommerce_order.order_id
-    left join users_user 
-        on users_user.user_id = ecommerce_order.order_purchaser_user_id 
-    left join ecommerce_line 
+    left join users_user
+        on users_user.user_id = ecommerce_order.order_purchaser_user_id
+    left join ecommerce_line
         on ecommerce_line.order_id = ecommerce_order.order_id
     left join program_runs
         on ecommerce_line.programrun_id = program_runs.programrun_id
@@ -204,19 +204,19 @@ with coupon as (
         on course_runs.course_id = courses.course_id
     left join productversion
         on productversion.productversion_id = ecommerce_line.productversion_id
-    where 
-        ecommerce_couponpaymentversion.couponpaymentversion_coupon_type = 'single-use' 
-        and ecommerce_couponpaymentversion.couponpaymentversion_discount_amount = 1.0000 
+    where
+        ecommerce_couponpaymentversion.couponpaymentversion_coupon_type = 'single-use'
+        and ecommerce_couponpaymentversion.couponpaymentversion_discount_amount = 1.0000
         and coupon.coupon_id not in (
             select coupon_id
-            from productcouponassignment 
+            from productcouponassignment
         )
         and not exists (
             select b2b_ecommerce_b2border.couponpaymentversion_id
             from b2b_ecommerce_b2border
-            where 
+            where
                 b2b_ecommerce_b2border.couponpaymentversion_id = ecommerce_couponpaymentversion.couponpaymentversion_id
-        ) 
+        )
 )
 
 , b2b_coupon_fields as (
@@ -228,7 +228,7 @@ with coupon as (
         , coupon.couponpayment_name
         , b2b_ecommerce_b2border.b2border_contract_number
         , b2b_ecommerce_b2border.product_id
-        , ecommerce_couponpaymentversion.couponpaymentversion_payment_transaction 
+        , ecommerce_couponpaymentversion.couponpaymentversion_payment_transaction
         , program_runs.programrun_readable_id
         , program_runs.program_title
         , course_runs.courserun_readable_id
@@ -239,25 +239,25 @@ with coupon as (
         , cast(ecommerce_order.order_id as varchar) as order_ids
         , ecommerce_order.order_state as combined_order_state
         , b2b_ecommerce_b2breceipt.req_reference_number
-        , case 
+        , case
             when couponredemption.couponredemption_id is not null
-                then 'true' 
-            else 'false' 
+                then 'true'
+            else 'false'
         end as coupon_redeemed
-    from b2b_ecommerce_b2border 
-    inner join ecommerce_couponpaymentversion 
+    from b2b_ecommerce_b2border
+    inner join ecommerce_couponpaymentversion
         on ecommerce_couponpaymentversion.couponpaymentversion_id = b2b_ecommerce_b2border.couponpaymentversion_id
-    inner join ecommerce_couponversion 
+    inner join ecommerce_couponversion
         on ecommerce_couponversion.couponpaymentversion_id = ecommerce_couponpaymentversion.couponpaymentversion_id
-    inner join coupon 
+    inner join coupon
         on coupon.coupon_id = ecommerce_couponversion.coupon_id
-    left join couponredemption 
+    left join couponredemption
         on couponredemption.couponversion_id = ecommerce_couponversion.couponversion_id
-    left join ecommerce_order 
+    left join ecommerce_order
         on ecommerce_order.order_id = couponredemption.order_id
-    left join b2b_ecommerce_b2breceipt 
+    left join b2b_ecommerce_b2breceipt
         on b2b_ecommerce_b2breceipt.b2border_id = b2b_ecommerce_b2border.b2border_id
-    left join ecommerce_line 
+    left join ecommerce_line
         on ecommerce_line.order_id = ecommerce_order.order_id
     left join program_runs
         on ecommerce_line.programrun_id = program_runs.programrun_id
@@ -267,12 +267,12 @@ with coupon as (
         on course_runs.course_id = courses.course_id
     left join productversion
         on productversion.productversion_id = b2b_ecommerce_b2border.productversion_id
-    left join users_user    
+    left join users_user
         on ecommerce_order.order_purchaser_user_id = users_user.user_id
 )
 
 
-select 
+select
     reg_coupon_fields.coupon_email
     , reg_coupon_fields.coupon_code
     , reg_coupon_fields.coupon_id
@@ -299,7 +299,7 @@ where reg_coupon_fields.coupon_id not in (select coupon_id from b2b_coupon_field
 
 union distinct
 
-select 
+select
     b2b_coupon_fields.b2border_email as coupon_email
     , b2b_coupon_fields.coupon_code
     , b2b_coupon_fields.coupon_id
@@ -323,7 +323,7 @@ from b2b_coupon_fields
 
 union distinct
 
-select 
+select
     coupon_email
     , coupon_code
     , coupon_id
@@ -331,7 +331,7 @@ select
     , couponpayment_name
     , b2border_contract_number
     , product_id
-    , couponpaymentversion_payment_transaction  
+    , couponpaymentversion_payment_transaction
     , req_reference_number
     , programrun_readable_id
     , program_title
@@ -344,6 +344,6 @@ select
     , cast(order_ids as varchar) as order_ids
     , combined_order_state
 from unassigned_enrollment_codes
-where 
+where
     coupon_id not in (select coupon_id from reg_coupon_fields)
     and coupon_id not in (select coupon_id from b2b_coupon_fields)

--- a/src/ol_dbt/models/intermediate/mitxpro/int__mitxpro__ecommerce_combinedcoupons.sql
+++ b/src/ol_dbt/models/intermediate/mitxpro/int__mitxpro__ecommerce_combinedcoupons.sql
@@ -69,17 +69,17 @@ with coupon as (
 )
 
 , payment_transactions as (
-    select distinct
+    select distinct 
         ecommerce_couponversion.coupon_id
         , ecommerce_couponpaymentversion.couponpaymentversion_payment_transaction
     from ecommerce_couponpaymentversion
-    inner join ecommerce_couponversion
+    inner join ecommerce_couponversion 
         on ecommerce_couponpaymentversion.couponpaymentversion_id = ecommerce_couponversion.couponpaymentversion_id
     where ecommerce_couponpaymentversion.couponpaymentversion_payment_transaction is not null
 )
 
 , reg_coupon_summary as (
-    select
+    select 
         coupon.coupon_id
         , ecommerce_couponversion.couponversion_updated_on
         , program_runs.programrun_readable_id
@@ -95,15 +95,15 @@ with coupon as (
         , array_join(array_distinct(array_agg(ecommerce_order.order_id)), ', ') as order_ids
         , array_join(array_distinct(array_agg(ecommerce_order.order_state)), ', ') as combined_order_state
     from coupon
-    left join ecommerce_couponversion
+    left join ecommerce_couponversion 
         on coupon.coupon_id = ecommerce_couponversion.coupon_id
     left join couponredemption
         on ecommerce_couponversion.couponversion_id = couponredemption.couponversion_id
-    left join ecommerce_couponpaymentversion
+    left join ecommerce_couponpaymentversion 
         on ecommerce_couponpaymentversion.couponpaymentversion_id = ecommerce_couponversion.couponpaymentversion_id
     left join ecommerce_order
         on ecommerce_order.order_id = couponredemption.order_id
-    left join ecommerce_line
+    left join ecommerce_line 
         on ecommerce_line.order_id = ecommerce_order.order_id
     left join program_runs
         on ecommerce_line.programrun_id = program_runs.programrun_id
@@ -113,9 +113,9 @@ with coupon as (
         on course_runs.course_id = courses.course_id
     left join productversion
         on productversion.productversion_id = ecommerce_line.productversion_id
-    left join users_user
+    left join users_user    
         on ecommerce_order.order_purchaser_user_id = users_user.user_id
-    group by
+    group by 
         coupon.coupon_id
         , ecommerce_couponversion.couponversion_updated_on
         , program_runs.programrun_readable_id
@@ -128,14 +128,14 @@ with coupon as (
 )
 
 , reg_coupon_fields as (
-    select
+    select 
         productcouponassignment.productcouponassignment_email as coupon_email
         , coupon.coupon_code
         , coupon.coupon_id
         , coupon.coupon_created_on
         , coupon.couponpayment_name
         , productcouponassignment.product_id
-        , payment_transactions.couponpaymentversion_payment_transaction
+        , payment_transactions.couponpaymentversion_payment_transaction 
         , productcouponassignment.productcouponassignment_is_redeemed
     from coupon
     left join productcouponassignment
@@ -154,7 +154,7 @@ with coupon as (
         , coupon.couponpayment_name
         , b2b_ecommerce_b2border.b2border_contract_number
         , b2b_ecommerce_b2border.product_id
-        , ecommerce_couponpaymentversion.couponpaymentversion_payment_transaction
+        , ecommerce_couponpaymentversion.couponpaymentversion_payment_transaction 
         , program_runs.programrun_readable_id
         , program_runs.program_title
         , course_runs.courserun_readable_id
@@ -162,10 +162,10 @@ with coupon as (
         , productversion.productversion_readable_id
         , ecommerce_couponpaymentversion.couponpaymentversion_coupon_type
         , ecommerce_couponpaymentversion.couponpaymentversion_discount_amount
-        , users_user.user_email as combined_user_emails
-        , users_user.user_address_country as user_address_countries
-        , ecommerce_order.order_id as order_ids
-        , ecommerce_order.order_state as combined_order_state
+        , cast(users_user.user_email as bigint) as combined_user_emails
+        , cast(users_user.user_address_country as bigint) as user_address_countries
+        , cast(ecommerce_order.order_id as bigint) as order_ids
+        , cast(ecommerce_order.order_state as bigint) as combined_order_state
         , replace(
             cast(
                 json_extract(b2b_ecommerce_b2breceipt.b2breceipt_data, '$.req_reference_number'
@@ -173,25 +173,25 @@ with coupon as (
                 as varchar
             ), '"', ''
         ) as req_reference_number
-        , case
+        , case 
             when couponredemption.couponredemption_id is not null
-                then 'true'
-            else 'false'
+                then 'true' 
+            else 'false' 
         end as coupon_redeemed
-    from b2b_ecommerce_b2border
-    inner join ecommerce_couponpaymentversion
+    from b2b_ecommerce_b2border 
+    inner join ecommerce_couponpaymentversion 
         on ecommerce_couponpaymentversion.couponpaymentversion_id = b2b_ecommerce_b2border.couponpaymentversion_id
-    inner join ecommerce_couponversion
+    inner join ecommerce_couponversion 
         on ecommerce_couponversion.couponpaymentversion_id = ecommerce_couponpaymentversion.couponpaymentversion_id
-    inner join coupon
+    inner join coupon 
         on coupon.coupon_id = ecommerce_couponversion.coupon_id
-    left join couponredemption
+    left join couponredemption 
         on couponredemption.couponversion_id = ecommerce_couponversion.couponversion_id
-    left join ecommerce_order
+    left join ecommerce_order 
         on ecommerce_order.order_id = couponredemption.order_id
-    left join b2b_ecommerce_b2breceipt
+    left join b2b_ecommerce_b2breceipt 
         on b2b_ecommerce_b2breceipt.b2border_id = b2b_ecommerce_b2border.b2border_id
-    left join ecommerce_line
+    left join ecommerce_line 
         on ecommerce_line.order_id = ecommerce_order.order_id
     left join program_runs
         on ecommerce_line.programrun_id = program_runs.programrun_id
@@ -201,12 +201,12 @@ with coupon as (
         on course_runs.course_id = courses.course_id
     left join productversion
         on productversion.productversion_id = b2b_ecommerce_b2border.productversion_id
-    left join users_user
+    left join users_user    
         on ecommerce_order.order_purchaser_user_id = users_user.user_id
 )
 
 
-select
+select 
     reg_coupon_fields.coupon_email
     , reg_coupon_fields.coupon_code
     , reg_coupon_fields.coupon_id
@@ -237,7 +237,7 @@ where reg_coupon_fields.coupon_id not in (select coupon_id from b2b_coupon_field
 
 union distinct
 
-select
+select 
     b2b_coupon_fields.b2border_email as coupon_email
     , b2b_coupon_fields.coupon_code
     , b2b_coupon_fields.coupon_id
@@ -257,8 +257,8 @@ select
     , b2b_coupon_fields.couponpaymentversion_coupon_type
     , b2b_coupon_fields.couponpaymentversion_discount_amount
     , b2b_coupon_fields.coupon_redeemed
-    , cast(b2b_coupon_fields.combined_user_emails as bigint) as combined_user_emails
-    , cast(b2b_coupon_fields.user_address_countries as bigint) as user_address_countries
-    , cast(b2b_coupon_fields.order_ids as bigint) as order_ids
-    , cast(b2b_coupon_fields.combined_order_state as bigint) as combined_order_state
+    , b2b_coupon_fields.combined_user_emails
+    , b2b_coupon_fields.user_address_countries
+    , b2b_coupon_fields.order_ids
+    , b2b_coupon_fields.combined_order_state
 from b2b_coupon_fields

--- a/src/ol_dbt/models/intermediate/mitxpro/int__mitxpro__ecommerce_combinedcoupons.sql
+++ b/src/ol_dbt/models/intermediate/mitxpro/int__mitxpro__ecommerce_combinedcoupons.sql
@@ -69,17 +69,17 @@ with coupon as (
 )
 
 , payment_transactions as (
-    select distinct 
+    select distinct
         ecommerce_couponversion.coupon_id
         , ecommerce_couponpaymentversion.couponpaymentversion_payment_transaction
     from ecommerce_couponpaymentversion
-    inner join ecommerce_couponversion 
+    inner join ecommerce_couponversion
         on ecommerce_couponpaymentversion.couponpaymentversion_id = ecommerce_couponversion.couponpaymentversion_id
     where ecommerce_couponpaymentversion.couponpaymentversion_payment_transaction is not null
 )
 
 , reg_coupon_summary as (
-    select 
+    select
         coupon.coupon_id
         , ecommerce_couponversion.couponversion_updated_on
         , program_runs.programrun_readable_id
@@ -95,15 +95,15 @@ with coupon as (
         , array_join(array_distinct(array_agg(ecommerce_order.order_id)), ', ') as order_ids
         , array_join(array_distinct(array_agg(ecommerce_order.order_state)), ', ') as combined_order_state
     from coupon
-    left join ecommerce_couponversion 
+    left join ecommerce_couponversion
         on coupon.coupon_id = ecommerce_couponversion.coupon_id
     left join couponredemption
         on ecommerce_couponversion.couponversion_id = couponredemption.couponversion_id
-    left join ecommerce_couponpaymentversion 
+    left join ecommerce_couponpaymentversion
         on ecommerce_couponpaymentversion.couponpaymentversion_id = ecommerce_couponversion.couponpaymentversion_id
     left join ecommerce_order
         on ecommerce_order.order_id = couponredemption.order_id
-    left join ecommerce_line 
+    left join ecommerce_line
         on ecommerce_line.order_id = ecommerce_order.order_id
     left join program_runs
         on ecommerce_line.programrun_id = program_runs.programrun_id
@@ -113,9 +113,9 @@ with coupon as (
         on course_runs.course_id = courses.course_id
     left join productversion
         on productversion.productversion_id = ecommerce_line.productversion_id
-    left join users_user    
+    left join users_user
         on ecommerce_order.order_purchaser_user_id = users_user.user_id
-    group by 
+    group by
         coupon.coupon_id
         , ecommerce_couponversion.couponversion_updated_on
         , program_runs.programrun_readable_id
@@ -128,14 +128,14 @@ with coupon as (
 )
 
 , reg_coupon_fields as (
-    select 
+    select
         productcouponassignment.productcouponassignment_email as coupon_email
         , coupon.coupon_code
         , coupon.coupon_id
         , coupon.coupon_created_on
         , coupon.couponpayment_name
         , productcouponassignment.product_id
-        , payment_transactions.couponpaymentversion_payment_transaction 
+        , payment_transactions.couponpaymentversion_payment_transaction
         , productcouponassignment.productcouponassignment_is_redeemed
     from coupon
     left join productcouponassignment
@@ -154,7 +154,7 @@ with coupon as (
         , coupon.couponpayment_name
         , b2b_ecommerce_b2border.b2border_contract_number
         , b2b_ecommerce_b2border.product_id
-        , ecommerce_couponpaymentversion.couponpaymentversion_payment_transaction 
+        , ecommerce_couponpaymentversion.couponpaymentversion_payment_transaction
         , program_runs.programrun_readable_id
         , program_runs.program_title
         , course_runs.courserun_readable_id
@@ -173,25 +173,25 @@ with coupon as (
                 as varchar
             ), '"', ''
         ) as req_reference_number
-        , case 
+        , case
             when couponredemption.couponredemption_id is not null
-                then 'true' 
-            else 'false' 
+                then 'true'
+            else 'false'
         end as coupon_redeemed
-    from b2b_ecommerce_b2border 
-    inner join ecommerce_couponpaymentversion 
+    from b2b_ecommerce_b2border
+    inner join ecommerce_couponpaymentversion
         on ecommerce_couponpaymentversion.couponpaymentversion_id = b2b_ecommerce_b2border.couponpaymentversion_id
-    inner join ecommerce_couponversion 
+    inner join ecommerce_couponversion
         on ecommerce_couponversion.couponpaymentversion_id = ecommerce_couponpaymentversion.couponpaymentversion_id
-    inner join coupon 
+    inner join coupon
         on coupon.coupon_id = ecommerce_couponversion.coupon_id
-    left join couponredemption 
+    left join couponredemption
         on couponredemption.couponversion_id = ecommerce_couponversion.couponversion_id
-    left join ecommerce_order 
+    left join ecommerce_order
         on ecommerce_order.order_id = couponredemption.order_id
-    left join b2b_ecommerce_b2breceipt 
+    left join b2b_ecommerce_b2breceipt
         on b2b_ecommerce_b2breceipt.b2border_id = b2b_ecommerce_b2border.b2border_id
-    left join ecommerce_line 
+    left join ecommerce_line
         on ecommerce_line.order_id = ecommerce_order.order_id
     left join program_runs
         on ecommerce_line.programrun_id = program_runs.programrun_id
@@ -201,12 +201,12 @@ with coupon as (
         on course_runs.course_id = courses.course_id
     left join productversion
         on productversion.productversion_id = b2b_ecommerce_b2border.productversion_id
-    left join users_user    
+    left join users_user
         on ecommerce_order.order_purchaser_user_id = users_user.user_id
 )
 
 
-select 
+select
     reg_coupon_fields.coupon_email
     , reg_coupon_fields.coupon_code
     , reg_coupon_fields.coupon_id
@@ -237,7 +237,7 @@ where reg_coupon_fields.coupon_id not in (select coupon_id from b2b_coupon_summa
 
 union distinct
 
-select 
+select
     b2b_coupon_fields.b2border_email as coupon_email
     , b2b_coupon_fields.coupon_code
     , b2b_coupon_fields.coupon_id

--- a/src/ol_dbt/models/intermediate/mitxpro/int__mitxpro__ecommerce_combinedcoupons.sql
+++ b/src/ol_dbt/models/intermediate/mitxpro/int__mitxpro__ecommerce_combinedcoupons.sql
@@ -69,17 +69,17 @@ with coupon as (
 )
 
 , payment_transactions as (
-    select distinct
+    select distinct 
         ecommerce_couponversion.coupon_id
         , ecommerce_couponpaymentversion.couponpaymentversion_payment_transaction
     from ecommerce_couponpaymentversion
-    inner join ecommerce_couponversion
+    inner join ecommerce_couponversion 
         on ecommerce_couponpaymentversion.couponpaymentversion_id = ecommerce_couponversion.couponpaymentversion_id
     where ecommerce_couponpaymentversion.couponpaymentversion_payment_transaction is not null
 )
 
 , reg_coupon_summary as (
-    select
+    select 
         coupon.coupon_id
         , ecommerce_couponversion.couponversion_updated_on
         , program_runs.programrun_readable_id
@@ -95,15 +95,15 @@ with coupon as (
         , array_join(array_distinct(array_agg(ecommerce_order.order_id)), ', ') as order_ids
         , array_join(array_distinct(array_agg(ecommerce_order.order_state)), ', ') as combined_order_state
     from coupon
-    left join ecommerce_couponversion
+    left join ecommerce_couponversion 
         on coupon.coupon_id = ecommerce_couponversion.coupon_id
     left join couponredemption
         on ecommerce_couponversion.couponversion_id = couponredemption.couponversion_id
-    left join ecommerce_couponpaymentversion
+    left join ecommerce_couponpaymentversion 
         on ecommerce_couponpaymentversion.couponpaymentversion_id = ecommerce_couponversion.couponpaymentversion_id
     left join ecommerce_order
         on ecommerce_order.order_id = couponredemption.order_id
-    left join ecommerce_line
+    left join ecommerce_line 
         on ecommerce_line.order_id = ecommerce_order.order_id
     left join program_runs
         on ecommerce_line.programrun_id = program_runs.programrun_id
@@ -113,9 +113,9 @@ with coupon as (
         on course_runs.course_id = courses.course_id
     left join productversion
         on productversion.productversion_id = ecommerce_line.productversion_id
-    left join users_user
+    left join users_user    
         on ecommerce_order.order_purchaser_user_id = users_user.user_id
-    group by
+    group by 
         coupon.coupon_id
         , ecommerce_couponversion.couponversion_updated_on
         , program_runs.programrun_readable_id
@@ -128,14 +128,14 @@ with coupon as (
 )
 
 , reg_coupon_fields as (
-    select
+    select 
         productcouponassignment.productcouponassignment_email as coupon_email
         , coupon.coupon_code
         , coupon.coupon_id
         , coupon.coupon_created_on
         , coupon.couponpayment_name
         , productcouponassignment.product_id
-        , payment_transactions.couponpaymentversion_payment_transaction
+        , payment_transactions.couponpaymentversion_payment_transaction 
         , productcouponassignment.productcouponassignment_is_redeemed
     from coupon
     left join productcouponassignment
@@ -154,7 +154,7 @@ with coupon as (
         , coupon.couponpayment_name
         , b2b_ecommerce_b2border.b2border_contract_number
         , b2b_ecommerce_b2border.product_id
-        , ecommerce_couponpaymentversion.couponpaymentversion_payment_transaction
+        , ecommerce_couponpaymentversion.couponpaymentversion_payment_transaction 
         , program_runs.programrun_readable_id
         , program_runs.program_title
         , course_runs.courserun_readable_id
@@ -173,25 +173,25 @@ with coupon as (
                 as varchar
             ), '"', ''
         ) as req_reference_number
-        , case
+        , case 
             when couponredemption.couponredemption_id is not null
-                then 'true'
-            else 'false'
+                then 'true' 
+            else 'false' 
         end as coupon_redeemed
-    from b2b_ecommerce_b2border
-    inner join ecommerce_couponpaymentversion
+    from b2b_ecommerce_b2border 
+    inner join ecommerce_couponpaymentversion 
         on ecommerce_couponpaymentversion.couponpaymentversion_id = b2b_ecommerce_b2border.couponpaymentversion_id
-    inner join ecommerce_couponversion
+    inner join ecommerce_couponversion 
         on ecommerce_couponversion.couponpaymentversion_id = ecommerce_couponpaymentversion.couponpaymentversion_id
-    inner join coupon
+    inner join coupon 
         on coupon.coupon_id = ecommerce_couponversion.coupon_id
-    left join couponredemption
+    left join couponredemption 
         on couponredemption.couponversion_id = ecommerce_couponversion.couponversion_id
-    left join ecommerce_order
+    left join ecommerce_order 
         on ecommerce_order.order_id = couponredemption.order_id
-    left join b2b_ecommerce_b2breceipt
+    left join b2b_ecommerce_b2breceipt 
         on b2b_ecommerce_b2breceipt.b2border_id = b2b_ecommerce_b2border.b2border_id
-    left join ecommerce_line
+    left join ecommerce_line 
         on ecommerce_line.order_id = ecommerce_order.order_id
     left join program_runs
         on ecommerce_line.programrun_id = program_runs.programrun_id
@@ -201,12 +201,12 @@ with coupon as (
         on course_runs.course_id = courses.course_id
     left join productversion
         on productversion.productversion_id = b2b_ecommerce_b2border.productversion_id
-    left join users_user
+    left join users_user    
         on ecommerce_order.order_purchaser_user_id = users_user.user_id
 )
 
 
-select
+select 
     reg_coupon_fields.coupon_email
     , reg_coupon_fields.coupon_code
     , reg_coupon_fields.coupon_id
@@ -237,7 +237,7 @@ where reg_coupon_fields.coupon_id not in (select coupon_id from b2b_coupon_field
 
 union distinct
 
-select
+select 
     b2b_coupon_fields.b2border_email as coupon_email
     , b2b_coupon_fields.coupon_code
     , b2b_coupon_fields.coupon_id
@@ -257,8 +257,8 @@ select
     , b2b_coupon_fields.couponpaymentversion_coupon_type
     , b2b_coupon_fields.couponpaymentversion_discount_amount
     , b2b_coupon_fields.coupon_redeemed
-    , b2b_coupon_fields.combined_user_emails
-    , b2b_coupon_fields.user_address_countries
-    , b2b_coupon_fields.order_ids
-    , b2b_coupon_fields.combined_order_state
+    , cast(b2b_coupon_fields.combined_user_emails as bigint) as combined_user_emails
+    , cast(b2b_coupon_fields.user_address_countries as bigint) as user_address_countries
+    , cast(b2b_coupon_fields.order_ids as bigint) as order_ids
+    , cast(b2b_coupon_fields.combined_order_state as bigint) as combined_order_state
 from b2b_coupon_fields

--- a/src/ol_dbt/models/intermediate/mitxpro/int__mitxpro__ecommerce_combinedcoupons.sql
+++ b/src/ol_dbt/models/intermediate/mitxpro/int__mitxpro__ecommerce_combinedcoupons.sql
@@ -64,22 +64,24 @@ with coupon as (
 )
 
 , b2b_ecommerce_b2breceipt as (
-    select *
+    select
+        b2border_id
+        , json_query(b2breceipt_data, 'lax $. req_reference_number' omit quotes) as req_reference_number
     from {{ ref('int__mitxpro__b2becommerce_b2breceipt') }}
 )
 
 , payment_transactions as (
-    select distinct
+    select distinct 
         ecommerce_couponversion.coupon_id
         , ecommerce_couponpaymentversion.couponpaymentversion_payment_transaction
     from ecommerce_couponpaymentversion
-    inner join ecommerce_couponversion
+    inner join ecommerce_couponversion 
         on ecommerce_couponpaymentversion.couponpaymentversion_id = ecommerce_couponversion.couponpaymentversion_id
     where ecommerce_couponpaymentversion.couponpaymentversion_payment_transaction is not null
 )
 
 , latest_couponversion as (
-    select
+    select 
         coupon_id
         , max(couponversion_updated_on) as max_couponversion_updated_on
     from ecommerce_couponversion
@@ -87,38 +89,38 @@ with coupon as (
 )
 
 , reg_coupon_summary as (
-    select
+    select 
         coupon.coupon_id
-        , cast(array_join(array_distinct(array_agg(program_runs.programrun_readable_id)), ', ') as varchar)
+        , cast(array_join(array_distinct(array_agg(program_runs.programrun_readable_id)), ', ') as varchar) 
             as programrun_readable_id
         , cast(array_join(array_distinct(array_agg(program_runs.program_title)), ', ') as varchar) as program_title
-        , cast(array_join(array_distinct(array_agg(course_runs.courserun_readable_id)), ', ') as varchar)
+        , cast(array_join(array_distinct(array_agg(course_runs.courserun_readable_id)), ', ') as varchar) 
             as courserun_readable_id
         , cast(array_join(array_distinct(array_agg(courses.course_title)), ', ') as varchar) as course_title
-        , cast(array_join(array_distinct(array_agg(productversion.productversion_readable_id)), ', ') as varchar)
+        , cast(array_join(array_distinct(array_agg(productversion.productversion_readable_id)), ', ') as varchar) 
             as productversion_readable_id
         , cast(array_join(array_distinct(array_agg(users_user.user_email)), ', ') as varchar) as combined_user_emails
-        , cast(array_join(array_distinct(array_agg(users_user.user_address_country)), ', ') as varchar)
+        , cast(array_join(array_distinct(array_agg(users_user.user_address_country)), ', ') as varchar) 
             as user_address_countries
         , cast(array_join(array_distinct(array_agg(ecommerce_order.order_id)), ', ') as varchar) as order_ids
-        , cast(array_join(array_distinct(array_agg(ecommerce_order.order_state)), ', ') as varchar)
+        , cast(array_join(array_distinct(array_agg(ecommerce_order.order_state)), ', ') as varchar) 
             as combined_order_state
         , case when (count(couponredemption.couponredemption_id) >= 1) then 'true' else 'false' end as coupon_redeemed
-
+        
     from coupon
     left join latest_couponversion
         on coupon.coupon_id = latest_couponversion.coupon_id
-    left join ecommerce_couponversion
-        on
-            latest_couponversion.coupon_id = ecommerce_couponversion.coupon_id
+    left join ecommerce_couponversion 
+        on 
+            latest_couponversion.coupon_id = ecommerce_couponversion.coupon_id 
             and ecommerce_couponversion.couponversion_updated_on = latest_couponversion.max_couponversion_updated_on
     left join couponredemption
         on ecommerce_couponversion.couponversion_id = couponredemption.couponversion_id
-    left join ecommerce_couponpaymentversion
+    left join ecommerce_couponpaymentversion 
         on ecommerce_couponpaymentversion.couponpaymentversion_id = ecommerce_couponversion.couponpaymentversion_id
     left join ecommerce_order
         on ecommerce_order.order_id = couponredemption.order_id
-    left join ecommerce_line
+    left join ecommerce_line 
         on ecommerce_line.order_id = ecommerce_order.order_id
     left join program_runs
         on ecommerce_line.programrun_id = program_runs.programrun_id
@@ -128,22 +130,22 @@ with coupon as (
         on course_runs.course_id = courses.course_id
     left join productversion
         on productversion.productversion_id = ecommerce_line.productversion_id
-    left join users_user
+    left join users_user    
         on ecommerce_order.order_purchaser_user_id = users_user.user_id
     where ecommerce_order.order_state = 'fulfilled' or ecommerce_order.order_state = 'refunded'
-    group by
+    group by 
         coupon.coupon_id
 )
 
 , reg_coupon_fields as (
-    select
+    select 
         productcouponassignment.productcouponassignment_email as coupon_email
         , coupon.coupon_code
         , coupon.coupon_id
         , coupon.coupon_created_on
         , coupon.couponpayment_name
         , productcouponassignment.product_id
-        , payment_transactions.couponpaymentversion_payment_transaction
+        , payment_transactions.couponpaymentversion_payment_transaction 
         , productcouponassignment.productcouponassignment_is_redeemed
     from coupon
     left join productcouponassignment
@@ -153,13 +155,13 @@ with coupon as (
 )
 
 , unassigned_enrollment_codes as (
-    select
+    select 
         coupon.coupon_code
         , coupon.coupon_id
         , coupon.coupon_created_on as coupon_created_on
         , coupon.couponpayment_name
         , b2b_ecommerce_b2border.b2border_contract_number
-        , payment_transactions.couponpaymentversion_payment_transaction
+        , payment_transactions.couponpaymentversion_payment_transaction  
         , program_runs.programrun_readable_id
         , program_runs.program_title
         , course_runs.courserun_readable_id
@@ -177,22 +179,22 @@ with coupon as (
     inner join latest_couponversion
         on coupon.coupon_id = latest_couponversion.coupon_id
     inner join ecommerce_couponversion
-        on
-            latest_couponversion.coupon_id = ecommerce_couponversion.coupon_id
+        on 
+            latest_couponversion.coupon_id = ecommerce_couponversion.coupon_id 
             and ecommerce_couponversion.couponversion_updated_on = latest_couponversion.max_couponversion_updated_on
     inner join ecommerce_couponpaymentversion
-        on ecommerce_couponpaymentversion.couponpaymentversion_id = ecommerce_couponversion.couponpaymentversion_id
-    left join b2b_ecommerce_b2border
+        on ecommerce_couponpaymentversion.couponpaymentversion_id = ecommerce_couponversion.couponpaymentversion_id 
+    left join b2b_ecommerce_b2border 
         on ecommerce_couponpaymentversion.couponpaymentversion_id = b2b_ecommerce_b2border.couponpaymentversion_id
-    left join payment_transactions
-        on payment_transactions.coupon_id = coupon.coupon_id
+    left join payment_transactions 
+        on payment_transactions.coupon_id = coupon.coupon_id   
     left join couponredemption
         on couponredemption.couponversion_id = ecommerce_couponversion.couponversion_id
-    left join ecommerce_order
+    left join ecommerce_order 
         on couponredemption.order_id = ecommerce_order.order_id
-    left join users_user
-        on users_user.user_id = ecommerce_order.order_purchaser_user_id
-    left join ecommerce_line
+    left join users_user 
+        on users_user.user_id = ecommerce_order.order_purchaser_user_id 
+    left join ecommerce_line 
         on ecommerce_line.order_id = ecommerce_order.order_id
     left join program_runs
         on ecommerce_line.programrun_id = program_runs.programrun_id
@@ -202,19 +204,19 @@ with coupon as (
         on course_runs.course_id = courses.course_id
     left join productversion
         on productversion.productversion_id = ecommerce_line.productversion_id
-    where
-        ecommerce_couponpaymentversion.couponpaymentversion_coupon_type = 'single-use'
-        and ecommerce_couponpaymentversion.couponpaymentversion_discount_amount = 1.0000
+    where 
+        ecommerce_couponpaymentversion.couponpaymentversion_coupon_type = 'single-use' 
+        and ecommerce_couponpaymentversion.couponpaymentversion_discount_amount = 1.0000 
         and coupon.coupon_id not in (
             select coupon_id
-            from productcouponassignment
+            from productcouponassignment 
         )
         and not exists (
             select b2b_ecommerce_b2border.couponpaymentversion_id
             from b2b_ecommerce_b2border
-            where
+            where 
                 b2b_ecommerce_b2border.couponpaymentversion_id = ecommerce_couponpaymentversion.couponpaymentversion_id
-        )
+        ) 
 )
 
 , b2b_coupon_fields as (
@@ -226,7 +228,7 @@ with coupon as (
         , coupon.couponpayment_name
         , b2b_ecommerce_b2border.b2border_contract_number
         , b2b_ecommerce_b2border.product_id
-        , ecommerce_couponpaymentversion.couponpaymentversion_payment_transaction
+        , ecommerce_couponpaymentversion.couponpaymentversion_payment_transaction 
         , program_runs.programrun_readable_id
         , program_runs.program_title
         , course_runs.courserun_readable_id
@@ -243,25 +245,25 @@ with coupon as (
                 as varchar
             ), '"', ''
         ) as req_reference_number
-        , case
+        , case 
             when couponredemption.couponredemption_id is not null
-                then 'true'
-            else 'false'
+                then 'true' 
+            else 'false' 
         end as coupon_redeemed
-    from b2b_ecommerce_b2border
-    inner join ecommerce_couponpaymentversion
+    from b2b_ecommerce_b2border 
+    inner join ecommerce_couponpaymentversion 
         on ecommerce_couponpaymentversion.couponpaymentversion_id = b2b_ecommerce_b2border.couponpaymentversion_id
-    inner join ecommerce_couponversion
+    inner join ecommerce_couponversion 
         on ecommerce_couponversion.couponpaymentversion_id = ecommerce_couponpaymentversion.couponpaymentversion_id
-    inner join coupon
+    inner join coupon 
         on coupon.coupon_id = ecommerce_couponversion.coupon_id
-    left join couponredemption
+    left join couponredemption 
         on couponredemption.couponversion_id = ecommerce_couponversion.couponversion_id
-    left join ecommerce_order
+    left join ecommerce_order 
         on ecommerce_order.order_id = couponredemption.order_id
-    left join b2b_ecommerce_b2breceipt
+    left join b2b_ecommerce_b2breceipt 
         on b2b_ecommerce_b2breceipt.b2border_id = b2b_ecommerce_b2border.b2border_id
-    left join ecommerce_line
+    left join ecommerce_line 
         on ecommerce_line.order_id = ecommerce_order.order_id
     left join program_runs
         on ecommerce_line.programrun_id = program_runs.programrun_id
@@ -271,12 +273,12 @@ with coupon as (
         on course_runs.course_id = courses.course_id
     left join productversion
         on productversion.productversion_id = b2b_ecommerce_b2border.productversion_id
-    left join users_user
+    left join users_user    
         on ecommerce_order.order_purchaser_user_id = users_user.user_id
 )
 
 
-select
+select 
     reg_coupon_fields.coupon_email
     , reg_coupon_fields.coupon_code
     , reg_coupon_fields.coupon_id
@@ -303,7 +305,7 @@ where reg_coupon_fields.coupon_id not in (select coupon_id from b2b_coupon_field
 
 union distinct
 
-select
+select 
     b2b_coupon_fields.b2border_email as coupon_email
     , b2b_coupon_fields.coupon_code
     , b2b_coupon_fields.coupon_id
@@ -327,7 +329,7 @@ from b2b_coupon_fields
 
 union distinct
 
-select
+select 
     coupon_email
     , coupon_code
     , coupon_id
@@ -335,7 +337,7 @@ select
     , couponpayment_name
     , b2border_contract_number
     , product_id
-    , couponpaymentversion_payment_transaction
+    , couponpaymentversion_payment_transaction  
     , req_reference_number
     , programrun_readable_id
     , program_title
@@ -348,6 +350,5 @@ select
     , cast(order_ids as varchar) as order_ids
     , combined_order_state
 from unassigned_enrollment_codes
-where
-    coupon_id not in (select coupon_id from reg_coupon_fields)
-    and coupon_id not in (select coupon_id from b2b_coupon_fields)
+where coupon_id not in (select coupon_id from reg_coupon_fields)
+and coupon_id not in (select coupon_id from b2b_coupon_fields)

--- a/src/ol_dbt/models/intermediate/mitxpro/int__mitxpro__ecommerce_combinedcoupons.sql
+++ b/src/ol_dbt/models/intermediate/mitxpro/int__mitxpro__ecommerce_combinedcoupons.sql
@@ -69,17 +69,17 @@ with coupon as (
 )
 
 , payment_transactions as (
-    select distinct 
+    select distinct
         ecommerce_couponversion.coupon_id
         , ecommerce_couponpaymentversion.couponpaymentversion_payment_transaction
     from ecommerce_couponpaymentversion
-    inner join ecommerce_couponversion 
+    inner join ecommerce_couponversion
         on ecommerce_couponpaymentversion.couponpaymentversion_id = ecommerce_couponversion.couponpaymentversion_id
     where ecommerce_couponpaymentversion.couponpaymentversion_payment_transaction is not null
 )
 
 , latest_couponversion as (
-    select 
+    select
         coupon_id
         , max(couponversion_updated_on) as max_couponversion_updated_on
     from ecommerce_couponversion
@@ -87,38 +87,38 @@ with coupon as (
 )
 
 , reg_coupon_summary as (
-    select 
+    select
         coupon.coupon_id
-        , cast(array_join(array_distinct(array_agg(program_runs.programrun_readable_id)), ', ') as varchar) 
+        , cast(array_join(array_distinct(array_agg(program_runs.programrun_readable_id)), ', ') as varchar)
             as programrun_readable_id
         , cast(array_join(array_distinct(array_agg(program_runs.program_title)), ', ') as varchar) as program_title
-        , cast(array_join(array_distinct(array_agg(course_runs.courserun_readable_id)), ', ') as varchar) 
+        , cast(array_join(array_distinct(array_agg(course_runs.courserun_readable_id)), ', ') as varchar)
             as courserun_readable_id
         , cast(array_join(array_distinct(array_agg(courses.course_title)), ', ') as varchar) as course_title
-        , cast(array_join(array_distinct(array_agg(productversion.productversion_readable_id)), ', ') as varchar) 
+        , cast(array_join(array_distinct(array_agg(productversion.productversion_readable_id)), ', ') as varchar)
             as productversion_readable_id
         , cast(array_join(array_distinct(array_agg(users_user.user_email)), ', ') as varchar) as combined_user_emails
-        , cast(array_join(array_distinct(array_agg(users_user.user_address_country)), ', ') as varchar) 
+        , cast(array_join(array_distinct(array_agg(users_user.user_address_country)), ', ') as varchar)
             as user_address_countries
         , cast(array_join(array_distinct(array_agg(ecommerce_order.order_id)), ', ') as varchar) as order_ids
-        , cast(array_join(array_distinct(array_agg(ecommerce_order.order_state)), ', ') as varchar) 
+        , cast(array_join(array_distinct(array_agg(ecommerce_order.order_state)), ', ') as varchar)
             as combined_order_state
         , case when (count(couponredemption.couponredemption_id) >= 1) then 'true' else 'false' end as coupon_redeemed
-        
+
     from coupon
     left join latest_couponversion
         on coupon.coupon_id = latest_couponversion.coupon_id
-    left join ecommerce_couponversion 
-        on 
-            latest_couponversion.coupon_id = ecommerce_couponversion.coupon_id 
+    left join ecommerce_couponversion
+        on
+            latest_couponversion.coupon_id = ecommerce_couponversion.coupon_id
             and ecommerce_couponversion.couponversion_updated_on = latest_couponversion.max_couponversion_updated_on
     left join couponredemption
         on ecommerce_couponversion.couponversion_id = couponredemption.couponversion_id
-    left join ecommerce_couponpaymentversion 
+    left join ecommerce_couponpaymentversion
         on ecommerce_couponpaymentversion.couponpaymentversion_id = ecommerce_couponversion.couponpaymentversion_id
     left join ecommerce_order
         on ecommerce_order.order_id = couponredemption.order_id
-    left join ecommerce_line 
+    left join ecommerce_line
         on ecommerce_line.order_id = ecommerce_order.order_id
     left join program_runs
         on ecommerce_line.programrun_id = program_runs.programrun_id
@@ -128,22 +128,22 @@ with coupon as (
         on course_runs.course_id = courses.course_id
     left join productversion
         on productversion.productversion_id = ecommerce_line.productversion_id
-    left join users_user    
+    left join users_user
         on ecommerce_order.order_purchaser_user_id = users_user.user_id
     where ecommerce_order.order_state = 'fulfilled' or ecommerce_order.order_state = 'refunded'
-    group by 
+    group by
         coupon.coupon_id
 )
 
 , reg_coupon_fields as (
-    select 
+    select
         productcouponassignment.productcouponassignment_email as coupon_email
         , coupon.coupon_code
         , coupon.coupon_id
         , coupon.coupon_created_on
         , coupon.couponpayment_name
         , productcouponassignment.product_id
-        , payment_transactions.couponpaymentversion_payment_transaction 
+        , payment_transactions.couponpaymentversion_payment_transaction
         , productcouponassignment.productcouponassignment_is_redeemed
     from coupon
     left join productcouponassignment
@@ -153,13 +153,13 @@ with coupon as (
 )
 
 , unassigned_enrollment_codes as (
-    select 
+    select
         coupon.coupon_code
         , coupon.coupon_id
         , coupon.coupon_created_on as coupon_created_on
         , coupon.couponpayment_name
         , b2b_ecommerce_b2border.b2border_contract_number
-        , payment_transactions.couponpaymentversion_payment_transaction  
+        , payment_transactions.couponpaymentversion_payment_transaction
         , program_runs.programrun_readable_id
         , program_runs.program_title
         , course_runs.courserun_readable_id
@@ -177,22 +177,22 @@ with coupon as (
     inner join latest_couponversion
         on coupon.coupon_id = latest_couponversion.coupon_id
     inner join ecommerce_couponversion
-        on 
-            latest_couponversion.coupon_id = ecommerce_couponversion.coupon_id 
+        on
+            latest_couponversion.coupon_id = ecommerce_couponversion.coupon_id
             and ecommerce_couponversion.couponversion_updated_on = latest_couponversion.max_couponversion_updated_on
     inner join ecommerce_couponpaymentversion
-        on ecommerce_couponpaymentversion.couponpaymentversion_id = ecommerce_couponversion.couponpaymentversion_id 
-    left join b2b_ecommerce_b2border 
+        on ecommerce_couponpaymentversion.couponpaymentversion_id = ecommerce_couponversion.couponpaymentversion_id
+    left join b2b_ecommerce_b2border
         on ecommerce_couponpaymentversion.couponpaymentversion_id = b2b_ecommerce_b2border.couponpaymentversion_id
-    left join payment_transactions 
-        on payment_transactions.coupon_id = coupon.coupon_id   
+    left join payment_transactions
+        on payment_transactions.coupon_id = coupon.coupon_id
     left join ecommerce_couponredemption
         on ecommerce_couponredemption.couponversion_id = ecommerce_couponversion.couponversion_id
-    left join ecommerce_order 
+    left join ecommerce_order
         on ecommerce_couponredemption.order_id = ecommerce_order.order_id
-    left join users_user 
-        on users_user.user_id = ecommerce_order.order_purchaser_user_id 
-    left join ecommerce_line 
+    left join users_user
+        on users_user.user_id = ecommerce_order.order_purchaser_user_id
+    left join ecommerce_line
         on ecommerce_line.order_id = ecommerce_order.order_id
     left join program_runs
         on ecommerce_line.programrun_id = program_runs.programrun_id
@@ -202,19 +202,19 @@ with coupon as (
         on course_runs.course_id = courses.course_id
     left join productversion
         on productversion.productversion_id = ecommerce_line.productversion_id
-    where 
-        ecommerce_couponpaymentversion.couponpaymentversion_coupon_type = 'single-use' 
-        and ecommerce_couponpaymentversion.couponpaymentversion_discount_amount = 1.0000 
+    where
+        ecommerce_couponpaymentversion.couponpaymentversion_coupon_type = 'single-use'
+        and ecommerce_couponpaymentversion.couponpaymentversion_discount_amount = 1.0000
         and coupon.coupon_id not in (
             select coupon_id
-            from ecommerce_productcouponassignment 
+            from ecommerce_productcouponassignment
         )
         and not exists (
             select b2b_ecommerce_b2border.couponpaymentversion_id
             from b2b_ecommerce_b2border
-            where 
+            where
                 b2b_ecommerce_b2border.couponpaymentversion_id = ecommerce_couponpaymentversion.couponpaymentversion_id
-        ) 
+        )
 )
 
 , b2b_coupon_fields as (
@@ -226,7 +226,7 @@ with coupon as (
         , coupon.couponpayment_name
         , b2b_ecommerce_b2border.b2border_contract_number
         , b2b_ecommerce_b2border.product_id
-        , ecommerce_couponpaymentversion.couponpaymentversion_payment_transaction 
+        , ecommerce_couponpaymentversion.couponpaymentversion_payment_transaction
         , program_runs.programrun_readable_id
         , program_runs.program_title
         , course_runs.courserun_readable_id
@@ -243,25 +243,25 @@ with coupon as (
                 as varchar
             ), '"', ''
         ) as req_reference_number
-        , case 
+        , case
             when couponredemption.couponredemption_id is not null
-                then 'true' 
-            else 'false' 
+                then 'true'
+            else 'false'
         end as coupon_redeemed
-    from b2b_ecommerce_b2border 
-    inner join ecommerce_couponpaymentversion 
+    from b2b_ecommerce_b2border
+    inner join ecommerce_couponpaymentversion
         on ecommerce_couponpaymentversion.couponpaymentversion_id = b2b_ecommerce_b2border.couponpaymentversion_id
-    inner join ecommerce_couponversion 
+    inner join ecommerce_couponversion
         on ecommerce_couponversion.couponpaymentversion_id = ecommerce_couponpaymentversion.couponpaymentversion_id
-    inner join coupon 
+    inner join coupon
         on coupon.coupon_id = ecommerce_couponversion.coupon_id
-    left join couponredemption 
+    left join couponredemption
         on couponredemption.couponversion_id = ecommerce_couponversion.couponversion_id
-    left join ecommerce_order 
+    left join ecommerce_order
         on ecommerce_order.order_id = couponredemption.order_id
-    left join b2b_ecommerce_b2breceipt 
+    left join b2b_ecommerce_b2breceipt
         on b2b_ecommerce_b2breceipt.b2border_id = b2b_ecommerce_b2border.b2border_id
-    left join ecommerce_line 
+    left join ecommerce_line
         on ecommerce_line.order_id = ecommerce_order.order_id
     left join program_runs
         on ecommerce_line.programrun_id = program_runs.programrun_id
@@ -271,12 +271,12 @@ with coupon as (
         on course_runs.course_id = courses.course_id
     left join productversion
         on productversion.productversion_id = b2b_ecommerce_b2border.productversion_id
-    left join users_user    
+    left join users_user
         on ecommerce_order.order_purchaser_user_id = users_user.user_id
 )
 
 
-select 
+select
     reg_coupon_fields.coupon_email
     , reg_coupon_fields.coupon_code
     , reg_coupon_fields.coupon_id
@@ -303,7 +303,7 @@ where reg_coupon_fields.coupon_id not in (select coupon_id from b2b_coupon_field
 
 union distinct
 
-select 
+select
     b2b_coupon_fields.b2border_email as coupon_email
     , b2b_coupon_fields.coupon_code
     , b2b_coupon_fields.coupon_id
@@ -327,7 +327,7 @@ from b2b_coupon_fields
 
 union distinct
 
-select 
+select
     coupon_email
     , coupon_code
     , coupon_id
@@ -335,7 +335,7 @@ select
     , couponpayment_name
     , b2border_contract_number
     , product_id
-    , couponpaymentversion_payment_transaction  
+    , couponpaymentversion_payment_transaction
     , req_reference_number
     , programrun_readable_id
     , program_title

--- a/src/ol_dbt/models/intermediate/mitxpro/int__mitxpro__ecommerce_combinedcoupons.sql
+++ b/src/ol_dbt/models/intermediate/mitxpro/int__mitxpro__ecommerce_combinedcoupons.sql
@@ -69,17 +69,17 @@ with coupon as (
 )
 
 , payment_transactions as (
-    select distinct 
+    select distinct
         ecommerce_couponversion.coupon_id
         , ecommerce_couponpaymentversion.couponpaymentversion_payment_transaction
     from ecommerce_couponpaymentversion
-    inner join ecommerce_couponversion 
+    inner join ecommerce_couponversion
         on ecommerce_couponpaymentversion.couponpaymentversion_id = ecommerce_couponversion.couponpaymentversion_id
     where ecommerce_couponpaymentversion.couponpaymentversion_payment_transaction is not null
 )
 
 , latest_couponversion as (
-    select 
+    select
         coupon_id
         , max(couponversion_updated_on) as max_couponversion_updated_on
     from ecommerce_couponversion
@@ -87,38 +87,38 @@ with coupon as (
 )
 
 , reg_coupon_summary as (
-    select 
+    select
         coupon.coupon_id
-        , cast(array_join(array_distinct(array_agg(program_runs.programrun_readable_id)), ', ') as varchar) 
+        , cast(array_join(array_distinct(array_agg(program_runs.programrun_readable_id)), ', ') as varchar)
             as programrun_readable_id
         , cast(array_join(array_distinct(array_agg(program_runs.program_title)), ', ') as varchar) as program_title
-        , cast(array_join(array_distinct(array_agg(course_runs.courserun_readable_id)), ', ') as varchar) 
+        , cast(array_join(array_distinct(array_agg(course_runs.courserun_readable_id)), ', ') as varchar)
             as courserun_readable_id
         , cast(array_join(array_distinct(array_agg(courses.course_title)), ', ') as varchar) as course_title
-        , cast(array_join(array_distinct(array_agg(productversion.productversion_readable_id)), ', ') as varchar) 
+        , cast(array_join(array_distinct(array_agg(productversion.productversion_readable_id)), ', ') as varchar)
             as productversion_readable_id
         , cast(array_join(array_distinct(array_agg(users_user.user_email)), ', ') as varchar) as combined_user_emails
-        , cast(array_join(array_distinct(array_agg(users_user.user_address_country)), ', ') as varchar) 
+        , cast(array_join(array_distinct(array_agg(users_user.user_address_country)), ', ') as varchar)
             as user_address_countries
         , cast(array_join(array_distinct(array_agg(ecommerce_order.order_id)), ', ') as varchar) as order_ids
-        , cast(array_join(array_distinct(array_agg(ecommerce_order.order_state)), ', ') as varchar) 
+        , cast(array_join(array_distinct(array_agg(ecommerce_order.order_state)), ', ') as varchar)
             as combined_order_state
         , case when (count(couponredemption.couponredemption_id) >= 1) then 'true' else 'false' end as coupon_redeemed
-        
+
     from coupon
     left join latest_couponversion
         on coupon.coupon_id = latest_couponversion.coupon_id
-    left join ecommerce_couponversion 
-        on 
-            latest_couponversion.coupon_id = ecommerce_couponversion.coupon_id 
+    left join ecommerce_couponversion
+        on
+            latest_couponversion.coupon_id = ecommerce_couponversion.coupon_id
             and ecommerce_couponversion.couponversion_updated_on = latest_couponversion.max_couponversion_updated_on
     left join couponredemption
         on ecommerce_couponversion.couponversion_id = couponredemption.couponversion_id
-    left join ecommerce_couponpaymentversion 
+    left join ecommerce_couponpaymentversion
         on ecommerce_couponpaymentversion.couponpaymentversion_id = ecommerce_couponversion.couponpaymentversion_id
     left join ecommerce_order
         on ecommerce_order.order_id = couponredemption.order_id
-    left join ecommerce_line 
+    left join ecommerce_line
         on ecommerce_line.order_id = ecommerce_order.order_id
     left join program_runs
         on ecommerce_line.programrun_id = program_runs.programrun_id
@@ -128,22 +128,22 @@ with coupon as (
         on course_runs.course_id = courses.course_id
     left join productversion
         on productversion.productversion_id = ecommerce_line.productversion_id
-    left join users_user    
+    left join users_user
         on ecommerce_order.order_purchaser_user_id = users_user.user_id
     where ecommerce_order.order_state = 'fulfilled' or ecommerce_order.order_state = 'refunded'
-    group by 
+    group by
         coupon.coupon_id
 )
 
 , reg_coupon_fields as (
-    select 
+    select
         productcouponassignment.productcouponassignment_email as coupon_email
         , coupon.coupon_code
         , coupon.coupon_id
         , coupon.coupon_created_on
         , coupon.couponpayment_name
         , productcouponassignment.product_id
-        , payment_transactions.couponpaymentversion_payment_transaction 
+        , payment_transactions.couponpaymentversion_payment_transaction
         , productcouponassignment.productcouponassignment_is_redeemed
     from coupon
     left join productcouponassignment
@@ -153,13 +153,13 @@ with coupon as (
 )
 
 , unassigned_enrollment_codes as (
-    select 
+    select
         coupon.coupon_code
         , coupon.coupon_id
         , coupon.coupon_created_on as coupon_created_on
         , coupon.couponpayment_name
         , b2b_ecommerce_b2border.b2border_contract_number
-        , payment_transactions.couponpaymentversion_payment_transaction  
+        , payment_transactions.couponpaymentversion_payment_transaction
         , program_runs.programrun_readable_id
         , program_runs.program_title
         , course_runs.courserun_readable_id
@@ -177,22 +177,22 @@ with coupon as (
     inner join latest_couponversion
         on coupon.coupon_id = latest_couponversion.coupon_id
     inner join ecommerce_couponversion
-        on 
-            latest_couponversion.coupon_id = ecommerce_couponversion.coupon_id 
+        on
+            latest_couponversion.coupon_id = ecommerce_couponversion.coupon_id
             and ecommerce_couponversion.couponversion_updated_on = latest_couponversion.max_couponversion_updated_on
     inner join ecommerce_couponpaymentversion
-        on ecommerce_couponpaymentversion.couponpaymentversion_id = ecommerce_couponversion.couponpaymentversion_id 
-    left join b2b_ecommerce_b2border 
+        on ecommerce_couponpaymentversion.couponpaymentversion_id = ecommerce_couponversion.couponpaymentversion_id
+    left join b2b_ecommerce_b2border
         on ecommerce_couponpaymentversion.couponpaymentversion_id = b2b_ecommerce_b2border.couponpaymentversion_id
-    left join payment_transactions 
-        on payment_transactions.coupon_id = coupon.coupon_id   
+    left join payment_transactions
+        on payment_transactions.coupon_id = coupon.coupon_id
     left join couponredemption
         on couponredemption.couponversion_id = ecommerce_couponversion.couponversion_id
-    left join ecommerce_order 
+    left join ecommerce_order
         on couponredemption.order_id = ecommerce_order.order_id
-    left join users_user 
-        on users_user.user_id = ecommerce_order.order_purchaser_user_id 
-    left join ecommerce_line 
+    left join users_user
+        on users_user.user_id = ecommerce_order.order_purchaser_user_id
+    left join ecommerce_line
         on ecommerce_line.order_id = ecommerce_order.order_id
     left join program_runs
         on ecommerce_line.programrun_id = program_runs.programrun_id
@@ -202,19 +202,19 @@ with coupon as (
         on course_runs.course_id = courses.course_id
     left join productversion
         on productversion.productversion_id = ecommerce_line.productversion_id
-    where 
-        ecommerce_couponpaymentversion.couponpaymentversion_coupon_type = 'single-use' 
-        and ecommerce_couponpaymentversion.couponpaymentversion_discount_amount = 1.0000 
+    where
+        ecommerce_couponpaymentversion.couponpaymentversion_coupon_type = 'single-use'
+        and ecommerce_couponpaymentversion.couponpaymentversion_discount_amount = 1.0000
         and coupon.coupon_id not in (
             select coupon_id
-            from productcouponassignment 
+            from productcouponassignment
         )
         and not exists (
             select b2b_ecommerce_b2border.couponpaymentversion_id
             from b2b_ecommerce_b2border
-            where 
+            where
                 b2b_ecommerce_b2border.couponpaymentversion_id = ecommerce_couponpaymentversion.couponpaymentversion_id
-        ) 
+        )
 )
 
 , b2b_coupon_fields as (
@@ -226,7 +226,7 @@ with coupon as (
         , coupon.couponpayment_name
         , b2b_ecommerce_b2border.b2border_contract_number
         , b2b_ecommerce_b2border.product_id
-        , ecommerce_couponpaymentversion.couponpaymentversion_payment_transaction 
+        , ecommerce_couponpaymentversion.couponpaymentversion_payment_transaction
         , program_runs.programrun_readable_id
         , program_runs.program_title
         , course_runs.courserun_readable_id
@@ -243,25 +243,25 @@ with coupon as (
                 as varchar
             ), '"', ''
         ) as req_reference_number
-        , case 
+        , case
             when couponredemption.couponredemption_id is not null
-                then 'true' 
-            else 'false' 
+                then 'true'
+            else 'false'
         end as coupon_redeemed
-    from b2b_ecommerce_b2border 
-    inner join ecommerce_couponpaymentversion 
+    from b2b_ecommerce_b2border
+    inner join ecommerce_couponpaymentversion
         on ecommerce_couponpaymentversion.couponpaymentversion_id = b2b_ecommerce_b2border.couponpaymentversion_id
-    inner join ecommerce_couponversion 
+    inner join ecommerce_couponversion
         on ecommerce_couponversion.couponpaymentversion_id = ecommerce_couponpaymentversion.couponpaymentversion_id
-    inner join coupon 
+    inner join coupon
         on coupon.coupon_id = ecommerce_couponversion.coupon_id
-    left join couponredemption 
+    left join couponredemption
         on couponredemption.couponversion_id = ecommerce_couponversion.couponversion_id
-    left join ecommerce_order 
+    left join ecommerce_order
         on ecommerce_order.order_id = couponredemption.order_id
-    left join b2b_ecommerce_b2breceipt 
+    left join b2b_ecommerce_b2breceipt
         on b2b_ecommerce_b2breceipt.b2border_id = b2b_ecommerce_b2border.b2border_id
-    left join ecommerce_line 
+    left join ecommerce_line
         on ecommerce_line.order_id = ecommerce_order.order_id
     left join program_runs
         on ecommerce_line.programrun_id = program_runs.programrun_id
@@ -271,12 +271,12 @@ with coupon as (
         on course_runs.course_id = courses.course_id
     left join productversion
         on productversion.productversion_id = b2b_ecommerce_b2border.productversion_id
-    left join users_user    
+    left join users_user
         on ecommerce_order.order_purchaser_user_id = users_user.user_id
 )
 
 
-select 
+select
     reg_coupon_fields.coupon_email
     , reg_coupon_fields.coupon_code
     , reg_coupon_fields.coupon_id
@@ -303,7 +303,7 @@ where reg_coupon_fields.coupon_id not in (select coupon_id from b2b_coupon_field
 
 union distinct
 
-select 
+select
     b2b_coupon_fields.b2border_email as coupon_email
     , b2b_coupon_fields.coupon_code
     , b2b_coupon_fields.coupon_id
@@ -327,7 +327,7 @@ from b2b_coupon_fields
 
 union distinct
 
-select 
+select
     coupon_email
     , coupon_code
     , coupon_id
@@ -335,7 +335,7 @@ select
     , couponpayment_name
     , b2border_contract_number
     , product_id
-    , couponpaymentversion_payment_transaction  
+    , couponpaymentversion_payment_transaction
     , req_reference_number
     , programrun_readable_id
     , program_title
@@ -348,5 +348,6 @@ select
     , cast(order_ids as varchar) as order_ids
     , combined_order_state
 from unassigned_enrollment_codes
-where coupon_id not in (select coupon_id from reg_coupon_fields)
-and coupon_id not in (select coupon_id from b2b_coupon_fields)
+where
+    coupon_id not in (select coupon_id from reg_coupon_fields)
+    and coupon_id not in (select coupon_id from b2b_coupon_fields)

--- a/src/ol_dbt/models/intermediate/mitxpro/int__mitxpro__ecommerce_combinedcoupons.sql
+++ b/src/ol_dbt/models/intermediate/mitxpro/int__mitxpro__ecommerce_combinedcoupons.sql
@@ -71,17 +71,17 @@ with coupon as (
 )
 
 , payment_transactions as (
-    select distinct
+    select distinct 
         ecommerce_couponversion.coupon_id
-        , max(ecommerce_couponpaymentversion.couponpaymentversion_payment_transaction)
+        , ecommerce_couponpaymentversion.couponpaymentversion_payment_transaction
     from ecommerce_couponpaymentversion
-    inner join ecommerce_couponversion
+    inner join ecommerce_couponversion 
         on ecommerce_couponpaymentversion.couponpaymentversion_id = ecommerce_couponversion.couponpaymentversion_id
     where ecommerce_couponpaymentversion.couponpaymentversion_payment_transaction is not null
 )
 
 , latest_couponversion as (
-    select
+    select 
         coupon_id
         , max(couponversion_updated_on) as max_couponversion_updated_on
     from ecommerce_couponversion
@@ -89,38 +89,38 @@ with coupon as (
 )
 
 , reg_coupon_summary as (
-    select
+    select 
         coupon.coupon_id
-        , cast(array_join(array_distinct(array_agg(program_runs.programrun_readable_id)), ', ') as varchar)
+        , cast(array_join(array_distinct(array_agg(program_runs.programrun_readable_id)), ', ') as varchar) 
             as programrun_readable_id
         , cast(array_join(array_distinct(array_agg(program_runs.program_title)), ', ') as varchar) as program_title
-        , cast(array_join(array_distinct(array_agg(course_runs.courserun_readable_id)), ', ') as varchar)
+        , cast(array_join(array_distinct(array_agg(course_runs.courserun_readable_id)), ', ') as varchar) 
             as courserun_readable_id
         , cast(array_join(array_distinct(array_agg(courses.course_title)), ', ') as varchar) as course_title
-        , cast(array_join(array_distinct(array_agg(productversion.productversion_readable_id)), ', ') as varchar)
+        , cast(array_join(array_distinct(array_agg(productversion.productversion_readable_id)), ', ') as varchar) 
             as productversion_readable_id
         , cast(array_join(array_distinct(array_agg(users_user.user_email)), ', ') as varchar) as combined_user_emails
-        , cast(array_join(array_distinct(array_agg(users_user.user_address_country)), ', ') as varchar)
+        , cast(array_join(array_distinct(array_agg(users_user.user_address_country)), ', ') as varchar) 
             as user_address_countries
         , cast(array_join(array_distinct(array_agg(ecommerce_order.order_id)), ', ') as varchar) as order_ids
-        , cast(array_join(array_distinct(array_agg(ecommerce_order.order_state)), ', ') as varchar)
+        , cast(array_join(array_distinct(array_agg(ecommerce_order.order_state)), ', ') as varchar) 
             as combined_order_state
         , case when (count(couponredemption.couponredemption_id) >= 1) then 'true' else 'false' end as coupon_redeemed
-
+        
     from coupon
     left join latest_couponversion
         on coupon.coupon_id = latest_couponversion.coupon_id
-    left join ecommerce_couponversion
-        on
-            latest_couponversion.coupon_id = ecommerce_couponversion.coupon_id
+    left join ecommerce_couponversion 
+        on 
+            latest_couponversion.coupon_id = ecommerce_couponversion.coupon_id 
             and ecommerce_couponversion.couponversion_updated_on = latest_couponversion.max_couponversion_updated_on
     left join couponredemption
         on ecommerce_couponversion.couponversion_id = couponredemption.couponversion_id
-    left join ecommerce_couponpaymentversion
+    left join ecommerce_couponpaymentversion 
         on ecommerce_couponpaymentversion.couponpaymentversion_id = ecommerce_couponversion.couponpaymentversion_id
     left join ecommerce_order
         on ecommerce_order.order_id = couponredemption.order_id
-    left join ecommerce_line
+    left join ecommerce_line 
         on ecommerce_line.order_id = ecommerce_order.order_id
     left join program_runs
         on ecommerce_line.programrun_id = program_runs.programrun_id
@@ -130,22 +130,22 @@ with coupon as (
         on course_runs.course_id = courses.course_id
     left join productversion
         on productversion.productversion_id = ecommerce_line.productversion_id
-    left join users_user
+    left join users_user    
         on ecommerce_order.order_purchaser_user_id = users_user.user_id
     where ecommerce_order.order_state = 'fulfilled' or ecommerce_order.order_state = 'refunded'
-    group by
+    group by 
         coupon.coupon_id
 )
 
 , reg_coupon_fields as (
-    select
+    select 
         productcouponassignment.productcouponassignment_email as coupon_email
         , coupon.coupon_code
         , coupon.coupon_id
         , coupon.coupon_created_on
         , coupon.couponpayment_name
         , productcouponassignment.product_id
-        , payment_transactions.couponpaymentversion_payment_transaction
+        , payment_transactions.couponpaymentversion_payment_transaction 
         , productcouponassignment.productcouponassignment_is_redeemed
     from coupon
     left join productcouponassignment
@@ -155,13 +155,13 @@ with coupon as (
 )
 
 , unassigned_enrollment_codes as (
-    select
+    select 
         coupon.coupon_code
         , coupon.coupon_id
         , coupon.coupon_created_on as coupon_created_on
         , coupon.couponpayment_name
         , b2b_ecommerce_b2border.b2border_contract_number
-        , payment_transactions.couponpaymentversion_payment_transaction
+        , payment_transactions.couponpaymentversion_payment_transaction  
         , program_runs.programrun_readable_id
         , program_runs.program_title
         , course_runs.courserun_readable_id
@@ -179,22 +179,22 @@ with coupon as (
     inner join latest_couponversion
         on coupon.coupon_id = latest_couponversion.coupon_id
     inner join ecommerce_couponversion
-        on
-            latest_couponversion.coupon_id = ecommerce_couponversion.coupon_id
+        on 
+            latest_couponversion.coupon_id = ecommerce_couponversion.coupon_id 
             and ecommerce_couponversion.couponversion_updated_on = latest_couponversion.max_couponversion_updated_on
     inner join ecommerce_couponpaymentversion
-        on ecommerce_couponpaymentversion.couponpaymentversion_id = ecommerce_couponversion.couponpaymentversion_id
-    left join b2b_ecommerce_b2border
+        on ecommerce_couponpaymentversion.couponpaymentversion_id = ecommerce_couponversion.couponpaymentversion_id 
+    left join b2b_ecommerce_b2border 
         on ecommerce_couponpaymentversion.couponpaymentversion_id = b2b_ecommerce_b2border.couponpaymentversion_id
-    left join payment_transactions
-        on payment_transactions.coupon_id = coupon.coupon_id
+    left join payment_transactions 
+        on payment_transactions.coupon_id = coupon.coupon_id   
     left join couponredemption
         on couponredemption.couponversion_id = ecommerce_couponversion.couponversion_id
-    left join ecommerce_order
+    left join ecommerce_order 
         on couponredemption.order_id = ecommerce_order.order_id
-    left join users_user
-        on users_user.user_id = ecommerce_order.order_purchaser_user_id
-    left join ecommerce_line
+    left join users_user 
+        on users_user.user_id = ecommerce_order.order_purchaser_user_id 
+    left join ecommerce_line 
         on ecommerce_line.order_id = ecommerce_order.order_id
     left join program_runs
         on ecommerce_line.programrun_id = program_runs.programrun_id
@@ -204,19 +204,19 @@ with coupon as (
         on course_runs.course_id = courses.course_id
     left join productversion
         on productversion.productversion_id = ecommerce_line.productversion_id
-    where
-        ecommerce_couponpaymentversion.couponpaymentversion_coupon_type = 'single-use'
-        and ecommerce_couponpaymentversion.couponpaymentversion_discount_amount = 1.0000
+    where 
+        ecommerce_couponpaymentversion.couponpaymentversion_coupon_type = 'single-use' 
+        and ecommerce_couponpaymentversion.couponpaymentversion_discount_amount = 1.0000 
         and coupon.coupon_id not in (
             select coupon_id
-            from productcouponassignment
+            from productcouponassignment 
         )
         and not exists (
             select b2b_ecommerce_b2border.couponpaymentversion_id
             from b2b_ecommerce_b2border
-            where
+            where 
                 b2b_ecommerce_b2border.couponpaymentversion_id = ecommerce_couponpaymentversion.couponpaymentversion_id
-        )
+        ) 
 )
 
 , b2b_coupon_fields as (
@@ -228,7 +228,7 @@ with coupon as (
         , coupon.couponpayment_name
         , b2b_ecommerce_b2border.b2border_contract_number
         , b2b_ecommerce_b2border.product_id
-        , ecommerce_couponpaymentversion.couponpaymentversion_payment_transaction
+        , ecommerce_couponpaymentversion.couponpaymentversion_payment_transaction 
         , program_runs.programrun_readable_id
         , program_runs.program_title
         , course_runs.courserun_readable_id
@@ -239,25 +239,25 @@ with coupon as (
         , cast(ecommerce_order.order_id as varchar) as order_ids
         , ecommerce_order.order_state as combined_order_state
         , b2b_ecommerce_b2breceipt.req_reference_number
-        , case
+        , case 
             when couponredemption.couponredemption_id is not null
-                then 'true'
-            else 'false'
+                then 'true' 
+            else 'false' 
         end as coupon_redeemed
-    from b2b_ecommerce_b2border
-    inner join ecommerce_couponpaymentversion
+    from b2b_ecommerce_b2border 
+    inner join ecommerce_couponpaymentversion 
         on ecommerce_couponpaymentversion.couponpaymentversion_id = b2b_ecommerce_b2border.couponpaymentversion_id
-    inner join ecommerce_couponversion
+    inner join ecommerce_couponversion 
         on ecommerce_couponversion.couponpaymentversion_id = ecommerce_couponpaymentversion.couponpaymentversion_id
-    inner join coupon
+    inner join coupon 
         on coupon.coupon_id = ecommerce_couponversion.coupon_id
-    left join couponredemption
+    left join couponredemption 
         on couponredemption.couponversion_id = ecommerce_couponversion.couponversion_id
-    left join ecommerce_order
+    left join ecommerce_order 
         on ecommerce_order.order_id = couponredemption.order_id
-    left join b2b_ecommerce_b2breceipt
+    left join b2b_ecommerce_b2breceipt 
         on b2b_ecommerce_b2breceipt.b2border_id = b2b_ecommerce_b2border.b2border_id
-    left join ecommerce_line
+    left join ecommerce_line 
         on ecommerce_line.order_id = ecommerce_order.order_id
     left join program_runs
         on ecommerce_line.programrun_id = program_runs.programrun_id
@@ -267,12 +267,12 @@ with coupon as (
         on course_runs.course_id = courses.course_id
     left join productversion
         on productversion.productversion_id = b2b_ecommerce_b2border.productversion_id
-    left join users_user
+    left join users_user    
         on ecommerce_order.order_purchaser_user_id = users_user.user_id
 )
 
 
-select
+select 
     reg_coupon_fields.coupon_email
     , reg_coupon_fields.coupon_code
     , reg_coupon_fields.coupon_id
@@ -299,7 +299,7 @@ where reg_coupon_fields.coupon_id not in (select coupon_id from b2b_coupon_field
 
 union distinct
 
-select
+select 
     b2b_coupon_fields.b2border_email as coupon_email
     , b2b_coupon_fields.coupon_code
     , b2b_coupon_fields.coupon_id
@@ -323,7 +323,7 @@ from b2b_coupon_fields
 
 union distinct
 
-select
+select 
     coupon_email
     , coupon_code
     , coupon_id
@@ -331,7 +331,7 @@ select
     , couponpayment_name
     , b2border_contract_number
     , product_id
-    , couponpaymentversion_payment_transaction
+    , couponpaymentversion_payment_transaction  
     , req_reference_number
     , programrun_readable_id
     , program_title
@@ -344,6 +344,6 @@ select
     , cast(order_ids as varchar) as order_ids
     , combined_order_state
 from unassigned_enrollment_codes
-where
+where 
     coupon_id not in (select coupon_id from reg_coupon_fields)
     and coupon_id not in (select coupon_id from b2b_coupon_fields)

--- a/src/ol_dbt/models/intermediate/mitxpro/int__mitxpro__ecommerce_combinedcoupons.sql
+++ b/src/ol_dbt/models/intermediate/mitxpro/int__mitxpro__ecommerce_combinedcoupons.sql
@@ -71,17 +71,17 @@ with coupon as (
 )
 
 , payment_transactions as (
-    select distinct
+    select distinct 
         ecommerce_couponversion.coupon_id
-        , ecommerce_couponpaymentversion.couponpaymentversion_payment_transaction
+        , max(ecommerce_couponpaymentversion.couponpaymentversion_payment_transaction)
     from ecommerce_couponpaymentversion
-    inner join ecommerce_couponversion
+    inner join ecommerce_couponversion 
         on ecommerce_couponpaymentversion.couponpaymentversion_id = ecommerce_couponversion.couponpaymentversion_id
     where ecommerce_couponpaymentversion.couponpaymentversion_payment_transaction is not null
 )
 
 , latest_couponversion as (
-    select
+    select 
         coupon_id
         , max(couponversion_updated_on) as max_couponversion_updated_on
     from ecommerce_couponversion
@@ -89,38 +89,38 @@ with coupon as (
 )
 
 , reg_coupon_summary as (
-    select
+    select 
         coupon.coupon_id
-        , cast(array_join(array_distinct(array_agg(program_runs.programrun_readable_id)), ', ') as varchar)
+        , cast(array_join(array_distinct(array_agg(program_runs.programrun_readable_id)), ', ') as varchar) 
             as programrun_readable_id
         , cast(array_join(array_distinct(array_agg(program_runs.program_title)), ', ') as varchar) as program_title
-        , cast(array_join(array_distinct(array_agg(course_runs.courserun_readable_id)), ', ') as varchar)
+        , cast(array_join(array_distinct(array_agg(course_runs.courserun_readable_id)), ', ') as varchar) 
             as courserun_readable_id
         , cast(array_join(array_distinct(array_agg(courses.course_title)), ', ') as varchar) as course_title
-        , cast(array_join(array_distinct(array_agg(productversion.productversion_readable_id)), ', ') as varchar)
+        , cast(array_join(array_distinct(array_agg(productversion.productversion_readable_id)), ', ') as varchar) 
             as productversion_readable_id
         , cast(array_join(array_distinct(array_agg(users_user.user_email)), ', ') as varchar) as combined_user_emails
-        , cast(array_join(array_distinct(array_agg(users_user.user_address_country)), ', ') as varchar)
+        , cast(array_join(array_distinct(array_agg(users_user.user_address_country)), ', ') as varchar) 
             as user_address_countries
         , cast(array_join(array_distinct(array_agg(ecommerce_order.order_id)), ', ') as varchar) as order_ids
-        , cast(array_join(array_distinct(array_agg(ecommerce_order.order_state)), ', ') as varchar)
+        , cast(array_join(array_distinct(array_agg(ecommerce_order.order_state)), ', ') as varchar) 
             as combined_order_state
         , case when (count(couponredemption.couponredemption_id) >= 1) then 'true' else 'false' end as coupon_redeemed
-
+        
     from coupon
     left join latest_couponversion
         on coupon.coupon_id = latest_couponversion.coupon_id
-    left join ecommerce_couponversion
-        on
-            latest_couponversion.coupon_id = ecommerce_couponversion.coupon_id
+    left join ecommerce_couponversion 
+        on 
+            latest_couponversion.coupon_id = ecommerce_couponversion.coupon_id 
             and ecommerce_couponversion.couponversion_updated_on = latest_couponversion.max_couponversion_updated_on
     left join couponredemption
         on ecommerce_couponversion.couponversion_id = couponredemption.couponversion_id
-    left join ecommerce_couponpaymentversion
+    left join ecommerce_couponpaymentversion 
         on ecommerce_couponpaymentversion.couponpaymentversion_id = ecommerce_couponversion.couponpaymentversion_id
     left join ecommerce_order
         on ecommerce_order.order_id = couponredemption.order_id
-    left join ecommerce_line
+    left join ecommerce_line 
         on ecommerce_line.order_id = ecommerce_order.order_id
     left join program_runs
         on ecommerce_line.programrun_id = program_runs.programrun_id
@@ -130,22 +130,22 @@ with coupon as (
         on course_runs.course_id = courses.course_id
     left join productversion
         on productversion.productversion_id = ecommerce_line.productversion_id
-    left join users_user
+    left join users_user    
         on ecommerce_order.order_purchaser_user_id = users_user.user_id
     where ecommerce_order.order_state = 'fulfilled' or ecommerce_order.order_state = 'refunded'
-    group by
+    group by 
         coupon.coupon_id
 )
 
 , reg_coupon_fields as (
-    select
+    select 
         productcouponassignment.productcouponassignment_email as coupon_email
         , coupon.coupon_code
         , coupon.coupon_id
         , coupon.coupon_created_on
         , coupon.couponpayment_name
         , productcouponassignment.product_id
-        , payment_transactions.couponpaymentversion_payment_transaction
+        , payment_transactions.couponpaymentversion_payment_transaction 
         , productcouponassignment.productcouponassignment_is_redeemed
     from coupon
     left join productcouponassignment
@@ -155,13 +155,13 @@ with coupon as (
 )
 
 , unassigned_enrollment_codes as (
-    select
+    select 
         coupon.coupon_code
         , coupon.coupon_id
         , coupon.coupon_created_on as coupon_created_on
         , coupon.couponpayment_name
         , b2b_ecommerce_b2border.b2border_contract_number
-        , payment_transactions.couponpaymentversion_payment_transaction
+        , payment_transactions.couponpaymentversion_payment_transaction  
         , program_runs.programrun_readable_id
         , program_runs.program_title
         , course_runs.courserun_readable_id
@@ -179,22 +179,22 @@ with coupon as (
     inner join latest_couponversion
         on coupon.coupon_id = latest_couponversion.coupon_id
     inner join ecommerce_couponversion
-        on
-            latest_couponversion.coupon_id = ecommerce_couponversion.coupon_id
+        on 
+            latest_couponversion.coupon_id = ecommerce_couponversion.coupon_id 
             and ecommerce_couponversion.couponversion_updated_on = latest_couponversion.max_couponversion_updated_on
     inner join ecommerce_couponpaymentversion
-        on ecommerce_couponpaymentversion.couponpaymentversion_id = ecommerce_couponversion.couponpaymentversion_id
-    left join b2b_ecommerce_b2border
+        on ecommerce_couponpaymentversion.couponpaymentversion_id = ecommerce_couponversion.couponpaymentversion_id 
+    left join b2b_ecommerce_b2border 
         on ecommerce_couponpaymentversion.couponpaymentversion_id = b2b_ecommerce_b2border.couponpaymentversion_id
-    left join payment_transactions
-        on payment_transactions.coupon_id = coupon.coupon_id
+    left join payment_transactions 
+        on payment_transactions.coupon_id = coupon.coupon_id   
     left join couponredemption
         on couponredemption.couponversion_id = ecommerce_couponversion.couponversion_id
-    left join ecommerce_order
+    left join ecommerce_order 
         on couponredemption.order_id = ecommerce_order.order_id
-    left join users_user
-        on users_user.user_id = ecommerce_order.order_purchaser_user_id
-    left join ecommerce_line
+    left join users_user 
+        on users_user.user_id = ecommerce_order.order_purchaser_user_id 
+    left join ecommerce_line 
         on ecommerce_line.order_id = ecommerce_order.order_id
     left join program_runs
         on ecommerce_line.programrun_id = program_runs.programrun_id
@@ -204,19 +204,19 @@ with coupon as (
         on course_runs.course_id = courses.course_id
     left join productversion
         on productversion.productversion_id = ecommerce_line.productversion_id
-    where
-        ecommerce_couponpaymentversion.couponpaymentversion_coupon_type = 'single-use'
-        and ecommerce_couponpaymentversion.couponpaymentversion_discount_amount = 1.0000
+    where 
+        ecommerce_couponpaymentversion.couponpaymentversion_coupon_type = 'single-use' 
+        and ecommerce_couponpaymentversion.couponpaymentversion_discount_amount = 1.0000 
         and coupon.coupon_id not in (
             select coupon_id
-            from productcouponassignment
+            from productcouponassignment 
         )
         and not exists (
             select b2b_ecommerce_b2border.couponpaymentversion_id
             from b2b_ecommerce_b2border
-            where
+            where 
                 b2b_ecommerce_b2border.couponpaymentversion_id = ecommerce_couponpaymentversion.couponpaymentversion_id
-        )
+        ) 
 )
 
 , b2b_coupon_fields as (
@@ -228,7 +228,7 @@ with coupon as (
         , coupon.couponpayment_name
         , b2b_ecommerce_b2border.b2border_contract_number
         , b2b_ecommerce_b2border.product_id
-        , ecommerce_couponpaymentversion.couponpaymentversion_payment_transaction
+        , ecommerce_couponpaymentversion.couponpaymentversion_payment_transaction 
         , program_runs.programrun_readable_id
         , program_runs.program_title
         , course_runs.courserun_readable_id
@@ -239,25 +239,25 @@ with coupon as (
         , cast(ecommerce_order.order_id as varchar) as order_ids
         , ecommerce_order.order_state as combined_order_state
         , b2b_ecommerce_b2breceipt.req_reference_number
-        , case
+        , case 
             when couponredemption.couponredemption_id is not null
-                then 'true'
-            else 'false'
+                then 'true' 
+            else 'false' 
         end as coupon_redeemed
-    from b2b_ecommerce_b2border
-    inner join ecommerce_couponpaymentversion
+    from b2b_ecommerce_b2border 
+    inner join ecommerce_couponpaymentversion 
         on ecommerce_couponpaymentversion.couponpaymentversion_id = b2b_ecommerce_b2border.couponpaymentversion_id
-    inner join ecommerce_couponversion
+    inner join ecommerce_couponversion 
         on ecommerce_couponversion.couponpaymentversion_id = ecommerce_couponpaymentversion.couponpaymentversion_id
-    inner join coupon
+    inner join coupon 
         on coupon.coupon_id = ecommerce_couponversion.coupon_id
-    left join couponredemption
+    left join couponredemption 
         on couponredemption.couponversion_id = ecommerce_couponversion.couponversion_id
-    left join ecommerce_order
+    left join ecommerce_order 
         on ecommerce_order.order_id = couponredemption.order_id
-    left join b2b_ecommerce_b2breceipt
+    left join b2b_ecommerce_b2breceipt 
         on b2b_ecommerce_b2breceipt.b2border_id = b2b_ecommerce_b2border.b2border_id
-    left join ecommerce_line
+    left join ecommerce_line 
         on ecommerce_line.order_id = ecommerce_order.order_id
     left join program_runs
         on ecommerce_line.programrun_id = program_runs.programrun_id
@@ -267,12 +267,12 @@ with coupon as (
         on course_runs.course_id = courses.course_id
     left join productversion
         on productversion.productversion_id = b2b_ecommerce_b2border.productversion_id
-    left join users_user
+    left join users_user    
         on ecommerce_order.order_purchaser_user_id = users_user.user_id
 )
 
 
-select
+select 
     reg_coupon_fields.coupon_email
     , reg_coupon_fields.coupon_code
     , reg_coupon_fields.coupon_id
@@ -299,7 +299,7 @@ where reg_coupon_fields.coupon_id not in (select coupon_id from b2b_coupon_field
 
 union distinct
 
-select
+select 
     b2b_coupon_fields.b2border_email as coupon_email
     , b2b_coupon_fields.coupon_code
     , b2b_coupon_fields.coupon_id
@@ -323,7 +323,7 @@ from b2b_coupon_fields
 
 union distinct
 
-select
+select 
     coupon_email
     , coupon_code
     , coupon_id
@@ -331,7 +331,7 @@ select
     , couponpayment_name
     , b2border_contract_number
     , product_id
-    , couponpaymentversion_payment_transaction
+    , couponpaymentversion_payment_transaction  
     , req_reference_number
     , programrun_readable_id
     , program_title
@@ -344,6 +344,6 @@ select
     , cast(order_ids as varchar) as order_ids
     , combined_order_state
 from unassigned_enrollment_codes
-where
+where 
     coupon_id not in (select coupon_id from reg_coupon_fields)
     and coupon_id not in (select coupon_id from b2b_coupon_fields)

--- a/src/ol_dbt/models/intermediate/mitxpro/int__mitxpro__ecommerce_combinedcoupons.sql
+++ b/src/ol_dbt/models/intermediate/mitxpro/int__mitxpro__ecommerce_combinedcoupons.sql
@@ -69,17 +69,17 @@ with coupon as (
 )
 
 , payment_transactions as (
-    select distinct 
+    select distinct
         ecommerce_couponversion.coupon_id
         , ecommerce_couponpaymentversion.couponpaymentversion_payment_transaction
     from ecommerce_couponpaymentversion
-    inner join ecommerce_couponversion 
+    inner join ecommerce_couponversion
         on ecommerce_couponpaymentversion.couponpaymentversion_id = ecommerce_couponversion.couponpaymentversion_id
     where ecommerce_couponpaymentversion.couponpaymentversion_payment_transaction is not null
 )
 
 
-select 
+select
     productcouponassignment.productcouponassignment_email as coupon_email
     , coupon.coupon_code
     , coupon.coupon_id
@@ -87,7 +87,7 @@ select
     , coupon.couponpayment_name
     , null as b2border_contract_number
     , productcouponassignment.product_id
-    , payment_transactions.couponpaymentversion_payment_transaction 
+    , payment_transactions.couponpaymentversion_payment_transaction
     , null as req_reference_number
     , program_runs.programrun_readable_id
     , program_runs.program_title
@@ -97,7 +97,7 @@ select
     , 'regular coupon' as combinedcoupon_table_source
     , ecommerce_couponpaymentversion.couponpaymentversion_coupon_type
     , ecommerce_couponpaymentversion.couponpaymentversion_discount_amount
-    , case when (count(couponredemption.couponredemption_id) >= 1) then true else false end as coupon_redeemed
+    , coalesce ((count(couponredemption.couponredemption_id) >= 1), false) as coupon_redeemed
     , array_join(array_distinct(array_agg(users_user.user_email)), ', ') as combined_user_emails
     , array_join(array_distinct(array_agg(users_user.user_address_country)), ', ') as user_address_countries
     , array_join(array_distinct(array_agg(ecommerce_order.order_id)), ', ') as order_ids
@@ -105,19 +105,19 @@ select
 from coupon
 left join productcouponassignment
     on productcouponassignment.coupon_id = coupon.coupon_id
-left join ecommerce_couponversion 
+left join ecommerce_couponversion
     on coupon.coupon_id = ecommerce_couponversion.coupon_id
-left join ecommerce_couponpaymentversion 
+left join ecommerce_couponpaymentversion
     on ecommerce_couponpaymentversion.couponpaymentversion_id = ecommerce_couponversion.couponpaymentversion_id
 left join couponredemption
     on ecommerce_couponversion.couponversion_id = couponredemption.couponversion_id
 left join ecommerce_order
     on ecommerce_order.order_id = couponredemption.order_id
-left join users_user    
+left join users_user
     on ecommerce_order.order_purchaser_user_id = users_user.user_id
 left join payment_transactions
     on coupon.coupon_id = payment_transactions.coupon_id
-left join ecommerce_line 
+left join ecommerce_line
     on ecommerce_line.order_id = ecommerce_order.order_id
 left join program_runs
     on ecommerce_line.programrun_id = program_runs.programrun_id
@@ -127,14 +127,14 @@ left join courses
     on course_runs.course_id = courses.course_id
 left join productversion
     on productversion.productversion_id = ecommerce_line.productversion_id
-group by 
-    productcouponassignment.productcouponassignment_email 
+group by
+    productcouponassignment.productcouponassignment_email
     , coupon.coupon_code
     , coupon.coupon_id
     , coupon.coupon_created_on
     , coupon.couponpayment_name
     , productcouponassignment.product_id
-    , payment_transactions.couponpaymentversion_payment_transaction 
+    , payment_transactions.couponpaymentversion_payment_transaction
     , program_runs.programrun_readable_id
     , program_runs.program_title
     , course_runs.courserun_readable_id
@@ -145,7 +145,7 @@ group by
 
 union distinct
 
-select 
+select
     b2b_ecommerce_b2border.b2border_email as coupon_email
     , coupon.coupon_code
     , coupon.coupon_id
@@ -153,7 +153,7 @@ select
     , coupon.couponpayment_name
     , b2b_ecommerce_b2border.b2border_contract_number
     , b2b_ecommerce_b2border.product_id
-    , ecommerce_couponpaymentversion.couponpaymentversion_payment_transaction 
+    , ecommerce_couponpaymentversion.couponpaymentversion_payment_transaction
     , replace(
         cast(
             json_extract(b2b_ecommerce_b2breceipt.b2breceipt_data, '$.req_reference_number'
@@ -169,31 +169,27 @@ select
     , 'b2b coupon' as combinedcoupon_table_source
     , ecommerce_couponpaymentversion.couponpaymentversion_coupon_type
     , ecommerce_couponpaymentversion.couponpaymentversion_discount_amount
-    , case 
-        when (count(couponredemption.couponredemption_id) >= 1) 
-            then true 
-        else false 
-    end as coupon_redeemed
+    , coalesce ((count(couponredemption.couponredemption_id) >= 1), false) as coupon_redeemed
     , array_join(array_distinct(array_agg(users_user.user_email)), ', ') as combined_user_emails
     , array_join(array_distinct(array_agg(users_user.user_address_country)), ', ') as user_address_countries
     , array_join(array_distinct(array_agg(ecommerce_order.order_id)), ', ') as order_ids
     , array_join(array_distinct(array_agg(ecommerce_order.order_state)), ', ') as combined_order_state
-from b2b_ecommerce_b2border 
-left join ecommerce_couponpaymentversion 
+from b2b_ecommerce_b2border
+left join ecommerce_couponpaymentversion
     on ecommerce_couponpaymentversion.couponpaymentversion_id = b2b_ecommerce_b2border.couponpaymentversion_id
-left join coupon 
-    on coupon.coupon_id = b2b_ecommerce_b2border.b2bcoupon_id 
-left join ecommerce_couponversion 
+left join coupon
+    on coupon.coupon_id = b2b_ecommerce_b2border.b2bcoupon_id
+left join ecommerce_couponversion
     on ecommerce_couponversion.coupon_id = coupon.coupon_id
-left join couponredemption 
+left join couponredemption
     on couponredemption.couponversion_id = ecommerce_couponversion.couponversion_id
-left join ecommerce_order 
+left join ecommerce_order
     on ecommerce_order.order_id = couponredemption.order_id
-left join users_user    
+left join users_user
     on ecommerce_order.order_purchaser_user_id = users_user.user_id
-left join b2b_ecommerce_b2breceipt 
+left join b2b_ecommerce_b2breceipt
     on b2b_ecommerce_b2breceipt.b2border_id = b2b_ecommerce_b2border.b2border_id
-left join ecommerce_line 
+left join ecommerce_line
     on ecommerce_line.order_id = ecommerce_order.order_id
 left join program_runs
     on ecommerce_line.programrun_id = program_runs.programrun_id
@@ -203,21 +199,21 @@ left join courses
     on course_runs.course_id = courses.course_id
 left join productversion
     on productversion.productversion_id = b2b_ecommerce_b2border.productversion_id
-group by 
-    b2b_ecommerce_b2border.b2border_email 
+group by
+    b2b_ecommerce_b2border.b2border_email
     , coupon.coupon_code
     , coupon.coupon_id
     , coupon.coupon_created_on
     , coupon.couponpayment_name
     , b2b_ecommerce_b2border.b2border_contract_number
     , b2b_ecommerce_b2border.product_id
-    , ecommerce_couponpaymentversion.couponpaymentversion_payment_transaction 
+    , ecommerce_couponpaymentversion.couponpaymentversion_payment_transaction
     , replace(
         cast(
             json_extract(b2b_ecommerce_b2breceipt.b2breceipt_data, '$.req_reference_number')
             as varchar
         ), '"', ''
-    ) 
+    )
     , program_runs.programrun_readable_id
     , program_runs.program_title
     , course_runs.courserun_readable_id

--- a/src/ol_dbt/models/intermediate/mitxpro/int__mitxpro__ecommerce_combinedcoupons.sql
+++ b/src/ol_dbt/models/intermediate/mitxpro/int__mitxpro__ecommerce_combinedcoupons.sql
@@ -69,17 +69,17 @@ with coupon as (
 )
 
 , payment_transactions as (
-    select distinct
+    select distinct 
         ecommerce_couponversion.coupon_id
         , ecommerce_couponpaymentversion.couponpaymentversion_payment_transaction
     from ecommerce_couponpaymentversion
-    inner join ecommerce_couponversion
+    inner join ecommerce_couponversion 
         on ecommerce_couponpaymentversion.couponpaymentversion_id = ecommerce_couponversion.couponpaymentversion_id
     where ecommerce_couponpaymentversion.couponpaymentversion_payment_transaction is not null
 )
 
 , latest_couponversion as (
-    select
+    select 
         coupon_id
         , max(couponversion_updated_on) as max_couponversion_updated_on
     from ecommerce_couponversion
@@ -87,38 +87,38 @@ with coupon as (
 )
 
 , reg_coupon_summary as (
-    select
+    select 
         coupon.coupon_id
-        , cast(array_join(array_distinct(array_agg(program_runs.programrun_readable_id)), ', ') as varchar)
+        , cast(array_join(array_distinct(array_agg(program_runs.programrun_readable_id)), ', ') as varchar) 
             as programrun_readable_id
         , cast(array_join(array_distinct(array_agg(program_runs.program_title)), ', ') as varchar) as program_title
-        , cast(array_join(array_distinct(array_agg(course_runs.courserun_readable_id)), ', ') as varchar)
+        , cast(array_join(array_distinct(array_agg(course_runs.courserun_readable_id)), ', ') as varchar) 
             as courserun_readable_id
         , cast(array_join(array_distinct(array_agg(courses.course_title)), ', ') as varchar) as course_title
-        , cast(array_join(array_distinct(array_agg(productversion.productversion_readable_id)), ', ') as varchar)
+        , cast(array_join(array_distinct(array_agg(productversion.productversion_readable_id)), ', ') as varchar) 
             as productversion_readable_id
         , cast(array_join(array_distinct(array_agg(users_user.user_email)), ', ') as varchar) as combined_user_emails
-        , cast(array_join(array_distinct(array_agg(users_user.user_address_country)), ', ') as varchar)
+        , cast(array_join(array_distinct(array_agg(users_user.user_address_country)), ', ') as varchar) 
             as user_address_countries
         , cast(array_join(array_distinct(array_agg(ecommerce_order.order_id)), ', ') as varchar) as order_ids
-        , cast(array_join(array_distinct(array_agg(ecommerce_order.order_state)), ', ') as varchar)
+        , cast(array_join(array_distinct(array_agg(ecommerce_order.order_state)), ', ') as varchar) 
             as combined_order_state
         , case when (count(couponredemption.couponredemption_id) >= 1) then 'true' else 'false' end as coupon_redeemed
-
+        
     from coupon
     left join latest_couponversion
         on coupon.coupon_id = latest_couponversion.coupon_id
-    left join ecommerce_couponversion
-        on
-            latest_couponversion.coupon_id = ecommerce_couponversion.coupon_id
+    left join ecommerce_couponversion 
+        on 
+            latest_couponversion.coupon_id = ecommerce_couponversion.coupon_id 
             and ecommerce_couponversion.couponversion_updated_on = latest_couponversion.max_couponversion_updated_on
     left join couponredemption
         on ecommerce_couponversion.couponversion_id = couponredemption.couponversion_id
-    left join ecommerce_couponpaymentversion
+    left join ecommerce_couponpaymentversion 
         on ecommerce_couponpaymentversion.couponpaymentversion_id = ecommerce_couponversion.couponpaymentversion_id
     left join ecommerce_order
         on ecommerce_order.order_id = couponredemption.order_id
-    left join ecommerce_line
+    left join ecommerce_line 
         on ecommerce_line.order_id = ecommerce_order.order_id
     left join program_runs
         on ecommerce_line.programrun_id = program_runs.programrun_id
@@ -128,22 +128,22 @@ with coupon as (
         on course_runs.course_id = courses.course_id
     left join productversion
         on productversion.productversion_id = ecommerce_line.productversion_id
-    left join users_user
+    left join users_user    
         on ecommerce_order.order_purchaser_user_id = users_user.user_id
     where ecommerce_order.order_state = 'fulfilled' or ecommerce_order.order_state = 'refunded'
-    group by
+    group by 
         coupon.coupon_id
 )
 
 , reg_coupon_fields as (
-    select
+    select 
         productcouponassignment.productcouponassignment_email as coupon_email
         , coupon.coupon_code
         , coupon.coupon_id
         , coupon.coupon_created_on
         , coupon.couponpayment_name
         , productcouponassignment.product_id
-        , payment_transactions.couponpaymentversion_payment_transaction
+        , payment_transactions.couponpaymentversion_payment_transaction 
         , productcouponassignment.productcouponassignment_is_redeemed
     from coupon
     left join productcouponassignment
@@ -153,13 +153,13 @@ with coupon as (
 )
 
 , unassigned_enrollment_codes as (
-    select
+    select 
         coupon.coupon_code
         , coupon.coupon_id
         , coupon.coupon_created_on as coupon_created_on
         , coupon.couponpayment_name
         , b2b_ecommerce_b2border.b2border_contract_number
-        , payment_transactions.couponpaymentversion_payment_transaction
+        , payment_transactions.couponpaymentversion_payment_transaction  
         , program_runs.programrun_readable_id
         , program_runs.program_title
         , course_runs.courserun_readable_id
@@ -167,7 +167,7 @@ with coupon as (
         , productversion.productversion_readable_id
         , users_user.user_email as combined_user_emails
         , users_user.user_address_country as user_address_countries
-        , ecommerce_couponredemption.order_id as order_ids
+        , couponredemption.order_id as order_ids
         , ecommerce_order.order_state as combined_order_state
         , null as coupon_email
         , null as product_id
@@ -177,22 +177,22 @@ with coupon as (
     inner join latest_couponversion
         on coupon.coupon_id = latest_couponversion.coupon_id
     inner join ecommerce_couponversion
-        on
-            latest_couponversion.coupon_id = ecommerce_couponversion.coupon_id
+        on 
+            latest_couponversion.coupon_id = ecommerce_couponversion.coupon_id 
             and ecommerce_couponversion.couponversion_updated_on = latest_couponversion.max_couponversion_updated_on
     inner join ecommerce_couponpaymentversion
-        on ecommerce_couponpaymentversion.couponpaymentversion_id = ecommerce_couponversion.couponpaymentversion_id
-    left join b2b_ecommerce_b2border
+        on ecommerce_couponpaymentversion.couponpaymentversion_id = ecommerce_couponversion.couponpaymentversion_id 
+    left join b2b_ecommerce_b2border 
         on ecommerce_couponpaymentversion.couponpaymentversion_id = b2b_ecommerce_b2border.couponpaymentversion_id
-    left join payment_transactions
-        on payment_transactions.coupon_id = coupon.coupon_id
-    left join ecommerce_couponredemption
-        on ecommerce_couponredemption.couponversion_id = ecommerce_couponversion.couponversion_id
-    left join ecommerce_order
-        on ecommerce_couponredemption.order_id = ecommerce_order.order_id
-    left join users_user
-        on users_user.user_id = ecommerce_order.order_purchaser_user_id
-    left join ecommerce_line
+    left join payment_transactions 
+        on payment_transactions.coupon_id = coupon.coupon_id   
+    left join couponredemption
+        on couponredemption.couponversion_id = ecommerce_couponversion.couponversion_id
+    left join ecommerce_order 
+        on couponredemption.order_id = ecommerce_order.order_id
+    left join users_user 
+        on users_user.user_id = ecommerce_order.order_purchaser_user_id 
+    left join ecommerce_line 
         on ecommerce_line.order_id = ecommerce_order.order_id
     left join program_runs
         on ecommerce_line.programrun_id = program_runs.programrun_id
@@ -202,19 +202,19 @@ with coupon as (
         on course_runs.course_id = courses.course_id
     left join productversion
         on productversion.productversion_id = ecommerce_line.productversion_id
-    where
-        ecommerce_couponpaymentversion.couponpaymentversion_coupon_type = 'single-use'
-        and ecommerce_couponpaymentversion.couponpaymentversion_discount_amount = 1.0000
+    where 
+        ecommerce_couponpaymentversion.couponpaymentversion_coupon_type = 'single-use' 
+        and ecommerce_couponpaymentversion.couponpaymentversion_discount_amount = 1.0000 
         and coupon.coupon_id not in (
             select coupon_id
-            from ecommerce_productcouponassignment
+            from ecommerce_productcouponassignment 
         )
         and not exists (
             select b2b_ecommerce_b2border.couponpaymentversion_id
             from b2b_ecommerce_b2border
-            where
+            where 
                 b2b_ecommerce_b2border.couponpaymentversion_id = ecommerce_couponpaymentversion.couponpaymentversion_id
-        )
+        ) 
 )
 
 , b2b_coupon_fields as (
@@ -226,7 +226,7 @@ with coupon as (
         , coupon.couponpayment_name
         , b2b_ecommerce_b2border.b2border_contract_number
         , b2b_ecommerce_b2border.product_id
-        , ecommerce_couponpaymentversion.couponpaymentversion_payment_transaction
+        , ecommerce_couponpaymentversion.couponpaymentversion_payment_transaction 
         , program_runs.programrun_readable_id
         , program_runs.program_title
         , course_runs.courserun_readable_id
@@ -243,25 +243,25 @@ with coupon as (
                 as varchar
             ), '"', ''
         ) as req_reference_number
-        , case
+        , case 
             when couponredemption.couponredemption_id is not null
-                then 'true'
-            else 'false'
+                then 'true' 
+            else 'false' 
         end as coupon_redeemed
-    from b2b_ecommerce_b2border
-    inner join ecommerce_couponpaymentversion
+    from b2b_ecommerce_b2border 
+    inner join ecommerce_couponpaymentversion 
         on ecommerce_couponpaymentversion.couponpaymentversion_id = b2b_ecommerce_b2border.couponpaymentversion_id
-    inner join ecommerce_couponversion
+    inner join ecommerce_couponversion 
         on ecommerce_couponversion.couponpaymentversion_id = ecommerce_couponpaymentversion.couponpaymentversion_id
-    inner join coupon
+    inner join coupon 
         on coupon.coupon_id = ecommerce_couponversion.coupon_id
-    left join couponredemption
+    left join couponredemption 
         on couponredemption.couponversion_id = ecommerce_couponversion.couponversion_id
-    left join ecommerce_order
+    left join ecommerce_order 
         on ecommerce_order.order_id = couponredemption.order_id
-    left join b2b_ecommerce_b2breceipt
+    left join b2b_ecommerce_b2breceipt 
         on b2b_ecommerce_b2breceipt.b2border_id = b2b_ecommerce_b2border.b2border_id
-    left join ecommerce_line
+    left join ecommerce_line 
         on ecommerce_line.order_id = ecommerce_order.order_id
     left join program_runs
         on ecommerce_line.programrun_id = program_runs.programrun_id
@@ -271,12 +271,12 @@ with coupon as (
         on course_runs.course_id = courses.course_id
     left join productversion
         on productversion.productversion_id = b2b_ecommerce_b2border.productversion_id
-    left join users_user
+    left join users_user    
         on ecommerce_order.order_purchaser_user_id = users_user.user_id
 )
 
 
-select
+select 
     reg_coupon_fields.coupon_email
     , reg_coupon_fields.coupon_code
     , reg_coupon_fields.coupon_id
@@ -303,7 +303,7 @@ where reg_coupon_fields.coupon_id not in (select coupon_id from b2b_coupon_field
 
 union distinct
 
-select
+select 
     b2b_coupon_fields.b2border_email as coupon_email
     , b2b_coupon_fields.coupon_code
     , b2b_coupon_fields.coupon_id
@@ -327,7 +327,7 @@ from b2b_coupon_fields
 
 union distinct
 
-select
+select 
     coupon_email
     , coupon_code
     , coupon_id
@@ -335,7 +335,7 @@ select
     , couponpayment_name
     , b2border_contract_number
     , product_id
-    , couponpaymentversion_payment_transaction
+    , couponpaymentversion_payment_transaction  
     , req_reference_number
     , programrun_readable_id
     , program_title

--- a/src/ol_dbt/models/intermediate/mitxpro/int__mitxpro__ecommerce_combinedcoupons.sql
+++ b/src/ol_dbt/models/intermediate/mitxpro/int__mitxpro__ecommerce_combinedcoupons.sql
@@ -69,17 +69,17 @@ with coupon as (
 )
 
 , payment_transactions as (
-    select distinct
+    select distinct 
         ecommerce_couponversion.coupon_id
         , ecommerce_couponpaymentversion.couponpaymentversion_payment_transaction
     from ecommerce_couponpaymentversion
-    inner join ecommerce_couponversion
+    inner join ecommerce_couponversion 
         on ecommerce_couponpaymentversion.couponpaymentversion_id = ecommerce_couponversion.couponpaymentversion_id
     where ecommerce_couponpaymentversion.couponpaymentversion_payment_transaction is not null
 )
 
 , reg_coupon_summary as (
-    select
+    select 
         coupon.coupon_id
         , ecommerce_couponversion.couponversion_updated_on
         , program_runs.programrun_readable_id
@@ -95,15 +95,15 @@ with coupon as (
         , array_join(array_distinct(array_agg(ecommerce_order.order_id)), ', ') as order_ids
         , array_join(array_distinct(array_agg(ecommerce_order.order_state)), ', ') as combined_order_state
     from coupon
-    left join ecommerce_couponversion
+    left join ecommerce_couponversion 
         on coupon.coupon_id = ecommerce_couponversion.coupon_id
     left join couponredemption
         on ecommerce_couponversion.couponversion_id = couponredemption.couponversion_id
-    left join ecommerce_couponpaymentversion
+    left join ecommerce_couponpaymentversion 
         on ecommerce_couponpaymentversion.couponpaymentversion_id = ecommerce_couponversion.couponpaymentversion_id
     left join ecommerce_order
         on ecommerce_order.order_id = couponredemption.order_id
-    left join ecommerce_line
+    left join ecommerce_line 
         on ecommerce_line.order_id = ecommerce_order.order_id
     left join program_runs
         on ecommerce_line.programrun_id = program_runs.programrun_id
@@ -113,9 +113,9 @@ with coupon as (
         on course_runs.course_id = courses.course_id
     left join productversion
         on productversion.productversion_id = ecommerce_line.productversion_id
-    left join users_user
+    left join users_user    
         on ecommerce_order.order_purchaser_user_id = users_user.user_id
-    group by
+    group by 
         coupon.coupon_id
         , ecommerce_couponversion.couponversion_updated_on
         , program_runs.programrun_readable_id
@@ -128,14 +128,14 @@ with coupon as (
 )
 
 , reg_coupon_fields as (
-    select
+    select 
         productcouponassignment.productcouponassignment_email as coupon_email
         , coupon.coupon_code
         , coupon.coupon_id
         , coupon.coupon_created_on
         , coupon.couponpayment_name
         , productcouponassignment.product_id
-        , payment_transactions.couponpaymentversion_payment_transaction
+        , payment_transactions.couponpaymentversion_payment_transaction 
         , productcouponassignment.productcouponassignment_is_redeemed
     from coupon
     left join productcouponassignment
@@ -154,7 +154,7 @@ with coupon as (
         , coupon.couponpayment_name
         , b2b_ecommerce_b2border.b2border_contract_number
         , b2b_ecommerce_b2border.product_id
-        , ecommerce_couponpaymentversion.couponpaymentversion_payment_transaction
+        , ecommerce_couponpaymentversion.couponpaymentversion_payment_transaction 
         , program_runs.programrun_readable_id
         , program_runs.program_title
         , course_runs.courserun_readable_id
@@ -162,10 +162,10 @@ with coupon as (
         , productversion.productversion_readable_id
         , ecommerce_couponpaymentversion.couponpaymentversion_coupon_type
         , ecommerce_couponpaymentversion.couponpaymentversion_discount_amount
-        , cast(users_user.user_email as bigint) as combined_user_emails
-        , cast(users_user.user_address_country as bigint) as user_address_countries
-        , cast(ecommerce_order.order_id as bigint) as order_ids
-        , cast(ecommerce_order.order_state as bigint) as combined_order_state
+        , TRY_CAST(users_user.user_email as BigInt) combined_user_emails 
+        , TRY_CAST(users_user.user_address_country as BigInt) user_address_countries 
+        , TRY_CAST(ecommerce_order.order_id as BigInt) as order_ids
+        , TRY_CAST(ecommerce_order.order_state as BigInt) as combined_order_state
         , replace(
             cast(
                 json_extract(b2b_ecommerce_b2breceipt.b2breceipt_data, '$.req_reference_number'
@@ -173,25 +173,25 @@ with coupon as (
                 as varchar
             ), '"', ''
         ) as req_reference_number
-        , case
+        , case 
             when couponredemption.couponredemption_id is not null
-                then 'true'
-            else 'false'
+                then 'true' 
+            else 'false' 
         end as coupon_redeemed
-    from b2b_ecommerce_b2border
-    inner join ecommerce_couponpaymentversion
+    from b2b_ecommerce_b2border 
+    inner join ecommerce_couponpaymentversion 
         on ecommerce_couponpaymentversion.couponpaymentversion_id = b2b_ecommerce_b2border.couponpaymentversion_id
-    inner join ecommerce_couponversion
+    inner join ecommerce_couponversion 
         on ecommerce_couponversion.couponpaymentversion_id = ecommerce_couponpaymentversion.couponpaymentversion_id
-    inner join coupon
+    inner join coupon 
         on coupon.coupon_id = ecommerce_couponversion.coupon_id
-    left join couponredemption
+    left join couponredemption 
         on couponredemption.couponversion_id = ecommerce_couponversion.couponversion_id
-    left join ecommerce_order
+    left join ecommerce_order 
         on ecommerce_order.order_id = couponredemption.order_id
-    left join b2b_ecommerce_b2breceipt
+    left join b2b_ecommerce_b2breceipt 
         on b2b_ecommerce_b2breceipt.b2border_id = b2b_ecommerce_b2border.b2border_id
-    left join ecommerce_line
+    left join ecommerce_line 
         on ecommerce_line.order_id = ecommerce_order.order_id
     left join program_runs
         on ecommerce_line.programrun_id = program_runs.programrun_id
@@ -201,12 +201,12 @@ with coupon as (
         on course_runs.course_id = courses.course_id
     left join productversion
         on productversion.productversion_id = b2b_ecommerce_b2border.productversion_id
-    left join users_user
+    left join users_user    
         on ecommerce_order.order_purchaser_user_id = users_user.user_id
 )
 
 
-select
+select 
     reg_coupon_fields.coupon_email
     , reg_coupon_fields.coupon_code
     , reg_coupon_fields.coupon_id
@@ -237,7 +237,7 @@ where reg_coupon_fields.coupon_id not in (select coupon_id from b2b_coupon_field
 
 union distinct
 
-select
+select 
     b2b_coupon_fields.b2border_email as coupon_email
     , b2b_coupon_fields.coupon_code
     , b2b_coupon_fields.coupon_id
@@ -257,8 +257,8 @@ select
     , b2b_coupon_fields.couponpaymentversion_coupon_type
     , b2b_coupon_fields.couponpaymentversion_discount_amount
     , b2b_coupon_fields.coupon_redeemed
-    , cast(b2b_coupon_fields.combined_user_emails as bigint) as combined_user_emails
-    , cast(b2b_coupon_fields.user_address_countries as bigint) as user_address_countries
-    , cast(b2b_coupon_fields.order_ids as bigint) as order_ids
-    , cast(b2b_coupon_fields.combined_order_state as bigint) as combined_order_state
+    , b2b_coupon_fields.combined_user_emails
+    , b2b_coupon_fields.user_address_countries
+    , b2b_coupon_fields.order_ids
+    , b2b_coupon_fields.combined_order_state
 from b2b_coupon_fields

--- a/src/ol_dbt/models/intermediate/mitxpro/int__mitxpro__ecommerce_combinedcoupons.sql
+++ b/src/ol_dbt/models/intermediate/mitxpro/int__mitxpro__ecommerce_combinedcoupons.sql
@@ -71,17 +71,17 @@ with coupon as (
 )
 
 , payment_transactions as (
-    select distinct 
+    select distinct
         ecommerce_couponversion.coupon_id
         , ecommerce_couponpaymentversion.couponpaymentversion_payment_transaction
     from ecommerce_couponpaymentversion
-    inner join ecommerce_couponversion 
+    inner join ecommerce_couponversion
         on ecommerce_couponpaymentversion.couponpaymentversion_id = ecommerce_couponversion.couponpaymentversion_id
     where ecommerce_couponpaymentversion.couponpaymentversion_payment_transaction is not null
 )
 
 , latest_couponversion as (
-    select 
+    select
         coupon_id
         , max(couponversion_updated_on) as max_couponversion_updated_on
     from ecommerce_couponversion
@@ -89,38 +89,38 @@ with coupon as (
 )
 
 , reg_coupon_summary as (
-    select 
+    select
         coupon.coupon_id
-        , cast(array_join(array_distinct(array_agg(program_runs.programrun_readable_id)), ', ') as varchar) 
+        , cast(array_join(array_distinct(array_agg(program_runs.programrun_readable_id)), ', ') as varchar)
             as programrun_readable_id
         , cast(array_join(array_distinct(array_agg(program_runs.program_title)), ', ') as varchar) as program_title
-        , cast(array_join(array_distinct(array_agg(course_runs.courserun_readable_id)), ', ') as varchar) 
+        , cast(array_join(array_distinct(array_agg(course_runs.courserun_readable_id)), ', ') as varchar)
             as courserun_readable_id
         , cast(array_join(array_distinct(array_agg(courses.course_title)), ', ') as varchar) as course_title
-        , cast(array_join(array_distinct(array_agg(productversion.productversion_readable_id)), ', ') as varchar) 
+        , cast(array_join(array_distinct(array_agg(productversion.productversion_readable_id)), ', ') as varchar)
             as productversion_readable_id
         , cast(array_join(array_distinct(array_agg(users_user.user_email)), ', ') as varchar) as combined_user_emails
-        , cast(array_join(array_distinct(array_agg(users_user.user_address_country)), ', ') as varchar) 
+        , cast(array_join(array_distinct(array_agg(users_user.user_address_country)), ', ') as varchar)
             as user_address_countries
         , cast(array_join(array_distinct(array_agg(ecommerce_order.order_id)), ', ') as varchar) as order_ids
-        , cast(array_join(array_distinct(array_agg(ecommerce_order.order_state)), ', ') as varchar) 
+        , cast(array_join(array_distinct(array_agg(ecommerce_order.order_state)), ', ') as varchar)
             as combined_order_state
         , case when (count(couponredemption.couponredemption_id) >= 1) then 'true' else 'false' end as coupon_redeemed
-        
+
     from coupon
     left join latest_couponversion
         on coupon.coupon_id = latest_couponversion.coupon_id
-    left join ecommerce_couponversion 
-        on 
-            latest_couponversion.coupon_id = ecommerce_couponversion.coupon_id 
+    left join ecommerce_couponversion
+        on
+            latest_couponversion.coupon_id = ecommerce_couponversion.coupon_id
             and ecommerce_couponversion.couponversion_updated_on = latest_couponversion.max_couponversion_updated_on
     left join couponredemption
         on ecommerce_couponversion.couponversion_id = couponredemption.couponversion_id
-    left join ecommerce_couponpaymentversion 
+    left join ecommerce_couponpaymentversion
         on ecommerce_couponpaymentversion.couponpaymentversion_id = ecommerce_couponversion.couponpaymentversion_id
     left join ecommerce_order
         on ecommerce_order.order_id = couponredemption.order_id
-    left join ecommerce_line 
+    left join ecommerce_line
         on ecommerce_line.order_id = ecommerce_order.order_id
     left join program_runs
         on ecommerce_line.programrun_id = program_runs.programrun_id
@@ -130,22 +130,22 @@ with coupon as (
         on course_runs.course_id = courses.course_id
     left join productversion
         on productversion.productversion_id = ecommerce_line.productversion_id
-    left join users_user    
+    left join users_user
         on ecommerce_order.order_purchaser_user_id = users_user.user_id
     where ecommerce_order.order_state = 'fulfilled' or ecommerce_order.order_state = 'refunded'
-    group by 
+    group by
         coupon.coupon_id
 )
 
 , reg_coupon_fields as (
-    select 
+    select
         productcouponassignment.productcouponassignment_email as coupon_email
         , coupon.coupon_code
         , coupon.coupon_id
         , coupon.coupon_created_on
         , coupon.couponpayment_name
         , productcouponassignment.product_id
-        , payment_transactions.couponpaymentversion_payment_transaction 
+        , payment_transactions.couponpaymentversion_payment_transaction
         , productcouponassignment.productcouponassignment_is_redeemed
     from coupon
     left join productcouponassignment
@@ -155,13 +155,13 @@ with coupon as (
 )
 
 , unassigned_enrollment_codes as (
-    select 
+    select
         coupon.coupon_code
         , coupon.coupon_id
         , coupon.coupon_created_on as coupon_created_on
         , coupon.couponpayment_name
         , b2b_ecommerce_b2border.b2border_contract_number
-        , payment_transactions.couponpaymentversion_payment_transaction  
+        , payment_transactions.couponpaymentversion_payment_transaction
         , program_runs.programrun_readable_id
         , program_runs.program_title
         , course_runs.courserun_readable_id
@@ -179,22 +179,22 @@ with coupon as (
     inner join latest_couponversion
         on coupon.coupon_id = latest_couponversion.coupon_id
     inner join ecommerce_couponversion
-        on 
-            latest_couponversion.coupon_id = ecommerce_couponversion.coupon_id 
+        on
+            latest_couponversion.coupon_id = ecommerce_couponversion.coupon_id
             and ecommerce_couponversion.couponversion_updated_on = latest_couponversion.max_couponversion_updated_on
     inner join ecommerce_couponpaymentversion
-        on ecommerce_couponpaymentversion.couponpaymentversion_id = ecommerce_couponversion.couponpaymentversion_id 
-    left join b2b_ecommerce_b2border 
+        on ecommerce_couponpaymentversion.couponpaymentversion_id = ecommerce_couponversion.couponpaymentversion_id
+    left join b2b_ecommerce_b2border
         on ecommerce_couponpaymentversion.couponpaymentversion_id = b2b_ecommerce_b2border.couponpaymentversion_id
-    left join payment_transactions 
-        on payment_transactions.coupon_id = coupon.coupon_id   
+    left join payment_transactions
+        on payment_transactions.coupon_id = coupon.coupon_id
     left join couponredemption
         on couponredemption.couponversion_id = ecommerce_couponversion.couponversion_id
-    left join ecommerce_order 
+    left join ecommerce_order
         on couponredemption.order_id = ecommerce_order.order_id
-    left join users_user 
-        on users_user.user_id = ecommerce_order.order_purchaser_user_id 
-    left join ecommerce_line 
+    left join users_user
+        on users_user.user_id = ecommerce_order.order_purchaser_user_id
+    left join ecommerce_line
         on ecommerce_line.order_id = ecommerce_order.order_id
     left join program_runs
         on ecommerce_line.programrun_id = program_runs.programrun_id
@@ -204,19 +204,19 @@ with coupon as (
         on course_runs.course_id = courses.course_id
     left join productversion
         on productversion.productversion_id = ecommerce_line.productversion_id
-    where 
-        ecommerce_couponpaymentversion.couponpaymentversion_coupon_type = 'single-use' 
-        and ecommerce_couponpaymentversion.couponpaymentversion_discount_amount = 1.0000 
+    where
+        ecommerce_couponpaymentversion.couponpaymentversion_coupon_type = 'single-use'
+        and ecommerce_couponpaymentversion.couponpaymentversion_discount_amount = 1.0000
         and coupon.coupon_id not in (
             select coupon_id
-            from productcouponassignment 
+            from productcouponassignment
         )
         and not exists (
             select b2b_ecommerce_b2border.couponpaymentversion_id
             from b2b_ecommerce_b2border
-            where 
+            where
                 b2b_ecommerce_b2border.couponpaymentversion_id = ecommerce_couponpaymentversion.couponpaymentversion_id
-        ) 
+        )
 )
 
 , b2b_coupon_fields as (
@@ -228,7 +228,7 @@ with coupon as (
         , coupon.couponpayment_name
         , b2b_ecommerce_b2border.b2border_contract_number
         , b2b_ecommerce_b2border.product_id
-        , ecommerce_couponpaymentversion.couponpaymentversion_payment_transaction 
+        , ecommerce_couponpaymentversion.couponpaymentversion_payment_transaction
         , program_runs.programrun_readable_id
         , program_runs.program_title
         , course_runs.courserun_readable_id
@@ -239,25 +239,25 @@ with coupon as (
         , cast(ecommerce_order.order_id as varchar) as order_ids
         , ecommerce_order.order_state as combined_order_state
         , req_reference_number
-        , case 
+        , case
             when couponredemption.couponredemption_id is not null
-                then 'true' 
-            else 'false' 
+                then 'true'
+            else 'false'
         end as coupon_redeemed
-    from b2b_ecommerce_b2border 
-    inner join ecommerce_couponpaymentversion 
+    from b2b_ecommerce_b2border
+    inner join ecommerce_couponpaymentversion
         on ecommerce_couponpaymentversion.couponpaymentversion_id = b2b_ecommerce_b2border.couponpaymentversion_id
-    inner join ecommerce_couponversion 
+    inner join ecommerce_couponversion
         on ecommerce_couponversion.couponpaymentversion_id = ecommerce_couponpaymentversion.couponpaymentversion_id
-    inner join coupon 
+    inner join coupon
         on coupon.coupon_id = ecommerce_couponversion.coupon_id
-    left join couponredemption 
+    left join couponredemption
         on couponredemption.couponversion_id = ecommerce_couponversion.couponversion_id
-    left join ecommerce_order 
+    left join ecommerce_order
         on ecommerce_order.order_id = couponredemption.order_id
-    left join b2b_ecommerce_b2breceipt 
+    left join b2b_ecommerce_b2breceipt
         on b2b_ecommerce_b2breceipt.b2border_id = b2b_ecommerce_b2border.b2border_id
-    left join ecommerce_line 
+    left join ecommerce_line
         on ecommerce_line.order_id = ecommerce_order.order_id
     left join program_runs
         on ecommerce_line.programrun_id = program_runs.programrun_id
@@ -267,12 +267,12 @@ with coupon as (
         on course_runs.course_id = courses.course_id
     left join productversion
         on productversion.productversion_id = b2b_ecommerce_b2border.productversion_id
-    left join users_user    
+    left join users_user
         on ecommerce_order.order_purchaser_user_id = users_user.user_id
 )
 
 
-select 
+select
     reg_coupon_fields.coupon_email
     , reg_coupon_fields.coupon_code
     , reg_coupon_fields.coupon_id
@@ -299,7 +299,7 @@ where reg_coupon_fields.coupon_id not in (select coupon_id from b2b_coupon_field
 
 union distinct
 
-select 
+select
     b2b_coupon_fields.b2border_email as coupon_email
     , b2b_coupon_fields.coupon_code
     , b2b_coupon_fields.coupon_id
@@ -323,7 +323,7 @@ from b2b_coupon_fields
 
 union distinct
 
-select 
+select
     coupon_email
     , coupon_code
     , coupon_id
@@ -331,7 +331,7 @@ select
     , couponpayment_name
     , b2border_contract_number
     , product_id
-    , couponpaymentversion_payment_transaction  
+    , couponpaymentversion_payment_transaction
     , req_reference_number
     , programrun_readable_id
     , program_title
@@ -344,5 +344,6 @@ select
     , cast(order_ids as varchar) as order_ids
     , combined_order_state
 from unassigned_enrollment_codes
-where coupon_id not in (select coupon_id from reg_coupon_fields)
-and coupon_id not in (select coupon_id from b2b_coupon_fields)
+where
+    coupon_id not in (select coupon_id from reg_coupon_fields)
+    and coupon_id not in (select coupon_id from b2b_coupon_fields)

--- a/src/ol_dbt/models/intermediate/mitxpro/int__mitxpro__ecommerce_combinedcoupons.sql
+++ b/src/ol_dbt/models/intermediate/mitxpro/int__mitxpro__ecommerce_combinedcoupons.sql
@@ -69,17 +69,17 @@ with coupon as (
 )
 
 , payment_transactions as (
-    select distinct
+    select distinct 
         ecommerce_couponversion.coupon_id
         , ecommerce_couponpaymentversion.couponpaymentversion_payment_transaction
     from ecommerce_couponpaymentversion
-    inner join ecommerce_couponversion
+    inner join ecommerce_couponversion 
         on ecommerce_couponpaymentversion.couponpaymentversion_id = ecommerce_couponversion.couponpaymentversion_id
     where ecommerce_couponpaymentversion.couponpaymentversion_payment_transaction is not null
 )
 
 , reg_coupon_summary as (
-    select
+    select 
         coupon.coupon_id
         , ecommerce_couponversion.couponversion_updated_on
         , program_runs.programrun_readable_id
@@ -95,15 +95,15 @@ with coupon as (
         , array_join(array_distinct(array_agg(ecommerce_order.order_id)), ', ') as order_ids
         , array_join(array_distinct(array_agg(ecommerce_order.order_state)), ', ') as combined_order_state
     from coupon
-    left join ecommerce_couponversion
+    left join ecommerce_couponversion 
         on coupon.coupon_id = ecommerce_couponversion.coupon_id
     left join couponredemption
         on ecommerce_couponversion.couponversion_id = couponredemption.couponversion_id
-    left join ecommerce_couponpaymentversion
+    left join ecommerce_couponpaymentversion 
         on ecommerce_couponpaymentversion.couponpaymentversion_id = ecommerce_couponversion.couponpaymentversion_id
     left join ecommerce_order
         on ecommerce_order.order_id = couponredemption.order_id
-    left join ecommerce_line
+    left join ecommerce_line 
         on ecommerce_line.order_id = ecommerce_order.order_id
     left join program_runs
         on ecommerce_line.programrun_id = program_runs.programrun_id
@@ -113,9 +113,9 @@ with coupon as (
         on course_runs.course_id = courses.course_id
     left join productversion
         on productversion.productversion_id = ecommerce_line.productversion_id
-    left join users_user
+    left join users_user    
         on ecommerce_order.order_purchaser_user_id = users_user.user_id
-    group by
+    group by 
         coupon.coupon_id
         , ecommerce_couponversion.couponversion_updated_on
         , program_runs.programrun_readable_id
@@ -128,14 +128,14 @@ with coupon as (
 )
 
 , reg_coupon_fields as (
-    select
+    select 
         productcouponassignment.productcouponassignment_email as coupon_email
         , coupon.coupon_code
         , coupon.coupon_id
         , coupon.coupon_created_on
         , coupon.couponpayment_name
         , productcouponassignment.product_id
-        , payment_transactions.couponpaymentversion_payment_transaction
+        , payment_transactions.couponpaymentversion_payment_transaction 
         , productcouponassignment.productcouponassignment_is_redeemed
     from coupon
     left join productcouponassignment
@@ -154,7 +154,7 @@ with coupon as (
         , coupon.couponpayment_name
         , b2b_ecommerce_b2border.b2border_contract_number
         , b2b_ecommerce_b2border.product_id
-        , ecommerce_couponpaymentversion.couponpaymentversion_payment_transaction
+        , ecommerce_couponpaymentversion.couponpaymentversion_payment_transaction 
         , program_runs.programrun_readable_id
         , program_runs.program_title
         , course_runs.courserun_readable_id
@@ -162,36 +162,36 @@ with coupon as (
         , productversion.productversion_readable_id
         , ecommerce_couponpaymentversion.couponpaymentversion_coupon_type
         , ecommerce_couponpaymentversion.couponpaymentversion_discount_amount
-        , try_cast(users_user.user_email as BigInt) as combined_user_emails
-        , try_cast(users_user.user_address_country as BigInt) as user_address_countries
-        , try_cast(ecommerce_order.order_id as BigInt) as order_ids
-        , try_cast(ecommerce_order.order_state as BigInt) as combined_order_state
+        , TRY_CAST(users_user.user_email as BigInt) combined_user_emails 
+        , TRY_CAST(users_user.user_address_country as BigInt) user_address_countries 
+        , TRY_CAST(ecommerce_order.order_id as BigInt) as order_ids
+        , TRY_CAST(ecommerce_order.order_state as BigInt) as combined_order_state
         , replace(
             cast(
                 json_extract(b2b_ecommerce_b2breceipt.b2breceipt_data, '$.req_reference_number'
                 )
-                as Varchar
+                as varchar
             ), '"', ''
         ) as req_reference_number
-        , case
+        , case 
             when couponredemption.couponredemption_id is not null
-                then 'true'
-            else 'false'
+                then 'true' 
+            else 'false' 
         end as coupon_redeemed
-    from b2b_ecommerce_b2border
-    inner join ecommerce_couponpaymentversion
+    from b2b_ecommerce_b2border 
+    inner join ecommerce_couponpaymentversion 
         on ecommerce_couponpaymentversion.couponpaymentversion_id = b2b_ecommerce_b2border.couponpaymentversion_id
-    inner join ecommerce_couponversion
+    inner join ecommerce_couponversion 
         on ecommerce_couponversion.couponpaymentversion_id = ecommerce_couponpaymentversion.couponpaymentversion_id
-    inner join coupon
+    inner join coupon 
         on coupon.coupon_id = ecommerce_couponversion.coupon_id
-    left join couponredemption
+    left join couponredemption 
         on couponredemption.couponversion_id = ecommerce_couponversion.couponversion_id
-    left join ecommerce_order
+    left join ecommerce_order 
         on ecommerce_order.order_id = couponredemption.order_id
-    left join b2b_ecommerce_b2breceipt
+    left join b2b_ecommerce_b2breceipt 
         on b2b_ecommerce_b2breceipt.b2border_id = b2b_ecommerce_b2border.b2border_id
-    left join ecommerce_line
+    left join ecommerce_line 
         on ecommerce_line.order_id = ecommerce_order.order_id
     left join program_runs
         on ecommerce_line.programrun_id = program_runs.programrun_id
@@ -201,12 +201,12 @@ with coupon as (
         on course_runs.course_id = courses.course_id
     left join productversion
         on productversion.productversion_id = b2b_ecommerce_b2border.productversion_id
-    left join users_user
+    left join users_user    
         on ecommerce_order.order_purchaser_user_id = users_user.user_id
 )
 
 
-select
+select 
     reg_coupon_fields.coupon_email
     , reg_coupon_fields.coupon_code
     , reg_coupon_fields.coupon_id
@@ -226,10 +226,10 @@ select
     , reg_coupon_summary.couponpaymentversion_coupon_type
     , reg_coupon_summary.couponpaymentversion_discount_amount
     , reg_coupon_summary.coupon_redeemed
-    , cast(reg_coupon_summary.combined_user_emails as Bigint) as combined_user_emails
-    , cast(reg_coupon_summary.user_address_countries as Bigint) as user_address_countries
-    , cast(reg_coupon_summary.order_ids as Bigint) as order_ids
-    , cast(reg_coupon_summary.combined_order_state as Bigint) as combined_order_state
+    , TRY_CAST(reg_coupon_summary.combined_user_emails as BigInt) as combined_user_emails
+    , TRY_CAST(reg_coupon_summary.user_address_countries as BigInt) as user_address_countries
+    , TRY_CAST(reg_coupon_summary.order_ids as BigInt) as order_ids
+    , TRY_CAST(reg_coupon_summary.combined_order_state as BigInt) as combined_order_state
 from reg_coupon_fields
 inner join reg_coupon_summary
     on reg_coupon_fields.coupon_id = reg_coupon_summary.coupon_id
@@ -237,7 +237,7 @@ where reg_coupon_fields.coupon_id not in (select coupon_id from b2b_coupon_field
 
 union distinct
 
-select
+select 
     b2b_coupon_fields.b2border_email as coupon_email
     , b2b_coupon_fields.coupon_code
     , b2b_coupon_fields.coupon_id

--- a/src/ol_dbt/models/intermediate/mitxpro/int__mitxpro__ecommerce_combinedcoupons.sql
+++ b/src/ol_dbt/models/intermediate/mitxpro/int__mitxpro__ecommerce_combinedcoupons.sql
@@ -69,17 +69,17 @@ with coupon as (
 )
 
 , payment_transactions as (
-    select distinct
+    select distinct 
         ecommerce_couponversion.coupon_id
         , ecommerce_couponpaymentversion.couponpaymentversion_payment_transaction
     from ecommerce_couponpaymentversion
-    inner join ecommerce_couponversion
+    inner join ecommerce_couponversion 
         on ecommerce_couponpaymentversion.couponpaymentversion_id = ecommerce_couponversion.couponpaymentversion_id
     where ecommerce_couponpaymentversion.couponpaymentversion_payment_transaction is not null
 )
 
 , reg_coupon_summary as (
-    select
+    select 
         coupon.coupon_id
         , ecommerce_couponversion.couponversion_updated_on
         , program_runs.programrun_readable_id
@@ -95,15 +95,15 @@ with coupon as (
         , array_join(array_distinct(array_agg(ecommerce_order.order_id)), ', ') as order_ids
         , array_join(array_distinct(array_agg(ecommerce_order.order_state)), ', ') as combined_order_state
     from coupon
-    left join ecommerce_couponversion
+    left join ecommerce_couponversion 
         on coupon.coupon_id = ecommerce_couponversion.coupon_id
     left join couponredemption
         on ecommerce_couponversion.couponversion_id = couponredemption.couponversion_id
-    left join ecommerce_couponpaymentversion
+    left join ecommerce_couponpaymentversion 
         on ecommerce_couponpaymentversion.couponpaymentversion_id = ecommerce_couponversion.couponpaymentversion_id
     left join ecommerce_order
         on ecommerce_order.order_id = couponredemption.order_id
-    left join ecommerce_line
+    left join ecommerce_line 
         on ecommerce_line.order_id = ecommerce_order.order_id
     left join program_runs
         on ecommerce_line.programrun_id = program_runs.programrun_id
@@ -113,9 +113,9 @@ with coupon as (
         on course_runs.course_id = courses.course_id
     left join productversion
         on productversion.productversion_id = ecommerce_line.productversion_id
-    left join users_user
+    left join users_user    
         on ecommerce_order.order_purchaser_user_id = users_user.user_id
-    group by
+    group by 
         coupon.coupon_id
         , ecommerce_couponversion.couponversion_updated_on
         , program_runs.programrun_readable_id
@@ -128,14 +128,14 @@ with coupon as (
 )
 
 , reg_coupon_fields as (
-    select
+    select 
         productcouponassignment.productcouponassignment_email as coupon_email
         , coupon.coupon_code
         , coupon.coupon_id
         , coupon.coupon_created_on
         , coupon.couponpayment_name
         , productcouponassignment.product_id
-        , payment_transactions.couponpaymentversion_payment_transaction
+        , payment_transactions.couponpaymentversion_payment_transaction 
         , productcouponassignment.productcouponassignment_is_redeemed
     from coupon
     left join productcouponassignment
@@ -154,7 +154,7 @@ with coupon as (
         , coupon.couponpayment_name
         , b2b_ecommerce_b2border.b2border_contract_number
         , b2b_ecommerce_b2border.product_id
-        , ecommerce_couponpaymentversion.couponpaymentversion_payment_transaction
+        , ecommerce_couponpaymentversion.couponpaymentversion_payment_transaction 
         , program_runs.programrun_readable_id
         , program_runs.program_title
         , course_runs.courserun_readable_id
@@ -173,25 +173,25 @@ with coupon as (
                 as varchar
             ), '"', ''
         ) as req_reference_number
-        , case
+        , case 
             when couponredemption.couponredemption_id is not null
-                then 'true'
-            else 'false'
+                then 'true' 
+            else 'false' 
         end as coupon_redeemed
-    from b2b_ecommerce_b2border
-    inner join ecommerce_couponpaymentversion
+    from b2b_ecommerce_b2border 
+    inner join ecommerce_couponpaymentversion 
         on ecommerce_couponpaymentversion.couponpaymentversion_id = b2b_ecommerce_b2border.couponpaymentversion_id
-    inner join ecommerce_couponversion
+    inner join ecommerce_couponversion 
         on ecommerce_couponversion.couponpaymentversion_id = ecommerce_couponpaymentversion.couponpaymentversion_id
-    inner join coupon
+    inner join coupon 
         on coupon.coupon_id = ecommerce_couponversion.coupon_id
-    left join couponredemption
+    left join couponredemption 
         on couponredemption.couponversion_id = ecommerce_couponversion.couponversion_id
-    left join ecommerce_order
+    left join ecommerce_order 
         on ecommerce_order.order_id = couponredemption.order_id
-    left join b2b_ecommerce_b2breceipt
+    left join b2b_ecommerce_b2breceipt 
         on b2b_ecommerce_b2breceipt.b2border_id = b2b_ecommerce_b2border.b2border_id
-    left join ecommerce_line
+    left join ecommerce_line 
         on ecommerce_line.order_id = ecommerce_order.order_id
     left join program_runs
         on ecommerce_line.programrun_id = program_runs.programrun_id
@@ -201,12 +201,12 @@ with coupon as (
         on course_runs.course_id = courses.course_id
     left join productversion
         on productversion.productversion_id = b2b_ecommerce_b2border.productversion_id
-    left join users_user
+    left join users_user    
         on ecommerce_order.order_purchaser_user_id = users_user.user_id
 )
 
 
-select
+select 
     reg_coupon_fields.coupon_email
     , reg_coupon_fields.coupon_code
     , reg_coupon_fields.coupon_id
@@ -233,11 +233,11 @@ select
 from reg_coupon_fields
 inner join reg_coupon_summary
     on reg_coupon_fields.coupon_id = reg_coupon_summary.coupon_id
-where reg_coupon_fields.coupon_id not in (select coupon_id from b2b_coupon_summary)
+where reg_coupon_fields.coupon_id not in (select coupon_id from b2b_coupon_fields)
 
 union distinct
 
-select
+select 
     b2b_coupon_fields.b2border_email as coupon_email
     , b2b_coupon_fields.coupon_code
     , b2b_coupon_fields.coupon_id

--- a/src/ol_dbt/models/intermediate/mitxpro/int__mitxpro__ecommerce_combinedcoupons.sql
+++ b/src/ol_dbt/models/intermediate/mitxpro/int__mitxpro__ecommerce_combinedcoupons.sql
@@ -69,17 +69,17 @@ with coupon as (
 )
 
 , payment_transactions as (
-    select distinct
+    select distinct 
         ecommerce_couponversion.coupon_id
         , ecommerce_couponpaymentversion.couponpaymentversion_payment_transaction
     from ecommerce_couponpaymentversion
-    inner join ecommerce_couponversion
+    inner join ecommerce_couponversion 
         on ecommerce_couponpaymentversion.couponpaymentversion_id = ecommerce_couponversion.couponpaymentversion_id
     where ecommerce_couponpaymentversion.couponpaymentversion_payment_transaction is not null
 )
 
 , reg_coupon_summary as (
-    select
+    select 
         coupon.coupon_id
         , ecommerce_couponversion.couponversion_updated_on
         , program_runs.programrun_readable_id
@@ -95,15 +95,15 @@ with coupon as (
         , array_join(array_distinct(array_agg(ecommerce_order.order_id)), ', ') as order_ids
         , array_join(array_distinct(array_agg(ecommerce_order.order_state)), ', ') as combined_order_state
     from coupon
-    left join ecommerce_couponversion
+    left join ecommerce_couponversion 
         on coupon.coupon_id = ecommerce_couponversion.coupon_id
     left join couponredemption
         on ecommerce_couponversion.couponversion_id = couponredemption.couponversion_id
-    left join ecommerce_couponpaymentversion
+    left join ecommerce_couponpaymentversion 
         on ecommerce_couponpaymentversion.couponpaymentversion_id = ecommerce_couponversion.couponpaymentversion_id
     left join ecommerce_order
         on ecommerce_order.order_id = couponredemption.order_id
-    left join ecommerce_line
+    left join ecommerce_line 
         on ecommerce_line.order_id = ecommerce_order.order_id
     left join program_runs
         on ecommerce_line.programrun_id = program_runs.programrun_id
@@ -113,9 +113,9 @@ with coupon as (
         on course_runs.course_id = courses.course_id
     left join productversion
         on productversion.productversion_id = ecommerce_line.productversion_id
-    left join users_user
+    left join users_user    
         on ecommerce_order.order_purchaser_user_id = users_user.user_id
-    group by
+    group by 
         coupon.coupon_id
         , ecommerce_couponversion.couponversion_updated_on
         , program_runs.programrun_readable_id
@@ -128,14 +128,14 @@ with coupon as (
 )
 
 , reg_coupon_fields as (
-    select
+    select 
         productcouponassignment.productcouponassignment_email as coupon_email
         , coupon.coupon_code
         , coupon.coupon_id
         , coupon.coupon_created_on
         , coupon.couponpayment_name
         , productcouponassignment.product_id
-        , payment_transactions.couponpaymentversion_payment_transaction
+        , payment_transactions.couponpaymentversion_payment_transaction 
         , productcouponassignment.productcouponassignment_is_redeemed
     from coupon
     left join productcouponassignment
@@ -154,7 +154,7 @@ with coupon as (
         , coupon.couponpayment_name
         , b2b_ecommerce_b2border.b2border_contract_number
         , b2b_ecommerce_b2border.product_id
-        , ecommerce_couponpaymentversion.couponpaymentversion_payment_transaction
+        , ecommerce_couponpaymentversion.couponpaymentversion_payment_transaction 
         , program_runs.programrun_readable_id
         , program_runs.program_title
         , course_runs.courserun_readable_id
@@ -173,25 +173,25 @@ with coupon as (
                 as varchar
             ), '"', ''
         ) as req_reference_number
-        , case
+        , case 
             when couponredemption.couponredemption_id is not null
-                then 'true'
-            else 'false'
+                then 'true' 
+            else 'false' 
         end as coupon_redeemed
-    from b2b_ecommerce_b2border
-    inner join ecommerce_couponpaymentversion
+    from b2b_ecommerce_b2border 
+    inner join ecommerce_couponpaymentversion 
         on ecommerce_couponpaymentversion.couponpaymentversion_id = b2b_ecommerce_b2border.couponpaymentversion_id
-    inner join ecommerce_couponversion
+    inner join ecommerce_couponversion 
         on ecommerce_couponversion.couponpaymentversion_id = ecommerce_couponpaymentversion.couponpaymentversion_id
-    inner join coupon
+    inner join coupon 
         on coupon.coupon_id = ecommerce_couponversion.coupon_id
-    left join couponredemption
+    left join couponredemption 
         on couponredemption.couponversion_id = ecommerce_couponversion.couponversion_id
-    left join ecommerce_order
+    left join ecommerce_order 
         on ecommerce_order.order_id = couponredemption.order_id
-    left join b2b_ecommerce_b2breceipt
+    left join b2b_ecommerce_b2breceipt 
         on b2b_ecommerce_b2breceipt.b2border_id = b2b_ecommerce_b2border.b2border_id
-    left join ecommerce_line
+    left join ecommerce_line 
         on ecommerce_line.order_id = ecommerce_order.order_id
     left join program_runs
         on ecommerce_line.programrun_id = program_runs.programrun_id
@@ -201,12 +201,12 @@ with coupon as (
         on course_runs.course_id = courses.course_id
     left join productversion
         on productversion.productversion_id = b2b_ecommerce_b2border.productversion_id
-    left join users_user
+    left join users_user    
         on ecommerce_order.order_purchaser_user_id = users_user.user_id
 )
 
 
-select
+select 
     reg_coupon_fields.coupon_email
     , reg_coupon_fields.coupon_code
     , reg_coupon_fields.coupon_id
@@ -217,14 +217,14 @@ select
     , reg_coupon_fields.product_id
     , reg_coupon_fields.couponpaymentversion_payment_transaction
     , null as req_reference_number
-    , reg_coupon_fields.programrun_readable_id
-    , reg_coupon_fields.program_title
-    , reg_coupon_fields.courserun_readable_id
-    , reg_coupon_fields.course_title
-    , reg_coupon_fields.productversion_readable_id
+    , reg_coupon_summary.programrun_readable_id
+    , reg_coupon_summary.program_title
+    , reg_coupon_summary.courserun_readable_id
+    , reg_coupon_summary.course_title
+    , reg_coupon_summary.productversion_readable_id
     , 'regular coupon' as combinedcoupon_table_source
-    , reg_coupon_fields.couponpaymentversion_coupon_type
-    , reg_coupon_fields.couponpaymentversion_discount_amount
+    , reg_coupon_summary.couponpaymentversion_coupon_type
+    , reg_coupon_summary.couponpaymentversion_discount_amount
     , reg_coupon_summary.coupon_redeemed
     , reg_coupon_summary.combined_user_emails
     , reg_coupon_summary.user_address_countries
@@ -237,7 +237,7 @@ where reg_coupon_fields.coupon_id not in (select coupon_id from b2b_coupon_field
 
 union distinct
 
-select
+select 
     b2b_coupon_fields.b2border_email as coupon_email
     , b2b_coupon_fields.coupon_code
     , b2b_coupon_fields.coupon_id

--- a/src/ol_dbt/models/intermediate/mitxpro/int__mitxpro__ecommerce_combinedcoupons.sql
+++ b/src/ol_dbt/models/intermediate/mitxpro/int__mitxpro__ecommerce_combinedcoupons.sql
@@ -69,17 +69,17 @@ with coupon as (
 )
 
 , payment_transactions as (
-    select distinct
+    select distinct 
         ecommerce_couponversion.coupon_id
         , ecommerce_couponpaymentversion.couponpaymentversion_payment_transaction
     from ecommerce_couponpaymentversion
-    inner join ecommerce_couponversion
+    inner join ecommerce_couponversion 
         on ecommerce_couponpaymentversion.couponpaymentversion_id = ecommerce_couponversion.couponpaymentversion_id
     where ecommerce_couponpaymentversion.couponpaymentversion_payment_transaction is not null
 )
 
 , latest_couponversion as (
-    select
+    select 
         coupon_id
         , max(couponversion_updated_on) as max_couponversion_updated_on
     from ecommerce_couponversion
@@ -87,38 +87,38 @@ with coupon as (
 )
 
 , reg_coupon_summary as (
-    select
+    select 
         coupon.coupon_id
-        , cast(array_join(array_distinct(array_agg(program_runs.programrun_readable_id)), ', ') as varchar)
+        , cast(array_join(array_distinct(array_agg(program_runs.programrun_readable_id)), ', ') as varchar) 
             as programrun_readable_id
         , cast(array_join(array_distinct(array_agg(program_runs.program_title)), ', ') as varchar) as program_title
-        , cast(array_join(array_distinct(array_agg(course_runs.courserun_readable_id)), ', ') as varchar)
+        , cast(array_join(array_distinct(array_agg(course_runs.courserun_readable_id)), ', ') as varchar) 
             as courserun_readable_id
         , cast(array_join(array_distinct(array_agg(courses.course_title)), ', ') as varchar) as course_title
-        , cast(array_join(array_distinct(array_agg(productversion.productversion_readable_id)), ', ') as varchar)
+        , cast(array_join(array_distinct(array_agg(productversion.productversion_readable_id)), ', ') as varchar) 
             as productversion_readable_id
         , cast(array_join(array_distinct(array_agg(users_user.user_email)), ', ') as varchar) as combined_user_emails
-        , cast(array_join(array_distinct(array_agg(users_user.user_address_country)), ', ') as varchar)
+        , cast(array_join(array_distinct(array_agg(users_user.user_address_country)), ', ') as varchar) 
             as user_address_countries
         , cast(array_join(array_distinct(array_agg(ecommerce_order.order_id)), ', ') as varchar) as order_ids
-        , cast(array_join(array_distinct(array_agg(ecommerce_order.order_state)), ', ') as varchar)
+        , cast(array_join(array_distinct(array_agg(ecommerce_order.order_state)), ', ') as varchar) 
             as combined_order_state
         , case when (count(couponredemption.couponredemption_id) >= 1) then 'true' else 'false' end as coupon_redeemed
-
+        
     from coupon
     left join latest_couponversion
         on coupon.coupon_id = latest_couponversion.coupon_id
-    left join ecommerce_couponversion
-        on
-            latest_couponversion.coupon_id = ecommerce_couponversion.coupon_id
+    left join ecommerce_couponversion 
+        on 
+            latest_couponversion.coupon_id = ecommerce_couponversion.coupon_id 
             and ecommerce_couponversion.couponversion_updated_on = latest_couponversion.max_couponversion_updated_on
     left join couponredemption
         on ecommerce_couponversion.couponversion_id = couponredemption.couponversion_id
-    left join ecommerce_couponpaymentversion
+    left join ecommerce_couponpaymentversion 
         on ecommerce_couponpaymentversion.couponpaymentversion_id = ecommerce_couponversion.couponpaymentversion_id
     left join ecommerce_order
         on ecommerce_order.order_id = couponredemption.order_id
-    left join ecommerce_line
+    left join ecommerce_line 
         on ecommerce_line.order_id = ecommerce_order.order_id
     left join program_runs
         on ecommerce_line.programrun_id = program_runs.programrun_id
@@ -128,22 +128,22 @@ with coupon as (
         on course_runs.course_id = courses.course_id
     left join productversion
         on productversion.productversion_id = ecommerce_line.productversion_id
-    left join users_user
+    left join users_user    
         on ecommerce_order.order_purchaser_user_id = users_user.user_id
     where ecommerce_order.order_state = 'fulfilled' or ecommerce_order.order_state = 'refunded'
-    group by
+    group by 
         coupon.coupon_id
 )
 
 , reg_coupon_fields as (
-    select
+    select 
         productcouponassignment.productcouponassignment_email as coupon_email
         , coupon.coupon_code
         , coupon.coupon_id
         , coupon.coupon_created_on
         , coupon.couponpayment_name
         , productcouponassignment.product_id
-        , payment_transactions.couponpaymentversion_payment_transaction
+        , payment_transactions.couponpaymentversion_payment_transaction 
         , productcouponassignment.productcouponassignment_is_redeemed
     from coupon
     left join productcouponassignment
@@ -153,13 +153,13 @@ with coupon as (
 )
 
 , unassigned_enrollment_codes as (
-    select
+    select 
         coupon.coupon_code
         , coupon.coupon_id
         , coupon.coupon_created_on as coupon_created_on
         , coupon.couponpayment_name
         , b2b_ecommerce_b2border.b2border_contract_number
-        , payment_transactions.couponpaymentversion_payment_transaction
+        , payment_transactions.couponpaymentversion_payment_transaction  
         , program_runs.programrun_readable_id
         , program_runs.program_title
         , course_runs.courserun_readable_id
@@ -173,26 +173,26 @@ with coupon as (
         , null as product_id
         , null as req_reference_number
         , case when ecommerce_order.order_id is not null then 'true' else 'false' end as redeemed
-    from int__mitxpro__ecommerce_coupon as coupon
+    from coupon
     inner join latest_couponversion
         on coupon.coupon_id = latest_couponversion.coupon_id
     inner join ecommerce_couponversion
-        on
-            latest_couponversion.coupon_id = ecommerce_couponversion.coupon_id
+        on 
+            latest_couponversion.coupon_id = ecommerce_couponversion.coupon_id 
             and ecommerce_couponversion.couponversion_updated_on = latest_couponversion.max_couponversion_updated_on
     inner join ecommerce_couponpaymentversion
-        on ecommerce_couponpaymentversion.couponpaymentversion_id = ecommerce_couponversion.couponpaymentversion_id
-    left join b2b_ecommerce_b2border
+        on ecommerce_couponpaymentversion.couponpaymentversion_id = ecommerce_couponversion.couponpaymentversion_id 
+    left join b2b_ecommerce_b2border 
         on ecommerce_couponpaymentversion.couponpaymentversion_id = b2b_ecommerce_b2border.couponpaymentversion_id
-    left join payment_transactions
-        on payment_transactions.coupon_id = coupon.coupon_id
+    left join payment_transactions 
+        on payment_transactions.coupon_id = coupon.coupon_id   
     left join ecommerce_couponredemption
         on ecommerce_couponredemption.couponversion_id = ecommerce_couponversion.couponversion_id
-    left join ecommerce_order
+    left join ecommerce_order 
         on ecommerce_couponredemption.order_id = ecommerce_order.order_id
-    left join users_user
-        on users_user.user_id = ecommerce_order.order_purchaser_user_id
-    left join ecommerce_line
+    left join users_user 
+        on users_user.user_id = ecommerce_order.order_purchaser_user_id 
+    left join ecommerce_line 
         on ecommerce_line.order_id = ecommerce_order.order_id
     left join program_runs
         on ecommerce_line.programrun_id = program_runs.programrun_id
@@ -202,19 +202,19 @@ with coupon as (
         on course_runs.course_id = courses.course_id
     left join productversion
         on productversion.productversion_id = ecommerce_line.productversion_id
-    where
-        ecommerce_couponpaymentversion.couponpaymentversion_coupon_type = 'single-use'
-        and ecommerce_couponpaymentversion.couponpaymentversion_discount_amount = 1.0000
+    where 
+        ecommerce_couponpaymentversion.couponpaymentversion_coupon_type = 'single-use' 
+        and ecommerce_couponpaymentversion.couponpaymentversion_discount_amount = 1.0000 
         and coupon.coupon_id not in (
             select coupon_id
-            from ecommerce_productcouponassignment
+            from ecommerce_productcouponassignment 
         )
         and not exists (
             select b2b_ecommerce_b2border.couponpaymentversion_id
             from b2b_ecommerce_b2border
-            where
+            where 
                 b2b_ecommerce_b2border.couponpaymentversion_id = ecommerce_couponpaymentversion.couponpaymentversion_id
-        )
+        ) 
 )
 
 , b2b_coupon_fields as (
@@ -226,7 +226,7 @@ with coupon as (
         , coupon.couponpayment_name
         , b2b_ecommerce_b2border.b2border_contract_number
         , b2b_ecommerce_b2border.product_id
-        , ecommerce_couponpaymentversion.couponpaymentversion_payment_transaction
+        , ecommerce_couponpaymentversion.couponpaymentversion_payment_transaction 
         , program_runs.programrun_readable_id
         , program_runs.program_title
         , course_runs.courserun_readable_id
@@ -243,25 +243,25 @@ with coupon as (
                 as varchar
             ), '"', ''
         ) as req_reference_number
-        , case
+        , case 
             when couponredemption.couponredemption_id is not null
-                then 'true'
-            else 'false'
+                then 'true' 
+            else 'false' 
         end as coupon_redeemed
-    from b2b_ecommerce_b2border
-    inner join ecommerce_couponpaymentversion
+    from b2b_ecommerce_b2border 
+    inner join ecommerce_couponpaymentversion 
         on ecommerce_couponpaymentversion.couponpaymentversion_id = b2b_ecommerce_b2border.couponpaymentversion_id
-    inner join ecommerce_couponversion
+    inner join ecommerce_couponversion 
         on ecommerce_couponversion.couponpaymentversion_id = ecommerce_couponpaymentversion.couponpaymentversion_id
-    inner join coupon
+    inner join coupon 
         on coupon.coupon_id = ecommerce_couponversion.coupon_id
-    left join couponredemption
+    left join couponredemption 
         on couponredemption.couponversion_id = ecommerce_couponversion.couponversion_id
-    left join ecommerce_order
+    left join ecommerce_order 
         on ecommerce_order.order_id = couponredemption.order_id
-    left join b2b_ecommerce_b2breceipt
+    left join b2b_ecommerce_b2breceipt 
         on b2b_ecommerce_b2breceipt.b2border_id = b2b_ecommerce_b2border.b2border_id
-    left join ecommerce_line
+    left join ecommerce_line 
         on ecommerce_line.order_id = ecommerce_order.order_id
     left join program_runs
         on ecommerce_line.programrun_id = program_runs.programrun_id
@@ -271,12 +271,12 @@ with coupon as (
         on course_runs.course_id = courses.course_id
     left join productversion
         on productversion.productversion_id = b2b_ecommerce_b2border.productversion_id
-    left join users_user
+    left join users_user    
         on ecommerce_order.order_purchaser_user_id = users_user.user_id
 )
 
 
-select
+select 
     reg_coupon_fields.coupon_email
     , reg_coupon_fields.coupon_code
     , reg_coupon_fields.coupon_id
@@ -303,7 +303,7 @@ where reg_coupon_fields.coupon_id not in (select coupon_id from b2b_coupon_field
 
 union distinct
 
-select
+select 
     b2b_coupon_fields.b2border_email as coupon_email
     , b2b_coupon_fields.coupon_code
     , b2b_coupon_fields.coupon_id
@@ -327,7 +327,7 @@ from b2b_coupon_fields
 
 union distinct
 
-select
+select 
     coupon_email
     , coupon_code
     , coupon_id
@@ -335,7 +335,7 @@ select
     , couponpayment_name
     , b2border_contract_number
     , product_id
-    , couponpaymentversion_payment_transaction
+    , couponpaymentversion_payment_transaction  
     , req_reference_number
     , programrun_readable_id
     , program_title

--- a/src/ol_dbt/models/intermediate/mitxpro/int__mitxpro__ecommerce_combinedcoupons.sql
+++ b/src/ol_dbt/models/intermediate/mitxpro/int__mitxpro__ecommerce_combinedcoupons.sql
@@ -71,17 +71,17 @@ with coupon as (
 )
 
 , payment_transactions as (
-    select distinct 
+    select distinct
         ecommerce_couponversion.coupon_id
         , ecommerce_couponpaymentversion.couponpaymentversion_payment_transaction
     from ecommerce_couponpaymentversion
-    inner join ecommerce_couponversion 
+    inner join ecommerce_couponversion
         on ecommerce_couponpaymentversion.couponpaymentversion_id = ecommerce_couponversion.couponpaymentversion_id
     where ecommerce_couponpaymentversion.couponpaymentversion_payment_transaction is not null
 )
 
 , latest_couponversion as (
-    select 
+    select
         coupon_id
         , max(couponversion_updated_on) as max_couponversion_updated_on
     from ecommerce_couponversion
@@ -89,38 +89,38 @@ with coupon as (
 )
 
 , reg_coupon_summary as (
-    select 
+    select
         coupon.coupon_id
-        , cast(array_join(array_distinct(array_agg(program_runs.programrun_readable_id)), ', ') as varchar) 
+        , cast(array_join(array_distinct(array_agg(program_runs.programrun_readable_id)), ', ') as varchar)
             as programrun_readable_id
         , cast(array_join(array_distinct(array_agg(program_runs.program_title)), ', ') as varchar) as program_title
-        , cast(array_join(array_distinct(array_agg(course_runs.courserun_readable_id)), ', ') as varchar) 
+        , cast(array_join(array_distinct(array_agg(course_runs.courserun_readable_id)), ', ') as varchar)
             as courserun_readable_id
         , cast(array_join(array_distinct(array_agg(courses.course_title)), ', ') as varchar) as course_title
-        , cast(array_join(array_distinct(array_agg(productversion.productversion_readable_id)), ', ') as varchar) 
+        , cast(array_join(array_distinct(array_agg(productversion.productversion_readable_id)), ', ') as varchar)
             as productversion_readable_id
         , cast(array_join(array_distinct(array_agg(users_user.user_email)), ', ') as varchar) as combined_user_emails
-        , cast(array_join(array_distinct(array_agg(users_user.user_address_country)), ', ') as varchar) 
+        , cast(array_join(array_distinct(array_agg(users_user.user_address_country)), ', ') as varchar)
             as user_address_countries
         , cast(array_join(array_distinct(array_agg(ecommerce_order.order_id)), ', ') as varchar) as order_ids
-        , cast(array_join(array_distinct(array_agg(ecommerce_order.order_state)), ', ') as varchar) 
+        , cast(array_join(array_distinct(array_agg(ecommerce_order.order_state)), ', ') as varchar)
             as combined_order_state
         , case when (count(couponredemption.couponredemption_id) >= 1) then 'true' else 'false' end as coupon_redeemed
-        
+
     from coupon
     left join latest_couponversion
         on coupon.coupon_id = latest_couponversion.coupon_id
-    left join ecommerce_couponversion 
-        on 
-            latest_couponversion.coupon_id = ecommerce_couponversion.coupon_id 
+    left join ecommerce_couponversion
+        on
+            latest_couponversion.coupon_id = ecommerce_couponversion.coupon_id
             and ecommerce_couponversion.couponversion_updated_on = latest_couponversion.max_couponversion_updated_on
     left join couponredemption
         on ecommerce_couponversion.couponversion_id = couponredemption.couponversion_id
-    left join ecommerce_couponpaymentversion 
+    left join ecommerce_couponpaymentversion
         on ecommerce_couponpaymentversion.couponpaymentversion_id = ecommerce_couponversion.couponpaymentversion_id
     left join ecommerce_order
         on ecommerce_order.order_id = couponredemption.order_id
-    left join ecommerce_line 
+    left join ecommerce_line
         on ecommerce_line.order_id = ecommerce_order.order_id
     left join program_runs
         on ecommerce_line.programrun_id = program_runs.programrun_id
@@ -130,22 +130,22 @@ with coupon as (
         on course_runs.course_id = courses.course_id
     left join productversion
         on productversion.productversion_id = ecommerce_line.productversion_id
-    left join users_user    
+    left join users_user
         on ecommerce_order.order_purchaser_user_id = users_user.user_id
     where ecommerce_order.order_state = 'fulfilled' or ecommerce_order.order_state = 'refunded'
-    group by 
+    group by
         coupon.coupon_id
 )
 
 , reg_coupon_fields as (
-    select 
+    select
         productcouponassignment.productcouponassignment_email as coupon_email
         , coupon.coupon_code
         , coupon.coupon_id
         , coupon.coupon_created_on
         , coupon.couponpayment_name
         , productcouponassignment.product_id
-        , payment_transactions.couponpaymentversion_payment_transaction 
+        , payment_transactions.couponpaymentversion_payment_transaction
         , productcouponassignment.productcouponassignment_is_redeemed
     from coupon
     left join productcouponassignment
@@ -155,13 +155,13 @@ with coupon as (
 )
 
 , unassigned_enrollment_codes as (
-    select 
+    select
         coupon.coupon_code
         , coupon.coupon_id
         , coupon.coupon_created_on as coupon_created_on
         , coupon.couponpayment_name
         , b2b_ecommerce_b2border.b2border_contract_number
-        , payment_transactions.couponpaymentversion_payment_transaction  
+        , payment_transactions.couponpaymentversion_payment_transaction
         , program_runs.programrun_readable_id
         , program_runs.program_title
         , course_runs.courserun_readable_id
@@ -179,22 +179,22 @@ with coupon as (
     inner join latest_couponversion
         on coupon.coupon_id = latest_couponversion.coupon_id
     inner join ecommerce_couponversion
-        on 
-            latest_couponversion.coupon_id = ecommerce_couponversion.coupon_id 
+        on
+            latest_couponversion.coupon_id = ecommerce_couponversion.coupon_id
             and ecommerce_couponversion.couponversion_updated_on = latest_couponversion.max_couponversion_updated_on
     inner join ecommerce_couponpaymentversion
-        on ecommerce_couponpaymentversion.couponpaymentversion_id = ecommerce_couponversion.couponpaymentversion_id 
-    left join b2b_ecommerce_b2border 
+        on ecommerce_couponpaymentversion.couponpaymentversion_id = ecommerce_couponversion.couponpaymentversion_id
+    left join b2b_ecommerce_b2border
         on ecommerce_couponpaymentversion.couponpaymentversion_id = b2b_ecommerce_b2border.couponpaymentversion_id
-    left join payment_transactions 
-        on payment_transactions.coupon_id = coupon.coupon_id   
+    left join payment_transactions
+        on payment_transactions.coupon_id = coupon.coupon_id
     left join couponredemption
         on couponredemption.couponversion_id = ecommerce_couponversion.couponversion_id
-    left join ecommerce_order 
+    left join ecommerce_order
         on couponredemption.order_id = ecommerce_order.order_id
-    left join users_user 
-        on users_user.user_id = ecommerce_order.order_purchaser_user_id 
-    left join ecommerce_line 
+    left join users_user
+        on users_user.user_id = ecommerce_order.order_purchaser_user_id
+    left join ecommerce_line
         on ecommerce_line.order_id = ecommerce_order.order_id
     left join program_runs
         on ecommerce_line.programrun_id = program_runs.programrun_id
@@ -204,19 +204,19 @@ with coupon as (
         on course_runs.course_id = courses.course_id
     left join productversion
         on productversion.productversion_id = ecommerce_line.productversion_id
-    where 
-        ecommerce_couponpaymentversion.couponpaymentversion_coupon_type = 'single-use' 
-        and ecommerce_couponpaymentversion.couponpaymentversion_discount_amount = 1.0000 
+    where
+        ecommerce_couponpaymentversion.couponpaymentversion_coupon_type = 'single-use'
+        and ecommerce_couponpaymentversion.couponpaymentversion_discount_amount = 1.0000
         and coupon.coupon_id not in (
             select coupon_id
-            from productcouponassignment 
+            from productcouponassignment
         )
         and not exists (
             select b2b_ecommerce_b2border.couponpaymentversion_id
             from b2b_ecommerce_b2border
-            where 
+            where
                 b2b_ecommerce_b2border.couponpaymentversion_id = ecommerce_couponpaymentversion.couponpaymentversion_id
-        ) 
+        )
 )
 
 , b2b_coupon_fields as (
@@ -228,7 +228,7 @@ with coupon as (
         , coupon.couponpayment_name
         , b2b_ecommerce_b2border.b2border_contract_number
         , b2b_ecommerce_b2border.product_id
-        , ecommerce_couponpaymentversion.couponpaymentversion_payment_transaction 
+        , ecommerce_couponpaymentversion.couponpaymentversion_payment_transaction
         , program_runs.programrun_readable_id
         , program_runs.program_title
         , course_runs.courserun_readable_id
@@ -239,25 +239,25 @@ with coupon as (
         , cast(ecommerce_order.order_id as varchar) as order_ids
         , ecommerce_order.order_state as combined_order_state
         , req_reference_number
-        , case 
+        , case
             when couponredemption.couponredemption_id is not null
-                then 'true' 
-            else 'false' 
+                then 'true'
+            else 'false'
         end as coupon_redeemed
-    from b2b_ecommerce_b2border 
-    inner join ecommerce_couponpaymentversion 
+    from b2b_ecommerce_b2border
+    inner join ecommerce_couponpaymentversion
         on ecommerce_couponpaymentversion.couponpaymentversion_id = b2b_ecommerce_b2border.couponpaymentversion_id
-    inner join ecommerce_couponversion 
+    inner join ecommerce_couponversion
         on ecommerce_couponversion.couponpaymentversion_id = ecommerce_couponpaymentversion.couponpaymentversion_id
-    inner join coupon 
+    inner join coupon
         on coupon.coupon_id = ecommerce_couponversion.coupon_id
-    left join couponredemption 
+    left join couponredemption
         on couponredemption.couponversion_id = ecommerce_couponversion.couponversion_id
-    left join ecommerce_order 
+    left join ecommerce_order
         on ecommerce_order.order_id = couponredemption.order_id
-    left join b2b_ecommerce_b2breceipt 
+    left join b2b_ecommerce_b2breceipt
         on b2b_ecommerce_b2breceipt.b2border_id = b2b_ecommerce_b2border.b2border_id
-    left join ecommerce_line 
+    left join ecommerce_line
         on ecommerce_line.order_id = ecommerce_order.order_id
     left join program_runs
         on ecommerce_line.programrun_id = program_runs.programrun_id
@@ -267,12 +267,12 @@ with coupon as (
         on course_runs.course_id = courses.course_id
     left join productversion
         on productversion.productversion_id = b2b_ecommerce_b2border.productversion_id
-    left join users_user    
+    left join users_user
         on ecommerce_order.order_purchaser_user_id = users_user.user_id
 )
 
 
-select 
+select
     reg_coupon_fields.coupon_email
     , reg_coupon_fields.coupon_code
     , reg_coupon_fields.coupon_id
@@ -299,7 +299,7 @@ where reg_coupon_fields.coupon_id not in (select coupon_id from b2b_coupon_field
 
 union distinct
 
-select 
+select
     b2b_coupon_fields.b2border_email as coupon_email
     , b2b_coupon_fields.coupon_code
     , b2b_coupon_fields.coupon_id
@@ -323,7 +323,7 @@ from b2b_coupon_fields
 
 union distinct
 
-select 
+select
     coupon_email
     , coupon_code
     , coupon_id
@@ -331,7 +331,7 @@ select
     , couponpayment_name
     , b2border_contract_number
     , product_id
-    , couponpaymentversion_payment_transaction  
+    , couponpaymentversion_payment_transaction
     , req_reference_number
     , programrun_readable_id
     , program_title
@@ -344,6 +344,6 @@ select
     , cast(order_ids as varchar) as order_ids
     , combined_order_state
 from unassigned_enrollment_codes
-where 
+where
     coupon_id not in (select coupon_id from reg_coupon_fields)
     and coupon_id not in (select coupon_id from b2b_coupon_fields)

--- a/src/ol_dbt/models/intermediate/mitxpro/int__mitxpro__ecommerce_combinedcoupons.sql
+++ b/src/ol_dbt/models/intermediate/mitxpro/int__mitxpro__ecommerce_combinedcoupons.sql
@@ -69,17 +69,17 @@ with coupon as (
 )
 
 , payment_transactions as (
-    select distinct 
+    select distinct
         ecommerce_couponversion.coupon_id
         , ecommerce_couponpaymentversion.couponpaymentversion_payment_transaction
     from ecommerce_couponpaymentversion
-    inner join ecommerce_couponversion 
+    inner join ecommerce_couponversion
         on ecommerce_couponpaymentversion.couponpaymentversion_id = ecommerce_couponversion.couponpaymentversion_id
     where ecommerce_couponpaymentversion.couponpaymentversion_payment_transaction is not null
 )
 
 
-select 
+select
     productcouponassignment.productcouponassignment_email as coupon_email
     , coupon.coupon_code
     , coupon.coupon_id
@@ -87,7 +87,7 @@ select
     , coupon.couponpayment_name
     , null as b2border_contract_number
     , productcouponassignment.product_id
-    , payment_transactions.couponpaymentversion_payment_transaction 
+    , payment_transactions.couponpaymentversion_payment_transaction
     , null as req_reference_number
     , program_runs.programrun_readable_id
     , program_runs.program_title
@@ -105,19 +105,19 @@ select
 from coupon
 left join productcouponassignment
     on productcouponassignment.coupon_id = coupon.coupon_id
-left join ecommerce_couponversion 
+left join ecommerce_couponversion
     on coupon.coupon_id = ecommerce_couponversion.coupon_id
-left join ecommerce_couponpaymentversion 
+left join ecommerce_couponpaymentversion
     on ecommerce_couponpaymentversion.couponpaymentversion_id = ecommerce_couponversion.couponpaymentversion_id
 left join couponredemption
     on ecommerce_couponversion.couponversion_id = couponredemption.couponversion_id
 left join ecommerce_order
     on ecommerce_order.order_id = couponredemption.order_id
-left join users_user    
+left join users_user
     on ecommerce_order.order_purchaser_user_id = users_user.user_id
 left join payment_transactions
     on coupon.coupon_id = payment_transactions.coupon_id
-left join ecommerce_line 
+left join ecommerce_line
     on ecommerce_line.order_id = ecommerce_order.order_id
 left join program_runs
     on ecommerce_line.programrun_id = program_runs.programrun_id
@@ -127,14 +127,14 @@ left join courses
     on course_runs.course_id = courses.course_id
 left join productversion
     on productversion.productversion_id = ecommerce_line.productversion_id
-group by 
-    productcouponassignment.productcouponassignment_email 
+group by
+    productcouponassignment.productcouponassignment_email
     , coupon.coupon_code
     , coupon.coupon_id
     , coupon.coupon_created_on
     , coupon.couponpayment_name
     , productcouponassignment.product_id
-    , payment_transactions.couponpaymentversion_payment_transaction 
+    , payment_transactions.couponpaymentversion_payment_transaction
     , program_runs.programrun_readable_id
     , program_runs.program_title
     , course_runs.courserun_readable_id
@@ -145,7 +145,7 @@ group by
 
 union distinct
 
-select 
+select
     b2b_ecommerce_b2border.b2border_email as coupon_email
     , coupon.coupon_code
     , coupon.coupon_id
@@ -153,7 +153,7 @@ select
     , coupon.couponpayment_name
     , b2b_ecommerce_b2border.b2border_contract_number
     , b2b_ecommerce_b2border.product_id
-    , ecommerce_couponpaymentversion.couponpaymentversion_payment_transaction 
+    , ecommerce_couponpaymentversion.couponpaymentversion_payment_transaction
     , replace(
         cast(
             json_extract(b2b_ecommerce_b2breceipt.b2breceipt_data, '$.req_reference_number'
@@ -169,31 +169,31 @@ select
     , 'b2b coupon' as combinedcoupon_table_source
     , ecommerce_couponpaymentversion.couponpaymentversion_coupon_type
     , ecommerce_couponpaymentversion.couponpaymentversion_discount_amount
-    , case 
-        when (count(couponredemption.couponredemption_id) >= 1) 
-            then 'true' 
-        else 'false' 
+    , case
+        when (count(couponredemption.couponredemption_id) >= 1)
+            then 'true'
+        else 'false'
     end as coupon_redeemed
     , array_join(array_distinct(array_agg(users_user.user_email)), ', ') as combined_user_emails
     , array_join(array_distinct(array_agg(users_user.user_address_country)), ', ') as user_address_countries
     , array_join(array_distinct(array_agg(ecommerce_order.order_id)), ', ') as order_ids
     , array_join(array_distinct(array_agg(ecommerce_order.order_state)), ', ') as combined_order_state
-from b2b_ecommerce_b2border 
-left join ecommerce_couponpaymentversion 
+from b2b_ecommerce_b2border
+left join ecommerce_couponpaymentversion
     on ecommerce_couponpaymentversion.couponpaymentversion_id = b2b_ecommerce_b2border.couponpaymentversion_id
-left join coupon 
-    on coupon.coupon_id = b2b_ecommerce_b2border.b2bcoupon_id 
-left join ecommerce_couponversion 
+left join coupon
+    on coupon.coupon_id = b2b_ecommerce_b2border.b2bcoupon_id
+left join ecommerce_couponversion
     on ecommerce_couponversion.coupon_id = coupon.coupon_id
-left join couponredemption 
+left join couponredemption
     on couponredemption.couponversion_id = ecommerce_couponversion.couponversion_id
-left join ecommerce_order 
+left join ecommerce_order
     on ecommerce_order.order_id = couponredemption.order_id
-left join users_user    
+left join users_user
     on ecommerce_order.order_purchaser_user_id = users_user.user_id
-left join b2b_ecommerce_b2breceipt 
+left join b2b_ecommerce_b2breceipt
     on b2b_ecommerce_b2breceipt.b2border_id = b2b_ecommerce_b2border.b2border_id
-left join ecommerce_line 
+left join ecommerce_line
     on ecommerce_line.order_id = ecommerce_order.order_id
 left join program_runs
     on ecommerce_line.programrun_id = program_runs.programrun_id
@@ -203,21 +203,21 @@ left join courses
     on course_runs.course_id = courses.course_id
 left join productversion
     on productversion.productversion_id = b2b_ecommerce_b2border.productversion_id
-group by 
-    b2b_ecommerce_b2border.b2border_email 
+group by
+    b2b_ecommerce_b2border.b2border_email
     , coupon.coupon_code
     , coupon.coupon_id
     , coupon.coupon_created_on
     , coupon.couponpayment_name
     , b2b_ecommerce_b2border.b2border_contract_number
     , b2b_ecommerce_b2border.product_id
-    , ecommerce_couponpaymentversion.couponpaymentversion_payment_transaction 
+    , ecommerce_couponpaymentversion.couponpaymentversion_payment_transaction
     , replace(
         cast(
             json_extract(b2b_ecommerce_b2breceipt.b2breceipt_data, '$.req_reference_number')
             as varchar
         ), '"', ''
-    ) 
+    )
     , program_runs.programrun_readable_id
     , program_runs.program_title
     , course_runs.courserun_readable_id

--- a/src/ol_dbt/models/intermediate/mitxpro/int__mitxpro__ecommerce_combinedcoupons.sql
+++ b/src/ol_dbt/models/intermediate/mitxpro/int__mitxpro__ecommerce_combinedcoupons.sql
@@ -71,17 +71,17 @@ with coupon as (
 )
 
 , payment_transactions as (
-    select distinct
+    select distinct 
         ecommerce_couponversion.coupon_id
         , ecommerce_couponpaymentversion.couponpaymentversion_payment_transaction
     from ecommerce_couponpaymentversion
-    inner join ecommerce_couponversion
+    inner join ecommerce_couponversion 
         on ecommerce_couponpaymentversion.couponpaymentversion_id = ecommerce_couponversion.couponpaymentversion_id
     where ecommerce_couponpaymentversion.couponpaymentversion_payment_transaction is not null
 )
 
 , latest_couponversion as (
-    select
+    select 
         coupon_id
         , max(couponversion_updated_on) as max_couponversion_updated_on
     from ecommerce_couponversion
@@ -89,38 +89,38 @@ with coupon as (
 )
 
 , reg_coupon_summary as (
-    select
+    select 
         coupon.coupon_id
-        , cast(array_join(array_distinct(array_agg(program_runs.programrun_readable_id)), ', ') as varchar)
+        , cast(array_join(array_distinct(array_agg(program_runs.programrun_readable_id)), ', ') as varchar) 
             as programrun_readable_id
         , cast(array_join(array_distinct(array_agg(program_runs.program_title)), ', ') as varchar) as program_title
-        , cast(array_join(array_distinct(array_agg(course_runs.courserun_readable_id)), ', ') as varchar)
+        , cast(array_join(array_distinct(array_agg(course_runs.courserun_readable_id)), ', ') as varchar) 
             as courserun_readable_id
         , cast(array_join(array_distinct(array_agg(courses.course_title)), ', ') as varchar) as course_title
-        , cast(array_join(array_distinct(array_agg(productversion.productversion_readable_id)), ', ') as varchar)
+        , cast(array_join(array_distinct(array_agg(productversion.productversion_readable_id)), ', ') as varchar) 
             as productversion_readable_id
         , cast(array_join(array_distinct(array_agg(users_user.user_email)), ', ') as varchar) as combined_user_emails
-        , cast(array_join(array_distinct(array_agg(users_user.user_address_country)), ', ') as varchar)
+        , cast(array_join(array_distinct(array_agg(users_user.user_address_country)), ', ') as varchar) 
             as user_address_countries
         , cast(array_join(array_distinct(array_agg(ecommerce_order.order_id)), ', ') as varchar) as order_ids
-        , cast(array_join(array_distinct(array_agg(ecommerce_order.order_state)), ', ') as varchar)
+        , cast(array_join(array_distinct(array_agg(ecommerce_order.order_state)), ', ') as varchar) 
             as combined_order_state
         , case when (count(couponredemption.couponredemption_id) >= 1) then 'true' else 'false' end as coupon_redeemed
-
+        
     from coupon
     left join latest_couponversion
         on coupon.coupon_id = latest_couponversion.coupon_id
-    left join ecommerce_couponversion
-        on
-            latest_couponversion.coupon_id = ecommerce_couponversion.coupon_id
+    left join ecommerce_couponversion 
+        on 
+            latest_couponversion.coupon_id = ecommerce_couponversion.coupon_id 
             and ecommerce_couponversion.couponversion_updated_on = latest_couponversion.max_couponversion_updated_on
     left join couponredemption
         on ecommerce_couponversion.couponversion_id = couponredemption.couponversion_id
-    left join ecommerce_couponpaymentversion
+    left join ecommerce_couponpaymentversion 
         on ecommerce_couponpaymentversion.couponpaymentversion_id = ecommerce_couponversion.couponpaymentversion_id
     left join ecommerce_order
         on ecommerce_order.order_id = couponredemption.order_id
-    left join ecommerce_line
+    left join ecommerce_line 
         on ecommerce_line.order_id = ecommerce_order.order_id
     left join program_runs
         on ecommerce_line.programrun_id = program_runs.programrun_id
@@ -130,22 +130,22 @@ with coupon as (
         on course_runs.course_id = courses.course_id
     left join productversion
         on productversion.productversion_id = ecommerce_line.productversion_id
-    left join users_user
+    left join users_user    
         on ecommerce_order.order_purchaser_user_id = users_user.user_id
     where ecommerce_order.order_state = 'fulfilled' or ecommerce_order.order_state = 'refunded'
-    group by
+    group by 
         coupon.coupon_id
 )
 
 , reg_coupon_fields as (
-    select
+    select 
         productcouponassignment.productcouponassignment_email as coupon_email
         , coupon.coupon_code
         , coupon.coupon_id
         , coupon.coupon_created_on
         , coupon.couponpayment_name
         , productcouponassignment.product_id
-        , payment_transactions.couponpaymentversion_payment_transaction
+        , payment_transactions.couponpaymentversion_payment_transaction 
         , productcouponassignment.productcouponassignment_is_redeemed
     from coupon
     left join productcouponassignment
@@ -155,13 +155,13 @@ with coupon as (
 )
 
 , unassigned_enrollment_codes as (
-    select
+    select 
         coupon.coupon_code
         , coupon.coupon_id
         , coupon.coupon_created_on as coupon_created_on
         , coupon.couponpayment_name
         , b2b_ecommerce_b2border.b2border_contract_number
-        , payment_transactions.couponpaymentversion_payment_transaction
+        , payment_transactions.couponpaymentversion_payment_transaction  
         , program_runs.programrun_readable_id
         , program_runs.program_title
         , course_runs.courserun_readable_id
@@ -179,22 +179,22 @@ with coupon as (
     inner join latest_couponversion
         on coupon.coupon_id = latest_couponversion.coupon_id
     inner join ecommerce_couponversion
-        on
-            latest_couponversion.coupon_id = ecommerce_couponversion.coupon_id
+        on 
+            latest_couponversion.coupon_id = ecommerce_couponversion.coupon_id 
             and ecommerce_couponversion.couponversion_updated_on = latest_couponversion.max_couponversion_updated_on
     inner join ecommerce_couponpaymentversion
-        on ecommerce_couponpaymentversion.couponpaymentversion_id = ecommerce_couponversion.couponpaymentversion_id
-    left join b2b_ecommerce_b2border
+        on ecommerce_couponpaymentversion.couponpaymentversion_id = ecommerce_couponversion.couponpaymentversion_id 
+    left join b2b_ecommerce_b2border 
         on ecommerce_couponpaymentversion.couponpaymentversion_id = b2b_ecommerce_b2border.couponpaymentversion_id
-    left join payment_transactions
-        on payment_transactions.coupon_id = coupon.coupon_id
+    left join payment_transactions 
+        on payment_transactions.coupon_id = coupon.coupon_id   
     left join couponredemption
         on couponredemption.couponversion_id = ecommerce_couponversion.couponversion_id
-    left join ecommerce_order
+    left join ecommerce_order 
         on couponredemption.order_id = ecommerce_order.order_id
-    left join users_user
-        on users_user.user_id = ecommerce_order.order_purchaser_user_id
-    left join ecommerce_line
+    left join users_user 
+        on users_user.user_id = ecommerce_order.order_purchaser_user_id 
+    left join ecommerce_line 
         on ecommerce_line.order_id = ecommerce_order.order_id
     left join program_runs
         on ecommerce_line.programrun_id = program_runs.programrun_id
@@ -204,19 +204,19 @@ with coupon as (
         on course_runs.course_id = courses.course_id
     left join productversion
         on productversion.productversion_id = ecommerce_line.productversion_id
-    where
-        ecommerce_couponpaymentversion.couponpaymentversion_coupon_type = 'single-use'
-        and ecommerce_couponpaymentversion.couponpaymentversion_discount_amount = 1.0000
+    where 
+        ecommerce_couponpaymentversion.couponpaymentversion_coupon_type = 'single-use' 
+        and ecommerce_couponpaymentversion.couponpaymentversion_discount_amount = 1.0000 
         and coupon.coupon_id not in (
             select coupon_id
-            from productcouponassignment
+            from productcouponassignment 
         )
         and not exists (
             select b2b_ecommerce_b2border.couponpaymentversion_id
             from b2b_ecommerce_b2border
-            where
+            where 
                 b2b_ecommerce_b2border.couponpaymentversion_id = ecommerce_couponpaymentversion.couponpaymentversion_id
-        )
+        ) 
 )
 
 , b2b_coupon_fields as (
@@ -228,7 +228,7 @@ with coupon as (
         , coupon.couponpayment_name
         , b2b_ecommerce_b2border.b2border_contract_number
         , b2b_ecommerce_b2border.product_id
-        , ecommerce_couponpaymentversion.couponpaymentversion_payment_transaction
+        , ecommerce_couponpaymentversion.couponpaymentversion_payment_transaction 
         , program_runs.programrun_readable_id
         , program_runs.program_title
         , course_runs.courserun_readable_id
@@ -239,25 +239,25 @@ with coupon as (
         , cast(ecommerce_order.order_id as varchar) as order_ids
         , ecommerce_order.order_state as combined_order_state
         , b2b_ecommerce_b2breceipt.req_reference_number
-        , case
+        , case 
             when couponredemption.couponredemption_id is not null
-                then 'true'
-            else 'false'
+                then 'true' 
+            else 'false' 
         end as coupon_redeemed
-    from b2b_ecommerce_b2border
-    inner join ecommerce_couponpaymentversion
+    from b2b_ecommerce_b2border 
+    inner join ecommerce_couponpaymentversion 
         on ecommerce_couponpaymentversion.couponpaymentversion_id = b2b_ecommerce_b2border.couponpaymentversion_id
-    inner join ecommerce_couponversion
+    inner join ecommerce_couponversion 
         on ecommerce_couponversion.couponpaymentversion_id = ecommerce_couponpaymentversion.couponpaymentversion_id
-    inner join coupon
+    inner join coupon 
         on coupon.coupon_id = ecommerce_couponversion.coupon_id
-    left join couponredemption
+    left join couponredemption 
         on couponredemption.couponversion_id = ecommerce_couponversion.couponversion_id
-    left join ecommerce_order
+    left join ecommerce_order 
         on ecommerce_order.order_id = couponredemption.order_id
-    left join b2b_ecommerce_b2breceipt
+    left join b2b_ecommerce_b2breceipt 
         on b2b_ecommerce_b2breceipt.b2border_id = b2b_ecommerce_b2border.b2border_id
-    left join ecommerce_line
+    left join ecommerce_line 
         on ecommerce_line.order_id = ecommerce_order.order_id
     left join program_runs
         on ecommerce_line.programrun_id = program_runs.programrun_id
@@ -267,12 +267,12 @@ with coupon as (
         on course_runs.course_id = courses.course_id
     left join productversion
         on productversion.productversion_id = b2b_ecommerce_b2border.productversion_id
-    left join users_user
+    left join users_user    
         on ecommerce_order.order_purchaser_user_id = users_user.user_id
 )
 
 
-select
+select 
     reg_coupon_fields.coupon_email
     , reg_coupon_fields.coupon_code
     , reg_coupon_fields.coupon_id
@@ -299,7 +299,7 @@ where reg_coupon_fields.coupon_id not in (select coupon_id from b2b_coupon_field
 
 union distinct
 
-select
+select 
     b2b_coupon_fields.b2border_email as coupon_email
     , b2b_coupon_fields.coupon_code
     , b2b_coupon_fields.coupon_id
@@ -323,7 +323,7 @@ from b2b_coupon_fields
 
 union distinct
 
-select
+select 
     coupon_email
     , coupon_code
     , coupon_id
@@ -331,7 +331,7 @@ select
     , couponpayment_name
     , b2border_contract_number
     , product_id
-    , couponpaymentversion_payment_transaction
+    , couponpaymentversion_payment_transaction  
     , req_reference_number
     , programrun_readable_id
     , program_title
@@ -344,6 +344,6 @@ select
     , cast(order_ids as varchar) as order_ids
     , combined_order_state
 from unassigned_enrollment_codes
-where
+where 
     coupon_id not in (select coupon_id from reg_coupon_fields)
     and coupon_id not in (select coupon_id from b2b_coupon_fields)

--- a/src/ol_dbt/models/intermediate/mitxpro/int__mitxpro__ecommerce_combinedcoupons.sql
+++ b/src/ol_dbt/models/intermediate/mitxpro/int__mitxpro__ecommerce_combinedcoupons.sql
@@ -71,17 +71,17 @@ with coupon as (
 )
 
 , payment_transactions as (
-    select distinct 
+    select distinct
         ecommerce_couponversion.coupon_id
         , ecommerce_couponpaymentversion.couponpaymentversion_payment_transaction
     from ecommerce_couponpaymentversion
-    inner join ecommerce_couponversion 
+    inner join ecommerce_couponversion
         on ecommerce_couponpaymentversion.couponpaymentversion_id = ecommerce_couponversion.couponpaymentversion_id
     where ecommerce_couponpaymentversion.couponpaymentversion_payment_transaction is not null
 )
 
 , latest_couponversion as (
-    select 
+    select
         coupon_id
         , max(couponversion_updated_on) as max_couponversion_updated_on
     from ecommerce_couponversion
@@ -89,38 +89,38 @@ with coupon as (
 )
 
 , reg_coupon_summary as (
-    select 
+    select
         coupon.coupon_id
-        , cast(array_join(array_distinct(array_agg(program_runs.programrun_readable_id)), ', ') as varchar) 
+        , cast(array_join(array_distinct(array_agg(program_runs.programrun_readable_id)), ', ') as varchar)
             as programrun_readable_id
         , cast(array_join(array_distinct(array_agg(program_runs.program_title)), ', ') as varchar) as program_title
-        , cast(array_join(array_distinct(array_agg(course_runs.courserun_readable_id)), ', ') as varchar) 
+        , cast(array_join(array_distinct(array_agg(course_runs.courserun_readable_id)), ', ') as varchar)
             as courserun_readable_id
         , cast(array_join(array_distinct(array_agg(courses.course_title)), ', ') as varchar) as course_title
-        , cast(array_join(array_distinct(array_agg(productversion.productversion_readable_id)), ', ') as varchar) 
+        , cast(array_join(array_distinct(array_agg(productversion.productversion_readable_id)), ', ') as varchar)
             as productversion_readable_id
         , cast(array_join(array_distinct(array_agg(users_user.user_email)), ', ') as varchar) as combined_user_emails
-        , cast(array_join(array_distinct(array_agg(users_user.user_address_country)), ', ') as varchar) 
+        , cast(array_join(array_distinct(array_agg(users_user.user_address_country)), ', ') as varchar)
             as user_address_countries
         , cast(array_join(array_distinct(array_agg(ecommerce_order.order_id)), ', ') as varchar) as order_ids
-        , cast(array_join(array_distinct(array_agg(ecommerce_order.order_state)), ', ') as varchar) 
+        , cast(array_join(array_distinct(array_agg(ecommerce_order.order_state)), ', ') as varchar)
             as combined_order_state
         , case when (count(couponredemption.couponredemption_id) >= 1) then 'true' else 'false' end as coupon_redeemed
-        
+
     from coupon
     left join latest_couponversion
         on coupon.coupon_id = latest_couponversion.coupon_id
-    left join ecommerce_couponversion 
-        on 
-            latest_couponversion.coupon_id = ecommerce_couponversion.coupon_id 
+    left join ecommerce_couponversion
+        on
+            latest_couponversion.coupon_id = ecommerce_couponversion.coupon_id
             and ecommerce_couponversion.couponversion_updated_on = latest_couponversion.max_couponversion_updated_on
     left join couponredemption
         on ecommerce_couponversion.couponversion_id = couponredemption.couponversion_id
-    left join ecommerce_couponpaymentversion 
+    left join ecommerce_couponpaymentversion
         on ecommerce_couponpaymentversion.couponpaymentversion_id = ecommerce_couponversion.couponpaymentversion_id
     left join ecommerce_order
         on ecommerce_order.order_id = couponredemption.order_id
-    left join ecommerce_line 
+    left join ecommerce_line
         on ecommerce_line.order_id = ecommerce_order.order_id
     left join program_runs
         on ecommerce_line.programrun_id = program_runs.programrun_id
@@ -130,22 +130,22 @@ with coupon as (
         on course_runs.course_id = courses.course_id
     left join productversion
         on productversion.productversion_id = ecommerce_line.productversion_id
-    left join users_user    
+    left join users_user
         on ecommerce_order.order_purchaser_user_id = users_user.user_id
     where ecommerce_order.order_state = 'fulfilled' or ecommerce_order.order_state = 'refunded'
-    group by 
+    group by
         coupon.coupon_id
 )
 
 , reg_coupon_fields as (
-    select 
+    select
         productcouponassignment.productcouponassignment_email as coupon_email
         , coupon.coupon_code
         , coupon.coupon_id
         , coupon.coupon_created_on
         , coupon.couponpayment_name
         , productcouponassignment.product_id
-        , payment_transactions.couponpaymentversion_payment_transaction 
+        , payment_transactions.couponpaymentversion_payment_transaction
         , productcouponassignment.productcouponassignment_is_redeemed
     from coupon
     left join productcouponassignment
@@ -155,13 +155,13 @@ with coupon as (
 )
 
 , unassigned_enrollment_codes as (
-    select 
+    select
         coupon.coupon_code
         , coupon.coupon_id
         , coupon.coupon_created_on as coupon_created_on
         , coupon.couponpayment_name
         , b2b_ecommerce_b2border.b2border_contract_number
-        , payment_transactions.couponpaymentversion_payment_transaction  
+        , payment_transactions.couponpaymentversion_payment_transaction
         , program_runs.programrun_readable_id
         , program_runs.program_title
         , course_runs.courserun_readable_id
@@ -179,22 +179,22 @@ with coupon as (
     inner join latest_couponversion
         on coupon.coupon_id = latest_couponversion.coupon_id
     inner join ecommerce_couponversion
-        on 
-            latest_couponversion.coupon_id = ecommerce_couponversion.coupon_id 
+        on
+            latest_couponversion.coupon_id = ecommerce_couponversion.coupon_id
             and ecommerce_couponversion.couponversion_updated_on = latest_couponversion.max_couponversion_updated_on
     inner join ecommerce_couponpaymentversion
-        on ecommerce_couponpaymentversion.couponpaymentversion_id = ecommerce_couponversion.couponpaymentversion_id 
-    left join b2b_ecommerce_b2border 
+        on ecommerce_couponpaymentversion.couponpaymentversion_id = ecommerce_couponversion.couponpaymentversion_id
+    left join b2b_ecommerce_b2border
         on ecommerce_couponpaymentversion.couponpaymentversion_id = b2b_ecommerce_b2border.couponpaymentversion_id
-    left join payment_transactions 
-        on payment_transactions.coupon_id = coupon.coupon_id   
+    left join payment_transactions
+        on payment_transactions.coupon_id = coupon.coupon_id
     left join couponredemption
         on couponredemption.couponversion_id = ecommerce_couponversion.couponversion_id
-    left join ecommerce_order 
+    left join ecommerce_order
         on couponredemption.order_id = ecommerce_order.order_id
-    left join users_user 
-        on users_user.user_id = ecommerce_order.order_purchaser_user_id 
-    left join ecommerce_line 
+    left join users_user
+        on users_user.user_id = ecommerce_order.order_purchaser_user_id
+    left join ecommerce_line
         on ecommerce_line.order_id = ecommerce_order.order_id
     left join program_runs
         on ecommerce_line.programrun_id = program_runs.programrun_id
@@ -204,19 +204,19 @@ with coupon as (
         on course_runs.course_id = courses.course_id
     left join productversion
         on productversion.productversion_id = ecommerce_line.productversion_id
-    where 
-        ecommerce_couponpaymentversion.couponpaymentversion_coupon_type = 'single-use' 
-        and ecommerce_couponpaymentversion.couponpaymentversion_discount_amount = 1.0000 
+    where
+        ecommerce_couponpaymentversion.couponpaymentversion_coupon_type = 'single-use'
+        and ecommerce_couponpaymentversion.couponpaymentversion_discount_amount = 1.0000
         and coupon.coupon_id not in (
             select coupon_id
-            from productcouponassignment 
+            from productcouponassignment
         )
         and not exists (
             select b2b_ecommerce_b2border.couponpaymentversion_id
             from b2b_ecommerce_b2border
-            where 
+            where
                 b2b_ecommerce_b2border.couponpaymentversion_id = ecommerce_couponpaymentversion.couponpaymentversion_id
-        ) 
+        )
 )
 
 , b2b_coupon_fields as (
@@ -228,7 +228,7 @@ with coupon as (
         , coupon.couponpayment_name
         , b2b_ecommerce_b2border.b2border_contract_number
         , b2b_ecommerce_b2border.product_id
-        , ecommerce_couponpaymentversion.couponpaymentversion_payment_transaction 
+        , ecommerce_couponpaymentversion.couponpaymentversion_payment_transaction
         , program_runs.programrun_readable_id
         , program_runs.program_title
         , course_runs.courserun_readable_id
@@ -239,25 +239,25 @@ with coupon as (
         , cast(ecommerce_order.order_id as varchar) as order_ids
         , ecommerce_order.order_state as combined_order_state
         , b2b_ecommerce_b2breceipt.req_reference_number
-        , case 
+        , case
             when couponredemption.couponredemption_id is not null
-                then 'true' 
-            else 'false' 
+                then 'true'
+            else 'false'
         end as coupon_redeemed
-    from b2b_ecommerce_b2border 
-    inner join ecommerce_couponpaymentversion 
+    from b2b_ecommerce_b2border
+    inner join ecommerce_couponpaymentversion
         on ecommerce_couponpaymentversion.couponpaymentversion_id = b2b_ecommerce_b2border.couponpaymentversion_id
-    inner join ecommerce_couponversion 
+    inner join ecommerce_couponversion
         on ecommerce_couponversion.couponpaymentversion_id = ecommerce_couponpaymentversion.couponpaymentversion_id
-    inner join coupon 
+    inner join coupon
         on coupon.coupon_id = ecommerce_couponversion.coupon_id
-    left join couponredemption 
+    left join couponredemption
         on couponredemption.couponversion_id = ecommerce_couponversion.couponversion_id
-    left join ecommerce_order 
+    left join ecommerce_order
         on ecommerce_order.order_id = couponredemption.order_id
-    left join b2b_ecommerce_b2breceipt 
+    left join b2b_ecommerce_b2breceipt
         on b2b_ecommerce_b2breceipt.b2border_id = b2b_ecommerce_b2border.b2border_id
-    left join ecommerce_line 
+    left join ecommerce_line
         on ecommerce_line.order_id = ecommerce_order.order_id
     left join program_runs
         on ecommerce_line.programrun_id = program_runs.programrun_id
@@ -267,12 +267,12 @@ with coupon as (
         on course_runs.course_id = courses.course_id
     left join productversion
         on productversion.productversion_id = b2b_ecommerce_b2border.productversion_id
-    left join users_user    
+    left join users_user
         on ecommerce_order.order_purchaser_user_id = users_user.user_id
 )
 
 
-select 
+select
     reg_coupon_fields.coupon_email
     , reg_coupon_fields.coupon_code
     , reg_coupon_fields.coupon_id
@@ -299,7 +299,7 @@ where reg_coupon_fields.coupon_id not in (select coupon_id from b2b_coupon_field
 
 union distinct
 
-select 
+select
     b2b_coupon_fields.b2border_email as coupon_email
     , b2b_coupon_fields.coupon_code
     , b2b_coupon_fields.coupon_id
@@ -323,7 +323,7 @@ from b2b_coupon_fields
 
 union distinct
 
-select 
+select
     coupon_email
     , coupon_code
     , coupon_id
@@ -331,7 +331,7 @@ select
     , couponpayment_name
     , b2border_contract_number
     , product_id
-    , couponpaymentversion_payment_transaction  
+    , couponpaymentversion_payment_transaction
     , req_reference_number
     , programrun_readable_id
     , program_title
@@ -344,6 +344,6 @@ select
     , cast(order_ids as varchar) as order_ids
     , combined_order_state
 from unassigned_enrollment_codes
-where 
+where
     coupon_id not in (select coupon_id from reg_coupon_fields)
     and coupon_id not in (select coupon_id from b2b_coupon_fields)

--- a/src/ol_dbt/models/intermediate/mitxpro/int__mitxpro__ecommerce_combinedcoupons.sql
+++ b/src/ol_dbt/models/intermediate/mitxpro/int__mitxpro__ecommerce_combinedcoupons.sql
@@ -69,159 +69,245 @@ with coupon as (
 )
 
 , payment_transactions as (
-    select distinct
+    select distinct 
         ecommerce_couponversion.coupon_id
         , ecommerce_couponpaymentversion.couponpaymentversion_payment_transaction
     from ecommerce_couponpaymentversion
-    inner join ecommerce_couponversion
+    inner join ecommerce_couponversion 
         on ecommerce_couponpaymentversion.couponpaymentversion_id = ecommerce_couponversion.couponpaymentversion_id
     where ecommerce_couponpaymentversion.couponpaymentversion_payment_transaction is not null
 )
 
+, reg_coupon_summary as (
+    select 
+        coupon.coupon_id
+        , case when (count(couponredemption.couponredemption_id) >= 1) then 'true' else 'false' end as coupon_redeemed
+        , array_join(array_distinct(array_agg(users_user.user_email)), ', ') as combined_user_emails
+        , array_join(array_distinct(array_agg(users_user.user_address_country)), ', ') as user_address_countries
+        , array_join(array_distinct(array_agg(ecommerce_order.order_id)), ', ') as order_ids
+        , array_join(array_distinct(array_agg(ecommerce_order.order_state)), ', ') as combined_order_state
+    from coupon
+    left join ecommerce_couponversion 
+        on coupon.coupon_id = ecommerce_couponversion.coupon_id
+    left join couponredemption
+        on ecommerce_couponversion.couponversion_id = couponredemption.couponversion_id
+    left join ecommerce_order
+        on ecommerce_order.order_id = couponredemption.order_id
+    left join users_user    
+        on ecommerce_order.order_purchaser_user_id = users_user.user_id
+    group by 
+        coupon.coupon_id
+)
 
-select
-    productcouponassignment.productcouponassignment_email as coupon_email
-    , coupon.coupon_code
-    , coupon.coupon_id
-    , coupon.coupon_created_on
-    , coupon.couponpayment_name
+, reg_coupon_fields as (
+    select 
+        productcouponassignment.productcouponassignment_email as coupon_email
+        , coupon.coupon_code
+        , coupon.coupon_id
+        , coupon.coupon_created_on
+        , coupon.couponpayment_name
+        , productcouponassignment.product_id
+        , payment_transactions.couponpaymentversion_payment_transaction 
+        , program_runs.programrun_readable_id
+        , program_runs.program_title
+        , course_runs.courserun_readable_id
+        , courses.course_title
+        , productversion.productversion_readable_id
+        , ecommerce_couponpaymentversion.couponpaymentversion_coupon_type
+        , ecommerce_couponpaymentversion.couponpaymentversion_discount_amount
+    from coupon
+    left join productcouponassignment
+        on productcouponassignment.coupon_id = coupon.coupon_id
+    left join ecommerce_couponversion 
+        on coupon.coupon_id = ecommerce_couponversion.coupon_id
+    left join ecommerce_couponpaymentversion 
+        on ecommerce_couponpaymentversion.couponpaymentversion_id = ecommerce_couponversion.couponpaymentversion_id
+    left join couponredemption
+        on ecommerce_couponversion.couponversion_id = couponredemption.couponversion_id
+    left join ecommerce_order
+        on ecommerce_order.order_id = couponredemption.order_id
+    left join payment_transactions
+        on coupon.coupon_id = payment_transactions.coupon_id
+    left join ecommerce_line 
+        on ecommerce_line.order_id = ecommerce_order.order_id
+    left join program_runs
+        on ecommerce_line.programrun_id = program_runs.programrun_id
+    left join course_runs
+        on ecommerce_line.courserun_id = course_runs.courserun_id
+    left join courses
+        on course_runs.course_id = courses.course_id
+    left join productversion
+        on productversion.productversion_id = ecommerce_line.productversion_id
+    group by 
+        productcouponassignment.productcouponassignment_email 
+        , coupon.coupon_code
+        , coupon.coupon_id
+        , coupon.coupon_created_on
+        , coupon.couponpayment_name
+        , productcouponassignment.product_id
+        , payment_transactions.couponpaymentversion_payment_transaction 
+        , program_runs.programrun_readable_id
+        , program_runs.program_title
+        , course_runs.courserun_readable_id
+        , courses.course_title
+        , productversion.productversion_readable_id
+        , ecommerce_couponpaymentversion.couponpaymentversion_coupon_type
+        , ecommerce_couponpaymentversion.couponpaymentversion_discount_amount
+)
+
+, b2b_coupon_summary as (
+    select 
+        coupon.coupon_id
+        , case 
+            when (count(couponredemption.couponredemption_id) >= 1) 
+                then 'true' 
+            else 'false' 
+        end as coupon_redeemed
+        , array_join(array_distinct(array_agg(users_user.user_email)), ', ') as combined_user_emails
+        , array_join(array_distinct(array_agg(users_user.user_address_country)), ', ') as user_address_countries
+        , array_join(array_distinct(array_agg(ecommerce_order.order_id)), ', ') as order_ids
+        , array_join(array_distinct(array_agg(ecommerce_order.order_state)), ', ') as combined_order_state
+    from b2b_ecommerce_b2border 
+    inner join ecommerce_couponpaymentversion 
+        on ecommerce_couponpaymentversion.couponpaymentversion_id = b2b_ecommerce_b2border.couponpaymentversion_id
+    inner join ecommerce_couponversion 
+        on ecommerce_couponversion.couponpaymentversion_id = ecommerce_couponpaymentversion.couponpaymentversion_id
+    inner join coupon 
+        on coupon.coupon_id = ecommerce_couponversion.coupon_id 
+    left join couponredemption 
+        on couponredemption.couponversion_id = ecommerce_couponversion.couponversion_id
+    left join ecommerce_order 
+        on ecommerce_order.order_id = couponredemption.order_id
+    left join users_user    
+        on ecommerce_order.order_purchaser_user_id = users_user.user_id
+    group by 
+        coupon.coupon_id   
+)
+
+, b2b_coupon_fields as (
+    select
+        b2b_ecommerce_b2border.b2border_email
+        , coupon.coupon_code
+        , coupon.coupon_id
+        , coupon.coupon_created_on
+        , coupon.couponpayment_name
+        , b2b_ecommerce_b2border.b2border_contract_number
+        , b2b_ecommerce_b2border.product_id
+        , ecommerce_couponpaymentversion.couponpaymentversion_payment_transaction 
+        , program_runs.programrun_readable_id
+        , program_runs.program_title
+        , course_runs.courserun_readable_id
+        , courses.course_title
+        , productversion.productversion_readable_id
+        , ecommerce_couponpaymentversion.couponpaymentversion_coupon_type
+        , ecommerce_couponpaymentversion.couponpaymentversion_discount_amount
+        , replace(
+            cast(
+                json_extract(b2b_ecommerce_b2breceipt.b2breceipt_data, '$.req_reference_number'
+                )
+                as varchar
+            ), '"', ''
+        ) as req_reference_number
+    from b2b_ecommerce_b2border 
+    inner join ecommerce_couponpaymentversion 
+        on ecommerce_couponpaymentversion.couponpaymentversion_id = b2b_ecommerce_b2border.couponpaymentversion_id
+    inner join ecommerce_couponversion 
+        on ecommerce_couponversion.couponpaymentversion_id = ecommerce_couponpaymentversion.couponpaymentversion_id
+    inner join coupon 
+        on coupon.coupon_id = ecommerce_couponversion.coupon_id
+    left join couponredemption 
+        on couponredemption.couponversion_id = ecommerce_couponversion.couponversion_id
+    left join ecommerce_order 
+        on ecommerce_order.order_id = couponredemption.order_id
+    left join b2b_ecommerce_b2breceipt 
+        on b2b_ecommerce_b2breceipt.b2border_id = b2b_ecommerce_b2border.b2border_id
+    left join ecommerce_line 
+        on ecommerce_line.order_id = ecommerce_order.order_id
+    left join program_runs
+        on ecommerce_line.programrun_id = program_runs.programrun_id
+    left join course_runs
+        on ecommerce_line.courserun_id = course_runs.courserun_id
+    left join courses
+        on course_runs.course_id = courses.course_id
+    left join productversion
+        on productversion.productversion_id = b2b_ecommerce_b2border.productversion_id
+    group by 
+        b2b_ecommerce_b2border.b2border_email 
+        , coupon.coupon_code
+        , coupon.coupon_id
+        , coupon.coupon_created_on
+        , coupon.couponpayment_name
+        , b2b_ecommerce_b2border.b2border_contract_number
+        , b2b_ecommerce_b2border.product_id
+        , ecommerce_couponpaymentversion.couponpaymentversion_payment_transaction 
+        , program_runs.programrun_readable_id
+        , program_runs.program_title
+        , course_runs.courserun_readable_id
+        , courses.course_title
+        , productversion.productversion_readable_id
+        , ecommerce_couponpaymentversion.couponpaymentversion_coupon_type
+        , ecommerce_couponpaymentversion.couponpaymentversion_discount_amount
+        , replace(
+            cast(
+                json_extract(b2b_ecommerce_b2breceipt.b2breceipt_data, '$.req_reference_number')
+                as varchar
+            ), '"', ''
+        ) 
+)
+
+
+select 
+    reg_coupon_fields.coupon_email
+    , reg_coupon_fields.coupon_code
+    , reg_coupon_fields.coupon_id
+    , reg_coupon_fields.coupon_created_on
+    , reg_coupon_fields.couponpayment_name
     , null as b2border_contract_number
-    , productcouponassignment.product_id
-    , payment_transactions.couponpaymentversion_payment_transaction
+    , reg_coupon_fields.product_id
+    , reg_coupon_fields.couponpaymentversion_payment_transaction
     , null as req_reference_number
-    , program_runs.programrun_readable_id
-    , program_runs.program_title
-    , course_runs.courserun_readable_id
-    , courses.course_title
-    , productversion.productversion_readable_id
+    , reg_coupon_fields.programrun_readable_id
+    , reg_coupon_fields.program_title
+    , reg_coupon_fields.courserun_readable_id
+    , reg_coupon_fields.course_title
+    , reg_coupon_fields.productversion_readable_id
     , 'regular coupon' as combinedcoupon_table_source
-    , ecommerce_couponpaymentversion.couponpaymentversion_coupon_type
-    , ecommerce_couponpaymentversion.couponpaymentversion_discount_amount
-    , case when (count(couponredemption.couponredemption_id) >= 1) then 'true' else 'false' end as coupon_redeemed
-    , array_join(array_distinct(array_agg(users_user.user_email)), ', ') as combined_user_emails
-    , array_join(array_distinct(array_agg(users_user.user_address_country)), ', ') as user_address_countries
-    , array_join(array_distinct(array_agg(ecommerce_order.order_id)), ', ') as order_ids
-    , array_join(array_distinct(array_agg(ecommerce_order.order_state)), ', ') as combined_order_state
-from coupon
-left join productcouponassignment
-    on productcouponassignment.coupon_id = coupon.coupon_id
-left join ecommerce_couponversion
-    on coupon.coupon_id = ecommerce_couponversion.coupon_id
-left join ecommerce_couponpaymentversion
-    on ecommerce_couponpaymentversion.couponpaymentversion_id = ecommerce_couponversion.couponpaymentversion_id
-left join couponredemption
-    on ecommerce_couponversion.couponversion_id = couponredemption.couponversion_id
-left join ecommerce_order
-    on ecommerce_order.order_id = couponredemption.order_id
-left join users_user
-    on ecommerce_order.order_purchaser_user_id = users_user.user_id
-left join payment_transactions
-    on coupon.coupon_id = payment_transactions.coupon_id
-left join ecommerce_line
-    on ecommerce_line.order_id = ecommerce_order.order_id
-left join program_runs
-    on ecommerce_line.programrun_id = program_runs.programrun_id
-left join course_runs
-    on ecommerce_line.courserun_id = course_runs.courserun_id
-left join courses
-    on course_runs.course_id = courses.course_id
-left join productversion
-    on productversion.productversion_id = ecommerce_line.productversion_id
-group by
-    productcouponassignment.productcouponassignment_email
-    , coupon.coupon_code
-    , coupon.coupon_id
-    , coupon.coupon_created_on
-    , coupon.couponpayment_name
-    , productcouponassignment.product_id
-    , payment_transactions.couponpaymentversion_payment_transaction
-    , program_runs.programrun_readable_id
-    , program_runs.program_title
-    , course_runs.courserun_readable_id
-    , courses.course_title
-    , productversion.productversion_readable_id
-    , ecommerce_couponpaymentversion.couponpaymentversion_coupon_type
-    , ecommerce_couponpaymentversion.couponpaymentversion_discount_amount
+    , reg_coupon_fields.couponpaymentversion_coupon_type
+    , reg_coupon_fields.couponpaymentversion_discount_amount
+    , reg_coupon_summary.coupon_redeemed
+    , reg_coupon_summary.combined_user_emails
+    , reg_coupon_summary.user_address_countries
+    , reg_coupon_summary.order_ids
+    , reg_coupon_summary.combined_order_state
+from reg_coupon_fields
+inner join reg_coupon_summary
+    on reg_coupon_fields.coupon_id = reg_coupon_summary.coupon_id
 
 union distinct
 
-select
-    b2b_ecommerce_b2border.b2border_email as coupon_email
-    , coupon.coupon_code
-    , coupon.coupon_id
-    , coupon.coupon_created_on
-    , coupon.couponpayment_name
-    , b2b_ecommerce_b2border.b2border_contract_number
-    , b2b_ecommerce_b2border.product_id
-    , ecommerce_couponpaymentversion.couponpaymentversion_payment_transaction
-    , replace(
-        cast(
-            json_extract(b2b_ecommerce_b2breceipt.b2breceipt_data, '$.req_reference_number'
-            )
-            as varchar
-        ), '"', ''
-    ) as req_reference_number
-    , program_runs.programrun_readable_id
-    , program_runs.program_title
-    , course_runs.courserun_readable_id
-    , courses.course_title
-    , productversion.productversion_readable_id
+select 
+    b2b_coupon_fields.b2border_email as coupon_email
+    , b2b_coupon_fields.coupon_code
+    , b2b_coupon_fields.b2b_coupon_fields.coupon_id
+    , b2b_coupon_fields.coupon_created_on
+    , b2b_coupon_fields.couponpayment_name
+    , b2b_coupon_fields.b2border_contract_number
+    , b2b_coupon_fields.product_id
+    , b2b_coupon_fields.couponpaymentversion_payment_transaction
+    , b2b_coupon_fields.req_reference_number
+    , b2b_coupon_fields.programrun_readable_id
+    , b2b_coupon_fields.program_title
+    , b2b_coupon_fields.courserun_readable_id
+    , b2b_coupon_fields.course_title
+    , b2b_coupon_fields.productversion_readable_id
     , 'b2b coupon' as combinedcoupon_table_source
-    , ecommerce_couponpaymentversion.couponpaymentversion_coupon_type
-    , ecommerce_couponpaymentversion.couponpaymentversion_discount_amount
-    , case
-        when (count(couponredemption.couponredemption_id) >= 1)
-            then 'true'
-        else 'false'
-    end as coupon_redeemed
-    , array_join(array_distinct(array_agg(users_user.user_email)), ', ') as combined_user_emails
-    , array_join(array_distinct(array_agg(users_user.user_address_country)), ', ') as user_address_countries
-    , array_join(array_distinct(array_agg(ecommerce_order.order_id)), ', ') as order_ids
-    , array_join(array_distinct(array_agg(ecommerce_order.order_state)), ', ') as combined_order_state
-from b2b_ecommerce_b2border
-left join ecommerce_couponpaymentversion
-    on ecommerce_couponpaymentversion.couponpaymentversion_id = b2b_ecommerce_b2border.couponpaymentversion_id
-left join coupon
-    on coupon.coupon_id = b2b_ecommerce_b2border.b2bcoupon_id
-left join ecommerce_couponversion
-    on ecommerce_couponversion.coupon_id = coupon.coupon_id
-left join couponredemption
-    on couponredemption.couponversion_id = ecommerce_couponversion.couponversion_id
-left join ecommerce_order
-    on ecommerce_order.order_id = couponredemption.order_id
-left join users_user
-    on ecommerce_order.order_purchaser_user_id = users_user.user_id
-left join b2b_ecommerce_b2breceipt
-    on b2b_ecommerce_b2breceipt.b2border_id = b2b_ecommerce_b2border.b2border_id
-left join ecommerce_line
-    on ecommerce_line.order_id = ecommerce_order.order_id
-left join program_runs
-    on ecommerce_line.programrun_id = program_runs.programrun_id
-left join course_runs
-    on ecommerce_line.courserun_id = course_runs.courserun_id
-left join courses
-    on course_runs.course_id = courses.course_id
-left join productversion
-    on productversion.productversion_id = b2b_ecommerce_b2border.productversion_id
-group by
-    b2b_ecommerce_b2border.b2border_email
-    , coupon.coupon_code
-    , coupon.coupon_id
-    , coupon.coupon_created_on
-    , coupon.couponpayment_name
-    , b2b_ecommerce_b2border.b2border_contract_number
-    , b2b_ecommerce_b2border.product_id
-    , ecommerce_couponpaymentversion.couponpaymentversion_payment_transaction
-    , replace(
-        cast(
-            json_extract(b2b_ecommerce_b2breceipt.b2breceipt_data, '$.req_reference_number')
-            as varchar
-        ), '"', ''
-    )
-    , program_runs.programrun_readable_id
-    , program_runs.program_title
-    , course_runs.courserun_readable_id
-    , courses.course_title
-    , productversion.productversion_readable_id
-    , ecommerce_couponpaymentversion.couponpaymentversion_coupon_type
-    , ecommerce_couponpaymentversion.couponpaymentversion_discount_amount
+    , b2b_coupon_fields.couponpaymentversion_coupon_type
+    , b2b_coupon_fields.couponpaymentversion_discount_amount
+    , b2b_coupon_summary.coupon_redeemed
+    , b2b_coupon_summary.combined_user_emails
+    , b2b_coupon_summary.user_address_countries
+    , b2b_coupon_summary.order_ids
+    , b2b_coupon_summary.combined_order_state
+from b2b_coupon_fields
+inner join b2b_coupon_summary
+    on b2b_coupon_fields.coupon_id = b2b_coupon_summary.coupon_id

--- a/src/ol_dbt/models/intermediate/mitxpro/int__mitxpro__ecommerce_combinedcoupons.sql
+++ b/src/ol_dbt/models/intermediate/mitxpro/int__mitxpro__ecommerce_combinedcoupons.sql
@@ -69,17 +69,17 @@ with coupon as (
 )
 
 , payment_transactions as (
-    select distinct
+    select distinct 
         ecommerce_couponversion.coupon_id
         , ecommerce_couponpaymentversion.couponpaymentversion_payment_transaction
     from ecommerce_couponpaymentversion
-    inner join ecommerce_couponversion
+    inner join ecommerce_couponversion 
         on ecommerce_couponpaymentversion.couponpaymentversion_id = ecommerce_couponversion.couponpaymentversion_id
     where ecommerce_couponpaymentversion.couponpaymentversion_payment_transaction is not null
 )
 
 , reg_coupon_summary as (
-    select
+    select 
         coupon.coupon_id
         , case when (count(couponredemption.couponredemption_id) >= 1) then 'true' else 'false' end as coupon_redeemed
         , array_join(array_distinct(array_agg(users_user.user_email)), ', ') as combined_user_emails
@@ -87,27 +87,27 @@ with coupon as (
         , array_join(array_distinct(array_agg(ecommerce_order.order_id)), ', ') as order_ids
         , array_join(array_distinct(array_agg(ecommerce_order.order_state)), ', ') as combined_order_state
     from coupon
-    left join ecommerce_couponversion
+    left join ecommerce_couponversion 
         on coupon.coupon_id = ecommerce_couponversion.coupon_id
     left join couponredemption
         on ecommerce_couponversion.couponversion_id = couponredemption.couponversion_id
     left join ecommerce_order
         on ecommerce_order.order_id = couponredemption.order_id
-    left join users_user
+    left join users_user    
         on ecommerce_order.order_purchaser_user_id = users_user.user_id
-    group by
+    group by 
         coupon.coupon_id
 )
 
 , reg_coupon_fields as (
-    select
+    select 
         productcouponassignment.productcouponassignment_email as coupon_email
         , coupon.coupon_code
         , coupon.coupon_id
         , coupon.coupon_created_on
         , coupon.couponpayment_name
         , productcouponassignment.product_id
-        , payment_transactions.couponpaymentversion_payment_transaction
+        , payment_transactions.couponpaymentversion_payment_transaction 
         , program_runs.programrun_readable_id
         , program_runs.program_title
         , course_runs.courserun_readable_id
@@ -116,11 +116,11 @@ with coupon as (
         , ecommerce_couponpaymentversion.couponpaymentversion_coupon_type
         , ecommerce_couponpaymentversion.couponpaymentversion_discount_amount
     from coupon
-    left join productcouponassignment
+    inner join productcouponassignment
         on productcouponassignment.coupon_id = coupon.coupon_id
-    left join ecommerce_couponversion
+    left join ecommerce_couponversion 
         on coupon.coupon_id = ecommerce_couponversion.coupon_id
-    left join ecommerce_couponpaymentversion
+    left join ecommerce_couponpaymentversion 
         on ecommerce_couponpaymentversion.couponpaymentversion_id = ecommerce_couponversion.couponpaymentversion_id
     left join couponredemption
         on ecommerce_couponversion.couponversion_id = couponredemption.couponversion_id
@@ -128,7 +128,7 @@ with coupon as (
         on ecommerce_order.order_id = couponredemption.order_id
     left join payment_transactions
         on coupon.coupon_id = payment_transactions.coupon_id
-    left join ecommerce_line
+    left join ecommerce_line 
         on ecommerce_line.order_id = ecommerce_order.order_id
     left join program_runs
         on ecommerce_line.programrun_id = program_runs.programrun_id
@@ -138,14 +138,14 @@ with coupon as (
         on course_runs.course_id = courses.course_id
     left join productversion
         on productversion.productversion_id = ecommerce_line.productversion_id
-    group by
-        productcouponassignment.productcouponassignment_email
+    group by 
+        productcouponassignment.productcouponassignment_email 
         , coupon.coupon_code
         , coupon.coupon_id
         , coupon.coupon_created_on
         , coupon.couponpayment_name
         , productcouponassignment.product_id
-        , payment_transactions.couponpaymentversion_payment_transaction
+        , payment_transactions.couponpaymentversion_payment_transaction 
         , program_runs.programrun_readable_id
         , program_runs.program_title
         , course_runs.courserun_readable_id
@@ -156,32 +156,32 @@ with coupon as (
 )
 
 , b2b_coupon_summary as (
-    select
+    select 
         coupon.coupon_id
-        , case
-            when (count(couponredemption.couponredemption_id) >= 1)
-                then 'true'
-            else 'false'
+        , case 
+            when (count(couponredemption.couponredemption_id) >= 1) 
+                then 'true' 
+            else 'false' 
         end as coupon_redeemed
         , array_join(array_distinct(array_agg(users_user.user_email)), ', ') as combined_user_emails
         , array_join(array_distinct(array_agg(users_user.user_address_country)), ', ') as user_address_countries
         , array_join(array_distinct(array_agg(ecommerce_order.order_id)), ', ') as order_ids
         , array_join(array_distinct(array_agg(ecommerce_order.order_state)), ', ') as combined_order_state
-    from b2b_ecommerce_b2border
-    inner join ecommerce_couponpaymentversion
+    from b2b_ecommerce_b2border 
+    inner join ecommerce_couponpaymentversion 
         on ecommerce_couponpaymentversion.couponpaymentversion_id = b2b_ecommerce_b2border.couponpaymentversion_id
-    inner join ecommerce_couponversion
+    inner join ecommerce_couponversion 
         on ecommerce_couponversion.couponpaymentversion_id = ecommerce_couponpaymentversion.couponpaymentversion_id
-    inner join coupon
-        on coupon.coupon_id = ecommerce_couponversion.coupon_id
-    left join couponredemption
+    inner join coupon 
+        on coupon.coupon_id = ecommerce_couponversion.coupon_id 
+    left join couponredemption 
         on couponredemption.couponversion_id = ecommerce_couponversion.couponversion_id
-    left join ecommerce_order
+    left join ecommerce_order 
         on ecommerce_order.order_id = couponredemption.order_id
-    left join users_user
+    left join users_user    
         on ecommerce_order.order_purchaser_user_id = users_user.user_id
-    group by
-        coupon.coupon_id
+    group by 
+        coupon.coupon_id   
 )
 
 , b2b_coupon_fields as (
@@ -193,7 +193,7 @@ with coupon as (
         , coupon.couponpayment_name
         , b2b_ecommerce_b2border.b2border_contract_number
         , b2b_ecommerce_b2border.product_id
-        , ecommerce_couponpaymentversion.couponpaymentversion_payment_transaction
+        , ecommerce_couponpaymentversion.couponpaymentversion_payment_transaction 
         , program_runs.programrun_readable_id
         , program_runs.program_title
         , course_runs.courserun_readable_id
@@ -208,20 +208,20 @@ with coupon as (
                 as varchar
             ), '"', ''
         ) as req_reference_number
-    from b2b_ecommerce_b2border
-    inner join ecommerce_couponpaymentversion
+    from b2b_ecommerce_b2border 
+    inner join ecommerce_couponpaymentversion 
         on ecommerce_couponpaymentversion.couponpaymentversion_id = b2b_ecommerce_b2border.couponpaymentversion_id
-    inner join ecommerce_couponversion
+    inner join ecommerce_couponversion 
         on ecommerce_couponversion.couponpaymentversion_id = ecommerce_couponpaymentversion.couponpaymentversion_id
-    inner join coupon
+    inner join coupon 
         on coupon.coupon_id = ecommerce_couponversion.coupon_id
-    left join couponredemption
+    left join couponredemption 
         on couponredemption.couponversion_id = ecommerce_couponversion.couponversion_id
-    left join ecommerce_order
+    left join ecommerce_order 
         on ecommerce_order.order_id = couponredemption.order_id
-    left join b2b_ecommerce_b2breceipt
+    left join b2b_ecommerce_b2breceipt 
         on b2b_ecommerce_b2breceipt.b2border_id = b2b_ecommerce_b2border.b2border_id
-    left join ecommerce_line
+    left join ecommerce_line 
         on ecommerce_line.order_id = ecommerce_order.order_id
     left join program_runs
         on ecommerce_line.programrun_id = program_runs.programrun_id
@@ -231,15 +231,15 @@ with coupon as (
         on course_runs.course_id = courses.course_id
     left join productversion
         on productversion.productversion_id = b2b_ecommerce_b2border.productversion_id
-    group by
-        b2b_ecommerce_b2border.b2border_email
+    group by 
+        b2b_ecommerce_b2border.b2border_email 
         , coupon.coupon_code
         , coupon.coupon_id
         , coupon.coupon_created_on
         , coupon.couponpayment_name
         , b2b_ecommerce_b2border.b2border_contract_number
         , b2b_ecommerce_b2border.product_id
-        , ecommerce_couponpaymentversion.couponpaymentversion_payment_transaction
+        , ecommerce_couponpaymentversion.couponpaymentversion_payment_transaction 
         , program_runs.programrun_readable_id
         , program_runs.program_title
         , course_runs.courserun_readable_id
@@ -252,11 +252,11 @@ with coupon as (
                 json_extract(b2b_ecommerce_b2breceipt.b2breceipt_data, '$.req_reference_number')
                 as varchar
             ), '"', ''
-        )
+        ) 
 )
 
 
-select
+select 
     reg_coupon_fields.coupon_email
     , reg_coupon_fields.coupon_code
     , reg_coupon_fields.coupon_id
@@ -285,7 +285,7 @@ inner join reg_coupon_summary
 
 union distinct
 
-select
+select 
     b2b_coupon_fields.b2border_email as coupon_email
     , b2b_coupon_fields.coupon_code
     , b2b_coupon_fields.coupon_id

--- a/src/ol_dbt/models/marts/mitxpro/_marts__mitxpro__models.yml
+++ b/src/ol_dbt/models/marts/mitxpro/_marts__mitxpro__models.yml
@@ -22,19 +22,19 @@ models:
   - name: couponpayment_name
     description: string, human readable name for the coupon payment
   - name: b2border_contract_number
-    description: string, contract number used to identify the order  
+    description: string, contract number used to identify the order
   - name: product_id
-    description: int, foreign key in ecommerce_product 
+    description: int, foreign key in ecommerce_product
   - name: couponpaymentversion_payment_transaction
     description: string, string that identifies the payment invoice for coupon purchases
-      by companies 
+      by companies
   - name: req_reference_number
     description: b2b receipt req reference number for a payment
   - name: programrun_readable_id
     description: str, unique program run ID formatted as program-v1:{org}+{program
       code}+{run_tag} e.g. program-v1:xPRO+MLx+R1
   - name: program_title
-    description: str, title of the course run   
+    description: str, title of the course run
   - name: courserun_readable_id
     description: str, Open edX Course ID formatted as course-v1:{org}+{course code}+{run_tag}
       e.g. course-v1:xPRO+MLx1+R0

--- a/src/ol_dbt/models/marts/mitxpro/_marts__mitxpro__models.yml
+++ b/src/ol_dbt/models/marts/mitxpro/_marts__mitxpro__models.yml
@@ -9,24 +9,32 @@ models:
     description: string, email associated to the coupon
   - name: coupon_code
     description: string, coupon code for the coupon
+    tests:
+    - not_null
+  - name: coupon_id
+    description: int, foreign key referencing ecommerce_coupon
+    tests:
+    - not_null
   - name: coupon_created_on
     description: timestamp, specifying when the coupon was initially created
+    tests:
+    - not_null
   - name: couponpayment_name
     description: string, human readable name for the coupon payment
   - name: b2border_contract_number
-    description: string, contract number used to identify the order
+    description: string, contract number used to identify the order  
   - name: product_id
-    description: int, foreign key in ecommerce_product
+    description: int, foreign key in ecommerce_product 
   - name: couponpaymentversion_payment_transaction
     description: string, string that identifies the payment invoice for coupon purchases
-      by companies
+      by companies 
   - name: req_reference_number
     description: b2b receipt req reference number for a payment
   - name: programrun_readable_id
     description: str, unique program run ID formatted as program-v1:{org}+{program
       code}+{run_tag} e.g. program-v1:xPRO+MLx+R1
   - name: program_title
-    description: str, title of the course run
+    description: str, title of the course run   
   - name: courserun_readable_id
     description: str, Open edX Course ID formatted as course-v1:{org}+{course code}+{run_tag}
       e.g. course-v1:xPRO+MLx1+R0
@@ -34,9 +42,6 @@ models:
     description: str, title of the course
   - name: productversion_readable_id
     description: string, the readable_id field from the product object
-  - name: combinedcoupon_table_source
-    description: string, Describes whether the data on the combioned coupon table
-      is coming from b2b or elsewhere
   - name: couponpaymentversion_coupon_type
     description: string, one of 'single-use' or 'promo'. Promo coupon codes can be
       used multiple times
@@ -49,7 +54,10 @@ models:
   - name: user_address_countries
     description: str, country codes for the user(s)
   - name: order_ids
-    description: int, foreign key for ecommerce_orders
+    description: int, foreign key for ecommerce_orders all associated with the coupon
   - name: combined_order_state
     description: string, order state. Options are "fulfilled", "failed", "created"
-      "refunded"
+      "refunded" all associated with the coupon
+  tests:
+  - dbt_expectations.expect_compound_columns_to_be_unique:
+      column_list: ["coupon_id", "order_ids"]


### PR DESCRIPTION
This adds a new int table int__mitxpro__ecommerce_combinedcoupons  and a new mart table marts__mitxpro_ecommerce_combinedcoupons

# What are the relevant tickets?
https://github.com/mitodl/hq/issues/818

# Description (What does it do?)
creating data mart tables as described in https://github.com/mitodl/hq/issues/1803

# How can this be tested?
Run the following commands against your schema or QA
Run dbt build --select intermediate.mitxpro if you have all models, otherwise add + in front of intermediate.mitxpro to run upstream models

Run dbt build --select marts.mitxpro if you have all models, otherwise add + in front of marts.mitxpro to run upstream models


