### PR TITLE
fix courserun_platform in MITx Online courserun model

### DIFF
--- a/src/ol_dbt/models/staging/mitxonline/_stg_mitxonline__models.yml
+++ b/src/ol_dbt/models/staging/mitxonline/_stg_mitxonline__models.yml
@@ -947,7 +947,8 @@ models:
     - not_null
   - name: courserun_platform
     description: str, indicating whether this course runs on MITx Online or edX.org.
-      Some of edx.org data were migrated from MicroMasters
+      edx.org courses were migrated from MicroMasters. e.g. edx.org course IDs - MITx/14_73x/1T2014,
+      course-v1:MITx+14.100x+1T2017
     tests:
     - not_null
     - accepted_values:

--- a/src/ol_dbt/models/staging/mitxonline/stg__mitxonline__app__postgres__courses_courserun.sql
+++ b/src/ol_dbt/models/staging/mitxonline/stg__mitxonline__app__postgres__courses_courserun.sql
@@ -15,8 +15,9 @@ with source as (
         , run_tag as courserun_tag
         , is_self_paced as courserun_is_self_paced
         , case
-            when courseware_id like 'course-v1:MITxT+%' then '{{ var("mitxonline") }}'
-            else '{{ var("edxorg") }}'
+            when courseware_id like 'MITx/%' or courseware_id like 'course-v1:MITx+%'
+                then '{{ var("edxorg") }}'
+            else '{{ var("mitxonline") }}'
         end as courserun_platform
         , replace(replace(courseware_id, 'course-v1:', ''), '+', '/') as courserun_edx_readable_id
         ,{{ cast_timestamp_to_iso8601('start_date') }} as courserun_start_on


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
NA. Notice it while working on https://github.com/mitodl/ol-data-platform/pull/1001

### Description (What does it do?)
<!--- Describe your changes in detail -->
Fixing `courserun_platform` in `stg__mitxonline__app__postgres__courses_courserun` to count for runs that don't follow MITx Online course ID schema. e.g. `course-v1:MITxt+3.012Tx+2T2023`. So that all the MITx Online enrollments are included in int__mitx__courserun_enrollments and marts__mitxonline_course_enrollments.

Note that some edX.org courses were migrated from MicroMasters to MITx Online, so we needed `courserun_platform` as a filter for old edX.org courses.

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->
Run `dbt build --select stg__mitxonline__app__postgres__courses_courserun`

Then check `stg__mitxonline__app__postgres__courses_courserun`, all the runs should have the correct courserun_platform.  e.g.
    - `course-v1:MITxt+3.012Tx+2T2023`, course-v1:TestX+Test101+3T2022 should be MITx Online
    -  course-v1:MITx+14.740x+3T2017 , MITx/14.73x_1/1T2015 should be edX.org

