### PR TITLE
fix null program_num_required_courses on mitxonline series program

### DIFF
--- a/src/ol_dbt/models/intermediate/mitxonline/int__mitxonline__program_requirements.sql
+++ b/src/ol_dbt/models/intermediate/mitxonline/int__mitxonline__program_requirements.sql
@@ -114,8 +114,8 @@ with program_requirements as (
 
 select
     combined_requirements.*
-    , core_courses_count.program_num_core_courses
-    + elective_courses_count.program_num_elective_courses as program_num_required_courses
+    , coalesce(core_courses_count.program_num_core_courses, 0)
+    + coalesce(elective_courses_count.program_num_elective_courses, 0) as program_num_required_courses
 from combined_requirements
 left join core_courses_count on combined_requirements.program_id = core_courses_count.program_id
 left join elective_courses_count on combined_requirements.program_id = elective_courses_count.program_id


### PR DESCRIPTION
# What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
https://github.com/mitodl/ol-data-platform/issues/961

# Description (What does it do?)
<!--- Describe your changes in detail -->
Fixing bug on nulls when doing math on addition: 1 + NULL = NULL, which resulted null in program_num_required_courses for programs that only contain required courses. e.g. program_id=4,5,6,7,8,9

This bug also blocked a few downstream models (e.g. int__mitxonline__courserunenrollments) from being updated due to test failure.

# How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->
```
dbt build --select int__mitxonline__program_requirements
```
test should pass

```
SELECT program_num_required_courses FROM "ol_data_lake_production"."ol_warehouse_production_rlougee_intermediate"."int__mitxonline__program_requirements" 
where program_id in (4,5,6,7,8,9)
```
should have correct required course populated


<!--- Uncomment and add steps to be completed before merging this PR if necessary
## Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
