### PR TITLE
add primary key to micromasters program certificate models

### DIFF
--- a/src/ol_dbt/macros/generate_hash_id.sql
+++ b/src/ol_dbt/macros/generate_hash_id.sql
@@ -1,0 +1,10 @@
+{% macro generate_hash_id(string) %}
+    -- Be cautious about changing the hash function as it will impact the primary key used by Hightouch
+   lower(
+       to_hex(
+          sha256(
+                cast({{ string }} as varbinary) --noqa
+          )
+       )
+    )
+{% endmacro %}

--- a/src/ol_dbt/models/intermediate/edxorg/_int_edxorg__models.yml
+++ b/src/ol_dbt/models/intermediate/edxorg/_int_edxorg__models.yml
@@ -378,6 +378,11 @@ models:
   description: learners who completed MicroMasters and XSeries programs on edX.org.
     program_certificate_awarded_on might be null for some programs such as SCM
   columns:
+  - name: program_certificate_hashed_id
+    description: str, unique hash value used to identify the program certificate
+    tests:
+    - not_null
+    - unique
   - name: program_type
     description: str, the type of the program. The value are 'MicroMasters' and 'XSeries'
       for MITx programs on edX.org

--- a/src/ol_dbt/models/intermediate/edxorg/int__edxorg__mitx_program_certificates.sql
+++ b/src/ol_dbt/models/intermediate/edxorg/int__edxorg__mitx_program_certificates.sql
@@ -1,9 +1,7 @@
 with completed_program_learners as (
     select
         *
-        , lower(
-           to_hex(md5(cast(cast(user_id as varchar) as varbinary) || cast(program_uuid as varbinary))) --noqa
-        ) as program_certificate_hashed_id
+        , {{ generate_hash_id('cast(user_id as varchar) || program_uuid') }} as program_certificate_hashed_id
     from {{ ref('stg__edxorg__s3__program_learner_report') }}
     where user_has_completed_program = true
 )

--- a/src/ol_dbt/models/intermediate/edxorg/int__edxorg__mitx_program_certificates.sql
+++ b/src/ol_dbt/models/intermediate/edxorg/int__edxorg__mitx_program_certificates.sql
@@ -1,5 +1,10 @@
 with completed_program_learners as (
-    select * from {{ ref('stg__edxorg__s3__program_learner_report') }}
+    select
+        *
+        , lower(
+           to_hex(md5(cast(cast(user_id as varchar) as varbinary) || cast(program_uuid as varbinary))) --noqa
+        ) as program_certificate_hashed_id
+    from {{ ref('stg__edxorg__s3__program_learner_report') }}
     where user_has_completed_program = true
 )
 
@@ -16,7 +21,8 @@ with completed_program_learners as (
 )
 
 select
-    completed_program_learners_sorted.program_type
+    completed_program_learners_sorted.program_certificate_hashed_id
+    , completed_program_learners_sorted.program_type
     , completed_program_learners_sorted.program_uuid
     , completed_program_learners_sorted.program_title
     , completed_program_learners_sorted.user_id

--- a/src/ol_dbt/models/intermediate/micromasters/_int_micromasters__models.yml
+++ b/src/ol_dbt/models/intermediate/micromasters/_int_micromasters__models.yml
@@ -195,6 +195,11 @@ models:
     description: int, sequential ID representing a program in the mitxonline database
   - name: user_edxorg_id
     description: int, Numerical user ID of a learner on the edX platform
+  - name: program_certificate_hashed_id
+    description: str, unique hash value used to identify the program certificate
+    tests:
+    - unique
+    - not_null
   - name: program_completion_timestamp
     description: timestamp, timestamp of the course certificate that completed the
       program

--- a/src/ol_dbt/models/intermediate/micromasters/int__micromasters__program_certificates.sql
+++ b/src/ol_dbt/models/intermediate/micromasters/int__micromasters__program_certificates.sql
@@ -21,7 +21,8 @@ with program_certificates_dedp_from_micromasters as (
 
 , report as (
     select
-        user_edxorg_username
+        program_certificate_hashed_id
+        , user_edxorg_username
         , user_mitxonline_username
         , user_email
         , program_title
@@ -45,7 +46,8 @@ with program_certificates_dedp_from_micromasters as (
     union all
 
     select
-        user_edxorg_username
+        program_certificate_hashed_id
+        , user_edxorg_username
         , user_mitxonline_username
         , user_email
         , program_title
@@ -69,7 +71,8 @@ with program_certificates_dedp_from_micromasters as (
     union all
 
     select
-        user_edxorg_username
+        program_certificate_hashed_id
+        , user_edxorg_username
         , user_mitxonline_username
         , user_email
         , program_title
@@ -92,7 +95,8 @@ with program_certificates_dedp_from_micromasters as (
 
 
 select
-    user_edxorg_username
+    program_certificate_hashed_id
+    , user_edxorg_username
     , user_mitxonline_username
     , user_email
     , program_title

--- a/src/ol_dbt/models/intermediate/micromasters/subqueries/__int_micromasters_subqueries__models.yml
+++ b/src/ol_dbt/models/intermediate/micromasters/subqueries/__int_micromasters_subqueries__models.yml
@@ -157,6 +157,11 @@ models:
       the micromasters database
   - name: user_full_name
     description: str, The full name of the user on the edX platform
+  - name: program_certificate_hashed_id
+    description: str, unique hash used to identify the program certificate
+    tests:
+    - not_null
+    - unique
   - name: program_completion_timestamp
     description: timestamp, timestamp of the course certificate that completed the
       program
@@ -217,6 +222,11 @@ models:
       on MITx Online or MicroMasters.
   - name: user_full_name
     description: str, The full name from user's profile on MITx Online
+  - name: program_certificate_hashed_id
+    description: str, unique hash used to identify the program certificate
+    tests:
+    - unique
+    - not_null
   - name: program_completion_timestamp
     description: timestamp, timestamp of the course certificate that completed the
       program
@@ -279,6 +289,11 @@ models:
       the micromasters database
   - name: user_full_name
     description: str, The full name of the user on the edX platform
+  - name: program_certificate_hashed_id
+    description: str, unique hash used to identify the program certificate
+    tests:
+    - unique
+    - not_null
   - name: program_completion_timestamp
     description: timestamp, timestamp of the course certificate that completed the
       program

--- a/src/ol_dbt/models/intermediate/micromasters/subqueries/__micromasters_program_certificates_dedp_from_micromasters.sql
+++ b/src/ol_dbt/models/intermediate/micromasters/subqueries/__micromasters_program_certificates_dedp_from_micromasters.sql
@@ -38,7 +38,7 @@ select
     , micromasters_users.user_street_address
     , micromasters_users.user_address_state_or_territory
     , edx_users.user_full_name
-    , mm_program_certificates.programcertificate_hash as program_certificate_hashed_id
+    , {{ generate_hash_id('mm_program_certificates.programcertificate_hash') }} as program_certificate_hashed_id
     , mm_program_certificates.programcertificate_created_on as program_completion_timestamp
     , micromasters_users.user_id as micromasters_user_id
     , substring(micromasters_users.user_birth_date, 1, 4) as user_year_of_birth

--- a/src/ol_dbt/models/intermediate/micromasters/subqueries/__micromasters_program_certificates_dedp_from_micromasters.sql
+++ b/src/ol_dbt/models/intermediate/micromasters/subqueries/__micromasters_program_certificates_dedp_from_micromasters.sql
@@ -38,6 +38,7 @@ select
     , micromasters_users.user_street_address
     , micromasters_users.user_address_state_or_territory
     , edx_users.user_full_name
+    , mm_program_certificates.programcertificate_hash as program_certificate_hashed_id
     , mm_program_certificates.programcertificate_created_on as program_completion_timestamp
     , micromasters_users.user_id as micromasters_user_id
     , substring(micromasters_users.user_birth_date, 1, 4) as user_year_of_birth

--- a/src/ol_dbt/models/intermediate/micromasters/subqueries/__micromasters_program_certificates_dedp_from_mitxonline.sql
+++ b/src/ol_dbt/models/intermediate/micromasters/subqueries/__micromasters_program_certificates_dedp_from_mitxonline.sql
@@ -40,6 +40,7 @@ select
     , mitxonline_users.user_last_name
     , micromasters_users.user_address_postal_code
     , micromasters_users.user_street_address
+    , mitxonline_program_certificates.programcertificate_uuid as program_certificate_hashed_id
     , mitxonline_program_certificates.programcertificate_created_on as program_completion_timestamp
     , micromasters_users.user_id as micromasters_user_id
     , mitxonline_users.user_full_name

--- a/src/ol_dbt/models/intermediate/micromasters/subqueries/__micromasters_program_certificates_dedp_from_mitxonline.sql
+++ b/src/ol_dbt/models/intermediate/micromasters/subqueries/__micromasters_program_certificates_dedp_from_mitxonline.sql
@@ -40,7 +40,7 @@ select
     , mitxonline_users.user_last_name
     , micromasters_users.user_address_postal_code
     , micromasters_users.user_street_address
-    , mitxonline_program_certificates.programcertificate_uuid as program_certificate_hashed_id
+    , {{ generate_hash_id('mitxonline_program_certificates.programcertificate_uuid') }} as program_certificate_hashed_id
     , mitxonline_program_certificates.programcertificate_created_on as program_completion_timestamp
     , micromasters_users.user_id as micromasters_user_id
     , mitxonline_users.user_full_name

--- a/src/ol_dbt/models/intermediate/micromasters/subqueries/__micromasters_program_certificates_non_dedp.sql
+++ b/src/ol_dbt/models/intermediate/micromasters/subqueries/__micromasters_program_certificates_non_dedp.sql
@@ -52,6 +52,7 @@ with micromasters_program_certificates as (
         , micromasters_users.user_street_address
         , micromasters_users.user_address_state_or_territory
         , edx_users.user_full_name
+        , micromasters_program_certificates.program_certificate_hashed_id
         , micromasters_program_certificates.program_certificate_awarded_on as program_completion_timestamp
         , micromasters_users.user_id as micromasters_user_id
         , substring(micromasters_users.user_birth_date, 1, 4) as user_year_of_birth
@@ -88,6 +89,7 @@ with micromasters_program_certificates as (
         , micromasters_users.user_street_address
         , micromasters_users.user_address_state_or_territory
         , edx_users.user_full_name
+        , program_certificates_override_list.program_certificate_hashed_id
         , null as program_completion_timestamp
         , micromasters_users.user_id as micromasters_user_id
         , substring(micromasters_users.user_birth_date, 1, 4) as user_year_of_birth

--- a/src/ol_dbt/models/marts/micromasters/_marts_micromasters__models.yml
+++ b/src/ol_dbt/models/marts/micromasters/_marts_micromasters__models.yml
@@ -218,6 +218,11 @@ models:
     grants:
       select: ['mit_irx']
   columns:
+  - name: program_certificate_hashed_id
+    description: str, unique hash value used to identify the program certificate
+    tests:
+    - unique
+    - not_null
   - name: user_edxorg_username
     description: str, The username of the learner on the edX platform. For users who
       got DEDP certificates on MITx Online, this could be blank if they don't have

--- a/src/ol_dbt/models/staging/micromasters/_stg_micromasters__models.yml
+++ b/src/ol_dbt/models/staging/micromasters/_stg_micromasters__models.yml
@@ -252,6 +252,8 @@ models:
     meet all the program certificate requirements. This list has the user_id on user_edxorg
     and the program_id on micromasters production for those users
   columns:
+  - name: program_certificate_hashed_id
+    description: str, unique hash used to identify the program certificate
   - name: user_edxorg_id
     description: int, edxorg id for a user
     tests:

--- a/src/ol_dbt/models/staging/micromasters/stg__micromasters__app__user_program_certificate_override_list.sql
+++ b/src/ol_dbt/models/staging/micromasters/stg__micromasters__app__user_program_certificate_override_list.sql
@@ -1,4 +1,4 @@
 select * from (
     values
-    ('b637c358a896eb04eb613b87db59cb2e', 11479768, 1)   ---pragma: allowlist secret
+    ('74869f589baf0522ec4341ee3b7970526b6de2918bc6bf29873eae040d6c2359', 11479768, 1)   ---pragma: allowlist secret
 ) AS overwrite_list (program_certificate_hashed_id, user_edxorg_id, micromasters_program_id) -- noqa: L010,L025

--- a/src/ol_dbt/models/staging/micromasters/stg__micromasters__app__user_program_certificate_override_list.sql
+++ b/src/ol_dbt/models/staging/micromasters/stg__micromasters__app__user_program_certificate_override_list.sql
@@ -1,4 +1,4 @@
 select * from (
     values
-    (11479768, 1)
-) AS overwrite_list (user_edxorg_id, micromasters_program_id) -- noqa: L010,L025
+    ('b637c358a896eb04eb613b87db59cb2e', 11479768, 1)   ---pragma: allowlist secret
+) AS overwrite_list (program_certificate_hashed_id, user_edxorg_id, micromasters_program_id) -- noqa: L010,L025


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
https://github.com/mitodl/hq/issues/3806

### Description (What does it do?)
<!--- Describe your changes in detail -->
Adding `program_certificate_hashed_id` to marts__micromasters_program_certificates and its upstream models for primary key
  - For certificates sourced from MITx Online and MicroMasters, it uses the existing hash values from source since these don't change and they are unique
  - For certificates from edx.org (int__edxorg__mitx_program_certificates), it uses hash function to generate unique value from user_id and program_uuid
 
Adding unique test to ensure the new field is indeed unique

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->
Run the following command and tests should pass
```
dbt run --select +marts__micromasters_program_certificates
dbt test --select marts__micromasters_program_certificates
```