### PR TITLE
S3 object sync

### DIFF
--- a/src/ol_orchestrate/definitions/edx/normalize_tracking_logs.py
+++ b/src/ol_orchestrate/definitions/edx/normalize_tracking_logs.py
@@ -1,4 +1,4 @@
-import os  # noqa: INP001
+import os
 from datetime import UTC, datetime  # type: ignore  # noqa: PGH003
 from functools import partial
 from typing import Literal
@@ -10,6 +10,7 @@ from dagster import (
 )
 from dagster_aws.s3.resources import s3_resource
 from dagster_duckdb import DuckDBResource
+
 from ol_orchestrate.jobs.normalize_logs import (
     jsonify_tracking_logs,
     normalize_tracking_logs,

--- a/src/ol_orchestrate/definitions/edx/sync_program_credential_reports.py
+++ b/src/ol_orchestrate/definitions/edx/sync_program_credential_reports.py
@@ -1,0 +1,54 @@
+import os
+from functools import partial
+
+from dagster import DefaultSensorStatus, Definitions, SensorDefinition, job
+from dagster_aws.s3 import S3Resource
+
+from ol_orchestrate.ops.object_storage import SyncS3ObjectsConfig, sync_files_to_s3
+from ol_orchestrate.sensors.sync_gcs_to_s3 import check_new_s3_assets_sensor
+
+dagster_deployment = os.getenv("DAGSTER_ENVIRONMENT", "qa")
+sync_config = SyncS3ObjectsConfig(
+    source_bucket="edx-program-reports",
+    destination_bucket=f"ol-data-lake-raw-{dagster_deployment.lower()}",
+    destination_prefix="landing_zone",
+)
+
+
+@job(
+    name="sync_edxorg_program_reports",
+    description="Replicate program credential reports from edx.org into our own S3 "
+    "bucket so that it can be ingested into the OL data lake.",
+    config={"ops": {"sync_files_to_s3": {"config": sync_config.dict()}}},
+)
+def sync_edxorg_program_reports():
+    sync_files_to_s3()
+
+
+edxorg_program_reports = Definitions(
+    resources={"s3": S3Resource(profile_name="edxorg-programs")},
+    sensors=[
+        SensorDefinition(
+            name="edxorg_program_reports_sensor",
+            evaluation_fn=partial(
+                check_new_s3_assets_sensor,
+                "edx-program-reports",
+                bucket_prefix="reports_v2/MITx/",
+                run_config_fn=lambda new_keys: {
+                    "ops": {
+                        "sync_files_to_s3": {
+                            "config": {
+                                **sync_config.dict(),
+                                "object_keys": list(new_keys),
+                            }
+                        }
+                    }
+                },
+            ),
+            job=sync_edxorg_program_reports,
+            default_status=DefaultSensorStatus.RUNNING,
+            minimum_interval_seconds=86400,
+        )
+    ],
+    jobs=[sync_edxorg_program_reports],
+)

--- a/src/ol_orchestrate/definitions/edx/sync_program_credential_reports.py
+++ b/src/ol_orchestrate/definitions/edx/sync_program_credential_reports.py
@@ -4,14 +4,22 @@ from functools import partial
 from dagster import DefaultSensorStatus, Definitions, SensorDefinition, job
 from dagster_aws.s3 import S3Resource
 
-from ol_orchestrate.ops.object_storage import SyncS3ObjectsConfig, sync_files_to_s3
+from ol_orchestrate.ops.object_storage import (
+    S3DownloadConfig,
+    S3UploadConfig,
+    download_files_from_s3,
+    upload_files_to_s3,
+)
+from ol_orchestrate.resources.outputs import SimpleResultsDir
 from ol_orchestrate.sensors.sync_gcs_to_s3 import check_new_s3_assets_sensor
 
 dagster_deployment = os.getenv("DAGSTER_ENVIRONMENT", "qa")
-sync_config = SyncS3ObjectsConfig(
+download_config = S3DownloadConfig(
     source_bucket="edx-program-reports",
-    destination_bucket=f"ol-data-lake-raw-{dagster_deployment.lower()}",
-    destination_prefix="landing_zone",
+)
+upload_config = S3UploadConfig(
+    destination_bucket=f"ol-data-lake-landing-zone-{dagster_deployment.lower()}",
+    destination_prefix="edxorg-program-credentials",
 )
 
 
@@ -19,14 +27,24 @@ sync_config = SyncS3ObjectsConfig(
     name="sync_edxorg_program_reports",
     description="Replicate program credential reports from edx.org into our own S3 "
     "bucket so that it can be ingested into the OL data lake.",
-    config={"ops": {"sync_files_to_s3": {"config": sync_config.dict()}}},
+    config={
+        "ops": {
+            "download_files_from_s3": {"config": download_config.dict()},
+            "upload_files_to_s3": {"config": upload_config.dict()},
+        }
+    },
 )
 def sync_edxorg_program_reports():
-    sync_files_to_s3()
+    upload_files_to_s3(download_files_from_s3())
 
 
 edxorg_program_reports = Definitions(
-    resources={"s3": S3Resource(profile_name="edxorg-programs")},
+    resources={
+        "s3": S3Resource(profile_name="edxorg"),
+        "s3_download": S3Resource(profile_name="edxorg"),
+        "s3_upload": S3Resource(),
+        "results_dir": SimpleResultsDir.configure_at_launch(),
+    },
     sensors=[
         SensorDefinition(
             name="edxorg_program_reports_sensor",
@@ -36,12 +54,13 @@ edxorg_program_reports = Definitions(
                 bucket_prefix="reports_v2/MITx/",
                 run_config_fn=lambda new_keys: {
                     "ops": {
-                        "sync_files_to_s3": {
+                        "download_files_from_s3": {
                             "config": {
-                                **sync_config.dict(),
+                                **download_config.dict(),
                                 "object_keys": list(new_keys),
                             }
-                        }
+                        },
+                        "upload_files_to_s3": {"config": upload_config.dict()},
                     }
                 },
             ),

--- a/src/ol_orchestrate/ops/object_storage.py
+++ b/src/ol_orchestrate/ops/object_storage.py
@@ -1,0 +1,35 @@
+from typing import Optional
+
+from dagster import Config, op
+from pydantic import Field
+
+
+class SyncS3ObjectsConfig(Config):
+    source_bucket: str = Field(description="S3 bucket to sync from")
+    destination_bucket: str = Field(description="S3 bucket to sync to")
+    object_keys: Optional[list[str]] = Field(
+        description="List of S3 object keys to sync"
+    )
+    destination_prefix: str = Field(
+        default="", description="S3 object key prefix to sync to"
+    )
+
+
+@op(
+    required_resource_keys={"s3"},
+    description="Synchronize a list of files from one bucket to another.",
+)
+def sync_files_to_s3(context, config: SyncS3ObjectsConfig) -> None:
+    """Sync S3 objects between two buckets"""
+    for object_key in config.object_keys or []:
+        context.log.info(
+            "Copying %s from %s to %s",
+            object_key,
+            config.source_bucket,
+            config.destination_bucket,
+        )
+        context.resources.s3.copy(
+            {"Bucket": config.source_bucket, "Key": object_key},
+            config.destination_bucket,
+            f"{config.destination_prefix}/{object_key}",
+        )

--- a/src/ol_orchestrate/ops/object_storage.py
+++ b/src/ol_orchestrate/ops/object_storage.py
@@ -1,7 +1,9 @@
 from typing import Optional
 
-from dagster import Config, op
+from dagster import Config, In, Out, op
 from pydantic import Field
+
+from ol_orchestrate.lib.dagster_types.files import DagsterPath
 
 
 class SyncS3ObjectsConfig(Config):
@@ -33,3 +35,61 @@ def sync_files_to_s3(context, config: SyncS3ObjectsConfig) -> None:
             config.destination_bucket,
             f"{config.destination_prefix}/{object_key}",
         )
+
+
+class S3DownloadConfig(Config):
+    source_bucket: str = Field(description="S3 bucket to sync from")
+    object_keys: Optional[list[str]] = Field(
+        description="List of S3 object keys to sync"
+    )
+
+
+@op(
+    required_resource_keys={"s3_download", "results_dir"},
+    description="Synchronize a list of files from one bucket to another.",
+    out={"downloaded_objects": Out()},
+)
+def download_files_from_s3(context, config: S3DownloadConfig) -> DagsterPath:
+    """Download a list of objects from an S3 bucket."""
+    for object_key in config.object_keys or []:
+        context.log.info(
+            "Downloading %s from %s",
+            object_key,
+            config.source_bucket,
+        )
+        # Ensure that all of the path components are present in the destination
+        # directory.
+        context.resources.results_dir.path.joinpath(object_key).parent.mkdir(
+            parents=True, exist_ok=True
+        )
+        context.resources.s3_download.download_file(
+            Bucket=config.source_bucket,
+            Key=object_key,
+            Filename=context.resources.results_dir.path.joinpath(object_key),
+        )
+    return context.resources.results_dir.path
+
+
+class S3UploadConfig(Config):
+    destination_bucket: str = Field(description="S3 bucket to sync to")
+    destination_prefix: str = Field(
+        default="", description="S3 object key prefix to sync to"
+    )
+
+
+@op(required_resource_keys={"s3_upload"}, ins={"downloaded_objects": In()})
+def upload_files_to_s3(
+    context, config: S3UploadConfig, downloaded_objects: DagsterPath
+) -> None:
+    """Upload the contents of a directory to an S3 bucket."""
+    for fpath in downloaded_objects.rglob("*"):
+        if fpath.is_file():
+            object_key = fpath.relative_to(downloaded_objects)
+            context.log.info(
+                "Uploading %s to %s", object_key, config.destination_bucket
+            )
+            context.resources.s3_upload.upload_file(
+                Filename=fpath,
+                Bucket=config.destination_bucket,
+                Key=f"{config.destination_prefix}/{object_key}",
+            )

--- a/src/ol_orchestrate/repositories/edx_gcs_courses.py
+++ b/src/ol_orchestrate/repositories/edx_gcs_courses.py
@@ -1,4 +1,5 @@
 import os
+from functools import partial
 
 from dagster import DefaultSensorStatus, Definitions, SensorDefinition
 from dagster_aws.s3.resources import s3_resource
@@ -42,7 +43,10 @@ gcs_sync_job = sync_gcs_to_s3.to_job(
 edx_gcs_courses = Definitions(
     sensors=[
         SensorDefinition(
-            evaluation_fn=check_new_gcs_assets_sensor,
+            evaluation_fn=partial(
+                check_new_gcs_assets_sensor, "simeon-mitx-course-tarballs"
+            ),
+            name="edxorg_course_bundle_sensor",
             minimum_interval_seconds=86400,
             job=gcs_sync_job,
             default_status=DefaultSensorStatus.RUNNING,

--- a/src/ol_orchestrate/sensors/sync_gcs_to_s3.py
+++ b/src/ol_orchestrate/sensors/sync_gcs_to_s3.py
@@ -1,21 +1,84 @@
 import json
+from collections.abc import Callable
 
 from dagster import RunRequest, SensorEvaluationContext, SkipReason
+from dagster_aws.s3 import s3_resource
 
 from ol_orchestrate.resources.gcp_gcs import GCSConnection
 
 
-def check_new_gcs_assets_sensor(
-    context: SensorEvaluationContext, gcp_gcs: GCSConnection
+def dummy_filter(object_name: str) -> bool:  # noqa: ARG001
+    return True
+
+
+def dummy_run_config_fn(object_keys: set[str]) -> dict:  # noqa: ARG001
+    return {}
+
+
+def check_new_gcs_assets_sensor(  # noqa: PLR0913
+    bucket_name: str,
+    context: SensorEvaluationContext,
+    gcp_gcs: GCSConnection,
+    bucket_prefix: str = "",
+    object_filter_fn: Callable[[str], bool] = dummy_filter,
+    run_config_fn: Callable[[set[str]], dict] = dummy_run_config_fn,
 ):
+    """Check S3 bucket for new files to operate on.
+
+    :param bucket_name: Name of the Google Cloud Storage bucket to watch
+    :param context: The Dagster sensor evaluation context
+    :param s3: Configured GCSConnection resource
+    :param run_config_fn: Optional function that returns a dictionary of run config
+        values when given a `set` object of new keys
+
+    :yields: RunRequest or SkipReason if there are no new files to operate on
+    """
     storage_client = gcp_gcs.client
-    bucket = storage_client.get_bucket("simeon-mitx-course-tarballs")
-    bucket_files = {file.name for file in storage_client.list_blobs(bucket)}
-    new_files = bucket_files.difference(set(context.cursor or []))
+    bucket = storage_client.get_bucket(bucket_name)
+    bucket_files = {
+        file.name
+        for file in storage_client.list_blobs(bucket, prefix=bucket_prefix)
+        if object_filter_fn(file.name)
+    }
+    new_files: set[str] = bucket_files.difference(set(context.cursor or []))
     if new_files:
         context.update_cursor(json.dumps(list(bucket_files)))
         yield RunRequest(
-            run_config={},
+            run_config=run_config_fn(new_files),
         )
     else:
         yield SkipReason("No new files in GCS bucket")
+
+
+def check_new_s3_assets_sensor(  # noqa: PLR0913
+    bucket_name: str,
+    context: SensorEvaluationContext,
+    s3: s3_resource,
+    bucket_prefix: str = "",
+    object_filter_fn: Callable[[str], bool] = dummy_filter,
+    run_config_fn: Callable[[set[str]], dict] = dummy_run_config_fn,
+):
+    """Check S3 bucket for new files to operate on.
+
+    :param bucket_name: Name of the S3 bucket to watch
+    :param context: The Dagster sensor evaluation context
+    :param s3: Configured S3 resource
+    :param run_config_fn: Optional function that returns a dictionary of run config
+        values when given a `set` object of new keys
+
+    :yields: RunRequest or SkipReason if there are no new files to operate on
+    """
+    bucket = s3.Bucket(bucket_name)
+    bucket_files = {
+        file.key
+        for file in bucket.objects.filter(prefix=bucket_prefix)
+        if object_filter_fn(file.key)
+    }
+    new_files: set[str] = bucket_files.difference(set(context.cursor or []))
+    if new_files:
+        context.update_cursor(json.dumps(list(bucket_files)))
+        yield RunRequest(
+            run_config=run_config_fn(new_files),
+        )
+    else:
+        yield SkipReason("No new files in S3 bucket")


### PR DESCRIPTION
# What are the relevant tickets?
https://github.com/mitodl/hq/issues/1592

# Description (What does it do?)
- Creates a pipeline for keeping the edx.org program credential reports synchronized to our own S3 bucket so that they can be ingested to the data lake via Airbyte.
- Creates a generic S3 sensor for identifying new files to be retrieved
- Creates a set of generic `op`s for copying, downloading, or uploading objects between S3 buckets or local storage.

# How can this be tested?
This has been tested by running the pipeline locally with the command `dagster dev -d src/ol_orchestrate/ -f src/ol_orchestrate/definitions/edx/sync_program_credential_reports.py` from the root of the repository.

# Additional Context
There is a corresponding change in ol-infrastructure that is needed to support this workflow defined in https://github.com/mitodl/ol-infrastructure/pull/1784