### PR TITLE
add new email optout table to staging

### DIFF
--- a/src/ol_dbt/models/staging/mitxonline/_mitxonline__sources.yml
+++ b/src/ol_dbt/models/staging/mitxonline/_mitxonline__sources.yml
@@ -12,9 +12,9 @@ sources:
     - name: id
       description: int, sequential ID tracking a email optout
     - name: user_id
-      description: int, foreign key to the users_user table
+      description: int, unique ID for each user on the MITx Online platform
     - name: course_id
-      description: int, foreign key to courses_course representing a single MITx Online
+      description: string, unique ID representing a single MITx Online course run
         course
 
   - name: raw__mitxonline__app__postgres__ecommerce_basketdiscount

--- a/src/ol_dbt/models/staging/mitxonline/_mitxonline__sources.yml
+++ b/src/ol_dbt/models/staging/mitxonline/_mitxonline__sources.yml
@@ -7,6 +7,16 @@ sources:
   database: '{{ target.database }}'
   schema: '{{ target.schema.replace(var("schema_suffix", ""), "").rstrip("_") }}_raw'
   tables:
+  - name: raw__mitxonline__openedx__mysql__bulk_email_optout
+    columns:
+    - name: id
+      description: int, sequential ID tracking a email optout
+    - name: user_id
+      description: int, foreign key to the users_user table
+    - name: course_id
+      description: int, foreign key to courses_course representing a single MITx Online
+        course
+
   - name: raw__mitxonline__app__postgres__ecommerce_basketdiscount
     columns:
     - name: id

--- a/src/ol_dbt/models/staging/mitxonline/_stg_mitxonline__models.yml
+++ b/src/ol_dbt/models/staging/mitxonline/_stg_mitxonline__models.yml
@@ -9,10 +9,10 @@ models:
     tests:
     - unique
     - not_null
-  - name: user_id
+  - name: openedx_user_id
     description: int, unique ID for each user on the MITx Online platform
-  - name: course_id
-    description: int, primary key representing a single MITx Online course
+  - name: courserun_readable_id
+    description: string, unique ID representing a single MITx Online course run
 
 - name: stg__mitxonline__app__postgres__courses_courserunenrollment
   columns:

--- a/src/ol_dbt/models/staging/mitxonline/_stg_mitxonline__models.yml
+++ b/src/ol_dbt/models/staging/mitxonline/_stg_mitxonline__models.yml
@@ -10,9 +10,16 @@ models:
     - unique
     - not_null
   - name: openedx_user_id
-    description: int, unique ID for each user on the MITx Online platform
+    description: int, unique ID for each user on the MITx Online open edX platform
+    tests:
+    - not_null
   - name: courserun_readable_id
     description: string, unique ID representing a single MITx Online course run
+    tests:
+    - not_null
+  tests:
+  - dbt_expectations.expect_compound_columns_to_be_unique:
+      column_list: ["openedx_user_id", "courserun_readable_id"]
 
 - name: stg__mitxonline__app__postgres__courses_courserunenrollment
   columns:

--- a/src/ol_dbt/models/staging/mitxonline/_stg_mitxonline__models.yml
+++ b/src/ol_dbt/models/staging/mitxonline/_stg_mitxonline__models.yml
@@ -2,6 +2,18 @@
 version: 2
 
 models:
+- name: stg__mitxonline__openedx__mysql__bulk_email_optout
+  columns:
+  - name: email_optout_id
+    description: int, sequential ID tracking a email optout
+    tests:
+    - unique
+    - not_null
+  - name: user_id
+    description: int, unique ID for each user on the MITx Online platform
+  - name: course_id
+    description: int, primary key representing a single MITx Online course
+
 - name: stg__mitxonline__app__postgres__courses_courserunenrollment
   columns:
   - name: courserunenrollment_id

--- a/src/ol_dbt/models/staging/mitxonline/stg__mitxonline__openedx__mysql__bulk_email_optout.sql
+++ b/src/ol_dbt/models/staging/mitxonline/stg__mitxonline__openedx__mysql__bulk_email_optout.sql
@@ -7,8 +7,8 @@ with source as (
 , cleaned as (
     select
         id as email_optout_id
-        , user_id
-        , course_id
+        , user_id as openedx_user_id
+        , course_id as courserun_readable_id
     from source
 )
 

--- a/src/ol_dbt/models/staging/mitxonline/stg__mitxonline__openedx__mysql__bulk_email_optout.sql
+++ b/src/ol_dbt/models/staging/mitxonline/stg__mitxonline__openedx__mysql__bulk_email_optout.sql
@@ -1,0 +1,15 @@
+-- MITx Online Openedx mySQL Bulk Email Optout
+
+with source as (
+    select * from {{ source('ol_warehouse_raw_data','raw__mitxonline__openedx__mysql__bulk_email_optout') }}
+)
+
+, cleaned as (
+    select
+        id as email_optout_id
+        , user_id
+        , course_id
+    from source
+)
+
+select * from cleaned


### PR DESCRIPTION
# What are the relevant tickets?
https://github.com/mitodl/hq/issues/1545

# Description (What does it do?)
adds table stg__mitxonline__openedx__mysql__bulk_email_optout from raw to staging

# How can this be tested?
Run the following commands against your schema or QA
Run dbt build --select staging.mitxonline if you have all models, otherwise add + in front of  staging.mitxonline to run upstream models

