### PR TITLE
add new mitxonline email optout table to intermediate

### DIFF
--- a/src/ol_dbt/models/intermediate/mitxonline/_int_mitxonline__models.yml
+++ b/src/ol_dbt/models/intermediate/mitxonline/_int_mitxonline__models.yml
@@ -2,7 +2,7 @@
 version: 2
 
 models:
-- name: int__mitxonline__openedx__mysql__bulk_email_optout
+- name: int__mitxonline__bulk_email_optin
   columns:
   - name: openedx_user_id
     description: int, unique ID for each user on the MITx Online open edX platform
@@ -19,9 +19,8 @@ models:
   - name: courserun_title
     description: str, title of the course run
   - name: email_opted_in
-    description: int, if this field is 0 then we've recieved an email optout otherwise
-      it will be 1
-
+    description: int, if this field is 0 then we've recieved an email optout otherwise it will be 1
+  
 - name: int__mitxonline__ecommerce_basketdiscount
   columns:
   - name: basketdiscount_id

--- a/src/ol_dbt/models/intermediate/mitxonline/_int_mitxonline__models.yml
+++ b/src/ol_dbt/models/intermediate/mitxonline/_int_mitxonline__models.yml
@@ -19,8 +19,9 @@ models:
   - name: courserun_title
     description: str, title of the course run
   - name: email_opted_in
-    description: int, if this field is 0 then we've recieved an email optout otherwise it will be 1
-  
+    description: int, if this field is 0 then we've recieved an email optout otherwise
+      it will be 1
+
 - name: int__mitxonline__ecommerce_basketdiscount
   columns:
   - name: basketdiscount_id

--- a/src/ol_dbt/models/intermediate/mitxonline/_int_mitxonline__models.yml
+++ b/src/ol_dbt/models/intermediate/mitxonline/_int_mitxonline__models.yml
@@ -23,7 +23,7 @@ models:
     description: str, name chosen by user and used for login
   - name: user_email
     description: str, user email associated with their account
-
+  
 - name: int__mitxonline__ecommerce_basketdiscount
   columns:
   - name: basketdiscount_id
@@ -1140,6 +1140,17 @@ models:
     tests:
     - unique
     - not_null
+  - name: program_type
+    description: str, type of the program. Value is free text, it could be MicroMasters®,
+      Series, etc
+  - name: program_is_dedp
+    description: boolean, specifying if the program is DEDP from readable_id
+    tests:
+    - not_null
+  - name: program_is_micromasters
+    description: boolean, specifying if the program is MITx MicroMasters® Program
+    tests:
+    - not_null
 
 - name: int__mitxonline__program_requirements
   columns:
@@ -1224,6 +1235,17 @@ models:
     - not_null
   - name: program_readable_id
     description: str, Open edX ID formatted as program-v1:{org}+{program code}
+    tests:
+    - not_null
+  - name: program_type
+    description: str, type of the program. Value is free text, it could be MicroMasters®,
+      Series, etc
+  - name: program_is_dedp
+    description: boolean, specifying if the program is DEDP from readable_id
+    tests:
+    - not_null
+  - name: program_is_micromasters
+    description: boolean, specifying if the program is MITx MicroMasters® Program
     tests:
     - not_null
   - name: user_username

--- a/src/ol_dbt/models/intermediate/mitxonline/_int_mitxonline__models.yml
+++ b/src/ol_dbt/models/intermediate/mitxonline/_int_mitxonline__models.yml
@@ -23,7 +23,7 @@ models:
     description: str, name chosen by user and used for login
   - name: user_email
     description: str, user email associated with their account
-  
+
 - name: int__mitxonline__ecommerce_basketdiscount
   columns:
   - name: basketdiscount_id

--- a/src/ol_dbt/models/intermediate/mitxonline/_int_mitxonline__models.yml
+++ b/src/ol_dbt/models/intermediate/mitxonline/_int_mitxonline__models.yml
@@ -4,26 +4,23 @@ version: 2
 models:
 - name: int__mitxonline__openedx__mysql__bulk_email_optout
   columns:
-  - name: email_optout_id
-    description: int, sequential ID tracking a email optout
-    tests:
-    - unique
-    - not_null
   - name: openedx_user_id
     description: int, unique ID for each user on the MITx Online open edX platform
     tests:
     - not_null
-  - name: courserun_readable_id
-    description: string, unique ID representing a single MITx Online course run
-  - name: courserun_title
-    description: str, title of the course run
   - name: user_full_name
     description: str, user full name
   - name: user_username
     description: str, name chosen by user and used for login
   - name: user_email
     description: str, user email associated with their account
-
+  - name: courserun_readable_id
+    description: string, unique ID representing a single MITx Online course run
+  - name: courserun_title
+    description: str, title of the course run
+  - name: email_opted_in
+    description: int, if this field is 0 then we've recieved an email optout otherwise it will be 1
+  
 - name: int__mitxonline__ecommerce_basketdiscount
   columns:
   - name: basketdiscount_id
@@ -1052,7 +1049,6 @@ models:
     description: str, the full URL to the certificate on MITx Online
     tests:
     - unique
-    - not_null
   - name: courserun_id
     description: int, foreign key to courses_courserun representing a single course
       run

--- a/src/ol_dbt/models/intermediate/mitxonline/_int_mitxonline__models.yml
+++ b/src/ol_dbt/models/intermediate/mitxonline/_int_mitxonline__models.yml
@@ -2,6 +2,28 @@
 version: 2
 
 models:
+- name: int__mitxonline__openedx__mysql__bulk_email_optout
+  columns:
+  - name: email_optout_id
+    description: int, sequential ID tracking a email optout
+    tests:
+    - unique
+    - not_null
+  - name: openedx_user_id
+    description: int, unique ID for each user on the MITx Online open edX platform
+    tests:
+    - not_null
+  - name: courserun_readable_id
+    description: string, unique ID representing a single MITx Online course run
+  - name: courserun_title
+    description: str, title of the course run
+  - name: user_full_name
+    description: str, user full name
+  - name: user_username
+    description: str, name chosen by user and used for login
+  - name: user_email
+    description: str, user email associated with their account
+  
 - name: int__mitxonline__ecommerce_basketdiscount
   columns:
   - name: basketdiscount_id
@@ -1030,6 +1052,7 @@ models:
     description: str, the full URL to the certificate on MITx Online
     tests:
     - unique
+    - not_null
   - name: courserun_id
     description: int, foreign key to courses_courserun representing a single course
       run
@@ -1117,17 +1140,6 @@ models:
     tests:
     - unique
     - not_null
-  - name: program_type
-    description: str, type of the program. Value is free text, it could be MicroMasters®,
-      Series, etc
-  - name: program_is_dedp
-    description: boolean, specifying if the program is DEDP from readable_id
-    tests:
-    - not_null
-  - name: program_is_micromasters
-    description: boolean, specifying if the program is MITx MicroMasters® Program
-    tests:
-    - not_null
 
 - name: int__mitxonline__program_requirements
   columns:
@@ -1212,17 +1224,6 @@ models:
     - not_null
   - name: program_readable_id
     description: str, Open edX ID formatted as program-v1:{org}+{program code}
-    tests:
-    - not_null
-  - name: program_type
-    description: str, type of the program. Value is free text, it could be MicroMasters®,
-      Series, etc
-  - name: program_is_dedp
-    description: boolean, specifying if the program is DEDP from readable_id
-    tests:
-    - not_null
-  - name: program_is_micromasters
-    description: boolean, specifying if the program is MITx MicroMasters® Program
     tests:
     - not_null
   - name: user_username

--- a/src/ol_dbt/models/intermediate/mitxonline/int__mitxonline__bulk_email_optin.sql
+++ b/src/ol_dbt/models/intermediate/mitxonline/int__mitxonline__bulk_email_optin.sql
@@ -1,4 +1,4 @@
--- Email optout information for MITx Online openededx
+-- Email optin information for MITx Online openededx
 
 with email_optout as (
     select *

--- a/src/ol_dbt/models/intermediate/mitxonline/int__mitxonline__openedx__mysql__bulk_email_optout.sql
+++ b/src/ol_dbt/models/intermediate/mitxonline/int__mitxonline__openedx__mysql__bulk_email_optout.sql
@@ -16,15 +16,16 @@ with email_optout as (
 )
 
 select
-    email_optout.email_optout_id
-    , email_optout.openedx_user_id
-    , email_optout.courserun_readable_id
-    , courserun.courserun_title
+    users.openedx_user_id
     , users.user_full_name
     , users.user_username
     , users.user_email
-from email_optout
-inner join users
-    on email_optout.openedx_user_id = users.openedx_user_id
+    , email_optout.courserun_readable_id
+    , courserun.courserun_title
+    , case when email_optout.email_optout_id is null then 1 else 0 end as email_opted_in
+from users
+left join email_optout
+    on users.openedx_user_id = email_optout.openedx_user_id
 left join courserun
     on email_optout.courserun_readable_id = courserun.courserun_readable_id
+where users.openedx_user_id is not null

--- a/src/ol_dbt/models/intermediate/mitxonline/int__mitxonline__openedx__mysql__bulk_email_optout.sql
+++ b/src/ol_dbt/models/intermediate/mitxonline/int__mitxonline__openedx__mysql__bulk_email_optout.sql
@@ -1,0 +1,30 @@
+-- Email optout information for MITx Online openededx
+
+with email_optout as (
+    select *
+    from {{ ref('stg__mitxonline__openedx__mysql__bulk_email_optout') }}
+)
+
+, courserun as (
+    select *
+    from {{ ref('stg__mitxonline__app__postgres__courses_courserun') }}
+)
+
+, users as (
+    select *
+    from {{ ref('int__mitxonline__users') }}
+)
+
+select
+    email_optout.email_optout_id
+    , email_optout.openedx_user_id
+    , email_optout.courserun_readable_id
+    , courserun.courserun_title
+    , users.user_full_name
+    , users.user_username
+    , users.user_email
+from email_optout
+inner join users
+    on email_optout.openedx_user_id = users.openedx_user_id
+left join courserun
+    on email_optout.courserun_readable_id = courserun.courserun_readable_id


### PR DESCRIPTION
# What are the relevant tickets?
https://github.com/mitodl/hq/issues/1545

# Description (What does it do?)
adds table int__mitxonline__openedx__mysql__bulk_email_optout to intermediate

# How can this be tested?
Run the following commands against your schema or QA
Run dbt build --select intermediate.mitxonline if you have all models, otherwise add + in front of intermediate.mitxonline to run upstream models

