### PR TITLE
add subsection grading to staging and intermediate

### DIFF
--- a/src/ol_dbt/models/intermediate/mitxonline/_int_mitxonline__models.yml
+++ b/src/ol_dbt/models/intermediate/mitxonline/_int_mitxonline__models.yml
@@ -1579,3 +1579,54 @@ models:
   tests:
   - dbt_expectations.expect_table_row_count_to_equal_other_table:
       compare_model: ref('stg__mitxonline__openedx__api__course_structure')
+
+- name: int__mitxonline__courserun_subsection_grades
+  description: Persistent values for learners' subsection (aka sequential) grades
+    combined with override grades
+  columns:
+  - name: courserun_readable_id
+    description: str, Open edX Course ID formatted as course-v1:{org}+{course code}+{run_tag}
+    tests:
+    - not_null
+  - name: coursestructure_block_id
+    description: str, block ID of the subsection (sequential) - foreign key to course_structure
+    tests:
+    - not_null
+  - name: coursestructure_block_title
+    description: str, title of the subsection
+  - name: coursestructure_chapter_id
+    description: str, block id of chapter within which this subsection belongs to
+  - name: openedx_user_id
+    description: int, foreign key to auth_user from open edX platform
+    tests:
+    - not_null
+  - name: subsectiongrade_total_score
+    description: float, total score of all problems (both graded and ungraded) for
+      the subsection
+    tests:
+    - not_null
+  - name: subsectiongrade_total_earned_score
+    description: float, user's total earned score of all problems (both graded and
+      ungraded) for the subsection
+    tests:
+    - not_null
+  - name: subsectiongrade_total_graded_score
+    description: float, total score of all graded problems for the subsection.
+    tests:
+    - not_null
+  - name: subsectiongrade_total_earned_graded_score
+    description: float, user's total earned score of all graded problems for the subsection.
+    tests:
+    - not_null
+  - name: subsectiongrade_is_overridden
+    description: boolean, indicating whether this subsection grades are overridden
+  - name: subsectiongrade_first_attempted_on
+    description: timestamp, time of the user's first attempt at a problem in the subsection.
+  - name: subsectiongrade_created_on
+    description: timestamp, datetime of the subsection grade was first calculated
+      for this user for this subsection.
+    tests:
+    - not_null
+  tests:
+  - dbt_expectations.expect_compound_columns_to_be_unique:
+      column_list: ["openedx_user_id", "courserun_readable_id", "coursestructure_block_id"]

--- a/src/ol_dbt/models/intermediate/mitxonline/int__mitxonline__courserun_subsection_grades.sql
+++ b/src/ol_dbt/models/intermediate/mitxonline/int__mitxonline__courserun_subsection_grades.sql
@@ -1,0 +1,53 @@
+with subsection_grades as (
+    select * from {{ ref('stg__mitxonline__openedx__mysql__grades_subsectiongrade') }}
+)
+
+, subsection_grade_overrides as (
+    select * from {{ ref('stg__mitxonline__openedx__mysql__grades_subsectiongradeoverride') }}
+)
+
+, course_structure as (
+    select
+        *
+        , row_number() over (
+            partition by courserun_readable_id, coursestructure_block_id order by coursestructure_retrieved_at desc
+        ) as row_num
+    from {{ ref('int__mitxonline__course_structure') }}
+)
+
+, subsection_grades_joined as (
+    select
+        subsection_grades.courserun_readable_id
+        , subsection_grades.coursestructure_block_id
+        , course_structure.coursestructure_block_title
+        , course_structure.coursestructure_chapter_id
+        , subsection_grades.openedx_user_id
+        , subsection_grades.subsectiongrade_first_attempted_on
+        , subsection_grades.subsectiongrade_created_on
+        , coalesce(
+            subsection_grade_overrides.subsectiongradeoverride_total_score
+            , subsection_grades.subsectiongrade_total_score
+        ) as subsectiongrade_total_score
+        , coalesce(
+            subsection_grade_overrides.subsectiongradeoverride_total_earned_score
+            , subsection_grades.subsectiongrade_total_earned_score
+        ) as subsectiongrade_total_earned_score
+        , coalesce(
+            subsection_grade_overrides.subsectiongradeoverride_total_graded_score
+            , subsection_grades.subsectiongrade_total_graded_score
+        ) as subsectiongrade_total_graded_score
+        , coalesce(
+            subsection_grade_overrides.subsectiongradeoverride_total_earned_graded_score
+            , subsection_grades.subsectiongrade_total_earned_graded_score
+        ) as subsectiongrade_total_earned_graded_score
+        , if(subsection_grade_overrides.subsectiongradeoverride_id is not null, true, false)
+            as subsectiongrade_is_overridden
+    from subsection_grades
+    inner join course_structure
+        on subsection_grades.coursestructure_block_id = course_structure.coursestructure_block_id
+    left join subsection_grade_overrides
+        on subsection_grades.subsectiongrade_id = subsection_grade_overrides.subsectiongrade_id
+    where course_structure.row_num = 1
+)
+
+select * from subsection_grades_joined

--- a/src/ol_dbt/models/staging/mitxonline/_mitxonline__sources.yml
+++ b/src/ol_dbt/models/staging/mitxonline/_mitxonline__sources.yml
@@ -904,3 +904,87 @@ sources:
     - name: modified
       description: timestamp, datetime when this row was last updated. A change in
         this field implies that there was a state change.
+
+  - name: raw__mitxonline__openedx__mysql__grades_persistentsubsectiongrade
+    description: Persistent values for learners' subsection (aka sequential) grades.
+    columns:
+    - name: id
+      description: int, the auto-incremented ID for this table
+    - name: course_id
+      description: str, Open edX Course ID formatted as course-v1:{org}+{course code}+{run_tag}
+    - name: course_version
+      description: str, The version number of the course in the Split Modulestore
+        when the grade was computed. Currently used for debugging purposes only.
+    - name: usage_key
+      description: str, block ID of the subsection (sequential) - foreign key to course_structure
+    - name: user_id
+      description: int, foreign key to auth_user from open edX platform
+    - name: visibleblocks_hash
+      description: str, foreign key to grades_visibleblocks
+    - name: possible_all
+      description: float, the aggregated "total_weighted_possible" score in the subsection,
+        calculated by summing all "weighted_possible" values of all (graded and ungraded)
+        problems in the subsection.
+    - name: possible_graded
+      description: float, The aggregated "total_weighted_possible" score in the subsection,
+        calculated by summing all "weighted_possible" values of all "graded" problems
+        in the subsection.
+    - name: earned_all
+      description: float, The user's aggregated "total_weighted_earned" score in the
+        subsection, calculated by summing all "weighted_earned" values of all (graded
+        and ungraded) problems in the subsection.
+    - name: earned_graded
+      description: float, The user's aggregated "total_weighted_earned" score in the
+        subsection, calculated by summing all "weighted_earned" values of all "graded"
+        problems in the subsection.
+    - name: first_attempted
+      description: timestamp, time of the user's first attempt at a problem in the
+        subsection.
+    - name: created
+      description: timestamp, datetime of the subsection grade was first calculated
+        for this user for this subsection.
+    - name: modified
+      description: timestamp, datetime of the subsection grade was last updated for
+        this user for this subsection.
+
+  - name: raw__mitxonline__openedx__mysql__grades_persistentsubsectiongradeoverride
+    description: Stores the most recent override grades for a given subsection
+    columns:
+    - name: id
+      description: int, the auto-incremented ID for this table
+    - name: grade_id
+      description: int, foreign key to grades_persistentsubsectiongrade
+    - name: possible_all_override
+      description: float, total score of all problems (both graded and ungraded) for
+        the subsection
+    - name: possible_graded_override
+      description: float, total score of all graded problems for the subsection
+    - name: earned_all_override
+      description: float, total earned score (graded and ungraded) to be overridden.
+    - name: earned_graded_override
+      description: float, override to learner's earned_graded score for the subsection
+    - name: first_attempted
+      description: timestamp, time of the user's first attempt at a problem in the
+        subsection.
+    - name: override_reason
+      description: str, instructor provided reason for override
+    - name: system
+      description: str, indicating system where the override was performed. Possible
+        values are grade-import, PROCTORING and GRADEBOOK
+    - name: created
+      description: timestamp, datetime when the override was first created.
+    - name: modified
+      description: timestamp, datetime when the override was last modified.
+
+  - name: raw__mitxonline__openedx__mysql__grades_visibleblocks
+    description: Stores an ordered list of visible blocks within a subsection for
+      a learner at the time of computing the subsection grade.
+    columns:
+    - name: id
+      description: int, the auto-incremented ID for this table
+    - name: course_id
+      description: str, Open edX Course ID formatted as course-v1:{org}+{course code}+{run_tag}
+    - name: hashed
+      description: str, SHA1 hash of the blocks_json value.
+    - name: blocks_json
+      description: str, json object of all visible blocks within a subsection

--- a/src/ol_dbt/models/staging/mitxonline/_stg_mitxonline__models.yml
+++ b/src/ol_dbt/models/staging/mitxonline/_stg_mitxonline__models.yml
@@ -1395,3 +1395,135 @@ models:
   tests:
   - dbt_expectations.expect_compound_columns_to_be_unique:
       column_list: ["openedx_user_id", "courserun_readable_id", "coursestructure_block_id"]
+
+- name: stg__mitxonline__openedx__mysql__grades_subsectiongrade
+  description: Persistent values for learners' subsection (aka sequential) grades.
+  columns:
+  - name: subsectiongrade_id
+    description: int, the auto-incremented ID for this table
+    tests:
+    - not_null
+    - unique
+  - name: courserun_readable_id
+    description: str, Open edX Course ID formatted as course-v1:{org}+{course code}+{run_tag}
+    tests:
+    - not_null
+  - name: coursestructure_block_id
+    description: str, block ID of the subsection (sequential) - foreign key to course_structure
+    tests:
+    - not_null
+  - name: openedx_user_id
+    description: int, foreign key to auth_user from open edX platform
+    tests:
+    - not_null
+  - name: visibleblocks_hash
+    description: str, foreign key to grades_visibleblocks. This field might be useful
+      for identifying whether the course content was the same for two grades.
+    tests:
+    - not_null
+  - name: subsectiongrade_total_score
+    description: float, the aggregated "total_weighted_possible" score in the subsection,
+      calculated by summing all "weighted_possible" values of all (graded and ungraded)
+      problems in the subsection.
+    tests:
+    - not_null
+  - name: subsectiongrade_total_graded_score
+    description: float, The aggregated "total_weighted_possible" score in the subsection,
+      calculated by summing all "weighted_possible" values of all "graded" problems
+      in the subsection.
+    tests:
+    - not_null
+  - name: subsectiongrade_total_earned_score
+    description: float, The user's aggregated "total_weighted_earned" score in the
+      subsection, calculated by summing all "weighted_earned" values of all (graded
+      and ungraded) problems in the subsection.
+    tests:
+    - not_null
+  - name: subsectiongrade_total_earned_graded_score
+    description: float, The user's aggregated "total_weighted_earned" score in the
+      subsection, calculated by summing all "weighted_earned" values of all "graded"
+      problems in the subsection.
+    tests:
+    - not_null
+  - name: subsectiongrade_first_attempted_on
+    description: timestamp, time of the user's first attempt at a problem in the subsection.
+  - name: subsectiongrade_created_on
+    description: timestamp, datetime of the subsection grade was first calculated
+      for this user for this subsection.
+    tests:
+    - not_null
+  - name: subsectiongrade_updated_on
+    description: timestamp, datetime of the subsection grade was last updated for
+      this user for this subsection.
+    tests:
+    - not_null
+  tests:
+  - dbt_expectations.expect_compound_columns_to_be_unique:
+      column_list: ["openedx_user_id", "courserun_readable_id", "coursestructure_block_id"]
+
+- name: stg__mitxonline__openedx__mysql__grades_subsectiongradeoverride
+  description: Stores the most recent override grades for a given subsection
+  columns:
+  - name: subsectiongradeoverride_id
+    description: int, the auto-incremented ID for this table
+    tests:
+    - not_null
+    - unique
+  - name: subsectiongrade_id
+    description: int, foreign key to grades_persistentsubsectiongrade
+    tests:
+    - not_null
+    - unique
+  - name: subsectiongradeoverride_total_score
+    description: float, total score of all problems (both graded and ungraded) for
+      the subsection
+    tests:
+    - not_null
+  - name: subsectiongradeoverride_total_graded_score
+    description: float, total score of all graded problems for the subsection
+    tests:
+    - not_null
+  - name: subsectiongradeoverride_total_earned_score
+    description: float, total earned score (graded and ungraded) to be overridden.
+  - name: subsectiongradeoverride_total_earned_graded_score
+    description: float, override to learner's total_earned_graded score for the subsection
+    tests:
+    - not_null
+  - name: subsectiongradeoverride_reason
+    description: str, instructor provided reason for override
+  - name: subsectiongradeoverride_system
+    description: str, indicating system where the override was performed. Possible
+      values are grade-import, PROCTORING and GRADEBOOK
+    tests:
+    - not_null
+  - name: subsectiongradeoverride_created_on
+    description: timestamp, datetime when the override was first created.
+    tests:
+    - not_null
+  - name: subsectiongradeoverride_updated_on
+    description: timestamp, datetime when the override was last modified.
+    tests:
+    - not_null
+
+- name: stg__mitxonline__openedx__mysql__grades_visibleblocks
+  description: Stores an ordered list of visible blocks within a subsection for a
+    learner at the time of computing the subsection grade.
+  columns:
+  - name: visibleblocks_id
+    description: int, the auto-incremented ID for this table
+    tests:
+    - not_null
+    - unique
+  - name: courserun_readable_id
+    description: str, Open edX Course ID formatted as course-v1:{org}+{course code}+{run_tag}
+    tests:
+    - not_null
+  - name: visibleblocks_hash
+    description: str, SHA1 hash of the blocks_json value.
+    tests:
+    - not_null
+    - unique
+  - name: visibleblocks_json
+    description: str, json object of all visible blocks within a subsection
+    tests:
+    - not_null

--- a/src/ol_dbt/models/staging/mitxonline/stg__mitxonline__openedx__mysql__grades_subsectiongrade.sql
+++ b/src/ol_dbt/models/staging/mitxonline/stg__mitxonline__openedx__mysql__grades_subsectiongrade.sql
@@ -1,0 +1,24 @@
+with source as (
+    select *
+    from {{ source('ol_warehouse_raw_data', 'raw__mitxonline__openedx__mysql__grades_persistentsubsectiongrade') }}
+)
+
+, cleaned as (
+
+    select
+        id as subsectiongrade_id
+        , course_id as courserun_readable_id
+        , user_id as openedx_user_id
+        , usage_key as coursestructure_block_id
+        , visible_blocks_hash as visibleblocks_hash
+        , possible_all as subsectiongrade_total_score
+        , possible_graded as subsectiongrade_total_graded_score
+        , earned_all as subsectiongrade_total_earned_score
+        , earned_graded as subsectiongrade_total_earned_graded_score
+        , to_iso8601(from_iso8601_timestamp_nanos(first_attempted)) as subsectiongrade_first_attempted_on
+        , to_iso8601(from_iso8601_timestamp_nanos(created)) as subsectiongrade_created_on
+        , to_iso8601(from_iso8601_timestamp_nanos(modified)) as subsectiongrade_updated_on
+    from source
+)
+
+select * from cleaned

--- a/src/ol_dbt/models/staging/mitxonline/stg__mitxonline__openedx__mysql__grades_subsectiongradeoverride.sql
+++ b/src/ol_dbt/models/staging/mitxonline/stg__mitxonline__openedx__mysql__grades_subsectiongradeoverride.sql
@@ -1,0 +1,23 @@
+with source as (
+    select * from {{
+     source('ol_warehouse_raw_data', 'raw__mitxonline__openedx__mysql__grades_persistentsubsectiongradeoverride')
+   }}
+)
+
+, cleaned as (
+
+    select
+        id as subsectiongradeoverride_id
+        , grade_id as subsectiongrade_id
+        , possible_all_override as subsectiongradeoverride_total_score
+        , possible_graded_override as subsectiongradeoverride_total_graded_score
+        , earned_all_override as subsectiongradeoverride_total_earned_score
+        , earned_graded_override as subsectiongradeoverride_total_earned_graded_score
+        , override_reason as subsectiongradeoverride_reason
+        , system as subsectiongradeoverride_system
+        , to_iso8601(from_iso8601_timestamp_nanos(created)) as subsectiongradeoverride_created_on
+        , to_iso8601(from_iso8601_timestamp_nanos(modified)) as subsectiongradeoverride_updated_on
+    from source
+)
+
+select * from cleaned

--- a/src/ol_dbt/models/staging/mitxonline/stg__mitxonline__openedx__mysql__grades_visibleblocks.sql
+++ b/src/ol_dbt/models/staging/mitxonline/stg__mitxonline__openedx__mysql__grades_visibleblocks.sql
@@ -1,0 +1,15 @@
+with source as (
+    select * from {{ source('ol_warehouse_raw_data', 'raw__mitxonline__openedx__mysql__grades_visibleblocks') }}
+)
+
+, cleaned as (
+
+    select
+        id as visibleblocks_id
+        , course_id as courserun_readable_id
+        , hashed as visibleblocks_hash
+        , blocks_json as visibleblocks_json
+    from source
+)
+
+select * from cleaned


### PR DESCRIPTION
# What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
part of https://github.com/mitodl/hq/issues/3063

# Description (What does it do?)
<!--- Describe your changes in detail -->
Adding course subsection grading related tables to staging and intermediate 
- stg__mitxonline__openedx__mysql__grades_subsectiongrade
- stg__mitxonline__openedx__mysql__grades_subsectiongradeoverride
- stg__mitxonline__openedx__mysql__grades_visibleblocks
- int__mitxonline__courserun_subsection_grades

# How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->
```
dbt build +int__mitxonline__courserun_subsection_grades
dbt build stg__mitxonline__openedx__mysql__grades_visibleblocks
```