### PR TITLE
Create a combined user course roles from MITx Online, xPro and Residential

### DIFF
--- a/src/ol_dbt/dbt_project.yml
+++ b/src/ol_dbt/dbt_project.yml
@@ -35,6 +35,7 @@ vars:
     mitxpro: 'xPro'
     micromasters: 'MicroMasters'
     mitxonline: 'MITx Online'
+    residential: 'Residential MITx'
     dedp_micromasters_program_id: 2
     dedp_mitxonline_international_development_program_id: 1
     dedp_mitxonline_public_policy_program_id: 2

--- a/src/ol_dbt/models/intermediate/combined/_combined_models.yml
+++ b/src/ol_dbt/models/intermediate/combined/_combined_models.yml
@@ -134,3 +134,39 @@ models:
   tests:
   - dbt_expectations.expect_compound_columns_to_be_unique:
       column_list: ["platform", "user_username", "courserun_readable_id"]
+
+- name: int__combined__user_course_roles
+  description: lists the users who have a privileged role or roles for working in
+    a course on MITx Online, MIT xPro and Residential MITx platforms
+  columns:
+  - name: platform
+    description: str, the open edX platform where the data is from
+    tests:
+    - not_null
+  - name: courserun_readable_id
+    description: str, the open edX Course ID formatted as course-v1:{org}+{course
+      number}+{run_tag}
+    tests:
+    - not_null
+  - name: user_username
+    description: str, unique username on the open edX platform
+    tests:
+    - not_null
+  - name: user_email
+    description: str, user's email on the open edX platform
+    tests:
+    - not_null
+  - name: user_full_name
+    description: str, full name from user's profile on MITx Online or xPro application.
+      For Residential, this is from the open edX users table.
+  - name: organization
+    description: str, organization that lists the course. e.g. MITx, MITxT
+  - name: courseaccess_role
+    description: str, the privilege level assigned to the user for working in this
+      course. Currently the assigned roles are instructor, staff, limited_staff, beta_testers
+      and data_researcher on the open edX platform.
+    tests:
+    - not_null
+  tests:
+  - dbt_expectations.expect_compound_columns_to_be_unique:
+      column_list: ["user_username", "courserun_readable_id", "courseaccess_role"]

--- a/src/ol_dbt/models/intermediate/combined/int__combined__user_course_roles.sql
+++ b/src/ol_dbt/models/intermediate/combined/int__combined__user_course_roles.sql
@@ -1,0 +1,82 @@
+with mitxonline_courseroles as (
+    select * from {{ ref('stg__mitxonline__openedx__mysql__user_courseaccessrole') }}
+)
+
+, mitxonline_app_users as (
+    select * from {{ ref('stg__mitxonline__app__postgres__users_user') }}
+)
+
+, mitxonline_openedx_users as (
+    select * from {{ ref('stg__mitxonline__openedx__mysql__auth_user') }}
+)
+
+, mitxpro_courseroles as (
+    select * from {{ ref('stg__mitxpro__openedx__mysql__user_courseaccessrole') }}
+)
+
+, mitxpro_app_users as (
+    select * from {{ ref('stg__mitxpro__app__postgres__users_user') }}
+)
+
+, mitxpro_openedx_users as (
+    select * from {{ ref('stg__mitxpro__openedx__mysql__auth_user') }}
+)
+
+, residential_courseroles as (
+    select * from {{ ref('stg__mitxresidential__openedx__user_courseaccessrole') }}
+)
+
+, residential_openedx_users as (
+    select * from {{ ref('stg__mitxresidential__openedx__auth_user') }}
+)
+
+, combined_courseroles as (
+    select
+        '{{ var("mitxonline") }}' as platform
+        , mitxonline_openedx_users.user_username
+        , mitxonline_openedx_users.user_email
+        , mitxonline_app_users.user_full_name
+        , mitxonline_courseroles.courserun_readable_id
+        , mitxonline_courseroles.organization
+        , mitxonline_courseroles.courseaccess_role
+    from mitxonline_courseroles
+    inner join mitxonline_openedx_users
+        on mitxonline_courseroles.openedx_user_id = mitxonline_openedx_users.openedx_user_id
+    left join mitxonline_app_users
+        on
+            mitxonline_openedx_users.user_username = mitxonline_app_users.user_username
+            or mitxonline_openedx_users.user_email = mitxonline_app_users.user_email
+
+    union all
+
+    select
+        '{{ var("mitxpro") }}' as platform
+        , mitxpro_openedx_users.user_username
+        , mitxpro_openedx_users.user_email
+        , mitxpro_app_users.user_full_name
+        , mitxpro_courseroles.courserun_readable_id
+        , mitxpro_courseroles.organization
+        , mitxpro_courseroles.courseaccess_role
+    from mitxpro_courseroles
+    inner join mitxpro_openedx_users
+        on mitxpro_courseroles.openedx_user_id = mitxpro_openedx_users.openedx_user_id
+    left join mitxpro_app_users
+        on
+            mitxpro_openedx_users.user_username = mitxpro_app_users.user_username
+            or mitxpro_openedx_users.user_email = mitxpro_app_users.user_email
+
+    union all
+
+    select
+        '{{ var("residential") }}' as platform
+        , residential_openedx_users.user_username
+        , residential_openedx_users.user_email
+        , residential_openedx_users.user_full_name
+        , residential_courseroles.courserun_readable_id
+        , residential_courseroles.organization
+        , residential_courseroles.courseaccess_role
+    from residential_courseroles
+    inner join residential_openedx_users on residential_courseroles.user_id = residential_openedx_users.user_id
+)
+
+select * from combined_courseroles

--- a/src/ol_dbt/models/staging/mitxonline/_mitxonline__sources.yml
+++ b/src/ol_dbt/models/staging/mitxonline/_mitxonline__sources.yml
@@ -1575,18 +1575,24 @@ sources:
       description: int, the foreign key referencing the criterion option
 
   - name: raw__mitxonline__openedx__mysql__student_courseaccessrole
-    description: MITx Online open edX student course access roles
+    description: MITx Online open edX student course access roles that lists the users
+      who have a privileged role or roles for working in a course on MITx Online open
+      edX platform
     columns:
     - name: course_id
-      description: string, unique ID representing a single MITx Online course run
+      description: string, open edX Course ID formatted as course-v1:{org}+{course
+        code}+{run_tag}
     - name: org
-      description: string, the organization the course belongs to
+      description: string, the organization the course belongs to. e.g. MITxT
     - name: id
       description: int, the auto-incremented ID for this table
     - name: role
-      description: string, the course access student role
+      description: string, the privilege level assigned to the user for working in
+        this course. Currently the assigned roles are instructor, staff, beta_testers
+        and data_researcher on MITx Online open edX platform.
     - name: user_id
-      description: int, unique ID for each user on the MITx Online platform
+      description: int, unique ID for each user on the MITx Online platform. Note
+        that this is different from user_id from MITx Online app
 
   - name: raw__mitxonline__openedx__mysql__assessment_criterion
     description: MITx Online open edX assessment criteria
@@ -1692,22 +1698,3 @@ sources:
       description: str, the name of the assessment workflow step
     - name: submitter_completed_at
       description: timestamp, specifying when assessment workflow step was completed
-
-  - name: raw__mitxonline__openedx__mysql__student_courseaccessrole
-    description: lists the users who have a privileged role or roles for working in
-      a course on MITx Online open edX platform
-    columns:
-    - name: id
-      description: int, primary key tracking a course access role assigned in this
-        table
-    - name: courserun_readable_id
-      description: str, open edX Course ID formatted as course-v1:{org}+{course code}+{run_tag}
-    - name: openedx_user_id
-      description: int, user ID on MITx Online open edX platform. Note that this is
-        different from user_id from MITx Online app
-    - name: organization
-      description: str, organization that lists the course. e.g. MITxT
-    - name: courseaccess_role
-      description: str, the privilege level assigned to the user for working in this
-        course. Currently the assigned roles are instructor, staff, beta_testers and
-        data_researcher on MITx Online open edX platform.

--- a/src/ol_dbt/models/staging/mitxonline/_mitxonline__sources.yml
+++ b/src/ol_dbt/models/staging/mitxonline/_mitxonline__sources.yml
@@ -1692,3 +1692,22 @@ sources:
       description: str, the name of the assessment workflow step
     - name: submitter_completed_at
       description: timestamp, specifying when assessment workflow step was completed
+
+  - name: raw__mitxonline__openedx__mysql__student_courseaccessrole
+    description: lists the users who have a privileged role or roles for working in
+      a course on MITx Online open edX platform
+    columns:
+    - name: id
+      description: int, primary key tracking a course access role assigned in this
+        table
+    - name: courserun_readable_id
+      description: str, open edX Course ID formatted as course-v1:{org}+{course code}+{run_tag}
+    - name: openedx_user_id
+      description: int, user ID on MITx Online open edX platform. Note that this is
+        different from user_id from MITx Online app
+    - name: organization
+      description: str, organization that lists the course. e.g. MITxT
+    - name: courseaccess_role
+      description: str, the privilege level assigned to the user for working in this
+        course. Currently the assigned roles are instructor, staff, beta_testers and
+        data_researcher on MITx Online open edX platform.

--- a/src/ol_dbt/models/staging/mitxonline/_stg_mitxonline__models.yml
+++ b/src/ol_dbt/models/staging/mitxonline/_stg_mitxonline__models.yml
@@ -1532,3 +1532,37 @@ models:
     description: str, json object of all visible blocks within a subsection
     tests:
     - not_null
+
+- name: stg__mitxonline__openedx__mysql__user_courseaccessrole
+  description: lists the users who have a privileged role or roles for working in
+    a course on MITx Online open edX platform
+  columns:
+  - name: courseaccessrole_id
+    description: int, primary key tracking a course access role assigned in this table
+    tests:
+    - unique
+    - not_null
+  - name: courserun_readable_id
+    description: str, open edX Course ID formatted as course-v1:{org}+{course code}+{run_tag}
+    tests:
+    - not_null
+  - name: openedx_user_id
+    description: int, user ID on MITx Online open edX platform. Note that this is
+      different from user_id from MITx Online app
+    tests:
+    - not_null
+  - name: organization
+    description: str, organization that lists the course. e.g. MITxT
+  - name: courseaccess_role
+    description: str, the privilege level assigned to the user for working in this
+      course. Currently the assigned roles are instructor, staff, beta_testers and
+      data_researcher on MITx Online open edX platform.
+    tests:
+    - not_null
+    - accepted_values:
+        values: ['staff', 'limited_staff', 'data_researcher', 'instructor', 'finance_admin',
+          'sales_admin', 'beta_testers', 'library_user', 'org_course_creator_group',
+          'course_creator_group', 'support']
+  tests:
+  - dbt_expectations.expect_compound_columns_to_be_unique:
+      column_list: ["courserun_readable_id", "openedx_user_id", "courseaccess_role"]

--- a/src/ol_dbt/models/staging/mitxonline/stg__mitxonline__openedx__mysql__user_courseaccessrole.sql
+++ b/src/ol_dbt/models/staging/mitxonline/stg__mitxonline__openedx__mysql__user_courseaccessrole.sql
@@ -1,0 +1,15 @@
+with source as (
+    select * from {{ source('ol_warehouse_raw_data','raw__mitxonline__openedx__mysql__student_courseaccessrole') }}
+)
+
+, cleaned as (
+    select
+        id as courseaccessrole_id
+        , course_id as courserun_readable_id
+        , user_id as openedx_user_id
+        , role as courseaccess_role
+        , if(lower(org) = 'mitxt', 'MITxT', org) as organization
+    from source
+)
+
+select * from cleaned

--- a/src/ol_dbt/models/staging/mitxpro/_mitxpro__sources.yml
+++ b/src/ol_dbt/models/staging/mitxpro/_mitxpro__sources.yml
@@ -2005,18 +2005,24 @@ sources:
       description: int, the foreign key referencing the criterion option
 
   - name: raw__xpro__openedx__mysql__student_courseaccessrole
-    description: MITx Pro open edX student course access roles
+    description: MITx Pro open edX student course access roles that list the users
+      who have a privileged role or roles for working in a course on MIT xPro open
+      edX platform
     columns:
     - name: course_id
-      description: string, unique ID representing a single MITx Pro course run
+      description: string, Open edX Course ID formatted as course-v1:{org}+{course
+        code}+{run_tag}
     - name: org
-      description: string, the organization the course belongs to
+      description: string, the organization the course belongs to. e.g. xPro
     - name: id
       description: int, the auto-incremented ID for this table
     - name: role
-      description: string, the course access student role
+      description: string, the course access student role. Currently the assigned
+        roles are instructor, staff, limited_staff, beta_testers and data_researcher
+        on MIT xPro open edX platform.
     - name: user_id
-      description: int, unique ID for each user on the MITx Pro platform
+      description: int, unique ID for each user on the MITx Pro platform. Note that
+        this is different from user_id on MIT xPro app
 
   - name: raw__xpro__openedx__mysql__assessment_criterion
     description: MITx Pro open edX assessment criteria
@@ -2214,22 +2220,3 @@ sources:
     - name: modified
       description: timestamp, datetime when this row was last updated. A change in
         this field implies that there was a state change.
-
-  - name: raw__xpro__openedx__mysql__student_courseaccessrole
-    description: lists the users who have a privileged role or roles for working in
-      a course on MIT xPro open edX platform
-    columns:
-    - name: id
-      description: int, primary key tracking a course access role assigned in this
-        table
-    - name: courserun_readable_id
-      description: str, Open edX Course ID formatted as course-v1:{org}+{course code}+{run_tag}
-    - name: openedx_user_id
-      description: int, user ID on the open edX platform. Note that this is different
-        from user_id on MITx Online app
-    - name: organization
-      description: str, organization that lists the course. e.g. MITxT
-    - name: courseaccess_role
-      description: str, the privilege level assigned to the user for working in this
-        course. Currently the assigned roles are instructor, staff, limited_staff,
-        beta_testers and data_researcher on MIT xPro open edX platform.

--- a/src/ol_dbt/models/staging/mitxpro/_mitxpro__sources.yml
+++ b/src/ol_dbt/models/staging/mitxpro/_mitxpro__sources.yml
@@ -2214,3 +2214,22 @@ sources:
     - name: modified
       description: timestamp, datetime when this row was last updated. A change in
         this field implies that there was a state change.
+
+  - name: raw__xpro__openedx__mysql__student_courseaccessrole
+    description: lists the users who have a privileged role or roles for working in
+      a course on MIT xPro open edX platform
+    columns:
+    - name: id
+      description: int, primary key tracking a course access role assigned in this
+        table
+    - name: courserun_readable_id
+      description: str, Open edX Course ID formatted as course-v1:{org}+{course code}+{run_tag}
+    - name: openedx_user_id
+      description: int, user ID on the open edX platform. Note that this is different
+        from user_id on MITx Online app
+    - name: organization
+      description: str, organization that lists the course. e.g. MITxT
+    - name: courseaccess_role
+      description: str, the privilege level assigned to the user for working in this
+        course. Currently the assigned roles are instructor, staff, limited_staff,
+        beta_testers and data_researcher on MIT xPro open edX platform.

--- a/src/ol_dbt/models/staging/mitxpro/_stg_mitxpro__models.yml
+++ b/src/ol_dbt/models/staging/mitxpro/_stg_mitxpro__models.yml
@@ -1969,3 +1969,38 @@ models:
   tests:
   - dbt_expectations.expect_compound_columns_to_be_unique:
       column_list: ["openedx_user_id", "courserun_readable_id", "coursestructure_block_id"]
+
+- name: stg__mitxpro__openedx__mysql__user_courseaccessrole
+  description: lists the users who have a privileged role or roles for working in
+    a course on MIT xPro open edX platform
+  columns:
+  - name: courseaccessrole_id
+    description: int, sequential ID tracking a course access role assigned in this
+      table
+    tests:
+    - unique
+    - not_null
+  - name: courserun_readable_id
+    description: str, Open edX Course ID formatted as course-v1:{org}+{course code}+{run_tag}
+    tests:
+    - not_null
+  - name: openedx_user_id
+    description: int, user ID on MIT xPro open edX platform. Note that this is different
+      from user_id on MIT xPro app
+    tests:
+    - not_null
+  - name: organization
+    description: str, organization that lists the course. e.g. xPro
+  - name: courseaccess_role
+    description: str, the privilege level assigned to the user for working in this
+      course. Currently the assigned roles are instructor, staff, limited_staff, beta_testers
+      and data_researcher on MIT xPro open edX platform.
+    tests:
+    - not_null
+    - accepted_values:
+        values: ['staff', 'limited_staff', 'data_researcher', 'instructor', 'finance_admin',
+          'sales_admin', 'beta_testers', 'library_user', 'org_course_creator_group',
+          'course_creator_group', 'support']
+  tests:
+  - dbt_expectations.expect_compound_columns_to_be_unique:
+      column_list: ["courserun_readable_id", "openedx_user_id", "courseaccess_role"]

--- a/src/ol_dbt/models/staging/mitxpro/stg__mitxpro__openedx__mysql__user_courseaccessrole.sql
+++ b/src/ol_dbt/models/staging/mitxpro/stg__mitxpro__openedx__mysql__user_courseaccessrole.sql
@@ -1,14 +1,14 @@
 with source as (
-    select * from {{ source('ol_warehouse_raw_data','raw__mitx__openedx__mysql__student_courseaccessrole') }}
+    select * from {{ source('ol_warehouse_raw_data','raw__xpro__openedx__mysql__student_courseaccessrole') }}
 )
 
 , cleaned as (
     select
         id as courseaccessrole_id
         , course_id as courserun_readable_id
-        , user_id
+        , user_id as openedx_user_id
         , role as courseaccess_role
-        , if(lower(org) = 'mitx', 'MITx', org) as organization
+        , org as organization
     from source
 )
 

--- a/src/ol_dbt/models/staging/mitxresidential/_stg_mitxresidential__models.yml
+++ b/src/ol_dbt/models/staging/mitxresidential/_stg_mitxresidential__models.yml
@@ -24,6 +24,8 @@ models:
     description: str, user's last name
     tests:
     - not_null
+  - name: user_full_name
+    description: str, user's full name on Residential open edx platform if applicable
   - name: user_email
     description: str, user's email associated with their account
     tests:
@@ -50,7 +52,8 @@ models:
     description: timestamp, date and time when user last login
 
 - name: stg__mitxresidential__openedx__user_courseaccessrole
-  description: Residential MITx user course-level roles
+  description: This table lists the users who have a privileged role or roles for
+    working in a course on Residential MITx Platform
   columns:
   - name: courseaccessrole_id
     description: int, sequential ID for a single user course role on Residential MITx
@@ -67,15 +70,12 @@ models:
     description: int, user ID on Residential MITx open edx platform
     tests:
     - not_null
-    - relationships:
-        to: ref('stg__mitxresidential__openedx__auth_user')
-        field: user_id
-  - name: courserun_org
-    description: str, course organization e.g. MITx
-  - name: courseaccessrole_role
-    description: str, user role, possible values are staff, data_researcher, instructor,
-      beta_testers, finance_admin, sales_admin, library_user, org_course_creator_group,
-      course_creator_group, support
+  - name: organization
+    description: str, organization that lists the course. e.g. MITx
+  - name: courseaccess_role
+    description: str, the privilege level assigned to the user for working in this
+      course. Currently the assigned roles are instructor, staff, beta_testers and
+      data_researcher on the Residential MITx platform.
     tests:
     - not_null
     - accepted_values:
@@ -84,7 +84,7 @@ models:
           'support']
   tests:
   - dbt_expectations.expect_compound_columns_to_be_unique:
-      column_list: ["courserun_readable_id", "user_id", "courseaccessrole_role"]
+      column_list: ["courserun_readable_id", "user_id", "courseaccess_role"]
 
 - name: stg__mitxresidential__openedx__courserun
   description: Residential MITx open edX courses

--- a/src/ol_dbt/models/staging/mitxresidential/stg__mitxresidential__openedx__auth_user.sql
+++ b/src/ol_dbt/models/staging/mitxresidential/stg__mitxresidential__openedx__auth_user.sql
@@ -12,8 +12,9 @@ with source as (
         , is_active as user_is_active
         , is_staff as user_is_staff
         , is_superuser as user_is_superuser
-        ,{{ cast_timestamp_to_iso8601('date_joined') }} as user_joined_on
-        ,{{ cast_timestamp_to_iso8601('last_login') }} as user_last_login
+        , concat_ws(' ', first_name, last_name) as user_full_name
+        , to_iso8601(from_iso8601_timestamp_nanos(date_joined)) as user_joined_on
+        , to_iso8601(from_iso8601_timestamp_nanos(last_login)) as user_last_login
     from source
 )
 


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
Part of https://github.com/mitodl/ol-data-platform/issues/561


### Description (What does it do?)
<!--- Describe your changes in detail -->

- Creating `stg__mitxonline__openedx__mysql__user_courseaccessrole`, `stg__mitxpro__openedx__mysql__user_courseaccessrole`
- Creating `int__combined__user_course_roles` from MITx Online, xPro and Residential open edx platform
  - Can be used for our Superset course access control
  - Can be used for https://github.com/mitodl/ol-data-platform/issues/561 report

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->
```
dbt build +int__combined__user_course_roles
```