### PR TITLE
fix dbt test error for certificate_url

### DIFF
--- a/src/ol_dbt/models/intermediate/mitxonline/_int_mitxonline__models.yml
+++ b/src/ol_dbt/models/intermediate/mitxonline/_int_mitxonline__models.yml
@@ -993,7 +993,6 @@ models:
     description: str, the full URL to the certificate on MITx Online
     tests:
     - unique
-    - not_null
   - name: courserun_id
     description: int, foreign key to courses_courserun representing a single course
       run


### PR DESCRIPTION
# What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
N/A

# Description (What does it do?)
<!--- Describe your changes in detail -->
This fixes the following dbt test error noted in https://pipelines.odl.mit.edu/runs/170b1684-c3d4-4d07-b028-3ae8c1de38d3
```
Failure in test not_null_int__mitxonline__courserun_certificates_courseruncertificate_url (models/intermediate/mitxonline/_int_mitxonline__models.yml)
Got 66 results, configured to fail if >10
```
The `courseruncertificate_url` in `int__mitxonline__courserun_certificates` could be null for revoked certificates, thus need to remove not_null test


# How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->
Run ` dbt test --select int__mitxonline__courserun_certificates --target production` should now be no error