### PR TITLE
add grade and course fields to marts

### DIFF
--- a/src/ol_dbt/models/marts/combined/_marts__combined__models.yml
+++ b/src/ol_dbt/models/marts/combined/_marts__combined__models.yml
@@ -250,6 +250,13 @@ models:
   - name: product_program_readable_id
     description: str, open edX program readable ID associated to ecommerce products
       on MITx Online or xPro. Blank means that the product is course run.
+  - name: courserungrade_grade
+    description: float, course grade on edX.org or MITxOnline or xPro range from 0 to 1
+  - name: courserungrade_is_passing
+    description: boolean, indicating whether the user has passed the passing score
+      set for this course on edX.org or MITxOnline or xPro
+  - name: course_title
+    description: str, title of the course
   tests:
   - dbt_expectations.expect_compound_columns_to_be_unique:
       column_list: ["user_username", "courserun_readable_id"]

--- a/src/ol_dbt/models/marts/combined/_marts__combined__models.yml
+++ b/src/ol_dbt/models/marts/combined/_marts__combined__models.yml
@@ -251,8 +251,7 @@ models:
     description: str, open edX program readable ID associated to ecommerce products
       on MITx Online or xPro. Blank means that the product is course run.
   - name: courserungrade_grade
-    description: float, course grade on edX.org or MITxOnline or xPro range from 0
-      to 1
+    description: float, course grade on edX.org or MITxOnline or xPro range from 0 to 1
   - name: courserungrade_is_passing
     description: boolean, indicating whether the user has passed the passing score
       set for this course on edX.org or MITxOnline or xPro

--- a/src/ol_dbt/models/marts/combined/_marts__combined__models.yml
+++ b/src/ol_dbt/models/marts/combined/_marts__combined__models.yml
@@ -251,7 +251,8 @@ models:
     description: str, open edX program readable ID associated to ecommerce products
       on MITx Online or xPro. Blank means that the product is course run.
   - name: courserungrade_grade
-    description: float, course grade on edX.org or MITxOnline or xPro range from 0 to 1
+    description: float, course grade on edX.org or MITxOnline or xPro range from 0
+      to 1
   - name: courserungrade_is_passing
     description: boolean, indicating whether the user has passed the passing score
       set for this course on edX.org or MITxOnline or xPro

--- a/src/ol_dbt/models/marts/combined/marts__combined_course_enrollment_detail.sql
+++ b/src/ol_dbt/models/marts/combined/marts__combined_course_enrollment_detail.sql
@@ -149,7 +149,7 @@ with mitx_enrollments as (
             and mitx_enrollments.courserun_id = mitxonline_completed_orders.courserun_id
             and mitxonline_completed_orders.row_num = 1
     left join mitx_grades
-        on 
+        on
             mitx_enrollments.courserun_readable_id = mitx_grades.courserun_readable_id
             and mitx_enrollments.user_mitxonline_username = mitx_grades.user_mitxonline_username
     left join mitx_courses
@@ -218,7 +218,7 @@ with mitx_enrollments as (
             and mitx_enrollments.courserun_readable_id = micromasters_completed_orders.courserun_edxorg_readable_id
             and micromasters_completed_orders.row_num = 1
     left join mitx_grades
-        on 
+        on
             mitx_enrollments.courserun_readable_id = mitx_grades.courserun_readable_id
             and mitx_enrollments.user_edxorg_username = mitx_grades.user_edxorg_username
     left join mitx_courses
@@ -291,7 +291,7 @@ with mitx_enrollments as (
     left join mitxpro_lines
         on mitxpro_completed_orders.order_id = mitxpro_lines.order_id
     left join mitxpro_grades
-        on 
+        on
             mitxpro_enrollments.courserun_readable_id = mitxpro_grades.courserun_readable_id
             and mitxpro_enrollments.user_username = mitxpro_grades.user_username
     left join mitxpro_courseruns

--- a/src/ol_dbt/models/marts/combined/marts__combined_course_enrollment_detail.sql
+++ b/src/ol_dbt/models/marts/combined/marts__combined_course_enrollment_detail.sql
@@ -22,6 +22,30 @@ with mitx_enrollments as (
     select * from {{ ref('int__bootcamps__courserun_certificates') }}
 )
 
+, mitx_grades as (
+    select * from {{ ref('int__mitx__courserun_grades') }}
+)
+
+, mitxpro_grades as (
+    select * from {{ ref('int__mitxpro__courserun_grades') }}
+)
+
+, bootcamps_courses as (
+    select * from {{ ref('int__bootcamps__courses') }}
+)
+
+, bootcamps_courseruns as (
+    select * from {{ ref('int__bootcamps__course_runs') }}
+)
+
+, mitx_courses as (
+    select * from {{ ref('int__mitx__courses') }}
+)
+
+, mitxpro_courses as (
+    select * from {{ ref('int__mitxpro__courses') }}
+)
+
 , mitxonline_completed_orders as (
     select
         *
@@ -107,6 +131,9 @@ with mitx_enrollments as (
         , mitxonline_completed_orders.program_readable_id as product_program_readable_id
         , mitxonline_completed_orders.discount_amount_text as discount
         , mitxonline_completed_orders.discount_amount
+        , mitx_grades.courserungrade_grade
+        , mitx_grades.courserungrade_is_passing
+        , mitx_courses.course_title
     from mitx_enrollments
     left join mitx_certificates
         on
@@ -117,6 +144,12 @@ with mitx_enrollments as (
             mitx_enrollments.user_id = mitxonline_completed_orders.user_id
             and mitx_enrollments.courserun_id = mitxonline_completed_orders.courserun_id
             and mitxonline_completed_orders.row_num = 1
+    left join mitx_grades
+        on 
+            mitx_enrollments.courserun_readable_id = mitx_grades.courserun_readable_id
+            and mitx_enrollments.user_mitxonline_username = mitx_grades.user_mitxonline_username
+    left join mitx_courses
+        on mitx_enrollments.course_number = mitx_courses.course_number
     where mitx_enrollments.platform = '{{ var("mitxonline") }}'
 
     union all
@@ -166,6 +199,9 @@ with mitx_enrollments as (
         , null as product_program_readable_id
         , micromasters_completed_orders.coupon_discount_amount_text as discount
         , micromasters_completed_orders.coupon_amount as discount_amount
+        , mitx_grades.courserungrade_grade
+        , mitx_grades.courserungrade_is_passing
+        , mitx_courses.course_title
     from mitx_enrollments
     left join mitx_certificates
         on
@@ -177,6 +213,12 @@ with mitx_enrollments as (
             micromasters_users.user_id = micromasters_completed_orders.user_id
             and mitx_enrollments.courserun_readable_id = micromasters_completed_orders.courserun_edxorg_readable_id
             and micromasters_completed_orders.row_num = 1
+    left join mitx_grades
+        on 
+            mitx_enrollments.courserun_readable_id = mitx_grades.courserun_readable_id
+            and mitx_enrollments.user_edxorg_username = mitx_grades.user_edxorg_username
+    left join mitx_courses
+        on mitx_enrollments.course_number = mitx_courses.course_number
     where mitx_enrollments.platform = '{{ var("edxorg") }}'
 
 
@@ -232,6 +274,9 @@ with mitx_enrollments as (
                 then mitxpro_lines.product_price * mitxpro_completed_orders.couponpaymentversion_discount_amount
             else mitxpro_completed_orders.couponpaymentversion_discount_amount
         end as discount_amount
+        , mitxpro_grades.courserungrade_grade
+        , mitxpro_grades.courserungrade_is_passing
+        , mitxpro_courses.course_title
     from mitxpro_enrollments
     left join mitxpro_certificates
         on
@@ -241,6 +286,13 @@ with mitx_enrollments as (
         on mitxpro_enrollments.ecommerce_order_id = mitxpro_completed_orders.order_id
     left join mitxpro_lines
         on mitxpro_completed_orders.order_id = mitxpro_lines.order_id
+    left join mitxpro_grades
+        on 
+            mitxpro_enrollments.courserun_readable_id = mitxpro_grades.courserun_readable_id
+            and mitxpro_enrollments.user_username = mitxpro_grades.user_username
+    left join mitxpro_courses
+        on mitxpro_enrollments.course_readable_id = mitxpro_courses.course_readable_id
+
 
     union all
 
@@ -289,6 +341,9 @@ with mitx_enrollments as (
         , null as product_program_readable_id
         , null as discount
         , null as discount_amount
+        , null as courserungrade_grade
+        , null as courserungrade_is_passing
+        , bootcamps_courses.course_title
     from bootcamps_enrollments
     left join bootcamps_certificates
         on
@@ -298,6 +353,10 @@ with mitx_enrollments as (
         on
             bootcamps_enrollments.user_id = bootcamps_completed_orders.order_purchaser_user_id
             and bootcamps_enrollments.courserun_id = bootcamps_completed_orders.courserun_id
+    left join bootcamps_courseruns
+        on bootcamps_enrollments.courserun_id = bootcamps_courseruns.courserun_id
+    left join bootcamps_courses
+        on bootcamps_courseruns.course_id = bootcamps_courses.course_id
 )
 
 select * from combined_enrollment_detail

--- a/src/ol_dbt/models/marts/combined/marts__combined_course_enrollment_detail.sql
+++ b/src/ol_dbt/models/marts/combined/marts__combined_course_enrollment_detail.sql
@@ -42,6 +42,10 @@ with mitx_enrollments as (
     select * from {{ ref('int__mitx__courses') }}
 )
 
+, mitxpro_courseruns as (
+    select * from {{ ref('int__mitxpro__course_runs') }}
+)
+
 , mitxpro_courses as (
     select * from {{ ref('int__mitxpro__courses') }}
 )
@@ -145,7 +149,7 @@ with mitx_enrollments as (
             and mitx_enrollments.courserun_id = mitxonline_completed_orders.courserun_id
             and mitxonline_completed_orders.row_num = 1
     left join mitx_grades
-        on
+        on 
             mitx_enrollments.courserun_readable_id = mitx_grades.courserun_readable_id
             and mitx_enrollments.user_mitxonline_username = mitx_grades.user_mitxonline_username
     left join mitx_courses
@@ -214,7 +218,7 @@ with mitx_enrollments as (
             and mitx_enrollments.courserun_readable_id = micromasters_completed_orders.courserun_edxorg_readable_id
             and micromasters_completed_orders.row_num = 1
     left join mitx_grades
-        on
+        on 
             mitx_enrollments.courserun_readable_id = mitx_grades.courserun_readable_id
             and mitx_enrollments.user_edxorg_username = mitx_grades.user_edxorg_username
     left join mitx_courses
@@ -287,11 +291,13 @@ with mitx_enrollments as (
     left join mitxpro_lines
         on mitxpro_completed_orders.order_id = mitxpro_lines.order_id
     left join mitxpro_grades
-        on
+        on 
             mitxpro_enrollments.courserun_readable_id = mitxpro_grades.courserun_readable_id
             and mitxpro_enrollments.user_username = mitxpro_grades.user_username
+    left join mitxpro_courseruns
+        on mitxpro_enrollments.courserun_readable_id = mitxpro_courseruns.courserun_readable_id
     left join mitxpro_courses
-        on mitxpro_enrollments.course_readable_id = mitxpro_courses.course_readable_id
+        on mitxpro_courseruns.course_id = mitxpro_courses.course_id
 
 
     union all

--- a/src/ol_dbt/models/marts/combined/marts__combined_course_enrollment_detail.sql
+++ b/src/ol_dbt/models/marts/combined/marts__combined_course_enrollment_detail.sql
@@ -145,7 +145,7 @@ with mitx_enrollments as (
             and mitx_enrollments.courserun_id = mitxonline_completed_orders.courserun_id
             and mitxonline_completed_orders.row_num = 1
     left join mitx_grades
-        on 
+        on
             mitx_enrollments.courserun_readable_id = mitx_grades.courserun_readable_id
             and mitx_enrollments.user_mitxonline_username = mitx_grades.user_mitxonline_username
     left join mitx_courses
@@ -214,7 +214,7 @@ with mitx_enrollments as (
             and mitx_enrollments.courserun_readable_id = micromasters_completed_orders.courserun_edxorg_readable_id
             and micromasters_completed_orders.row_num = 1
     left join mitx_grades
-        on 
+        on
             mitx_enrollments.courserun_readable_id = mitx_grades.courserun_readable_id
             and mitx_enrollments.user_edxorg_username = mitx_grades.user_edxorg_username
     left join mitx_courses
@@ -287,7 +287,7 @@ with mitx_enrollments as (
     left join mitxpro_lines
         on mitxpro_completed_orders.order_id = mitxpro_lines.order_id
     left join mitxpro_grades
-        on 
+        on
             mitxpro_enrollments.courserun_readable_id = mitxpro_grades.courserun_readable_id
             and mitxpro_enrollments.user_username = mitxpro_grades.user_username
     left join mitxpro_courses


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/3767

### Description (What does it do?)
adds course run grade, course run passing indicator, and course title to marts__combined_course_enrollment_detail from the different platforms (bootcamps, xpro, edx, mitxonline)

### How can this be tested?
dbt build --select marts__combined_course_enrollment_detail
