### PR TITLE
fix: rename product_is_visible_in_bulk_form to is_private

### DIFF
--- a/src/ol_dbt/models/intermediate/mitxpro/_int_mitxpro__models.yml
+++ b/src/ol_dbt/models/intermediate/mitxpro/_int_mitxpro__models.yml
@@ -847,8 +847,7 @@ models:
   - name: product_updated_on
     description: timestamp, the timestamp the product was last updated
   - name: product_is_private
-    description: boolean, Public product is purchasable through the bulk form at
-        /ecommerce/bulk
+    description: boolean, Public product is purchasable through the bulk form at /ecommerce/bulk
     tests:
     - not_null
   - name: courserun_id

--- a/src/ol_dbt/models/intermediate/mitxpro/_int_mitxpro__models.yml
+++ b/src/ol_dbt/models/intermediate/mitxpro/_int_mitxpro__models.yml
@@ -846,9 +846,9 @@ models:
     description: timestamp, the timestamp the product was created
   - name: product_updated_on
     description: timestamp, the timestamp the product was last updated
-  - name: product_is_visible_in_bulk_form
-    description: boolean, whether or not the product is purchasable through the bulk
-      form at /ecommerce/bulk
+  - name: product_is_private
+    description: boolean, Public product is purchasable through the bulk form at
+        /ecommerce/bulk
     tests:
     - not_null
   - name: courserun_id


### PR DESCRIPTION
# What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
None, Just a follow-up of https://github.com/mitodl/ol-data-platform/pull/827. Noticed while working on https://github.com/mitodl/ol-data-platform/pull/880

# Description (What does it do?)
<!--- Describe your changes in detail -->
A field was renamed in xPro from product_is_visible_in_bulk_form to is_private. It was also renamed in the data platform, but somehow I missed an instance.


# How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

Run `dbt build -s +marts__mitxpro_ecommerce_productlist --vars 'schema_suffix: asad'` without these changes and with these changes.
