### PR TITLE
fix dbt warn - inconsistent gender value from bigquery

### DIFF
--- a/src/ol_dbt/models/staging/edxorg/_stg__edxorg__models.yml
+++ b/src/ol_dbt/models/staging/edxorg/_stg__edxorg__models.yml
@@ -67,7 +67,7 @@ models:
       means this student signed up before this information was collected
     tests:
     - accepted_values:
-        values: ['Male', 'Female', 'Other/Prefer Not to Say', '', null]
+        values: '{{ var("gender_values") }}'
   - name: user_highest_education
     description: str, user's Level of education- blank means User did not specify
       level of education. Null means this student signed up before this information
@@ -201,7 +201,7 @@ models:
     description: str, Gender selected by the user on their profile
     tests:
     - accepted_values:
-        values: ['Male', 'Female', 'Other/Prefer Not to Say', '', null]
+        values: '{{ var("gender_values") }}'
   - name: user_country
     description: str, Country selected by the learner on their profile
   - name: user_city

--- a/src/ol_dbt/models/staging/edxorg/stg__edxorg__bigquery__mitx_person_course.sql
+++ b/src/ol_dbt/models/staging/edxorg/stg__edxorg__bigquery__mitx_person_course.sql
@@ -49,7 +49,10 @@ with source as (
         , certified as courseruncertificate_is_earned
         , cert_status as courseruncertificate_status
         , coalesce(is_active = 1, false) as courserunenrollment_is_active
-        ,{{ transform_gender_value('gender') }} as user_gender
+        --- trino doesn't have function to convert first letter to upper case
+        , regexp_replace(
+            {{ transform_gender_value('gender') }}, '(^[a-z])(.)', x -> upper(x[1]) || x[2] -- noqa
+        ) as user_gender
         ,{{ transform_education_value('loe') }} as user_highest_education
         ,{{ cast_timestamp_to_iso8601('start_time') }} as courserunenrollment_created_on
         ,{{ cast_timestamp_to_iso8601('verified_enroll_time') }} as courserunenrollment_enrolled_on

--- a/src/ol_dbt/models/staging/edxorg/stg__edxorg__bigquery__mitx_user_info_combo.sql
+++ b/src/ol_dbt/models/staging/edxorg/stg__edxorg__bigquery__mitx_user_info_combo.sql
@@ -36,7 +36,10 @@ with source as (
         , certificate_verify_uuid as courseruncertificate_verify_uuid
         , certificate_name as courseruncertificate_name
         , certificate_status as courseruncertificate_status
-        ,{{ transform_gender_value('profile_gender') }} as user_gender
+        --- trino doesn't have function to convert first letter to upper case
+        , regexp_replace(
+            {{ transform_gender_value('profile_gender') }}, '(^[a-z])(.)', x -> upper(x[1]) || x[2] -- noqa
+        ) as user_gender
         ,{{ transform_education_value('profile_level_of_education') }} as user_highest_education
         ,{{ cast_timestamp_to_iso8601('date_joined') }} as user_joined_on
         ,{{ cast_timestamp_to_iso8601('last_login') }} as user_last_login


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
N/A
Two warnings from dbt production run
![image](https://github.com/mitodl/ol-data-platform/assets/3138890/2adc6576-6cfd-4724-a0d0-e74f21cfff93)

### Description (What does it do?)
<!--- Describe your changes in detail -->
This fixes two warnings on user_gender in `stg__edxorg__bigquery__mitx_person_course` and `stg__edxorg__bigquery__mitx_user_info_combo`
  - this two raw tables loaded from IRx BigQuery are mixed with our own open edx and edxorg data, and somehow it gets inconsistent value. This should standardize the gender value from these two bigquery tables.

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->
There should be no warning running these two commands
```
 dbt build --select stg__edxorg__bigquery__mitx_person_course
dbt build --select stg__edxorg__bigquery__mitx_user_info_combo
```
