### PR TITLE
refactor: Migrate results dir resource to use Pythonic interface

### DIFF
--- a/src/ol_orchestrate/jobs/open_edx.py
+++ b/src/ol_orchestrate/jobs/open_edx.py
@@ -24,7 +24,7 @@ from ol_orchestrate.resources.healthchecks import (
     healthchecks_io_resource,
 )
 from ol_orchestrate.resources.mysql_db import mysql_db_resource
-from ol_orchestrate.resources.outputs import daily_dir
+from ol_orchestrate.resources.outputs import DailyResultsDir
 from ol_orchestrate.resources.sqlite_db import sqlite_db_resource
 
 
@@ -64,7 +64,7 @@ def edx_course_pipeline():
 dev_resources = {
     "sqldb": sqlite_db_resource,
     "s3": s3_resource,
-    "results_dir": daily_dir,
+    "results_dir": DailyResultsDir.configure_at_launch(),
     "healthchecks": healthchecks_dummy_resource,
     "io_manager": fs_io_manager,
 }
@@ -72,7 +72,7 @@ dev_resources = {
 production_resources = {
     "sqldb": mysql_db_resource,
     "s3": s3_resource,
-    "results_dir": daily_dir,
+    "results_dir": DailyResultsDir.configure_at_launch(),
     "healthchecks": healthchecks_io_resource,
     "io_manager": s3_pickle_io_manager,
 }

--- a/src/ol_orchestrate/repositories/edx_gcs_courses.py
+++ b/src/ol_orchestrate/repositories/edx_gcs_courses.py
@@ -6,7 +6,7 @@ from dagster_aws.s3.resources import s3_resource
 from ol_orchestrate.jobs.edx_gcs_courses import sync_gcs_to_s3
 from ol_orchestrate.lib.yaml_config_helper import load_yaml_config
 from ol_orchestrate.resources.gcp_gcs import GCSConnection
-from ol_orchestrate.resources.outputs import daily_dir
+from ol_orchestrate.resources.outputs import DailyResultsDir
 from ol_orchestrate.sensors.sync_gcs_to_s3 import check_new_gcs_assets_sensor
 
 resources = {
@@ -16,7 +16,7 @@ resources = {
         ]
     ),
     "s3": s3_resource,
-    "results_dir": daily_dir,
+    "results_dir": DailyResultsDir.configure_at_launch(),
 }
 
 course_upload_bucket = {

--- a/src/ol_orchestrate/resources/outputs.py
+++ b/src/ol_orchestrate/resources/outputs.py
@@ -1,116 +1,76 @@
-import os
 import shutil
-from collections.abc import Generator
 from datetime import datetime
+from pathlib import Path
 from typing import Optional
 
-from dagster import Field, InitResourceContext, String, resource
+from dagster import ConfigurableResource, InitResourceContext
+from pydantic import Field, validator
 
 from ol_orchestrate.lib.dagster_types.files import DagsterPath
 
 
-class ResultsDir:
-    def __init__(self, root_dir: Optional[str] = None):
-        if root_dir is None:
-            self.root_dir = DagsterPath(os.getcwd())  # noqa: PTH109
-        else:
-            self.root_dir = DagsterPath(root_dir)
-        self.dir_name = "results"
+class BaseResultsDir(ConfigurableResource):
+    outputs_root_dir: str = Field(
+        default=None,
+        description=(
+            "Base directory used for creating a results folder. Should be configured to"
+            " allow writing by the Dagster user"
+        ),
+    )
+
+    @validator("outputs_root_dir", always=True)
+    def validate_outputs_root_dir(cls, value: str) -> str:  # noqa: N805
+        if value is None:
+            value = Path.cwd()
+        return str(value)
 
     def create_dir(self):
-        try:
-            os.makedirs(self.path)  # noqa: PTH103
-        except FileExistsError:
-            return
+        self.path.mkdir(parents=True, exist_ok=True)
 
     def clean_dir(self):
         shutil.rmtree(self.path)
 
     @property
     def path(self) -> DagsterPath:
-        return DagsterPath(os.path.join(self.root_dir, self.dir_name))  # noqa: PTH118
+        return DagsterPath(Path(self.outputs_root_dir).joinpath(self.dir_name))
 
     @property
     def absolute_path(self) -> str:
         return str(self.path)
 
+    def setup_for_execution(self, context: InitResourceContext) -> None:  # noqa: ARG002
+        self.create_dir()
 
-class DailyResultsDir(ResultsDir):
-    def __init__(
-        self,
-        root_dir: Optional[str] = None,
-        date_format: str = "%Y-%m-%d",
-        date_override: Optional[str] = None,
-    ):
-        """Instantiate a results directory that defaults to being named according to the current date.  # noqa: E501
+    def teardown_for_execution(
+        self, context: InitResourceContext  # noqa: ARG002
+    ) -> None:
+        self.clean_dir()
 
-        :param root_dir: The base directory within which the results directory will be created  # noqa: E501
-        :type root_dir: str
 
-        :param date_format: The format string for specifying how the date will be represented in the directory name  # noqa: E501
-        :type date_format: str
+class SimpleResultsDir(BaseResultsDir):
+    dir_name: str = "results"
 
-        :param date_override: A string representing an override of the date to be used for the generated directory.  # noqa: E501
-            Primarily used for cases where a backfill process needs to occur.
-        :type date_override: str
-        """  # noqa: E501
-        super().__init__(root_dir)
-        if date_override:
-            dir_date = datetime.strptime(date_override, date_format)  # noqa: DTZ007
+
+class DailyResultsDir(BaseResultsDir):
+    date_format: str = Field(
+        default="%Y-%m-%d",
+        description="Format string for structuring the name of the daily outputs "
+        "directory",
+    )
+    date_override: Optional[str] = Field(
+        default=None,
+        description=(
+            "Specified date object to override the default of using the current"
+            " date. Intended only for purposes of backfill operations."
+        ),
+    )
+
+    @property
+    def dir_name(self) -> str:
+        if self.date_override is not None:
+            dir_date = datetime.strptime(  # noqa: DTZ007
+                self.date_override, self.date_format
+            )
         else:
             dir_date = datetime.utcnow()  # noqa: DTZ003
-        self.dir_name = dir_date.strftime(date_format)
-
-
-@resource(
-    config_schema={
-        "outputs_root_dir": Field(
-            String,
-            default_value="",
-            is_required=False,
-            description=(
-                "Base directory used for creating a results folder. Should be configured to allow writing "  # noqa: E501
-                "by the Dagster user"
-            ),
-        ),
-        "outputs_directory_date_format": Field(
-            String,
-            default_value="%Y-%m-%d",
-            is_required=False,
-            description="Format string for structuring the name of the daily outputs directory",  # noqa: E501
-        ),
-        "outputs_directory_date_override": Field(
-            String,
-            default_value="",
-            is_required=False,
-            description=(
-                "Specified date object to override the default of using the current date. Intended only for "  # noqa: E501
-                "purposes of backfill operations."
-            ),
-        ),
-    }
-)
-def daily_dir(
-    resource_context: InitResourceContext,
-) -> Generator[DailyResultsDir, None, None]:
-    """Create a resource definition for a daily results directory.
-
-    :param resource_context: The Dagster context for configuring the resource instance
-    :type resource_context: InitResourceContext
-
-    :yield: An instance of a daily results directory
-    """
-    run_dir = os.path.join(  # noqa: PTH118
-        os.getcwd()  # noqa: PTH109
-        or resource_context.resource_config["outputs_root_dir"],
-        resource_context.dagster_run.run_id,
-    )
-    results_dir = DailyResultsDir(
-        root_dir=run_dir,
-        date_format=resource_context.resource_config["outputs_directory_date_format"],
-        date_override=resource_context.resource_config[
-            "outputs_directory_date_override"
-        ],
-    )
-    results_dir.create_dir()
-    yield results_dir
+        return dir_date.strftime(self.date_format)


### PR DESCRIPTION
# What are the relevant tickets?
N/A

# Description (What does it do?)
Newer releases of Dagster have migrated to a more "pythonic" interface for configuration that relies on Pydantic models. This migrates the results directory resource to use the new interface.

# How can this be tested?
Execute the Dagster dev server that targets one of the modified execution graphs to ensure that everything loads and renders properly.
