### PR TITLE
add additional profile fields to mitx and combined users

### DIFF
--- a/src/ol_dbt/models/intermediate/combined/_combined_models.yml
+++ b/src/ol_dbt/models/intermediate/combined/_combined_models.yml
@@ -32,6 +32,16 @@ models:
       platform
   - name: user_birth_year
     description: int, user's birth year
+  - name: user_company
+    description: str, user's company
+  - name: user_job_title
+    description: str, user's job title
+  - name: user_industry
+    description: str, user's job industry
+  - name: user_joined_on
+    description: timestamp, user join timestamp
+  - name: user_last_login
+    description: timestamp, user last login
 
 - name: int__combined__courserun_enrollments
   description: Intermediate model for user course enrollments from different platforms

--- a/src/ol_dbt/models/intermediate/combined/int__combined__users.sql
+++ b/src/ol_dbt/models/intermediate/combined/int__combined__users.sql
@@ -18,6 +18,10 @@ with mitxonline_users as (
     select * from {{ ref('int__edxorg__mitx_users') }}
 )
 
+, micromasters_users as (
+    select * from {{ ref('int__micromasters__users') }}
+)
+
 , combined_users as (
     select
         '{{ var("mitxonline") }}' as platform
@@ -28,6 +32,11 @@ with mitxonline_users as (
         , user_highest_education
         , user_gender
         , user_birth_year
+        , user_company
+        , user_job_title
+        , user_industry
+        , users.user_joined_on
+        , users.user_last_login
     from mitxonline_users
 
     union all
@@ -41,7 +50,11 @@ with mitxonline_users as (
         , user_highest_education
         , user_gender
         , user_birth_year
-
+        , user_company
+        , user_job_title
+        , user_industry
+        , users.user_joined_on
+        , users.user_last_login
     from mitxpro_users
 
     union all
@@ -55,21 +68,31 @@ with mitxonline_users as (
         , user_highest_education
         , user_gender
         , user_birth_year
+        , user_company
+        , user_job_title
+        , user_industry
+        , users.user_joined_on
+        , users.user_last_login
     from bootcamps_users
 
     union all
 
     select
         '{{ var("edxorg") }}' as platform
-        , user_id
-        , user_username
-        , user_email
-        , user_country as user_address_country
-        , user_highest_education
-        , user_gender
-        , user_birth_year
-
+        , edxorg_users.user_id
+        , edxorg_users.user_username
+        , edxorg_users.user_email
+        , edxorg_users.user_country as user_address_country
+        , edxorg_users.user_highest_education
+        , edxorg_users.user_gender
+        , edxorg_users.user_birth_year
+        , micromasters_users.user_company_name as user_company
+        , micromasters_users.user_job_position as user_job_title
+        , micromasters_users.user_company_industry as user_industry
+        , edxorg_users.users.user_joined_on
+        , edxorg_users.users.user_last_login
     from edxorg_users
+    left join micromasters_users on edxorg_users.user_username = micromasters_users.user_edxorg_username
 )
 
 select * from combined_users

--- a/src/ol_dbt/models/intermediate/mitx/_int_mitx__models.yml
+++ b/src/ol_dbt/models/intermediate/mitx/_int_mitx__models.yml
@@ -140,6 +140,14 @@ models:
   - name: user_edxorg_email
     description: str, user email on edX.org. Not unique as some edxorg users found
       with same email for different username and user ID
+  - name: user_joined_on_mitxonline
+    description: timestamp, user join timestamp on MITx Online
+  - name: user_joined_on_edxorg
+    description: timestamp, user join timestamp on edX.org
+  - name: user_last_login_on_mitxonline
+    description: timestamp, user last log in on MITx Online
+  - name: user_last_login_on_edxorg
+    description: timestamp, user last log in on edX.org
   - name: user_full_name
     description: str, user full name on edX.org or MITxOnline. Very small number of
       edX.org users have blank full name, their name couldn't be populated from other

--- a/src/ol_dbt/models/intermediate/mitx/int__mitx__users.sql
+++ b/src/ol_dbt/models/intermediate/mitx/int__mitx__users.sql
@@ -29,6 +29,8 @@ with mitxonline_users as (
         , mitxonline_users.user_company
         , mitxonline_users.user_job_title
         , mitxonline_users.user_industry
+        , mitxonline_users.user_joined_on
+        , mitxonline_users.user_last_login
         , true as is_mitxonline_user
     from mitxonline_users
 )
@@ -43,6 +45,8 @@ with mitxonline_users as (
         , edxorg_users.user_highest_education
         , edxorg_users.user_gender
         , edxorg_users.user_birth_year
+        , edxorg_users.user_joined_on
+        , edxorg_users.user_last_login
         , micromasters_users.user_company_name
         , micromasters_users.user_company_industry
         , micromasters_users.user_job_position
@@ -59,6 +63,10 @@ with mitxonline_users as (
         , edxorg_users_view.user_edxorg_username
         , mitxonline_users_view.user_mitxonline_email
         , edxorg_users_view.user_edxorg_email
+        , mitxonline_users_view.user_joined_on as user_joined_on_mitxonline
+        , edxorg_users_view.user_joined_on as user_joined_on_edxorg
+        , mitxonline_users_view.user_last_login as user_last_login_on_mitxonline
+        , edxorg_users_view.user_last_login as user_last_login_on_edxorg
         , coalesce(mitxonline_users_view.is_mitxonline_user is not null, false) as is_mitxonline_user
         , coalesce(edxorg_users_view.is_edxorg_user is not null, false) as is_edxorg_user
         , coalesce(mitxonline_users_view.user_full_name, edxorg_users_view.user_full_name) as user_full_name


### PR DESCRIPTION
# What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
https://github.com/mitodl/hq/issues/2652

# Description (What does it do?)
<!--- Describe your changes in detail -->

Adds additional profile fields to `int__mitx__users` and `int__combined__users`
user_company, user_job_title, user_industry, user_joined_on, user_last_login


# How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->
` ``
dbt build --select int__mitx__users
dbt build --select int__combined__users
```

# Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->


<!--- Uncomment and add steps to be completed before merging this PR if necessary
## Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
