### PR TITLE
add user_is_active to intermediate and mart

### DIFF
--- a/src/ol_dbt/models/intermediate/combined/_combined_models.yml
+++ b/src/ol_dbt/models/intermediate/combined/_combined_models.yml
@@ -42,6 +42,11 @@ models:
     description: timestamp, user join timestamp
   - name: user_last_login
     description: timestamp, user last login
+  - name: user_is_active
+    description: boolean, indicating if user's account is active on xPro, Bootcamps,
+      edX.org, or MITx Online. Note that we do export compliance checks for all users
+      in xPro and Bootcamps, so users didn't pass export compliance will remain user_is_active=false
+      in xPro and Bootcamps. That doesn't apply for edx.org and MITx Online.
 
 - name: int__combined__courserun_enrollments
   description: Intermediate model for user course enrollments from different platforms

--- a/src/ol_dbt/models/intermediate/combined/int__combined__users.sql
+++ b/src/ol_dbt/models/intermediate/combined/int__combined__users.sql
@@ -37,6 +37,7 @@ with mitxonline_users as (
         , user_industry
         , user_joined_on
         , user_last_login
+        , user_is_active
     from mitxonline_users
 
     union all
@@ -55,6 +56,7 @@ with mitxonline_users as (
         , user_industry
         , user_joined_on
         , user_last_login
+        , user_is_active
     from mitxpro_users
 
     union all
@@ -73,6 +75,7 @@ with mitxonline_users as (
         , user_industry
         , user_joined_on
         , user_last_login
+        , user_is_active
     from bootcamps_users
 
     union all
@@ -91,6 +94,7 @@ with mitxonline_users as (
         , micromasters_users.user_company_industry as user_industry
         , edxorg_users.user_joined_on
         , edxorg_users.user_last_login
+        , edxorg_users.user_is_active
     from edxorg_users
     left join micromasters_users on edxorg_users.user_username = micromasters_users.user_edxorg_username
 )

--- a/src/ol_dbt/models/intermediate/edxorg/_int_edxorg__models.yml
+++ b/src/ol_dbt/models/intermediate/edxorg/_int_edxorg__models.yml
@@ -226,6 +226,9 @@ models:
   - name: user_mitxonline_username
     description: str, username on MITx Online if user's account is linked on MicroMasters
       portal
+  - name: user_is_active
+    description: boolean, indicating if user's account is active on edx.org. A user
+      is inactive when their username or email is hashed.
 
 - name: int__edxorg__mitx_courserun_grades
   description: Intermediate model for course run grades from edx.org

--- a/src/ol_dbt/models/intermediate/edxorg/int__edxorg__mitx_users.sql
+++ b/src/ol_dbt/models/intermediate/edxorg/int__edxorg__mitx_users.sql
@@ -70,6 +70,7 @@ with user_info_combo as (
         , user_joined_on
         , user_gender
         , user_last_login
+        , if(user_email like 'retired__user%' or user_username like 'retired__user%', false, true) as user_is_active
     from combined_user_info
     where row_num = 1
 )

--- a/src/ol_dbt/models/intermediate/mitx/_int_mitx__models.yml
+++ b/src/ol_dbt/models/intermediate/mitx/_int_mitx__models.yml
@@ -148,6 +148,11 @@ models:
     description: timestamp, user last log in on MITx Online
   - name: user_last_login_on_edxorg
     description: timestamp, user last log in on edX.org
+  - name: user_is_active_on_mitxonline
+    description: boolean, indicating if user's account is active on MITx Online
+  - name: user_is_active_on_edxorg
+    description: boolean, indicating if user's account is active on edx.org. A user
+      is inactive when their username or email is hashed.
   - name: user_full_name
     description: str, user full name on edX.org or MITxOnline. Very small number of
       edX.org users have blank full name, their name couldn't be populated from other

--- a/src/ol_dbt/models/intermediate/mitx/int__mitx__users.sql
+++ b/src/ol_dbt/models/intermediate/mitx/int__mitx__users.sql
@@ -31,6 +31,7 @@ with mitxonline_users as (
         , mitxonline_users.user_industry
         , mitxonline_users.user_joined_on
         , mitxonline_users.user_last_login
+        , mitxonline_users.user_is_active
         , true as is_mitxonline_user
     from mitxonline_users
 )
@@ -47,6 +48,7 @@ with mitxonline_users as (
         , edxorg_users.user_birth_year
         , edxorg_users.user_joined_on
         , edxorg_users.user_last_login
+        , edxorg_users.user_is_active
         , micromasters_users.user_company_name
         , micromasters_users.user_company_industry
         , micromasters_users.user_job_position
@@ -67,6 +69,8 @@ with mitxonline_users as (
         , edxorg_users_view.user_joined_on as user_joined_on_edxorg
         , mitxonline_users_view.user_last_login as user_last_login_on_mitxonline
         , edxorg_users_view.user_last_login as user_last_login_on_edxorg
+        , mitxonline_users_view.user_is_active as user_is_active_on_mitxonline
+        , edxorg_users_view.user_is_active as user_is_active_on_edxorg
         , coalesce(mitxonline_users_view.is_mitxonline_user is not null, false) as is_mitxonline_user
         , coalesce(edxorg_users_view.is_edxorg_user is not null, false) as is_edxorg_user
         , coalesce(mitxonline_users_view.user_full_name, edxorg_users_view.user_full_name) as user_full_name

--- a/src/ol_dbt/models/marts/combined/_marts__combined__models.yml
+++ b/src/ol_dbt/models/marts/combined/_marts__combined__models.yml
@@ -8,15 +8,23 @@ models:
   - name: user_email
     description: string, user email on the corresponding platform including xpro,
       bootcamps, edX.org, or MITx Online. If the user is on edX.org and MITx Online
-      then the email will be chosen from the last platform they joined.
+      then the email will be chosen from the last platform they joined if their account
+      is active
   - name: user_joined_on
     description: timestamp, user join timestamp on the corresponding platform including
       xpro, bootcamps, edX.org, or MITx Online. If the user is on edX.org and MITx
-      Online then the timsestamp will be chosen from the latest platform they joined.
+      Online then the timestamp will be chosen from the latest platform they joined
+      if their account is active
   - name: user_last_login
     description: timestamp, user last login on the corresponding platform including
       xpro, bootcamps, edX.org, or MITx Online. If the user is on edX.org and MITx
-      Online then the timsestamp will be chosen from the latest login.
+      Online then the timestamp will be chosen from the latest login if their account
+      is active
+  - name: user_is_active
+    description: boolean, indicating if user's account is active on the corresponding
+      platform including xpro, bootcamps, edX.org, or MITx Online. If the user is
+      on edX.org and MITx Online then it will be true if their MITx Online account
+      is active, otherwise it will default to their edX.org account active status.
   - name: platforms
     description: string, application where the data is from
   - name: user_full_name

--- a/src/ol_dbt/models/marts/combined/marts__combined__users.sql
+++ b/src/ol_dbt/models/marts/combined/marts__combined__users.sql
@@ -23,27 +23,32 @@ with mitx__users as (
         , null as user_mitxpro_username
         , null as user_bootcamps_username
         , case
-            when user_joined_on_mitxonline > user_joined_on_edxorg
+            when user_is_active_on_mitxonline and user_joined_on_mitxonline > user_joined_on_edxorg
                 then user_mitxonline_email
             else coalesce(user_edxorg_email, user_mitxonline_email)
         end as user_email
         , case
-            when user_joined_on_mitxonline > user_joined_on_edxorg
+            when user_is_active_on_mitxonline and user_joined_on_mitxonline > user_joined_on_edxorg
                 then user_joined_on_mitxonline
             else coalesce(user_joined_on_edxorg, user_joined_on_mitxonline)
         end as user_joined_on
         , case
-            when user_last_login_on_mitxonline > user_last_login_on_edxorg
+            when user_is_active_on_mitxonline and user_last_login_on_mitxonline > user_last_login_on_edxorg
                 then user_last_login_on_mitxonline
             else coalesce(user_last_login_on_edxorg, user_last_login_on_mitxonline)
         end as user_last_login
         , case
+            when user_is_active_on_mitxonline
+                then user_is_active_on_mitxonline
+            else user_is_active_on_edxorg
+        end as user_is_active
+        , case
             when is_mitxonline_user = true and is_edxorg_user = true
-                then 'mitxonline and edxorg'
+                then concat('{{ var("mitxonline") }}', ' and ', '{{ var("edxorg") }}')
             when is_mitxonline_user = true
-                then 'mitxonline'
+                then '{{ var("mitxonline") }}'
             when is_edxorg_user = true
-                then 'edxorg'
+                then '{{ var("edxorg") }}'
         end as platforms
         , user_full_name
         , user_address_country
@@ -69,7 +74,8 @@ with mitx__users as (
         , user_email
         , user_joined_on
         , user_last_login
-        , 'mitxpro' as platforms
+        , user_is_active
+        , '{{ var("mitxpro") }}' as platforms
         , user_full_name
         , user_address_country
         , user_highest_education
@@ -94,7 +100,8 @@ with mitx__users as (
         , user_email
         , user_joined_on
         , user_last_login
-        , 'bootcamps' as platforms
+        , user_is_active
+        , '{{ var("bootcamps") }}' as platforms
         , user_full_name
         , user_address_country
         , user_highest_education
@@ -110,6 +117,7 @@ select
     user_email
     , user_joined_on
     , user_last_login
+    , user_is_active
     , platforms
     , user_full_name
     , user_address_country


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
NA
Part of https://github.com/mitodl/hq/issues/3613

### Description (What does it do?)
<!--- Describe your changes in detail -->
This adds user_is_active to intermediate models - int__combined__users, int__edxorg__mitx_users , int__mitx__users and marts__combined__users 
- it doesn't filter out inactive users in intermediate to make sure we don't drop order and enrollment data for any inactive users 
- for marts__combined__users, not sure if it makes sense to filter inactive users. But for now I've added user_is_active and pull the correct email if the account exist on both edx.org and MITx Online. 


### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

```
dbt build --select int__edxorg__mitx_users
dbt build --select int__mitx__users
dbt build --select int__combined__users
dbt build --select marts__combined__users
```