### PR TITLE
add receipt_authorization_code and receipt_transaction_id to the marts__combined__orders table and intermediate sourcing it

### DIFF
--- a/src/ol_dbt/models/intermediate/mitxpro/_int_mitxpro__models.yml
+++ b/src/ol_dbt/models/intermediate/mitxpro/_int_mitxpro__models.yml
@@ -53,6 +53,11 @@ models:
     description: json, cybersource req reference number for a payment
   - name: productversion_readable_id
     description: string, the readable_id field from the product object
+  - name: receipt_authorization_code
+    description: str, authorization code from cybersource payment.
+  - name: receipt_transaction_id
+    description: string, unique identifier. Either the transaction_id from cybersource
+      or a unique uuid
   tests:
   - dbt_expectations.expect_compound_columns_to_be_unique:
       column_list: ["order_id", "b2border_id", "line_id", "coupon_id"]

--- a/src/ol_dbt/models/intermediate/mitxpro/int__mitxpro__ecommerce_allorders.sql
+++ b/src/ol_dbt/models/intermediate/mitxpro/int__mitxpro__ecommerce_allorders.sql
@@ -130,8 +130,8 @@ with b2becommerce_b2border as (
         , null as b2bcoupon_id
         , null as b2border_contract_number
         , null as req_reference_number
-        , ecommerce_order.receipt_authorization_code 
-        , ecommerce_order.receipt_transaction_id 
+        , ecommerce_order.receipt_authorization_code
+        , ecommerce_order.receipt_transaction_id
         , case when ecommerce_couponredemption.couponredemption_id is not null then true end as redeemed
     from ecommerce_order
     inner join ecommerce_line

--- a/src/ol_dbt/models/intermediate/mitxpro/int__mitxpro__ecommerce_allorders.sql
+++ b/src/ol_dbt/models/intermediate/mitxpro/int__mitxpro__ecommerce_allorders.sql
@@ -78,6 +78,8 @@ with b2becommerce_b2border as (
         , b2becommerce_b2border.b2border_contract_number
         , productversion.productversion_readable_id
         , json_extract_scalar(b2becommerce_b2breceipt.b2breceipt_data, '$.req_reference_number') as req_reference_number
+        , json_extract_scalar(b2becommerce_b2breceipt.b2breceipt_data, '$.auth_code') as receipt_authorization_code
+        , json_extract_scalar(b2becommerce_b2breceipt.b2breceipt_data, '$.transaction_id') as receipt_transaction_id
         , case when b2becommerce_b2bcouponredemption.b2bcouponredemption_id is not null then true end as redeemed
     from b2becommerce_b2border
     left join ecommerce_couponpaymentversion
@@ -128,6 +130,8 @@ with b2becommerce_b2border as (
         , null as b2bcoupon_id
         , null as b2border_contract_number
         , null as req_reference_number
+        , ecommerce_order.receipt_authorization_code 
+        , ecommerce_order.receipt_transaction_id 
         , case when ecommerce_couponredemption.couponredemption_id is not null then true end as redeemed
     from ecommerce_order
     inner join ecommerce_line
@@ -169,6 +173,8 @@ select
     , b2border_contract_number
     , req_reference_number
     , productversion_readable_id
+    , receipt_authorization_code
+    , receipt_transaction_id
 from reg_order_fields
 
 union distinct
@@ -193,4 +199,6 @@ select
     , b2border_contract_number
     , req_reference_number
     , productversion_readable_id
+    , receipt_authorization_code
+    , receipt_transaction_id
 from b2b_order_fields

--- a/src/ol_dbt/models/marts/combined/_marts__combined__models.yml
+++ b/src/ol_dbt/models/marts/combined/_marts__combined__models.yml
@@ -39,6 +39,11 @@ models:
     description: int, foreign key referencing ecommerce_coupon or the b2b coupon table
   - name: coupon_name
     description: string, human readable name for the coupon payment
+  - name: receipt_authorization_code
+    description: str, authorization code from cybersource payment
+  - name: receipt_transaction_id
+    description: string, unique identifier. Either the transaction_id from cybersource
+      or a unique uuid
   tests:
   - dbt_expectations.expect_compound_columns_to_be_unique:
       column_list: ["order_id", "line_id", "b2b_only_indicator", "platform", "coupon_id"]

--- a/src/ol_dbt/models/marts/combined/marts__combined__orders.sql
+++ b/src/ol_dbt/models/marts/combined/marts__combined__orders.sql
@@ -46,6 +46,8 @@ with bootcamps__ecommerce_order as (
         , mitxpro__ecommerce_order.order_purchaser_user_id
         , mitxpro__ecommerce_order.order_total_price_paid
         , mitxpro__b2becommerce_b2border.b2border_total_price
+        , mitxpro__ecommerce_allorders.receipt_authorization_code
+        , mitxpro__ecommerce_allorders.receipt_transaction_id
         , coalesce(mitxpro__ecommerce_allorders.coupon_id, mitxpro__ecommerce_allorders.b2bcoupon_id) as coupon_id
         , coalesce(mitxpro__ecommerce_allorders.order_id, mitxpro__ecommerce_allorders.b2border_id) as order_id
         , case
@@ -73,6 +75,8 @@ with bootcamps__ecommerce_order as (
         , bootcamps__ecommerce_order.order_total_price_paid
         , bootcamps__ecommerce_order.order_purchaser_user_id
         , bootcamps__users.user_email
+        , bootcamps__ecommerce_order.receipt_authorization_code
+        , bootcamps__ecommerce_order.receipt_transaction_id
     from bootcamps__ecommerce_order
     left join bootcamps__users
         on bootcamps__ecommerce_order.order_purchaser_user_id = bootcamps__users.user_id
@@ -94,6 +98,8 @@ with bootcamps__ecommerce_order as (
         , null as b2b_only_indicator
         , null as coupon_id
         , null as coupon_name
+        , payment_authorization_code as receipt_authorization_code
+        , payment_transaction_id as receipt_transaction_id
     from mitxonline__ecommerce_order
 
     union all
@@ -113,6 +119,8 @@ with bootcamps__ecommerce_order as (
         , b2b_only_indicator
         , coupon_id
         , coupon_name
+        , receipt_authorization_code
+        , receipt_transaction_id
     from mitxpro_orders
 
     union all
@@ -132,6 +140,8 @@ with bootcamps__ecommerce_order as (
         , null as b2b_only_indicator
         , null as coupon_id
         , null as coupon_name
+        , receipt_authorization_code 
+        , receipt_transaction_id 
     from bootcamps_orders
 
 )

--- a/src/ol_dbt/models/marts/combined/marts__combined__orders.sql
+++ b/src/ol_dbt/models/marts/combined/marts__combined__orders.sql
@@ -140,8 +140,8 @@ with bootcamps__ecommerce_order as (
         , null as b2b_only_indicator
         , null as coupon_id
         , null as coupon_name
-        , receipt_authorization_code 
-        , receipt_transaction_id 
+        , receipt_authorization_code
+        , receipt_transaction_id
     from bootcamps_orders
 
 )


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/634

### Description (What does it do?)
This ticket adds Cybersource Auth codes and Transaction IDs to the Ecommerce order mart.

### How can this be tested?
dbt build --select +marts__combined__orders