### PR TITLE
add fields to marts__combined_course_enrollment_detail and upstream changes

### DIFF
--- a/src/ol_dbt/models/intermediate/bootcamps/_int_bootcamps__models.yml
+++ b/src/ol_dbt/models/intermediate/bootcamps/_int_bootcamps__models.yml
@@ -51,7 +51,7 @@ models:
     tests:
     - not_null
   - name: receipt_reference_number
-    description: str, transaction reference number from user's cybersource payment
+    description: str, req_reference_number from user's cybersource payment
     tests:
     - not_null
   - name: receipt_transaction_status
@@ -194,6 +194,8 @@ models:
   - name: courserun_readable_id
     description: str, unique string to identify a bootcamp course run (could be blank
       for older runs)
+  - name: courserun_start_on
+    description: timestamp, date and time when the course starts
   - name: user_username
     description: str, name chosen by user
     tests:
@@ -204,6 +206,8 @@ models:
     - not_null
   - name: user_full_name
     description: string, full name on user's profile
+  - name: user_address_country
+    description: str, country code for the user's address
   tests:
   - dbt_expectations.expect_table_row_count_to_equal_other_table:
       compare_model: ref('stg__bootcamps__app__postgres__courserunenrollment')

--- a/src/ol_dbt/models/intermediate/bootcamps/int__bootcamps__courserunenrollments.sql
+++ b/src/ol_dbt/models/intermediate/bootcamps/int__bootcamps__courserunenrollments.sql
@@ -22,9 +22,11 @@ with enrollments as (
         , enrollments.courserunenrollment_enrollment_status
         , runs.courserun_readable_id
         , runs.courserun_title
+        , runs.courserun_start_on
         , users.user_username
         , users.user_email
         , users.user_full_name
+        , users.user_address_country
     from enrollments
     inner join runs on enrollments.courserun_id = runs.courserun_id
     inner join users on enrollments.user_id = users.user_id

--- a/src/ol_dbt/models/intermediate/edxorg/_int_edxorg__models.yml
+++ b/src/ol_dbt/models/intermediate/edxorg/_int_edxorg__models.yml
@@ -129,6 +129,8 @@ models:
       that use new format
     tests:
     - not_null
+  - name: courserun_start_on
+    description: timestamp, date and time when the course starts
   - name: user_username
     description: str, username of a learner on the edX platform
     tests:

--- a/src/ol_dbt/models/intermediate/edxorg/int__edxorg__mitx_courserun_enrollments.sql
+++ b/src/ol_dbt/models/intermediate/edxorg/int__edxorg__mitx_courserun_enrollments.sql
@@ -40,10 +40,7 @@ with person_courses as (
 )
 
 , edxorg_runs as (
-    select
-        courserun_readable_id
-        , course_number
-        , courserun_title
+    select *
     from {{ ref('stg__edxorg__bigquery__mitx_courserun') }}
 )
 
@@ -101,6 +98,7 @@ with person_courses as (
         , edxorg_users.user_username
         , micromasters_users.user_mitxonline_username
         , edxorg_runs.courserun_title
+        , edxorg_runs.courserun_start_date as courserun_start_on
         , edxorg_users.user_country as user_address_country
         , coalesce(edxorg_users.user_full_name, micromasters_users.user_full_name) as user_full_name
         , case

--- a/src/ol_dbt/models/intermediate/micromasters/_int_micromasters__models.yml
+++ b/src/ol_dbt/models/intermediate/micromasters/_int_micromasters__models.yml
@@ -223,8 +223,12 @@ models:
     description: str, user full name on edX.org or MITxOnline
   - name: user_country
     description: str, user country on edX.org or MITxOnline
+  - name: courseruncertificate_uuid
+    description: str, unique identifier for the certificate on MITx Online, MicroMasters
+      or edX.org
   - name: courseruncertificate_url
-    description: str, the full URL to this DEDP course certificate on MITx Online
+    description: str, the full URL to this DEDP course certificate on MITx Online,
+      MicroMasters or edX.org
   - name: courseruncertificate_created_on
     description: timestamp, date and time when this course certificate was initially
       created
@@ -436,6 +440,8 @@ models:
   - name: receipt_authorization_code
     description: str, authorization code from most recent cybersource payment for
       the order
+  - name: receipt_reference_number
+    description: str, req_reference_number from cybersource payment
   - name: receipt_bill_to_address_state
     description: str, address state from most recent cybersource payment for the order
   - name: receipt_bill_to_address_country

--- a/src/ol_dbt/models/intermediate/micromasters/int__micromasters__course_certificates.sql
+++ b/src/ol_dbt/models/intermediate/micromasters/int__micromasters__course_certificates.sql
@@ -34,6 +34,7 @@ with course_certificates_dedp_from_micromasters as (
         , user_full_name
         , user_country
         , user_email
+        , coursecertificate_hash as courseruncertificate_uuid
         , coursecertificate_url as courseruncertificate_url
         , coursecertificate_created_on as courseruncertificate_created_on
     from course_certificates_dedp_from_micromasters
@@ -54,6 +55,7 @@ with course_certificates_dedp_from_micromasters as (
         , user_full_name
         , user_country
         , user_email
+        , courseruncertificate_uuid
         , courseruncertificate_url
         , courseruncertificate_created_on
     from course_certificates_dedp_from_mitxonline
@@ -75,6 +77,7 @@ with course_certificates_dedp_from_micromasters as (
         , user_full_name
         , user_country
         , user_email
+        , courseruncertificate_uuid
         , courseruncertificate_url
         , courseruncertificate_created_on
         , case
@@ -113,6 +116,7 @@ with course_certificates_dedp_from_micromasters as (
         , user_full_name
         , user_country
         , user_email
+        , courseruncertificate_uuid
         , courseruncertificate_url
         , courseruncertificate_created_on
     from dedp_course_certificates
@@ -132,6 +136,7 @@ with course_certificates_dedp_from_micromasters as (
         , user_full_name
         , user_country
         , user_email
+        , courseruncertificate_download_uuid as courseruncertificate_uuid
         , courseruncertificate_download_url as courseruncertificate_url
         , courseruncertificate_created_on
     from course_certificates_non_dedp_program

--- a/src/ol_dbt/models/intermediate/micromasters/int__micromasters__orders.sql
+++ b/src/ol_dbt/models/intermediate/micromasters/int__micromasters__orders.sql
@@ -32,6 +32,7 @@ select
     , lines.line_price
     , lines.courserun_readable_id
     , lines.courserun_edxorg_readable_id
+    , receipts.receipt_reference_number
     , receipts.receipt_transaction_id
     , receipts.receipt_payment_method
     , receipts.receipt_authorization_code

--- a/src/ol_dbt/models/intermediate/mitx/_int_mitx__models.yml
+++ b/src/ol_dbt/models/intermediate/mitx/_int_mitx__models.yml
@@ -206,6 +206,11 @@ models:
     tests:
     - accepted_values:
         values: ['deferred', 'transferred', 'refunded', 'unenrolled']
+  - name: courserunenrollment_is_edx_enrolled
+    description: boolean, indicating whether the user is enrolled on edX platform.
+      For edx.org course enrollment, it would always be true.
+    tests:
+    - not_null
   - name: user_id
     description: int, user ID on the corresponding platform - MITx Online or edX.org
     tests:
@@ -219,6 +224,8 @@ models:
     - not_null
   - name: courserun_title
     description: str, title of the course run, maybe blank for some edX.org runs
+  - name: courserun_start_on
+    description: timestamp, date and time when the course starts
   - name: user_email
     description: str, current user email on edX.org or MITxOnline. For edx.org, learners
       can update their emails, so this is not necessary the same email as when learner
@@ -362,6 +369,9 @@ models:
       earned certificate for the course
     tests:
     - not_null
+  - name: courseruncertificate_uuid
+    description: str, unique identifier for the certificate on MITx Online, MicroMasters
+      or edX.org
   - name: courseruncertificate_url
     description: str, URL to the course certificate
     tests:

--- a/src/ol_dbt/models/intermediate/mitx/int__mitx__courserun_certificates.sql
+++ b/src/ol_dbt/models/intermediate/mitx/int__mitx__courserun_certificates.sql
@@ -51,6 +51,7 @@ with mitxonline_certificates as (
         , course_number
         , courserun_title
         , courserun_readable_id
+        , courseruncertificate_uuid
         , courseruncertificate_url
         , courseruncertificate_created_on
         , user_username as user_mitxonline_username
@@ -66,6 +67,7 @@ with mitxonline_certificates as (
         , course_number
         , courserun_title
         , courserun_readable_id
+        , courseruncertificate_download_uuid as courseruncertificate_uuid
         , courseruncertificate_download_url as courseruncertificate_url
         , courseruncertificate_created_on
         , user_mitxonline_username
@@ -81,6 +83,7 @@ with mitxonline_certificates as (
         , course_number
         , courserun_title
         , courserun_readable_id
+        , courseruncertificate_uuid
         , courseruncertificate_url
         , courseruncertificate_created_on
         , user_mitxonline_username

--- a/src/ol_dbt/models/intermediate/mitx/int__mitx__courserun_enrollments.sql
+++ b/src/ol_dbt/models/intermediate/mitx/int__mitx__courserun_enrollments.sql
@@ -23,10 +23,12 @@ with mitxonline_enrollments as (
         , courserunenrollment_created_on
         , courserunenrollment_enrollment_mode
         , courserunenrollment_enrollment_status
+        , courserunenrollment_is_edx_enrolled
         , courserun_id
         , courserun_title
         , courserun_readable_id
         , course_number
+        , courserun_start_on
         , user_id
         , user_email
         , user_full_name
@@ -45,10 +47,12 @@ with mitxonline_enrollments as (
         , courserunenrollment_created_on
         , courserunenrollment_enrollment_mode
         , null as courserunenrollment_enrollment_status
+        , true as courserunenrollment_is_edx_enrolled
         , null as courserun_id
         , courserun_title
         , courserun_readable_id
         , course_number
+        , courserun_start_on
         , user_id
         , user_email
         , user_full_name

--- a/src/ol_dbt/models/intermediate/mitxonline/_int_mitxonline__models.yml
+++ b/src/ol_dbt/models/intermediate/mitxonline/_int_mitxonline__models.yml
@@ -436,6 +436,8 @@ models:
       May be blank for no payment required or refund.
   - name: transaction_authorization_code
     description: str, authorization code from cybersource payment
+  - name: receipt_reference_number
+    description: str, req_reference_number from cybersource payment
   - name: transaction_bill_to_address_state
     description: str, address state from cybersource payment
   - name: transaction_bill_to_address_country
@@ -532,6 +534,8 @@ models:
   - name: payment_method
     description: str, payment method from most recent cybersource payment. Value could
       be 'paypal' or 'card'.
+  - name: payment_req_reference_number
+    description: str, req_reference_number from cybersource payment
   - name: payment_bill_to_address_state
     description: str, address state from most recent cybersource payment
   - name: payment_bill_to_address_country
@@ -647,6 +651,8 @@ models:
     description: str, Open edX Course ID formatted as course-v1:{org}+{course code}+{run_tag}
     tests:
     - not_null
+  - name: courserun_start_on
+    description: timestamp, date and time when the course starts
   - name: user_username
     description: str, name chosen by user
     tests:

--- a/src/ol_dbt/models/intermediate/mitxonline/int__mitxonline__courserunenrollments.sql
+++ b/src/ol_dbt/models/intermediate/mitxonline/int__mitxonline__courserunenrollments.sql
@@ -109,6 +109,7 @@ with enrollments as (
         , mitxonline_runs.courserun_readable_id
         , mitxonline_runs.course_number
         , mitxonline_runs.course_id
+        , mitxonline_runs.courserun_start_on
         , mitxonline_users.user_username
         , mitxonline_users.user_email
         , mitxonline_users.user_edxorg_username

--- a/src/ol_dbt/models/intermediate/mitxonline/int__mitxonline__ecommerce_order.sql
+++ b/src/ol_dbt/models/intermediate/mitxonline/int__mitxonline__ecommerce_order.sql
@@ -79,6 +79,7 @@ select
     , payments.transaction_authorization_code as payment_authorization_code
     , payments.transaction_payment_method as payment_method
     , payments.transaction_readable_identifier as payment_transaction_id
+    , payments.transaction_reference_number as payment_req_reference_number
     , payments.transaction_bill_to_address_state as payment_bill_to_address_state
     , payments.transaction_bill_to_address_country as payment_bill_to_address_country
 from lines

--- a/src/ol_dbt/models/intermediate/mitxonline/int__mitxonline__ecommerce_transaction.sql
+++ b/src/ol_dbt/models/intermediate/mitxonline/int__mitxonline__ecommerce_transaction.sql
@@ -14,6 +14,7 @@ select
     , transaction_status
     , transaction_authorization_code
     , transaction_payment_method
+    , transaction_reference_number
     , transaction_bill_to_address_state
     , transaction_bill_to_address_country
 from transactions

--- a/src/ol_dbt/models/intermediate/mitxpro/_int_mitxpro__models.yml
+++ b/src/ol_dbt/models/intermediate/mitxpro/_int_mitxpro__models.yml
@@ -213,6 +213,25 @@ models:
     - not_null
   - name: b2border_id
     description: int, primary key in b2becommerce_b2border
+  - name: b2breceipt_transaction_status
+    description: str, transaction status from cybersource payment. Value could be
+      ACCEPT, CANCEL, ERROR, REVIEW or DECLINE.
+    tests:
+    - not_null
+  - name: b2breceipt_reference_number
+    description: str, transaction reference number from cybersource payment
+    tests:
+    - not_null
+  - name: b2breceipt_transaction_id
+    description: str, transaction identifier from cybersource payment
+  - name: b2breceipt_payment_method
+    description: str, payment method from cybersource payment. e.g. card
+  - name: b2breceipt_authorization_code
+    description: str, authorization code from cybersource payment
+  - name: b2breceipt_bill_to_address_state
+    description: str, address state from cybersource payment
+  - name: b2breceipt_bill_to_address_country
+    description: str, address country from cybersource payment
   tests:
   - dbt_expectations.expect_table_row_count_to_equal_other_table:
       compare_model: ref('stg__mitxpro__app__postgres__b2becommerce_b2breceipt')
@@ -974,6 +993,8 @@ models:
       e.g. course-v1:xPRO+MLx1+R0
     tests:
     - not_null
+  - name: courserun_start_on
+    description: timestamp, date and time when the course starts
   - name: user_username
     description: str, name chosen by user
     tests:
@@ -986,6 +1007,8 @@ models:
     description: str, the user's full name
     tests:
     - not_null
+  - name: user_address_country
+    description: str, country code for the user's address
   - name: ecommerce_order_id
     description: int, id of order associated with the payment for the enrollment
   - name: ecommerce_company_id

--- a/src/ol_dbt/models/intermediate/mitxpro/int__mitxpro__b2becommerce_b2breceipt.sql
+++ b/src/ol_dbt/models/intermediate/mitxpro/int__mitxpro__b2becommerce_b2breceipt.sql
@@ -9,4 +9,11 @@ select
     , b2breceipt_updated_on
     , b2breceipt_data
     , b2border_id
+    , b2breceipt_transaction_status
+    , b2breceipt_transaction_id
+    , b2breceipt_authorization_code
+    , b2breceipt_reference_number
+    , b2breceipt_payment_method
+    , b2breceipt_bill_to_address_state
+    , b2breceipt_bill_to_address_country
 from b2breceipts

--- a/src/ol_dbt/models/intermediate/mitxpro/int__mitxpro__courserunenrollments.sql
+++ b/src/ol_dbt/models/intermediate/mitxpro/int__mitxpro__courserunenrollments.sql
@@ -9,12 +9,7 @@ with enrollments as (
 )
 
 , users as (
-    select
-        user_id
-        , user_username
-        , user_email
-        , user_full_name
-    from {{ ref('stg__mitxpro__app__postgres__users_user') }}
+    select * from {{ ref('int__mitxpro__users') }}
 )
 
 , mitxpro_enrollments as (
@@ -28,9 +23,11 @@ with enrollments as (
         , enrollments.courserunenrollment_is_edx_enrolled
         , runs.courserun_readable_id
         , runs.courserun_title
+        , runs.courserun_start_on
         , users.user_username
         , users.user_email
         , users.user_full_name
+        , users.user_address_country
         , enrollments.ecommerce_company_id
         , enrollments.ecommerce_order_id
     from enrollments

--- a/src/ol_dbt/models/intermediate/mitxpro/int__mitxpro__ecommerce_allorders.sql
+++ b/src/ol_dbt/models/intermediate/mitxpro/int__mitxpro__ecommerce_allorders.sql
@@ -77,9 +77,9 @@ with b2becommerce_b2border as (
         , b2becommerce_b2border.b2border_email as user_email
         , b2becommerce_b2border.b2border_contract_number
         , productversion.productversion_readable_id
-        , json_extract_scalar(b2becommerce_b2breceipt.b2breceipt_data, '$.req_reference_number') as req_reference_number
-        , json_extract_scalar(b2becommerce_b2breceipt.b2breceipt_data, '$.auth_code') as receipt_authorization_code
-        , json_extract_scalar(b2becommerce_b2breceipt.b2breceipt_data, '$.transaction_id') as receipt_transaction_id
+        , b2becommerce_b2breceipt.b2breceipt_reference_number as req_reference_number
+        , b2becommerce_b2breceipt.b2breceipt_authorization_code as receipt_authorization_code
+        , b2becommerce_b2breceipt.b2breceipt_transaction_id as receipt_transaction_id
         , case when b2becommerce_b2bcouponredemption.b2bcouponredemption_id is not null then true end as redeemed
     from b2becommerce_b2border
     left join ecommerce_couponpaymentversion
@@ -129,7 +129,7 @@ with b2becommerce_b2border as (
         , productversion.productversion_readable_id
         , null as b2bcoupon_id
         , null as b2border_contract_number
-        , null as req_reference_number
+        , ecommerce_order.receipt_reference_number as req_reference_number
         , ecommerce_order.receipt_authorization_code
         , ecommerce_order.receipt_transaction_id
         , case when ecommerce_couponredemption.couponredemption_id is not null then true end as redeemed

--- a/src/ol_dbt/models/marts/combined/_marts__combined__models.yml
+++ b/src/ol_dbt/models/marts/combined/_marts__combined__models.yml
@@ -86,12 +86,18 @@ models:
   - name: courserunenrollment_enrollment_status
     description: string, enrollment status for users whose enrollment changed on the
       corresponding platform
+  - name: courserunenrollment_is_edx_enrolled
+    description: boolean, indicating whether the user is enrolled on edX platform.
+      For edx.org course enrollment, it would always be true. Null for Bootcamps as
+      it doesn't apply.
   - name: courserun_title
     description: string, title of the course run on the corresponding platform. Maybe
       blank for a few edX.org runs missing in int__edxorg__mitx_courseruns.
   - name: courserun_readable_id
     description: str, unique string to identify a course run on the corresponding
       platform
+  - name: courserun_start_on
+    description: timestamp, date and time when the course starts
   - name: user_username
     description: string, username to identify a user on the corresponding platform
     tests:
@@ -102,12 +108,19 @@ models:
     - not_null
   - name: user_full_name
     description: str, user full name from user's profile on the corresponding platform
+  - name: user_country_code
+    description: str, country code from the user's address on the corresponding platform
+  - name: courseruncertificate_uuid
+    description: str, unique identifier for the certificate on the corresponding platform
   - name: courseruncertificate_url
     description: str, URL to the course certificate for users who earned the certificate.
       This could be blank for revoked certificate.
   - name: courseruncertificate_created_on
     description: timestamp, date and time when the course certificate was initially
       created
+  - name: order_id
+    description: int, unique identifier/foreign key to ecommerce orders from the corresponding
+      platform
   - name: order_state
     description: string, order state from the corresponding platform. It doesn't include
       'created' order state
@@ -118,8 +131,8 @@ models:
       platform, e.g. mitxonline-production-20
   - name: order_total_price_paid
     description: number, total order amount for the order
-  - name: line_price
-    description: numeric, price for the order line item
+  - name: unit_price
+    description: numeric, price for the order line item before discount
   - name: coupon_discount_amount
     description: str, discount amount in readable format. e.g. $100 off, 30% off,
       etc
@@ -129,10 +142,26 @@ models:
     description: timestamp, specifying when the discount was redeemed by the user
   - name: payment_transaction_id
     description: str, transaction ID from cybersource payment
+  - name: payment_req_reference_number
+    description: str, req_reference_number from cybersource payment
   - name: payment_bill_to_address_state
     description: str, address state from cybersource payment receipt
   - name: payment_bill_to_address_country
     description: str, address country from cybersource payment receipt
+  - name: order_tax_country_code
+    description: str, the country code where the tax was applied. Only applicable
+      for xPro for now.
+  - name: order_tax_rate
+    description: numeric, the tax rate to apply. Only applicable for xPro for now.
+  - name: order_tax_rate_name
+    description: string, name of the tax rate assessed. Only applicable for xPro for
+      now.
+  - name: order_tax_amount
+    description: numeric, the amount of tax paid. Only applicable for xPro for now.
+  - name: order_total_price_paid_plus_tax
+    description: numeric, total order amount plus the amount of tax paid. For xPro,
+      this is calculated order_total_price_paid+order_tax_amount. For other platform,
+      this is the same as order_total_price_paid
   tests:
   - dbt_expectations.expect_compound_columns_to_be_unique:
       column_list: ["user_username", "courserun_readable_id"]

--- a/src/ol_dbt/models/marts/combined/marts__combined_course_enrollment_detail.sql
+++ b/src/ol_dbt/models/marts/combined/marts__combined_course_enrollment_detail.sql
@@ -73,24 +73,34 @@ with mitx_enrollments as (
         , mitx_enrollments.courserun_id
         , mitx_enrollments.courserun_title
         , mitx_enrollments.courserun_readable_id
+        , mitx_enrollments.courserun_start_on
         , mitx_enrollments.user_username
         , mitx_enrollments.user_email
         , mitx_enrollments.user_full_name
+        , mitx_enrollments.user_address_country as user_country_code
         , mitx_certificates.courseruncertificate_created_on
         , mitx_certificates.courseruncertificate_url
+        , mitx_certificates.courseruncertificate_uuid
+        , mitxonline_completed_orders.order_id
         , mitxonline_completed_orders.order_state
         , mitxonline_completed_orders.order_reference_number
-        , mitxonline_completed_orders.order_total_price_paid
         , mitxonline_completed_orders.order_created_on
-        , mitxonline_completed_orders.product_price as line_price
         , mitxonline_completed_orders.discount_code as coupon_code
         , mitxonline_completed_orders.discountredemption_timestamp as coupon_redeemed_on
         , mitxonline_completed_orders.discount_amount_text as coupon_discount_amount
         , mitxonline_completed_orders.payment_transaction_id
         , mitxonline_completed_orders.payment_authorization_code
         , mitxonline_completed_orders.payment_method
+        , mitxonline_completed_orders.payment_req_reference_number
         , mitxonline_completed_orders.payment_bill_to_address_state
         , mitxonline_completed_orders.payment_bill_to_address_country
+        , null as order_tax_country_code
+        , null as order_tax_rate
+        , null as order_tax_rate_name
+        , mitxonline_completed_orders.product_price as unit_price
+        , mitxonline_completed_orders.order_total_price_paid
+        , null as order_tax_amount
+        , mitxonline_completed_orders.order_total_price_paid as order_total_price_paid_plus_tax
     from mitx_enrollments
     left join mitx_certificates
         on
@@ -112,28 +122,39 @@ with mitx_enrollments as (
         , mitx_enrollments.courserunenrollment_created_on
         , mitx_enrollments.courserunenrollment_enrollment_mode
         , mitx_enrollments.courserunenrollment_enrollment_status
+        , mitx_enrollments.courserunenrollment_is_edx_enrolled
         , mitx_enrollments.user_id
         , mitx_enrollments.courserun_id
         , mitx_enrollments.courserun_title
         , mitx_enrollments.courserun_readable_id
+        , mitx_enrollments.courserun_start_on
         , mitx_enrollments.user_username
         , mitx_enrollments.user_email
         , mitx_enrollments.user_full_name
+        , mitx_enrollments.user_address_country as user_country_code
         , mitx_certificates.courseruncertificate_created_on
         , mitx_certificates.courseruncertificate_url
+        , mitx_certificates.courseruncertificate_uuid
+        , micromasters_completed_orders.order_id
         , micromasters_completed_orders.order_state
         , micromasters_completed_orders.order_reference_number
-        , micromasters_completed_orders.order_total_price_paid
         , micromasters_completed_orders.order_created_on
-        , micromasters_completed_orders.line_price
         , micromasters_completed_orders.coupon_code
         , micromasters_completed_orders.redeemedcoupon_created_on as coupon_redeemed_on
         , micromasters_completed_orders.coupon_discount_amount_text as coupon_discount_amount
         , micromasters_completed_orders.receipt_transaction_id as payment_transaction_id
         , micromasters_completed_orders.receipt_authorization_code as payment_authorization_code
         , micromasters_completed_orders.receipt_payment_method as payment_method
+        , micromasters_completed_orders.receipt_reference_number as payment_req_reference_number
         , micromasters_completed_orders.receipt_bill_to_address_state as payment_bill_to_address_state
         , micromasters_completed_orders.receipt_bill_to_address_country as payment_bill_to_address_country
+        , null as order_tax_country_code
+        , null as order_tax_rate
+        , null as order_tax_rate_name
+        , micromasters_completed_orders.line_price as unit_price
+        , micromasters_completed_orders.order_total_price_paid
+        , null as order_tax_amount
+        , micromasters_completed_orders.order_total_price_paid as order_total_price_paid_plus_tax
     from mitx_enrollments
     left join mitx_certificates
         on
@@ -158,28 +179,39 @@ with mitx_enrollments as (
         , mitxpro_enrollments.courserunenrollment_created_on
         , null as courserunenrollment_enrollment_mode
         , mitxpro_enrollments.courserunenrollment_enrollment_status
+        , mitxpro_enrollments.courserunenrollment_is_edx_enrolled
         , mitxpro_enrollments.user_id
         , mitxpro_enrollments.courserun_id
         , mitxpro_enrollments.courserun_title
         , mitxpro_enrollments.courserun_readable_id
+        , mitxpro_enrollments.courserun_start_on
         , mitxpro_enrollments.user_username
         , mitxpro_enrollments.user_email
         , mitxpro_enrollments.user_full_name
+        , mitxpro_enrollments.user_address_country as user_country_code
         , mitxpro_certificates.courseruncertificate_created_on
         , mitxpro_certificates.courseruncertificate_url
+        , mitxpro_certificates.courseruncertificate_uuid
+        , mitxpro_completed_orders.order_id
         , mitxpro_completed_orders.order_state
         , mitxpro_completed_orders.receipt_reference_number as order_reference_number
-        , mitxpro_completed_orders.order_total_price_paid
         , mitxpro_completed_orders.order_created_on
-        , mitxpro_lines.product_price as line_price
         , mitxpro_completed_orders.coupon_code
         , mitxpro_completed_orders.couponredemption_created_on as coupon_redeemed_on
         , mitxpro_completed_orders.couponpaymentversion_discount_amount_text as coupon_discount_amount
         , mitxpro_completed_orders.receipt_transaction_id as payment_transaction_id
         , mitxpro_completed_orders.receipt_authorization_code as payment_authorization_code
         , mitxpro_completed_orders.receipt_payment_method as payment_method
+        , mitxpro_completed_orders.receipt_reference_number as payment_req_reference_number
         , mitxpro_completed_orders.receipt_bill_to_address_state as payment_bill_to_address_state
         , mitxpro_completed_orders.receipt_bill_to_address_country as payment_bill_to_address_country
+        , mitxpro_completed_orders.order_tax_country_code
+        , mitxpro_completed_orders.order_tax_rate
+        , mitxpro_completed_orders.order_tax_rate_name
+        , mitxpro_lines.product_price as unit_price
+        , mitxpro_completed_orders.order_total_price_paid
+        , mitxpro_completed_orders.order_tax_amount
+        , mitxpro_completed_orders.order_total_price_paid_plus_tax
     from mitxpro_enrollments
     left join mitxpro_certificates
         on
@@ -188,9 +220,7 @@ with mitx_enrollments as (
     left join mitxpro_completed_orders
         on mitxpro_enrollments.ecommerce_order_id = mitxpro_completed_orders.order_id
     left join mitxpro_lines
-        on
-            mitxpro_completed_orders.order_id = mitxpro_lines.order_id
-            and mitxpro_enrollments.courserun_id = mitxpro_lines.courserun_id
+        on mitxpro_completed_orders.order_id = mitxpro_lines.order_id
 
     union all
 
@@ -201,28 +231,39 @@ with mitx_enrollments as (
         , bootcamps_enrollments.courserunenrollment_created_on
         , null as courserunenrollment_enrollment_mode
         , bootcamps_enrollments.courserunenrollment_enrollment_status
+        , null as courserunenrollment_is_edx_enrolled
         , bootcamps_enrollments.user_id
         , bootcamps_enrollments.courserun_id
         , bootcamps_enrollments.courserun_title
         , bootcamps_enrollments.courserun_readable_id
+        , bootcamps_enrollments.courserun_start_on
         , bootcamps_enrollments.user_username
         , bootcamps_enrollments.user_email
         , bootcamps_enrollments.user_full_name
+        , bootcamps_enrollments.user_address_country as user_country_code
         , bootcamps_certificates.courseruncertificate_created_on
         , bootcamps_certificates.courseruncertificate_url
+        , bootcamps_certificates.courseruncertificate_uuid
+        , bootcamps_completed_orders.order_id
         , bootcamps_completed_orders.order_state
         , bootcamps_completed_orders.order_reference_number
-        , bootcamps_completed_orders.order_total_price_paid
         , bootcamps_completed_orders.order_created_on
-        , bootcamps_completed_orders.line_price
         , null as coupon_code
         , null as coupon_redeemed_on
         , null as coupon_discount_amount
         , bootcamps_completed_orders.receipt_transaction_id as payment_transaction_id
         , bootcamps_completed_orders.receipt_authorization_code as payment_authorization_code
         , bootcamps_completed_orders.receipt_payment_method as payment_method
+        , bootcamps_completed_orders.receipt_reference_number as payment_req_reference_number
         , bootcamps_completed_orders.receipt_bill_to_address_state as payment_bill_to_address_state
         , bootcamps_completed_orders.receipt_bill_to_address_country as payment_bill_to_address_country
+        , null as order_tax_country_code
+        , null as order_tax_rate
+        , null as order_tax_rate_name
+        , bootcamps_completed_orders.line_price as unit_price
+        , bootcamps_completed_orders.order_total_price_paid
+        , null as order_tax_amount
+        , bootcamps_completed_orders.order_total_price_paid as order_total_price_paid_plus_tax
     from bootcamps_enrollments
     left join bootcamps_certificates
         on

--- a/src/ol_dbt/models/staging/mitxonline/stg__mitxonline__app__postgres__ecommerce_transaction.sql
+++ b/src/ol_dbt/models/staging/mitxonline/stg__mitxonline__app__postgres__ecommerce_transaction.sql
@@ -16,6 +16,7 @@ with source as (
         , json_query(data, 'lax $.decision' omit quotes) as transaction_status
         , json_query(data, 'lax $.auth_code' omit quotes) as transaction_authorization_code
         , json_query(data, 'lax $.req_payment_method' omit quotes) as transaction_payment_method
+        , json_query(data, 'lax $.req_reference_number' omit quotes) as transaction_reference_number
         , json_query(data, 'lax $.req_bill_to_address_state' omit quotes) as transaction_bill_to_address_state
         , json_query(data, 'lax $.req_bill_to_address_country' omit quotes) as transaction_bill_to_address_country
         ,{{ cast_timestamp_to_iso8601('created_on') }} as transaction_created_on

--- a/src/ol_dbt/models/staging/mitxpro/_stg_mitxpro__models.yml
+++ b/src/ol_dbt/models/staging/mitxpro/_stg_mitxpro__models.yml
@@ -51,6 +51,25 @@ models:
     - not_null
   - name: b2border_id
     description: int, primary key in b2becommerce_b2border
+  - name: b2breceipt_transaction_status
+    description: str, transaction status from cybersource payment. Value could be
+      ACCEPT, CANCEL, ERROR, REVIEW or DECLINE.
+    tests:
+    - not_null
+  - name: b2breceipt_reference_number
+    description: str, transaction reference number from cybersource payment
+    tests:
+    - not_null
+  - name: b2breceipt_transaction_id
+    description: str, transaction identifier from cybersource payment
+  - name: b2breceipt_payment_method
+    description: str, payment method from cybersource payment. e.g. card
+  - name: b2breceipt_authorization_code
+    description: str, authorization code from cybersource payment
+  - name: b2breceipt_bill_to_address_state
+    description: str, address state from cybersource payment
+  - name: b2breceipt_bill_to_address_country
+    description: str, address country from cybersource payment
 
 - name: stg__mitxpro__app__postgres__b2becommerce_b2borderaudit
   columns:

--- a/src/ol_dbt/models/staging/mitxpro/stg__mitxpro__app__postgres__b2becommerce_b2breceipt.sql
+++ b/src/ol_dbt/models/staging/mitxpro/stg__mitxpro__app__postgres__b2becommerce_b2breceipt.sql
@@ -10,6 +10,13 @@ with source as (
         id as b2breceipt_id
         , order_id as b2border_id
         , data as b2breceipt_data
+        , json_query(data, 'lax $.decision' omit quotes) as b2breceipt_transaction_status
+        , json_query(data, 'lax $.transaction_id' omit quotes) as b2breceipt_transaction_id
+        , json_query(data, 'lax $.auth_code' omit quotes) as b2breceipt_authorization_code
+        , json_query(data, 'lax $.req_reference_number' omit quotes) as b2breceipt_reference_number
+        , json_query(data, 'lax $.req_payment_method' omit quotes) as b2breceipt_payment_method
+        , json_query(data, 'lax $.req_bill_to_address_state' omit quotes) as b2breceipt_bill_to_address_state
+        , json_query(data, 'lax $.req_bill_to_address_country' omit quotes) as b2breceipt_bill_to_address_country
         ,{{ cast_timestamp_to_iso8601('created_on') }} as b2breceipt_created_on
         ,{{ cast_timestamp_to_iso8601('updated_on') }} as b2breceipt_updated_on
     from source


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
https://github.com/mitodl/ol-data-platform/issues/939

### Description (What does it do?)
<!--- Describe your changes in detail -->
- Adding is_edx_enrolled, courserun_start_on, user_country_code, courseruncertificate_uuid, payment_req_reference_number, and tax related fields to `marts__combined_course_enrollment_detail`
- fixing a couple things in `int__mitxpro__ecommerce_allorders`

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

```
dbt build +marts__combined_course_enrollment_detail
dbt build +int__mitxpro__ecommerce_allorders
```