### PR TITLE
Create OCW course mart

### DIFF
--- a/src/ol_dbt/models/intermediate/ocw/int__ocw__courses.sql
+++ b/src/ol_dbt/models/intermediate/ocw/int__ocw__courses.sql
@@ -32,6 +32,7 @@ select
     , websitecontents.course_primary_course_number
     , websitecontents.course_extra_course_numbers
     , websitecontents.course_topics
+    , websitecontents.course_department_numbers
     , websitecontents.course_learning_resource_types
 from websites
 inner join websitecontents

--- a/src/ol_dbt/models/marts/ocw/_marts__ocw__models.yml
+++ b/src/ol_dbt/models/marts/ocw/_marts__ocw__models.yml
@@ -3,7 +3,7 @@ version: 2
 
 models:
 - name: marts__ocw_courses
-  description: OpenCourseWare courses metadata
+  description: OCW courses managed in OCW Studio
   columns:
   - name: course_short_id
     description: str, short unique identifier for the OCW course. e.g. 18.05-spring-2022

--- a/src/ol_dbt/models/marts/ocw/_marts__ocw__models.yml
+++ b/src/ol_dbt/models/marts/ocw/_marts__ocw__models.yml
@@ -5,9 +5,8 @@ models:
 - name: marts__ocw_courses
   description: OpenCourseWare courses metadata
   columns:
-  - name: course_readable_id
+  - name: course_short_id
     description: str, short unique identifier for the OCW course. e.g. 18.05-spring-2022
-      The source of this field is short ID of the website.
     tests:
     - not_null
     - unique

--- a/src/ol_dbt/models/marts/ocw/_marts__ocw__models.yml
+++ b/src/ol_dbt/models/marts/ocw/_marts__ocw__models.yml
@@ -1,0 +1,73 @@
+---
+version: 2
+
+models:
+- name: marts__ocw_courses
+  description: OpenCourseWare courses metadata
+  columns:
+  - name: course_readable_id
+    description: str, short unique identifier for the OCW course. e.g. 18.05-spring-2022
+      The source of this field is short ID of the website.
+    tests:
+    - not_null
+    - unique
+  - name: course_name
+    description: str, unique name of the OCW course. It appears as part of OCW Studio
+      urls
+    tests:
+    - not_null
+    - unique
+  - name: course_title
+    description: str, title of the OCW course
+    tests:
+    - not_null
+  - name: course_live_url
+    description: str, url to the OCW course on production.
+  - name: course_is_live
+    description: boolean, indicating if the course website is currently published
+      on OCW production.
+    tests:
+    - not_null
+  - name: course_is_unpublished
+    description: boolean, indicating if the course website is currently unpublished
+      on OCW production.
+    tests:
+    - not_null
+  - name: course_has_never_published
+    description: boolean, indicating if the course website has never been published
+      on OCW production.
+    tests:
+    - not_null
+  - name: course_first_published_on
+    description: timestamp, date and time when the course website was first published
+      to OCW production
+  - name: course_publish_date_updated_on
+    description: timestamp, date and time when the publish date was most recently
+      updated on OCW production. The publish date is updated by the webhook to Concourse
+      pipeline (it rebuilds every site) whenever we do a release in ocw repos.
+  - name: course_term
+    description: str, course term. Possible values are Spring, Summer, Fall, January
+      IAP, or blank
+  - name: course_year
+    description: int, course year
+  - name: course_level
+    description: str, course level in comma-separated list. Possible values are Undergraduate
+      , Graduate, Non-Credit, High School, or blank
+  - name: course_primary_course_number
+    description: str, the primary course number e.g. 21A.850J
+    tests:
+    - not_null
+  - name: course_extra_course_numbers
+    description: str, the extra course number e.g. STS.484J
+  - name: course_department_numbers
+    description: str, course department numbers in comma-separate list. e.g. STS,
+      8
+  - name: course_topics
+    description: json, hierarchical course topics (topic, subtopic, speciality) in
+      json format
+  - name: course_instructors
+    description: str, course instructors in comma-separate list.
+  - name: course_learning_resource_types
+    description: str, course learning resource types or features in comma-separated
+      list. e.g. Lecture Notes, Problem Sets with Solutions.... Full list https://github.com/mitodl/ocw-hugo-projects/blob/049c85e6544a36ba69a89602e5014f6085ef8831/
+      ocw-course-v2/ocw-studio.yaml#L163-L207

--- a/src/ol_dbt/models/marts/ocw/_marts__ocw__models.yml
+++ b/src/ol_dbt/models/marts/ocw/_marts__ocw__models.yml
@@ -68,6 +68,8 @@ models:
   - name: course_instructors
     description: str, course instructors in comma-separate list.
   - name: course_learning_resource_types
-    description: str, course learning resource types or features in comma-separated
-      list. e.g. Lecture Notes, Problem Sets with Solutions.... Full list https://github.com/mitodl/ocw-hugo-projects/blob/049c85e6544a36ba69a89602e5014f6085ef8831/
-      ocw-course-v2/ocw-studio.yaml#L163-L207
+    description: |
+      str, course learning resource types or features in comma-separated
+      list. e.g. Lecture Notes, Problem Sets with Solutions...
+      Full list can be found at
+      https://github.com/mitodl/ocw-hugo-projects/blob/049c85e6544a36ba69a89602e5014f6085ef8831/ocw-course-v2/ocw-studio.yaml#L163-L207

--- a/src/ol_dbt/models/marts/ocw/marts__ocw_courses.sql
+++ b/src/ol_dbt/models/marts/ocw/marts__ocw_courses.sql
@@ -1,0 +1,33 @@
+with courses as (
+    select * from {{ ref('int__ocw__courses') }}
+)
+
+, instructors as (
+    select
+        course_uuid
+        , array_join(array_agg(course_instructor_title), ', ') as course_instructors
+    from {{ ref('int__ocw__course_instructors') }}
+    group by course_uuid
+)
+
+select
+    courses.course_readable_id
+    , courses.course_name
+    , courses.course_title
+    , courses.course_term
+    , courses.course_year
+    , courses.course_level
+    , courses.course_primary_course_number
+    , courses.course_extra_course_numbers
+    , courses.course_is_live
+    , courses.course_is_unpublished
+    , courses.course_has_never_published
+    , courses.course_live_url
+    , courses.course_first_published_on
+    , courses.course_publish_date_updated_on
+    , courses.course_topics
+    , courses.course_learning_resource_types
+    , courses.course_department_numbers
+    , instructors.course_instructors
+from courses
+left join instructors on courses.course_uuid = instructors.course_uuid

--- a/src/ol_dbt/models/marts/ocw/marts__ocw_courses.sql
+++ b/src/ol_dbt/models/marts/ocw/marts__ocw_courses.sql
@@ -11,7 +11,7 @@ with courses as (
 )
 
 select
-    courses.course_readable_id
+    courses.course_readable_id as course_short_id
     , courses.course_name
     , courses.course_title
     , courses.course_term


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
mart for https://github.com/mitodl/hq/issues/3609


### Description (What does it do?)
<!--- Describe your changes in detail -->
Create `marts__ocw_courses` to replace the query in https://bi.odl.mit.edu/queries/1353 with mart model. 
OCW course metadata are different from MITx Online or xPro platform, it makes sense to have it in a separate mart since most of the fields are unique to OCW.


### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->
Run the following command, tests should all pass.
```
dbt build --select +marts__ocw_courses  --vars 'schema_suffix: <YOURNAME>' --target dev_production
```
