### PR TITLE
add mitxpro b2b coupon redemption to intermediate

### DIFF
--- a/src/ol_dbt/models/intermediate/mitxpro/_int_mitxpro__models.yml
+++ b/src/ol_dbt/models/intermediate/mitxpro/_int_mitxpro__models.yml
@@ -10,17 +10,19 @@ models:
     description: int, primary key representing a b2b coupon redemption
     tests:
     - not_null
-    - unique 
+    - unique
   - name: b2border_id
     description: int, foreign key to b2becommerce_b2border
   - name: b2bcoupon_id
     description: int, foreign key representing a b2b coupon
   - name: b2bcouponredemption_updated_on
-    description: timestamp, specifying when the b2b coupon redemption was most recently updated
+    description: timestamp, specifying when the b2b coupon redemption was most recently
+      updated
     tests:
     - not_null
   - name: b2bcouponredemption_created_on
-    description: timestamp, specifying when the b2b coupon redemption was initially created
+    description: timestamp, specifying when the b2b coupon redemption was initially
+      created
     tests:
     - not_null
   tests:

--- a/src/ol_dbt/models/intermediate/mitxpro/_int_mitxpro__models.yml
+++ b/src/ol_dbt/models/intermediate/mitxpro/_int_mitxpro__models.yml
@@ -10,19 +10,21 @@ models:
     description: int, primary key representing a b2b coupon redemption
     tests:
     - not_null
-    - unique
+    - unique 
   - name: b2border_id
     description: int, foreign key to b2becommerce_b2border
+    tests:
+    - not_null
   - name: b2bcoupon_id
     description: int, foreign key representing a b2b coupon
+    tests:
+    - not_null
   - name: b2bcouponredemption_updated_on
-    description: timestamp, specifying when the b2b coupon redemption was most recently
-      updated
+    description: timestamp, specifying when the b2b coupon redemption was most recently updated
     tests:
     - not_null
   - name: b2bcouponredemption_created_on
-    description: timestamp, specifying when the b2b coupon redemption was initially
-      created
+    description: timestamp, specifying when the b2b coupon redemption was initially created
     tests:
     - not_null
   tests:

--- a/src/ol_dbt/models/intermediate/mitxpro/_int_mitxpro__models.yml
+++ b/src/ol_dbt/models/intermediate/mitxpro/_int_mitxpro__models.yml
@@ -10,7 +10,7 @@ models:
     description: int, primary key representing a b2b coupon redemption
     tests:
     - not_null
-    - unique 
+    - unique
   - name: b2border_id
     description: int, foreign key to b2becommerce_b2border
     tests:
@@ -20,11 +20,13 @@ models:
     tests:
     - not_null
   - name: b2bcouponredemption_updated_on
-    description: timestamp, specifying when the b2b coupon redemption was most recently updated
+    description: timestamp, specifying when the b2b coupon redemption was most recently
+      updated
     tests:
     - not_null
   - name: b2bcouponredemption_created_on
-    description: timestamp, specifying when the b2b coupon redemption was initially created
+    description: timestamp, specifying when the b2b coupon redemption was initially
+      created
     tests:
     - not_null
   tests:

--- a/src/ol_dbt/models/intermediate/mitxpro/_int_mitxpro__models.yml
+++ b/src/ol_dbt/models/intermediate/mitxpro/_int_mitxpro__models.yml
@@ -2,6 +2,30 @@
 version: 2
 
 models:
+- name: int__mitxpro__b2becommerce_b2bcouponredemption
+  description: A B2B coupon is considered redeemed when it's used to place an order.
+    The coupon provides a discount on the company's bulk order.
+  columns:
+  - name: b2bcouponredemption_id
+    description: int, primary key representing a b2b coupon redemption
+    tests:
+    - not_null
+    - unique 
+  - name: b2border_id
+    description: int, foreign key to b2becommerce_b2border
+  - name: b2bcoupon_id
+    description: int, foreign key representing a b2b coupon
+  - name: b2bcouponredemption_updated_on
+    description: timestamp, specifying when the b2b coupon redemption was most recently updated
+    tests:
+    - not_null
+  - name: b2bcouponredemption_created_on
+    description: timestamp, specifying when the b2b coupon redemption was initially created
+    tests:
+    - not_null
+  tests:
+  - dbt_expectations.expect_compound_columns_to_be_unique:
+      column_list: ["b2border_id", "b2bcoupon_id"]
 - name: int__mitxpro__ecommerce_allcoupons
   description: B2B and regular coupons combined into one table
   columns:

--- a/src/ol_dbt/models/intermediate/mitxpro/int__mitxpro__b2becommerce_b2bcouponredemption.sql
+++ b/src/ol_dbt/models/intermediate/mitxpro/int__mitxpro__b2becommerce_b2bcouponredemption.sql
@@ -1,0 +1,12 @@
+with b2bcouponredemption as (
+    select *
+    from {{ ref('stg__mitxpro__app__postgres__b2becommerce_b2bcouponredemption') }}
+)
+
+select
+    b2bcouponredemption_id
+    , b2border_id
+    , b2bcoupon_id
+    , b2bcouponredemption_updated_on
+    , b2bcouponredemption_created_on
+from b2bcouponredemption


### PR DESCRIPTION
# What are the relevant tickets?
https://github.com/mitodl/hq/issues/1803

# Description (What does it do?)
This adds the mitxpro b2b coupon redemption table to intermediate

# How can this be tested?
Run the following commands against your schema or QA
Run dbt build --select intermediate.mitxpro if you have all models, otherwise add + in front of intermediate.mitxpro to run upstream models