### PR TITLE
create mart for mitxonline video engagement

### DIFF
--- a/src/ol_dbt/models/intermediate/mitxonline/_int_mitxonline__models.yml
+++ b/src/ol_dbt/models/intermediate/mitxonline/_int_mitxonline__models.yml
@@ -1746,6 +1746,10 @@ models:
     description: str, block id of chapter within which this child block belongs to.
       Null for the 'course' block as it's the top block that doesn't belong to any
       chapter.
+  - name: coursestructure_chapter_title
+    description: str, title of chapter within which this child block belongs to.
+  - name: coursestructure_is_latest
+    description: boolean, indicating if the course content is the latest version
   tests:
   - dbt_expectations.expect_table_row_count_to_equal_other_table:
       compare_model: ref('stg__mitxonline__openedx__api__course_structure')

--- a/src/ol_dbt/models/intermediate/mitxonline/int__mitxonline__course_structure.sql
+++ b/src/ol_dbt/models/intermediate/mitxonline/int__mitxonline__course_structure.sql
@@ -4,6 +4,14 @@ with course_structure as (
 
 )
 
+, latest_course_structure_date as (
+    select
+        courserun_readable_id
+        , max(coursestructure_retrieved_at) as max_retrieved_date
+    from course_structure
+    group by courserun_readable_id
+)
+
 , chapters as (
     select * from course_structure
     where coursestructure_block_category = 'chapter'
@@ -13,6 +21,7 @@ with course_structure as (
     select
         course_structure.*
         , chapters.coursestructure_block_id as coursestructure_chapter_id
+        , chapters.coursestructure_block_title as coursestructure_chapter_title
         , row_number() over (
             partition by
                 course_structure.courserun_readable_id
@@ -42,7 +51,13 @@ select
     , course_structure.courserun_start_on
     , course_structure.coursestructure_retrieved_at
     , course_structure_with_chapters.coursestructure_chapter_id
+    , course_structure_with_chapters.coursestructure_chapter_title
+    , if(latest_course_structure_date.max_retrieved_date is not null, true, false) as coursestructure_is_latest
 from course_structure
+left join latest_course_structure_date
+    on
+        course_structure.courserun_readable_id = latest_course_structure_date.courserun_readable_id
+        and course_structure.coursestructure_retrieved_at = latest_course_structure_date.max_retrieved_date
 left join course_structure_with_chapters
     on
         course_structure.courserun_readable_id = course_structure_with_chapters.courserun_readable_id

--- a/src/ol_dbt/models/marts/mitxonline/_marts__mitxonline__models.yml
+++ b/src/ol_dbt/models/marts/mitxonline/_marts__mitxonline__models.yml
@@ -189,3 +189,64 @@ models:
   tests:
   - dbt_expectations.expect_compound_columns_to_be_unique:
       column_list: ["user_username", "courserun_readable_id", "courseactivity_date"]
+
+- name: marts__mitxonline_video_engagements
+  description: MITx Online learners video engagements - play, pause, seek or stop
+    video action
+  columns:
+  - name: courserun_readable_id
+    description: str, Open edX Course ID formatted as course-v1:{org}+{course code}+{run_tag}.
+    tests:
+    - not_null
+  - name: user_username
+    description: str, username of the open edX user
+    tests:
+    - not_null
+  - name: user_email
+    description: str, user email on MITx Online
+  - name: user_full_name
+    description: str, user full name on MITx Online
+  - name: course_number
+    description: str, unique string for the course. It can contain letters, numbers,
+      or periods. e.g. 18.03.1x
+    tests:
+    - not_null
+  - name: courserun_title
+    description: str, title of the course run
+  - name: courserun_start_on
+    description: timestamp, datetime on when the course begins
+  - name: courserun_end_on
+    description: timestamp, datetime on when the course ends
+  - name: video_event_type
+    description: str, type of this video event. The value is one of play_video, seek_video,
+      pause_video, stop_video, complete_video.
+    tests:
+    - not_null
+  - name: page_url
+    description: str, url of the page the user was visiting when this video event
+      was emitted.
+  - name: video_id
+    description: str, hash code for the video being watched.
+    tests:
+    - not_null
+  - name: video_title
+    description: str, title of this video.
+  - name: section_title
+    description: str, title of section (aka chapter) this video belongs to.
+  - name: video_duration
+    description: number, The length of the video file, in seconds.
+    tests:
+    - not_null
+  - name: video_currenttime
+    description: number, The time in the video when this event was emitted. May be
+      Null for seek_video
+  - name: video_old_time
+    description: number, time in the video, in seconds, at which the user chose to
+      go to a different point in time for 'seek_video' event
+  - name: video_new_time
+    description: number, time in the video, in seconds, that the user selected as
+      the destination point for 'seek_video' event
+  - name: video_event_timestamp
+    description: timestamp, time of this video event
+    tests:
+    - not_null

--- a/src/ol_dbt/models/marts/mitxonline/marts__mitxonline_video_engagements.sql
+++ b/src/ol_dbt/models/marts/mitxonline/marts__mitxonline_video_engagements.sql
@@ -1,0 +1,47 @@
+with video as (
+    select * from {{ ref('int__mitxonline__user_courseactivity_video') }}
+)
+
+, video_structure as (
+    select
+        *
+        , element_at(split(coursestructure_block_id, '@'), -1) as video_id
+    from {{ ref('int__mitxonline__course_structure') }}
+    where coursestructure_block_category = 'video' and coursestructure_is_latest = true
+)
+
+, course_runs as (
+    select * from {{ ref('int__mitxonline__course_runs') }}
+)
+
+, users as (
+    select * from {{ ref('int__mitxonline__users') }}
+)
+
+select
+    video.user_username
+    , video.courserun_readable_id
+    , video.useractivity_video_id as video_id
+    , video_structure.coursestructure_block_title as video_title
+    , video_structure.coursestructure_chapter_title as section_title
+    , video.useractivity_page_url as page_url
+    , video.useractivity_event_type as video_event_type
+    , video.useractivity_timestamp as video_event_timestamp
+    , video.useractivity_video_duration as video_duration
+    , video.useractivity_video_currenttime as video_currenttime
+    , video.useractivity_video_old_time as video_old_time
+    , video.useractivity_video_new_time as video_new_time
+    , users.user_full_name
+    , users.user_email
+    , course_runs.courserun_title
+    , course_runs.course_number
+    , course_runs.courserun_start_on
+    , course_runs.courserun_end_on
+from video
+inner join course_runs on video.courserun_readable_id = course_runs.courserun_readable_id
+left join video_structure
+    on
+        video.courserun_readable_id = video_structure.courserun_readable_id
+        and video.useractivity_video_id = video_structure.video_id
+left join users on video.user_username = users.user_username
+where video.useractivity_event_type in ('play_video', 'seek_video', 'complete_video', 'pause_video', 'stop_video')


### PR DESCRIPTION
# What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
https://github.com/mitodl/hq/issues/3222

# Description (What does it do?)
<!--- Describe your changes in detail -->
Creating `marts__mitxonline_video_engagements` for learners video events in a course, so that we can use this mart to create the video view reports indicated in the issue
Adding two fields to `int__mitxonline__course_structure`

# How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->
 dbt build --select int__mitxonline__course_structure
 dbt build --select marts__mitxonline_video_engagements