### PR TITLE
Giving mit_irx select privileges on program certificates tables

### DIFF
--- a/src/ol_dbt/models/intermediate/edxorg/_int_edxorg__models.yml
+++ b/src/ol_dbt/models/intermediate/edxorg/_int_edxorg__models.yml
@@ -377,9 +377,6 @@ models:
 - name: int__edxorg__mitx_program_certificates
   description: learners who completed MicroMasters and XSeries programs on edX.org.
     program_certificate_awarded_on might be null for some programs such as SCM
-  config:
-    grants:
-      select: ['mit_irx']
   columns:
   - name: program_type
     description: str, the type of the program. The value are 'MicroMasters' and 'XSeries'

--- a/src/ol_dbt/models/intermediate/edxorg/_int_edxorg__models.yml
+++ b/src/ol_dbt/models/intermediate/edxorg/_int_edxorg__models.yml
@@ -377,6 +377,9 @@ models:
 - name: int__edxorg__mitx_program_certificates
   description: learners who completed MicroMasters and XSeries programs on edX.org.
     program_certificate_awarded_on might be null for some programs such as SCM
+  config:
+    grants:
+      select: ['mit_irx']
   columns:
   - name: program_type
     description: str, the type of the program. The value are 'MicroMasters' and 'XSeries'

--- a/src/ol_dbt/models/marts/micromasters/_marts_micromasters__models.yml
+++ b/src/ol_dbt/models/marts/micromasters/_marts_micromasters__models.yml
@@ -110,6 +110,7 @@ models:
       use  differnt email addresses for their edxorg and mitxonline logins
   - name: program_certificates
     description: int, count of program certificates earned for the the program
+
 - name: marts__micromasters_summary
   description: MicroMasters aggregate statistics
   columns:
@@ -157,8 +158,12 @@ models:
     - not_null
   - name: program_certificates
     description: int, count of program certificates earned for the the program
+
 - name: marts__micromasters_program_certificates
   description: MicroMasters program certificate earners
+  config:
+    grants:
+      select: ['mit_irx']
   columns:
   - name: user_edxorg_username
     description: str, The username of the learner on the edX platform. For users who


### PR DESCRIPTION
These changes should give Jon and the IRX team access to the micromasters program credential data so they can include it in reports they provide to OL Finance.

### What are the relevant tickets?
Closes https://github.com/mitodl/hq/issues/3021
and https://github.mit.edu/micromasters/micromasters-issues/issues/40

### Description (What does it do?)
This is giving the mit_irx role select privileges on the following tables:
int__edxorg__mitx_program_certificates
marts__micromasters_program_certificates

### How can this be tested?
```
dbt build --select +int__edxorg__mitx_program_certificates
dbt build --select +marts__micromasters_program_certificates

```