### PR TITLE
fix duplicated SDS program learners

### DIFF
--- a/src/ol_dbt/models/intermediate/micromasters/subqueries/__int_micromasters_subqueries__models.yml
+++ b/src/ol_dbt/models/intermediate/micromasters/subqueries/__int_micromasters_subqueries__models.yml
@@ -223,8 +223,10 @@ models:
     description: str, user id in the micromasters database
 
 - name: __micromasters_program_certificates_non_dedp
-  description: Non DEDP program certificate earners. Calculated from joining edxorg
-    course certificate records to the program requirements from the micromasters database
+  description: Non DEDP program certificate earners. Data come from learners report
+    from edX.org with deduplication. If learners have records in both 'Statistics
+    and Data Science (General track)' and 'Statistics and Data Science', they only
+    appear once in this table
   columns:
   - name: user_edxorg_username
     description: str, The username of the learner on the edX platform
@@ -279,6 +281,9 @@ models:
       program
   - name: micromasters_user_id
     description: str, user id in the micromasters database
+  tests:
+  - dbt_expectations.expect_compound_columns_to_be_unique:
+      column_list: ["user_edxorg_username", "micromasters_program_id"]
 
 - name: __micromasters_course_certificates_dedp_from_micromasters
   description: DEDP course certificates from MicroMasters database


### PR DESCRIPTION
# What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
Related to https://github.com/mitodl/ol-data-platform/pull/920
and dbt test failure 
```
Failure in test dbt_expectations_expect_compound_columns_to_be_unique_int__micromasters__program_certificates_user_email__micromasters_program_id (models/intermediate/micromasters/_int_micromasters__models.yml)
ERROR Got 97 results, configured to fail if >10
```

# Description (What does it do?)
<!--- Describe your changes in detail -->
There are 97 learners who got both `Statistics and Data Science` and `Statistics and Data Science (General Track)` in 2U data, so it failed on user_email+micromasters_program_id unique check. Talked to @pdpinch about it, since the downstream reports expect this table to be unique on user per MM program, I updated the subquery to dedup these duplicate SDS learners, and keep `int__edxorg__mitx_program_certificates` the way it is.  

This will fix the SDS number in https://bi.odl.mit.edu/queries/1056 and https://bi.odl.mit.edu/queries/1276?p_created_on_after=2023-05-31 to not double count the same learner

# How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

Ran the following commands, tests should be fine now
```
dbt build --select __micromasters_program_certificates_non_dedp
dbt build --select int__micromasters__program_certificates
```
