### PR TITLE
remove accidentally added user_id from int__mitx__courserun_certificates

### DIFF
--- a/src/ol_dbt/models/intermediate/mitx/int__mitx__courserun_certificates.sql
+++ b/src/ol_dbt/models/intermediate/mitx/int__mitx__courserun_certificates.sql
@@ -57,7 +57,6 @@ with mitxonline_certificates as (
         , user_edxorg_username
         , user_email
         , user_full_name
-        , user_id
     from mitxonline_non_dedp_course_certificates
 
     union all
@@ -73,7 +72,6 @@ with mitxonline_certificates as (
         , user_username as user_edxorg_username
         , user_email
         , user_full_name
-        , user_id
     from edxorg_non_program_course_certificates
 
     union all


### PR DESCRIPTION
# What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
N/A

# Description (What does it do?)
<!--- Describe your changes in detail -->
I accidentally committed the changes for adding user_id in `int__mitx__courserun_certificates` in this [PR](https://github.com/mitodl/ol-data-platform/pull/882/files#diff-0ac4cb5f1bc08a758695fecd88e69fd6e12d45e1b1f82380fd42445b8bad68e3), which breaks this model build

# How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

run `dbt build --select int__mitx__courserun_certificates`, it should has no error 
