### PR TITLE
create stg__edxorg__s3__tracking_logs__user_activity

### DIFF
--- a/src/ol_dbt/models/staging/edxorg/_edxorg_sources.yml
+++ b/src/ol_dbt/models/staging/edxorg/_edxorg_sources.yml
@@ -547,3 +547,53 @@ sources:
     - name: course run start date
       description: str, the start date of the course run in the format 'YYYY-MM-DD
         HH:mm:ss Z' in UTC
+
+  - name: raw__irx__edxorg__s3__tracking_logs
+    description: edX.org event data that are emitted by server, the browser, or the
+      mobile device to capture information about user's interactions with a course
+    columns:
+    - name: username
+      description: str, username of the open edX user who caused the event to be emitted.
+        Some events are recorded with a blank username. This can occur when a user
+        logs out, or the login session times out, while a browser window remains open.
+        EdX recommends to ignore these events.
+    - name: context
+      description: object, it includes member fields that provide contextual information.
+        Common fields apply to all events are course_id, org_id, path, user_id. Other
+        member fields for applicable events are course_user_tags, module.
+    - name: event_source
+      description: str, specifies the source of the interaction that triggered the
+        event. The values are - browser, mobile, server, task
+    - name: event_type
+      description: str, type of event triggered. Values depend on event_source.
+    - name: name
+      description: str, type of event triggered. When this field is present for an
+        event, it supersedes the event_type field.
+    - name: event
+      description: object, it includes member fields that identify specifics of each
+        triggered event. Different member fields are supplied for different events.
+    - name: page
+      description: str, url of the page the user was visiting when the event was emitted.
+    - name: session
+      description: str, 32-character value to identify the user’s session. All browser
+        events and the server 'enrollment' events include a session value. Other server
+        events and mobile events do not include a session value.
+    - name: ip
+      description: str, IP address of the user who triggered the event. Empty for
+        mobile events.
+    - name: host
+      description: str, the site visited by the user. e.g. courses.mitxonline.mit.edu
+    - name: time
+      description: str, time at which the event was emitted. It has inconsistent formats
+        due to log collector switches, YYYY-MM-DD HH:mm:ss.SSSSSS for older records,
+        YYYY-MM-ddTHH:mm:ss.SSSSSS for newer records
+    - name: agent
+      description: str, browser agent string of the user who triggered the event.
+    - name: accept_language
+      description: str, value from the HTTP Accept-Language request-header field
+    - name: referer
+      description: str, URI from the HTTP Referer request-header field
+    - name: log_file
+      description: str, internal used field for log file location
+    - name: _ab_source_file_url
+      description: str, url path for the raw log file

--- a/src/ol_dbt/models/staging/edxorg/_stg__edxorg__models.yml
+++ b/src/ol_dbt/models/staging/edxorg/_stg__edxorg__models.yml
@@ -437,3 +437,78 @@ models:
   tests:
   - dbt_expectations.expect_compound_columns_to_be_unique:
       column_list: ["user_id", "courserun_readable_id", "program_uuid"]
+
+- name: stg__edxorg__s3__tracking_logs__user_activity
+  description: edX.org event data that are emitted by server, the browser, or the
+    mobile device to capture information about user's interactions with a course.
+    This table filters out events that don't supply user identifiers like username
+    and user_id.
+  columns:
+  - name: user_username
+    description: str, username of a learner on edX.org
+    tests:
+    - not_null
+  - name: user_id
+    description: int, learner's user ID on edX.org. Extracted from context field.
+    tests:
+    - not_null
+  - name: courserun_readable_id
+    description: str, Open edX Course ID formatted as course-v1:{org}+{course number}+{run_tag}.
+      Extracted from various fields - context.course_id, context.path, event_type
+      and page. Note that the course ID extracted from context field may not be a
+      valid. This field could be blank for any events that are not for any specific
+      course .e.g. user login/out.
+  - name: org_id
+    description: str, reference name in organizations_organization from open edX.
+      e.g. MITx . Extracted from context field.
+  - name: useractivity_path
+    description: str, URL that generated this event. Extracted from context field
+  - name: useractivity_context_object
+    description: object, it includes member fields that provide contextual information.
+      Common fields apply to all events are course_id, org_id, path, user_id. Other
+      member fields for applicable events are course_user_tags, module.
+  - name: useractivity_event_source
+    description: str, specifies the source of the interaction that triggered the event.
+      The values are - browser, mobile, server, task
+    tests:
+    - not_null
+  - name: useractivity_event_type
+    description: str, type of event triggered. Values depend on event_source.
+    tests:
+    - not_null
+  - name: useractivity_event_name
+    description: str, type of event triggered. When this field is present for an event,
+      it supersedes the event_type field.
+  - name: useractivity_event_object
+    description: object,it includes member fields that identify specifics of each
+      triggered event. Different member fields are supplied for different events.
+    tests:
+    - not_null
+  - name: useractivity_page_url
+    description: str, url of the page the user was visiting when the event was emitted.
+  - name: useractivity_session_id
+    description: str, 32-character value to identify the user’s session. All browser
+      events and the server 'enrollment' events include session value. Other server
+      events and mobile events do not include a session value.
+  - name: useractivity_ip
+    description: str, IP address of the user who triggered the event. Empty for mobile
+      events.
+  - name: useractivity_http_host
+    description: str, The site visited by the user. e.g. courses.edx.org
+    tests:
+    - not_null
+  - name: useractivity_http_user_agent
+    description: str, browser agent string of the user who triggered the event.
+  - name: useractivity_http_accept_language
+    description: str, value from the HTTP Accept-Language request-header field
+  - name: useractivity_http_referer
+    description: str, URI from the HTTP Referer request-header field
+  - name: useractivity_timestamp
+    description: timestamp, time at which the event was emitted, formatted as ISO
+      8601 string
+    tests:
+    - not_null
+  tests:
+  - dbt_expectations.expect_compound_columns_to_be_unique:
+      column_list: ["user_username", "useractivity_context_object", "useractivity_event_source",
+        "useractivity_event_type", "useractivity_event_object", "useractivity_timestamp"]

--- a/src/ol_dbt/models/staging/edxorg/stg__edxorg__s3__tracking_logs__user_activity.sql
+++ b/src/ol_dbt/models/staging/edxorg/stg__edxorg__s3__tracking_logs__user_activity.sql
@@ -1,0 +1,62 @@
+{{ config(
+    materialized='incremental',
+    unique_key = ['user_username', 'useractivity_context_object', 'useractivity_event_source',
+    'useractivity_event_type', 'useractivity_event_object', 'useractivity_timestamp'],
+    incremental_strategy='delete+insert',
+    views_enabled=false,
+  )
+}}
+
+with source as (
+    select * from {{ source('ol_warehouse_raw_data','raw__irx__edxorg__s3__tracking_logs') }}
+    where
+        username != ''
+        and json_query(context, 'lax $.user_id' omit quotes) is not null
+
+        {% if is_incremental() %}
+            and "time" > (select max(this.useractivity_timestamp) from {{ this }} as this)
+        {% endif %}
+)
+
+, source_sorted as (
+    select
+        *
+        , row_number() over (
+            partition by username, context, event_source, event_type, event, "time"
+            order by _airbyte_emitted_at desc, _ab_source_file_last_modified desc, "time" desc
+        ) as row_num
+    from source
+)
+
+, dedup_source as (
+    select * from source_sorted
+    where row_num = 1
+)
+
+, cleaned as (
+    select
+        username as user_username
+        , context as useractivity_context_object
+        , event as useractivity_event_object
+        , event_source as useractivity_event_source
+        , page as useractivity_page_url
+        , session as useractivity_session_id
+        , ip as useractivity_ip
+        , host as useractivity_http_host
+        , agent as useractivity_http_user_agent
+        , accept_language as useractivity_http_accept_language
+        , referer as useractivity_http_referer
+        , name as useractivity_event_name
+        , event_type as useractivity_event_type
+        , {{ extract_course_id_from_tracking_log() }} as courserun_readable_id
+        , json_query(context, 'lax $.user_id' omit quotes) as user_id
+        , json_query(context, 'lax $.org_id' omit quotes) as org_id
+        , json_query(context, 'lax $.path' omit quotes) as useractivity_path
+        --- use regex here to preserve the nanoseconds as date_parse truncates the fraction of second to milliseconds
+        , to_iso8601(from_iso8601_timestamp_nanos(
+            regexp_replace("time", '(\d{4}-\d{2}-\d{2})[ ](\d{2}:\d{2}:\d{2}\.\d+)(.*?)', '$1T$2$3')
+        )) as useractivity_timestamp
+    from dedup_source
+)
+
+select * from cleaned


### PR DESCRIPTION
# What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
https://github.com/mitodl/ol-data-platform/issues/917

# Description (What does it do?)
<!--- Describe your changes in detail -->
Creates staging model stg__edxorg__s3__tracking_logs__user_activity as incremental 

# How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

To test against production data, you will need to update your [profile.xml](https://github.com/mitodl/ol-data-platform/blob/main/src/ol_dbt/profiles.yml#L46) to `mitol-ol-data-lake-production.trino.galaxy.starburst.io` due to resource limitation of our QA cluster to run large model (https://github.com/mitodl/ol-data-platform/issues/793 is created to solve this problem without updating profiles.yml)

Run  `dbt build --select stg__edxorg__s3__tracking_logs__user_activity`

