### PR TITLE
Fix for issue 1908 to populate parent run id's more consistently

### DIFF
--- a/src/ol_dbt/models/marts/mitxpro/_marts__mitxpro__models.yml
+++ b/src/ol_dbt/models/marts/mitxpro/_marts__mitxpro__models.yml
@@ -19,6 +19,7 @@ models:
       code}+{run_tag} e.g. program-v1:xPRO+MLx+R1
     tests:
     - not_null
+    - unique
   - name: product_type
     description: string, readable product type
   - name: list_price
@@ -45,6 +46,3 @@ models:
     description: str, short description indicating about the time commitments
   - name: coursetopic_names
     description: str, all associated course topic names
-  tests:
-  - dbt_expectations.expect_compound_columns_to_be_unique:
-      column_list: ["product_id", "product_parent_run_id"]

--- a/src/ol_dbt/models/marts/mitxpro/marts__mitxpro_ecommerce_productlist.sql
+++ b/src/ol_dbt/models/marts/mitxpro/marts__mitxpro_ecommerce_productlist.sql
@@ -78,7 +78,7 @@ select
         , cast(ecommerce_product.product_id as varchar (50))
         , '">', course_runs.courserun_readable_id, '</a>'
     ) as link
-    , programs.program_readable_id as product_parent_run_id
+    , concat(programs.program_readable_id, '+', course_runs.courserun_tag) as product_parent_run_id
     , courses.cms_coursepage_duration as duration
     , courses.cms_coursepage_time_commitment as time_commitment
     , ecommerce_course_to_topics.coursetopic_name as coursetopic_names

--- a/src/ol_dbt/models/marts/mitxpro/marts__mitxpro_ecommerce_productlist.sql
+++ b/src/ol_dbt/models/marts/mitxpro/marts__mitxpro_ecommerce_productlist.sql
@@ -23,11 +23,6 @@ with ecommerce_product as (
     from {{ ref('int__mitxpro__program_runs') }}
 )
 
-, coursesinprogram as (
-    select *
-    from {{ ref('int__mitxpro__coursesinprogram') }}
-)
-
 , courses as (
     select *
     from {{ ref('int__mitxpro__courses') }}
@@ -83,7 +78,7 @@ select
         , cast(ecommerce_product.product_id as varchar (50))
         , '">', course_runs.courserun_readable_id, '</a>'
     ) as link
-    , concat(programs.program_readable_id, '+', course_runs.courserun_tag) as product_parent_run_id
+    , programs.program_readable_id as product_parent_run_id
     , courses.cms_coursepage_duration as duration
     , courses.cms_coursepage_time_commitment as time_commitment
     , ecommerce_course_to_topics.coursetopic_name as coursetopic_names
@@ -94,10 +89,8 @@ inner join course_runs
     on ecommerce_product.courserun_id = course_runs.courserun_id
 inner join courses
     on course_runs.course_id = courses.course_id
-left join coursesinprogram
-    on course_runs.course_id = coursesinprogram.course_id
 left join programs
-    on coursesinprogram.program_id = programs.program_id
+    on courses.program_id = programs.program_id
 left join ecommerce_course_to_topics
     on course_runs.course_id = ecommerce_course_to_topics.course_id
 where ecommerce_product.product_type = 'course run'


### PR DESCRIPTION
# What are the relevant tickets?
https://github.com/mitodl/hq/issues/1908

# Description (What does it do?)
changed the join to remove int__mitxpro__coursesinprogram and join directly to programs to pull the product parent run id field

# Screenshots (if appropriate):
see relevant ticket

# How can this be tested?
Run the following commands against your schema or QA
Run dbt build --select marts.mitxpro if you have all models, otherwise add + in front of marts.mitxpro to run upstream models