### PR TITLE
Create staging and intermediate models for bootcamps application related tables

### DIFF
--- a/src/ol_dbt/models/intermediate/bootcamps/_int_bootcamps__models.yml
+++ b/src/ol_dbt/models/intermediate/bootcamps/_int_bootcamps__models.yml
@@ -385,3 +385,62 @@ models:
   tests:
   - dbt_expectations.expect_table_row_count_to_equal_other_table:
       compare_model: ref('stg__bootcamps__app__postgres__courses_courseruncertificate')
+
+- name: int__bootcamps__applications
+  description: tracks bootcamp application status as well as personal price and payment
+    data
+  columns:
+  - name: application_id
+    description: int, primary key representing a single bootcamp application
+    tests:
+    - unique
+    - not_null
+  - name: courserun_id
+    description: int, foreign key representing a single bootcamp course run
+    tests:
+    - not_null
+  - name: courserun_title
+    description: str, title of the course run
+    tests:
+    - not_null
+  - name: courserun_readable_id
+    description: str, unique string to identify a bootcamp course run. e.g. bootcamp-v1:public+advanced-program-f2flng+R1
+  - name: courserun_start_on
+    description: timestamp, date and time when the bootcamp course starts
+  - name: courserun_end_on
+    description: timestamp, date and time when the bootcamp course ends
+  - name: user_id
+    description: str, foreign key to auth_user representing a single user
+    tests:
+    - not_null
+  - name: application_state
+    description: str, current state of the bootcamp application. Possible values are
+      awaiting_profile_completion, awaiting_resume, awaiting_user_submissions, awaiting_submission_review,
+      awaiting_payment, complete, rejected, refunded
+    tests:
+    - not_null
+  - name: application_linkedin_url
+    description: str, linkedIn profile url for the user in a bootcamp application
+  - name: application_resume_file
+    description: str, the resume file path for the user in a bootcamp application
+  - name: application_resume_uploaded_on
+    description: timestamp, specifying when the resume was uploaded to our system
+  - name: application_created_on
+    description: timestamp, specifying when the application was initially created
+    tests:
+    - not_null
+  - name: application_updated_on
+    description: timestamp, specifying when the application was most recently updated
+    tests:
+    - not_null
+  - name: personal_price
+    description: float, user's personal price for this bootcamp run
+  - name: list_price
+    description: float, the list price for the bootcamp run sourced from installment
+  - name: total_paid
+    description: float, total price paid for the bootcamp run from fulfilled order
+  - name: admitted_date
+    description: timestamp, specifying when the application review step is approved.
+  tests:
+  - dbt_expectations.expect_table_row_count_to_equal_other_table:
+      compare_model: ref('stg__bootcamps__app__postgres__applications_courserun_application')

--- a/src/ol_dbt/models/intermediate/bootcamps/int__bootcamps__applications.sql
+++ b/src/ol_dbt/models/intermediate/bootcamps/int__bootcamps__applications.sql
@@ -1,0 +1,101 @@
+with applications as (
+    select * from {{ ref('stg__bootcamps__app__postgres__applications_courserun_application') }}
+)
+
+, runs as (
+    select * from {{ ref('stg__bootcamps__app__postgres__courses_courserun') }}
+)
+
+, application_steps as (
+    select * from {{ ref('stg__bootcamps__app__postgres__applications_applicationstep') }}
+)
+
+, application_last_steps as (
+    select
+        course_id
+        , max(applicationstep_step_order) as last_step
+    from application_steps
+    group by course_id
+)
+
+, courserun_applicationstep as (
+    select * from {{ ref('stg__bootcamps__app__postgres__applications_courserun_applicationstep') }}
+)
+
+, applicationstep_submissions as (
+    select * from {{ ref('stg__bootcamps__app__postgres__applications_applicationstep_submission') }}
+)
+
+, personal_prices as (
+    select * from {{ ref('stg__bootcamps__app__postgres__courses_personalprice') }}
+)
+
+, installments as (
+    select
+        courserun_id
+        , sum(installment_amount) as list_price
+    from {{ ref('stg__bootcamps__app__postgres__courses_installment') }}
+    group by courserun_id
+)
+
+, fulfilled_orders as (
+    select
+        application_id
+        , sum(line_price) as total_paid
+    from {{ ref('int__bootcamps__ecommerce_order') }}
+    where order_state = 'fulfilled'
+    group by application_id
+)
+
+
+, courserun_last_steps as (
+    select
+        courserun_applicationstep.courserun_applicationstep_id
+        , courserun_applicationstep.courserun_id
+        , application_steps.applicationstep_step_order
+    from
+        courserun_applicationstep
+    inner join application_steps on courserun_applicationstep.applicationstep_id = application_steps.applicationstep_id
+    inner join application_last_steps
+        on
+            application_steps.course_id = application_last_steps.course_id
+            and application_steps.applicationstep_step_order = application_last_steps.last_step
+)
+
+select
+    applications.application_id
+    , applications.user_id
+    , applications.courserun_id
+    , runs.courserun_readable_id
+    , runs.courserun_title
+    , runs.courserun_start_on
+    , runs.courserun_end_on
+    , applications.application_linkedin_url
+    , applications.application_resume_file
+    , applications.application_resume_uploaded_on
+    , applications.application_state
+    , applications.application_created_on
+    , applications.application_updated_on
+    , personal_prices.personalprice as personal_price
+    , installments.list_price
+    , fulfilled_orders.total_paid
+    , case
+        when applicationstep_submissions.submission_review_status = 'approved'
+            then applicationstep_submissions.submission_reviewed_on
+    end as application_admitted_date
+from applications
+inner join runs on applications.courserun_id = runs.courserun_id
+left join courserun_last_steps
+    on applications.courserun_id = courserun_last_steps.courserun_id
+left join applicationstep_submissions
+    on
+        courserun_last_steps.courserun_applicationstep_id = applicationstep_submissions.courserun_applicationstep_id
+        and applications.application_id = applicationstep_submissions.application_id
+left join installments
+    on applications.courserun_id = installments.courserun_id
+left join personal_prices
+    on
+        applications.user_id = personal_prices.user_id
+        and applications.courserun_id = personal_prices.courserun_id
+left join fulfilled_orders
+    on applications.application_id = fulfilled_orders.application_id

--- a/src/ol_dbt/models/staging/bootcamps/_bootcamps__sources.yml
+++ b/src/ol_dbt/models/staging/bootcamps/_bootcamps__sources.yml
@@ -294,3 +294,122 @@ sources:
       description: timestamp, specifying when a certificate was most recently updated
     - name: is_revoked
       description: boolean, indicating whether the certificate is revoked and invalid
+
+  - name: raw__bootcamps__app__postgres__django_content_type
+    columns:
+    - name: id
+      description: int, sequential ID for the django model
+    - name: model
+      description: str, the name of the django model
+    - name: app_label
+      description: str, the  functional group the model belongs to
+
+  - name: raw__bootcamps__app__postgres__applications_bootcampapplication
+    columns:
+    - name: id
+      description: int, primary key representing a single bootcamp application
+    - name: bootcamp_run_id
+      description: int, foreign key to klasses_bootcamprun representing a single bootcamp
+        course run
+    - name: user_id
+      description: str, foreign key to auth_user representing a single user
+    - name: state
+      description: str, current state of the bootcamp application. Possible values
+        are awaiting_profile_completion, awaiting_resume, awaiting_user_submissions,
+        awaiting_submission_review, awaiting_payment, complete, rejected, refunded
+    - name: linkedin_url
+      description: str, linkedIn profile url for the user in a bootcamp application
+    - name: resume_file
+      description: str, the resume file path for the user in a bootcamp application
+    - name: resume_upload_date
+      description: timestamp, specifying when the resume was uploaded to our system
+    - name: created_on
+      description: timestamp, specifying when the application was initially created
+    - name: updated_on
+      description: timestamp, specifying when the application was most recently updated
+
+  - name: raw__bootcamps__app__postgres__applications_applicationstep
+    columns:
+    - name: id
+      description: int, primary key for this table
+    - name: bootcamp_id
+      description: int, foreign key to klasses_bootcamp representing a single bootcamp
+        course
+    - name: submission_type
+      description: str, indicating the state of the submitted item for review in a
+        bootcamp application. Possible values are videointerviewsubmission and quizsubmission,
+        but only videointerviewsubmission is currently used.
+    - name: step_order
+      description: int, indicating the stage in a bootcamp application for which users
+        must submit something for review
+
+  - name: raw__bootcamps__app__postgres__applications_bootcamprunapplicationstep
+    columns:
+    - name: id
+      description: int, primary key for this table
+    - name: bootcamp_run_id
+      description: int, foreign key to klasses_bootcamprun representing a single bootcamp
+        course run
+    - name: application_step_id
+      description: int, foreign key to applicationstep representing a single application
+        step
+    - name: due_date
+      description: timestamp, the due date of this application step for a bootcamp
+        run
+
+  - name: raw__bootcamps__app__postgres__applications_applicationstepsubmission
+    columns:
+    - name: id
+      description: int, primary key for this table
+    - name: bootcamp_application_id
+      description: int, foreign key to bootcampapplication
+    - name: content_type_id
+      description: int, foreign key to django_content_type. It's either videointerviewsubmission
+        or quizsubmission django model
+    - name: object_id
+      description: int, foreign key to applications_videointerviewsubmission or applications_quizsubmission
+        tables
+    - name: run_application_step_id
+      description: int, foreign key to applications_bootcamprunapplicationstep table
+    - name: review_status
+      description: str, review state for the bootcamp application. Possible values
+        are pending, approved, rejected and waitlisted.
+    - name: submission_status
+      description: str, submission state for the bootcamp application. Possible values
+        are pending and submitted
+    - name: submitted_date
+      description: timestamp, specifying when submitted_status was updated
+    - name: review_status_date
+      description: timestamp, specifying when review_status was updated
+    - name: created_on
+      description: timestamp, specifying when the row was initially created
+    - name: updated_on
+      description: timestamp, specifying when the row was most recently updated
+
+  - name: raw__bootcamps__app__postgres__klasses_personalprice
+    columns:
+    - name: id
+      description: int, primary key for this table
+    - name: bootcamp_run_id
+      description: int, foreign key to klasses_bootcamprun representing a single bootcamp
+        course run
+    - name: user_id
+      description: str, foreign key to auth_user representing a single user
+    - name: price
+      description: float, user's personal price for this bootcamp run
+    - name: application_stage
+      description: str, this was used to track the application from SMApply, now it's
+        is blank as application is managed in the bootcamps app. The state from bootcampapplication
+        is more correct then this field.
+
+  - name: raw__bootcamps__app__postgres__klasses_installment
+    columns:
+    - name: id
+      description: int, primary key for this table
+    - name: bootcamp_run_id
+      description: int, foreign key to klasses_bootcamprun representing a single bootcamp
+        course run
+    - name: deadline
+      description: timestamp, specifying when the installment payment was due
+    - name: amount
+      description: float, installment payment amount

--- a/src/ol_dbt/models/staging/bootcamps/_stg_bootcamps__models.yml
+++ b/src/ol_dbt/models/staging/bootcamps/_stg_bootcamps__models.yml
@@ -421,3 +421,219 @@ models:
   tests:
   - dbt_expectations.expect_compound_columns_to_be_unique:
       column_list: ["user_id", "courserun_id"]
+
+- name: stg__bootcamps__app__postgres__django_contenttype
+  description: stores the django models for the bootcamp app
+  columns:
+  - name: contenttype_id
+    description: int, sequential ID for the django model
+    tests:
+    - unique
+    - not_null
+  - name: contenttype_full_name
+    description: str, name for django model. A combination of the models name and
+      functional group. e.g. applications_videointerviewsubmission
+    tests:
+    - unique
+    - not_null
+
+- name: stg__bootcamps__app__postgres__applications_applicationstep
+  description: defines the bootcamp application steps such as Video Interview or Quiz
+    that users must completed
+  columns:
+  - name: applicationstep_id
+    description: int, primary key for this table
+    tests:
+    - unique
+    - not_null
+  - name: course_id
+    description: int, foreign key to klasses_bootcamp representing a single bootcamp
+      course
+    tests:
+    - not_null
+  - name: applicationstep_step_order
+    description: int, defining the order for this video interview or quiz submission
+      in a bootcamp application.
+  - name: applicationstep_submission_type
+    description: str, indicating the state of this video interview or quiz submission
+      submission in a bootcamp application. Possible values are videointerviewsubmission
+      and quizsubmission, but only videointerviewsubmission is currently used.
+    tests:
+    - not_null
+    - accepted_values:
+        values: ['videointerviewsubmission', 'quizsubmission']
+  tests:
+  - dbt_expectations.expect_compound_columns_to_be_unique:
+      column_list: ["course_id", "applicationstep_step_order"]
+
+- name: stg__bootcamps__app__postgres__applications_courserun_applicationstep
+  description: defines due date for the bootcamp application step in a bootcamp run
+  columns:
+  - name: courserun_applicationstep_id
+    description: int, primary key for this table
+    tests:
+    - unique
+    - not_null
+  - name: courserun_id
+    description: int, foreign key to klasses_bootcamprun representing a single bootcamp
+      course run
+    tests:
+    - not_null
+  - name: applicationstep_id
+    description: int, foreign key to applicationstep representing a single application
+      step
+    tests:
+    - not_null
+  - name: courserun_applicationstep_due_date
+    description: timestamp, the due date of this application step for a bootcamp run
+    tests:
+    - not_null
+
+- name: stg__bootcamps__app__postgres__applications_applicationstep_submission
+  description: tracks users video or quiz interview submission status as part of their
+    bootcamp applications
+  columns:
+  - name: submission_id
+    description: int, primary key for this table
+    tests:
+    - unique
+    - not_null
+  - name: application_id
+    description: int, foreign key to bootcampapplication
+    tests:
+    - not_null
+  - name: contenttype_id
+    description: int, foreign key to django_content_type.
+    tests:
+    - not_null
+  - name: submission_object_id
+    description: int, foreign key to applications_videointerviewsubmission or applications_quizsubmission
+      tables
+    tests:
+    - not_null
+  - name: courserun_applicationstep_id
+    description: int, foreign key to applications_bootcamprunapplicationstep
+    tests:
+    - not_null
+  - name: submission_review_status
+    description: str, review state for the bootcamp application. Possible values are
+      pending, rejected, approved and waitlisted
+    tests:
+    - not_null
+    - accepted_values:
+        values: ['pending', 'rejected', 'approved', 'waitlisted']
+  - name: submission_status
+    description: str, submission state for the bootcamp application. Possible values
+      are pending and submitted.
+    tests:
+    - not_null
+    - accepted_values:
+        values: ['pending', 'submitted']
+  - name: submission_submitted_on
+    description: timestamp, specifying when the interview submission is fulfilled
+  - name: submission_reviewed_on
+    description: timestamp, specifying when 'awaiting submission review' step is fulfilled
+  - name: submission_created_on
+    description: timestamp, specifying when the application step submission was initially
+      created
+    tests:
+    - not_null
+  - name: submission_updated_on
+    description: timestamp, specifying when the application step submission was most
+      recently updated
+    tests:
+    - not_null
+  tests:
+  - dbt_expectations.expect_compound_columns_to_be_unique:
+      column_list: ["application_id", "courserun_applicationstep_id"]
+
+- name: stg__bootcamps__app__postgres__applications_courserun_application
+  description: tracks users bootcamp applications
+  columns:
+  - name: application_id
+    description: int, primary key representing a single bootcamp application
+    tests:
+    - unique
+    - not_null
+  - name: courserun_id
+    description: int, foreign key representing a single bootcamp course run
+    tests:
+    - not_null
+  - name: user_id
+    description: str, foreign key to auth_user representing a single user
+    tests:
+    - not_null
+  - name: application_state
+    description: str, current state of the bootcamp application. Possible values are
+      awaiting_profile_completion, awaiting_resume, awaiting_user_submissions, awaiting_submission_review,
+      awaiting_payment, complete, rejected, refunded
+    tests:
+    - not_null
+    - accepted_values:
+        values: ['awaiting_profile_completion', 'awaiting_resume', 'awaiting_user_submissions',
+          'awaiting_submission_review', 'awaiting_payment', 'complete', 'rejected',
+          'refunded']
+  - name: application_linkedin_url
+    description: str, linkedIn profile url for the user in a bootcamp application
+  - name: application_resume_file
+    description: str, the resume file path for the user in a bootcamp application
+  - name: application_resume_uploaded_on
+    description: timestamp, specifying when the resume was uploaded to our system
+  - name: application_created_on
+    description: timestamp, specifying when the application was initially created
+    tests:
+    - not_null
+  - name: application_updated_on
+    description: timestamp, specifying when the application was most recently updated
+    tests:
+    - not_null
+
+- name: stg__bootcamps__app__postgres__courses_personalprice
+  description: users personal price for the bootcamp run
+  columns:
+  - name: personalprice_id
+    description: int, primary key for this table
+    tests:
+    - unique
+    - not_null
+  - name: courserun_id
+    description: int, foreign key to courses_courserun representing a single bootcamp
+      course run
+    tests:
+    - not_null
+  - name: user_id
+    description: str, foreign key to auth_user representing a single user
+    tests:
+    - not_null
+  - name: personalprice
+    description: float, user's personal price for this bootcamp run
+    tests:
+    - not_null
+  tests:
+  - dbt_expectations.expect_compound_columns_to_be_unique:
+      column_list: ["courserun_id", "user_id"]
+
+- name: stg__bootcamps__app__postgres__courses_installment
+  description: defines installment payments for the bootcamp run
+  columns:
+  - name: installment_id
+    description: int, primary key for this table
+    tests:
+    - unique
+    - not_null
+  - name: courserun_id
+    description: int, foreign key to courses_courserun representing a single bootcamp
+      course run
+    tests:
+    - not_null
+  - name: installment_deadline
+    description: timestamp, specifying when the installment payment was due
+    tests:
+    - not_null
+  - name: installment_amount
+    description: float, installment payment amount
+    tests:
+    - not_null
+  tests:
+  - dbt_expectations.expect_compound_columns_to_be_unique:
+      column_list: ["courserun_id", "installment_deadline"]

--- a/src/ol_dbt/models/staging/bootcamps/stg__bootcamps__app__postgres__applications_applicationstep.sql
+++ b/src/ol_dbt/models/staging/bootcamps/stg__bootcamps__app__postgres__applications_applicationstep.sql
@@ -1,0 +1,15 @@
+with source as (
+    select * from {{ source('ol_warehouse_raw_data', 'raw__bootcamps__app__postgres__applications_applicationstep') }}
+)
+
+, cleaned as (
+
+    select
+        id as applicationstep_id
+        , bootcamp_id as course_id
+        , step_order as applicationstep_step_order
+        , submission_type as applicationstep_submission_type
+    from source
+)
+
+select * from cleaned

--- a/src/ol_dbt/models/staging/bootcamps/stg__bootcamps__app__postgres__applications_applicationstep_submission.sql
+++ b/src/ol_dbt/models/staging/bootcamps/stg__bootcamps__app__postgres__applications_applicationstep_submission.sql
@@ -1,0 +1,23 @@
+with source as (
+    select *
+    from {{ source('ol_warehouse_raw_data', 'raw__bootcamps__app__postgres__applications_applicationstepsubmission') }}
+)
+
+, cleaned as (
+
+    select
+        id as submission_id
+        , bootcamp_application_id as application_id
+        , content_type_id as contenttype_id
+        , object_id as submission_object_id
+        , run_application_step_id as courserun_applicationstep_id
+        , review_status as submission_review_status
+        , submission_status
+        , {{ cast_timestamp_to_iso8601('submitted_date') }} as submission_submitted_on
+        , {{ cast_timestamp_to_iso8601('review_status_date') }} as submission_reviewed_on
+        , {{ cast_timestamp_to_iso8601('created_on') }} as submission_created_on
+        , {{ cast_timestamp_to_iso8601('updated_on') }} as submission_updated_on
+    from source
+)
+
+select * from cleaned

--- a/src/ol_dbt/models/staging/bootcamps/stg__bootcamps__app__postgres__applications_courserun_application.sql
+++ b/src/ol_dbt/models/staging/bootcamps/stg__bootcamps__app__postgres__applications_courserun_application.sql
@@ -1,0 +1,21 @@
+with source as (
+    select *
+    from {{ source('ol_warehouse_raw_data', 'raw__bootcamps__app__postgres__applications_bootcampapplication') }}
+)
+
+, cleaned as (
+
+    select
+        id as application_id
+        , user_id
+        , bootcamp_run_id as courserun_id
+        , resume_file as application_resume_file
+        , linkedin_url as application_linkedin_url
+        , lower(state) as application_state
+        , {{ cast_timestamp_to_iso8601('resume_upload_date') }} as application_resume_uploaded_on
+        , {{ cast_timestamp_to_iso8601('created_on') }} as application_created_on
+        , {{ cast_timestamp_to_iso8601('updated_on') }} as application_updated_on
+    from source
+)
+
+select * from cleaned

--- a/src/ol_dbt/models/staging/bootcamps/stg__bootcamps__app__postgres__applications_courserun_applicationstep.sql
+++ b/src/ol_dbt/models/staging/bootcamps/stg__bootcamps__app__postgres__applications_courserun_applicationstep.sql
@@ -1,0 +1,16 @@
+with source as (
+    select *
+    from {{ source('ol_warehouse_raw_data', 'raw__bootcamps__app__postgres__applications_bootcamprunapplicationstep') }}
+)
+
+, cleaned as (
+
+    select
+        id as courserun_applicationstep_id
+        , bootcamp_run_id as courserun_id
+        , application_step_id as applicationstep_id
+        , {{ cast_timestamp_to_iso8601('due_date') }} as courserun_applicationstep_due_date
+    from source
+)
+
+select * from cleaned

--- a/src/ol_dbt/models/staging/bootcamps/stg__bootcamps__app__postgres__courses_installment.sql
+++ b/src/ol_dbt/models/staging/bootcamps/stg__bootcamps__app__postgres__courses_installment.sql
@@ -1,0 +1,15 @@
+with source as (
+    select * from {{ source('ol_warehouse_raw_data', 'raw__bootcamps__app__postgres__klasses_installment') }}
+)
+
+, cleaned as (
+
+    select
+        id as installment_id
+        , bootcamp_run_id as courserun_id
+        , cast(amount as decimal(38, 2)) as installment_amount
+        , {{ cast_timestamp_to_iso8601('deadline') }} as installment_deadline
+    from source
+)
+
+select * from cleaned

--- a/src/ol_dbt/models/staging/bootcamps/stg__bootcamps__app__postgres__courses_personalprice.sql
+++ b/src/ol_dbt/models/staging/bootcamps/stg__bootcamps__app__postgres__courses_personalprice.sql
@@ -1,0 +1,15 @@
+with source as (
+    select * from {{ source('ol_warehouse_raw_data', 'raw__bootcamps__app__postgres__klasses_personalprice') }}
+)
+
+, cleaned as (
+
+    select
+        id as personalprice_id
+        , user_id
+        , bootcamp_run_id as courserun_id
+        , cast(price as decimal(38, 2)) as personalprice
+    from source
+)
+
+select * from cleaned

--- a/src/ol_dbt/models/staging/bootcamps/stg__bootcamps__app__postgres__django_contenttype.sql
+++ b/src/ol_dbt/models/staging/bootcamps/stg__bootcamps__app__postgres__django_contenttype.sql
@@ -1,0 +1,20 @@
+with source as (
+
+    select * from {{ source('ol_warehouse_raw_data', 'raw__bootcamps__app__postgres__django_content_type') }}
+
+)
+
+, renamed as (
+
+    select
+        id as contenttype_id
+        , concat_ws(
+            '_'
+            , app_label
+            , model
+        ) as contenttype_full_name
+    from source
+
+)
+
+select * from renamed


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
https://github.com/mitodl/ol-data-platform/issues/578

### Description (What does it do?)
<!--- Describe your changes in detail -->
- Creating  the following staging models for bootcamps application related tables
   - stg__bootcamps__app__postgres__courses_personalprice
   - stg__bootcamps__app__postgres__courses_installment
   - stg__bootcamps__app__postgres__django_contenttype
   - stg__bootcamps__app__postgres__applications_applicationstep
   - stg__bootcamps__app__postgres__applications_applicationstep_submission
   - stg__bootcamps__app__postgres__applications_courserun_application
   - stg__bootcamps__app__postgres__applications_courserun_applicationstep
- Creating  `int__bootcamps__applications` to combine these staging tables for replacing https://bi.odl.mit.edu/queries/969/source 

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->
```
dbt build -select +int__bootcamps__applications
```
and compare it with https://bi.odl.mit.edu/queries/969/source (Note that I didn't include users profile fields in this intermediate as that's in int__bootcamps__users)