### PR TITLE
Stage MITx Online course structure table

### DIFF
--- a/src/ol_dbt/models/staging/mitxonline/_mitxonline__sources.yml
+++ b/src/ol_dbt/models/staging/mitxonline/_mitxonline__sources.yml
@@ -819,3 +819,55 @@ sources:
     - name: environment
       description: str, internal used field to indicate environment for the event.
         e.g. mitxonline-production
+
+
+  - name: raw__mitxonline__openedx__api__course_structure
+    columns:
+    - name: course_id
+      description: str, Open edX Course ID formatted as course-v1:{org}+{course code}+{run_tag}
+    - name: content_hash
+      description: str, sha256 hashed string for the course content
+    - name: course_structure
+      description: str, json string of the course content
+    - name: course_structure_flattened
+      description: str, flatten json string of the course content. It flattens block's
+        category, metadata and children to same level.
+    - name: retrieved_at
+      description: timestamp, time indicating when this course structure was initially
+        retrieved from REST API.
+
+  - name: raw__mitxonline__openedx__api__course_blocks
+    columns:
+    - name: block_id
+      description: str, Unique ID for a distinct piece of content in a course, formatted
+        as block-v1:{org}+{course}+{run}type@{block type}+block@{hash code}
+    - name: block_index
+      description: int, sequence number giving order in which this block content appears
+        within the course
+    - name: block_parent
+      description: str, parent block ID, same format as block_id field
+    - name: block_type
+      description: str, category/type of the block, it identifies core structural
+        elements of a course. Value includes but not limited to course, chapter, sequential,
+        vertical, discussion, html, problem, video, etc.
+    - name: block_title
+      description: str, title of the block extracted from the metadata field of the
+        block. This field comes from name field for the section, subsection, or unit
+        on the Studio 'Course Outline' page
+    - name: block_details
+      description: str, json string of the block.
+    - name: course_id
+      description: str, Open edX Course ID formatted as course-v1:{org}+{course code}+{run_tag}
+    - name: course_title
+      description: str, title of the course extracted from the metadata field of 'course'
+        block
+    - name: course_content_hash
+      description: str, sha256 hashed string of the course content.
+    - name: block_content_hash
+      description: str, sha256 hashed string of the block content in a course
+    - name: course_start
+      description: timestamp, time indicating when the course starts, extracted from
+        metadata of the 'course' block
+    - name: retrieved_at
+      description: timestamp, time indicating when this block was initially retrieved
+        from REST API.

--- a/src/ol_dbt/models/staging/mitxonline/_stg_mitxonline__models.yml
+++ b/src/ol_dbt/models/staging/mitxonline/_stg_mitxonline__models.yml
@@ -1280,3 +1280,63 @@ models:
   - dbt_expectations.expect_compound_columns_to_be_unique:
       column_list: ["user_username", "useractivity_context_object", "useractivity_event_source",
         "useractivity_event_type", "useractivity_event_object", "useractivity_timestamp"]
+
+- name: stg__mitxonline__openedx__api__course_structure
+  description: this table contains historical changes to open edX's course content
+    data.
+  columns:
+  - name: courserun_readable_id
+    description: str, Open edX Course ID formatted as course-v1:{org}+{course code}+{run_tag}
+    tests:
+    - not_null
+  - name: coursestructure_content_hash
+    description: str, sha256 hashed string of the course content.
+    tests:
+    - not_null
+  - name: coursestructure_block_content_hash
+    description: str, sha256 hashed string of the block content in a course
+    tests:
+    - not_null
+  - name: coursestructure_block_id
+    description: str, Unique ID for a distinct piece of content in a course, formatted
+      as block-v1:{org}+{course}+{run}type@{block type}+block@{hash code}
+    tests:
+    - not_null
+  - name: coursestructure_parent_block_id
+    description: str, parent block ID, same format as block_id
+  - name: coursestructure_block_index
+    description: int, sequence number giving order in which this block content appears
+      within the course
+    tests:
+    - not_null
+  - name: coursestructure_block_category
+    description: str, category/type of the block, it identifies core structural elements
+      of a course. Value includes but not limited to course, chapter, sequential,
+      vertical, discussion, html, problem, video, etc.
+    tests:
+    - not_null
+  - name: coursestructure_block_title
+    description: str, title of the block extracted from the metadata of the block.
+      This field comes from name field for the section, subsection, or unit on the
+      Studio 'Course Outline' page.
+  - name: coursestructure_block_metadata
+    description: str, json string of the metadata field for the block. It provides
+      additional information about this block, different block type may have different
+      member fields inside metadata.
+    tests:
+    - not_null
+  - name: courserun_title
+    description: str, title of the course extracted from the metadata of 'course'
+      block
+  - name: courserun_start_on
+    description: timestamp, indicating when the course run starts extracted from the
+      metadata of 'course' block
+  - name: coursestructure_retrieved_at
+    description: timestamp, indicating when this course structure was initially retrieved
+      from REST API.
+    tests:
+    - not_null
+  tests:
+  - dbt_expectations.expect_compound_columns_to_be_unique:
+      column_list: ["courserun_readable_id", "coursestructure_block_id", "coursestructure_content_hash",
+        "coursestructure_retrieved_at"]

--- a/src/ol_dbt/models/staging/mitxonline/stg__mitxonline__openedx__api__course_structure.sql
+++ b/src/ol_dbt/models/staging/mitxonline/stg__mitxonline__openedx__api__course_structure.sql
@@ -1,0 +1,60 @@
+--- This table captures the changes made to course structure. It does so by comparing to course content from previous
+--  day. If no changes, then no new rows added to the table. If any changes to the course content, it adds all the
+--  blocks including the updated/new ones to the table.
+
+--- To get the course structure at any give time, use course_id + block_id + the last retrieved_at
+
+with course_structure_source as (
+    select * from {{ source('ol_warehouse_raw_data','raw__mitxonline__openedx__api__course_structure') }}
+)
+
+, course_block_source as (
+    select * from {{ source('ol_warehouse_raw_data','raw__mitxonline__openedx__api__course_blocks') }}
+)
+
+, course_structure as (
+    select * from (
+        select
+            *
+            , lag(
+                content_hash) over
+            (partition by course_id order by retrieved_at asc) as previous_content_hash
+        from course_structure_source
+    )
+    where previous_content_hash is null or previous_content_hash != content_hash
+)
+
+, course_block as (
+    select * from (
+        select
+            *
+            , lag(
+                course_content_hash) over
+            (partition by block_id, course_id order by retrieved_at asc) as previous_content_hash
+        from course_block_source
+    )
+    where previous_content_hash is null or previous_content_hash != course_content_hash
+)
+
+, cleaned as (
+    select
+        course_structure.course_id as courserun_readable_id
+        , course_block.course_title as courserun_title
+        , course_block.block_index as coursestructure_block_index
+        , course_block.block_id as coursestructure_block_id
+        , course_block.block_parent as coursestructure_parent_block_id
+        , course_block.block_type as coursestructure_block_category
+        , course_block.block_title as coursestructure_block_title
+        , course_structure.content_hash as coursestructure_content_hash
+        , course_block.block_content_hash as coursestructure_block_content_hash
+        , json_query(course_block.block_details, 'lax $.metadata') as coursestructure_block_metadata
+        , {{ cast_timestamp_to_iso8601('course_block.course_start') }} as courserun_start_on
+        , {{ cast_timestamp_to_iso8601('course_structure.retrieved_at') }} as coursestructure_retrieved_at
+    from course_block
+    inner join course_structure
+        on
+            course_block.course_id = course_structure.course_id
+            and course_block.course_content_hash = course_structure.content_hash
+)
+
+select * from cleaned


### PR DESCRIPTION
# What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
https://github.com/mitodl/ol-data-platform/issues/901

# Description (What does it do?)
<!--- Describe your changes in detail -->
Adding `stg__mitxonline__openedx__api__course_structure`

   - It combines raw__mitxonline__openedx__api__course_structure and raw__mitxonline__openedx__api__course_blocks
  - It will keeps the historical changes to the course structure for each course over time. The raw tables insert new rows daily even when there are no changes to the content, this staging table dedups that.

# How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->
dbt build --select stg__mitxonline__openedx__api__course_structure

review the table. e.g.
```
--- 1 row
SELECT * FROM "ol_data_lake_production"."ol_warehouse_production_rlougee_staging"."stg__mitxonline__openedx__api__course_structure" 
where courserun_readable_id='course-v1:MITxT+14.740x+2T2023'
and coursestructure_block_category ='course'

--- 16 rows
SELECT * FROM "ol_data_lake_production"."ol_warehouse_production_rlougee_staging"."stg__mitxonline__openedx__api__course_structure" 
where courserun_readable_id='course-v1:MITxT+14.740x+2T2023'
and coursestructure_block_category ='chapter'
```


