### PR TITLE
fix MicroMasters DEDP grades and certificates

### DIFF
--- a/src/ol_dbt/models/intermediate/micromasters/int__micromasters__course_certificates.sql
+++ b/src/ol_dbt/models/intermediate/micromasters/int__micromasters__course_certificates.sql
@@ -15,7 +15,7 @@ with course_certificates_dedp_from_micromasters as (
 
 -- DEDP course certificates come from MicroMasters and MITxOnline. We've migrated some learners data from
 -- MicroMasters to MITxOnline around Oct 2022, but only for those users who have MITxOnline account.
--- To avoid data overlapping, we dedup based on their social auth account linked on MicroMasters.
+-- To avoid data overlapping, we deduplicate based on their social auth account linked on MicroMasters.
 -- for old DEDP courses on edx.org, then we use certificates from MicroMasters
 -- for new DEDP course on MITx Online, then we use certificates from MITx Online
 

--- a/src/ol_dbt/models/intermediate/micromasters/int__micromasters__course_certificates.sql
+++ b/src/ol_dbt/models/intermediate/micromasters/int__micromasters__course_certificates.sql
@@ -15,8 +15,9 @@ with course_certificates_dedp_from_micromasters as (
 
 -- DEDP course certificates come from MicroMasters and MITxOnline. We've migrated some learners data from
 -- MicroMasters to MITxOnline around Oct 2022, but only for those users who have MITxOnline account.
--- To avoid data overlapping, we use the cut-off date 2022-10-01 to reduce duplication, but there are still
--- a small number dups so need to apply additional logic to dedup based on their linked MITxOnline account
+-- To avoid data overlapping, we dedup based on their social auth account linked on MicroMasters.
+-- for old DEDP courses on edx.org, then we use certificates from MicroMasters
+-- for new DEDP course on MITx Online, then we use certificates from MITx Online
 
 
 , dedp_course_certificates_combined as (
@@ -36,7 +37,7 @@ with course_certificates_dedp_from_micromasters as (
         , coursecertificate_url as courseruncertificate_url
         , coursecertificate_created_on as courseruncertificate_created_on
     from course_certificates_dedp_from_micromasters
-    where coursecertificate_created_on < '2022-10-01'
+    where courserun_platform = '{{ var("edxorg") }}'
 
     union all
 
@@ -56,7 +57,7 @@ with course_certificates_dedp_from_micromasters as (
         , courseruncertificate_url
         , courseruncertificate_created_on
     from course_certificates_dedp_from_mitxonline
-    where courseruncertificate_created_on >= '2022-10-01'
+    where courserun_platform = '{{ var("mitxonline") }}'
 
 )
 

--- a/src/ol_dbt/models/intermediate/micromasters/int__micromasters__course_grades.sql
+++ b/src/ol_dbt/models/intermediate/micromasters/int__micromasters__course_grades.sql
@@ -13,9 +13,11 @@ with course_grades_dedp_from_micromasters as (
     from {{ ref('__micromasters_course_grades_non_dedp_from_edxorg') }}
 )
 
--- DEDP course certificates come from MicroMasters and MITxOnline. We've migrated some learners data from
+-- DEDP course grades come from MicroMasters and MITxOnline. We've migrated some learners data from
 -- MicroMasters to MITxOnline around Oct 2022, but only for those users who have MITxOnline account.
--- To avoid data overlapping, we use the cut-off date 2022-10-01 and their linked MITxOnline account to dedup
+-- To avoid data overlapping, we dedup based on their social auth account linked on MicroMasters.
+-- for old DEDP courses on edx.org, then we use the grade from MicroMasters
+-- for new DEDP course on MITx Online, then we use the grade from MITx Online
 
 , dedp_course_grades_combined as (
     select
@@ -35,7 +37,7 @@ with course_grades_dedp_from_micromasters as (
         , true as is_passing
         , coursegrade_created_on as created_on
     from course_grades_dedp_from_micromasters
-    where coursegrade_created_on < '2022-10-01'
+    where courserun_platform = '{{ var("edxorg") }}'
 
     union all
 
@@ -56,7 +58,7 @@ with course_grades_dedp_from_micromasters as (
         , courserungrade_is_passing as is_passing
         , courserungrade_created_on as created_on
     from course_grades_dedp_from_mitxonline
-    where courserungrade_created_on >= '2022-10-01'
+    where courserun_platform = '{{ var("mitxonline") }}'
 
 )
 

--- a/src/ol_dbt/models/intermediate/micromasters/int__micromasters__course_grades.sql
+++ b/src/ol_dbt/models/intermediate/micromasters/int__micromasters__course_grades.sql
@@ -15,7 +15,7 @@ with course_grades_dedp_from_micromasters as (
 
 -- DEDP course grades come from MicroMasters and MITxOnline. We've migrated some learners data from
 -- MicroMasters to MITxOnline around Oct 2022, but only for those users who have MITxOnline account.
--- To avoid data overlapping, we dedup based on their social auth account linked on MicroMasters.
+-- To avoid data overlapping, we deduplicate based on their social auth account linked on MicroMasters.
 -- for old DEDP courses on edx.org, then we use the grade from MicroMasters
 -- for new DEDP course on MITx Online, then we use the grade from MITx Online
 

--- a/src/ol_dbt/models/intermediate/micromasters/subqueries/__micromasters_course_grades_dedp_from_micromasters.sql
+++ b/src/ol_dbt/models/intermediate/micromasters/subqueries/__micromasters_course_grades_dedp_from_micromasters.sql
@@ -6,6 +6,10 @@ with dedp_course_grades as (
     select * from {{ ref('stg__micromasters__app__postgres__grades_combinedcoursegrade') }}
 )
 
+, dedp_course_certificates as (
+    select * from {{ ref('stg__micromasters__app__postgres__grades_coursecertificate') }}
+)
+
 , courserun_grades as (
     select * from {{ ref('stg__micromasters__app__postgres__grades_courserungrade') }}
     where courserungrade_is_passing = true
@@ -27,11 +31,15 @@ with dedp_course_grades as (
         ) as row_num
     from courserun_grades
     inner join courseruns on courserun_grades.courserun_id = courseruns.courserun_id
+    inner join dedp_course_certificates
+        on
+            courserun_grades.user_id = dedp_course_certificates.user_id
+            and courseruns.course_id = dedp_course_certificates.course_id
+            and courseruns.courserun_start_on < dedp_course_certificates.coursecertificate_created_on
     inner join dedp_course_grades
         on
-            courserun_grades.user_id = dedp_course_grades.user_id
-            and courseruns.course_id = dedp_course_grades.course_id
-            and courseruns.courserun_start_on < dedp_course_grades.coursegrade_created_on
+            dedp_course_certificates.user_id = dedp_course_grades.user_id
+            and dedp_course_certificates.course_id = dedp_course_grades.course_id
 )
 
 , highest_courserun_grades as (

--- a/src/ol_dbt/models/marts/micromasters/_marts_micromasters__models.yml
+++ b/src/ol_dbt/models/marts/micromasters/_marts_micromasters__models.yml
@@ -55,11 +55,11 @@ models:
     - not_null
   - name: grade
     description: float, course grade for the corresponding certificate range from
-      0 to 1. Small amount of certificates generated on 2016 and 2017 don't have grades.
-      e.g. MITx/6.041x_3/2T2016
+      0 to 1. Blank for small amount of certificates for MITx/6.041x_3/2T2016.
   - name: is_passing
     description: boolean, indicating whether the user has passed the passing score
-      set for this course on edX.org or MITxOnline
+      set for this course on edX.org or MITxOnline. Blank for small amount of certificates
+      for MITx/6.041x_3/2T2016.
   tests:
   - dbt_expectations.expect_compound_columns_to_be_unique:
       column_list: ["user_email", "courserun_readable_id", "micromasters_program_id",

--- a/src/ol_dbt/models/marts/micromasters/_marts_micromasters__models.yml
+++ b/src/ol_dbt/models/marts/micromasters/_marts_micromasters__models.yml
@@ -53,6 +53,13 @@ models:
       created
     tests:
     - not_null
+  - name: grade
+    description: float, course grade for the corresponding certificate range from
+      0 to 1. Small amount of certificates generated on 2016 and 2017 don't have grades.
+      e.g. MITx/6.041x_3/2T2016
+  - name: is_passing
+    description: boolean, indicating whether the user has passed the passing score
+      set for this course on edX.org or MITxOnline
   tests:
   - dbt_expectations.expect_compound_columns_to_be_unique:
       column_list: ["user_email", "courserun_readable_id", "micromasters_program_id",

--- a/src/ol_dbt/models/marts/micromasters/marts__micromasters_course_certificates.sql
+++ b/src/ol_dbt/models/marts/micromasters/marts__micromasters_course_certificates.sql
@@ -29,3 +29,8 @@ left join grades
     on
         course_certificates.user_email = grades.user_email
         and course_certificates.courserun_readable_id = grades.courserun_readable_id
+        and
+        (
+            course_certificates.mitxonline_program_id = grades.mitxonline_program_id
+            or course_certificates.micromasters_program_id = grades.micromasters_program_id
+        )

--- a/src/ol_dbt/models/marts/micromasters/marts__micromasters_course_certificates.sql
+++ b/src/ol_dbt/models/marts/micromasters/marts__micromasters_course_certificates.sql
@@ -27,13 +27,5 @@ select
 from course_certificates
 left join grades
     on
-        (
-            course_certificates.user_edxorg_username = grades.user_edxorg_username
-            or course_certificates.user_mitxonline_username = grades.user_mitxonline_username
-        )
+        course_certificates.user_email = grades.user_email
         and course_certificates.courserun_readable_id = grades.courserun_readable_id
-        and
-        (
-            course_certificates.mitxonline_program_id = grades.mitxonline_program_id
-            or course_certificates.micromasters_program_id = grades.micromasters_program_id
-        )


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
NA
I noted this issue after reviewing https://github.com/mitodl/ol-data-platform/pull/986. There are null grades for DEDP certificates in the new mart, which doesn't seem right. Despite a few certificates for `MITx/6.041x_3/2T2016` (for SDS program) are missing grades (source data from BigQuery), DEDP certificates should have grades.

```
select * from marts__micromasters_course_certificates where grade is null
```

### Description (What does it do?)
<!--- Describe your changes in detail -->
This fixes DEDP data in `marts__micromasters_course_certificates` and its upstream models `int__micromasters__course_grades` , `int__micromasters__course_certificates`
- For old DEDP courses on edX.org, use MicroMasters data
- For new DEDP courses on MITx Online, use MITx Online data (deduped the data migrated from MicroMasters)

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->
```
dbt build --select +marts__micromasters_course_certificates

```
then 
```
select * from marts__micromasters_course_certificates where grade is null
```
Only a small amount of certificates with no grades from course `MITx/6.041x_3/2T2016`
DEDP certificates should have grade now
