### PR TITLE
feat: Add unnested course blocks to course structure retrieval

### DIFF
--- a/src/ol_orchestrate/jobs/open_edx.py
+++ b/src/ol_orchestrate/jobs/open_edx.py
@@ -69,4 +69,6 @@ def edx_course_pipeline():
     },
 )
 def extract_open_edx_data_to_ol_data_platform():
-    upload_files_to_s3(fetch_edx_course_structure_from_api(list_courses()))
+    fetch_edx_course_structure_from_api(list_courses()).map(
+        lambda fpath: upload_files_to_s3(fpath)
+    )

--- a/src/ol_orchestrate/lib/openedx.py
+++ b/src/ol_orchestrate/lib/openedx.py
@@ -1,0 +1,48 @@
+import datetime
+from typing import Any
+
+
+def un_nest_course_structure(
+    course_id: str, course_structure: dict[str, Any]
+) -> list[dict[str, Any]]:
+    """
+    Recursively unnest the course structure
+
+    :param course_structure: The course structure to unnest
+
+    :return: The unnested course structure
+    """
+    # Block per row
+    # Include children and parent
+    # Include full hierarchy as block IDs and block names
+    ancestry = {}
+    course_title = None
+    course_start = None
+    retrieved_at = datetime.datetime.now(tz=datetime.UTC).isoformat()
+    course_blocks = []
+    # We need to loop through the course structure twice. Once to populate the full
+    # ancestry and a second time to build the record structure so that we can pull the
+    # block parents.
+    for block_id, block_contents in course_structure.items():
+        if block_contents["category"] == "course":
+            course_title = block_contents["metadata"].get("display_name")
+            course_start = block_contents["metadata"].get("start")
+        for child in block_contents["children"]:
+            ancestry[child] = block_id
+    for block_id, block_contents in course_structure.items():
+        course_blocks.append(
+            {
+                "course_id": course_id,
+                "block_id": block_id,
+                "block_details": block_contents,
+                "block_parent": ancestry.get(block_id),
+                "block_title": block_contents["metadata"].get("display_name"),
+                "block_type": block_contents["category"],
+                "block_start": block_contents["metadata"].get("start"),
+                "block_due": block_contents["metadata"].get("due"),
+                "retrieved_at": retrieved_at,
+                "course_title": course_title,
+                "course_start": course_start,
+            }
+        )
+    return course_blocks


### PR DESCRIPTION
# What are the relevant tickets?
N/A

# Description (What does it do?)
This adds another output to the course structure retrieval with all of the blocks un-nested and including pointers to the parent blocks for easier processing in SQL.

The individual rows look like
```
{
  "course_id": "course-v1:Arbisoft+ARB_CRT_0001+2022_T1",
  "block_id": "block-v1:Arbisoft+ARB_CRT_0001+2022_T1+type@problem+block@ef812fb07d6d4e0785743fd8e8d15d97",
  "block_details": {
    "category": "problem",
    "children": [],
    "metadata": {
      "display_name": "Numerical Input",
      "group_access": {
        "50": [
          2
        ]
      },
      "markdown": "You can use this template as a guide to the simple editor markdown and OLX markup to use for numerical input problems. Edit this component to replace this template with your own assessment.\n\n>>What's 1+1 <<\n\n= 2\n"
    }
  },
  "block_parent": "block-v1:Arbisoft+ARB_CRT_0001+2022_T1+type@vertical+block@4b1dbd42f5de46fbb32f9e28d16dff6b",
  "block_title": "Numerical Input",
  "block_type": "problem",
  "block_start": null,
  "block_due": null,
  "retrieved_at": "2023-11-09T21:37:32.407502+00:00",
  "course_title": "Certificate Test Course",
  "course_start": "2022-01-09T00:00:00Z"
}
```

# How can this be tested?
First, log in to Vault with `vault login -address https://vault-qa.odl.mit.edu -method=github` to generate the auth token locally. Then:
```
> export DAGSTER_ENV="qa"
> dagster dev -d src/ol_orchestrate/ -f src/ol_orchestrate/definitions/edx/openedx_data_extract.py
```
