### PR TITLE
replace MicroMasters program certificates with 2U data

### DIFF
--- a/src/ol_dbt/models/intermediate/edxorg/_int_edxorg__models.yml
+++ b/src/ol_dbt/models/intermediate/edxorg/_int_edxorg__models.yml
@@ -411,6 +411,8 @@ models:
   - name: program_certificate_awarded_on
     description: timestamp, the date in ISO-8601 format that the learner has passed
       each of the courses in the program and was awarded a program certificate.
+  - name: micromasters_program_id
+    description: int, foreign key to program in the MicroMasters database
   tests:
   - dbt_expectations.expect_compound_columns_to_be_unique:
       column_list: ["user_id", "program_uuid"]

--- a/src/ol_dbt/models/intermediate/edxorg/int__edxorg__mitx_program_certificates.sql
+++ b/src/ol_dbt/models/intermediate/edxorg/int__edxorg__mitx_program_certificates.sql
@@ -3,6 +3,11 @@ with completed_program_learners as (
     where user_has_completed_program = true
 )
 
+, micromasters_programs as (
+    select * from {{ ref('int__mitx__programs') }}
+    where is_micromasters_program = true
+)
+
 , completed_program_learners_sorted as (
     select
         *
@@ -11,13 +16,22 @@ with completed_program_learners as (
 )
 
 select
-    program_type
-    , program_uuid
-    , program_title
-    , user_id
-    , user_username
-    , user_full_name
-    , user_has_completed_program
-    , program_certificate_awarded_on
+    completed_program_learners_sorted.program_type
+    , completed_program_learners_sorted.program_uuid
+    , completed_program_learners_sorted.program_title
+    , completed_program_learners_sorted.user_id
+    , completed_program_learners_sorted.user_username
+    , completed_program_learners_sorted.user_full_name
+    , completed_program_learners_sorted.user_has_completed_program
+    , completed_program_learners_sorted.program_certificate_awarded_on
+    , micromasters_programs.micromasters_program_id
 from completed_program_learners_sorted
-where row_num = 1
+left join micromasters_programs
+--- Finance is split into MIT Finance and Finance,
+--- Statistics and Data Science is split into Statistics and Data Science (General track)
+    -- and Statistics and Data Science
+    on (
+        completed_program_learners_sorted.program_title like micromasters_programs.program_title || '%'
+        or completed_program_learners_sorted.program_title like '%' || micromasters_programs.program_title
+    )
+where completed_program_learners_sorted.row_num = 1

--- a/src/ol_dbt/models/intermediate/micromasters/subqueries/__micromasters_program_certificates_non_dedp.sql
+++ b/src/ol_dbt/models/intermediate/micromasters/subqueries/__micromasters_program_certificates_non_dedp.sql
@@ -1,19 +1,14 @@
 {{ config(materialized='view') }}
 
-with edx_course_certificates as (
+with micromasters_program_certificates as (
     select *
-    from {{ ref('int__edxorg__mitx_courserun_certificates') }}
+    from {{ ref('int__edxorg__mitx_program_certificates') }}
+    where program_type = 'MicroMasters'
 )
 
 , edx_users as (
     select *
     from {{ ref('int__edxorg__mitx_users') }}
-)
-
-, micromasters_program_requirements as (
-    select *
-    from {{ ref('int__micromasters__program_requirements') }}
-    where program_id != {{ var("dedp_micromasters_program_id") }}
 )
 
 , micromasters_users as (
@@ -30,101 +25,6 @@ with edx_course_certificates as (
 , program_certificates_override_list as (
     select *
     from {{ ref('stg__micromasters__app__user_program_certificate_override_list') }}
-)
-
-, micromasters_courses as (
-    select
-        course_id
-        , program_id
-        , course_edx_key
-        , course_number
-        , course_edx_key as course_readable_id
-    from {{ ref('stg__micromasters__app__postgres__courses_course') }}
-)
-
-, micromasters_runs as (
-    select *
-    from {{ ref('stg__micromasters__app__postgres__courses_courserun') }}
-)
-
-, micromasters_user_requirement_completions as (
-    select
-        edx_course_certificates.user_id as user_edxorg_id
-        , edx_course_certificates.user_username as user_edxorg_username
-        , edx_course_certificates.courserun_readable_id
-        , edx_course_certificates.courseruncertificate_status
-        , edx_course_certificates.courseruncertificate_created_on
-        , edx_course_certificates.courserun_title
-        , micromasters_courses.program_id
-        , micromasters_courses.course_id as micromasters_course_id
-        , micromasters_program_requirements.programrequirement_type
-        , micromasters_program_requirements.program_num_required_courses
-        -- The next line makes electiveset_required_number set for both rows for elective completions
-        -- and rows for core course completions
-        , avg(
-            micromasters_program_requirements.electiveset_required_number
-        ) over (partition by micromasters_courses.program_id) as electiveset_required_number
-        -- We use this for a filter in the next subquery because trino sql does not allow distinct in window
-        -- functions and we don't want to count the same course against the program requirements multiple times
-        , row_number() over (
-            partition by edx_course_certificates.user_id, micromasters_courses.course_id
-            order by edx_course_certificates.courseruncertificate_created_on asc
-        ) as user_course_certificate_number
-    from edx_course_certificates
-    inner join
-        micromasters_runs
-        on edx_course_certificates.courserun_readable_id like micromasters_runs.courserun_edxorg_readable_id || '%'
-    inner join
-        micromasters_courses
-        on micromasters_runs.course_id = micromasters_courses.course_id
-    inner join
-        micromasters_program_requirements
-        on micromasters_courses.course_id = micromasters_program_requirements.course_id
-)
-
--- Some users continue to take courses in the program after earning a program certificate.
--- We calculate a running total of program requirement completions so we can use the date that
--- the user first completes the program requirements as the program completion date.
-, micromasters_user_requirement_completions_with_running_total as (
-    select
-        user_edxorg_id
-        , user_edxorg_username
-        , program_id
-        , program_num_required_courses
-        , courseruncertificate_created_on
-        , count(
-            micromasters_course_id) over (
-            partition by user_edxorg_id, program_id
-            order by courseruncertificate_created_on asc
-        ) as cumulative_courses_completed
-        , count(
-            case when programrequirement_type = 'Elective' then micromasters_course_id end
-        ) over (
-            partition by user_edxorg_id, program_id
-            order by courseruncertificate_created_on asc
-        ) as cumulative_electives_completed
-        , coalesce(electiveset_required_number, 0) as electiveset_required_number
-    from micromasters_user_requirement_completions
-    --we use this filter instead of distinct because Trino sql does not allow distinct in window function
-    where user_course_certificate_number = 1
-
-)
-
-, program_completions as (
-    select
-        user_edxorg_id
-        , user_edxorg_username
-        , program_id
-        -- With the filter, this is the first course after which the user has fulfilled the program requirements
-        , min(courseruncertificate_created_on) as program_completion_timestamp
-    from micromasters_user_requirement_completions_with_running_total
-    where
-        cumulative_electives_completed >= electiveset_required_number
-        and (
-            cumulative_courses_completed - cumulative_electives_completed
-            >= program_num_required_courses - electiveset_required_number
-        )
-    group by user_edxorg_id, user_edxorg_username, program_id
 )
 
 , non_dedp_certificates as (
@@ -145,10 +45,10 @@ with edx_course_certificates as (
         , micromasters_users.user_street_address
         , micromasters_users.user_address_state_or_territory
         , edx_users.user_full_name
-        , program_completions.program_completion_timestamp
+        , micromasters_program_certificates.program_certificate_awarded_on as program_completion_timestamp
         , micromasters_users.user_id as micromasters_user_id
         , substring(micromasters_users.user_birth_date, 1, 4) as user_year_of_birth
-    from program_completions
+    from micromasters_program_certificates
     left join edx_users
         on program_completions.user_edxorg_id = edx_users.user_id
     left join micromasters_users

--- a/src/ol_dbt/models/intermediate/micromasters/subqueries/__micromasters_program_certificates_non_dedp.sql
+++ b/src/ol_dbt/models/intermediate/micromasters/subqueries/__micromasters_program_certificates_non_dedp.sql
@@ -33,9 +33,9 @@ with micromasters_program_certificates as (
         , micromasters_users.user_mitxonline_username
         , edx_users.user_email
         , programs.micromasters_program_id
-        , programs.program_title
+        , micromasters_program_certificates.program_title
         , programs.mitxonline_program_id
-        , program_completions.user_edxorg_id
+        , micromasters_program_certificates.user_id as user_edxorg_id
         , edx_users.user_gender
         , edx_users.user_country
         , micromasters_users.user_address_city
@@ -50,11 +50,11 @@ with micromasters_program_certificates as (
         , substring(micromasters_users.user_birth_date, 1, 4) as user_year_of_birth
     from micromasters_program_certificates
     left join edx_users
-        on program_completions.user_edxorg_id = edx_users.user_id
+        on micromasters_program_certificates.user_id = edx_users.user_id
     left join micromasters_users
-        on program_completions.user_edxorg_username = micromasters_users.user_edxorg_username
+        on micromasters_program_certificates.user_username = micromasters_users.user_edxorg_username
     left join programs
-        on program_completions.program_id = programs.micromasters_program_id
+        on micromasters_program_certificates.micromasters_program_id = programs.micromasters_program_id
 )
 
 -- Some users should recieve a certificate even though they don't fulfill the requirements according

--- a/src/ol_dbt/models/staging/micromasters/stg__micromasters__app__user_program_certificate_override_list.sql
+++ b/src/ol_dbt/models/staging/micromasters/stg__micromasters__app__user_program_certificate_override_list.sql
@@ -1,8 +1,4 @@
 select * from (
     values
     (11479768, 1)
-    , (7752757, 4)
-    , (25033349, 4)
-    , (1586443, 4)
-    , (26106900, 1)
 ) AS overwrite_list (user_edxorg_id, micromasters_program_id) -- noqa: L010,L025


### PR DESCRIPTION
# What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
https://github.com/mitodl/ol-data-platform/issues/852

# Description (What does it do?)
<!--- Describe your changes in detail -->

- Replace MicroMasters program certificates data in `__micromasters_program_certificates_non_dedp` with learners program record data from 2U (Peter mentioned it in https://github.com/mitodl/ol-data-platform/issues/852#issuecomment-1793084516)

- Update the overwrite list in [this file](https://github.com/mitodl/ol-data-platform/blob/main/src/ol_dbt/models/staging/micromasters/stg__micromasters__app__user_program_certificate_override_list.sql) to only user_id =11479768 since the other 4 are already in `int__edxorg__mitx_program_certificates`

```
select * from ol_warehouse_production_intermediate.int__edxorg__mitx_program_certificates
where user_id in (11479768, 7752757, 25033349,1586443,26106900)
```

Note that Finance is now split into `Finance` and `MIT Finance` and Statistics and Data Science is split into `Statistics and Data Science`, `Statistics and Data Science (General track)` since these are different requirements.

I've sent Peter a list of these discrepancies for `Supply Chain Management` and  `Statistics and Data Science` in https://github.com/mitodl/ol-data-platform/issues/852#issuecomment-1804158604 as he is interested to see


# How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->
To test against production data for int__edxorg__mitx_program_certificates, you will need to update your [profile.xml](https://github.com/mitodl/ol-data-platform/blob/main/src/ol_dbt/profiles.yml#L46) to mitol-ol-data-lake-production.trino.galaxy.starburst.io due to resource limitation of our QA cluster to run large model (https://github.com/mitodl/ol-data-platform/issues/793 is created to solve this problem without updating profiles.yml)

```
dbt build --select int__edxorg__mitx_program_certificates
dbt build --select __micromasters_program_certificates_non_dedp

select count(*), program_title 
from "ol_data_lake_production"."ol_warehouse_production_rlougee_intermediate"."__micromasters_program_certificates_non_dedp" 
group by program_title
```
