### PR TITLE
add tax fields to mitxpro order table in staging

### DIFF
--- a/src/ol_dbt/models/staging/mitxpro/_mitxpro__sources.yml
+++ b/src/ol_dbt/models/staging/mitxpro/_mitxpro__sources.yml
@@ -579,6 +579,12 @@ sources:
       description: number, total order amount
     - name: purchaser_id
       description: int, primary key in users_user for the purchaser
+    - name: tax_country_code
+      description: string, the country code where the tax was applied
+    - name: tax_rate
+      description: numeric, the tax rate to apply
+    - name: tax_rate_name
+      description: string, name of the tax rate assessed
 
   - name: raw__xpro__app__postgres__courses_courserunenrollment
     freshness:

--- a/src/ol_dbt/models/staging/mitxpro/_stg_mitxpro__models.yml
+++ b/src/ol_dbt/models/staging/mitxpro/_stg_mitxpro__models.yml
@@ -847,12 +847,18 @@ models:
     description: number, total order amount
     tests:
     - not_null
-  - name: order_updated_on
-    description: timestamp, specifying when the order was most recently updated
-    tests:
-    - not_null
   - name: order_purchaser_user_id
     description: int, primary key in users_user for the purchaser
+    tests:
+    - not_null
+  - name: order_tax_country_code
+    description: string, the country code where the tax was applied
+  - name: order_tax_rate
+    description: numeric, the tax rate to apply
+  - name: order_tax_rate_name
+    description: string, name of the tax rate assessed
+  - name: order_updated_on
+    description: timestamp, specifying when the order was most recently updated
     tests:
     - not_null
   - name: order_created_on

--- a/src/ol_dbt/models/staging/mitxpro/stg__mitxpro__app__postgres__ecommerce_order.sql
+++ b/src/ol_dbt/models/staging/mitxpro/stg__mitxpro__app__postgres__ecommerce_order.sql
@@ -10,6 +10,9 @@ with source as (
         , status as order_state
         , total_price_paid as order_total_price_paid
         , purchaser_id as order_purchaser_user_id
+        , tax_country_code as order_tax_country_code
+        , tax_rate as order_tax_rate
+        , tax_rate_name as order_tax_rate_name
         ,{{ cast_timestamp_to_iso8601('updated_on') }} as order_updated_on
         ,{{ cast_timestamp_to_iso8601('created_on') }} as order_created_on
     from source


### PR DESCRIPTION
# What are the relevant tickets?
https://github.com/mitodl/mitxpro/issues/2771

# Description (What does it do?)
Adds order_tax_country_code, order_tax_rate, and order_tax_rate_name to the stg__mitxpro__app__postgres__ecommerce_order table

# How can this be tested?
Run the following commands against your schema or QA
Run dbt build --select staging.mitxpro if you have all models, otherwise add + in front of staging.mitxpro to run upstream models

