### PR TITLE
fix unique test for int__mitxpro__ecommerce_product

### DIFF
--- a/src/ol_dbt/models/intermediate/mitxpro/_int_mitxpro__models.yml
+++ b/src/ol_dbt/models/intermediate/mitxpro/_int_mitxpro__models.yml
@@ -969,6 +969,7 @@ models:
   tests:
   - dbt_expectations.expect_compound_columns_to_be_unique:
       column_list: ["product_type", "program_id", "courserun_id"]
+      row_condition: "product_is_active"
   - dbt_expectations.expect_table_row_count_to_equal_other_table:
       compare_model: ref('stg__mitxpro__app__postgres__ecommerce_product')
 - name: int__mitxpro__courserunenrollments


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
NA
One of warnings in https://pipelines.odl.mit.edu/runs/4f67327e-5c5c-4e64-82c7-c266c48997a4

### Description (What does it do?)
<!--- Describe your changes in detail -->
This fix the [unique test](https://github.com/mitodl/ol-data-platform/blob/main/src/ol_dbt/models/intermediate/mitxpro/_int_mitxpro__models.yml#L971) in `int__mitxpro__ecommerce_product` to count for inactive products. 
There are 3 inactive products (program-v1:xPRO+LASERx | R16/17/18) Bon recently created, which linked to ProgramRun. He wants these 3 inactive products to be deleted but he couldn't do so due to restriction on deleting products. But we should only test the uniqueness on ["product_type", "program_id", "courserun_id"] for `active` products for this reason.

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->
run `dbt test --select int__mitxpro__ecommerce_product --target production`, test should now pass

