### PR TITLE
add three tax fields to int__mitxpro__ecommerce_order

### DIFF
--- a/src/ol_dbt/models/intermediate/mitxpro/_int_mitxpro__models.yml
+++ b/src/ol_dbt/models/intermediate/mitxpro/_int_mitxpro__models.yml
@@ -713,6 +713,12 @@ models:
   - name: couponpaymentversion_id
     description: int, foreign key to ecommerce_couponpaymentversion for orders that
       use a coupon
+  - name: order_tax_country_code
+    description: string, the country code where the tax was applied
+  - name: order_tax_rate
+    description: numeric, the tax rate to apply
+  - name: order_tax_rate_name
+    description: string, name of the tax rate assessed
   tests:
   - dbt_expectations.expect_table_row_count_to_equal_other_table:
       compare_model: ref('stg__mitxpro__app__postgres__ecommerce_order')

--- a/src/ol_dbt/models/intermediate/mitxpro/int__mitxpro__ecommerce_order.sql
+++ b/src/ol_dbt/models/intermediate/mitxpro/int__mitxpro__ecommerce_order.sql
@@ -22,6 +22,9 @@ select
     , orders.order_updated_on
     , couponversion.coupon_id
     , couponversion.couponpaymentversion_id
+    , orders.order_tax_country_code
+    , orders.order_tax_rate
+    , orders.order_tax_rate_name
 from orders
 left join couponredemption on orders.order_id = couponredemption.order_id
 left join couponversion on couponredemption.couponversion_id = couponversion.couponversion_id


### PR DESCRIPTION
# What are the relevant tickets?
https://github.com/mitodl/mitxpro/issues/2771

# Description (What does it do?)
Adds order_tax_country_code, order_tax_rate, and order_tax_rate_name to the int__mitxpro__ecommerce_order table


# How can this be tested?
Run the following commands against your schema or QA
Run dbt build --select intermediate.mitxpro if you have all models, otherwise add + in front of intermediate.mitxpro to run upstream models

