### PR TITLE
Add data freshness tests

### DIFF
--- a/src/ol_dbt/models/staging/mitxonline/_mitxonline__sources.yml
+++ b/src/ol_dbt/models/staging/mitxonline/_mitxonline__sources.yml
@@ -373,6 +373,10 @@ sources:
       description: string, the  functional group the model belongs to
 
   - name: raw__mitxonline__app__postgres__courses_courserunenrollment
+    freshness:
+      warn_after: {count: 1, period: day}
+      error_after: {count: 2, period: day}
+    loaded_at_field: "from_iso8601_timestamp(created_on)"
     columns:
     - name: id
       description: int, sequential ID tracking a single user enrollment

--- a/src/ol_dbt/models/staging/mitxonline/_stg_mitxonline__models.yml
+++ b/src/ol_dbt/models/staging/mitxonline/_stg_mitxonline__models.yml
@@ -48,6 +48,13 @@ models:
   tests:
   - dbt_expectations.expect_compound_columns_to_be_unique:
       column_list: ["courserun_id", "user_id"]
+  - dbt_utils.recency:
+      datepart: day
+      field: from_iso8601_timestamp(courserunenrollment_created_on)
+      interval: 2
+      config:
+        severity: error
+        error_if: "!=0"
 
 - name: stg__mitxonline__app__postgres__courses_programenrollment
   columns:

--- a/src/ol_dbt/models/staging/mitxpro/_mitxpro__sources.yml
+++ b/src/ol_dbt/models/staging/mitxpro/_mitxpro__sources.yml
@@ -563,6 +563,10 @@ sources:
       description: int, primary key in users_user for the purchaser
 
   - name: raw__xpro__app__postgres__courses_courserunenrollment
+    freshness:
+      warn_after: {count: 2, period: day}
+      error_after: {count: 3, period: day}
+    loaded_at_field: "from_iso8601_timestamp(created_on)"
     columns:
     - name: id
       description: int, sequential ID tracking a single user enrollment

--- a/src/ol_dbt/models/staging/mitxpro/_stg_mitxpro__models.yml
+++ b/src/ol_dbt/models/staging/mitxpro/_stg_mitxpro__models.yml
@@ -1302,6 +1302,13 @@ models:
   tests:
   - dbt_expectations.expect_compound_columns_to_be_unique:
       column_list: ["user_id", "courserun_id", "ecommerce_order_id"]
+  - dbt_utils.recency:
+      datepart: day
+      field: from_iso8601_timestamp(courserunenrollment_created_on)
+      interval: 3
+      config:
+        severity: error
+        error_if: "!=0"
 
 - name: stg__mitxpro__app__postgres__courses_programenrollment
   columns:

--- a/src/ol_dbt/packages.yml
+++ b/src/ol_dbt/packages.yml
@@ -8,3 +8,5 @@ packages:
   version: 0.7.0
 - package: tnightengale/dbt_meta_testing
   version: 0.3.6
+- package: dbt-labs/dbt_utils
+  version: 1.1.1


### PR DESCRIPTION
# What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
https://github.com/mitodl/ol-data-platform/issues/723

# Description (What does it do?)
<!--- Describe your changes in detail -->
This adds freshness tests to our raw tables and staging model to warn about stale data in our data lake 
- source `raw__mitxonline__app__postgres__courses_courserunenrollment` (warn after 1 day, error after 2 days) and `raw__xpro__app__postgres__courses_courserunenrollment` (warn after 2 day, error after 3 days)
- staging models `stg__mitxpro__app__postgres__courses_courserunenrollment` and `stg__mitxonline__app__postgres__courses_courserunenrollment`

I use the following query to determine the freshness values. For MITxOnline, new enrollments are created every day since we launch ecommerce, so its not normal to not have new records in our raw tables after 1 day, but I set it to error after 2 days. For xPro, there could be no new records for up to 3 days. The values can be adjusted if too much noise.  
```
WITH next_time AS (
  SELECT 
	  created_on,
	  LEAD(created_on) OVER(ORDER BY created_on ASC) AS next_time 
     FROM "ol_data_lake_production"."ol_warehouse_production_raw"."raw__mitxonline__app__postgres__courses_courserunenrollment"
),
date_difference AS (
  SELECT 
      created_on,
      next_time,
	  date_diff('day', cast(from_iso8601_timestamp(created_on) as timestamp) , cast(from_iso8601_timestamp(next_time) as timestamp)) AS date_difference 
  FROM next_time
)

SELECT * FROM date_difference order by date_difference desc, created_on desc
```

The source freshness requires a separate command `dbt source freshness` to run the tests, it's not going to run as part of our dbt build, but staging model tests will be ran as part of dbt build. I added source tests for later.

I have to use [dbt-utils](https://github.com/dbt-labs/dbt-utils#recency-source) package instead of [dbt-expectations](https://github.com/calogica/dbt-expectations#expect_grouped_row_values_to_have_recent_data) because of Trino error `Function 'convert_timezone' not registered` for `expect_row_values_to_have_recent_data` test even after upgrading to latest version, it doesn't seem to list Trino as support in their github

# How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

For source table tests, run 
```
dbt source freshness --select source:ol_warehouse_raw_data.raw__mitxonline__app__postgres__courses_courserunenrollment --target production
dbt source freshness --select source:ol_warehouse_raw_data.raw__xpro__app__postgres__courses_courserunenrollment --target production
```

for staging model tests, run 
```
dbt build --select stg__mitxonline__app__postgres__courses_courserunenrollment --vars 'schema_suffix: rlougee' --target dev_production
dbt build --select stg__mitxpro__app__postgres__courses_courserunenrollment --vars 'schema_suffix: rlougee' --target dev_production
```
