### PR TITLE
Refactored path prefix to look for log_date in filename

### DIFF
--- a/src/ol_orchestrate/ops/normalize_logs.py
+++ b/src/ol_orchestrate/ops/normalize_logs.py
@@ -78,13 +78,10 @@ def load_files_to_table(
 
     """
     source_bucket = config.tracking_log_bucket
-    path_prefix = (
-        f"{config.path_prefix}/{log_date}"
-        if "-edxapp-tracking" in config.tracking_log_bucket
-        else config.path_prefix
-    )
     # DuckDB Glob Syntax: ** matches any number of subdirectories (including none)
-    s3_path = f"s3://{source_bucket}/{path_prefix}/**"
+    # * matches anything but slashes (log file must have date in filename)
+    path_prefix = f"{config.path_prefix}/**/*{log_date}*"
+    s3_path = f"s3://{source_bucket}/{path_prefix}"
     context.log.info(s3_path)
     with context.resources.duckdb.get_connection() as conn:
         conn.execute("DROP TABLE IF EXISTS tracking_logs")


### PR DESCRIPTION
# What are the relevant tickets?
Bugfix related to #1309 [Ingest CSV and tracking log data from edx.org via Airbyte](https://github.com/mitodl/hq/issues/1309)

The glob pattern `s3://ol-data-lake-landing-zone-qa/edxorg-raw-data/logs/**` was picking up all the files within the logs/ folder. This was unintended as the pattern should be filtering files matching the log date provided as input. This is needed for when we are running this pipeline by partitions.

# Description (What does it do?)
Refactored path prefix to look for log_date in filename
[Reduced to one glob pattern for both edx.org files and other deployments](https://www.digitalocean.com/community/tools/glob?comments=true&glob=s3%3A%2F%2Fol-data-lake-landing-zone-qa%2Fedxorg-raw-data%2Flogs%2F%2A%2A%2F%2A2023-10-10%2A&matches=false&tests=%23%20edxorg%20data%20files&tests=s3%3A%2F%2Fol-data-lake-landing-zone-qa%2Fedxorg-raw-data%2Flogs%2F2023-10-10%2Fmitx-edx-events-2023-10-10.log.gz&tests=%23%20other%20deployments&tests=s3%3A%2F%2Fol-data-lake-landing-zone-qa%2Fedxorg-raw-data%2Flogs%2F2023-10-10%2F2023-10-10_a_log_file.gz&tests=%23%20other%20examples&tests=s3%3A%2F%2Fol-data-lake-landing-zone-qa%2Fedxorg-raw-data%2Flogs%2F2023-10-10%2Fb_log_file_2023-10-10.gz&tests=s3%3A%2F%2Fol-data-lake-landing-zone-qa%2Fedxorg-raw-data%2Flogs%2F2023-10-10%2Ffoo%2Fbar%2Fmitx-edx-events-2023-10-10.log.file.zip)

# How can this be tested?
This was tested by running the pipeline locally via:
`dagster dev -d src/ol_orchestrate -f src/ol_orchestrate/definitions/edx/normalize_tracking_logs.py`
I ran this locally against QA files for each deployment: mitx, mitxonline, xpro, edxorg to confirm that the download steps were completing successfully.