### PR TITLE
updates to edxorg tracking log staging model

### DIFF
--- a/src/ol_dbt/models/staging/edxorg/_edxorg_sources.yml
+++ b/src/ol_dbt/models/staging/edxorg/_edxorg_sources.yml
@@ -548,7 +548,7 @@ sources:
       description: str, the start date of the course run in the format 'YYYY-MM-DD
         HH:mm:ss Z' in UTC
 
-  - name: raw__irx__edxorg__s3__tracking_logs
+  - name: raw__edxorg__s3__tracking_logs
     description: edX.org event data that are emitted by server, the browser, or the
       mobile device to capture information about user's interactions with a course
     columns:

--- a/src/ol_dbt/models/staging/edxorg/stg__edxorg__s3__tracking_logs__user_activity.sql
+++ b/src/ol_dbt/models/staging/edxorg/stg__edxorg__s3__tracking_logs__user_activity.sql
@@ -8,7 +8,7 @@
 }}
 
 with source as (
-    select * from {{ source('ol_warehouse_raw_data','raw__irx__edxorg__s3__tracking_logs') }}
+    select * from {{ source('ol_warehouse_raw_data','raw__edxorg__s3__tracking_logs') }}
     where
         username != ''
         and json_query(context, 'lax $.user_id' omit quotes) is not null
@@ -49,7 +49,7 @@ with source as (
         , name as useractivity_event_name
         , event_type as useractivity_event_type
         , {{ extract_course_id_from_tracking_log() }} as courserun_readable_id
-        , json_query(context, 'lax $.user_id' omit quotes) as user_id
+        , cast(json_query(context, 'lax $.user_id' omit quotes) as integer) as user_id
         , json_query(context, 'lax $.org_id' omit quotes) as org_id
         , json_query(context, 'lax $.path' omit quotes) as useractivity_path
         --- use regex here to preserve the nanoseconds as date_parse truncates the fraction of second to milliseconds


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
Part of https://github.com/mitodl/hq/issues/3713
The change to `int__edxorg__mitx_user_courseactivities` will need to wait until we have `courseware_studentmodule` in place for edx.org

### Description (What does it do?)
<!--- Describe your changes in detail -->
Updates `stg__edxorg__s3__tracking_logs__user_activity` to use our own edX.org tracking log table raw__edxorg__s3__tracking_logs


### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->
```
dbt build --select stg__edxorg__s3__tracking_logs__user_activity --full-refresh
```
