### PR TITLE
add platform name to tables

### DIFF
--- a/src/ol_dbt/models/intermediate/mitxpro/_int_mitxpro__models.yml
+++ b/src/ol_dbt/models/intermediate/mitxpro/_int_mitxpro__models.yml
@@ -931,8 +931,8 @@ models:
     description: boolean, whether the program is on an external platform
     tests:
     - not_null
-  - name: platform_id
-    description: int, id of the program platform
+  - name: platform_name
+    description: str, name of the program platform
   - name: cms_programpage_description
     description: str, the description displayed on the page
   - name: cms_programpage_duration
@@ -1006,8 +1006,8 @@ models:
     description: boolean, whether the course is on an external platform
     tests:
     - not_null
-  - name: platform_id
-    description: int, id of the course platform
+  - name: platform_name
+    description: str, name of the course platform
   - name: cms_coursepage_description
     description: str, the description displayed on the page
   - name: cms_coursepage_duration

--- a/src/ol_dbt/models/intermediate/mitxpro/int__mitxpro__courses.sql
+++ b/src/ol_dbt/models/intermediate/mitxpro/int__mitxpro__courses.sql
@@ -8,6 +8,10 @@ with courses as (
     select * from {{ ref('stg__mitxpro__app__postgres__cms_coursepage') }}
 )
 
+, platform as (
+    select * from {{ ref('stg__mitxpro__app__postgres__courses_platform') }}
+)
+
 select
     courses.course_id
     , courses.program_id
@@ -15,7 +19,7 @@ select
     , courses.course_is_live
     , courses.course_readable_id
     , courses.course_is_external
-    , courses.platform_id
+    , platform.platform_name
     , cms_courses.cms_coursepage_description
     , cms_courses.cms_coursepage_subhead
     , cms_courses.cms_coursepage_catalog_details
@@ -25,3 +29,5 @@ select
 from courses
 left join cms_courses
     on courses.course_id = cms_courses.course_id
+left join platform
+    on platform.platform_id = programs.platform_id

--- a/src/ol_dbt/models/intermediate/mitxpro/int__mitxpro__courses.sql
+++ b/src/ol_dbt/models/intermediate/mitxpro/int__mitxpro__courses.sql
@@ -30,4 +30,4 @@ from courses
 left join cms_courses
     on courses.course_id = cms_courses.course_id
 left join platform
-    on platform.platform_id = programs.platform_id
+    on courses.platform_id = platform.platform_id

--- a/src/ol_dbt/models/intermediate/mitxpro/int__mitxpro__programs.sql
+++ b/src/ol_dbt/models/intermediate/mitxpro/int__mitxpro__programs.sql
@@ -8,13 +8,17 @@ with programs as (
     select * from {{ ref('stg__mitxpro__app__postgres__cms_programpage') }}
 )
 
+, platform as (
+    select * from {{ ref('stg__mitxpro__app__postgres__courses_platform') }}
+)
+
 select
     programs.program_id
     , programs.program_title
     , programs.program_is_live
     , programs.program_readable_id
     , programs.program_is_external
-    , programs.platform_id
+    , platform.platform_name
     , cms_programs.cms_programpage_description
     , cms_programs.cms_programpage_subhead
     , cms_programs.cms_programpage_catalog_details
@@ -24,3 +28,5 @@ select
 from programs
 left join cms_programs
     on programs.program_id = cms_programs.program_id
+left join platform
+    on programs.platform_id = platform.platform_id


### PR DESCRIPTION
# What are the relevant tickets?
part of https://github.com/mitodl/hq/issues/1908

# Description (What does it do?)
adding platform_name to int__mitxpro__programs and int__mitxpro__courses since it's more useful than the id

# How can this be tested?
Run the following commands against your schema or QA
Run dbt build --select intermediate.mitxpro if you have all models, otherwise add + in front of intermediate.mitxpro to run upstream models