### PR TITLE
stage MITx Online tracking log table, update to xPro staging tracking log

### DIFF
--- a/src/ol_dbt/macros/extract_course_id_from_tracking_log.sql
+++ b/src/ol_dbt/macros/extract_course_id_from_tracking_log.sql
@@ -1,6 +1,7 @@
 {% macro extract_course_id_from_tracking_log() %}
     ---course ID format: course-v1:{org}+{course number}+{run_tag}
-    {% set course_id_regex = 'course-v(\d{1}):([^\/]+)\+([^\/]+)\+([^\/\]]+)' %}
+    ---Course number and run tag can be letters, numbers, period, dashes, underscores
+    {% set course_id_regex = 'course-v(\d{1}):([\w\.\-\_]+)\+([\w\.\-\_]+)\+([\w\.\-\_]+)' %}
       case
           when regexp_extract(json_query(context, 'lax $.course_id' omit quotes), '{{ course_id_regex }}') is not null
              then json_query(context, 'lax $.course_id' omit quotes)

--- a/src/ol_dbt/models/staging/mitxonline/_mitxonline__sources.yml
+++ b/src/ol_dbt/models/staging/mitxonline/_mitxonline__sources.yml
@@ -751,3 +751,59 @@ sources:
         on the open edX platform
     - name: last_login
       description: timestamp, date and time when user last login on the open edX platform
+
+  - name: raw__mitxonline__openedx__tracking_logs
+    description: MITx Online Open edX event data that are emitted by server, the browser,
+      or the mobile device to capture information about user's interactions with a
+      course
+    columns:
+    - name: username
+      description: str, username of the open edX user who caused the event to be emitted.
+        Some events are recorded with a blank username. This can occur when a user
+        logs out, or the login session times out, while a browser window remains open.
+        EdX recommends to ignore these events.
+    - name: context
+      description: object, it includes member fields that provide contextual information.
+        Common fields apply to all events are course_id, org_id, path, user_id. Other
+        member fields for applicable events are course_user_tags, module.
+    - name: event_source
+      description: str, specifies the source of the interaction that triggered the
+        event. The values are - browser, mobile, server, task
+    - name: event_type
+      description: str, type of event triggered. Values depend on event_source.
+    - name: name
+      description: str, type of event triggered. When this field is present for an
+        event, it supersedes the event_type field.
+    - name: event
+      description: object, it includes member fields that identify specifics of each
+        triggered event. Different member fields are supplied for different events.
+    - name: page
+      description: str, url of the page the user was visiting when the event was emitted.
+    - name: session
+      description: str, 32-character value to identify the user’s session. All browser
+        events and the server 'enrollment' events include a session value. Other server
+        events and mobile events do not include a session value.
+    - name: ip
+      description: str, IP address of the user who triggered the event. Empty for
+        mobile events.
+    - name: host
+      description: str, the site visited by the user. e.g. courses.mitxonline.mit.edu
+    - name: time
+      description: str, time at which the event was emitted. It has inconsistent formats
+        due to log collector switches, YYYY-MM-DD HH:mm:ss.SSSSSS for older records,
+        YYYY-MM-ddTHH:mm:ss.SSSSSS for newer records
+    - name: agent
+      description: str, browser agent string of the user who triggered the event.
+    - name: accept_language
+      description: str, value from the HTTP Accept-Language request-header field
+    - name: referer
+      description: str, URI from the HTTP Referer request-header field
+    - name: log_file
+      description: str, internal used field for log file location
+    - name: _ab_source_file_url
+      description: str, url path for the raw log file
+    - name: vector_timestamp
+      description: str, time when Vector processed this record. Blank for old records.
+    - name: environment
+      description: str, internal used field to indicate environment for the event.
+        e.g. mitxonline-production

--- a/src/ol_dbt/models/staging/mitxonline/_stg_mitxonline__models.yml
+++ b/src/ol_dbt/models/staging/mitxonline/_stg_mitxonline__models.yml
@@ -1151,3 +1151,79 @@ models:
       platform
     tests:
     - not_null
+
+- name: stg__mitxonline__openedx__tracking_logs__user_activity
+  description: This table is deduped as raw table has duplicate events. It filters
+    out blank username events since these don't supply user identifiers and also those
+    server "exception" events due to server errors
+  columns:
+  - name: user_username
+    description: str, username of the open edX user who caused the event to be emitted.
+    tests:
+    - not_null
+  - name: openedx_user_id
+    description: int, reference user id in auth_user from open edX. Extracted from
+      context field.
+    tests:
+    - not_null
+  - name: courserun_readable_id
+    description: str, Open edX Course ID formatted as course-v1:{org}+{course number}+{run_tag}.
+      Extracted from various fields - context.course_id, context.path, event_type
+      and page. The course ID extracted from context field may not be valid, it would
+      require joining with courserun table to be sure. This field could be blank for
+      any events that are not for any specific course .e.g. user login/out, visiting
+      dashboard, some course team events e.g. course export from studio
+  - name: org_id
+    description: str, reference name in organizations_organization from open edX.
+      e.g. MITxT . Extracted from context field
+  - name: useractivity_path
+    description: str, URL that generated this event. Extracted from context field
+  - name: useractivity_context_object
+    description: object, it includes member fields that provide contextual information.
+      Common fields apply to all events are course_id, org_id, path, user_id. Other
+      member fields for applicable events are course_user_tags, module.
+  - name: useractivity_event_source
+    description: str, specifies the source of the interaction that triggered the event.
+      The values are - browser, mobile, server, task
+    tests:
+    - not_null
+  - name: useractivity_event_type
+    description: str, type of event triggered. Values depend on event_source.
+    tests:
+    - not_null
+  - name: useractivity_event_name
+    description: str, type of event triggered. When this field is present for an event,
+      it supersedes the event_type field.
+  - name: useractivity_event_object
+    description: object,it includes member fields that identify specifics of each
+      triggered event. Different member fields are supplied for different events.
+    tests:
+    - not_null
+  - name: useractivity_page_url
+    description: str, url of the page the user was visiting when the event was emitted.
+  - name: useractivity_session_id
+    description: str, 32-character value to identify the user’s session. All browser
+      events and the server 'enrollment' events include session value. Other server
+      events and mobile events do not include a session value.
+  - name: useractivity_ip
+    description: str, IP address of the user who triggered the event. Empty for mobile
+      events.
+  - name: useractivity_http_host
+    description: str, The site visited by the user. e.g. courses.mitxonline.mit.edu
+    tests:
+    - not_null
+  - name: useractivity_http_user_agent
+    description: str, browser agent string of the user who triggered the event.
+  - name: useractivity_http_accept_language
+    description: str, value from the HTTP Accept-Language request-header field
+  - name: useractivity_http_referer
+    description: str, URI from the HTTP Referer request-header field
+  - name: useractivity_timestamp
+    description: timestamp, time at which the event was emitted, formatted as ISO
+      8601 string
+    tests:
+    - not_null
+  tests:
+  - dbt_expectations.expect_compound_columns_to_be_unique:
+      column_list: ["user_username", "useractivity_context_object", "useractivity_event_source",
+        "useractivity_event_type", "useractivity_event_object", "useractivity_timestamp"]

--- a/src/ol_dbt/models/staging/mitxonline/stg__mitxonline__openedx__tracking_logs__user_activity.sql
+++ b/src/ol_dbt/models/staging/mitxonline/stg__mitxonline__openedx__tracking_logs__user_activity.sql
@@ -1,4 +1,4 @@
--- xPro user activities from tracking logs
+-- MITx Online user activities from tracking logs
 -- Due to size of the raw table, build this model as incremental and apply dedup on new rows
 {{ config(
     materialized='incremental',
@@ -10,7 +10,7 @@
 }}
 
 with source as (
-    select * from {{ source('ol_warehouse_raw_data','raw__xpro__openedx__tracking_logs') }}
+    select * from {{ source('ol_warehouse_raw_data','raw__mitxonline__openedx__tracking_logs') }}
     where
         username != ''
         and json_query(context, 'lax $.user_id' omit quotes) is not null
@@ -25,7 +25,7 @@ with source as (
     select
         *
         , row_number() over (
-            partition by username, context, event_source, event_type, event, "time"   --noqa
+            partition by username, context, event_source, event_type, event, "time"  --noqa
             order by _airbyte_emitted_at desc, _ab_source_file_last_modified desc, vector_timestamp desc
         ) as row_num
     from source

--- a/src/ol_dbt/models/staging/mitxpro/_mitxpro__sources.yml
+++ b/src/ol_dbt/models/staging/mitxpro/_mitxpro__sources.yml
@@ -887,8 +887,9 @@ sources:
         education", "Other education"
 
   - name: raw__xpro__openedx__tracking_logs
-    description: event data that are emitted by server, the browser, or the mobile
-      device to capture information about user's interactions with a course
+    description: MIT xPro Open edX event data that are emitted by server, the browser,
+      or the mobile device to capture information about user's interactions with a
+      course
     columns:
     - name: username
       description: str, username of the open edX user who caused the event to be emitted.

--- a/src/ol_dbt/models/staging/mitxpro/_stg_mitxpro__models.yml
+++ b/src/ol_dbt/models/staging/mitxpro/_stg_mitxpro__models.yml
@@ -1347,8 +1347,9 @@ models:
       column_list: ["user_id", "program_id", "ecommerce_order_id"]
 
 - name: stg__mitxpro__openedx__tracking_logs__user_activity
-  description: xPro open edX user activity table that tracks student and course team
-    events
+  description: This table is deduped as raw table has duplicate events. It filters
+    out blank username events since these don't supply user identifiers and also those
+    server "exception" events due to server errors
   columns:
   - name: user_username
     description: str, username of the open edX user who caused the event to be emitted.
@@ -1418,5 +1419,5 @@ models:
     - not_null
   tests:
   - dbt_expectations.expect_compound_columns_to_be_unique:
-      column_list: ["user_username", "useractivity_event_type", "useractivity_context_object",
-        "useractivity_timestamp"]
+      column_list: ["user_username", "useractivity_context_object", "useractivity_event_source",
+        "useractivity_event_type", "useractivity_event_object", "useractivity_timestamp"]


### PR DESCRIPTION
# What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
https://github.com/mitodl/ol-data-platform/issues/729

# Description (What does it do?)
<!--- Describe your changes in detail -->
This adds `stg__mitxonline__openedx__tracking_logs__user_activity` as an incremental model for performance. It has dedupe logic because raw data contains duplicates. It also updates to `stg__mitxpro__openedx__tracking_logs__user_activity` to be consistent with mitxonline. 

# How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->
To test against production data, you will need to update your [profile.xml](https://github.com/mitodl/ol-data-platform/blob/main/src/ol_dbt/profiles.yml#L46) with production host `mitol-ol-data-lake-production.trino.galaxy.starburst.io` due to resource limitation of our QA cluster to run large model (https://github.com/mitodl/ol-data-platform/issues/793 is created to solve this problem without updating profiles.yml)
 then run 
```
 dbt build --select stg__mitxonline__openedx__tracking_logs__user_activity --vars 'schema_suffix: YOURSCHEMA' --target dev_production 

 dbt build --select stg__mitxpro__openedx__tracking_logs__user_activity --vars 'schema_suffix: YOURSCHEMA' --target dev_production --full-refresh

```
Tests should all pass
