### PR TITLE
edX Tracking Log Normalization

### DIFF
--- a/src/ol_orchestrate/ops/normalize_logs.py
+++ b/src/ol_orchestrate/ops/normalize_logs.py
@@ -80,7 +80,11 @@ def load_files_to_table(
     source_bucket = config.tracking_log_bucket
     path_prefix = config.path_prefix
     # DuckDB Glob Syntax: ** matches any number of subdirectories (including none)
-    s3_path = f"s3://{source_bucket}/{path_prefix}/{log_date}**"
+    s3_path = (
+        f"s3://{source_bucket}/{path_prefix}/{log_date}**"
+        if config.path_prefix == "logs"
+        else f"s3://{source_bucket}/{path_prefix}"
+    )
     context.log.info(s3_path)
     with context.resources.duckdb.get_connection() as conn:
         conn.execute("DROP TABLE IF EXISTS tracking_logs")
@@ -91,6 +95,7 @@ def load_files_to_table(
             LOAD httpfs;
             SET s3_access_key_id="{config.s3_key}";
             SET s3_secret_access_key="{config.s3_secret}";
+            SET GLOBAL memory_limit="10GB";
             """
         )
         if config.s3_token:


### PR DESCRIPTION
# What are the relevant tickets?

Closes #1309 [Ingest CSV and tracking log data from edx.org via Airbyte](https://github.com/mitodl/hq/issues/1309)

# Description (What does it do?)
We have a normalization pipeline to transform tracking log files to properly escape nested json so that all the field values can be parsed and ingested into our data lake. We have now obtained edxorg tracking log data, so we need to run normalization on them before being ably to sync them into our raw data base.

These changes extend the normalize_tracking_logs Dagster pipeline to process edx.org files we have loaded to S3.
The pipeline definitions were extended to include the edx.org deployment.
Conditional logic was added to handle generating the file paths for edx.org files since they are slightly different than the other deployments. Besides that, we are now explicitly setting a global memory_limit for duckdb to give it some additional overhead.

# How can this be tested?
The normalization pipeline should be run locally to test the normalization.
More faster iterations, you could update the path_prefix for the files being processed to a single file.

Command to initiate a Dagster instance locally:
`dagster dev -d src/ol_orchestrate -f src/ol_orchestrate/definitions/edx/normalize_tracking_logs.py`

This has already been tested locally during development and transformed files were inspected to confirm that nested json was formatted correctly.