### PR TITLE
add 4 new fields to new xpro mart table marts__mitxpro_ecommerce_productlist

### DIFF
--- a/src/ol_dbt/models/marts/mitxpro/_marts__mitxpro__models.yml
+++ b/src/ol_dbt/models/marts/mitxpro/_marts__mitxpro__models.yml
@@ -36,11 +36,11 @@ models:
   - name: link
     description: link to the xPro checkout page
   - name: product_parent_run_id
-    description: str, Open edX ID which includes the Run number. For example 
-      the Product Parent Run of course-v1:xPRO+SysEngx4+R18 is program-v1:xPRO+SysEngx+R18.
+    description: str, Open edX ID which includes the Run number. For example the Product
+      Parent Run of course-v1:xPRO+SysEngx4+R18 is program-v1:xPRO+SysEngx+R18.
   - name: duration
-    description: str, a short description indicating how long the course or program takes to
-      complete (e.g. '4 weeks')
+    description: str, a short description indicating how long the course or program
+      takes to complete (e.g. '4 weeks')
   - name: time_commitment
     description: str, short description indicating about the time commitments
   - name: coursetopic_name

--- a/src/ol_dbt/models/marts/mitxpro/_marts__mitxpro__models.yml
+++ b/src/ol_dbt/models/marts/mitxpro/_marts__mitxpro__models.yml
@@ -36,15 +36,15 @@ models:
   - name: link
     description: link to the xPro checkout page
   - name: product_parent_run_id
-    description: str, Open edX ID which includes the Run number. For example the Product
-      Parent Run of course-v1:xPRO+SysEngx4+R18 is program-v1:xPRO+SysEngx+R18.
+    description: str, Open edX ID which includes the Run number. For example 
+      the Product Parent Run of course-v1:xPRO+SysEngx4+R18 is program-v1:xPRO+SysEngx+R18.
   - name: duration
-    description: str, a short description indicating how long the course or program
-      takes to complete (e.g. '4 weeks')
+    description: str, a short description indicating how long the course or program takes to
+      complete (e.g. '4 weeks')
   - name: time_commitment
     description: str, short description indicating about the time commitments
   - name: coursetopic_name
     description: str, name of a course topic
   tests:
   - dbt_expectations.expect_compound_columns_to_be_unique:
-      column_list: ["product_id", "product_parent_run_id"]
+      column_list: ["product_id", "product_parent_run_id", "coursetopic_name"]

--- a/src/ol_dbt/models/marts/mitxpro/_marts__mitxpro__models.yml
+++ b/src/ol_dbt/models/marts/mitxpro/_marts__mitxpro__models.yml
@@ -36,3 +36,13 @@ models:
     description: timestamp, specifying when enrollment ends
   - name: link
     description: link to the xPro checkout page
+  - name: product_parent_run_id
+    description: str, Open edX ID which includes the Run number. For example 
+      the Product Parent Run of course-v1:xPRO+SysEngx4+R18 is program-v1:xPRO+SysEngx+R18.
+  - name: duration
+    description: str, a short description indicating how long the course or program takes to
+      complete (e.g. '4 weeks')
+  - name: time_commitment
+    description: str, short description indicating about the time commitments
+  - name: coursetopic_name
+    description: str, name of a course topic

--- a/src/ol_dbt/models/marts/mitxpro/_marts__mitxpro__models.yml
+++ b/src/ol_dbt/models/marts/mitxpro/_marts__mitxpro__models.yml
@@ -19,7 +19,6 @@ models:
       code}+{run_tag} e.g. program-v1:xPRO+MLx+R1
     tests:
     - not_null
-    - unique
   - name: product_type
     description: string, readable product type
   - name: list_price
@@ -37,12 +36,15 @@ models:
   - name: link
     description: link to the xPro checkout page
   - name: product_parent_run_id
-    description: str, Open edX ID which includes the Run number. For example the Product
-      Parent Run of course-v1:xPRO+SysEngx4+R18 is program-v1:xPRO+SysEngx+R18.
+    description: str, Open edX ID which includes the Run number. For example 
+      the Product Parent Run of course-v1:xPRO+SysEngx4+R18 is program-v1:xPRO+SysEngx+R18.
   - name: duration
-    description: str, a short description indicating how long the course or program
-      takes to complete (e.g. '4 weeks')
+    description: str, a short description indicating how long the course or program takes to
+      complete (e.g. '4 weeks')
   - name: time_commitment
     description: str, short description indicating about the time commitments
   - name: coursetopic_name
     description: str, name of a course topic
+  tests:
+  - dbt_expectations.expect_compound_columns_to_be_unique:
+      column_list: ["product_id", "product_parent_run_id"]

--- a/src/ol_dbt/models/marts/mitxpro/_marts__mitxpro__models.yml
+++ b/src/ol_dbt/models/marts/mitxpro/_marts__mitxpro__models.yml
@@ -36,11 +36,11 @@ models:
   - name: link
     description: link to the xPro checkout page
   - name: product_parent_run_id
-    description: str, Open edX ID which includes the Run number. For example the Product
-      Parent Run of course-v1:xPRO+SysEngx4+R18 is program-v1:xPRO+SysEngx+R18.
+    description: str, Open edX ID which includes the Run number. For example 
+      the Product Parent Run of course-v1:xPRO+SysEngx4+R18 is program-v1:xPRO+SysEngx+R18.
   - name: duration
-    description: str, a short description indicating how long the course or program
-      takes to complete (e.g. '4 weeks')
+    description: str, a short description indicating how long the course or program takes to
+      complete (e.g. '4 weeks')
   - name: time_commitment
     description: str, short description indicating about the time commitments
   - name: coursetopic_names

--- a/src/ol_dbt/models/marts/mitxpro/_marts__mitxpro__models.yml
+++ b/src/ol_dbt/models/marts/mitxpro/_marts__mitxpro__models.yml
@@ -36,11 +36,11 @@ models:
   - name: link
     description: link to the xPro checkout page
   - name: product_parent_run_id
-    description: str, Open edX ID which includes the Run number. For example 
-      the Product Parent Run of course-v1:xPRO+SysEngx4+R18 is program-v1:xPRO+SysEngx+R18.
+    description: str, Open edX ID which includes the Run number. For example the Product
+      Parent Run of course-v1:xPRO+SysEngx4+R18 is program-v1:xPRO+SysEngx+R18.
   - name: duration
-    description: str, a short description indicating how long the course or program takes to
-      complete (e.g. '4 weeks')
+    description: str, a short description indicating how long the course or program
+      takes to complete (e.g. '4 weeks')
   - name: time_commitment
     description: str, short description indicating about the time commitments
   - name: coursetopic_names

--- a/src/ol_dbt/models/marts/mitxpro/_marts__mitxpro__models.yml
+++ b/src/ol_dbt/models/marts/mitxpro/_marts__mitxpro__models.yml
@@ -36,15 +36,15 @@ models:
   - name: link
     description: link to the xPro checkout page
   - name: product_parent_run_id
-    description: str, Open edX ID which includes the Run number. For example the Product
-      Parent Run of course-v1:xPRO+SysEngx4+R18 is program-v1:xPRO+SysEngx+R18.
+    description: str, Open edX ID which includes the Run number. For example 
+      the Product Parent Run of course-v1:xPRO+SysEngx4+R18 is program-v1:xPRO+SysEngx+R18.
   - name: duration
-    description: str, a short description indicating how long the course or program
-      takes to complete (e.g. '4 weeks')
+    description: str, a short description indicating how long the course or program takes to
+      complete (e.g. '4 weeks')
   - name: time_commitment
     description: str, short description indicating about the time commitments
   - name: coursetopic_names
-    description: str, all associated course topic names comma seperated
+    description: str, all associated course topic names
   tests:
   - dbt_expectations.expect_compound_columns_to_be_unique:
       column_list: ["product_id", "product_parent_run_id"]

--- a/src/ol_dbt/models/marts/mitxpro/_marts__mitxpro__models.yml
+++ b/src/ol_dbt/models/marts/mitxpro/_marts__mitxpro__models.yml
@@ -36,15 +36,15 @@ models:
   - name: link
     description: link to the xPro checkout page
   - name: product_parent_run_id
-    description: str, Open edX ID which includes the Run number. For example the Product
-      Parent Run of course-v1:xPRO+SysEngx4+R18 is program-v1:xPRO+SysEngx+R18.
+    description: str, Open edX ID which includes the Run number. For example 
+      the Product Parent Run of course-v1:xPRO+SysEngx4+R18 is program-v1:xPRO+SysEngx+R18.
   - name: duration
-    description: str, a short description indicating how long the course or program
-      takes to complete (e.g. '4 weeks')
+    description: str, a short description indicating how long the course or program takes to
+      complete (e.g. '4 weeks')
   - name: time_commitment
     description: str, short description indicating about the time commitments
-  - name: coursetopic_name
-    description: str, name of a course topic
+  - name: coursetopic_names
+    description: str, all associated course topic names
   tests:
   - dbt_expectations.expect_compound_columns_to_be_unique:
       column_list: ["product_id", "product_parent_run_id", "coursetopic_name"]

--- a/src/ol_dbt/models/marts/mitxpro/_marts__mitxpro__models.yml
+++ b/src/ol_dbt/models/marts/mitxpro/_marts__mitxpro__models.yml
@@ -37,11 +37,11 @@ models:
   - name: link
     description: link to the xPro checkout page
   - name: product_parent_run_id
-    description: str, Open edX ID which includes the Run number. For example 
-      the Product Parent Run of course-v1:xPRO+SysEngx4+R18 is program-v1:xPRO+SysEngx+R18.
+    description: str, Open edX ID which includes the Run number. For example the Product
+      Parent Run of course-v1:xPRO+SysEngx4+R18 is program-v1:xPRO+SysEngx+R18.
   - name: duration
-    description: str, a short description indicating how long the course or program takes to
-      complete (e.g. '4 weeks')
+    description: str, a short description indicating how long the course or program
+      takes to complete (e.g. '4 weeks')
   - name: time_commitment
     description: str, short description indicating about the time commitments
   - name: coursetopic_name

--- a/src/ol_dbt/models/marts/mitxpro/_marts__mitxpro__models.yml
+++ b/src/ol_dbt/models/marts/mitxpro/_marts__mitxpro__models.yml
@@ -36,15 +36,15 @@ models:
   - name: link
     description: link to the xPro checkout page
   - name: product_parent_run_id
-    description: str, Open edX ID which includes the Run number. For example the Product
-      Parent Run of course-v1:xPRO+SysEngx4+R18 is program-v1:xPRO+SysEngx+R18.
+    description: str, Open edX ID which includes the Run number. For example 
+      the Product Parent Run of course-v1:xPRO+SysEngx4+R18 is program-v1:xPRO+SysEngx+R18.
   - name: duration
-    description: str, a short description indicating how long the course or program
-      takes to complete (e.g. '4 weeks')
+    description: str, a short description indicating how long the course or program takes to
+      complete (e.g. '4 weeks')
   - name: time_commitment
     description: str, short description indicating about the time commitments
   - name: coursetopic_names
-    description: str, all associated course topic names
+    description: str, all associated course topic names comma seperated
   tests:
   - dbt_expectations.expect_compound_columns_to_be_unique:
-      column_list: ["product_id", "product_parent_run_id", "coursetopic_name"]
+      column_list: ["product_id", "product_parent_run_id"]

--- a/src/ol_dbt/models/marts/mitxpro/marts__mitxpro_ecommerce_productlist.sql
+++ b/src/ol_dbt/models/marts/mitxpro/marts__mitxpro_ecommerce_productlist.sql
@@ -81,13 +81,12 @@ left join ecommerce_productversion_latest
     on ecommerce_product.product_id = ecommerce_productversion_latest.product_id
 inner join course_runs
     on ecommerce_product.courserun_id = course_runs.courserun_id
-inner join courses
-    on course_runs.course_id = courses.course_id
 left join coursesinprogram
     on course_runs.course_id = coursesinprogram.course_id
 left join programs
     on coursesinprogram.program_id = programs.program_id
-
+left join courses
+    on course_runs.course_id = courses.course_id
 left join course_to_topics
     on course_runs.course_id = course_to_topics.course_id
 left join coursetopic

--- a/src/ol_dbt/models/marts/mitxpro/marts__mitxpro_ecommerce_productlist.sql
+++ b/src/ol_dbt/models/marts/mitxpro/marts__mitxpro_ecommerce_productlist.sql
@@ -23,6 +23,26 @@ with ecommerce_product as (
     from {{ ref('int__mitxpro__program_runs') }}
 )
 
+, coursesinprogram as (
+    select *
+    from {{ ref('int__mitxpro__coursesinprogram') }}
+)
+
+, courses as (
+    select *
+    from {{ ref('int__mitxpro__courses') }}
+)
+
+, course_to_topics as (
+    select *
+    from {{ ref('int__mitxpro__courses_to_topics') }}
+)
+
+, coursetopic as (
+    select *
+    from {{ ref('int__mitxpro__coursetopic') }}
+)
+
 , ecommerce_productversion_latest as (
     select *
     from (
@@ -52,11 +72,25 @@ select
         , cast(ecommerce_product.product_id as varchar (50))
         , '">', course_runs.courserun_readable_id, '</a>'
     ) as link
+    , concat(programs.program_readable_id, '+', course_runs.courserun_tag) as product_parent_run_id
+    , courses.cms_coursepage_duration as duration
+    , courses.cms_coursepage_time_commitment as time_commitment
+    , coursetopic.coursetopic_name
 from ecommerce_product
 left join ecommerce_productversion_latest
     on ecommerce_product.product_id = ecommerce_productversion_latest.product_id
 inner join course_runs
     on ecommerce_product.courserun_id = course_runs.courserun_id
+left join coursesinprogram
+    on course_runs.course_id = coursesinprogram.course_id
+left join programs
+    on coursesinprogram.program_id = programs.program_id
+left join courses
+    on course_runs.course_id = courses.course_id
+left join course_to_topics
+    on course_runs.course_id = course_to_topics.course_id
+left join coursetopic
+    on course_to_topics.coursetopic_id = coursetopic.coursetopic_id
 where ecommerce_product.product_type = 'course run'
 
 union all
@@ -78,6 +112,10 @@ select
         , program_runs.programrun_readable_id
         , '">', program_runs.programrun_readable_id, '</a>'
     ) as link
+    , null as product_parent_run_id
+    , programs.cms_programpage_duration as duration
+    , programs.cms_programpage_time_commitment as time_commitment
+    , null as coursetopic_name
 from ecommerce_product
 left join ecommerce_productversion_latest
     on ecommerce_product.product_id = ecommerce_productversion_latest.product_id

--- a/src/ol_dbt/models/marts/mitxpro/marts__mitxpro_ecommerce_productlist.sql
+++ b/src/ol_dbt/models/marts/mitxpro/marts__mitxpro_ecommerce_productlist.sql
@@ -56,7 +56,7 @@ with ecommerce_product as (
 )
 
 , ecommerce_course_to_topics as (
-    select
+    select 
         course_to_topics.course_id
         , array_join(array_distinct(array_agg(coursetopic.coursetopic_name)), ', ') as coursetopic_name
     from course_to_topics
@@ -85,7 +85,7 @@ select
     , concat(programs.program_readable_id, '+', course_runs.courserun_tag) as product_parent_run_id
     , courses.cms_coursepage_duration as duration
     , courses.cms_coursepage_time_commitment as time_commitment
-    , ecommerce_course_to_topics.coursetopic_names
+    , ecommerce_course_to_topics.coursetopic_name as coursetopic_names
 from ecommerce_product
 left join ecommerce_productversion_latest
     on ecommerce_product.product_id = ecommerce_productversion_latest.product_id

--- a/src/ol_dbt/models/marts/mitxpro/marts__mitxpro_ecommerce_productlist.sql
+++ b/src/ol_dbt/models/marts/mitxpro/marts__mitxpro_ecommerce_productlist.sql
@@ -81,12 +81,13 @@ left join ecommerce_productversion_latest
     on ecommerce_product.product_id = ecommerce_productversion_latest.product_id
 inner join course_runs
     on ecommerce_product.courserun_id = course_runs.courserun_id
+inner join courses
+    on course_runs.course_id = courses.course_id
 left join coursesinprogram
     on course_runs.course_id = coursesinprogram.course_id
 left join programs
     on coursesinprogram.program_id = programs.program_id
-left join courses
-    on course_runs.course_id = courses.course_id
+
 left join course_to_topics
     on course_runs.course_id = course_to_topics.course_id
 left join coursetopic

--- a/src/ol_dbt/models/marts/mitxpro/marts__mitxpro_ecommerce_productlist.sql
+++ b/src/ol_dbt/models/marts/mitxpro/marts__mitxpro_ecommerce_productlist.sql
@@ -56,11 +56,11 @@ with ecommerce_product as (
 )
 
 , ecommerce_course_to_topics as (
-    select
+    select 
         course_to_topics.course_id
-        , array_join(array_distinct(array_agg(coursetopic.coursetopic_name)), ', ') as coursetopic_name
+        , array_join(array_agg(coursetopic.coursetopic_name), ', ') as coursetopic_name
     from course_to_topics
-    left join coursetopic
+    inner join coursetopic
         on course_to_topics.coursetopic_id = coursetopic.coursetopic_id
     group by course_to_topics.course_id
 )

--- a/src/ol_dbt/models/marts/mitxpro/marts__mitxpro_ecommerce_productlist.sql
+++ b/src/ol_dbt/models/marts/mitxpro/marts__mitxpro_ecommerce_productlist.sql
@@ -56,7 +56,7 @@ with ecommerce_product as (
 )
 
 , ecommerce_course_to_topics as (
-    select 
+    select
         course_to_topics.course_id
         , array_join(array_distinct(array_agg(coursetopic.coursetopic_name)), ', ') as coursetopic_name
     from course_to_topics

--- a/src/ol_dbt/models/marts/mitxpro/marts__mitxpro_ecommerce_productlist.sql
+++ b/src/ol_dbt/models/marts/mitxpro/marts__mitxpro_ecommerce_productlist.sql
@@ -56,7 +56,7 @@ with ecommerce_product as (
 )
 
 , ecommerce_course_to_topics as (
-    select
+    select 
         course_to_topics.course_id
         , array_join(array_distinct(array_agg(coursetopic.coursetopic_name)), ', ') as coursetopic_name
     from course_to_topics
@@ -64,6 +64,7 @@ with ecommerce_product as (
         on course_to_topics.coursetopic_id = coursetopic.coursetopic_id
     group by course_to_topics.course_id
 )
+--there can occationally be multiple topics per course
 
 select
     'xPRO' as product_platform

--- a/src/ol_dbt/models/marts/mitxpro/marts__mitxpro_ecommerce_productlist.sql
+++ b/src/ol_dbt/models/marts/mitxpro/marts__mitxpro_ecommerce_productlist.sql
@@ -56,7 +56,7 @@ with ecommerce_product as (
 )
 
 , ecommerce_course_to_topics as (
-    select 
+    select
         course_to_topics.course_id
         , array_join(array_agg(coursetopic.coursetopic_name), ', ') as coursetopic_name
     from course_to_topics


### PR DESCRIPTION
# What are the relevant tickets?
https://github.com/mitodl/hq/issues/1908

# Description (What does it do?)
This change is to modify a new data mart table marts__mitxpro_ecommerce_productlist. Add the product parent run to the product data mart, but only for course-run products.
And Enhance the product mart with CMS data, specifically: duration, time_commitment, topics.

# How can this be tested?
Run the following commands against your schema or QA
Run dbt build --select marts.mitxpro if you have all models, otherwise add + in front of marts.mitxpro to run upstream models


