### PR TITLE
add two new fields for tax amounts to int__mitxpro__ecommerce_order

### DIFF
--- a/src/ol_dbt/models/intermediate/mitxpro/_int_mitxpro__models.yml
+++ b/src/ol_dbt/models/intermediate/mitxpro/_int_mitxpro__models.yml
@@ -719,6 +719,10 @@ models:
     description: numeric, the tax rate to apply
   - name: order_tax_rate_name
     description: string, name of the tax rate assessed
+  - name: order_tax_amount
+    description: numeric, the amount of tax paid
+  - name: order_total_price_paid_plus_tax
+    description: numeric, total order amount plus the amount of tax paid
   tests:
   - dbt_expectations.expect_table_row_count_to_equal_other_table:
       compare_model: ref('stg__mitxpro__app__postgres__ecommerce_order')

--- a/src/ol_dbt/models/intermediate/mitxpro/int__mitxpro__ecommerce_order.sql
+++ b/src/ol_dbt/models/intermediate/mitxpro/int__mitxpro__ecommerce_order.sql
@@ -31,7 +31,7 @@ select
     , orders.order_tax_rate
     , orders.order_tax_rate_name
     , (orders.order_total_price_paid * (orders.order_tax_rate / 100)) as order_tax_amount
-    , (orders.order_total_price_paid * (orders.order_tax_rate / 100))
+    , (orders.order_total_price_paid * (orders.order_tax_rate / 100)) 
     + orders.order_total_price_paid as order_total_price_paid_plus_tax
 from orders
 left join couponredemption on orders.order_id = couponredemption.order_id

--- a/src/ol_dbt/models/intermediate/mitxpro/int__mitxpro__ecommerce_order.sql
+++ b/src/ol_dbt/models/intermediate/mitxpro/int__mitxpro__ecommerce_order.sql
@@ -13,11 +13,6 @@ with orders as (
     from {{ ref('stg__mitxpro__app__postgres__ecommerce_couponversion') }}
 )
 
-, couponpaymentversion as (
-    select *
-    from {{ ref('stg__mitxpro__app__postgres__ecommerce_couponpaymentversion') }}
-)
-
 select
     orders.order_id
     , orders.order_state
@@ -31,9 +26,8 @@ select
     , orders.order_tax_rate
     , orders.order_tax_rate_name
     , (orders.order_total_price_paid * (orders.order_tax_rate / 100)) as order_tax_amount
-    , (orders.order_total_price_paid * (orders.order_tax_rate / 100))
+    , (orders.order_total_price_paid * (orders.order_tax_rate / 100)) 
     + orders.order_total_price_paid as order_total_price_paid_plus_tax
 from orders
 left join couponredemption on orders.order_id = couponredemption.order_id
 left join couponversion on couponredemption.couponversion_id = couponversion.couponversion_id
-left join couponpaymentversion on couponversion.couponpaymentversion_id = couponpaymentversion.couponpaymentversion_id

--- a/src/ol_dbt/models/intermediate/mitxpro/int__mitxpro__ecommerce_order.sql
+++ b/src/ol_dbt/models/intermediate/mitxpro/int__mitxpro__ecommerce_order.sql
@@ -13,6 +13,11 @@ with orders as (
     from {{ ref('stg__mitxpro__app__postgres__ecommerce_couponversion') }}
 )
 
+, couponpaymentversion as (
+    select *
+    from {{ ref('stg__mitxpro__app__postgres__ecommerce_couponpaymentversion') }}
+)
+
 select
     orders.order_id
     , orders.order_state
@@ -25,6 +30,10 @@ select
     , orders.order_tax_country_code
     , orders.order_tax_rate
     , orders.order_tax_rate_name
+    , (orders.order_total_price_paid * (orders.order_tax_rate/100)) as order_tax_amount
+    , (orders.order_total_price_paid * (orders.order_tax_rate/100)) 
+        + orders.order_total_price_paid as order_total_price_paid_plus_tax
 from orders
 left join couponredemption on orders.order_id = couponredemption.order_id
 left join couponversion on couponredemption.couponversion_id = couponversion.couponversion_id
+left join couponpaymentversion on couponversion.couponpaymentversion_id = couponpaymentversion.couponpaymentversion_id

--- a/src/ol_dbt/models/intermediate/mitxpro/int__mitxpro__ecommerce_order.sql
+++ b/src/ol_dbt/models/intermediate/mitxpro/int__mitxpro__ecommerce_order.sql
@@ -30,9 +30,9 @@ select
     , orders.order_tax_country_code
     , orders.order_tax_rate
     , orders.order_tax_rate_name
-    , (orders.order_total_price_paid * (orders.order_tax_rate/100)) as order_tax_amount
-    , (orders.order_total_price_paid * (orders.order_tax_rate/100)) 
-        + orders.order_total_price_paid as order_total_price_paid_plus_tax
+    , (orders.order_total_price_paid * (orders.order_tax_rate / 100)) as order_tax_amount
+    , (orders.order_total_price_paid * (orders.order_tax_rate / 100))
+    + orders.order_total_price_paid as order_total_price_paid_plus_tax
 from orders
 left join couponredemption on orders.order_id = couponredemption.order_id
 left join couponversion on couponredemption.couponversion_id = couponversion.couponversion_id

--- a/src/ol_dbt/models/intermediate/mitxpro/int__mitxpro__ecommerce_order.sql
+++ b/src/ol_dbt/models/intermediate/mitxpro/int__mitxpro__ecommerce_order.sql
@@ -31,7 +31,7 @@ select
     , orders.order_tax_rate
     , orders.order_tax_rate_name
     , (orders.order_total_price_paid * (orders.order_tax_rate / 100)) as order_tax_amount
-    , (orders.order_total_price_paid * (orders.order_tax_rate / 100)) 
+    , (orders.order_total_price_paid * (orders.order_tax_rate / 100))
     + orders.order_total_price_paid as order_total_price_paid_plus_tax
 from orders
 left join couponredemption on orders.order_id = couponredemption.order_id

--- a/src/ol_dbt/models/intermediate/mitxpro/int__mitxpro__ecommerce_order.sql
+++ b/src/ol_dbt/models/intermediate/mitxpro/int__mitxpro__ecommerce_order.sql
@@ -26,7 +26,7 @@ select
     , orders.order_tax_rate
     , orders.order_tax_rate_name
     , (orders.order_total_price_paid * (orders.order_tax_rate / 100)) as order_tax_amount
-    , (orders.order_total_price_paid * (orders.order_tax_rate / 100)) 
+    , (orders.order_total_price_paid * (orders.order_tax_rate / 100))
     + orders.order_total_price_paid as order_total_price_paid_plus_tax
 from orders
 left join couponredemption on orders.order_id = couponredemption.order_id


### PR DESCRIPTION
# What are the relevant tickets?
https://github.com/mitodl/mitxpro/issues/2771

# Description (What does it do?)
add order_tax_amount and order_total_price_paid_plus_tax to the int__mitxpro__ecommerce_order table

# How can this be tested?
Run the following commands against your schema or QA
Run dbt build --select intermediate.mitxpro if you have all models, otherwise add + in front of intermediate.mitxpro to run upstream models
