### PR TITLE
add email optout table to int

### DIFF
--- a/src/ol_dbt/models/intermediate/mitxonline/_int_mitxonline__models.yml
+++ b/src/ol_dbt/models/intermediate/mitxonline/_int_mitxonline__models.yml
@@ -2,6 +2,25 @@
 version: 2
 
 models:
+- name: int__mitxonline__openedx__mysql__bulk_email_optout
+  columns:
+  - name: email_optout_id
+    description: int, sequential ID tracking a email optout
+    tests:
+    - unique
+    - not_null
+  - name: openedx_user_id
+    description: int, unique ID for each user on the MITx Online open edX platform
+    tests:
+    - not_null
+  - name: courserun_readable_id
+    description: string, unique ID representing a single MITx Online course run
+    tests:
+    - not_null
+  tests:
+  - dbt_expectations.expect_compound_columns_to_be_unique:
+      column_list: ["openedx_user_id", "courserun_readable_id"]
+
 - name: int__mitxonline__ecommerce_basketdiscount
   columns:
   - name: basketdiscount_id

--- a/src/ol_dbt/models/intermediate/mitxonline/int__mitxonline__openedx__mysql__bulk_email_optout.sql
+++ b/src/ol_dbt/models/intermediate/mitxonline/int__mitxonline__openedx__mysql__bulk_email_optout.sql
@@ -1,0 +1,9 @@
+-- MITx Online Openedx mySQL Bulk Email Optout
+
+with bulk_email_optout as (
+    select *
+    from {{ ref('stg__mitxonline__openedx__mysql__bulk_email_optout') }}
+)
+
+select *
+from bulk_email_optout


### PR DESCRIPTION
# What are the relevant tickets?
https://github.com/mitodl/hq/issues/1545

# Description (What does it do?)
adds table int__mitxonline__openedx__mysql__bulk_email_optout to intermediate from staging

# How can this be tested?
Run the following commands against your schema or QA
Run dbt build --select intermediate.mitxonline if you have all models, otherwise add + in front of intermediate.mitxonline to run upstream models