### PR TITLE
fix user profiles in MicroMaster program certificates models

### DIFF
--- a/src/ol_dbt/models/intermediate/micromasters/_int_micromasters__models.yml
+++ b/src/ol_dbt/models/intermediate/micromasters/_int_micromasters__models.yml
@@ -147,36 +147,37 @@ models:
     description: timestamp, timestamp of the course certificate that completed the
       program
   - name: user_gender
-    description: str, user's gender from edxorg - blank means user did not specify
-      a gender. Null means this student signed up before this information was collected
+    description: str, user's gender from user's profile on MITx Online or edX.org.
+      blank means user did not specify a gender. Null means this student signed up
+      before this information was collected
     tests:
     - accepted_values:
-        values: ['Male', 'Female', 'Other/Prefer Not to Say', '', null]
+        values: '{{ var("gender_values") }}'
   - name: user_address_city
-    description: str, city where user lives in, collected from the micromasters database
+    description: str, city where user lives in from user's profile on MicroMasters.
+      Note that this data isn't available on MITx Online.
   - name: user_first_name
-    description: str, first from the micromasters profile
+    description: str, first name from user's profile on MITx Online or MicroMasters.
   - name: user_last_name
-    description: str, last name from the micromasters profile
+    description: str, last name from user's profile on MITx Online or MicroMasters.
   - name: user_full_name
-    description: str, The full name of the user. Taken from either the edX database
-      or the mitxonline database
+    description: str, The full name from user's profile on MITx Online or MicroMasters.
   - name: user_year_of_birth
-    description: str, user's birth year from the profile in the micromasters database
+    description: str, user's birth year from user's profile on MITx Online or MicroMasters.
   - name: user_country
-    description: str, Country provided by the user either on the edX platform or the
-      mitxonline platform
+    description: str, Country from user's profile on MITx Online or MicroMasters
   - name: user_address_postal_code
-    description: str, postal code where user lives in from the profile in micromasters
+    description: str, postal code where user lives in from the profile on MicroMasters.
+      Note that this data isn't available on MITx Online.
   - name: user_street_address
-    description: str, street address where user lives in from the profile in the micromasters
-      database
+    description: str, street address where user lives in from user's profile on MicroMasters.
+      Note that this data isn't available on MITx Online.
   - name: user_address_state_or_territory
-    description: str,  state or territory where user lives in from the profile in
-      the micromasters database
+    description: str,  state or territory where user lives in from user's profile
+      on MITx Online or MicroMasters.
   tests:
   - dbt_expectations.expect_compound_columns_to_be_unique:
-      column_list: ["user_email", "micromasters_program_id"]
+      column_list: ["user_email", "micromasters_program_id", "mitxonline_program_id"]
 
 - name: int__micromasters__course_certificates
   description: course certificates earned for MicroMasters programs. This include

--- a/src/ol_dbt/models/intermediate/micromasters/subqueries/__int_micromasters_subqueries__models.yml
+++ b/src/ol_dbt/models/intermediate/micromasters/subqueries/__int_micromasters_subqueries__models.yml
@@ -216,7 +216,7 @@ models:
     description: str,  state or territory where user lives in from user's profile
       on MITx Online
   - name: user_full_name
-    description: str, The full name from user's profile on MITx Online or MicroMasters
+    description: str, The full name from user's profile on MITx Online
   - name: program_completion_timestamp
     description: timestamp, timestamp of the course certificate that completed the
       program

--- a/src/ol_dbt/models/intermediate/micromasters/subqueries/__int_micromasters_subqueries__models.yml
+++ b/src/ol_dbt/models/intermediate/micromasters/subqueries/__int_micromasters_subqueries__models.yml
@@ -189,14 +189,14 @@ models:
   - name: user_edxorg_id
     description: int, Numerical user ID of a learner on the edX platform
   - name: user_gender
-    description: str, user's gender from user's profile on MITx Online. blank means
-      user did not specify a gender. Null means this student signed up before this
-      information was collected
+    description: str, user's gender from user's profile on MITx Online or MicroMasters.
+      blank means user did not specify a gender. Null means this student signed up
+      before this information was collected
     tests:
     - accepted_values:
         values: '{{ var("gender_values") }}'
   - name: user_country
-    description: str, Country from user's profile on MITx Online.
+    description: str, Country from user's profile on MITx Online or MicroMasters.
   - name: user_address_city
     description: str, city where user lives in from user's profile on MicroMasters.
       Note that this data isn't available on MITx Online.
@@ -205,7 +205,7 @@ models:
   - name: user_last_name
     description: str, last name from user's profile on MITx Online.
   - name: user_year_of_birth
-    description: str, user's birth year from user's profile on MITx Online.
+    description: str, user's birth year from user's profile on MITx Online or MicroMasters.
   - name: user_address_postal_code
     description: str, postal code where user lives in from user's profile on MicroMasters.
       Note that this data isn't available on MITx Online.
@@ -214,7 +214,7 @@ models:
       Note that this data isn't available on MITx Online.
   - name: user_address_state_or_territory
     description: str,  state or territory where user lives in from user's profile
-      on MITx Online
+      on MITx Online or MicroMasters.
   - name: user_full_name
     description: str, The full name from user's profile on MITx Online
   - name: program_completion_timestamp

--- a/src/ol_dbt/models/intermediate/micromasters/subqueries/__int_micromasters_subqueries__models.yml
+++ b/src/ol_dbt/models/intermediate/micromasters/subqueries/__int_micromasters_subqueries__models.yml
@@ -175,7 +175,7 @@ models:
     tests:
     - not_null
   - name: user_email
-    description: str, The email address of the learner on the edX platform
+    description: str, user's email address on MITx Online
     tests:
     - not_null
   - name: micromasters_program_id
@@ -189,31 +189,34 @@ models:
   - name: user_edxorg_id
     description: int, Numerical user ID of a learner on the edX platform
   - name: user_gender
-    description: str, user's gender from edxorg - blank means user did not specify
-      a gender. Null means this student signed up before this information was collected
+    description: str, user's gender from user's profile on MITx Online. blank means
+      user did not specify a gender. Null means this student signed up before this
+      information was collected
     tests:
     - accepted_values:
-        values: ['Male', 'Female', 'Other/Prefer Not to Say', '', null]
+        values: '{{ var("gender_values") }}'
   - name: user_country
-    description: str, Country provided by the user on the edX platform
+    description: str, Country from user's profile on MITx Online.
   - name: user_address_city
-    description: str, city where user lives in, collected from the micromasters database
+    description: str, city where user lives in from user's profile on MicroMasters.
+      Note that this data isn't available on MITx Online.
   - name: user_first_name
-    description: str, first from the micromasters profile
+    description: str, first name from user's profile on MITx Online.
   - name: user_last_name
-    description: str, last name from the micromasters profile
+    description: str, last name from user's profile on MITx Online.
   - name: user_year_of_birth
-    description: str, user's birth year from the profile in the micromasters database
+    description: str, user's birth year from user's profile on MITx Online.
   - name: user_address_postal_code
-    description: str, postal code where user lives in from the profile in micromasters
+    description: str, postal code where user lives in from user's profile on MicroMasters.
+      Note that this data isn't available on MITx Online.
   - name: user_street_address
-    description: str, street address where user lives in from the profile in the micromasters
-      database
+    description: str, street address where user lives in from user's profile on MicroMasters.
+      Note that this data isn't available on MITx Online.
   - name: user_address_state_or_territory
-    description: str,  state or territory where user lives in from the profile in
-      the micromasters database
+    description: str,  state or territory where user lives in from user's profile
+      on MITx Online
   - name: user_full_name
-    description: str, The full name of the user on the edX platform
+    description: str, The full name from user's profile on MITx Online or MicroMasters
   - name: program_completion_timestamp
     description: timestamp, timestamp of the course certificate that completed the
       program

--- a/src/ol_dbt/models/intermediate/micromasters/subqueries/__micromasters_program_certificates_dedp_from_mitxonline.sql
+++ b/src/ol_dbt/models/intermediate/micromasters/subqueries/__micromasters_program_certificates_dedp_from_mitxonline.sql
@@ -30,23 +30,23 @@ with mitxonline_program_certificates as (
 select
     micromasters_users.user_edxorg_username as user_edxorg_username
     , mitxonline_users.user_username as user_mitxonline_username
-    , micromasters_users.user_email
+    , mitxonline_users.user_email
     , mitx_programs.micromasters_program_id
     , mitx_programs.program_title
     , mitx_programs.mitxonline_program_id
     , edx_users.user_id as user_edxorg_id
-    , edx_users.user_gender
+    , mitxonline_users.user_gender as user_gender
     , micromasters_users.user_address_city
-    , micromasters_users.user_first_name
-    , micromasters_users.user_last_name
+    , mitxonline_users.user_first_name as user_first_name
+    , mitxonline_users.user_last_name as user_last_name
     , micromasters_users.user_address_postal_code
     , micromasters_users.user_street_address
-    , micromasters_users.user_address_state_or_territory
+    , mitxonline_users.user_address_state as user_address_state_or_territory
     , mitxonline_program_certificates.programcertificate_created_on as program_completion_timestamp
     , micromasters_users.user_id as micromasters_user_id
-    , coalesce(edx_users.user_country, mitxonline_users.user_address_country) as user_country
-    , coalesce(edx_users.user_full_name, mitxonline_users.user_full_name) as user_full_name
-    , substring(micromasters_users.user_birth_date, 1, 4) as user_year_of_birth
+    , mitxonline_users.user_address_country as user_country
+    , mitxonline_users.user_full_name as user_full_name
+    , cast(mitxonline_users.user_birth_year as varchar) as user_year_of_birth
 from mitxonline_program_certificates
 left join mitxonline_users on mitxonline_program_certificates.user_id = mitxonline_users.user_id
 left join micromasters_users on mitxonline_users.user_micromasters_profile_id = micromasters_users.user_profile_id

--- a/src/ol_dbt/models/intermediate/micromasters/subqueries/__micromasters_program_certificates_dedp_from_mitxonline.sql
+++ b/src/ol_dbt/models/intermediate/micromasters/subqueries/__micromasters_program_certificates_dedp_from_mitxonline.sql
@@ -35,18 +35,22 @@ select
     , mitx_programs.program_title
     , mitx_programs.mitxonline_program_id
     , edx_users.user_id as user_edxorg_id
-    , mitxonline_users.user_gender as user_gender
     , micromasters_users.user_address_city
     , mitxonline_users.user_first_name as user_first_name
     , mitxonline_users.user_last_name as user_last_name
     , micromasters_users.user_address_postal_code
     , micromasters_users.user_street_address
-    , mitxonline_users.user_address_state as user_address_state_or_territory
     , mitxonline_program_certificates.programcertificate_created_on as program_completion_timestamp
     , micromasters_users.user_id as micromasters_user_id
-    , mitxonline_users.user_address_country as user_country
     , mitxonline_users.user_full_name as user_full_name
-    , cast(mitxonline_users.user_birth_year as varchar) as user_year_of_birth
+    , coalesce(mitxonline_users.user_gender, micromasters_users.user_gender) as user_gender
+    , coalesce(mitxonline_users.user_address_state, micromasters_users.user_address_state_or_territory)
+        as user_address_state_or_territory
+    , coalesce(mitxonline_users.user_address_country, micromasters_users.user_address_country) as user_country
+    , coalesce(
+        cast(mitxonline_users.user_birth_year as varchar)
+        , substring(micromasters_users.user_birth_date, 1, 4)
+    ) as user_year_of_birth
 from mitxonline_program_certificates
 left join mitxonline_users on mitxonline_program_certificates.user_id = mitxonline_users.user_id
 left join micromasters_users on mitxonline_users.user_micromasters_profile_id = micromasters_users.user_profile_id

--- a/src/ol_dbt/models/marts/micromasters/_marts_micromasters__models.yml
+++ b/src/ol_dbt/models/marts/micromasters/_marts_micromasters__models.yml
@@ -171,33 +171,34 @@ models:
     description: timestamp, timestamp of the course certificate that completed the
       program
   - name: user_gender
-    description: str, user's gender from edxorg - blank means user did not specify
-      a gender. Null means this student signed up before this information was collected
+    description: str, user's gender from user's profile on MITx Online or MicroMasters.
+      blank means user did not specify a gender. Null means this student signed up
+      before this information was collected
     tests:
     - accepted_values:
-        values: ['Male', 'Female', 'Other/Prefer Not to Say', '', null]
+        values: '{{ var("gender_values") }}'
   - name: user_address_city
-    description: str, city where user lives in, collected from the micromasters database
+    description: str,  city where user lives in from user's profile on MicroMasters.
+      Note that this data isn't available on MITx Online.
   - name: user_first_name
-    description: str, first from the micromasters profile
+    description: str, first name from user's profile on MITx Online or MicroMasters
   - name: user_last_name
-    description: str, last name from the micromasters profile
+    description: str, last name from user's profile on MITx Online or MicroMasters
   - name: user_full_name
-    description: str, The full name of the user. Taken from either the edX database
-      or the mitxonline database
+    description: str, The full name from user's profile on MITx Online or MicroMasters
   - name: user_year_of_birth
-    description: str, user's birth year from the profile in the micromasters database
+    description: str, user's birth year from user's profile on MITx Online or MicroMasters
   - name: user_country
-    description: str, Country provided by the user either on the edX platform or the
-      mitxonline platform
+    description: str, Country from user's profile on MITx Online or MicroMasters
   - name: user_address_postal_code
-    description: str, postal code where user lives in from the profile in micromasters
+    description: str, postal code where user lives in from the profile on MicroMasters.
+      Note that this data isn't available on MITx Online.
   - name: user_street_address
-    description: str, street address where user lives in from the profile in the micromasters
-      database
+    description: str, street address where user lives in from user's profile on MicroMasters.
+      Note that this data isn't available on MITx Online.
   - name: user_address_state_or_territory
-    description: str,  state or territory where user lives in from the profile in
-      the micromasters database
+    description: str,  state or territory where user lives in from user's profile
+      on MITx Online or MicroMasters.
   - name: micromasters_program_id
     description: int, id of the program in the micromasters database
   - name: mitxonline_program_id


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
https://github.com/mitodl/hq/issues/3435

### Description (What does it do?)
<!--- Describe your changes in detail -->
Fixing a few warnings generated https://pipelines.odl.mit.edu/runs/6c4e62bf-1d18-472d-9f20-48d7c5fd48ba
from `int__micromasters__program_certificates`. 
The warns are due to some of new DEDP certificate holders' social auth mitxonline_username on MicroMasters don't match with username on MITx Online, so we couldn't match their email and profile on MicroMasters.
For DEDP certificates on MITx Online, we are now pulling email and profile data from MITx Online directly. If profile data is blank, then fill in with MicroMasters'

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

Run the following command, data should be fixed now with no warnings

```
dbt run +int__micromasters__program_certificates
dbt test int__micromasters__program_certificates
dbt build marts__micromasters_course_certificates
```
