### PR TITLE
add new combined user mart

### DIFF
--- a/src/ol_dbt/models/marts/combined/_marts__combined__models.yml
+++ b/src/ol_dbt/models/marts/combined/_marts__combined__models.yml
@@ -6,11 +6,17 @@ models:
   description: Mart model for users from different platforms
   columns:
   - name: user_email
-    description: string, user email on the corresponding platform
+    description: string, user email on the corresponding platform including xpro, 
+      bootcamps, edX.org, or MITx Online. If the user is on edX.org and MITx Online
+      then the email will be chosen from the last platform they joined.
   - name: user_joined_on
-    description: timestamp, user join timestamp
+    description: timestamp, user join timestamp on the corresponding platform including xpro, 
+      bootcamps, edX.org, or MITx Online. If the user is on edX.org and MITx Online
+      then the timsestamp will be chosen from the latest platform they joined.
   - name: user_last_login
-    description: timestamp, user last login
+    description: timestamp, user last login on the corresponding platform including xpro, 
+      bootcamps, edX.org, or MITx Online. If the user is on edX.org and MITx Online
+      then the timsestamp will be chosen from the latest login. 
   - name: platforms
     description: string, application where the data is from
   - name: user_full_name

--- a/src/ol_dbt/models/marts/combined/_marts__combined__models.yml
+++ b/src/ol_dbt/models/marts/combined/_marts__combined__models.yml
@@ -14,9 +14,9 @@ models:
   - name: platforms
     description: string, application where the data is from
   - name: user_full_name
-    description: str, user full name. Very small number of
-      edX.org users have blank full name, their name couldn't be populated from other
-      sources if they don't have their accounts linked on MicroMasters.
+    description: str, user full name. Very small number of edX.org users have blank
+      full name, their name couldn't be populated from other sources if they don't
+      have their accounts linked on MicroMasters.
   - name: user_address_country
     description: str, country code provided by the user on the corresponding platform
   - name: user_highest_education
@@ -50,7 +50,8 @@ models:
     description: string, username on bootcamps
   tests:
   - dbt_expectations.expect_compound_columns_to_be_unique:
-      column_list: ["user_mitxonline_id", "user_edxorg_id", "user_mitxpro_id", "user_bootcamps_id", "platforms"]
+      column_list: ["user_mitxonline_id", "user_edxorg_id", "user_mitxpro_id", "user_bootcamps_id",
+        "platforms"]
 
 - name: marts__combined__orders
   description: B2B and regular orders combined into one table

--- a/src/ol_dbt/models/marts/combined/_marts__combined__models.yml
+++ b/src/ol_dbt/models/marts/combined/_marts__combined__models.yml
@@ -2,6 +2,56 @@
 version: 2
 
 models:
+- name: marts__combined__users
+  description: Mart model for users from different platforms
+  columns:
+  - name: user_email
+    description: string, user email on the corresponding platform
+  - name: user_joined_on
+    description: timestamp, user join timestamp
+  - name: user_last_login
+    description: timestamp, user last login
+  - name: platforms
+    description: string, application where the data is from
+  - name: user_full_name
+    description: str, user full name. Very small number of
+      edX.org users have blank full name, their name couldn't be populated from other
+      sources if they don't have their accounts linked on MicroMasters.
+  - name: user_address_country
+    description: str, country code provided by the user on the corresponding platform
+  - name: user_highest_education
+    description: str, user's level of education
+  - name: user_gender
+    description: str, Gender selected by the user on their profile on the corresponding
+      platform
+  - name: user_birth_year
+    description: int, user's birth year
+  - name: user_company
+    description: str, user's company
+  - name: user_job_title
+    description: str, user's job title
+  - name: user_industry
+    description: str, user's job industry
+  - name: user_mitxonline_id
+    description: int, user ID on MITxOnline
+  - name: user_edxorg_id
+    description: int, user ID on edX.org
+  - name: user_mitxpro_id
+    description: int, user ID on MITxPRO
+  - name: user_bootcamps_id
+    description: int, user ID on bootcamps
+  - name: user_mitxonline_username
+    description: string, username on MITxOnline
+  - name: user_edxorg_username
+    description: string, username on edX.org
+  - name: user_mitxpro_username
+    description: string, username on MITxPRO
+  - name: user_bootcamps_username
+    description: string, username on bootcamps
+  tests:
+  - dbt_expectations.expect_compound_columns_to_be_unique:
+      column_list: ["user_mitxonline_id", "user_edxorg_id", "user_mitxpro_id", "user_bootcamps_id", "platforms"]
+
 - name: marts__combined__orders
   description: B2B and regular orders combined into one table
   columns:

--- a/src/ol_dbt/models/marts/combined/_marts__combined__models.yml
+++ b/src/ol_dbt/models/marts/combined/_marts__combined__models.yml
@@ -6,17 +6,17 @@ models:
   description: Mart model for users from different platforms
   columns:
   - name: user_email
-    description: string, user email on the corresponding platform including xpro, 
+    description: string, user email on the corresponding platform including xpro,
       bootcamps, edX.org, or MITx Online. If the user is on edX.org and MITx Online
       then the email will be chosen from the last platform they joined.
   - name: user_joined_on
-    description: timestamp, user join timestamp on the corresponding platform including xpro, 
-      bootcamps, edX.org, or MITx Online. If the user is on edX.org and MITx Online
-      then the timsestamp will be chosen from the latest platform they joined.
+    description: timestamp, user join timestamp on the corresponding platform including
+      xpro, bootcamps, edX.org, or MITx Online. If the user is on edX.org and MITx
+      Online then the timsestamp will be chosen from the latest platform they joined.
   - name: user_last_login
-    description: timestamp, user last login on the corresponding platform including xpro, 
-      bootcamps, edX.org, or MITx Online. If the user is on edX.org and MITx Online
-      then the timsestamp will be chosen from the latest login. 
+    description: timestamp, user last login on the corresponding platform including
+      xpro, bootcamps, edX.org, or MITx Online. If the user is on edX.org and MITx
+      Online then the timsestamp will be chosen from the latest login.
   - name: platforms
     description: string, application where the data is from
   - name: user_full_name

--- a/src/ol_dbt/models/marts/combined/marts__combined__users.sql
+++ b/src/ol_dbt/models/marts/combined/marts__combined__users.sql
@@ -30,12 +30,12 @@ with mitx__users as (
         , case
             when user_joined_on_mitxonline > user_joined_on_edxorg
                 then user_joined_on_mitxonline
-            else user_joined_on_edxorg
+            else coalesce(user_joined_on_edxorg, user_joined_on_mitxonline)
         end as user_joined_on
         , case
             when user_last_login_on_mitxonline > user_last_login_on_edxorg
                 then user_last_login_on_mitxonline
-            else user_last_login_on_edxorg
+            else coalesce(user_last_login_on_edxorg, user_last_login_on_mitxonline)
         end as user_last_login
         , case
             when is_mitxonline_user = true and is_edxorg_user = true

--- a/src/ol_dbt/models/marts/combined/marts__combined__users.sql
+++ b/src/ol_dbt/models/marts/combined/marts__combined__users.sql
@@ -22,31 +22,31 @@ with mitx__users as (
         , user_edxorg_username
         , null as user_mitxpro_username
         , null as user_bootcamps_username
-        , case
-            when is_mitxonline_user = false
+        , case 
+            when is_mitxonline_user = false 
                 then user_edxorg_email
-            when user_edxorg_email = false
+            when is_edxorg_user = false
                 then user_mitxonline_email
-            when user_joined_on_mitxonline > user_joined_on_edxorg
+            when user_joined_on_mitxonline > user_joined_on_edxorg 
                 then user_mitxonline_email
             else coalesce(user_edxorg_email, user_mitxonline_email)
         end as user_email
-        , case
-            when user_joined_on_mitxonline > user_joined_on_edxorg
+        , case 
+            when user_joined_on_mitxonline > user_joined_on_edxorg 
                 then user_joined_on_edxorg
             else user_joined_on_mitxonline
         end as user_joined_on
-        , case
+        , case 
             when user_last_login_on_mitxonline > user_last_login_on_edxorg
                 then user_last_login_on_mitxonline
             else user_last_login_on_edxorg
         end as user_last_login
-        , case
+        , case 
             when is_mitxonline_user = true and is_edxorg_user = true
                 then 'mitxonline and edxorg'
-            when is_mitxonline_user = true
+            when is_mitxonline_user = true 
                 then 'mitxonline'
-            when is_edxorg_user = true
+            when is_edxorg_user = true 
                 then 'edxorg'
         end as platforms
         , user_full_name
@@ -70,7 +70,7 @@ with mitx__users as (
         , null as user_edxorg_username
         , user_username as user_mitxpro_username
         , null as user_bootcamps_username
-        , user_email
+        , user_email 
         , user_joined_on
         , user_last_login
         , 'mitxpro' as platforms
@@ -110,7 +110,7 @@ with mitx__users as (
     from bootcamps_users
 )
 
-select
+select 
     user_email
     , user_joined_on
     , user_last_login

--- a/src/ol_dbt/models/marts/combined/marts__combined__users.sql
+++ b/src/ol_dbt/models/marts/combined/marts__combined__users.sql
@@ -1,0 +1,134 @@
+--- This model combines intermediate users from different platforms
+
+with mitx__users as (
+    select * from {{ ref('int__mitx__users') }}
+)
+
+, mitxpro_users as (
+    select * from {{ ref('int__mitxpro__users') }}
+)
+
+, bootcamps_users as (
+    select * from {{ ref('int__bootcamps__users') }}
+)
+
+, combined__users as (
+    select
+        user_mitxonline_id
+        , user_edxorg_id
+        , null as user_mitxpro_id
+        , null as user_bootcamps_id
+        , user_mitxonline_username
+        , user_edxorg_username
+        , null as user_mitxpro_username
+        , null as user_bootcamps_username
+        , case 
+            when is_mitxonline_user = false 
+                then user_edxorg_email
+            when user_edxorg_email = false
+                then user_mitxonline_email
+            when user_joined_on_mitxonline > user_joined_on_edxorg 
+                then user_mitxonline_email
+            else coalesce(user_edxorg_email, user_mitxonline_email)
+        end as user_email
+        , case 
+            when user_joined_on_mitxonline > user_joined_on_edxorg 
+                then user_joined_on_edxorg
+            else user_joined_on_mitxonline
+        end as user_joined_on
+        , case 
+            when user_last_login_on_mitxonline > user_last_login_on_edxorg
+                then user_last_login_on_mitxonline
+            else user_last_login_on_edxorg
+        end as user_last_login
+        , case 
+            when is_mitxonline_user = true and is_edxorg_user = true
+                then 'mitxonline and edxorg'
+            when is_mitxonline_user = true 
+                then 'mitxonline'
+            when is_edxorg_user = true 
+                then 'edxorg'
+        end as platforms
+        , user_full_name
+        , user_address_country
+        , user_highest_education
+        , user_gender
+        , user_birth_year
+        , user_company
+        , user_job_title
+        , user_industry
+    from mitx__users
+
+    union all
+
+    select
+        null as user_mitxonline_id
+        , null as user_edxorg_id
+        , user_id as user_mitxpro_id
+        , null as user_bootcamps_id
+        , null as user_mitxonline_username
+        , null as user_edxorg_username
+        , user_username as user_mitxpro_username
+        , null as user_bootcamps_username
+        , user_email 
+        , user_joined_on
+        , user_last_login
+        , 'mitxpro' as platforms
+        , user_full_name
+        , user_address_country
+        , user_highest_education
+        , user_gender
+        , user_birth_year
+        , user_company
+        , user_job_title
+        , user_industry
+    from mitxpro_users
+
+    union all
+
+    select
+        null as user_mitxonline_id
+        , null as user_edxorg_id
+        , null as user_mitxpro_id
+        , user_id as user_bootcamps_id
+        , null as user_mitxonline_username
+        , null as user_edxorg_username
+        , null as user_mitxpro_username
+        , user_username as user_bootcamps_username
+        , user_email
+        , user_joined_on
+        , user_last_login
+        , 'bootcamps' as platforms
+        , user_full_name
+        , user_address_country
+        , user_highest_education
+        , user_gender
+        , user_birth_year
+        , user_company
+        , user_job_title
+        , user_industry
+    from bootcamps_users
+)
+
+select 
+    user_email
+    , user_joined_on
+    , user_last_login
+    , platforms
+    , user_full_name
+    , user_address_country
+    , user_highest_education
+    , user_gender
+    , user_birth_year
+    , user_company
+    , user_job_title
+    , user_industry
+    , user_mitxonline_id
+    , user_edxorg_id
+    , user_mitxpro_id
+    , user_bootcamps_id
+    , user_mitxonline_username
+    , user_edxorg_username
+    , user_mitxpro_username
+    , user_bootcamps_username
+from combined__users

--- a/src/ol_dbt/models/marts/combined/marts__combined__users.sql
+++ b/src/ol_dbt/models/marts/combined/marts__combined__users.sql
@@ -23,18 +23,14 @@ with mitx__users as (
         , null as user_mitxpro_username
         , null as user_bootcamps_username
         , case
-            when is_mitxonline_user = false
-                then user_edxorg_email
-            when is_edxorg_user = false
-                then user_mitxonline_email
             when user_joined_on_mitxonline > user_joined_on_edxorg
                 then user_mitxonline_email
             else coalesce(user_edxorg_email, user_mitxonline_email)
         end as user_email
         , case
             when user_joined_on_mitxonline > user_joined_on_edxorg
-                then user_joined_on_edxorg
-            else user_joined_on_mitxonline
+                then user_joined_on_mitxonline
+            else user_joined_on_edxorg
         end as user_joined_on
         , case
             when user_last_login_on_mitxonline > user_last_login_on_edxorg

--- a/src/ol_dbt/models/marts/combined/marts__combined__users.sql
+++ b/src/ol_dbt/models/marts/combined/marts__combined__users.sql
@@ -22,31 +22,31 @@ with mitx__users as (
         , user_edxorg_username
         , null as user_mitxpro_username
         , null as user_bootcamps_username
-        , case 
-            when is_mitxonline_user = false 
+        , case
+            when is_mitxonline_user = false
                 then user_edxorg_email
             when is_edxorg_user = false
                 then user_mitxonline_email
-            when user_joined_on_mitxonline > user_joined_on_edxorg 
+            when user_joined_on_mitxonline > user_joined_on_edxorg
                 then user_mitxonline_email
             else coalesce(user_edxorg_email, user_mitxonline_email)
         end as user_email
-        , case 
-            when user_joined_on_mitxonline > user_joined_on_edxorg 
+        , case
+            when user_joined_on_mitxonline > user_joined_on_edxorg
                 then user_joined_on_edxorg
             else user_joined_on_mitxonline
         end as user_joined_on
-        , case 
+        , case
             when user_last_login_on_mitxonline > user_last_login_on_edxorg
                 then user_last_login_on_mitxonline
             else user_last_login_on_edxorg
         end as user_last_login
-        , case 
+        , case
             when is_mitxonline_user = true and is_edxorg_user = true
                 then 'mitxonline and edxorg'
-            when is_mitxonline_user = true 
+            when is_mitxonline_user = true
                 then 'mitxonline'
-            when is_edxorg_user = true 
+            when is_edxorg_user = true
                 then 'edxorg'
         end as platforms
         , user_full_name
@@ -70,7 +70,7 @@ with mitx__users as (
         , null as user_edxorg_username
         , user_username as user_mitxpro_username
         , null as user_bootcamps_username
-        , user_email 
+        , user_email
         , user_joined_on
         , user_last_login
         , 'mitxpro' as platforms
@@ -110,7 +110,7 @@ with mitx__users as (
     from bootcamps_users
 )
 
-select 
+select
     user_email
     , user_joined_on
     , user_last_login

--- a/src/ol_dbt/models/marts/combined/marts__combined__users.sql
+++ b/src/ol_dbt/models/marts/combined/marts__combined__users.sql
@@ -22,31 +22,31 @@ with mitx__users as (
         , user_edxorg_username
         , null as user_mitxpro_username
         , null as user_bootcamps_username
-        , case 
-            when is_mitxonline_user = false 
+        , case
+            when is_mitxonline_user = false
                 then user_edxorg_email
             when user_edxorg_email = false
                 then user_mitxonline_email
-            when user_joined_on_mitxonline > user_joined_on_edxorg 
+            when user_joined_on_mitxonline > user_joined_on_edxorg
                 then user_mitxonline_email
             else coalesce(user_edxorg_email, user_mitxonline_email)
         end as user_email
-        , case 
-            when user_joined_on_mitxonline > user_joined_on_edxorg 
+        , case
+            when user_joined_on_mitxonline > user_joined_on_edxorg
                 then user_joined_on_edxorg
             else user_joined_on_mitxonline
         end as user_joined_on
-        , case 
+        , case
             when user_last_login_on_mitxonline > user_last_login_on_edxorg
                 then user_last_login_on_mitxonline
             else user_last_login_on_edxorg
         end as user_last_login
-        , case 
+        , case
             when is_mitxonline_user = true and is_edxorg_user = true
                 then 'mitxonline and edxorg'
-            when is_mitxonline_user = true 
+            when is_mitxonline_user = true
                 then 'mitxonline'
-            when is_edxorg_user = true 
+            when is_edxorg_user = true
                 then 'edxorg'
         end as platforms
         , user_full_name
@@ -70,7 +70,7 @@ with mitx__users as (
         , null as user_edxorg_username
         , user_username as user_mitxpro_username
         , null as user_bootcamps_username
-        , user_email 
+        , user_email
         , user_joined_on
         , user_last_login
         , 'mitxpro' as platforms
@@ -110,7 +110,7 @@ with mitx__users as (
     from bootcamps_users
 )
 
-select 
+select
     user_email
     , user_joined_on
     , user_last_login


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/1644

### Description (What does it do?)
creates the marts__combined__users by sourcing de-duplicated mitx data as well as bootcamp and xpro platform data from the intermediate layer

### How can this be tested?
dbt build --select marts__combined__users