### PR TITLE
add program_type and fix micromasters program certificates

### DIFF
--- a/src/ol_dbt/models/intermediate/mitx/_int_mitx__models.yml
+++ b/src/ol_dbt/models/intermediate/mitx/_int_mitx__models.yml
@@ -15,7 +15,7 @@ models:
     tests:
     - unique
   - name: micromasters_program_id
-    description: int, primary key representing the program in the MicroMasters database
+    description: int, primary key representing the program in the MicroMasters database.
     tests:
     - unique
   - name: program_description

--- a/src/ol_dbt/models/intermediate/mitx/int__mitx__program_certificates.sql
+++ b/src/ol_dbt/models/intermediate/mitx/int__mitx__program_certificates.sql
@@ -7,11 +7,7 @@ with micromasters_program_certificates as (
 , mitxonline_program_certificates as (
     select * from {{ ref('int__mitxonline__program_certificates') }}
     --- dedp is handled in micromasters_program_certificates
-    where
-        program_id not in (
-            {{ var("dedp_mitxonline_public_policy_program_id") }}
-            , {{ var("dedp_mitxonline_international_development_program_id") }}
-        )
+    where program_is_dedp = false
 )
 
 , mitx_programs as (
@@ -22,15 +18,13 @@ with micromasters_program_certificates as (
     select
         micromasters_program_certificates.program_title
         , micromasters_program_certificates.micromasters_program_id
-        , mitx_programs.mitxonline_program_id
+        , micromasters_program_certificates.mitxonline_program_id
         , micromasters_program_certificates.program_completion_timestamp
         , micromasters_program_certificates.user_mitxonline_username
         , micromasters_program_certificates.user_edxorg_username
         , micromasters_program_certificates.user_email
         , micromasters_program_certificates.user_full_name
     from micromasters_program_certificates
-    left join mitx_programs
-        on micromasters_program_certificates.micromasters_program_id = mitx_programs.micromasters_program_id
 
     union all
 

--- a/src/ol_dbt/models/intermediate/mitx/int__mitx__programs.sql
+++ b/src/ol_dbt/models/intermediate/mitx/int__mitx__programs.sql
@@ -26,22 +26,6 @@ select
     , mitxonline_programs.program_id as mitxonline_program_id
     , null as program_description
     , mitxonline_programs.program_title
-    , case
-        when
-            mitxonline_programs.program_id in
-            (
-                {{ var("dedp_mitxonline_public_policy_program_id") }}
-                , {{ var("dedp_mitxonline_international_development_program_id") }}
-            ) then true
-        else false
-    end as is_micromasters_program
-    , case
-        when
-            mitxonline_programs.program_id in
-            (
-                {{ var("dedp_mitxonline_public_policy_program_id") }}
-                , {{ var("dedp_mitxonline_international_development_program_id") }}
-            ) then true
-        else false
-    end as is_dedp_program
+    , mitxonline_programs.program_is_micromasters as is_micromasters_program
+    , mitxonline_programs.program_is_dedp as is_dedp_program
 from mitxonline_programs

--- a/src/ol_dbt/models/intermediate/mitxonline/_int_mitxonline__models.yml
+++ b/src/ol_dbt/models/intermediate/mitxonline/_int_mitxonline__models.yml
@@ -1080,6 +1080,17 @@ models:
     tests:
     - unique
     - not_null
+  - name: program_type
+    description: str, type of the program. Value is free text, it could be MicroMasters®,
+      Series, etc
+  - name: program_is_dedp
+    description: boolean, specifying if the program is DEDP from readable_id
+    tests:
+    - not_null
+  - name: program_is_micromasters
+    description: boolean, specifying if the program is MITx MicroMasters® Program
+    tests:
+    - not_null
 
 - name: int__mitxonline__program_requirements
   columns:
@@ -1164,6 +1175,17 @@ models:
     - not_null
   - name: program_readable_id
     description: str, Open edX ID formatted as program-v1:{org}+{program code}
+    tests:
+    - not_null
+  - name: program_type
+    description: str, type of the program. Value is free text, it could be MicroMasters®,
+      Series, etc
+  - name: program_is_dedp
+    description: boolean, specifying if the program is DEDP from readable_id
+    tests:
+    - not_null
+  - name: program_is_micromasters
+    description: boolean, specifying if the program is MITx MicroMasters® Program
     tests:
     - not_null
   - name: user_username

--- a/src/ol_dbt/models/intermediate/mitxonline/int__mitxonline__program_certificates.sql
+++ b/src/ol_dbt/models/intermediate/mitxonline/int__mitxonline__program_certificates.sql
@@ -19,6 +19,9 @@ with certificates as (
         , certificates.program_id
         , programs.program_title
         , programs.program_readable_id
+        , programs.program_type
+        , programs.program_is_dedp
+        , programs.program_is_micromasters
         , certificates.programcertificate_is_revoked
         , certificates.programcertificate_created_on
         , certificates.programcertificate_updated_on

--- a/src/ol_dbt/models/intermediate/mitxonline/int__mitxonline__programs.sql
+++ b/src/ol_dbt/models/intermediate/mitxonline/int__mitxonline__programs.sql
@@ -9,4 +9,7 @@ select
     , program_title
     , program_is_live
     , program_readable_id
+    , program_type
+    , program_is_dedp
+    , program_is_micromasters
 from programs

--- a/src/ol_dbt/models/staging/mitxonline/_mitxonline__sources.yml
+++ b/src/ol_dbt/models/staging/mitxonline/_mitxonline__sources.yml
@@ -504,13 +504,8 @@ sources:
         MITx Online website
     - name: title
       description: str, title of the course
-    - name: program_id
-      description: id, foreign key to courses_program (deprecating)
     - name: readable_id
       description: str, Open edX ID formatted as course-v1:{org}+{course code}
-    - name: position_in_program
-      description: int, sequential number indicating the course position in a program
-        (deprecating)
     - name: created_on
       description: timestamp, specifying when a course was initially created
     - name: updated_on
@@ -599,6 +594,9 @@ sources:
       description: str, title of the program
     - name: readable_id
       description: str, Open edX ID formatted as program-v1:{org}+{program code}
+    - name: program_type
+      description: str, type of the program. Value is free text, it could be MicroMasters®,
+        Series, etc
     - name: created_on
       description: timestamp, specifying when a program was initially created
     - name: updated_on

--- a/src/ol_dbt/models/staging/mitxonline/_stg_mitxonline__models.yml
+++ b/src/ol_dbt/models/staging/mitxonline/_stg_mitxonline__models.yml
@@ -814,6 +814,17 @@ models:
     description: str, title of the program
     tests:
     - not_null
+  - name: program_type
+    description: str, type of the program. Value is free text, it could be MicroMasters®,
+      Series, etc
+  - name: program_is_dedp
+    description: boolean, specifying if the program is DEDP from readable_id
+    tests:
+    - not_null
+  - name: program_is_micromasters
+    description: boolean, specifying if the program is MITx MicroMasters® Program
+    tests:
+    - not_null
   - name: program_readable_id
     description: str, Open edX ID formatted as program-v1:{org}+{program code}
     tests:

--- a/src/ol_dbt/models/staging/mitxonline/stg__mitxonline__app__postgres__courses_program.sql
+++ b/src/ol_dbt/models/staging/mitxonline/stg__mitxonline__app__postgres__courses_program.sql
@@ -10,6 +10,9 @@ with source as (
         , live as program_is_live
         , title as program_title
         , readable_id as program_readable_id
+        , program_type
+        , if(program_type like 'MicroMasters%', true, false) as program_is_micromasters
+        , if(readable_id like '%DEDP%', true, false) as program_is_dedp
         ,{{ cast_timestamp_to_iso8601('created_on') }} as program_created_on
         ,{{ cast_timestamp_to_iso8601('updated_on') }} as program_updated_on
     from source


### PR DESCRIPTION
# What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
https://github.com/mitodl/ol-data-platform/issues/883

I've also created https://github.com/mitodl/ol-data-platform/issues/916 but it doesn't need to be handled in this PR

# Description (What does it do?)
<!--- Describe your changes in detail -->

- add `program_type`, `program_is_dedp` and `program_is_micromasters` to staging and intermediate for MITx Online
- 11 program certificates for `program-v1:MITx+DEDP+2T2023` should now in `int__micromasters__program_certificates`


# How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->
dbt build +int__mitx__program_certificates

```
--11
SELECT count(*) FROM "ol_data_lake_production"."ol_warehouse_production_rlougee_intermediate"."int__micromasters__program_certificates" 
where mitxonline_program_id = 3

---7213
SELECT count(*) FROM "ol_data_lake_production"."ol_warehouse_production_rlougee_intermediate"."int__mitx__program_certificates" 

---7213
SELECT count(*) FROM "ol_data_lake_production"."ol_warehouse_production_rlougee_intermediate"."int__micromasters__program_certificates" 
````
