### PR TITLE
Grant Config Permissions Fix

### DIFF
--- a/src/ol_dbt/dbt_project.yml
+++ b/src/ol_dbt/dbt_project.yml
@@ -60,10 +60,10 @@ models:
       format: "'PARQUET'"
     +required_docs: true
     +grants:
-      select: ['accountadmin', 'read_only_production', 'production_analyst']
-      insert: ['accountadmin', 'production_analyst']
-      update: ['accountadmin', 'production_analyst']
-      delete: ['accountadmin', 'production_analyst']
+      select: ['read_only_production', 'production_analyst']
+      insert: ['production_analyst']
+      update: ['production_analyst']
+      delete: ['production_analyst']
       all privileges: ['accountadmin']
     staging:
       +materialized: table


### PR DESCRIPTION
Removing accountadmin from the grant configs for specific sql commands except for 'all privileges'.

# What are the relevant tickets?
This PR addresses a bug that was causing [dbt failures](https://pipelines.odl.mit.edu/runs/9f38c6b2-df52-48d6-973b-8e017636fb10?selection=%2A&logFileKey=ismyzewd) on some of the 'view' models in production.

# Description (What does it do?)
There is a bug in the [recent changes to the dbt_project.yml](https://github.com/mitodl/ol-data-platform/commit/7935f454cea3ad0268f826d5c5a1a31708fdb0da) where we added grant configs to give specific roles privileges to tables, schemas, and models. The bug was causing the dbt run to error out when trying to revoke access for certain roles as [noted by Rachel on Slack](https://mitodl.slack.com/archives/C03FSKKJNTV/p1701793913235079?thread_ts=1701792901.791589&cid=C03FSKKJNTV).
`# examplexw
revoke select on "ol_data_lake_production"."ol_warehouse_production_intermediate"."int__mitx__courserun_grades" from accountadmin`

# How can this be tested?
Running dbt locally and making sure that there are no Trino user errors:
`TrinoUserError(type=USER_ERROR, name=NOT_SUPPORTED, message="Galaxy only supports a ROLE as a grantee", query_id=20231201_173937_86549_e7xft`
caused by any of the GRANT or REVOKE statements run by dbt.

## Checklist:
- [ ] Run a full dbt refresh
- [ ] Confirm TrinoUserErrors are resolved

