### PR TITLE
Create combined course certificate and add certificate field to combined enrollment

### DIFF
--- a/src/ol_dbt/models/intermediate/bootcamps/_int_bootcamps__models.yml
+++ b/src/ol_dbt/models/intermediate/bootcamps/_int_bootcamps__models.yml
@@ -158,6 +158,8 @@ models:
     description: str, user email associated with their account
     tests:
     - not_null
+  - name: user_full_name
+    description: string, full name
   tests:
   - dbt_expectations.expect_table_row_count_to_equal_other_table:
       compare_model: ref('stg__bootcamps__app__postgres__courserunenrollment')
@@ -308,6 +310,11 @@ models:
     - relationships:
         to: ref('int__bootcamps__users')
         field: user_id
+  - name: courseruncertificate_url
+    description: str, the full URL to the certificate on Bootcamps if it's not invoked
+    tests:
+    - unique
+    - not_null
   - name: courseruncertificate_is_revoked
     description: boolean, indicating whether the certificate is revoked and invalid
   - name: courserun_title
@@ -322,6 +329,8 @@ models:
     description: string, email
     tests:
     - not_null
+  - name: user_full_name
+    description: string, full name
   - name: courseruncertificate_created_on
     description: timestamp, specifying when a certificate was initially created
   - name: courseruncertificate_updated_on

--- a/src/ol_dbt/models/intermediate/bootcamps/int__bootcamps__courserun_certificates.sql
+++ b/src/ol_dbt/models/intermediate/bootcamps/int__bootcamps__courserun_certificates.sql
@@ -9,7 +9,7 @@ with certificates as (
 )
 
 , users as (
-    select * from {{ ref('stg__bootcamps__app__postgres__auth_user') }}
+    select * from {{ ref('int__bootcamps__users') }}
 )
 
 , bootcamps_certificates as (
@@ -21,11 +21,13 @@ with certificates as (
         , runs.courserun_readable_id
         , runs.course_id
         , certificates.courseruncertificate_is_revoked
+        , certificates.courseruncertificate_url
         , certificates.courseruncertificate_created_on
         , certificates.courseruncertificate_updated_on
         , certificates.user_id
         , users.user_username
         , users.user_email
+        , users.user_full_name
     from certificates
     inner join runs on certificates.courserun_id = runs.courserun_id
     inner join users on certificates.user_id = users.user_id

--- a/src/ol_dbt/models/intermediate/bootcamps/int__bootcamps__courserunenrollments.sql
+++ b/src/ol_dbt/models/intermediate/bootcamps/int__bootcamps__courserunenrollments.sql
@@ -9,7 +9,7 @@ with enrollments as (
 )
 
 , users as (
-    select * from {{ ref('stg__bootcamps__app__postgres__auth_user') }}
+    select * from {{ ref('int__bootcamps__users') }}
 )
 
 , bootcamps_enrollments as (
@@ -24,6 +24,7 @@ with enrollments as (
         , runs.courserun_title
         , users.user_username
         , users.user_email
+        , users.user_full_name
     from enrollments
     inner join runs on enrollments.courserun_id = runs.courserun_id
     inner join users on enrollments.user_id = users.user_id

--- a/src/ol_dbt/models/intermediate/combined/_combined_models.yml
+++ b/src/ol_dbt/models/intermediate/combined/_combined_models.yml
@@ -88,3 +88,62 @@ models:
     description: string, user email on the corresponding platform
     tests:
     - not_null
+  - name: user_full_name
+    description: str, user full name on the corresponding platform
+  - name: user_has_certificate
+    description: boolean, indicating if user has earned certificate for enrolled course-run
+      on the corresponding platform.
+    tests:
+    - not_null
+  tests:
+  - dbt_expectations.expect_compound_columns_to_be_unique:
+      column_list: ["platform", "user_username", "courserun_readable_id"]
+
+- name: int__combined__courserun_certificates
+  description: course certificates model combined from different platforms. It excludes
+    certificates that are revoked.
+  columns:
+  - name: platform
+    description: string, application where the data is from
+    tests:
+    - not_null
+    - accepted_values:
+        values: '{{ var("platforms") }}'
+  - name: user_id
+    description: int, user ID on the corresponding platform
+    tests:
+    - not_null
+  - name: courserun_id
+    description: int, primary key representing a single course run on the corresponding
+      platform. Null for course runs from edx.org
+  - name: courserun_title
+    description: string, title of the course run on the corresponding platform. Maybe
+      blank for a few edX.org runs missing in int__edxorg__mitx_courseruns.
+  - name: courserun_readable_id
+    description: str, unique string to identify a course run on the corresponding
+      platform
+    tests:
+    - not_null
+  - name: user_username
+    description: string, username on the corresponding platform
+    tests:
+    - not_null
+  - name: user_email
+    description: string, user email on the corresponding platform
+    tests:
+    - not_null
+  - name: user_full_name
+    description: str, user full name on the corresponding platform
+  - name: courseruncertificate_url
+    description: str, the full URL to the certificate on the corresponding platform
+      if it's not invoked
+    tests:
+    - not_null
+  - name: courseruncertificate_created_on
+    description: timestamp, date and time when this course certificate was initially
+      created on the corresponding platform
+    tests:
+    - not_null
+  tests:
+  - dbt_expectations.expect_compound_columns_to_be_unique:
+      column_list: ["platform", "user_username", "courserun_readable_id"]

--- a/src/ol_dbt/models/intermediate/combined/int__combined__courserun_certificates.sql
+++ b/src/ol_dbt/models/intermediate/combined/int__combined__courserun_certificates.sql
@@ -1,0 +1,59 @@
+{{ config(materialized='view') }}
+
+with mitx_certificates as (
+    --revoked certificates are already filtered
+    select * from {{ ref('int__mitx__courserun_certificates') }}
+)
+
+, mitxpro_certificates as (
+    select * from {{ ref('int__mitxpro__courserun_certificates') }}
+    where courseruncertificate_is_revoked = false
+)
+
+, bootcamps_certificates as (
+    select * from {{ ref('int__bootcamps__courserun_certificates') }}
+    where courseruncertificate_is_revoked = false
+)
+
+select
+    platform
+    , courseruncertificate_url
+    , courseruncertificate_created_on
+    , user_id
+    , courserun_id
+    , courserun_title
+    , courserun_readable_id
+    , if(platform = '{{ var("mitxonline") }}', user_mitxonline_username, user_edxorg_username) as user_username
+    , user_email
+    , user_full_name
+from mitx_certificates
+
+union all
+
+select
+    '{{ var("mitxpro") }}' as platform
+    , courseruncertificate_url
+    , courseruncertificate_created_on
+    , user_id
+    , courserun_id
+    , courserun_title
+    , courserun_readable_id
+    , user_username
+    , user_email
+    , user_full_name
+from mitxpro_certificates
+
+union all
+
+select
+    '{{ var("bootcamps") }}' as platform
+    , courseruncertificate_url
+    , courseruncertificate_created_on
+    , user_id
+    , courserun_id
+    , courserun_title
+    , courserun_readable_id
+    , user_username
+    , user_email
+    , user_full_name
+from bootcamps_certificates

--- a/src/ol_dbt/models/intermediate/combined/int__combined__courserun_enrollments.sql
+++ b/src/ol_dbt/models/intermediate/combined/int__combined__courserun_enrollments.sql
@@ -14,6 +14,10 @@ with mitx_enrollments as (
     select * from {{ ref('int__bootcamps__courserunenrollments') }}
 )
 
+, combined_certificates as (
+    select * from {{ ref('int__combined__courserun_certificates') }}
+)
+
 , combined_enrollments as (
     select
         platform
@@ -27,6 +31,7 @@ with mitx_enrollments as (
         , courserun_readable_id
         , user_username
         , user_email
+        , user_full_name
     from mitx_enrollments
 
     union all
@@ -43,6 +48,7 @@ with mitx_enrollments as (
         , courserun_readable_id
         , user_username
         , user_email
+        , user_full_name
     from mitxpro_enrollments
 
     union all
@@ -59,7 +65,16 @@ with mitx_enrollments as (
         , courserun_readable_id
         , user_username
         , user_email
+        , user_full_name
     from bootcamps_enrollments
 )
 
-select * from combined_enrollments
+select
+    combined_enrollments.*
+    , if(combined_certificates.platform is not null, true, false) as user_has_certificate
+from combined_enrollments
+left join combined_certificates
+    on
+        combined_enrollments.platform = combined_certificates.platform
+        and combined_enrollments.user_username = combined_certificates.user_username
+        and combined_enrollments.courserun_readable_id = combined_certificates.courserun_readable_id

--- a/src/ol_dbt/models/intermediate/mitxpro/_int_mitxpro__models.yml
+++ b/src/ol_dbt/models/intermediate/mitxpro/_int_mitxpro__models.yml
@@ -918,6 +918,10 @@ models:
     description: str, user email associated with their account
     tests:
     - not_null
+  - name: user_full_name
+    description: str, the user's full name
+    tests:
+    - not_null
   - name: ecommerce_order_id
     description: int, id of order associated with the payment for the enrollment
   - name: ecommerce_company_id
@@ -1339,6 +1343,11 @@ models:
     - relationships:
         to: ref('int__mitxpro__users')
         field: user_id
+  - name: courseruncertificate_url
+    description: str, the full URL to the certificate on MIT xPro if it's not invoked
+    tests:
+    - unique
+    - not_null
   - name: courseruncertificate_is_revoked
     description: boolean, indicating whether the certificate is revoked and invalid
   - name: courseruncertificate_created_on
@@ -1361,6 +1370,10 @@ models:
     - not_null
   - name: user_email
     description: str, email
+    tests:
+    - not_null
+  - name: user_full_name
+    description: str, the user's full name
     tests:
     - not_null
   tests:

--- a/src/ol_dbt/models/intermediate/mitxpro/int__mitxpro__courserun_certificates.sql
+++ b/src/ol_dbt/models/intermediate/mitxpro/int__mitxpro__courserun_certificates.sql
@@ -22,11 +22,13 @@ with certificates as (
         , runs.courserun_url
         , runs.course_id
         , certificates.courseruncertificate_is_revoked
+        , certificates.courseruncertificate_url
         , certificates.courseruncertificate_created_on
         , certificates.courseruncertificate_updated_on
         , certificates.user_id
         , users.user_username
         , users.user_email
+        , users.user_full_name
     from certificates
     inner join runs on certificates.courserun_id = runs.courserun_id
     inner join users on certificates.user_id = users.user_id

--- a/src/ol_dbt/models/intermediate/mitxpro/int__mitxpro__courserunenrollments.sql
+++ b/src/ol_dbt/models/intermediate/mitxpro/int__mitxpro__courserunenrollments.sql
@@ -13,6 +13,7 @@ with enrollments as (
         user_id
         , user_username
         , user_email
+        , user_full_name
     from {{ ref('stg__mitxpro__app__postgres__users_user') }}
 )
 
@@ -29,6 +30,7 @@ with enrollments as (
         , runs.courserun_title
         , users.user_username
         , users.user_email
+        , users.user_full_name
         , enrollments.ecommerce_company_id
         , enrollments.ecommerce_order_id
     from enrollments

--- a/src/ol_dbt/models/staging/bootcamps/_stg_bootcamps__models.yml
+++ b/src/ol_dbt/models/staging/bootcamps/_stg_bootcamps__models.yml
@@ -382,6 +382,11 @@ models:
     - relationships:
         to: ref('stg__bootcamps__app__postgres__auth_user')
         field: user_id
+  - name: courseruncertificate_url
+    description: str, the full URL to the certificate on Bootcamps if it's not invoked
+    tests:
+    - unique
+    - not_null
   - name: courseruncertificate_created_on
     description: timestamp, specifying when a certificate was initially created
   - name: courseruncertificate_updated_on

--- a/src/ol_dbt/models/staging/bootcamps/stg__bootcamps__app__postgres__courses_courseruncertificate.sql
+++ b/src/ol_dbt/models/staging/bootcamps/stg__bootcamps__app__postgres__courses_courseruncertificate.sql
@@ -11,6 +11,8 @@ with source as (
         , bootcamp_run_id as courserun_id
         , user_id
         , is_revoked as courseruncertificate_is_revoked
+        , if(is_revoked = false, concat('https://bootcamps.mit.edu/certificate/', uuid), null)
+            as courseruncertificate_url
         ,{{ cast_timestamp_to_iso8601('created_on') }} as courseruncertificate_created_on
         ,{{ cast_timestamp_to_iso8601('updated_on') }} as courseruncertificate_updated_on
     from source

--- a/src/ol_dbt/models/staging/mitxonline/_stg_mitxonline__models.yml
+++ b/src/ol_dbt/models/staging/mitxonline/_stg_mitxonline__models.yml
@@ -1015,7 +1015,7 @@ models:
     - unique
     - not_null
   - name: courseruncertificate_url
-    description: str, the full URL to the certificate on MITx Online
+    description: str, the full URL to the certificate on MITx Online if it's not invoked
     tests:
     - unique
     - not_null

--- a/src/ol_dbt/models/staging/mitxonline/stg__mitxonline__app__postgres__courses_courseruncertificate.sql
+++ b/src/ol_dbt/models/staging/mitxonline/stg__mitxonline__app__postgres__courses_courseruncertificate.sql
@@ -12,7 +12,8 @@ with source as (
         , user_id
         , certificate_page_revision_id  --- rename it after the referenced model is created
         , is_revoked as courseruncertificate_is_revoked
-        , concat('https://mitxonline.mit.edu/certificate/', uuid) as courseruncertificate_url
+        , if(is_revoked = false, concat('https://mitxonline.mit.edu/certificate/', uuid), null)
+            as courseruncertificate_url
         ,{{ cast_timestamp_to_iso8601('created_on') }} as courseruncertificate_created_on
         ,{{ cast_timestamp_to_iso8601('updated_on') }} as courseruncertificate_updated_on
     from source

--- a/src/ol_dbt/models/staging/mitxpro/_stg_mitxpro__models.yml
+++ b/src/ol_dbt/models/staging/mitxpro/_stg_mitxpro__models.yml
@@ -1255,6 +1255,11 @@ models:
     - relationships:
         to: ref('stg__mitxpro__app__postgres__users_user')
         field: user_id
+  - name: courseruncertificate_url
+    description: str, the full URL to the certificate on xPro if it's not invoked
+    tests:
+    - unique
+    - not_null
   - name: certificate_page_revision_id
     description: int, foreign key to wagtailcore_pagerevision (could be blank)
   - name: courseruncertificate_created_on

--- a/src/ol_dbt/models/staging/mitxpro/stg__mitxpro__app__postgres__courses_courseruncertificate.sql
+++ b/src/ol_dbt/models/staging/mitxpro/stg__mitxpro__app__postgres__courses_courseruncertificate.sql
@@ -12,6 +12,7 @@ with source as (
         , user_id
         , certificate_page_revision_id  --- rename it after the referenced model is created
         , is_revoked as courseruncertificate_is_revoked
+        , if(is_revoked = false, concat('https://xpro.mit.edu/certificate/', uuid), null) as courseruncertificate_url
         ,{{ cast_timestamp_to_iso8601('created_on') }} as courseruncertificate_created_on
         ,{{ cast_timestamp_to_iso8601('updated_on') }} as courseruncertificate_updated_on
     from source


### PR DESCRIPTION

# What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
N/A

# Description (What does it do?)
<!--- Describe your changes in detail -->
Creates `int__combined__courserun_certificates` from MITx, xPro and Bootcamps
Adds `user_has_certificate` to `int__combined__courserun_enrollments` to simplify query like https://github.com/mitodl/hq/issues/2652 
Adds `courseruncertificate_url` to upstream models

# How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->
Since it touches upstream models, it should run
```
dbt run +int__combined__courserun_certificates
dbt run +int__combined__courserun_enrollments
```
