### PR TITLE
add MITx program report to staging and intermediate

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,6 +62,7 @@ templater = "jinja"
 dialect = "hive"
 sql_file_exts = ".sql,.sql.j2,.dml,.ddl"
 max_line_length = 120
+exclude_rules = "CV10"
 
 [tool.sqlfluff.templater]
 unwrap_wrapped_queries = true

--- a/src/ol_dbt/models/intermediate/edxorg/_int_edxorg__models.yml
+++ b/src/ol_dbt/models/intermediate/edxorg/_int_edxorg__models.yml
@@ -368,3 +368,49 @@ models:
   tests:
   - dbt_expectations.expect_compound_columns_to_be_unique:
       column_list: ["user_id", "courserun_readable_id"]
+
+- name: int__edxorg__mitx_program_certificates
+  description: learners who completed MicroMasters and XSeries programs on edX.org.
+    program_certificate_awarded_on might be null for some programs such as SCM
+  columns:
+  - name: program_type
+    description: str, the type of the program. The value are 'MicroMasters' and 'XSeries'
+      for MITx programs on edX.org
+    tests:
+    - not_null
+  - name: program_uuid
+    description: str, the UUID of the program on edX.org. 'MIT Finance' and 'Finance'
+      are two different UUIDs, as they have different required courses. 'Statistics
+      and Data Science' is split into 'Statistics and Data Science' and 'Statistics
+      and Data Science (General track)', which are also two different program UUIDs.
+    tests:
+    - not_null
+  - name: program_title
+    description: str, title of the program on edX.org.
+    tests:
+    - not_null
+  - name: user_id
+    description: int, the edX learner ID in the LMS in a user's course run enrollment
+      record.
+    tests:
+    - not_null
+  - name: user_username
+    description: str, username of the user on edX.org
+    tests:
+    - not_null
+  - name: user_full_name
+    description: str, the full name of an edX learner in the LMS in a user's user
+      profile record. Retired users will have no full name available.
+    tests:
+    - not_null
+  - name: user_has_completed_program
+    description: boolean, whether the learner has passed each of the courses in the
+      program with a grade that qualifies them for a verified certificate.
+    tests:
+    - not_null
+  - name: program_certificate_awarded_on
+    description: timestamp, the date in ISO-8601 format that the learner has passed
+      each of the courses in the program and was awarded a program certificate.
+  tests:
+  - dbt_expectations.expect_compound_columns_to_be_unique:
+      column_list: ["user_id", "program_uuid"]

--- a/src/ol_dbt/models/intermediate/edxorg/int__edxorg__mitx_program_certificates.sql
+++ b/src/ol_dbt/models/intermediate/edxorg/int__edxorg__mitx_program_certificates.sql
@@ -1,0 +1,23 @@
+with completed_program_learners as (
+    select * from {{ ref('stg__edxorg__s3__program_learner_report') }}
+    where user_has_completed_program = true
+)
+
+, completed_program_learners_sorted as (
+    select
+        *
+        , row_number() over (partition by user_id, program_uuid order by program_certificate_awarded_on desc) as row_num
+    from completed_program_learners
+)
+
+select
+    program_type
+    , program_uuid
+    , program_title
+    , user_id
+    , user_username
+    , user_full_name
+    , user_has_completed_program
+    , program_certificate_awarded_on
+from completed_program_learners_sorted
+where row_num = 1

--- a/src/ol_dbt/models/staging/edxorg/_edxorg_sources.yml
+++ b/src/ol_dbt/models/staging/edxorg/_edxorg_sources.yml
@@ -451,3 +451,99 @@ sources:
     - name: preference_set_datetime
       description: timestamp, specifying when email opt in preference was most recently
         updated
+
+  - name: raw__edxorg__program_learner_report
+    description: learners program and course performance in MicroMasters and XSeries
+      programs from edX.org
+    columns:
+    - name: authoring institution
+      description: str, the name of the organization that is the author for the program
+        for which this report was generated. Currently, it's MITx for all records.
+    - name: program type
+      description: str, the type of the program. The value are 'MicroMasters' and
+        'XSeries' for MITx programs on edX.org
+    - name: program uuid
+      description: str, the UUID of the program on edX.org. 'MIT Finance' and 'Finance'
+        are two different UUIDs, as they have different required courses. 'Statistics
+        and Data Science' is split into 'Statistics and Data Science' and 'Statistics
+        and Data Science (General track)', which are also two different program UUIDs
+    - name: program title
+      description: str, title of the program on edX.org
+    - name: user_id
+      description: str, the edX learner ID in the LMS in a user's course run enrollment
+        record.
+    - name: username
+      description: str, username of the user on edX.org
+    - name: name
+      description: str, The full name of an edX learner in the LMS in a user's user
+        profile record. Retired users will have no full name available.
+    - name: user roles
+      description: str, roles assigned to the user. A user can have multiple roles.
+        Values are beta_testers, data_researcher, finance_admin, sales_admin, instructor,
+        staff, etc.
+    - name: course run key
+      description: str, the key of the course-run the learner has enrolled in, formatted
+        as course-v1:{org}+{course}+{run}
+    - name: course title
+      description: str, the course run title on edX.org
+    - name: track
+      description: str, the course mode of the learner's enrollment in this course-run.
+        Also called enrollment mode. Values are 'audit', 'verified', 'honor' and 'credit'
+        in this table.
+    - name: letter grade
+      description: str, the letter grade for the user in the course run. This value
+        is based on the course run's grading policy. The letter grade may be blank
+        if the grading/credentials task has not yet run for this learner. Values are
+        'A', 'B', 'C', 'D', 'F', 'Pass'.
+    - name: grade
+      description: str, the current grade for the user in this course-run as a decimal
+        (e.g. 0.84). If this value is null, the user does not yet have a course grade
+        in this course-run.
+    - name: currently enrolled
+      description: str, whether the learner is currently enrolled in the course. 'true'
+        or 'false'
+    - name: purchased as bundle
+      description: str, whether the learner has purchased this course as bundle. 'true'
+        or 'false'
+    - name: completed
+      description: str, whether the learner completed the course run. 'true' if a
+        verified learner has earned a certificate in a course run that counts towards
+        program completion. This is based on the user's course certificate in the
+        LMS. A course certificate counts towards completion if the learner has passed
+        the course and the course run mode matches the mode of the course. Learner
+        certificates for unverified accounts do not count towards program completion
+        until the account is verified.
+    - name: completed program
+      description: str, whether the learner has passed each of the courses in the
+        program with a grade that qualifies them for a verified certificate. 'true'
+        or 'false'.
+    - name: date completed
+      description: str, the date in the format 'YYYY-MM-DD HH:mm:ss Z' in UTC that
+        the learner earned a passing certificate for this course run. If a user passes
+        the course before verification, then the completed date will reflect the date
+        the certificate was generated for that verified learner.
+    - name: date program certificate awarded
+      description: str, the date in the format 'YYYY-MM-DDTHH:mm:ssZ' in UTC that
+        the learner has passed each of the courses in the program and was awarded
+        a program certificate.
+    - name: last activity date
+      description: str, the date in the format 'YYYY-MM-DD' in UTC that the learner
+        was last active in the course run.
+    - name: date first enrolled
+      description: str, the date in the format 'YYYY-MM-DD HH:mm:ss Z' in UTC that
+        the learner enrolled in this course run for the first time. For example, if
+        the learner enrolled in the course run, unenrolled, and then re-enrolled,
+        this value would represent the time that they enrolled in the course run for
+        the first time.
+    - name: date last unenrolled
+      description: str, the date in the format 'YYYY-MM-DD HH:mm:ss Z' in UTC that
+        the learner last unenrolled in this course run. This will be null if the learner
+        has never unenrolled from this course run. For example, if the learner enrolled
+        in the course run, unenrolled, reenrolled, and then unenrolled, this value
+        would represent the most recent time that they unenrolled in the course run.
+    - name: date first upgraded to verified
+      description: str, the date in the format 'YYYY-MM-DD HH:mm:ss Z' in UTC that
+        the learner first upgraded to the verified track course mode.
+    - name: course run start date
+      description: str, the start date of the course run in the format 'YYYY-MM-DD
+        HH:mm:ss Z' in UTC

--- a/src/ol_dbt/models/staging/edxorg/_stg__edxorg__models.yml
+++ b/src/ol_dbt/models/staging/edxorg/_stg__edxorg__models.yml
@@ -312,3 +312,128 @@ models:
   tests:
   - dbt_expectations.expect_compound_columns_to_be_unique:
       column_list: ["user_id", "courserun_readable_id"]
+
+- name: stg__edxorg__s3__program_learner_report
+  description: learners program and course records in MicroMasters and XSeries programs
+    from edX.org
+  columns:
+  - name: org_id
+    description: str, the name of the organization that is the author for the program
+      for which this report was generated. Currently, it's MITx for all records.
+    tests:
+    - not_null
+  - name: program_type
+    description: str, the type of the program. The value are 'MicroMasters' and 'XSeries'
+      for MITx programs on edX.org
+    tests:
+    - not_null
+    - accepted_values:
+        values: ['MicroMasters', 'XSeries']
+  - name: program_uuid
+    description: str, the UUID of the program on edX.org. 'MIT Finance' and 'Finance'
+      are two different UUIDs, as they have different required courses. 'Statistics
+      and Data Science' is split into 'Statistics and Data Science' and 'Statistics
+      and Data Science (General track)', which are also two different program UUIDs.
+    tests:
+    - not_null
+  - name: program_title
+    description: str, title of the program on edX.org
+    tests:
+    - not_null
+  - name: user_id
+    description: int, the edX learner ID in the LMS in a user's course run enrollment
+      record.
+    tests:
+    - not_null
+  - name: user_username
+    description: str, username of the user on edX.org
+    tests:
+    - not_null
+  - name: user_full_name
+    description: str, the full name of an edX learner in the LMS in a user's user
+      profile record. Retired users will have no full name available.
+    tests:
+    - not_null
+  - name: user_roles
+    description: str, roles assigned to the user. A user can have multiple roles.
+      Values are beta_testers, data_researcher, finance_admin, sales_admin, instructor,
+      staff, etc.
+  - name: courserun_readable_id
+    description: str, the key of the course-run the learner has enrolled in, formatted
+      as course-v1:{org}+{course}+{run}
+    tests:
+    - not_null
+  - name: course_title
+    description: str, the course run title on edX.org
+    tests:
+    - not_null
+  - name: courserunenrollment_enrollment_mode
+    description: str, the course mode of the learner's enrollment in this course-run.
+      Also called enrollment mode. Values are 'audit', 'verified', 'honor' and 'credit'
+      in this table.
+    tests:
+    - not_null
+  - name: courserungrade_letter_grade
+    description: str, the letter grade for the user in the course run. This value
+      is based on the course run's grading policy. The letter grade may be blank if
+      the grading/credentials task has not yet run for this learner. Values are 'A',
+      'B', 'C', 'D', 'F', 'Pass'
+  - name: courserungrade_grade
+    description: str, the current grade for the user in this course-run as a decimal
+      (e.g. 0.84). If this value is null, the user does not yet have a course grade
+      in this course-run.
+  - name: courserunenrollment_is_active
+    description: boolean, whether the learner is currently enrolled in the course.
+    tests:
+    - not_null
+  - name: user_has_purchased_as_bundle
+    description: boolean, whether the learner has purchased this course as bundle.
+    tests:
+    - not_null
+  - name: user_has_completed_program
+    description: boolean, whether the learner has passed each of the courses in the
+      program with a grade that qualifies them for a verified certificate.
+    tests:
+    - not_null
+  - name: user_has_completed_course
+    description: boolean, whether the learner completed the course run. true if a
+      verified learner has earned a certificate in a course run that counts towards
+      program completion. This is based on the user's course certificate in the LMS.
+      A course certificate counts towards completion if the learner has passed the
+      course and the course run mode matches the mode of the course. Learner certificates
+      for unverified accounts do not count towards program completion until the account
+      is verified.
+  - name: completed_course_on
+    description: timestamp, the date in ISO-8601 format that the learner earned a
+      passing certificate for this course run. If a user passes the course before
+      verification, then the completed date will reflect the date the certificate
+      was generated for that verified learner.
+  - name: program_certificate_awarded_on
+    description: timestamp, the date in ISO-8601 format that the learner has passed
+      each of the courses in the program and was awarded a program certificate.
+  - name: courserun_start_on
+    description: timestamp, the start date of the course run in ISO-8601 string.
+    tests:
+    - not_null
+  - name: courserunenrollment_created_on
+    description: timestamp,the date in ISO-8601 format that the learner enrolled in
+      this course run for the first time. For example, if the learner enrolled in
+      the course run, unenrolled, and then re-enrolled, this value would represent
+      the time that they enrolled in the course run for the first time.
+    tests:
+    - not_null
+  - name: courseactivity_last_activity_date
+    description: date, the date in ISO-8601 format that the learner was last active
+      in the course run.
+  - name: courserunenrollment_unenrolled_on
+    description: timestamp, the date in ISO-8601 format that the learner last unenrolled
+      in this course run. This will be null if the learner has never unenrolled from
+      this course run. For example, if the learner enrolled in the course run, unenrolled,
+      reenrolled, and then unenrolled, this value would represent the most recent
+      time that they unenrolled in the course run.
+  - name: courserunenrollment_upgraded_on
+    description: timestamp, the date in ISO-8601 format that the learner first upgraded
+      to the verified track course mode.
+  tests:
+  - dbt_expectations.expect_compound_columns_to_be_unique:
+      column_list: ["user_id", "courserun_readable_id", "program_uuid"]

--- a/src/ol_dbt/models/staging/edxorg/stg__edxorg__s3__program_learner_report.sql
+++ b/src/ol_dbt/models/staging/edxorg/stg__edxorg__s3__program_learner_report.sql
@@ -1,0 +1,70 @@
+with source as (
+    select * from {{ source('ol_warehouse_raw_data','raw__edxorg__program_learner_report') }}
+)
+
+, source_sorted as (
+    select
+        *
+        , row_number() over (
+            partition by "user id", "course run key", "program uuid"
+            order by _airbyte_emitted_at desc, _ab_source_file_last_modified desc
+        ) as row_num
+    from source
+)
+
+, dedup_source as (
+    select * from source_sorted
+    where row_num = 1
+)
+
+, cleaned as (
+
+    select
+        "authoring institution" as org_id
+        , "program type" as program_type
+        , "program uuid" as program_uuid
+        , username as user_username
+        , name as user_full_name
+        , "course run key" as courserun_readable_id
+        , "course title" as course_title
+        , track as courserunenrollment_enrollment_mode
+        , cast("user id" as integer) as user_id
+        , cast(completed as boolean) as user_has_completed_course
+        , cast("completed program" as boolean) as user_has_completed_program
+        , cast("currently enrolled" as boolean) as courserunenrollment_is_active
+        , cast("purchased as bundle" as boolean) as user_has_purchased_as_bundle
+        , if("user roles" = 'null', null, "user roles") as user_roles
+        , if("letter grade" = 'null', null, "letter grade") as courserungrade_letter_grade
+        , if(grade = 'null', null, grade) as courserungrade_grade
+        , case
+            when "program uuid" like '%941d3eaf56966c7' then 'Finance'
+            when "program uuid" like '%3173ff51e11a748' then 'MIT Finance'
+            else "program title"
+        end as program_title
+        , to_iso8601(date_parse("course run start date", '%Y-%m-%d %H:%i:%s Z')) as courserun_start_on
+        , to_iso8601(date_parse("date first enrolled", '%Y-%m-%d %H:%i:%s Z')) as courserunenrollment_created_on
+        , case
+            when "date completed" = 'null' then null
+            else to_iso8601(date_parse("date completed", '%Y-%m-%d %H:%i:%s Z'))
+        end as completed_course_on
+        , case
+            when "last activity date" = 'null' then null
+            else {{ cast_date_to_iso8601('"last activity date"') }}
+        end as courseactivity_last_activity_date
+        , case
+            when "date last unenrolled" = 'null' then null
+            else to_iso8601(date_parse("date last unenrolled", '%Y-%m-%d %H:%i:%s Z'))
+        end as courserunenrollment_unenrolled_on
+        , case
+            when "date first upgraded to verified" = 'null' then null
+            else to_iso8601(date_parse("date first upgraded to verified", '%Y-%m-%d %H:%i:%s Z'))
+        end as courserunenrollment_upgraded_on
+        , case
+            when "date program certificate awarded" = 'null' then null
+            else to_iso8601(date_parse("date program certificate awarded", '%Y-%m-%dT%H:%i:%sZ'))
+        end as program_certificate_awarded_on
+    from dedup_source
+
+)
+
+select * from cleaned


### PR DESCRIPTION
# What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
part of https://github.com/mitodl/ol-data-platform/issues/852

# Description (What does it do?)
<!--- Describe your changes in detail -->
Adds `stg__edxorg__s3__program_learner_report` and `int__edxorg__mitx_program_certificates`, which are deduped from `raw__edxorg__program_learner_report`

It doesn't replace the MicroMasters program data in `__micromasters_program_certificates_non_dedp` yet as we need to figure out the discrepancies first


# How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->
Needs to update [this line](https://github.com/mitodl/ol-data-platform/blob/main/src/ol_dbt/profiles.yml#L46) to `mitol-ol-data-lake-production.trino.galaxy.starburst.io` to run against `dev_production` due to size of this table
```
dbt build --select stg__edxorg__s3__program_learner_report
dbt build --select int__edxorg__mitx_program_certificates
```
