### PR TITLE
create mart for MITx Online enrollments and demographics

### DIFF
--- a/src/ol_dbt/models/marts/mitxonline/_marts__mitxonline__models.yml
+++ b/src/ol_dbt/models/marts/mitxonline/_marts__mitxonline__models.yml
@@ -74,3 +74,69 @@ models:
     tests:
     - accepted_values:
         values: '{{ var("highest_education_values") }}'
+
+- name: marts__mitxonline_course_enrollments
+  description: learners MITx Online course enrollments and demographics
+  columns:
+  - name: course_number
+    description: str, unique string for the course. It can contain letters, numbers,
+      or periods. e.g. 6.002.1x
+    tests:
+    - not_null
+  - name: courserun_title
+    description: str, title of the course run
+    tests:
+    - not_null
+  - name: courserun_readable_id
+    description: str, course run readable ID for MITx Online courses
+    tests:
+    - not_null
+  - name: courserunenrollment_is_active
+    description: boolean, indicating whether the user is still enrolled in the run
+    tests:
+    - not_null
+  - name: courserunenrollment_created_on
+    description: timestamp, specifying when an enrollment was initially created
+    tests:
+    - not_null
+  - name: courserunenrollment_enrollment_mode
+    description: str, enrollment mode for MITx courses. DEDP enrollments are verified
+      in either MITx Online or MicroMasters orders. For DEDP runs on edX.org or DEDP
+      runs on MITx Online in '3T2021', '1T2022', '2T2022', these are paid and verified
+      in MicroMasters. For other DEDP courses that run on MITx Online, they are paid
+      and verified in MITx Online
+    tests:
+    - not_null
+  - name: courserunenrollment_enrollment_status
+    description: str, enrollment status for users whose enrollment changed. Only applicable
+      for MITx Online, In MITx Online options are 'deferred', 'transferred', 'refunded',
+      'enrolled', 'unenrolled', maybe blank
+  - name: user_email
+    description: str, user email on MITx Online
+    tests:
+    - not_null
+  - name: user_username
+    description: str, username on MITx Online
+    tests:
+    - not_null
+  - name: user_full_name
+    description: str, user full name on MITxOnline
+    tests:
+    - not_null
+  - name: user_address_country
+    description: str, country code in user's profile on MITx Online
+  - name: user_highest_education
+    description: str, user's level of education in user's profile on MITx Online
+  - name: user_gender
+    description: str, user's gender in user's profile on MITx Online
+  - name: user_birth_year
+    description: int, user's birth year in user's profile on MITx Online
+  - name: user_company
+    description: str, user's company in user's profile on MITx Online
+  - name: user_job_title
+    description: str, user's job title in user's profile on MITx Online
+  - name: user_industry
+    description: str, user's job industry in user's profile on MITx Online
+  tests:
+  - dbt_expectations.expect_compound_columns_to_be_unique:
+      column_list: ["user_username", "courserun_readable_id"]

--- a/src/ol_dbt/models/marts/mitxonline/marts__mitxonline_course_enrollments.sql
+++ b/src/ol_dbt/models/marts/mitxonline/marts__mitxonline_course_enrollments.sql
@@ -1,0 +1,29 @@
+with enrollments as (
+    select * from {{ ref('int__mitx__courserun_enrollments') }}
+    where platform = '{{ var("mitxonline") }}'
+)
+
+, users as (
+    select * from {{ ref('int__mitxonline__users') }}
+)
+
+select
+    enrollments.course_number
+    , enrollments.courserun_title
+    , enrollments.courserun_readable_id
+    , enrollments.courserunenrollment_is_active
+    , enrollments.courserunenrollment_enrollment_mode
+    , enrollments.courserunenrollment_enrollment_status
+    , enrollments.courserunenrollment_created_on
+    , enrollments.user_mitxonline_username as user_username
+    , enrollments.user_email
+    , enrollments.user_full_name
+    , users.user_address_country
+    , users.user_highest_education
+    , users.user_gender
+    , users.user_birth_year
+    , users.user_company
+    , users.user_job_title
+    , users.user_industry
+from enrollments
+left join users on enrollments.user_mitxonline_username = users.user_username


### PR DESCRIPTION
# What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
https://github.com/mitodl/ol-data-platform/issues/866

# Description (What does it do?)
<!--- Describe your changes in detail -->
create a mart for MITx Online enrollments and demographics
    course_number
    courserun_title
    courserun_readable_id
    courserunenrollment_is_active
    courserunenrollment_enrollment_mode
    courserunenrollment_enrollment_status
    courserunenrollment_created_on
    user_username
    user_email
    user_full_name
    user_address_country
    user_highest_education
    user_gender
    user_birth_year
    user_company
    user_job_title
    user_industry


# How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->
dbt build --select marts__mitxonline_course_enrollments


