### PR TITLE
add income fields to mitxonline users mart

### DIFF
--- a/src/ol_dbt/models/marts/mitxonline/_marts__mitxonline__models.yml
+++ b/src/ol_dbt/models/marts/mitxonline/_marts__mitxonline__models.yml
@@ -81,6 +81,12 @@ models:
     tests:
     - accepted_values:
         values: '{{ var("highest_education_values") }}'
+  - name: latest_income_usd
+    description: numeric, latest user income in usd
+  - name: latest_original_income
+    description: numeric, latest user income in it's original currency
+  - name: latest_original_currency
+    description: string, latest currency code of orginal income
 
 - name: marts__mitxonline_course_enrollments
   description: learners MITx Online course enrollments and demographics

--- a/src/ol_dbt/models/marts/mitxonline/marts__mitxonline_user_profiles.sql
+++ b/src/ol_dbt/models/marts/mitxonline/marts__mitxonline_user_profiles.sql
@@ -7,12 +7,12 @@ with users as (
 )
 
 , user_income as (
-    select 
+    select
         user_id
         , flexiblepriceapplication_income_usd
         , flexiblepriceapplication_original_income
         , flexiblepriceapplication_original_currency
-        , rank() over (partition by user_id order by flexiblepriceapplication_updated_on desc) as rnk  
+        , rank() over (partition by user_id order by flexiblepriceapplication_updated_on desc) as rnk
     from income
 )
 
@@ -31,6 +31,6 @@ select
     , user_income.flexiblepriceapplication_original_currency as latest_original_currency
 from users
 left join user_income
-    on 
+    on
         users.user_id = user_income.user_id
         and user_income.rnk = 1

--- a/src/ol_dbt/models/marts/mitxonline/marts__mitxonline_user_profiles.sql
+++ b/src/ol_dbt/models/marts/mitxonline/marts__mitxonline_user_profiles.sql
@@ -7,12 +7,12 @@ with users as (
 )
 
 , user_income as (
-    select
+    select 
         user_id
         , flexiblepriceapplication_income_usd
         , flexiblepriceapplication_original_income
         , flexiblepriceapplication_original_currency
-        , rank() over (partition by user_id order by flexiblepriceapplication_updated_on desc) as rnk
+        , rank() over (partition by user_id order by flexiblepriceapplication_updated_on desc) as rnk  
     from income
 )
 
@@ -31,6 +31,6 @@ select
     , user_income.flexiblepriceapplication_original_currency as latest_original_currency
 from users
 left join user_income
-    on
-        users.user_id = users.user_id
+    on 
+        users.user_id = user_income.user_id
         and user_income.rnk = 1

--- a/src/ol_dbt/models/marts/mitxonline/marts__mitxonline_user_profiles.sql
+++ b/src/ol_dbt/models/marts/mitxonline/marts__mitxonline_user_profiles.sql
@@ -3,12 +3,12 @@ with users as (
 )
 
 , user_income as (
-    select 
+    select
         user_id
         , flexiblepriceapplication_income_usd
         , flexiblepriceapplication_original_income
         , flexiblepriceapplication_original_currency
-        , rank() over (partition by user_id order by flexiblepriceapplication_updated_on desc) as rnk  
+        , rank() over (partition by user_id order by flexiblepriceapplication_updated_on desc) as rnk
     from int__mitxonline__flexiblepricing_flexiblepriceapplication
 )
 
@@ -27,6 +27,6 @@ select
     , user_income.flexiblepriceapplication_original_currency as latest_original_currency
 from users
 left join user_income
-    on 
+    on
         users.user_id = users.user_id
         and user_income.rnk = 1

--- a/src/ol_dbt/models/marts/mitxonline/marts__mitxonline_user_profiles.sql
+++ b/src/ol_dbt/models/marts/mitxonline/marts__mitxonline_user_profiles.sql
@@ -2,14 +2,18 @@ with users as (
     select * from {{ ref('int__mitxonline__users') }}
 )
 
+, income as (
+    select * from {{ ref('int__mitxonline__flexiblepricing_flexiblepriceapplication') }}
+)
+
 , user_income as (
-    select
+    select 
         user_id
         , flexiblepriceapplication_income_usd
         , flexiblepriceapplication_original_income
         , flexiblepriceapplication_original_currency
-        , rank() over (partition by user_id order by flexiblepriceapplication_updated_on desc) as rnk
-    from int__mitxonline__flexiblepricing_flexiblepriceapplication
+        , rank() over (partition by user_id order by flexiblepriceapplication_updated_on desc) as rnk  
+    from income
 )
 
 
@@ -27,6 +31,6 @@ select
     , user_income.flexiblepriceapplication_original_currency as latest_original_currency
 from users
 left join user_income
-    on
+    on 
         users.user_id = users.user_id
         and user_income.rnk = 1

--- a/src/ol_dbt/models/marts/mitxonline/marts__mitxonline_user_profiles.sql
+++ b/src/ol_dbt/models/marts/mitxonline/marts__mitxonline_user_profiles.sql
@@ -2,13 +2,31 @@ with users as (
     select * from {{ ref('int__mitxonline__users') }}
 )
 
+, user_income as (
+    select 
+        user_id
+        , flexiblepriceapplication_income_usd
+        , flexiblepriceapplication_original_income
+        , flexiblepriceapplication_original_currency
+        , rank() over (partition by user_id order by flexiblepriceapplication_updated_on desc) as rnk  
+    from int__mitxonline__flexiblepricing_flexiblepriceapplication
+)
+
+
 select
-    user_username
-    , user_full_name
-    , user_email
-    , user_address_country
-    , user_address_state
-    , user_birth_year
-    , user_gender
-    , user_highest_education
+    users.user_username
+    , users.user_full_name
+    , users.user_email
+    , users.user_address_country
+    , users.user_address_state
+    , users.user_birth_year
+    , users.user_gender
+    , users.user_highest_education
+    , user_income.flexiblepriceapplication_income_usd as latest_income_usd
+    , user_income.flexiblepriceapplication_original_income as latest_original_income
+    , user_income.flexiblepriceapplication_original_currency as latest_original_currency
 from users
+left join user_income
+    on 
+        users.user_id = users.user_id
+        and user_income.rnk = 1

--- a/src/ol_dbt/models/marts/mitxonline/marts__mitxonline_user_profiles.sql
+++ b/src/ol_dbt/models/marts/mitxonline/marts__mitxonline_user_profiles.sql
@@ -7,12 +7,12 @@ with users as (
 )
 
 , user_income as (
-    select 
+    select
         user_id
         , flexiblepriceapplication_income_usd
         , flexiblepriceapplication_original_income
         , flexiblepriceapplication_original_currency
-        , rank() over (partition by user_id order by flexiblepriceapplication_updated_on desc) as rnk  
+        , rank() over (partition by user_id order by flexiblepriceapplication_updated_on desc) as rnk
     from income
 )
 
@@ -31,6 +31,6 @@ select
     , user_income.flexiblepriceapplication_original_currency as latest_original_currency
 from users
 left join user_income
-    on 
+    on
         users.user_id = users.user_id
         and user_income.rnk = 1


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/3656

### Description (What does it do?)
adds income fields(latest_income_usd, latest_original_income, latest_original_currency) to mitxonline users mart (marts__mitxonline_user_profiles)

### How can this be tested?
dbt build --select +marts__mitxonline_user_profiles