### PR TITLE
populate openedx_user_id for mitxonline app users

### DIFF
--- a/src/ol_dbt/models/intermediate/mitxonline/_int_mitxonline__models.yml
+++ b/src/ol_dbt/models/intermediate/mitxonline/_int_mitxonline__models.yml
@@ -1273,9 +1273,8 @@ models:
     - not_null
   - name: openedx_user_id
     description: int, foreign key to open edX users. Not all app users have openedx_user_id
-      due to username mismatch between app and open edX.
-    tests:
-    - unique
+      due to username or email mismatch between app and open edX. Also, there may
+      be multiple mitxonline users matching with same open edx user.
   - name: user_username
     description: string, username
     tests:

--- a/src/ol_dbt/models/intermediate/mitxonline/int__mitxonline__users.sql
+++ b/src/ol_dbt/models/intermediate/mitxonline/int__mitxonline__users.sql
@@ -76,4 +76,7 @@ left join micromasters_profile on users.user_username = micromasters_profile.use
 left join micromasters_users
     on micromasters_profile.user_profile_id = micromasters_users.user_profile_id
 left join openedx_users
-    on users.user_username = openedx_users.user_username
+    on (
+        users.user_username = openedx_users.user_username
+        or users.user_email = openedx_users.user_email
+    )

--- a/src/ol_dbt/models/marts/mitxonline/_marts__mitxonline__models.yml
+++ b/src/ol_dbt/models/marts/mitxonline/_marts__mitxonline__models.yml
@@ -29,11 +29,11 @@ models:
     tests:
     - not_null
   - name: user_username
-    description: str, username on MITx Online
+    description: str, username on MITx Online at the time of generating certificate
     tests:
     - not_null
   - name: user_email
-    description: str, user email on MITx Online
+    description: str, user email on MITx Online at the time of generating certificate
     tests:
     - not_null
   - name: user_full_name
@@ -41,8 +41,9 @@ models:
     tests:
     - not_null
   - name: openedx_user_id
-    description: int, foreign key to open edX users. Not all app users have openedx_user_id
-      due to username mismatch between app and open edX.
+    description: int, foreign key to open edX users.
+    tests:
+    - not_null
 
 - name: marts__mitxonline_user_profiles
   description: MITx Online user profiles

--- a/src/ol_dbt/models/marts/mitxonline/marts__mitxonline_course_certificates.sql
+++ b/src/ol_dbt/models/marts/mitxonline/marts__mitxonline_course_certificates.sql
@@ -18,4 +18,8 @@ select
     , course_certificates.user_full_name
     , users.openedx_user_id
 from course_certificates
-left join users on course_certificates.user_mitxonline_username = users.user_username
+left join users
+    on (
+        course_certificates.user_mitxonline_username = users.user_username
+        or course_certificates.user_email = users.user_email
+    )


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
Part of https://github.com/mitodl/ol-data-platform/issues/782

### Description (What does it do?)
<!--- Describe your changes in detail -->
populate `openedx_user_id` in `int__mitxonline__users` and `marts__mitxonline_course_certificates` based on matching username or email between app and open edx. 

There are sill some app users who don't have `openedx_user_id` in `int__mitxonline__users`, but there should be none flowing in `marts__mitxonline_course_certificates` since the only user in this table where openedx_user_id is null can be populated based on email match.


### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->
```
dbt build --select +marts__mitxonline_course_certificates
```
