### PR TITLE
add courseactivity_num_chapters_visited and related upstream changes

### DIFF
--- a/src/ol_dbt/models/intermediate/mitxonline/_int_mitxonline__models.yml
+++ b/src/ol_dbt/models/intermediate/mitxonline/_int_mitxonline__models.yml
@@ -1347,7 +1347,10 @@ models:
     tests:
     - not_null
   - name: openedx_user_id
-    description: int, reference user id in auth_user from open edX.
+    description: int, open edX user ID extracted from context field. This id doesn't
+      always match with auth_user in open edX table, there can be multiple openedx_user_ids
+      for the same user_username. For those cases, use openedx_user_id from auth_user
+      open edX table.
     tests:
     - not_null
   - name: courserun_readable_id
@@ -1397,7 +1400,10 @@ models:
     tests:
     - not_null
   - name: openedx_user_id
-    description: int, reference user id in auth_user from open edX.
+    description: int, open edX user ID extracted from context field. This id doesn't
+      always match with auth_user in open edX table, there can be multiple openedx_user_ids
+      for the same user_username. For those cases, use openedx_user_id from auth_user
+      open edX table.
     tests:
     - not_null
   - name: courserun_readable_id
@@ -1450,6 +1456,11 @@ models:
     description: str, username of the open edX user who caused the event to be emitted.
     tests:
     - not_null
+  - name: openedx_user_id
+    description: int, either reference openedx_user_id in open edX users table, or
+      from tracking logs if no reference found.
+    tests:
+    - not_null
   - name: courserun_readable_id
     description: str, Open edX Course ID formatted as course-v1:{org}+{course code}+{run_tag}.
     tests:
@@ -1474,6 +1485,8 @@ models:
     description: int, number of play_video events
   - name: courseactivity_num_unique_play_video
     description: int, number of unique videos played within a course
+  - name: courseactivity_num_chapters_visited
+    description: int, number of unique chapters visited within a course
   - name: courseactivity_last_play_video_timestamp
     description: timestamp, timestamp of user's last play_video event within a course
   - name: courseactivity_last_problem_check_timestamp
@@ -1482,3 +1495,67 @@ models:
   tests:
   - dbt_expectations.expect_compound_columns_to_be_unique:
       column_list: ["user_username", "courserun_readable_id"]
+
+- name: int__mitxonline__course_structure
+  description: this table contains historical changes to open edX's course content
+    data. It adds coursestructure_chapter_id that identifies chapter each subsection
+    belongs to
+  columns:
+  - name: courserun_readable_id
+    description: str, Open edX Course ID formatted as course-v1:{org}+{course code}+{run_tag}
+    tests:
+    - not_null
+  - name: coursestructure_content_hash
+    description: str, sha256 hashed string of the course content.
+    tests:
+    - not_null
+  - name: coursestructure_block_content_hash
+    description: str, sha256 hashed string of the block content in a course
+    tests:
+    - not_null
+  - name: coursestructure_block_id
+    description: str, Unique ID for a distinct piece of content in a course, formatted
+      as block-v1:{org}+{course}+{run}type@{block type}+block@{hash code}
+    tests:
+    - not_null
+  - name: coursestructure_parent_block_id
+    description: str, parent block ID, same format as block_id
+  - name: coursestructure_block_index
+    description: int, sequence number giving order in which this block content appears
+      within the course
+    tests:
+    - not_null
+  - name: coursestructure_block_category
+    description: str, category/type of the block, it identifies core structural elements
+      of a course. Value includes but not limited to course, chapter, sequential,
+      vertical, discussion, html, problem, video, etc.
+    tests:
+    - not_null
+  - name: coursestructure_block_title
+    description: str, title of the block extracted from the metadata of the block.
+      This field comes from name field for the section, subsection, or unit on the
+      Studio 'Course Outline' page.
+  - name: coursestructure_block_metadata
+    description: str, json string of the metadata field for the block. It provides
+      additional information about this block, different block type may have different
+      member fields inside metadata.
+    tests:
+    - not_null
+  - name: courserun_title
+    description: str, title of the course extracted from the metadata of 'course'
+      block
+  - name: courserun_start_on
+    description: timestamp, indicating when the course run starts extracted from the
+      metadata of 'course' block
+  - name: coursestructure_retrieved_at
+    description: timestamp, indicating when this course structure was initially retrieved
+      from REST API.
+    tests:
+    - not_null
+  - name: coursestructure_chapter_id
+    description: str, block id of chapter within which this child block belongs to.
+      Null for the 'course' block as it's the top block that doesn't belong to any
+      chapter.
+  tests:
+  - dbt_expectations.expect_table_row_count_to_equal_other_table:
+      compare_model: ref('stg__mitxonline__openedx__api__course_structure')

--- a/src/ol_dbt/models/intermediate/mitxonline/int__mitxonline__course_structure.sql
+++ b/src/ol_dbt/models/intermediate/mitxonline/int__mitxonline__course_structure.sql
@@ -1,0 +1,51 @@
+with course_structure as (
+    select * from {{ ref('stg__mitxonline__openedx__api__course_structure') }}
+    order by courserun_readable_id, coursestructure_retrieved_at, coursestructure_block_index
+
+)
+
+, chapters as (
+    select * from course_structure
+    where coursestructure_block_category = 'chapter'
+)
+
+, course_structure_with_chapters as (
+    select
+        course_structure.*
+        , chapters.coursestructure_block_id as coursestructure_chapter_id
+        , row_number() over (
+            partition by
+                course_structure.courserun_readable_id
+                , course_structure.coursestructure_block_index
+                , course_structure.coursestructure_retrieved_at
+            order by chapters.coursestructure_block_index desc
+        ) as row_num
+    from course_structure
+    inner join chapters
+        on
+            course_structure.courserun_readable_id = chapters.courserun_readable_id
+            and course_structure.coursestructure_retrieved_at = chapters.coursestructure_retrieved_at
+            and course_structure.coursestructure_block_index >= chapters.coursestructure_block_index
+)
+
+select
+    course_structure.courserun_readable_id
+    , course_structure.courserun_title
+    , course_structure.coursestructure_block_index
+    , course_structure.coursestructure_block_id
+    , course_structure.coursestructure_parent_block_id
+    , course_structure.coursestructure_block_category
+    , course_structure.coursestructure_block_title
+    , course_structure.coursestructure_content_hash
+    , course_structure.coursestructure_block_content_hash
+    , course_structure.coursestructure_block_metadata
+    , course_structure.courserun_start_on
+    , course_structure.coursestructure_retrieved_at
+    , course_structure_with_chapters.coursestructure_chapter_id
+from course_structure
+left join course_structure_with_chapters
+    on
+        course_structure.courserun_readable_id = course_structure_with_chapters.courserun_readable_id
+        and course_structure.coursestructure_block_id = course_structure_with_chapters.coursestructure_block_id
+        and course_structure.coursestructure_retrieved_at = course_structure_with_chapters.coursestructure_retrieved_at
+        and course_structure_with_chapters.row_num = 1

--- a/src/ol_dbt/models/staging/mitxonline/_mitxonline__sources.yml
+++ b/src/ol_dbt/models/staging/mitxonline/_mitxonline__sources.yml
@@ -871,3 +871,36 @@ sources:
     - name: retrieved_at
       description: timestamp, time indicating when this block was initially retrieved
         from REST API.
+
+  - name: raw__mitxonline__openedx__mysql__courseware_studentmodule
+    columns:
+    - name: id
+      description: int, the auto-incremented ID for this table
+    - name: student_id
+      description: int, reference user id in auth_user from open edX
+    - name: course_id
+      description: str, Open edX Course ID in the format course-v1:{org}+{course code}+{run_tag}
+    - name: module_id
+      description: str, block ID for a distinct piece of content in a course, referencing
+        course_structure
+    - name: module_type
+      description: str, category/type of the block, referencing course_structure.
+    - name: state
+      description: str, JSON text indicating the learner's last known state within
+        a course.
+    - name: done
+      description: str, not used. The value is 'na' in every row
+    - name: grade
+      description: float, floating point value indicating the total unweighted grade
+        for this problem that the learner has scored. e.g. how many responses they
+        got right within the problem. This data is also available in courseactivity_problemcheck
+    - name: max_grade
+      description: float, floating point value indicating the total possible unweighted
+        grade for this problem, or basically the number of responses that are in this
+        problem. This data is also available in courseactivity_problemcheck
+    - name: created
+      description: timestamp, datetime when this row was created, which is typically
+        when the learner first accesses this piece of content.
+    - name: modified
+      description: timestamp, datetime when this row was last updated. A change in
+        this field implies that there was a state change.

--- a/src/ol_dbt/models/staging/mitxonline/_stg_mitxonline__models.yml
+++ b/src/ol_dbt/models/staging/mitxonline/_stg_mitxonline__models.yml
@@ -1207,16 +1207,18 @@ models:
 
 - name: stg__mitxonline__openedx__tracking_logs__user_activity
   description: This table is deduped as raw table has duplicate events. It filters
-    out blank username events since these don't supply user identifiers and also those
-    server "exception" events due to server errors
+    out blank username or user_id events since these don't supply user identifiers
+    and also those server "exception" events due to server errors
   columns:
   - name: user_username
     description: str, username of the open edX user who caused the event to be emitted.
     tests:
     - not_null
   - name: openedx_user_id
-    description: int, reference user id in auth_user from open edX. Extracted from
-      context field.
+    description: int, open edX user ID extracted from context field. This id doesn't
+      always match with auth_user in open edX table, there can be multiple openedx_user_ids
+      for the same user_username. For those cases, use openedx_user_id from auth_user
+      open edX table.
     tests:
     - not_null
   - name: courserun_readable_id
@@ -1340,3 +1342,58 @@ models:
   - dbt_expectations.expect_compound_columns_to_be_unique:
       column_list: ["courserun_readable_id", "coursestructure_block_id", "coursestructure_content_hash",
         "coursestructure_retrieved_at"]
+
+- name: stg__mitxonline__openedx__mysql__courseware_studentmodule
+  description: It holds the most current course state and score for learners on MITx
+    Online, including the most recent problem submission and the unit visited in each
+    subsection of the course content. It has a separate row for every piece of content
+    that a learner accesses.
+  columns:
+  - name: studentmodule_id
+    description: int, the auto-incremented ID for this table
+    tests:
+    - not_null
+    - unique
+  - name: openedx_user_id
+    description: int, reference user id in auth_user from open edX
+    tests:
+    - not_null
+  - name: courserun_readable_id
+    description: str, Open edX Course ID in the format course-v1:{org}+{course code}+{run_tag}
+    tests:
+    - not_null
+  - name: coursestructure_block_id
+    description: str, block ID for a distinct piece of content in a course, referencing
+      course_structure
+    tests:
+    - not_null
+  - name: coursestructure_block_category
+    description: str, category/type of the block, referencing course_structure.
+    tests:
+    - not_null
+  - name: studentmodule_state_data
+    description: json, JSON string indicating the learner's last known state within
+      a course.
+    tests:
+    - not_null
+  - name: studentmodule_problem_grade
+    description: float, floating point value indicating the total unweighted grade
+      for this problem that the learner has scored. e.g. how many responses they got
+      right within the problem. This data is also available in courseactivity_problemcheck
+  - name: studentmodule_problem_max_grade
+    description: float, floating point value indicating the total possible unweighted
+      grade for this problem, or basically the number of responses that are in this
+      problem. This data is also available in courseactivity_problemcheck
+  - name: studentmodule_created_on
+    description: timestamp, datetime when this row was created, which is typically
+      when the learner first accesses this piece of content.
+    tests:
+    - not_null
+  - name: studentmodule_updated_on
+    description: timestamp, datetime when this row was last updated. A change in this
+      field implies that there was a state change.
+    tests:
+    - not_null
+  tests:
+  - dbt_expectations.expect_compound_columns_to_be_unique:
+      column_list: ["openedx_user_id", "courserun_readable_id", "coursestructure_block_id"]

--- a/src/ol_dbt/models/staging/mitxonline/stg__mitxonline__openedx__mysql__courseware_studentmodule.sql
+++ b/src/ol_dbt/models/staging/mitxonline/stg__mitxonline__openedx__mysql__courseware_studentmodule.sql
@@ -1,0 +1,21 @@
+with source as (
+    select * from {{ source('ol_warehouse_raw_data', 'raw__mitxonline__openedx__mysql__courseware_studentmodule') }}
+)
+
+, cleaned as (
+
+    select
+        id as studentmodule_id
+        , course_id as courserun_readable_id
+        , module_id as coursestructure_block_id
+        , module_type as coursestructure_block_category
+        , student_id as openedx_user_id
+        , state as studentmodule_state_data
+        , grade as studentmodule_problem_grade
+        , max_grade as studentmodule_problem_max_grade
+        , to_iso8601(from_iso8601_timestamp_nanos(created)) as studentmodule_created_on
+        , to_iso8601(from_iso8601_timestamp_nanos(modified)) as studentmodule_updated_on
+    from source
+)
+
+select * from cleaned

--- a/src/ol_dbt/models/staging/mitxonline/stg__mitxonline__openedx__tracking_logs__user_activity.sql
+++ b/src/ol_dbt/models/staging/mitxonline/stg__mitxonline__openedx__tracking_logs__user_activity.sql
@@ -13,7 +13,7 @@ with source as (
     select * from {{ source('ol_warehouse_raw_data','raw__mitxonline__openedx__tracking_logs') }}
     where
         username != ''
-        and json_query(context, 'lax $.user_id' omit quotes) is not null
+        and json_query(context, 'lax $.user_id' omit quotes) != 'null'
         and json_query(event, 'lax $.exception' omit quotes) is null
 
     {% if is_incremental() %}
@@ -54,7 +54,7 @@ with source as (
         , event_type as useractivity_event_type
         , {{ extract_course_id_from_tracking_log() }} as courserun_readable_id
         --- extract common fields from context object
-        , json_query(context, 'lax $.user_id' omit quotes) as openedx_user_id
+        , cast(json_query(context, 'lax $.user_id' omit quotes) as integer) as openedx_user_id
         , json_query(context, 'lax $.org_id' omit quotes) as org_id
         , json_query(context, 'lax $.path' omit quotes) as useractivity_path
         --- due to log collector changes, values of time field come with different formats

--- a/src/ol_dbt/profiles.yml
+++ b/src/ol_dbt/profiles.yml
@@ -43,7 +43,7 @@ open_learning:
       database: ol_data_lake_production
       port: 443
       schema: ol_warehouse_production{{ "_{}".format(var('schema_suffix')) }}
-      host: mitol-ol-data-lake-qa-0.trino.galaxy.starburst.io
+      host: mitol-ol-data-lake-production.trino.galaxy.starburst.io
       http_scheme: https
       threads: 4
     dev:


### PR DESCRIPTION
# What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
https://github.com/mitodl/ol-data-platform/issues/799

# Description (What does it do?)
<!--- Describe your changes in detail -->
- Creating `stg__mitxonline__openedx__mysql__courseware_studentmodule `
- Creating `int__mitxonline__course_structure` with additional chapter_id 
- Adding  `courseactivity_num_chapters_visited` to int__mitxonline__user_courseactivities
- Fixing openedx_user_id type issue in upstream model

# How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->
Update `host` to be `mitol-ol-data-lake-production.trino.galaxy.starburst.io` in profiles.yml for dev_production target in order to run the large tables from production

- Manually drop table `stg__mitxonline__openedx__tracking_logs__user_activity` if it exists 
- Run `dbt build +int__mitxonline__user_courseactivities`
