### PR TITLE
Create combined enrollment mart and upstream changes

### DIFF
--- a/src/ol_dbt/models/intermediate/bootcamps/_int_bootcamps__models.yml
+++ b/src/ol_dbt/models/intermediate/bootcamps/_int_bootcamps__models.yml
@@ -50,6 +50,27 @@ models:
     description: json, cybersource data for a payment
     tests:
     - not_null
+  - name: receipt_reference_number
+    description: str, transaction reference number from user's cybersource payment
+    tests:
+    - not_null
+  - name: receipt_transaction_status
+    description: str, transaction status from cybersource payment. Value could be
+      ACCEPT, CANCEL, ERROR, REVIEW or DECLINE.
+    tests:
+    - not_null
+  - name: receipt_transaction_id
+    description: str, transaction identifier from cybersource payment. Maybe blank
+      for CANCEL or ERROR transactions.
+  - name: receipt_payment_method
+    description: str, payment method from cybersource transaction. Value could be
+      'paypal' or 'card' if payment is not cancelled
+  - name: receipt_authorization_code
+    description: str, authorization code from cybersource payment
+  - name: receipt_bill_to_address_state
+    description: str, address state from cybersource payment
+  - name: receipt_bill_to_address_country
+    description: str, address country from cybersource payment
   - name: order_id
     description: int, primary key in ecommerce_order
   tests:
@@ -60,6 +81,11 @@ models:
   columns:
   - name: order_id
     description: int, primary key representing a single bootcamps order
+    tests:
+    - unique
+    - not_null
+  - name: order_reference_number
+    description: string, readable id for the order formatted as BOOTCAMP-prod-<ORDER_ID>
     tests:
     - unique
     - not_null
@@ -107,6 +133,24 @@ models:
     description: int, foreign key in courses_courserun of the purchased run
     tests:
     - not_null
+  - name: line_price
+    description: numeric, list price for the order line
+    tests:
+    - not_null
+  - name: receipt_reference_number
+    description: str, transaction reference number from cybersource payment
+  - name: receipt_transaction_id
+    description: str, transaction identifier from cybersource payment. Maybe blank
+      for CANCEL or ERROR transactions.
+  - name: receipt_payment_method
+    description: str, payment method from cybersource transaction. Value could be
+      'paypal' or 'card' if payment is not cancelled
+  - name: receipt_authorization_code
+    description: str, authorization code from cybersource payment
+  - name: receipt_bill_to_address_state
+    description: str, address state from cybersource payment
+  - name: receipt_bill_to_address_country
+    description: str, address country from cybersource payment
   tests:
   - dbt_expectations.expect_table_row_count_to_equal_other_table:
       compare_model: ref('stg__bootcamps__app__postgres__ecommerce_order')

--- a/src/ol_dbt/models/intermediate/bootcamps/int__bootcamps__ecommerce_order.sql
+++ b/src/ol_dbt/models/intermediate/bootcamps/int__bootcamps__ecommerce_order.sql
@@ -8,8 +8,13 @@ with orders as (
     from {{ ref('stg__bootcamps__app__postgres__ecommerce_line') }}
 )
 
+, receipts as (
+    select * from {{ ref('stg__bootcamps__app__postgres__ecommerce_receipt') }}
+)
+
 select
     orders.order_id
+    , orders.order_reference_number
     , orders.order_state
     , orders.order_purchaser_user_id
     , orders.application_id
@@ -20,5 +25,13 @@ select
     , lines.line_id
     , lines.line_description
     , lines.courserun_id
+    , lines.line_price
+    , receipts.receipt_transaction_id
+    , receipts.receipt_reference_number
+    , receipts.receipt_payment_method
+    , receipts.receipt_authorization_code
+    , receipts.receipt_bill_to_address_state
+    , receipts.receipt_bill_to_address_country
 from lines
 inner join orders on lines.order_id = orders.order_id
+left join receipts on orders.order_id = receipts.order_id

--- a/src/ol_dbt/models/intermediate/bootcamps/int__bootcamps__ecommerce_receipt.sql
+++ b/src/ol_dbt/models/intermediate/bootcamps/int__bootcamps__ecommerce_receipt.sql
@@ -7,6 +7,13 @@ select
     receipt_id
     , receipt_created_on
     , receipt_updated_on
+    , receipt_transaction_status
+    , receipt_transaction_id
+    , receipt_payment_method
+    , receipt_authorization_code
+    , receipt_reference_number
+    , receipt_bill_to_address_state
+    , receipt_bill_to_address_country
     , receipt_data
     , order_id
 from receipts

--- a/src/ol_dbt/models/intermediate/micromasters/_int_micromasters__models.yml
+++ b/src/ol_dbt/models/intermediate/micromasters/_int_micromasters__models.yml
@@ -386,3 +386,68 @@ models:
   tests:
   - dbt_expectations.expect_table_row_count_to_equal_other_table:
       compare_model: ref('__micromasters__users')
+
+- name: int__micromasters__orders
+  columns:
+  - name: order_id
+    description: int, primary key representing a single  order
+    tests:
+    - unique
+    - not_null
+  - name: order_created_on
+    description: timestamp, specifying when the order was initially created
+    tests:
+    - not_null
+  - name: order_state
+    description: string, order state. Options are "fulfilled", "failed", "created"
+      "refunded", "partially_refunded"
+    tests:
+    - not_null
+  - name: order_total_price_paid
+    description: number, total order amount
+    tests:
+    - not_null
+  - name: user_id
+    description: int, primary key in users_user for the purchaser
+    tests:
+    - not_null
+  - name: order_reference_number
+    description: string, readable id for the order
+    tests:
+    - unique
+  - name: line_price
+    description: numeric, list price for the order line
+    tests:
+    - not_null
+  - name: courserun_readable_id
+    description: string, courserun_readable_id from courses_courserun
+    tests:
+    - not_null
+  - name: courserun_edxorg_readable_id
+    description: str, courserun_readable_id formatted as {org}/{course code}/{run_tag}
+      to match course in edxorg
+  - name: receipt_transaction_id
+    description: str, transaction identifier from most recent cybersource payment
+      for the order
+  - name: receipt_payment_method
+    description: str, payment method from most recent cybersource payment for the
+      order
+  - name: receipt_authorization_code
+    description: str, authorization code from most recent cybersource payment for
+      the order
+  - name: receipt_bill_to_address_state
+    description: str, address state from most recent cybersource payment for the order
+  - name: receipt_bill_to_address_country
+    description: str, address country from most recent cybersource payment for the
+      order
+  - name: coupon_discount_amount_text
+    description: str, discount amount in readable format. It can be fixed discount
+      which is $<dollar amount> off, fixed-price which is $<dollar amount> or percent-discount
+      which is <percentage> % off
+  - name: coupon_code
+    description: str, coupon code for the redeemed coupon
+  - name: redeemedcoupon_created_on
+    description: timestamp, specifying when the coupon was redeemed for the order
+  tests:
+  - dbt_expectations.expect_table_row_count_to_equal_other_table:
+      compare_model: ref('stg__micromasters__app__postgres__ecommerce_order')

--- a/src/ol_dbt/models/intermediate/micromasters/int__micromasters__orders.sql
+++ b/src/ol_dbt/models/intermediate/micromasters/int__micromasters__orders.sql
@@ -1,0 +1,47 @@
+with orders as (
+    select * from {{ ref('stg__micromasters__app__postgres__ecommerce_order') }}
+)
+
+, lines as (
+    select * from {{ ref('stg__micromasters__app__postgres__ecommerce_line') }}
+)
+
+, coupons as (
+    select * from {{ ref('stg__micromasters__app__postgres__ecommerce_coupon') }}
+)
+
+, redeemedcoupons as (
+    select * from {{ ref('stg__micromasters__app__postgres__ecommerce_redeemedcoupon') }}
+)
+
+, receipts as (
+    select
+        *
+        , row_number() over (partition by order_id order by receipt_created_on desc) as row_num
+    from {{ ref('stg__micromasters__app__postgres__ecommerce_receipt') }}
+    where receipt_transaction_status != 'ERROR'
+)
+
+select
+    orders.order_id
+    , orders.user_id
+    , orders.order_state
+    , orders.order_reference_number
+    , orders.order_total_price_paid
+    , orders.order_created_on
+    , lines.line_price
+    , lines.courserun_readable_id
+    , lines.courserun_edxorg_readable_id
+    , receipts.receipt_transaction_id
+    , receipts.receipt_payment_method
+    , receipts.receipt_authorization_code
+    , receipts.receipt_bill_to_address_state
+    , receipts.receipt_bill_to_address_country
+    , coupons.coupon_code
+    , coupons.coupon_discount_amount_text
+    , redeemedcoupons.redeemedcoupon_created_on
+from orders
+inner join lines on orders.order_id = lines.order_id
+left join redeemedcoupons on orders.order_id = redeemedcoupons.order_id
+left join coupons on redeemedcoupons.coupon_id = coupons.coupon_id
+left join receipts on orders.order_id = receipts.order_id and receipts.row_num = 1

--- a/src/ol_dbt/models/intermediate/mitx/_int_mitx__models.yml
+++ b/src/ol_dbt/models/intermediate/mitx/_int_mitx__models.yml
@@ -178,6 +178,11 @@ models:
     - not_null
     - accepted_values:
         values: ["MITx Online", "edX.org"]
+  - name: courserunenrollment_id
+    description: int, internal ID and foreign key to courserunenrollments in MITx
+      Online. Null for enrollments on edX.org.
+    tests:
+    - unique
   - name: courserunenrollment_is_active
     description: boolean, indicating whether the user is still enrolled in the run
     tests:

--- a/src/ol_dbt/models/intermediate/mitx/int__mitx__courserun_enrollments.sql
+++ b/src/ol_dbt/models/intermediate/mitx/int__mitx__courserun_enrollments.sql
@@ -18,6 +18,7 @@ with mitxonline_enrollments as (
 , mitx_enrollments as (
     select
         '{{ var("mitxonline") }}' as platform
+        , courserunenrollment_id
         , courserunenrollment_is_active
         , courserunenrollment_created_on
         , courserunenrollment_enrollment_mode
@@ -39,6 +40,7 @@ with mitxonline_enrollments as (
 
     select
         '{{ var("edxorg") }}' as platform
+        , null as courserunenrollment_id
         , courserunenrollment_is_active
         , courserunenrollment_created_on
         , courserunenrollment_enrollment_mode

--- a/src/ol_dbt/models/intermediate/mitxonline/_int_mitxonline__models.yml
+++ b/src/ol_dbt/models/intermediate/mitxonline/_int_mitxonline__models.yml
@@ -408,6 +408,18 @@ models:
     tests:
     - accepted_values:
         values: ["refund", "payment"]
+  - name: transaction_status
+    description: str, transaction status from user's cybersource payment. Value could
+      be ACCEPT, REVIEW. May be blank for no payment required or refund.
+  - name: transaction_payment_method
+    description: str, payment method from cybersource Value could be 'paypal' or 'card'.
+      May be blank for no payment required or refund.
+  - name: transaction_authorization_code
+    description: str, authorization code from cybersource payment
+  - name: transaction_bill_to_address_state
+    description: str, address state from cybersource payment
+  - name: transaction_bill_to_address_country
+    description: str, address country from cybersource payment
   tests:
   - dbt_expectations.expect_table_row_count_to_equal_other_table:
       compare_model: ref('stg__mitxonline__app__postgres__ecommerce_transaction')
@@ -465,6 +477,10 @@ models:
     description: int. Versioned product
     tests:
     - not_null
+  - name: product_price
+    description: numeric, the price of the product for order line item
+    tests:
+    - not_null
   - name: product_type
     description: string, readable product type
     tests:
@@ -479,6 +495,27 @@ models:
     description: int, primary key representing a single MITx Online course run
   - name: programrun_id
     description: int, primary key representing a single MITx Online program run
+  - name: discount_amount_text
+    description: str, discount amount in readable format from the most recent coupon
+      redemption for the order. It can be percent-off which is <dollar amount>% off,
+      dollars-off which is $<dollar amount> off or fixed-price
+  - name: discount_code
+    description: str, discount code from the most recent coupon redemption for the
+      order
+  - name: discountredemption_timestamp
+    description: timestamp, specifying when the discount was redeemed from the most
+      recent coupon redemption for the order
+  - name: payment_transaction_id
+    description: str, unique identifier from most recent cybersource payment or UUID.
+  - name: payment_authorization_code
+    description: str, authorization code from most recent cybersource payment
+  - name: payment_method
+    description: str, payment method from most recent cybersource payment. Value could
+      be 'paypal' or 'card'.
+  - name: payment_bill_to_address_state
+    description: str, address state from most recent cybersource payment
+  - name: payment_bill_to_address_country
+    description: str, address country from most recent cybersource payment
   tests:
   - dbt_expectations.expect_table_row_count_to_equal_other_table:
       compare_model: ref('stg__mitxonline__app__postgres__ecommerce_order')

--- a/src/ol_dbt/models/intermediate/mitxonline/int__mitxonline__ecommerce_order.sql
+++ b/src/ol_dbt/models/intermediate/mitxonline/int__mitxonline__ecommerce_order.sql
@@ -32,6 +32,27 @@ with lines as (
     select * from {{ ref('int__mitxonline__ecommerce_product') }}
 )
 
+, discounts as (
+    select * from {{ ref('stg__mitxonline__app__postgres__ecommerce_discount') }}
+)
+
+, discountredemptions as (
+    select
+        *
+        , row_number() over (partition by order_id order by discountredemption_timestamp desc) as row_num
+    from {{ ref('stg__mitxonline__app__postgres__ecommerce_discountredemption') }}
+
+)
+
+---- small amounts of duplicated payments for the same order. For those, we pick the most recent one
+, payments as (
+    select
+        *
+        , row_number() over (partition by order_id order by transaction_created_on desc) as row_num
+    from {{ ref('stg__mitxonline__app__postgres__ecommerce_transaction') }}
+    where transaction_type = 'payment'
+)
+
 select
     orders.order_id
     , orders.order_state
@@ -44,12 +65,26 @@ select
     , users.user_email
     , lines.line_id
     , lines.product_version_id
+    , intermediate_products_view.product_price
     , intermediate_products_view.product_type
     , intermediate_products_view.product_id
     , intermediate_products_view.courserun_id
     , intermediate_products_view.programrun_id
+    , discounts.discount_code
+    , discounts.discount_amount_text
+    , discountredemptions.discountredemption_timestamp
+    , payments.transaction_authorization_code as payment_authorization_code
+    , payments.transaction_payment_method as payment_method
+    , payments.transaction_readable_identifier as payment_transaction_id
+    , payments.transaction_bill_to_address_state as payment_bill_to_address_state
+    , payments.transaction_bill_to_address_country as payment_bill_to_address_country
 from lines
 inner join orders on lines.order_id = orders.order_id
 inner join users on orders.order_purchaser_user_id = users.user_id
 inner join versions on lines.product_version_id = versions.version_id
 inner join intermediate_products_view on versions.version_object_id = intermediate_products_view.product_id
+left join payments
+    on orders.order_id = payments.order_id and payments.row_num = 1
+left join discountredemptions
+    on orders.order_id = discountredemptions.order_id and discountredemptions.row_num = 1
+left join discounts on discountredemptions.discount_id = discounts.discount_id

--- a/src/ol_dbt/models/intermediate/mitxonline/int__mitxonline__ecommerce_order.sql
+++ b/src/ol_dbt/models/intermediate/mitxonline/int__mitxonline__ecommerce_order.sql
@@ -36,6 +36,9 @@ with lines as (
     select * from {{ ref('stg__mitxonline__app__postgres__ecommerce_discount') }}
 )
 
+---- this table doesn't have constraint so apply additional logic here as there should be only one discount
+---- that's actually applied to an order
+
 , discountredemptions as (
     select
         *

--- a/src/ol_dbt/models/intermediate/mitxonline/int__mitxonline__ecommerce_transaction.sql
+++ b/src/ol_dbt/models/intermediate/mitxonline/int__mitxonline__ecommerce_transaction.sql
@@ -11,4 +11,9 @@ select
     , transactions.transaction_created_on
     , transactions.transaction_readable_identifier
     , transactions.transaction_type
+    , transaction_status
+    , transaction_authorization_code
+    , transaction_payment_method
+    , transaction_bill_to_address_state
+    , transaction_bill_to_address_country
 from transactions

--- a/src/ol_dbt/models/intermediate/mitxpro/_int_mitxpro__models.yml
+++ b/src/ol_dbt/models/intermediate/mitxpro/_int_mitxpro__models.yml
@@ -469,6 +469,11 @@ models:
     description: number, either dollar amount or percentage (between 0 and 1) discount
     tests:
     - not_null
+  - name: couponpaymentversion_discount_amount_text
+    description: string, discount amount in readable format. It can be percent-off
+      which is <dollar amount * 100>% off, dollars-off which is $<dollar amount> off
+    tests:
+    - not_null
   - name: couponpayment_name
     description: string, human readable name for the coupon payment
     tests:
@@ -710,6 +715,8 @@ models:
     - not_null
   - name: coupon_id
     description: int, foreign key to ecommerce_coupon for orders that use a coupon
+  - name: coupon_code
+    description: string, coupon code for orders that use a coupon
   - name: couponpaymentversion_id
     description: int, foreign key to ecommerce_couponpaymentversion for orders that
       use a coupon
@@ -723,6 +730,30 @@ models:
     description: numeric, the amount of tax paid
   - name: order_total_price_paid_plus_tax
     description: numeric, total order amount plus the amount of tax paid
+  - name: couponpaymentversion_payment_transaction
+    description: string, string that identifies the payment invoice for coupon purchases
+      by companies
+  - name: couponpaymentversion_coupon_type
+    description: string, one of 'single-use' or 'promo'. Promo coupon codes can be
+      used multiple times
+  - name: couponpaymentversion_discount_amount_text
+    description: string, discount amount in readable format. It can be percent-off
+      which is <dollar amount * 100>% off, dollars-off which is $<dollar amount> off
+  - name: couponredemption_created_on
+    description: timestamp, specifying when the coupon was redeemed
+  - name: receipt_reference_number
+    description: str, transaction reference number from cybersource payment
+  - name: receipt_transaction_id
+    description: str, transaction identifier from cybersource payment.
+  - name: receipt_payment_method
+    description: str, payment method from cybersource payment. Value could be 'paypal'
+      or 'card' if payment is not cancelled
+  - name: receipt_authorization_code
+    description: str, authorization code from cybersource payment
+  - name: receipt_bill_to_address_state
+    description: str, address state from cybersource payment
+  - name: receipt_bill_to_address_country
+    description: str, address country from cybersource payment
   tests:
   - dbt_expectations.expect_table_row_count_to_equal_other_table:
       compare_model: ref('stg__mitxpro__app__postgres__ecommerce_order')
@@ -781,6 +812,10 @@ models:
   - name: productversion_id
     description: int, foreign key in the ecommerce_productversion table. Versioned
       product
+    tests:
+    - not_null
+  - name: product_price
+    description: numeric, product price for this order line
     tests:
     - not_null
   - name: courserun_id

--- a/src/ol_dbt/models/intermediate/mitxpro/_int_mitxpro__models.yml
+++ b/src/ol_dbt/models/intermediate/mitxpro/_int_mitxpro__models.yml
@@ -678,6 +678,27 @@ models:
     description: json, cybersource data for a payment
     tests:
     - not_null
+  - name: receipt_transaction_status
+    description: str, transaction status from user's cybersource payment. Value could
+      be ACCEPT, CANCEL, ERROR, REVIEW or DECLINE.
+    tests:
+    - not_null
+  - name: receipt_reference_number
+    description: str, transaction reference number from user's cybersource payment
+    tests:
+    - not_null
+  - name: receipt_transaction_id
+    description: str, transaction identifier from user's cybersource payment. Maybe
+      blank for CANCEL or ERROR transactions
+  - name: receipt_payment_method
+    description: str, payment method from user's cybersource payment. Value could
+      be 'paypal' or 'card' if payment is not cancelled
+  - name: receipt_authorization_code
+    description: str, authorization code from user's cybersource payment
+  - name: receipt_bill_to_address_state
+    description: str, address state from user's cybersource payment
+  - name: receipt_bill_to_address_country
+    description: str, address country from user's cybersource payment
   - name: order_id
     description: int, primary key in ecommerce_order
   tests:

--- a/src/ol_dbt/models/intermediate/mitxpro/int__mitxpro__ecommerce_allcoupons.sql
+++ b/src/ol_dbt/models/intermediate/mitxpro/int__mitxpro__ecommerce_allcoupons.sql
@@ -39,28 +39,7 @@ with coupon as (
         , 'ecommerce_coupon' as coupon_source_table
         , null as b2bcoupon_id
         , coupon.coupon_id
-        , case
-            when ecommerce_couponpaymentversion.couponpaymentversion_discount_type = 'dollars-off'
-                then
-                    (
-                        '$'
-                        || cast(
-                            ecommerce_couponpaymentversion.couponpaymentversion_discount_amount
-                            as varchar
-                        )
-                        || ' off'
-                    )
-            when ecommerce_couponpaymentversion.couponpaymentversion_discount_type = 'percent-off'
-                then
-                    (
-                        cast(
-                            (ecommerce_couponpaymentversion.couponpaymentversion_discount_amount * 100)
-                            as varchar
-                        )
-                        || '% off'
-                    )
-        end
-            as discount_amount
+        , ecommerce_couponpaymentversion.couponpaymentversion_discount_amount_text as discount_amount
     from coupon
     inner join latest_couponversion
         on coupon.coupon_id = latest_couponversion.coupon_id

--- a/src/ol_dbt/models/intermediate/mitxpro/int__mitxpro__ecommerce_couponpaymentversion.sql
+++ b/src/ol_dbt/models/intermediate/mitxpro/int__mitxpro__ecommerce_couponpaymentversion.sql
@@ -25,6 +25,7 @@ select
     , couponpaymentversion.couponpaymentversion_payment_transaction
     , couponpaymentversion.couponpaymentversion_tag
     , couponpaymentversion.couponpaymentversion_discount_type
+    , couponpaymentversion.couponpaymentversion_discount_amount_text
     , couponpaymentversion.couponpaymentversion_max_redemptions
 from couponpaymentversion
 inner join couponpayment on couponpaymentversion.couponpayment_id = couponpayment.couponpayment_id

--- a/src/ol_dbt/models/intermediate/mitxpro/int__mitxpro__ecommerce_line.sql
+++ b/src/ol_dbt/models/intermediate/mitxpro/int__mitxpro__ecommerce_line.sql
@@ -22,6 +22,7 @@ select
     lines.line_id
     , lines.order_id
     , lines.productversion_id
+    , productversions.productversion_price as product_price
     , lines.line_created_on
     , lines.line_updated_on
     , products.product_id

--- a/src/ol_dbt/models/intermediate/mitxpro/int__mitxpro__ecommerce_order.sql
+++ b/src/ol_dbt/models/intermediate/mitxpro/int__mitxpro__ecommerce_order.sql
@@ -13,6 +13,22 @@ with orders as (
     from {{ ref('stg__mitxpro__app__postgres__ecommerce_couponversion') }}
 )
 
+, coupon as (
+    select *
+    from {{ ref('stg__mitxpro__app__postgres__ecommerce_coupon') }}
+)
+
+, couponpaymentversion as (
+    select *
+    from {{ ref('stg__mitxpro__app__postgres__ecommerce_couponpaymentversion') }}
+)
+
+, receipts as (
+    select *
+    from {{ ref('stg__mitxpro__app__postgres__ecommerce_receipt') }}
+    where receipt_transaction_status != 'ERROR'
+)
+
 select
     orders.order_id
     , orders.order_state
@@ -25,9 +41,23 @@ select
     , orders.order_tax_country_code
     , orders.order_tax_rate
     , orders.order_tax_rate_name
+    , coupon.coupon_code
+    , couponpaymentversion.couponpaymentversion_payment_transaction
+    , couponpaymentversion.couponpaymentversion_coupon_type
+    , couponpaymentversion.couponpaymentversion_discount_amount_text
+    , couponredemption.couponredemption_created_on
+    , receipts.receipt_reference_number
+    , receipts.receipt_authorization_code
+    , receipts.receipt_payment_method
+    , receipts.receipt_transaction_id
+    , receipts.receipt_bill_to_address_state
+    , receipts.receipt_bill_to_address_country
     , (orders.order_total_price_paid * (orders.order_tax_rate / 100)) as order_tax_amount
     , (orders.order_total_price_paid * (orders.order_tax_rate / 100))
     + orders.order_total_price_paid as order_total_price_paid_plus_tax
 from orders
 left join couponredemption on orders.order_id = couponredemption.order_id
 left join couponversion on couponredemption.couponversion_id = couponversion.couponversion_id
+left join coupon on couponversion.coupon_id = coupon.coupon_id
+left join couponpaymentversion on couponversion.couponpaymentversion_id = couponpaymentversion.couponpaymentversion_id
+left join receipts on orders.order_id = receipts.order_id

--- a/src/ol_dbt/models/intermediate/mitxpro/int__mitxpro__ecommerce_receipt.sql
+++ b/src/ol_dbt/models/intermediate/mitxpro/int__mitxpro__ecommerce_receipt.sql
@@ -8,5 +8,12 @@ select
     , receipt_created_on
     , receipt_updated_on
     , receipt_data
+    , receipt_transaction_status
+    , receipt_transaction_id
+    , receipt_authorization_code
+    , receipt_payment_method
+    , receipt_reference_number
+    , receipt_bill_to_address_state
+    , receipt_bill_to_address_country
     , order_id
 from receipts

--- a/src/ol_dbt/models/marts/combined/_marts__combined__models.yml
+++ b/src/ol_dbt/models/marts/combined/_marts__combined__models.yml
@@ -1,0 +1,94 @@
+---
+version: 2
+
+models:
+- name: marts__combined_course_enrollment_detail
+  description: course enrollment detail with certificates, orders and coupons from
+    OL platforms.
+  columns:
+  - name: platform
+    description: string, application where the data is from
+    tests:
+    - not_null
+    - accepted_values:
+        values: '{{ var("platforms") }}'
+  - name: courserunenrollment_id
+    description: int, internal ID and foreign key to courserunenrollments on the corresponding
+      platform. Null for enrollments on edX.org.
+  - name: courserunenrollment_is_active
+    description: boolean, indicating whether the enrollment is active
+    tests:
+    - not_null
+  - name: user_id
+    description: int, user ID on the corresponding platform
+    tests:
+    - not_null
+  - name: courserun_id
+    description: int, primary key representing a single course run on the corresponding
+      platform. Null for course runs from edx.org
+  - name: courserunenrollment_created_on
+    description: timestamp, specifying when the enrollment was initially
+    tests:
+    - not_null
+  - name: courserunenrollment_enrollment_mode
+    description: string, enrollment mode for user on the corresponding platform
+  - name: courserunenrollment_enrollment_status
+    description: string, enrollment status for users whose enrollment changed on the
+      corresponding platform
+  - name: courserun_title
+    description: string, title of the course run on the corresponding platform. Maybe
+      blank for a few edX.org runs missing in int__edxorg__mitx_courseruns.
+  - name: courserun_readable_id
+    description: str, unique string to identify a course run on the corresponding
+      platform
+  - name: user_username
+    description: string, username to identify a user on the corresponding platform
+    tests:
+    - not_null
+  - name: user_email
+    description: string, user email that user registered on the corresponding platform
+    tests:
+    - not_null
+  - name: user_full_name
+    description: str, user full name from user's profile on the corresponding platform
+  - name: courseruncertificate_url
+    description: str, URL to the course certificate for users who earned the certificate.
+      This could be blank for revoked certificate.
+  - name: courseruncertificate_created_on
+    description: timestamp, date and time when the course certificate was initially
+      created
+  - name: order_state
+    description: string, order state from the corresponding platform. It doesn't include
+      'created' order state
+  - name: order_created_on
+    description: timestamp, specifying when the order was initially created
+  - name: order_reference_number
+    description: string, order reference number to identify an order on the corresponding
+      platform, e.g. mitxonline-production-20
+  - name: order_total_price_paid
+    description: number, total order amount for the order
+  - name: line_price
+    description: numeric, price for the order line item
+  - name: coupon_discount_amount
+    description: str, discount amount in readable format. e.g. $100 off, 30% off,
+      etc
+  - name: coupon_code
+    description: str, discount code for the redeemed coupon if applicable
+  - name: coupon_redeemed_on
+    description: timestamp, specifying when the discount was redeemed by the user
+  - name: payment_transaction_id
+    description: str, transaction ID from cybersource payment
+  - name: payment_bill_to_address_state
+    description: str, address state from cybersource payment receipt
+  - name: payment_bill_to_address_country
+    description: str, address country from cybersource payment receipt
+  tests:
+  - dbt_expectations.expect_compound_columns_to_be_unique:
+      column_list: ["user_username", "courserun_readable_id"]
+      row_condition: "platform='edX.org'"
+  - dbt_expectations.expect_compound_columns_to_be_unique:
+      column_list: ["courserunenrollment_id"]
+      row_condition: "platform in ('MITx Online', 'xPro')"
+  - dbt_expectations.expect_compound_columns_to_be_unique:
+      column_list: ["courserunenrollment_id", "order_reference_number"]
+      row_condition: "platform='Bootcamps'"

--- a/src/ol_dbt/models/marts/combined/_marts__combined__models.yml
+++ b/src/ol_dbt/models/marts/combined/_marts__combined__models.yml
@@ -88,7 +88,10 @@ models:
       row_condition: "platform='edX.org'"
   - dbt_expectations.expect_compound_columns_to_be_unique:
       column_list: ["courserunenrollment_id"]
-      row_condition: "platform in ('MITx Online', 'xPro')"
+      row_condition: "platform ='MITx Online'"
+  - dbt_expectations.expect_compound_columns_to_be_unique:
+      column_list: ["courserunenrollment_id"]
+      row_condition: "platform ='xPro'"
   - dbt_expectations.expect_compound_columns_to_be_unique:
       column_list: ["courserunenrollment_id", "order_reference_number"]
       row_condition: "platform='Bootcamps'"

--- a/src/ol_dbt/models/marts/combined/marts__combined_course_enrollment_detail.sql
+++ b/src/ol_dbt/models/marts/combined/marts__combined_course_enrollment_detail.sql
@@ -1,0 +1,237 @@
+with mitx_enrollments as (
+    select * from {{ ref('int__mitx__courserun_enrollments') }}
+)
+
+, mitxpro_enrollments as (
+    select * from {{ ref('int__mitxpro__courserunenrollments') }}
+)
+
+, bootcamps_enrollments as (
+    select * from {{ ref('int__bootcamps__courserunenrollments') }}
+)
+
+, mitx_certificates as (
+    select * from {{ ref('int__mitx__courserun_certificates') }}
+)
+
+, mitxpro_certificates as (
+    select * from {{ ref('int__mitxpro__courserun_certificates') }}
+)
+
+, bootcamps_certificates as (
+    select * from {{ ref('int__bootcamps__courserun_certificates') }}
+)
+
+, mitxonline_completed_orders as (
+    select
+        *
+        , row_number() over (
+            partition by user_id, courserun_id order by order_created_on desc
+        ) as row_num
+    from {{ ref('int__mitxonline__ecommerce_order') }}
+    where order_state in ('fulfilled', 'refunded')
+)
+
+, micromasters_completed_orders as (
+    select
+        *
+        , row_number() over (
+            partition by user_id, courserun_readable_id order by order_created_on desc, order_id desc
+        ) as row_num
+    from {{ ref('int__micromasters__orders') }}
+    where order_state in ('fulfilled', 'refunded', 'partially_refunded')
+)
+
+, micromasters_users as (
+    select * from {{ ref('int__micromasters__users') }}
+)
+
+, mitxpro_completed_orders as (
+    select * from {{ ref('int__mitxpro__ecommerce_order') }}
+    where order_state in ('fulfilled', 'refunded')
+)
+
+---Unlike other platforms, xPro lines and orders are not 1 to 1, so we can't combined them into one table
+, mitxpro_lines as (
+    select * from {{ ref('int__mitxpro__ecommerce_line') }}
+)
+
+, bootcamps_completed_orders as (
+    select * from {{ ref('int__bootcamps__ecommerce_order') }}
+    where order_state in ('fulfilled', 'refunded')
+)
+
+, combined_enrollment_detail as (
+    select
+        mitx_enrollments.platform
+        , mitx_enrollments.courserunenrollment_id
+        , mitx_enrollments.courserunenrollment_is_active
+        , mitx_enrollments.courserunenrollment_created_on
+        , mitx_enrollments.courserunenrollment_enrollment_mode
+        , mitx_enrollments.courserunenrollment_enrollment_status
+        , mitx_enrollments.user_id
+        , mitx_enrollments.courserun_id
+        , mitx_enrollments.courserun_title
+        , mitx_enrollments.courserun_readable_id
+        , mitx_enrollments.user_username
+        , mitx_enrollments.user_email
+        , mitx_enrollments.user_full_name
+        , mitx_certificates.courseruncertificate_created_on
+        , mitx_certificates.courseruncertificate_url
+        , mitxonline_completed_orders.order_state
+        , mitxonline_completed_orders.order_reference_number
+        , mitxonline_completed_orders.order_total_price_paid
+        , mitxonline_completed_orders.order_created_on
+        , mitxonline_completed_orders.product_price as line_price
+        , mitxonline_completed_orders.discount_code as coupon_code
+        , mitxonline_completed_orders.discountredemption_timestamp as coupon_redeemed_on
+        , mitxonline_completed_orders.discount_amount_text as coupon_discount_amount
+        , mitxonline_completed_orders.payment_transaction_id
+        , mitxonline_completed_orders.payment_authorization_code
+        , mitxonline_completed_orders.payment_method
+        , mitxonline_completed_orders.payment_bill_to_address_state
+        , mitxonline_completed_orders.payment_bill_to_address_country
+    from mitx_enrollments
+    left join mitx_certificates
+        on
+            mitx_enrollments.user_mitxonline_username = mitx_certificates.user_mitxonline_username
+            and mitx_enrollments.courserun_readable_id = mitx_certificates.courserun_readable_id
+    left join mitxonline_completed_orders
+        on
+            mitx_enrollments.user_id = mitxonline_completed_orders.user_id
+            and mitx_enrollments.courserun_id = mitxonline_completed_orders.courserun_id
+            and mitxonline_completed_orders.row_num = 1
+    where mitx_enrollments.platform = '{{ var("mitxonline") }}'
+
+    union all
+
+    select
+        mitx_enrollments.platform
+        , mitx_enrollments.courserunenrollment_id
+        , mitx_enrollments.courserunenrollment_is_active
+        , mitx_enrollments.courserunenrollment_created_on
+        , mitx_enrollments.courserunenrollment_enrollment_mode
+        , mitx_enrollments.courserunenrollment_enrollment_status
+        , mitx_enrollments.user_id
+        , mitx_enrollments.courserun_id
+        , mitx_enrollments.courserun_title
+        , mitx_enrollments.courserun_readable_id
+        , mitx_enrollments.user_username
+        , mitx_enrollments.user_email
+        , mitx_enrollments.user_full_name
+        , mitx_certificates.courseruncertificate_created_on
+        , mitx_certificates.courseruncertificate_url
+        , micromasters_completed_orders.order_state
+        , micromasters_completed_orders.order_reference_number
+        , micromasters_completed_orders.order_total_price_paid
+        , micromasters_completed_orders.order_created_on
+        , micromasters_completed_orders.line_price
+        , micromasters_completed_orders.coupon_code
+        , micromasters_completed_orders.redeemedcoupon_created_on as coupon_redeemed_on
+        , micromasters_completed_orders.coupon_discount_amount_text as coupon_discount_amount
+        , micromasters_completed_orders.receipt_transaction_id as payment_transaction_id
+        , micromasters_completed_orders.receipt_authorization_code as payment_authorization_code
+        , micromasters_completed_orders.receipt_payment_method as payment_method
+        , micromasters_completed_orders.receipt_bill_to_address_state as payment_bill_to_address_state
+        , micromasters_completed_orders.receipt_bill_to_address_country as payment_bill_to_address_country
+    from mitx_enrollments
+    left join mitx_certificates
+        on
+            mitx_enrollments.user_edxorg_username = mitx_certificates.user_edxorg_username
+            and mitx_enrollments.courserun_readable_id = mitx_certificates.courserun_readable_id
+    left join micromasters_users on mitx_enrollments.user_edxorg_username = micromasters_users.user_edxorg_username
+    left join micromasters_completed_orders
+        on
+            micromasters_users.user_id = micromasters_completed_orders.user_id
+            and mitx_enrollments.courserun_readable_id = micromasters_completed_orders.courserun_edxorg_readable_id
+            and micromasters_completed_orders.row_num = 1
+    where mitx_enrollments.platform = '{{ var("edxorg") }}'
+
+
+    union all
+
+
+    select
+        '{{ var("mitxpro") }}' as platform
+        , mitxpro_enrollments.courserunenrollment_id
+        , mitxpro_enrollments.courserunenrollment_is_active
+        , mitxpro_enrollments.courserunenrollment_created_on
+        , null as courserunenrollment_enrollment_mode
+        , mitxpro_enrollments.courserunenrollment_enrollment_status
+        , mitxpro_enrollments.user_id
+        , mitxpro_enrollments.courserun_id
+        , mitxpro_enrollments.courserun_title
+        , mitxpro_enrollments.courserun_readable_id
+        , mitxpro_enrollments.user_username
+        , mitxpro_enrollments.user_email
+        , mitxpro_enrollments.user_full_name
+        , mitxpro_certificates.courseruncertificate_created_on
+        , mitxpro_certificates.courseruncertificate_url
+        , mitxpro_completed_orders.order_state
+        , mitxpro_completed_orders.receipt_reference_number as order_reference_number
+        , mitxpro_completed_orders.order_total_price_paid
+        , mitxpro_completed_orders.order_created_on
+        , mitxpro_lines.product_price as line_price
+        , mitxpro_completed_orders.coupon_code
+        , mitxpro_completed_orders.couponredemption_created_on as coupon_redeemed_on
+        , mitxpro_completed_orders.couponpaymentversion_discount_amount_text as coupon_discount_amount
+        , mitxpro_completed_orders.receipt_transaction_id as payment_transaction_id
+        , mitxpro_completed_orders.receipt_authorization_code as payment_authorization_code
+        , mitxpro_completed_orders.receipt_payment_method as payment_method
+        , mitxpro_completed_orders.receipt_bill_to_address_state as payment_bill_to_address_state
+        , mitxpro_completed_orders.receipt_bill_to_address_country as payment_bill_to_address_country
+    from mitxpro_enrollments
+    left join mitxpro_certificates
+        on
+            mitxpro_enrollments.user_id = mitxpro_certificates.user_id
+            and mitxpro_enrollments.courserun_id = mitxpro_certificates.courserun_id
+    left join mitxpro_completed_orders
+        on mitxpro_enrollments.user_id = mitxpro_completed_orders.order_purchaser_user_id
+    left join mitxpro_lines
+        on
+            mitxpro_enrollments.courserun_id = mitxpro_lines.courserun_id
+            and mitxpro_completed_orders.order_id = mitxpro_lines.order_id
+
+    union all
+
+    select
+        '{{ var("bootcamps") }}' as platform
+        , bootcamps_enrollments.courserunenrollment_id
+        , bootcamps_enrollments.courserunenrollment_is_active
+        , bootcamps_enrollments.courserunenrollment_created_on
+        , null as courserunenrollment_enrollment_mode
+        , bootcamps_enrollments.courserunenrollment_enrollment_status
+        , bootcamps_enrollments.user_id
+        , bootcamps_enrollments.courserun_id
+        , bootcamps_enrollments.courserun_title
+        , bootcamps_enrollments.courserun_readable_id
+        , bootcamps_enrollments.user_username
+        , bootcamps_enrollments.user_email
+        , bootcamps_enrollments.user_full_name
+        , bootcamps_certificates.courseruncertificate_created_on
+        , bootcamps_certificates.courseruncertificate_url
+        , bootcamps_completed_orders.order_state
+        , bootcamps_completed_orders.order_reference_number
+        , bootcamps_completed_orders.order_total_price_paid
+        , bootcamps_completed_orders.order_created_on
+        , bootcamps_completed_orders.line_price
+        , null as coupon_code
+        , null as coupon_redeemed_on
+        , null as coupon_discount_amount
+        , bootcamps_completed_orders.receipt_transaction_id as payment_transaction_id
+        , bootcamps_completed_orders.receipt_authorization_code as payment_authorization_code
+        , bootcamps_completed_orders.receipt_payment_method as payment_method
+        , bootcamps_completed_orders.receipt_bill_to_address_state as payment_bill_to_address_state
+        , bootcamps_completed_orders.receipt_bill_to_address_country as payment_bill_to_address_country
+    from bootcamps_enrollments
+    left join bootcamps_certificates
+        on
+            bootcamps_enrollments.user_id = bootcamps_certificates.user_id
+            and bootcamps_enrollments.courserun_id = bootcamps_certificates.courserun_id
+    left join bootcamps_completed_orders
+        on
+            bootcamps_enrollments.user_id = bootcamps_completed_orders.order_purchaser_user_id
+            and bootcamps_enrollments.courserun_id = bootcamps_completed_orders.courserun_id
+)
+
+select * from combined_enrollment_detail

--- a/src/ol_dbt/models/marts/combined/marts__combined_course_enrollment_detail.sql
+++ b/src/ol_dbt/models/marts/combined/marts__combined_course_enrollment_detail.sql
@@ -186,11 +186,11 @@ with mitx_enrollments as (
             mitxpro_enrollments.user_id = mitxpro_certificates.user_id
             and mitxpro_enrollments.courserun_id = mitxpro_certificates.courserun_id
     left join mitxpro_completed_orders
-        on mitxpro_enrollments.user_id = mitxpro_completed_orders.order_purchaser_user_id
+        on mitxpro_enrollments.ecommerce_order_id = mitxpro_completed_orders.order_id
     left join mitxpro_lines
         on
-            mitxpro_enrollments.courserun_id = mitxpro_lines.courserun_id
-            and mitxpro_completed_orders.order_id = mitxpro_lines.order_id
+            mitxpro_completed_orders.order_id = mitxpro_lines.order_id
+            and mitxpro_enrollments.courserun_id = mitxpro_lines.courserun_id
 
     union all
 

--- a/src/ol_dbt/models/staging/bootcamps/_stg_bootcamps__models.yml
+++ b/src/ol_dbt/models/staging/bootcamps/_stg_bootcamps__models.yml
@@ -55,6 +55,27 @@ models:
     - not_null
   - name: order_id
     description: int, primary key in ecommerce_order
+  - name: receipt_reference_number
+    description: str, transaction reference number from user's cybersource payment
+    tests:
+    - not_null
+  - name: receipt_transaction_status
+    description: str, transaction status from cybersource payment. Value could be
+      ACCEPT, CANCEL, ERROR, REVIEW or DECLINE.
+    tests:
+    - not_null
+  - name: receipt_transaction_id
+    description: str, transaction identifier from cybersource payment. Maybe blank
+      for CANCEL or ERROR transactions.
+  - name: receipt_payment_method
+    description: str, payment method from cybersource transaction. Value could be
+      'paypal' or 'card' if payment is not cancelled
+  - name: receipt_authorization_code
+    description: str, authorization code from cybersource payment
+  - name: receipt_bill_to_address_state
+    description: str, address state from cybersource payment
+  - name: receipt_bill_to_address_country
+    description: str, address country from cybersource payment
 
 - name: stg__bootcamps__app__postgres__ecommerce_line
   columns:
@@ -115,6 +136,11 @@ models:
   columns:
   - name: order_id
     description: int, primary key representing a single bootcamps order
+    tests:
+    - unique
+    - not_null
+  - name: order_reference_number
+    description: string, readable id for the order formatted as BOOTCAMP-prod-<ORDER_ID>
     tests:
     - unique
     - not_null

--- a/src/ol_dbt/models/staging/bootcamps/stg__bootcamps__app__postgres__ecommerce_line.sql
+++ b/src/ol_dbt/models/staging/bootcamps/stg__bootcamps__app__postgres__ecommerce_line.sql
@@ -7,7 +7,7 @@ with source as (
 , renamed as (
     select
         id as line_id
-        , price as line_price
+        , cast(price as decimal(38, 2)) as line_price
         , description as line_description
         , order_id
         , bootcamp_run_id as courserun_id

--- a/src/ol_dbt/models/staging/bootcamps/stg__bootcamps__app__postgres__ecommerce_order.sql
+++ b/src/ol_dbt/models/staging/bootcamps/stg__bootcamps__app__postgres__ecommerce_order.sql
@@ -11,7 +11,7 @@ with source as (
         , user_id as order_purchaser_user_id
         , application_id as application_id
         , payment_type as order_payment_type
-        , total_price_paid as order_total_price_paid
+        , cast(total_price_paid as decimal(38, 2)) as order_total_price_paid
         , concat('BOOTCAMP-prod-', cast(id as varchar)) as order_reference_number
         ,{{ cast_timestamp_to_iso8601('created_on') }} as order_created_on
         ,{{ cast_timestamp_to_iso8601('updated_on') }} as order_updated_on

--- a/src/ol_dbt/models/staging/bootcamps/stg__bootcamps__app__postgres__ecommerce_order.sql
+++ b/src/ol_dbt/models/staging/bootcamps/stg__bootcamps__app__postgres__ecommerce_order.sql
@@ -12,6 +12,7 @@ with source as (
         , application_id as application_id
         , payment_type as order_payment_type
         , total_price_paid as order_total_price_paid
+        , concat('BOOTCAMP-prod-', cast(id as varchar)) as order_reference_number
         ,{{ cast_timestamp_to_iso8601('created_on') }} as order_created_on
         ,{{ cast_timestamp_to_iso8601('updated_on') }} as order_updated_on
     from source

--- a/src/ol_dbt/models/staging/bootcamps/stg__bootcamps__app__postgres__ecommerce_receipt.sql
+++ b/src/ol_dbt/models/staging/bootcamps/stg__bootcamps__app__postgres__ecommerce_receipt.sql
@@ -9,6 +9,13 @@ with source as (
         id as receipt_id
         , order_id
         , data as receipt_data
+        , json_query(data, 'lax $.decision' omit quotes) as receipt_transaction_status
+        , json_query(data, 'lax $.transaction_id' omit quotes) as receipt_transaction_id
+        , json_query(data, 'lax $.req_payment_method' omit quotes) as receipt_payment_method
+        , json_query(data, 'lax $.auth_code' omit quotes) as receipt_authorization_code
+        , json_query(data, 'lax $.req_reference_number' omit quotes) as receipt_reference_number
+        , json_query(data, 'lax $.req_bill_to_address_state' omit quotes) as receipt_bill_to_address_state
+        , json_query(data, 'lax $.req_bill_to_address_country' omit quotes) as receipt_bill_to_address_country
         ,{{ cast_timestamp_to_iso8601('created_on') }} as receipt_created_on
         ,{{ cast_timestamp_to_iso8601('updated_on') }} as receipt_updated_on
     from source

--- a/src/ol_dbt/models/staging/micromasters/_stg_micromasters__models.yml
+++ b/src/ol_dbt/models/staging/micromasters/_stg_micromasters__models.yml
@@ -41,6 +41,27 @@ models:
     description: timestamp, specifying when the receipt was most recently updated
     tests:
     - not_null
+  - name: receipt_reference_number
+    description: str, transaction reference number from user's cybersource payment
+    tests:
+    - not_null
+  - name: receipt_transaction_status
+    description: str, transaction status from user's cybersource payment. Value could
+      be ACCEPT, CANCEL, ERROR, REVIEW or DECLINE.
+    tests:
+    - not_null
+  - name: receipt_transaction_id
+    description: str, transaction identifier from user's cybersource payment. Maybe
+      blank for CANCEL or ERROR transactions.
+  - name: receipt_payment_method
+    description: str, payment method from cybersource transaction. Value could be
+      'paypal' or 'card' if payment is not cancelled
+  - name: receipt_authorization_code
+    description: str, authorization code from cybersource payment
+  - name: receipt_bill_to_address_state
+    description: str, address state from cybersource payment
+  - name: receipt_bill_to_address_country
+    description: str, address country from cybersource payment
   - name: receipt_data
     description: json, cybersource data for a payment
     tests:
@@ -182,7 +203,13 @@ models:
     - accepted_values:
         values: ['fixed-discount', 'fixed-price', 'percent-discount']
   - name: coupon_amount
-    description: numeric, discount amount. May be a precent or dollar amount
+    description: numeric, discount amount. May be a percent or dollar amount
+    tests:
+    - not_null
+  - name: coupon_discount_amount_text
+    description: str, discount amount in readable format. It can be fixed discount
+      which is $<dollar amount> off, fixed-price which is $<dollar amount> or percent-discount
+      which is <percentage> % off
     tests:
     - not_null
   - name: coupon_activated_on

--- a/src/ol_dbt/models/staging/micromasters/stg__micromasters__app__postgres__ecommerce_coupon.sql
+++ b/src/ol_dbt/models/staging/micromasters/stg__micromasters__app__postgres__ecommerce_coupon.sql
@@ -15,6 +15,14 @@ with source as (
         , enabled as coupon_is_active
         , content_type_id as contenttype_id
         , invoice_id as couponinvoice_id
+        , case
+            when amount_type = 'fixed-discount'
+                then concat(cast(amount as varchar), ' off')
+            when amount_type = 'fixed-price'
+                then concat('Fixed Price: ', cast(amount as varchar))
+            when amount_type = 'percent-discount'
+                then concat(cast(amount * 100 as varchar), '% off')
+        end as coupon_discount_amount_text
         ,{{ cast_timestamp_to_iso8601('created_on') }} as coupon_created_on
         ,{{ cast_timestamp_to_iso8601('updated_on') }} as coupon_updated_on
         ,{{ cast_timestamp_to_iso8601('activation_date') }} as coupon_activated_on

--- a/src/ol_dbt/models/staging/micromasters/stg__micromasters__app__postgres__ecommerce_coupon.sql
+++ b/src/ol_dbt/models/staging/micromasters/stg__micromasters__app__postgres__ecommerce_coupon.sql
@@ -11,17 +11,17 @@ with source as (
         , coupon_code
         , object_id as coupon_object_id
         , amount_type as coupon_amount_type
-        , amount as coupon_amount
+        , cast(amount as decimal(38, 2)) as coupon_amount
         , enabled as coupon_is_active
         , content_type_id as contenttype_id
         , invoice_id as couponinvoice_id
         , case
             when amount_type = 'fixed-discount'
-                then concat(cast(amount as varchar), ' off')
+                then concat(format('%.2f', amount), ' off')
             when amount_type = 'fixed-price'
-                then concat('Fixed Price: ', cast(amount as varchar))
+                then concat('Fixed Price: ', format('%.2f', amount))
             when amount_type = 'percent-discount'
-                then concat(cast(amount * 100 as varchar), '% off')
+                then concat(format('%.2f', amount * 100), '% off')
         end as coupon_discount_amount_text
         ,{{ cast_timestamp_to_iso8601('created_on') }} as coupon_created_on
         ,{{ cast_timestamp_to_iso8601('updated_on') }} as coupon_updated_on

--- a/src/ol_dbt/models/staging/micromasters/stg__micromasters__app__postgres__ecommerce_line.sql
+++ b/src/ol_dbt/models/staging/micromasters/stg__micromasters__app__postgres__ecommerce_line.sql
@@ -10,7 +10,7 @@ with source as (
         id as line_id
         , course_key as courserun_readable_id
         , replace(replace(course_key, 'course-v1:', ''), '+', '/') as courserun_edxorg_readable_id
-        , price as line_price
+        , cast(price as decimal(38, 2)) as line_price
         , description as line_description
         ,{{ cast_timestamp_to_iso8601('created_at') }} as line_created_on
         ,{{ cast_timestamp_to_iso8601('modified_at') }} as line_updated_on

--- a/src/ol_dbt/models/staging/micromasters/stg__micromasters__app__postgres__ecommerce_order.sql
+++ b/src/ol_dbt/models/staging/micromasters/stg__micromasters__app__postgres__ecommerce_order.sql
@@ -11,7 +11,7 @@ with source as (
         , status as order_state
         , user_id
         , reference_number as order_reference_number
-        , total_price_paid as order_total_price_paid
+        , cast(total_price_paid as decimal(38, 2)) as order_total_price_paid
         ,{{ cast_timestamp_to_iso8601('created_at') }} as order_created_on
         ,{{ cast_timestamp_to_iso8601('modified_at') }} as order_updated_on
     from source

--- a/src/ol_dbt/models/staging/micromasters/stg__micromasters__app__postgres__ecommerce_receipt.sql
+++ b/src/ol_dbt/models/staging/micromasters/stg__micromasters__app__postgres__ecommerce_receipt.sql
@@ -8,6 +8,13 @@ with source as (
     select
         id as receipt_id
         , order_id
+        , json_query(data, 'lax $.decision' omit quotes) as receipt_transaction_status
+        , json_query(data, 'lax $.transaction_id' omit quotes) as receipt_transaction_id
+        , json_query(data, 'lax $.req_payment_method' omit quotes) as receipt_payment_method
+        , json_query(data, 'lax $.auth_code' omit quotes) as receipt_authorization_code
+        , json_query(data, 'lax $.req_reference_number' omit quotes) as receipt_reference_number
+        , json_query(data, 'lax $.req_bill_to_address_state' omit quotes) as receipt_bill_to_address_state
+        , json_query(data, 'lax $.req_bill_to_address_country' omit quotes) as receipt_bill_to_address_country
         , data as receipt_data
         ,{{ cast_timestamp_to_iso8601('created_at') }} as receipt_created_on
         ,{{ cast_timestamp_to_iso8601('modified_at') }} as receipt_updated_on

--- a/src/ol_dbt/models/staging/mitxonline/_stg_mitxonline__models.yml
+++ b/src/ol_dbt/models/staging/mitxonline/_stg_mitxonline__models.yml
@@ -370,6 +370,11 @@ models:
     - not_null
     - accepted_values:
         values: ["percent-off", "dollars-off", "fixed-price"]
+  - name: discount_amount_text
+    description: str, discount amount in readable format. It can be percent-off which
+      is <dollar amount>% off, dollars-off which is $<dollar amount> off or fixed-price
+    tests:
+    - not_null
   - name: discount_redemption_type
     description: string, one of  "one-time",  "one-time-per-user" and "unlimited"
     tests:
@@ -442,6 +447,18 @@ models:
     tests:
     - accepted_values:
         values: ["refund", "payment"]
+  - name: transaction_status
+    description: str, transaction status from user's cybersource payment. Value could
+      be ACCEPT, REVIEW. May be blank for no payment required or refund.
+  - name: transaction_payment_method
+    description: str, payment method from cybersource Value could be 'paypal' or 'card'.
+      May be blank for no payment required or refund.
+  - name: transaction_authorization_code
+    description: str, authorization code from cybersource payment
+  - name: transaction_bill_to_address_state
+    description: str, address state from cybersource payment
+  - name: transaction_bill_to_address_country
+    description: str, address country from cybersource payment
 
 - name: stg__mitxonline__app__postgres__ecommerce_line
   description: ""

--- a/src/ol_dbt/models/staging/mitxonline/stg__mitxonline__app__postgres__ecommerce_discount.sql
+++ b/src/ol_dbt/models/staging/mitxonline/stg__mitxonline__app__postgres__ecommerce_discount.sql
@@ -8,7 +8,7 @@ with source as (
 
     select
         id as discount_id
-        , amount as discount_amount
+        , cast(amount as decimal(38, 2)) as discount_amount
         , discount_code
         , discount_type
         , max_redemptions as discount_max_redemptions
@@ -16,11 +16,11 @@ with source as (
         , payment_type as discount_source
         , case
             when discount_type = 'percent-off'
-                then concat(cast(amount as varchar), '% off')
+                then concat(format('%.2f', amount), '% off')
             when discount_type = 'dollars-off'
-                then concat('$', cast(amount as varchar), ' off')
+                then concat('$', format('%.2f', amount), ' off')
             when discount_type = 'fixed-price'
-                then concat('Fixed Price: ', cast(amount as varchar))
+                then concat('Fixed Price: ', format('%.2f', amount))
         end as discount_amount_text
         ,{{ cast_timestamp_to_iso8601('created_on') }} as discount_created_on
         ,{{ cast_timestamp_to_iso8601('updated_on') }} as discount_updated_on

--- a/src/ol_dbt/models/staging/mitxonline/stg__mitxonline__app__postgres__ecommerce_discount.sql
+++ b/src/ol_dbt/models/staging/mitxonline/stg__mitxonline__app__postgres__ecommerce_discount.sql
@@ -14,6 +14,14 @@ with source as (
         , max_redemptions as discount_max_redemptions
         , redemption_type as discount_redemption_type
         , payment_type as discount_source
+        , case
+            when discount_type = 'percent-off'
+                then concat(cast(amount as varchar), '% off')
+            when discount_type = 'dollars-off'
+                then concat('$', cast(amount as varchar), ' off')
+            when discount_type = 'fixed-price'
+                then concat('Fixed Price: ', cast(amount as varchar))
+        end as discount_amount_text
         ,{{ cast_timestamp_to_iso8601('created_on') }} as discount_created_on
         ,{{ cast_timestamp_to_iso8601('updated_on') }} as discount_updated_on
         ,{{ cast_timestamp_to_iso8601('activation_date') }} as discount_activated_on

--- a/src/ol_dbt/models/staging/mitxonline/stg__mitxonline__app__postgres__ecommerce_order.sql
+++ b/src/ol_dbt/models/staging/mitxonline/stg__mitxonline__app__postgres__ecommerce_order.sql
@@ -11,7 +11,7 @@ with source as (
         , state as order_state
         , purchaser_id as order_purchaser_user_id
         , reference_number as order_reference_number
-        , total_price_paid as order_total_price_paid
+        , cast(total_price_paid as decimal(38, 2)) as order_total_price_paid
         ,{{ cast_timestamp_to_iso8601('created_on') }} as order_created_on
         ,{{ cast_timestamp_to_iso8601('updated_on') }} as order_updated_on
     from source

--- a/src/ol_dbt/models/staging/mitxonline/stg__mitxonline__app__postgres__ecommerce_product.sql
+++ b/src/ol_dbt/models/staging/mitxonline/stg__mitxonline__app__postgres__ecommerce_product.sql
@@ -8,7 +8,7 @@ with source as (
 
     select
         id as product_id
-        , price as product_price
+        , cast(price as decimal(38, 2)) as product_price
         , is_active as product_is_active
         , object_id as product_object_id
         , description as product_description

--- a/src/ol_dbt/models/staging/mitxonline/stg__mitxonline__app__postgres__ecommerce_transaction.sql
+++ b/src/ol_dbt/models/staging/mitxonline/stg__mitxonline__app__postgres__ecommerce_transaction.sql
@@ -13,6 +13,11 @@ with source as (
         , order_id
         , transaction_id as transaction_readable_identifier
         , transaction_type as transaction_type
+        , json_query(data, 'lax $.decision' omit quotes) as transaction_status
+        , json_query(data, 'lax $.auth_code' omit quotes) as transaction_authorization_code
+        , json_query(data, 'lax $.req_payment_method' omit quotes) as transaction_payment_method
+        , json_query(data, 'lax $.req_bill_to_address_state' omit quotes) as transaction_bill_to_address_state
+        , json_query(data, 'lax $.req_bill_to_address_country' omit quotes) as transaction_bill_to_address_country
         ,{{ cast_timestamp_to_iso8601('created_on') }} as transaction_created_on
         ,{{ cast_timestamp_to_iso8601('updated_on') }} as transaction_updated_on
     from source

--- a/src/ol_dbt/models/staging/mitxpro/_stg_mitxpro__models.yml
+++ b/src/ol_dbt/models/staging/mitxpro/_stg_mitxpro__models.yml
@@ -470,6 +470,11 @@ models:
     description: one of percent-off or dollars-off
     tests:
     - not_null
+  - name: couponpaymentversion_discount_amount_text
+    description: str, discount amount in readable format. It can be percent-off which
+      is <dollar amount * 100>% off, dollars-off which is $<dollar amount> off
+    tests:
+    - not_null
 
 - name: stg__mitxpro__app__postgres__ecommerce_couponpayment
   description: Most of the information for coupon payments is in couponpaymentversion
@@ -663,6 +668,27 @@ models:
     - not_null
   - name: order_id
     description: int, primary key in ecommerce_order
+  - name: receipt_transaction_status
+    description: str, transaction status from user's cybersource payment. Value could
+      be ACCEPT, CANCEL, ERROR, REVIEW or DECLINE.
+    tests:
+    - not_null
+  - name: receipt_reference_number
+    description: str, transaction reference number from user's cybersource payment
+    tests:
+    - not_null
+  - name: receipt_transaction_id
+    description: str, transaction identifier from user's cybersource payment. Maybe
+      blank for CANCEL or ERROR transactions
+  - name: receipt_payment_method
+    description: str, payment method from user's cybersource payment. Value could
+      be 'paypal' or 'card' if payment is not cancelled
+  - name: receipt_authorization_code
+    description: str, authorization code from user's cybersource payment
+  - name: receipt_bill_to_address_state
+    description: str, address state from user's cybersource payment
+  - name: receipt_bill_to_address_country
+    description: str, address country from user's cybersource payment
 
 - name: stg__mitxpro__app__postgres__ecommerce_programrunline
   description: The program run the user selected when purchsing a program.

--- a/src/ol_dbt/models/staging/mitxpro/stg__mitxpro__app__postgres__ecommerce_couponpaymentversion.sql
+++ b/src/ol_dbt/models/staging/mitxpro/stg__mitxpro__app__postgres__ecommerce_couponpaymentversion.sql
@@ -22,9 +22,9 @@ with source as (
         , max_redemptions as couponpaymentversion_max_redemptions
         , case
             when discount_type = 'dollars-off'
-                then concat('$', cast(amount as varchar), ' off')
+                then concat('$', format('%.2f', amount), ' off')
             when discount_type = 'percent-off'
-                then concat(cast(amount * 100 as varchar), '% off')
+                then concat(format('%.2f', amount * 100), '% off')
         end as couponpaymentversion_discount_amount_text
         ,{{ cast_timestamp_to_iso8601('expiration_date') }} as couponpaymentversion_expires_on
         ,{{ cast_timestamp_to_iso8601('activation_date') }} as couponpaymentversion_activated_on

--- a/src/ol_dbt/models/staging/mitxpro/stg__mitxpro__app__postgres__ecommerce_couponpaymentversion.sql
+++ b/src/ol_dbt/models/staging/mitxpro/stg__mitxpro__app__postgres__ecommerce_couponpaymentversion.sql
@@ -20,6 +20,12 @@ with source as (
         , tag as couponpaymentversion_tag
         , discount_type as couponpaymentversion_discount_type
         , max_redemptions as couponpaymentversion_max_redemptions
+        , case
+            when discount_type = 'dollars-off'
+                then concat('$', cast(amount as varchar), ' off')
+            when discount_type = 'percent-off'
+                then concat(cast(amount * 100 as varchar), '% off')
+        end as couponpaymentversion_discount_amount_text
         ,{{ cast_timestamp_to_iso8601('expiration_date') }} as couponpaymentversion_expires_on
         ,{{ cast_timestamp_to_iso8601('activation_date') }} as couponpaymentversion_activated_on
         ,{{ cast_timestamp_to_iso8601('created_on') }} as couponpaymentversion_created_on

--- a/src/ol_dbt/models/staging/mitxpro/stg__mitxpro__app__postgres__ecommerce_order.sql
+++ b/src/ol_dbt/models/staging/mitxpro/stg__mitxpro__app__postgres__ecommerce_order.sql
@@ -8,7 +8,7 @@ with source as (
     select
         id as order_id
         , status as order_state
-        , total_price_paid as order_total_price_paid
+        , cast(total_price_paid as decimal(38, 2)) as order_total_price_paid
         , purchaser_id as order_purchaser_user_id
         , tax_country_code as order_tax_country_code
         , tax_rate as order_tax_rate

--- a/src/ol_dbt/models/staging/mitxpro/stg__mitxpro__app__postgres__ecommerce_productversion.sql
+++ b/src/ol_dbt/models/staging/mitxpro/stg__mitxpro__app__postgres__ecommerce_productversion.sql
@@ -9,7 +9,7 @@ with source as (
     select
         id as productversion_id
         , text_id as productversion_readable_id
-        , price as productversion_price
+        , cast(price as decimal(38, 2)) as productversion_price
         , description as productversion_description
         , product_id
         , requires_enrollment_code as productversion_requires_enrollment_code

--- a/src/ol_dbt/models/staging/mitxpro/stg__mitxpro__app__postgres__ecommerce_receipt.sql
+++ b/src/ol_dbt/models/staging/mitxpro/stg__mitxpro__app__postgres__ecommerce_receipt.sql
@@ -10,6 +10,13 @@ with source as (
         id as receipt_id
         , order_id
         , data as receipt_data
+        , json_query(data, 'lax $.decision' omit quotes) as receipt_transaction_status
+        , json_query(data, 'lax $.transaction_id' omit quotes) as receipt_transaction_id
+        , json_query(data, 'lax $.auth_code' omit quotes) as receipt_authorization_code
+        , json_query(data, 'lax $.req_payment_method' omit quotes) as receipt_payment_method
+        , json_query(data, 'lax $.req_reference_number' omit quotes) as receipt_reference_number
+        , json_query(data, 'lax $.req_bill_to_address_state' omit quotes) as receipt_bill_to_address_state
+        , json_query(data, 'lax $.req_bill_to_address_country' omit quotes) as receipt_bill_to_address_country
         ,{{ cast_timestamp_to_iso8601('created_on') }} as receipt_created_on
         ,{{ cast_timestamp_to_iso8601('updated_on') }} as receipt_updated_on
     from source


### PR DESCRIPTION
# What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
https://github.com/mitodl/ol-data-platform/issues/885

# Description (What does it do?)
<!--- Describe your changes in detail -->
- Creates `marts__combined_course_enrollment_detail` with enrollments, certificates, fulfilled/refunded orders, coupons and cybersource payment details from MITx, xPro and Bootcamps. It contains the following fields
    platform 
    courserunenrollment_is_active
    courserunenrollment_created_on
    courserunenrollment_enrollment_mode
    courserunenrollment_enrollment_status
    user_id
    courserun_id
    courserun_title
    courserun_readable_id
    user_username
    user_email
    user_full_name
    courseruncertificate_created_on
    courseruncertificate_url
    order_state
    order_reference_number
    order_total_price_paid
    order_created_on
    line_price
    coupon_code
    coupon_redeemed_on
    coupon_discount_amount
    payment_transaction_id
    payment_authorization_code
    payment_method
    payment_bill_to_address_state
    payment_bill_to_address_country
- Creates `int__micromasters__orders` for legacy DEDP orders
- A few upstream changes


# How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->
dbt build --select +int__bootcamps__ecommerce_receipt 
dbt build --select +int__bootcamps__ecommerce_order 
dbt build --select +int__micromasters__orders 
dbt build --select +int__mitxonline__ecommerce_transaction 
dbt build --select +int__mitxonline__ecommerce_order
dbt build --select +int__mitxpro__ecommerce_couponpaymentversion 
dbt build --select +int__mitxpro__ecommerce_coupon
dbt build --select +int__mitxpro__ecommerce_receipt 
dbt build --select +int__mitxpro__ecommerce_order 
dbt build --select +int__mitxpro__ecommerce_line 
dbt build --select +int__mitxpro__ecommerce_allcoupons 
dbt build --select marts__combined_course_enrollment_detail

or 

just run `dbt build --select +marts__combined_course_enrollment_detail` its going to take a while

Note if you see warning about something like `dbt_expectations_expect_table_row_count_to_equal_other_table_int__mitxpro__ecommerce_productversion`, that's because the above commands don't run the sibiling of these intermediate models,  you can just run that warned intermediate model, the test should pass