### PR TITLE
fix dbt failed tests

### DIFF
--- a/src/ol_dbt/models/staging/mitxonline/stg__mitxonline__openedx__api__course_structure.sql
+++ b/src/ol_dbt/models/staging/mitxonline/stg__mitxonline__openedx__api__course_structure.sql
@@ -4,24 +4,8 @@
 
 --- To get the course structure at any give time, use course_id + block_id + the last retrieved_at
 
-with course_structure_source as (
-    select * from {{ source('ol_warehouse_raw_data','raw__mitxonline__openedx__api__course_structure') }}
-)
-
-, course_block_source as (
+with course_block_source as (
     select * from {{ source('ol_warehouse_raw_data','raw__mitxonline__openedx__api__course_blocks') }}
-)
-
-, course_structure as (
-    select * from (
-        select
-            *
-            , lag(
-                content_hash) over
-            (partition by course_id order by retrieved_at asc) as previous_content_hash
-        from course_structure_source
-    )
-    where previous_content_hash is null or previous_content_hash != content_hash
 )
 
 , course_block as (
@@ -38,23 +22,19 @@ with course_structure_source as (
 
 , cleaned as (
     select
-        course_structure.course_id as courserun_readable_id
-        , course_block.course_title as courserun_title
-        , course_block.block_index as coursestructure_block_index
-        , course_block.block_id as coursestructure_block_id
-        , course_block.block_parent as coursestructure_parent_block_id
-        , course_block.block_type as coursestructure_block_category
-        , course_block.block_title as coursestructure_block_title
-        , course_structure.content_hash as coursestructure_content_hash
-        , course_block.block_content_hash as coursestructure_block_content_hash
-        , json_query(course_block.block_details, 'lax $.metadata') as coursestructure_block_metadata
-        , {{ cast_timestamp_to_iso8601('course_block.course_start') }} as courserun_start_on
-        , {{ cast_timestamp_to_iso8601('course_structure.retrieved_at') }} as coursestructure_retrieved_at
+        course_id as courserun_readable_id
+        , course_title as courserun_title
+        , block_index as coursestructure_block_index
+        , block_id as coursestructure_block_id
+        , block_parent as coursestructure_parent_block_id
+        , block_type as coursestructure_block_category
+        , block_title as coursestructure_block_title
+        , course_content_hash as coursestructure_content_hash
+        , block_content_hash as coursestructure_block_content_hash
+        , json_query(block_details, 'lax $.metadata') as coursestructure_block_metadata
+        , {{ cast_timestamp_to_iso8601('course_start') }} as courserun_start_on
+        , {{ cast_timestamp_to_iso8601('retrieved_at') }} as coursestructure_retrieved_at
     from course_block
-    inner join course_structure
-        on
-            course_block.course_id = course_structure.course_id
-            and course_block.course_content_hash = course_structure.content_hash
 )
 
 select * from cleaned

--- a/src/ol_dbt/models/staging/mitxpro/stg__mitxpro__openedx__api__course_structure.sql
+++ b/src/ol_dbt/models/staging/mitxpro/stg__mitxpro__openedx__api__course_structure.sql
@@ -4,23 +4,8 @@
 --- To get the course structure at any point in time, use course_id + block_id + the last retrieved_at that close to
 --  that time
 
-with course_structure_source as (
-    select * from {{ source('ol_warehouse_raw_data','raw__xpro__openedx__api__course_structure') }}
-)
-
-, course_block_source as (
+with course_block_source as (
     select * from {{ source('ol_warehouse_raw_data','raw__xpro__openedx__api__course_blocks') }}
-)
-
-, course_structure as (
-    select * from (
-        select
-            *
-            , lag(content_hash) over (partition by course_id order by retrieved_at asc)
-                as previous_content_hash
-        from course_structure_source
-    )
-    where previous_content_hash is null or previous_content_hash != content_hash
 )
 
 , course_block as (
@@ -36,23 +21,19 @@ with course_structure_source as (
 
 , cleaned as (
     select
-        course_structure.course_id as courserun_readable_id
-        , course_block.course_title as courserun_title
-        , course_block.block_index as coursestructure_block_index
-        , course_block.block_id as coursestructure_block_id
-        , course_block.block_parent as coursestructure_parent_block_id
-        , course_block.block_type as coursestructure_block_category
-        , course_block.block_title as coursestructure_block_title
-        , course_structure.content_hash as coursestructure_content_hash
-        , course_block.block_content_hash as coursestructure_block_content_hash
-        , json_query(course_block.block_details, 'lax $.metadata') as coursestructure_block_metadata
-        , {{ cast_timestamp_to_iso8601('course_block.course_start') }} as courserun_start_on
-        , {{ cast_timestamp_to_iso8601('course_structure.retrieved_at') }} as coursestructure_retrieved_at
+        course_id as courserun_readable_id
+        , course_title as courserun_title
+        , block_index as coursestructure_block_index
+        , block_id as coursestructure_block_id
+        , block_parent as coursestructure_parent_block_id
+        , block_type as coursestructure_block_category
+        , block_title as coursestructure_block_title
+        , course_content_hash as coursestructure_content_hash
+        , block_content_hash as coursestructure_block_content_hash
+        , json_query(block_details, 'lax $.metadata') as coursestructure_block_metadata
+        , {{ cast_timestamp_to_iso8601('course_start') }} as courserun_start_on
+        , {{ cast_timestamp_to_iso8601('retrieved_at') }} as coursestructure_retrieved_at
     from course_block
-    inner join course_structure
-        on
-            course_block.course_id = course_structure.course_id
-            and course_block.course_content_hash = course_structure.content_hash
 )
 
 select * from cleaned

--- a/src/ol_dbt/models/staging/mitxpro/stg__mitxpro__openedx__mysql__courseware_studentmodule.sql
+++ b/src/ol_dbt/models/staging/mitxpro/stg__mitxpro__openedx__mysql__courseware_studentmodule.sql
@@ -2,6 +2,22 @@ with source as (
     select * from {{ source('ol_warehouse_raw_data', 'raw__xpro__openedx__mysql__courseware_studentmodule') }}
 )
 
+--- guard against duplications by airbyte Incremental Sync - Append
+, source_sorted as (
+    select
+        *
+        , row_number() over (
+            partition by id order by _airbyte_emitted_at desc
+        ) as row_num
+    from source
+)
+
+, most_recent_source as (
+    select *
+    from source_sorted
+    where row_num = 1
+)
+
 , cleaned as (
 
     select
@@ -15,7 +31,7 @@ with source as (
         , max_grade as studentmodule_problem_max_grade
         , to_iso8601(from_iso8601_timestamp_nanos(created)) as studentmodule_created_on
         , to_iso8601(from_iso8601_timestamp_nanos(modified)) as studentmodule_updated_on
-    from source
+    from most_recent_source
 )
 
 select * from cleaned


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
NA
dbt failed tests in https://pipelines.odl.mit.edu/runs/d7cb7cca-74d1-4df7-bbc1-699c1799b1be due to some changes in airbyte sync mode

### Description (What does it do?)
<!--- Describe your changes in detail -->
- Updating `stg__mitxonline__openedx__api__course_structure` and `stg__mitxpro__openedx__api__course_structure` to use `course_blocks` raw table only, that eliminates the ambiguous join with `course_structure` 
- Updating `stg__mitxonline__openedx__mysql__courseware_studentmodule` and `stg__mitxpro__openedx__mysql__courseware_studentmodule` to guard against duplication introduced by airbyte sync mode - Incremental append

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

Run the following commands and tests should be all passed now

```
dbt build --select +int__mitxonline__course_structure
dbt build --select +int__mitxpro__course_structure
dbt build --select stg__mitxonline__openedx__mysql__courseware_studentmodule 
dbt build --select stg__mitxpro__openedx__mysql__courseware_studentmodule 
```