### PR TITLE
fix: Ensure that all edX files get uploaded

### DIFF
--- a/src/ol_orchestrate/jobs/open_edx.py
+++ b/src/ol_orchestrate/jobs/open_edx.py
@@ -44,13 +44,15 @@ from ol_orchestrate.resources.sqlite_db import sqlite_db_resource
 def edx_course_pipeline():
     course_list = list_courses()
     extracts_upload = upload_extracted_data(
-        write_course_list_csv(edx_course_ids=course_list),
-        enrolled_users(edx_course_ids=course_list),
-        student_submissions(edx_course_ids=course_list),
-        course_roles(edx_course_ids=course_list),
-        user_roles(edx_course_ids=course_list),
-        course_enrollments(edx_course_ids=course_list),
-        export_edx_forum_database(),
+        uploads=[
+            write_course_list_csv(edx_course_ids=course_list),
+            enrolled_users(edx_course_ids=course_list),
+            student_submissions(edx_course_ids=course_list),
+            course_roles(edx_course_ids=course_list),
+            user_roles(edx_course_ids=course_list),
+            course_enrollments(edx_course_ids=course_list),
+            export_edx_forum_database(),
+        ]
     )
     export_edx_courses.with_hooks(
         {

--- a/src/ol_orchestrate/ops/open_edx.py
+++ b/src/ol_orchestrate/ops/open_edx.py
@@ -660,16 +660,10 @@ def write_course_list_csv(context: OpExecutionContext, edx_course_ids: list[str]
     },
     out={"edx_daily_extracts_directory": Out(dagster_type=String)},
 )
-def upload_extracted_data(  # noqa: PLR0913
+def upload_extracted_data(
     context: OpExecutionContext,
-    edx_course_ids_csv: DagsterPath,  # noqa: ARG001
-    edx_course_roles: DagsterPath,  # noqa: ARG001
-    edx_user_roles: DagsterPath,  # noqa: ARG001
-    edx_enrolled_users: DagsterPath,  # noqa: ARG001
-    edx_student_submissions: DagsterPath,  # noqa: ARG001
-    edx_enrollment_records: DagsterPath,  # noqa: ARG001
-    edx_forum_data_directory: DagsterPath,  # noqa: ARG001
     config: UploadExtractedDataConfig,
+    uploads: list[DagsterPath],
 ):
     """Upload all data exports to S3 so that institutional research can ingest.
 
@@ -710,7 +704,7 @@ def upload_extracted_data(  # noqa: PLR0913
     :yield: The S3 path of the uploaded directory
     """
     results_bucket = config.edx_etl_results_bucket
-    for path_object in context.resources.results_dir.path.iterdir():
+    for path_object in uploads:
         if path_object.is_dir():
             for fpath in path_object.iterdir():
                 file_key = str(


### PR DESCRIPTION
# What are the relevant tickets?
Addresses https://github.mit.edu/IR/simeon-internal/issues/44

# Description (What does it do?)
Because the logic is iterating over the ResultsDir resource, there is no guarantee that the files are actually present in the resource as created in that step. This changes to accept a list of DagsterPath objects that get iterated over and recursively uploaded to be more explicit about passing of files.

# How can this be tested?
Run the open edX pipelines and ensure that all of the generated CSVs get properly uploaded to S3

# Additional Context
The results_dir resource definition was recently refactored to use the new Pythonic interface. That likely led to some implicit changes in how it functioned, leading to the implicit passing of files via the resource not functioning properly anymore.

