### PR TITLE
added mitxpro coupon redemption table to staging

### DIFF
--- a/src/ol_dbt/models/staging/mitxpro/_mitxpro__sources.yml
+++ b/src/ol_dbt/models/staging/mitxpro/_mitxpro__sources.yml
@@ -14,12 +14,12 @@ sources:
     - name: id
       description: int, primary key representing a b2b coupon redemption
     - name: order_id
-      description: int, primary key in b2becommerce_b2border  
+      description: int, primary key in b2becommerce_b2border
     - name: coupon_id
       description: int, foreign key to b2becommerce_b2bcoupon. A coupon that was redeemed
         for the order.
     - name: updated_on
-      description: timestamp, specifying when the b2b coupon redemption was most recently updated              
+      description: timestamp, specifying when the b2b coupon redemption was most recently updated
     - name: created_on
       description: timestamp, specifying when the b2b coupon redemption was initially created
 

--- a/src/ol_dbt/models/staging/mitxpro/_mitxpro__sources.yml
+++ b/src/ol_dbt/models/staging/mitxpro/_mitxpro__sources.yml
@@ -7,6 +7,22 @@ sources:
   database: '{{ target.database }}'
   schema: '{{ target.schema.replace(var("schema_suffix", ""), "").rstrip("_") }}_raw'
   tables:
+    - name: raw__xpro__app__postgres__b2b_ecommerce_b2bcouponredemption
+    description: A B2B coupon is considered redeemed when it's used to place an order.
+      The coupon provides a discount on the company's bulk order.
+    columns:
+    - name: id
+      description: int, primary key representing a b2b coupon redemption
+    - name: order_id
+      description: int, primary key in b2becommerce_b2border  
+    - name: coupon_id
+      description: int, foreign key to b2becommerce_b2bcoupon. A coupon that was redeemed
+        for the order.
+    - name: updated_on
+      description: timestamp, specifying when the b2b coupon redemption was most recently updated              
+    - name: created_on
+      description: timestamp, specifying when the b2b coupon redemption was initially created
+
   - name: raw__xpro__app__postgres__b2b_ecommerce_b2breceipt
     description: Data returned from cybersource when a user pays for a b2b order
     columns:

--- a/src/ol_dbt/models/staging/mitxpro/_mitxpro__sources.yml
+++ b/src/ol_dbt/models/staging/mitxpro/_mitxpro__sources.yml
@@ -7,19 +7,19 @@ sources:
   database: '{{ target.database }}'
   schema: '{{ target.schema.replace(var("schema_suffix", ""), "").rstrip("_") }}_raw'
   tables:
-    - name: raw__xpro__app__postgres__b2b_ecommerce_b2bcouponredemption
+  - name: raw__xpro__app__postgres__b2b_ecommerce_b2bcouponredemption
     description: A B2B coupon is considered redeemed when it's used to place an order.
       The coupon provides a discount on the company's bulk order.
     columns:
     - name: id
       description: int, primary key representing a b2b coupon redemption
     - name: order_id
-      description: int, primary key in b2becommerce_b2border
+      description: int, primary key in b2becommerce_b2border  
     - name: coupon_id
       description: int, foreign key to b2becommerce_b2bcoupon. A coupon that was redeemed
         for the order.
     - name: updated_on
-      description: timestamp, specifying when the b2b coupon redemption was most recently updated
+      description: timestamp, specifying when the b2b coupon redemption was most recently updated              
     - name: created_on
       description: timestamp, specifying when the b2b coupon redemption was initially created
 

--- a/src/ol_dbt/models/staging/mitxpro/_mitxpro__sources.yml
+++ b/src/ol_dbt/models/staging/mitxpro/_mitxpro__sources.yml
@@ -14,14 +14,16 @@ sources:
     - name: id
       description: int, primary key representing a b2b coupon redemption
     - name: order_id
-      description: int, primary key in b2becommerce_b2border  
+      description: int, primary key in b2becommerce_b2border
     - name: coupon_id
       description: int, foreign key to b2becommerce_b2bcoupon. A coupon that was redeemed
         for the order.
     - name: updated_on
-      description: timestamp, specifying when the b2b coupon redemption was most recently updated              
+      description: timestamp, specifying when the b2b coupon redemption was most recently
+        updated
     - name: created_on
-      description: timestamp, specifying when the b2b coupon redemption was initially created
+      description: timestamp, specifying when the b2b coupon redemption was initially
+        created
 
   - name: raw__xpro__app__postgres__b2b_ecommerce_b2breceipt
     description: Data returned from cybersource when a user pays for a b2b order

--- a/src/ol_dbt/models/staging/mitxpro/_stg_mitxpro__models.yml
+++ b/src/ol_dbt/models/staging/mitxpro/_stg_mitxpro__models.yml
@@ -10,17 +10,19 @@ models:
     description: int, primary key representing a b2b coupon redemption
     tests:
     - not_null
-    - unique 
+    - unique
   - name: b2border_id
     description: int, foreign key to b2becommerce_b2border
   - name: b2bcoupon_id
     description: int, foreign key representing a b2b coupon
   - name: b2bcouponredemption_updated_on
-    description: timestamp, specifying when the b2b coupon redemption was most recently updated
+    description: timestamp, specifying when the b2b coupon redemption was most recently
+      updated
     tests:
     - not_null
   - name: b2bcouponredemption_created_on
-    description: timestamp, specifying when the b2b coupon redemption was initially created
+    description: timestamp, specifying when the b2b coupon redemption was initially
+      created
     tests:
     - not_null
   - dbt_expectations.expect_compound_columns_to_be_unique:

--- a/src/ol_dbt/models/staging/mitxpro/_stg_mitxpro__models.yml
+++ b/src/ol_dbt/models/staging/mitxpro/_stg_mitxpro__models.yml
@@ -10,17 +10,19 @@ models:
     description: int, primary key representing a b2b coupon redemption
     tests:
     - not_null
-    - unique 
+    - unique
   - name: b2border_id
     description: int, foreign key to b2becommerce_b2border
   - name: b2bcoupon_id
     description: int, foreign key representing a b2b coupon
   - name: b2bcouponredemption_updated_on
-    description: timestamp, specifying when the b2b coupon redemption was most recently updated
+    description: timestamp, specifying when the b2b coupon redemption was most recently
+      updated
     tests:
     - not_null
   - name: b2bcouponredemption_created_on
-    description: timestamp, specifying when the b2b coupon redemption was initially created
+    description: timestamp, specifying when the b2b coupon redemption was initially
+      created
     tests:
     - not_null
   tests:

--- a/src/ol_dbt/models/staging/mitxpro/_stg_mitxpro__models.yml
+++ b/src/ol_dbt/models/staging/mitxpro/_stg_mitxpro__models.yml
@@ -10,7 +10,7 @@ models:
     description: int, primary key representing a b2b coupon redemption
     tests:
     - not_null
-    - unique
+    - unique 
   - name: b2border_id
     description: int, foreign key to b2becommerce_b2border
   - name: b2bcoupon_id

--- a/src/ol_dbt/models/staging/mitxpro/_stg_mitxpro__models.yml
+++ b/src/ol_dbt/models/staging/mitxpro/_stg_mitxpro__models.yml
@@ -10,21 +10,21 @@ models:
     description: int, primary key representing a b2b coupon redemption
     tests:
     - not_null
-    - unique
+    - unique 
   - name: b2border_id
     description: int, foreign key to b2becommerce_b2border
   - name: b2bcoupon_id
     description: int, foreign key representing a b2b coupon
   - name: b2bcouponredemption_updated_on
-    description: timestamp, specifying when the b2b coupon redemption was most recently
-      updated
+    description: timestamp, specifying when the b2b coupon redemption was most recently updated
     tests:
     - not_null
   - name: b2bcouponredemption_created_on
-    description: timestamp, specifying when the b2b coupon redemption was initially
-      created
+    description: timestamp, specifying when the b2b coupon redemption was initially created
     tests:
     - not_null
+  - dbt_expectations.expect_compound_columns_to_be_unique:
+      column_list: ["b2border_id", "b2bcoupon_id"]
 
 - name: stg__mitxpro__app__postgres__b2becommerce_b2breceipt
   description: Data returned from cybersource when a user pays for a b2b order

--- a/src/ol_dbt/models/staging/mitxpro/_stg_mitxpro__models.yml
+++ b/src/ol_dbt/models/staging/mitxpro/_stg_mitxpro__models.yml
@@ -10,21 +10,20 @@ models:
     description: int, primary key representing a b2b coupon redemption
     tests:
     - not_null
-    - unique
+    - unique 
   - name: b2border_id
     description: int, foreign key to b2becommerce_b2border
   - name: b2bcoupon_id
     description: int, foreign key representing a b2b coupon
   - name: b2bcouponredemption_updated_on
-    description: timestamp, specifying when the b2b coupon redemption was most recently
-      updated
+    description: timestamp, specifying when the b2b coupon redemption was most recently updated
     tests:
     - not_null
   - name: b2bcouponredemption_created_on
-    description: timestamp, specifying when the b2b coupon redemption was initially
-      created
+    description: timestamp, specifying when the b2b coupon redemption was initially created
     tests:
     - not_null
+  tests:
   - dbt_expectations.expect_compound_columns_to_be_unique:
       column_list: ["b2border_id", "b2bcoupon_id"]
 

--- a/src/ol_dbt/models/staging/mitxpro/_stg_mitxpro__models.yml
+++ b/src/ol_dbt/models/staging/mitxpro/_stg_mitxpro__models.yml
@@ -2,6 +2,28 @@
 version: 2
 
 models:
+- name: stg__mitxpro__app__postgres__b2becommerce_b2bcouponredemption
+  description: A B2B coupon is considered redeemed when it's used to place an order.
+    The coupon provides a discount on the company's bulk order.
+  columns:
+  - name: b2bcouponredemption_id
+    description: int, primary key representing a b2b coupon redemption
+    tests:
+    - not_null
+    - unique 
+  - name: b2border_id
+    description: int, foreign key to b2becommerce_b2border
+  - name: b2bcoupon_id
+    description: int, foreign key representing a b2b coupon
+  - name: b2bcouponredemption_updated_on
+    description: timestamp, specifying when the b2b coupon redemption was most recently updated
+    tests:
+    - not_null
+  - name: b2bcouponredemption_created_on
+    description: timestamp, specifying when the b2b coupon redemption was initially created
+    tests:
+    - not_null
+
 - name: stg__mitxpro__app__postgres__b2becommerce_b2breceipt
   description: Data returned from cybersource when a user pays for a b2b order
   columns:

--- a/src/ol_dbt/models/staging/mitxpro/_stg_mitxpro__models.yml
+++ b/src/ol_dbt/models/staging/mitxpro/_stg_mitxpro__models.yml
@@ -10,17 +10,19 @@ models:
     description: int, primary key representing a b2b coupon redemption
     tests:
     - not_null
-    - unique 
+    - unique
   - name: b2border_id
     description: int, foreign key to b2becommerce_b2border
   - name: b2bcoupon_id
     description: int, foreign key representing a b2b coupon
   - name: b2bcouponredemption_updated_on
-    description: timestamp, specifying when the b2b coupon redemption was most recently updated
+    description: timestamp, specifying when the b2b coupon redemption was most recently
+      updated
     tests:
     - not_null
   - name: b2bcouponredemption_created_on
-    description: timestamp, specifying when the b2b coupon redemption was initially created
+    description: timestamp, specifying when the b2b coupon redemption was initially
+      created
     tests:
     - not_null
 

--- a/src/ol_dbt/models/staging/mitxpro/_stg_mitxpro__models.yml
+++ b/src/ol_dbt/models/staging/mitxpro/_stg_mitxpro__models.yml
@@ -10,7 +10,7 @@ models:
     description: int, primary key representing a b2b coupon redemption
     tests:
     - not_null
-    - unique 
+    - unique
   - name: b2border_id
     description: int, foreign key to b2becommerce_b2border
   - name: b2bcoupon_id

--- a/src/ol_dbt/models/staging/mitxpro/stg__mitxpro__app__postgres__b2becommerce_b2bcouponredemption.sql
+++ b/src/ol_dbt/models/staging/mitxpro/stg__mitxpro__app__postgres__b2becommerce_b2bcouponredemption.sql
@@ -1,0 +1,18 @@
+with source as (
+
+    select * from {{ source('ol_warehouse_raw_data', 'raw__xpro__app__postgres__b2b_ecommerce_b2bcouponredemption') }}
+
+)
+
+, renamed as (
+
+    select
+        id as b2bcouponredemption_id
+        , order_id as b2border_id
+        , coupon_id as b2bcoupon_id
+        ,{{ cast_timestamp_to_iso8601('updated_on') }} as b2bcouponredemption_updated_on
+        ,{{ cast_timestamp_to_iso8601('created_on') }} as b2bcouponredemption_created_on
+    from source
+)
+
+select * from renamed


### PR DESCRIPTION
# What are the relevant tickets?
https://github.com/mitodl/hq/issues/1803

# Description (What does it do?)
Creates the new stg__mitxpro__app__postgres__b2becommerce_b2bcouponredemption table in staging

# How can this be tested?
Run the following commands against your schema or QA
Run dbt build --select staging.mitxpro if you have all models, otherwise add + in front of staging.mitxpro to run upstream models


