### PR TITLE
Log normalization bugfix

### DIFF
--- a/src/ol_orchestrate/definitions/edx/normalize_tracking_logs.py
+++ b/src/ol_orchestrate/definitions/edx/normalize_tracking_logs.py
@@ -52,7 +52,7 @@ def daily_tracking_log_config(
     global dagster_env  # noqa: PLW0603
     if dagster_env == "dev":
         dagster_env = "qa"
-        path_prefix = "edxorg-raw-data/logs" if deployment == "edxorg" else "logs"
+    path_prefix = "edxorg-raw-data/logs" if deployment == "edxorg" else "logs"
     log_bucket = (
         f"ol-data-lake-landing-zone-{dagster_env}"
         if deployment == "edxorg"


### PR DESCRIPTION
Bugfix, indentation was preventing path_prefix from being set in QA/PROD environments.

# What are the relevant tickets?
Original issue: #[1309](https://github.com/mitodl/hq/issues/1309)
[Pull request](https://github.com/mitodl/ol-data-platform/pull/876)

# Description (What does it do?)
In a previous pull request, [this line](https://github.com/mitodl/ol-data-platform/blob/main/src/ol_orchestrate/definitions/edx/normalize_tracking_logs.py#L55) was indented too far, falling within an in block that only executes in dev, which is why this wasn't a problem during testing.


# Screenshots (if appropriate):
This results in the following error on Dagster:
<img width="1363" alt="Screenshot 2023-10-23 at 11 49 45 AM" src="https://github.com/mitodl/ol-data-platform/assets/59845076/5fd616d9-8814-4201-8265-74749e85c316">


# How can this be tested?
This can be tested by running the log normalization pipeline locally.
Command to initiate a Dagster instance locally:
`dagster dev -d src/ol_orchestrate -f src/ol_orchestrate/definitions/edx/normalize_tracking_logs.py`


## Checklist:
- [ ] Test changes locally
- [ ] Test changes in QA using partitions
