### PR TITLE
feat: Add logic to re-process normalized tracking logs for IRx

### DIFF
--- a/src/ol_orchestrate/jobs/normalize_logs.py
+++ b/src/ol_orchestrate/jobs/normalize_logs.py
@@ -3,6 +3,7 @@ from dagster import graph
 
 from ol_orchestrate.ops.normalize_logs import (
     load_files_to_table,
+    jsonify_log_data,
     transform_log_data,
     write_file_to_s3,
 )
@@ -25,3 +26,22 @@ from ol_orchestrate.ops.normalize_logs import (
 def normalize_tracking_logs():
     # load all files for one date to duckDB
     write_file_to_s3(transform_log_data(load_files_to_table()))
+
+
+@graph(
+    description=(
+        "Normalize historical tracking log data stored in an S3 bucket"
+        "by loading them to DuckDB, transforming the data into a consistent"
+        "format, and uploading them to the 'logs/' path prefix in the same"
+        "bucket on an ad hoc basis."
+    ),
+    tags={
+        "source": "s3",
+        "destination": "s3",
+        "owner": "platform-engineering",
+        "consumer": "IRx",
+    },
+)
+def jsonify_tracking_logs():
+    # load all files for one date to duckDB
+    write_file_to_s3(jsonify_log_data(load_files_to_table()))


### PR DESCRIPTION
# What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
Closes https://github.mit.edu/IR/simeon-internal/issues/42

# Description (What does it do?)
The logic used by IRx expects the tracking logs to still contain JSON data in the context and event fields. This converts the stringified fields into JSON data, exports the converted records and re-uploads to the `logs` prefix that IRx is pulling their data from in S3.

# How can this be tested?
This is largely relying on an existing, functional pipeline with the logic reversed. To test we can deploy and run a backfill in QA before executing in production.