### PR TITLE
fix,refactor: Migrate GCS sensor to use Pythonic config and fix sensor

### DIFF
--- a/src/ol_orchestrate/ops/edx_gcs_courses.py
+++ b/src/ol_orchestrate/ops/edx_gcs_courses.py
@@ -40,7 +40,7 @@ class UploadEdxGcsCourseConfig(Config):
 def download_edx_gcs_course_data(context, config: DownloadEdxGcsCourseConfig):
     # TODO: replace context and config with a new asset config  # noqa: E501, FIX002, TD002, TD003
     # once resources have been migrated
-    storage_client = context.resources.gcp_gcs
+    storage_client = context.resources.gcp_gcs.client
     bucket = storage_client.get_bucket(config.edx_gcs_course_tarballs)
     edx_course_tarball_path = context.resources.results_dir.path.joinpath(
         config.edx_gcs_course_tarballs

--- a/src/ol_orchestrate/repositories/edx_gcs_courses.py
+++ b/src/ol_orchestrate/repositories/edx_gcs_courses.py
@@ -5,13 +5,13 @@ from dagster_aws.s3.resources import s3_resource
 
 from ol_orchestrate.jobs.edx_gcs_courses import sync_gcs_to_s3
 from ol_orchestrate.lib.yaml_config_helper import load_yaml_config
-from ol_orchestrate.resources.gcp_gcs import gcp_gcs_resource
+from ol_orchestrate.resources.gcp_gcs import GCSConnection
 from ol_orchestrate.resources.outputs import daily_dir
 from ol_orchestrate.sensors.sync_gcs_to_s3 import check_new_gcs_assets_sensor
 
 resources = {
-    "gcp_gcs": gcp_gcs_resource.configured(
-        load_yaml_config("/etc/dagster/edxorg_gcp.yaml")["resources"]["gcp_gcs"][
+    "gcp_gcs": GCSConnection(
+        **load_yaml_config("/etc/dagster/edxorg_gcp.yaml")["resources"]["gcp_gcs"][
             "config"
         ]
     ),
@@ -28,7 +28,6 @@ dagster_deployment = os.getenv("DAGSTER_ENVIRONMENT", "qa")
 
 gcs_sync_job = sync_gcs_to_s3.to_job(
     name="edx_gcs_course_retrieval",
-    resource_defs=resources,
     config={
         "ops": {
             "edx_upload_gcs_course_tarballs": {
@@ -49,5 +48,6 @@ edx_gcs_courses = Definitions(
             default_status=DefaultSensorStatus.RUNNING,
         )
     ],
+    resources=resources,
     jobs=[gcs_sync_job],
 )

--- a/src/ol_orchestrate/resources/gcp_gcs.py
+++ b/src/ol_orchestrate/resources/gcp_gcs.py
@@ -1,79 +1,59 @@
 """Resource for connecting to a gcs."""
 
-from dagster import Field, InitResourceContext, String, resource
+from contextlib import contextmanager
+
+from dagster import ConfigurableResource, InitResourceContext
 from google.cloud import storage
 from google.oauth2 import service_account
+from pydantic import Field, PrivateAttr
 
 
-@resource(
-    config_schema={
-        "project_id": Field(
-            String,
-            is_required=True,
-            description="service account project_id field",
-        ),
-        "client_x509_cert_url": Field(
-            String,
-            is_required=True,
-            description="service account client_x509_cert_url field",
-        ),
-        "private_key_id": Field(
-            String,
-            is_required=True,
-            description="service account private_key_id field",
-        ),
-        "auth_uri": Field(
-            String,
-            is_required=True,
-            description="service account auth_uri field",
-        ),
-        "token_uri": Field(
-            String,
-            is_required=True,
-            description="service account token_uri field",
-        ),
-        "client_id": Field(
-            String,
-            is_required=True,
-            description="service account client_id field",
-        ),
-        "private_key": Field(
-            String,
-            is_required=True,
-            description="service account private_key field",
-        ),
-        "client_email": Field(
-            String,
-            is_required=True,
-            description="service account client_email field",
-        ),
-    }
-)
-def gcp_gcs_resource(resource_context: InitResourceContext):
-    """Create a connection to gcs.
-
-    :param resource_context: Dagster execution context for configuration data
-    :type resource_context: InitResourceContext
-
-    :yields: A gcs client instance for use during pipeline execution.
-    """
-    access_json = {
-        "auth_provider_x509_cert_url": "https://www.googleapis.com/oauth2/v1/certs",
-        "project_id": resource_context.resource_config["project_id"],
-        "client_x509_cert_url": resource_context.resource_config[
-            "client_x509_cert_url"
-        ],
-        "private_key_id": resource_context.resource_config["private_key_id"],
-        "auth_uri": resource_context.resource_config["auth_uri"],
-        "token_uri": resource_context.resource_config["token_uri"],
-        "client_id": resource_context.resource_config["client_id"],
-        "private_key": resource_context.resource_config["private_key"],
-        "type": "service_account",
-        "client_email": resource_context.resource_config["client_email"],
-    }
-
-    credentials = service_account.Credentials.from_service_account_info(access_json)
-    yield storage.Client(
-        credentials=credentials,
-        project=credentials.project_id,
+class GCSConnection(ConfigurableResource):
+    project_id: str = Field(
+        description="service account project_id field",
     )
+    client_x509_cert_url: str = Field(
+        description="service account client_x509_cert_url field",
+    )
+    private_key_id: str = Field(
+        description="service account private_key_id field",
+    )
+    auth_uri: str = Field(
+        description="service account auth_uri field",
+    )
+    token_uri: str = Field(
+        description="service account token_uri field",
+    )
+    client_id: str = Field(
+        description="service account client_id field",
+    )
+    private_key: str = Field(
+        description="service account private_key field",
+    )
+    client_email: str = Field(
+        description="service account client_email field",
+    )
+    auth_provider_x509_cert_url: str = Field(
+        default="https://www.googleapis.com/oauth2/v1/certs",
+        description="URL for the x509 cert used by the auth provider",
+    )
+    type: str = Field(  # noqa: A003
+        default="service_account",
+        description="Credential type",
+    )
+
+    _gcs_client: storage.Client = PrivateAttr()
+
+    @contextmanager
+    def yield_for_execution(self, context: InitResourceContext):  # noqa: ARG002
+        access_json = self.dict()
+        credentials = service_account.Credentials.from_service_account_info(access_json)
+        self._gcs_client = storage.Client(
+            credentials=credentials,
+            project=credentials.project_id,
+        )
+        yield self
+
+    @property
+    def client(self) -> storage.Client:
+        return self._gcs_client

--- a/src/ol_orchestrate/sensors/sync_gcs_to_s3.py
+++ b/src/ol_orchestrate/sensors/sync_gcs_to_s3.py
@@ -1,22 +1,21 @@
-from dagster import RunRequest, SensorEvaluationContext, SkipReason, build_resources
+import json
 
-from ol_orchestrate.lib.yaml_config_helper import load_yaml_config
-from ol_orchestrate.resources.gcp_gcs import gcp_gcs_resource
+from dagster import RunRequest, SensorEvaluationContext, SkipReason
+
+from ol_orchestrate.resources.gcp_gcs import GCSConnection
 
 
-def check_new_gcs_assets_sensor(context: SensorEvaluationContext):
-    gcs_config = load_yaml_config("/etc/dagster/edxorg_gcp.yaml")
-    with build_resources(
-        resources={"gcp_gcs": gcp_gcs_resource}, resource_config=gcs_config["resources"]
-    ) as resources:
-        storage_client = resources.gcp_gcs
-        bucket = storage_client.get_bucket("simeon-mitx-course-tarballs")
-        new_files = storage_client.list_blobs(bucket)
-        if new_files:
-            context.update_cursor(str(new_files))
-            yield RunRequest(
-                run_key="new_gcs_file",
-                run_config=gcs_config,
-            )
-        else:
-            yield SkipReason("No new files in GCS bucket")
+def check_new_gcs_assets_sensor(
+    context: SensorEvaluationContext, gcp_gcs: GCSConnection
+):
+    storage_client = gcp_gcs.client
+    bucket = storage_client.get_bucket("simeon-mitx-course-tarballs")
+    bucket_files = {file.name for file in storage_client.list_blobs(bucket)}
+    new_files = bucket_files.difference(set(context.cursor or []))
+    if new_files:
+        context.update_cursor(json.dumps(list(bucket_files)))
+        yield RunRequest(
+            run_config={},
+        )
+    else:
+        yield SkipReason("No new files in GCS bucket")


### PR DESCRIPTION
# What are the relevant tickets?
N/A

# Description (What does it do?)
The sensor code was written with a hard-coded `run_key` which would always cause it to skip any runs after the first because that run key had already been triggered. This migrates the GCP GCS resource to use the Pythonic config so it can be more easily integrated into the sensor, and then updates the usage of the cursor to do set arithmetic for any files that have not yet been processed.

# How can this be tested?
This was tested by running `dagster dev -d src/ol_orchestrate/ -f src/ol_orchestrate/repositories/edx_gcs_courses.py` and then triggering a test evaluation of the sensor from the web UI