### PR TITLE
add company and position profile data to int__mitx__users

### DIFF
--- a/src/ol_dbt/models/intermediate/combined/int__combined__users.sql
+++ b/src/ol_dbt/models/intermediate/combined/int__combined__users.sql
@@ -1,5 +1,5 @@
---- This model combines intermediate users from different platform,
--- it's built as view with no additional data is stored
+--- This model combines intermediate users from different platforms, it contains duplicates for
+--  MITx Online and edX.org users, deduplication is handled in int__mitx__users
 {{ config(materialized='view') }}
 
 with mitxonline_users as (

--- a/src/ol_dbt/models/intermediate/mitx/_int_mitx__models.yml
+++ b/src/ol_dbt/models/intermediate/mitx/_int_mitx__models.yml
@@ -153,6 +153,12 @@ models:
       or edX.org
   - name: user_birth_year
     description: int, user's birth year from MITx Online or edX.org
+  - name: user_company
+    description: str, user's company pulled from MITx Online or MicroMasters
+  - name: user_job_title
+    description: str, user's job title pulled from MITx Online or MicroMasters
+  - name: user_industry
+    description: str, user's job industry pulled from MITx Online or MicroMasters
 
 - name: int__mitx__courserun_enrollments
   description: MITx courserun enrollments combined from MITx Online and edX.org

--- a/src/ol_dbt/models/staging/mitxonline/stg__mitxonline__app__postgres__users_userprofile.sql
+++ b/src/ol_dbt/models/staging/mitxonline/stg__mitxonline__app__postgres__users_userprofile.sql
@@ -7,12 +7,12 @@ with source as (
         id as user_profile_id
         , user_id
         , year_of_birth as user_birth_year
-        , company as user_company
-        , industry as user_industry
-        , job_title as user_job_title
-        , job_function as user_job_function
-        , leadership_level as user_leadership_level
-        , highest_education as user_highest_education
+        , nullif(company, '') as user_company
+        , nullif(industry, '') as user_industry
+        , nullif(job_title, '') as user_job_title
+        , nullif(job_function, '') as user_job_function
+        , nullif(leadership_level, '') as user_leadership_level
+        , nullif(highest_education, '') as user_highest_education
         , type_is_student as user_type_is_student
         , type_is_professional as user_type_is_professional
         , type_is_educator as user_type_is_educator


### PR DESCRIPTION
# What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
Part of https://github.com/mitodl/hq/issues/1644, so that Kate can work on mart

# Description (What does it do?)
<!--- Describe your changes in detail -->
This adds `user_company`, `user_job_title`, and `user_industry` to `int__mitx__users`, data combined from MITx Online and MicroMasters since these 3 fields are available from both app's databases


# How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->
dbt build on `+int__mitx__users`, test should pass

Note that there is one warning on the relationship test in `stg__mitxonline__app__postgres__users_userprofile`, that's due to our raw data sync issue, one user_id exists in raw__mitxonline__app__postgres__users_userprofile but not in raw__mitxonline__app__postgres__users_user.  It can be ignored as that user won't get propagated into intermediate 

