### PR TITLE
Add DBT Grant Configs for Trino Roles and Permissions

### DIFF
--- a/src/ol_dbt/dbt_project.yml
+++ b/src/ol_dbt/dbt_project.yml
@@ -60,7 +60,7 @@ models:
       format: "'PARQUET'"
     +required_docs: true
     +grants:
-      select: ['accountadmin', 'business_intelligence', 'read_only_production', 'production_analyst']
+      select: ['accountadmin', 'read_only_production', 'production_analyst']
       insert: ['accountadmin', 'production_analyst']
       update: ['accountadmin', 'production_analyst']
       delete: ['accountadmin', 'production_analyst']
@@ -77,13 +77,13 @@ models:
       +materialized: table
       +schema: intermediate
       +grants:
-        select: ['read_only_production']
+        select: ['read_only_production', 'business_intelligence']
         create: ['production_analyst']
     marts:
       +materialized: table
       +schema: mart
       +grants:
-        select: ['read_only_production', 'finance_access', 'reverse_etl']
+        select: ['read_only_production', 'business_intelligence', 'reverse_etl']
         create: ['production_analyst']
     sample:
 

--- a/src/ol_dbt/dbt_project.yml
+++ b/src/ol_dbt/dbt_project.yml
@@ -64,27 +64,22 @@ models:
       insert: ['accountadmin', 'production_analyst']
       update: ['accountadmin', 'production_analyst']
       delete: ['accountadmin', 'production_analyst']
-      create: ['accountadmin']
-      alter: ['accountadmin']
-      drop: ['accountadmin']
+      all privileges: ['accountadmin']
     staging:
       +materialized: table
       +schema: staging
       +grants:
         select: ['read_only_production']
-        create: ['production_analyst']
     intermediate:
       +materialized: table
       +schema: intermediate
       +grants:
         select: ['read_only_production', 'business_intelligence']
-        create: ['production_analyst']
     marts:
       +materialized: table
       +schema: mart
       +grants:
         select: ['read_only_production', 'business_intelligence', 'reverse_etl']
-        create: ['production_analyst']
     sample:
 
 

--- a/src/ol_dbt/dbt_project.yml
+++ b/src/ol_dbt/dbt_project.yml
@@ -59,15 +59,33 @@ models:
     +properties:
       format: "'PARQUET'"
     +required_docs: true
+    +grants:
+      select: ['accountadmin', 'business_intelligence', 'read_only_production', 'production_analyst']
+      insert: ['accountadmin', 'production_analyst']
+      update: ['accountadmin', 'production_analyst']
+      delete: ['accountadmin', 'production_analyst']
+      create: ['accountadmin']
+      alter: ['accountadmin']
+      drop: ['accountadmin']
     staging:
       +materialized: table
       +schema: staging
+      +grants:
+        select: ['read_only_production']
+        create: ['production_analyst']
     intermediate:
       +materialized: table
       +schema: intermediate
+      +grants:
+        select: ['read_only_production']
+        create: ['production_analyst']
     marts:
       +materialized: table
       +schema: mart
+      +grants:
+        select: ['read_only_production', 'finance_access', 'reverse_etl']
+        create: ['production_analyst']
+    sample:
 
 
 # Test severity config

--- a/src/ol_dbt/macros/apply_grants_macro_override.sql
+++ b/src/ol_dbt/macros/apply_grants_macro_override.sql
@@ -1,0 +1,9 @@
+{% macro apply_grants(relation, grant_config, should_revoke) %}
+    {% if target.name == 'production' %}
+        {#-- Only apply grants in production schema --#}
+        {{ return(adapter.dispatch("apply_grants", "dbt")(relation, grant_config, should_revoke)) }}
+    {% else %}
+        {#-- Bypass code-based grant application in non-prod targets. --#}
+        {#-- This is so that we don't accidentally expose test tables to end-consumers of data --#}
+    {% endif %}
+{% endmacro %}

--- a/src/ol_dbt/macros/starburst_trino_grant_sql.sql
+++ b/src/ol_dbt/macros/starburst_trino_grant_sql.sql
@@ -1,0 +1,6 @@
+-- This overrides the grant SQL to apply only to ROLEs since that is the requirement for
+-- Starburst Galaxy's permissions system.
+
+{%- macro trino__get_grant_sql(relation, privilege, grantees) -%}
+    GRANT {{ privilege }} ON {{ relation }} TO ROLE {{ adapter.quote(grantees[0]) }}
+{%- endmacro %}

--- a/src/ol_dbt/models/marts/combined/_marts__combined__models.yml
+++ b/src/ol_dbt/models/marts/combined/_marts__combined__models.yml
@@ -5,8 +5,9 @@ models:
 - name: marts__combined_course_enrollment_detail
   description: course enrollment detail with certificates, orders and coupons from
     OL platforms.
-  +grants:
-    select: ['finance']
+  config:
+    grants:
+      select: ['finance']
   columns:
   - name: platform
     description: string, application where the data is from

--- a/src/ol_dbt/models/marts/combined/_marts__combined__models.yml
+++ b/src/ol_dbt/models/marts/combined/_marts__combined__models.yml
@@ -5,6 +5,8 @@ models:
 - name: marts__combined_course_enrollment_detail
   description: course enrollment detail with certificates, orders and coupons from
     OL platforms.
+  +grants:
+    select: ['finance']
   columns:
   - name: platform
     description: string, application where the data is from

--- a/src/ol_dbt/models/marts/mitxonline/_marts__mitxonline__models.yml
+++ b/src/ol_dbt/models/marts/mitxonline/_marts__mitxonline__models.yml
@@ -4,6 +4,8 @@ version: 2
 models:
 - name: marts__mitxonline_course_certificates
   description: course certificates from MITx Online app
+  +grants:
+    select: ['mit_irx']
   columns:
   - name: course_number
     description: str, unique string for the course. It can contain letters, numbers,
@@ -43,6 +45,8 @@ models:
 
 - name: marts__mitxonline_user_profiles
   description: MITx Online user profiles
+  +grants:
+    select: ['mit_irx']
   columns:
   - name: user_username
     description: str, username on MITx Online

--- a/src/ol_dbt/models/marts/mitxonline/_marts__mitxonline__models.yml
+++ b/src/ol_dbt/models/marts/mitxonline/_marts__mitxonline__models.yml
@@ -4,8 +4,9 @@ version: 2
 models:
 - name: marts__mitxonline_course_certificates
   description: course certificates from MITx Online app
-  +grants:
-    select: ['mit_irx']
+  config:
+    grants:
+      select: ['mit_irx']
   columns:
   - name: course_number
     description: str, unique string for the course. It can contain letters, numbers,
@@ -45,8 +46,9 @@ models:
 
 - name: marts__mitxonline_user_profiles
   description: MITx Online user profiles
-  +grants:
-    select: ['mit_irx']
+  config:
+    grants:
+      select: ['mit_irx']
   columns:
   - name: user_username
     description: str, username on MITx Online

--- a/src/ol_dbt/models/marts/mitxpro/_marts__mitxpro__models.yml
+++ b/src/ol_dbt/models/marts/mitxpro/_marts__mitxpro__models.yml
@@ -4,6 +4,8 @@ version: 2
 models:
 - name: marts__mitxpro_ecommerce_productlist
   description: Xpro product line table with denormalized data
+  +grants:
+    select: ['finance']
   columns:
   - name: product_platform
     description: string, defaulted to xPro

--- a/src/ol_dbt/models/marts/mitxpro/_marts__mitxpro__models.yml
+++ b/src/ol_dbt/models/marts/mitxpro/_marts__mitxpro__models.yml
@@ -4,8 +4,9 @@ version: 2
 models:
 - name: marts__mitxpro_ecommerce_productlist
   description: Xpro product line table with denormalized data
-  +grants:
-    select: ['finance']
+  config:
+    grants:
+      select: ['finance']
   columns:
   - name: product_platform
     description: string, defaulted to xPro


### PR DESCRIPTION
Added grant configs for accountadmin, read_only_production, business_intelligence, production analyst, reverse_etl, and finance_access

# What are the relevant tickets?
Closes #924 

# Description (What does it do?)
The permissions we grant to different roles allow us to share data with data consumers. Role specific permissions in Trino are currently managed through [Starburst](https://mitol.galaxy.starburst.io/role). We have observed tags and permissions periodically disappearing from Starburst because of how dbt manages table definitions. When a table is deleted and recreated, Starburst loses the reference to the table during the rebuild and there is no reference to maintain the tag relationships.

To address this issue, we are defining roles and database permissions as code within the dbt project config and schema and table configs. This will ensure permissions are properly managed, versioned, and can be audited and reviewed more easily.

# How can this be tested?
I tested this by running dbt build locally against a separate schema and then looking at the roles/permissions granted on those tables. 

```
# build models
dbt run --select open_learning --var 'schema_suffix: qhoque' --target dev_qa
```
In starburst, check privileges on marts__mitxonline_user_profiles, confirm grant statements in dbt logs.

## Checklist:
- [x] There is a method for defining roles as code that get populated in Starburst
- [x] There is a method for defining permissions on those roles that is executed as part of table creation workflows
- [x] The existing role definitions and permissions are reflected as code.