### PR TITLE
add receipt_authorization_code and receipt_transaction_id to the marts__combined__orders table

### DIFF
--- a/src/ol_dbt/models/marts/combined/_marts__combined__models.yml
+++ b/src/ol_dbt/models/marts/combined/_marts__combined__models.yml
@@ -39,6 +39,11 @@ models:
     description: int, foreign key referencing ecommerce_coupon or the b2b coupon table
   - name: coupon_name
     description: string, human readable name for the coupon payment
+  - name: receipt_authorization_code
+    description: str, authorization code from cybersource payment
+  - name: receipt_transaction_id
+    description: string, unique identifier. Either the transaction_id from cybersource
+      or a unique uuid
   tests:
   - dbt_expectations.expect_compound_columns_to_be_unique:
       column_list: ["order_id", "line_id", "b2b_only_indicator", "platform", "coupon_id"]

--- a/src/ol_dbt/models/marts/combined/marts__combined__orders.sql
+++ b/src/ol_dbt/models/marts/combined/marts__combined__orders.sql
@@ -46,6 +46,8 @@ with bootcamps__ecommerce_order as (
         , mitxpro__ecommerce_order.order_purchaser_user_id
         , mitxpro__ecommerce_order.order_total_price_paid
         , mitxpro__b2becommerce_b2border.b2border_total_price
+        , mitxpro__ecommerce_order.receipt_authorization_code
+        , mitxpro__ecommerce_order.receipt_transaction_id
         , coalesce(mitxpro__ecommerce_allorders.coupon_id, mitxpro__ecommerce_allorders.b2bcoupon_id) as coupon_id
         , coalesce(mitxpro__ecommerce_allorders.order_id, mitxpro__ecommerce_allorders.b2border_id) as order_id
         , case
@@ -73,6 +75,8 @@ with bootcamps__ecommerce_order as (
         , bootcamps__ecommerce_order.order_total_price_paid
         , bootcamps__ecommerce_order.order_purchaser_user_id
         , bootcamps__users.user_email
+        , bootcamps__ecommerce_order.receipt_authorization_code
+        , bootcamps__ecommerce_order.receipt_transaction_id
     from bootcamps__ecommerce_order
     left join bootcamps__users
         on bootcamps__ecommerce_order.order_purchaser_user_id = bootcamps__users.user_id
@@ -94,6 +98,8 @@ with bootcamps__ecommerce_order as (
         , null as b2b_only_indicator
         , null as coupon_id
         , null as coupon_name
+        , payment_authorization_code as receipt_authorization_code
+        , payment_transaction_id as receipt_transaction_id
     from mitxonline__ecommerce_order
 
     union all
@@ -113,6 +119,10 @@ with bootcamps__ecommerce_order as (
         , b2b_only_indicator
         , coupon_id
         , coupon_name
+        , null as payment_authorization_code
+        , null as payment_transaction_id
+        , receipt_authorization_code
+        , receipt_transaction_id
     from mitxpro_orders
 
     union all
@@ -132,6 +142,8 @@ with bootcamps__ecommerce_order as (
         , null as b2b_only_indicator
         , null as coupon_id
         , null as coupon_name
+        , receipt_authorization_code 
+        , receipt_transaction_id 
     from bootcamps_orders
 
 )


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/634

### Description (What does it do?)
This ticket adds Cybersource Auth codes and Transaction IDs to the Ecommerce order mart.

### How can this be tested?
dbt build --select +marts__combined__orders





