### PR TITLE
Fixed file path for edx.org files in production.

### DIFF
--- a/src/ol_orchestrate/definitions/edx/normalize_tracking_logs.py
+++ b/src/ol_orchestrate/definitions/edx/normalize_tracking_logs.py
@@ -83,7 +83,7 @@ def daily_tracking_log_config(
                     "path_prefix": path_prefix if destination == "valid" else "valid",
                 },
                 "inputs": {
-                    "log_date": f"{log_date.strftime('%Y-%m-%d')}/",
+                    "log_date": f"{log_date.strftime('%Y-%m-%d')}",
                 },
             },
             "export_processed_data_to_s3": {
@@ -97,7 +97,7 @@ def daily_tracking_log_config(
                     else destination,
                 },
                 "inputs": {
-                    "log_date": f"{log_date.strftime('%Y-%m-%d')}/",
+                    "log_date": f"{log_date.strftime('%Y-%m-%d')}",
                 },
             },
         },

--- a/src/ol_orchestrate/definitions/edx/normalize_tracking_logs.py
+++ b/src/ol_orchestrate/definitions/edx/normalize_tracking_logs.py
@@ -92,7 +92,8 @@ def daily_tracking_log_config(
                     "source_path_prefix": path_prefix
                     if destination == "valid"
                     else "valid",
-                    "destination_path_prefix": f"{path_prefix}/{destination}"
+                    # replace "edxorg-raw-data/logs" with "edxorg-raw-data/valid"
+                    "destination_path_prefix": f"{path_prefix.rsplit('/', maxsplit=1)[-2]}/{destination}"  # noqa: E501
                     if deployment == "edxorg"
                     else destination,
                 },

--- a/src/ol_orchestrate/ops/normalize_logs.py
+++ b/src/ol_orchestrate/ops/normalize_logs.py
@@ -54,7 +54,7 @@ class WriteFilesConfig(Config):
     ins={
         "log_date": In(
             dagster_type=String,
-            description="Log date prefix to load files from (Format 'YYYY-MM-DD/')}'",
+            description="Log date prefix to load files from (Format 'YYYY-MM-DD')}'",
         )
     },
 )
@@ -73,18 +73,18 @@ def load_files_to_table(
     :param config: Dagster execution config for propagaint configuration data.
     :type config: Config
 
-    :log_date: S3 Bucket log date prefix to load logs from (Format 'YYYY-MM-DD/')
+    :log_date: S3 Bucket log date prefix to load logs from (Format 'YYYY-MM-DD')
     :type log_date: str
 
     """
     source_bucket = config.tracking_log_bucket
-    path_prefix = config.path_prefix
-    # DuckDB Glob Syntax: ** matches any number of subdirectories (including none)
-    s3_path = (
-        f"s3://{source_bucket}/{path_prefix}/{log_date}**"
-        if config.path_prefix == "logs"
-        else f"s3://{source_bucket}/{path_prefix}/**"
+    path_prefix = (
+        f"{config.path_prefix}/{log_date}"
+        if "-edxapp-tracking" in config.tracking_log_bucket
+        else config.path_prefix
     )
+    # DuckDB Glob Syntax: ** matches any number of subdirectories (including none)
+    s3_path = f"s3://{source_bucket}/{path_prefix}/**"
     context.log.info(s3_path)
     with context.resources.duckdb.get_connection() as conn:
         conn.execute("DROP TABLE IF EXISTS tracking_logs")
@@ -222,7 +222,7 @@ def jsonify_log_data(context: OpExecutionContext) -> Nothing:
         "columns": In(dagster_type=List[String]),
         "log_date": In(
             dagster_type=String,
-            description="Log date prefix to load files from (Format 'YYYY-MM-DD/')}'",
+            description="Log date prefix to load files from (Format 'YYYY-MM-DD')}'",
         ),
     },
 )
@@ -268,7 +268,7 @@ def write_file_to_s3(
             context.resources.s3.upload_file(
                 Filename=local_file_name,
                 Bucket=config.tracking_log_bucket,
-                Key=f"{config.destination_path_prefix}/{log_date}{local_file_name}",
+                Key=f"{config.destination_path_prefix}/{log_date}/{local_file_name}",
             )
             Path(local_file_name).unlink()
     Path(context.resources.duckdb.database).unlink()

--- a/src/ol_orchestrate/ops/normalize_logs.py
+++ b/src/ol_orchestrate/ops/normalize_logs.py
@@ -83,7 +83,7 @@ def load_files_to_table(
     s3_path = (
         f"s3://{source_bucket}/{path_prefix}/{log_date}**"
         if config.path_prefix == "logs"
-        else f"s3://{source_bucket}/{path_prefix}**"
+        else f"s3://{source_bucket}/{path_prefix}/**"
     )
     context.log.info(s3_path)
     with context.resources.duckdb.get_connection() as conn:


### PR DESCRIPTION
# What are the relevant tickets?
Bugfix related to #1309 [Ingest CSV and tracking log data from edx.org via Airbyte](https://github.com/mitodl/hq/issues/1309)

# Description (What does it do?)
Most of our tracking log sources have a dated directory with a set of log files under the `logs` directory matching this glob pattern: `bucket/logs/date/logfile.gz` (mitxonline, mitxonline, xpro : qa + prod)
However, the edx.org logs are currently stored at this path: `bucket/edxorg-raw-data/logs/logfile.gz` (edxorg: qa + prod)

This PR updates the glob pattern we are using currently to filter files in order to capture edx.org logs.
The glob pattern should be: "s3://{source_bucket}/edxorg-raw-data/logs/**") for edx.org files and 
 is: `s3_path = f"s3://{source_bucket}/{logs}/{log_date}/**"` for all the other deployments.

Keeping track of whether or not the trailing slash was passed in at the config level was a bit confusing, so this PR updates all of the path variables and config elements to remove trailing slashes. Trailing slashes are added where necessary when a full path is actually being composed or used within an op.

That edx.org path is in our control because our retrieve_edx_exports pipeline downloads those files from GCP and stages them in an S3 bucket. Ideally, the retrieve_edx_exports upload op code should be refactored to include a dated subdirectory, which ensures we are matching the same structure of the other tracking log buckets. This will reduce the number of conditional statements needed and improve readability. When that change happens, this will need to be refactored to update the glob pattern for edx.org logs.

# How can this be tested?
This was tested by running the pipeline locally via:
`dagster dev -d src/ol_orchestrate -f src/ol_orchestrate/definitions/edx/normalize_tracking_logs.py`
I ran this locally against QA files for each deployment: mitx, mitxonline, xpro, edxorg to confirm that the download steps were completing successfully. I commented out the SQL executions in the transformation code in order to speed up testing.