### PR TITLE
add a edx program enrollment int table

### DIFF
--- a/src/ol_dbt/models/intermediate/edxorg/_int_edxorg__models.yml
+++ b/src/ol_dbt/models/intermediate/edxorg/_int_edxorg__models.yml
@@ -463,4 +463,3 @@ models:
   tests:
   - dbt_expectations.expect_compound_columns_to_be_unique:
       column_list: ["user_id", "program_uuid"]
-

--- a/src/ol_dbt/models/intermediate/edxorg/_int_edxorg__models.yml
+++ b/src/ol_dbt/models/intermediate/edxorg/_int_edxorg__models.yml
@@ -378,11 +378,6 @@ models:
   description: learners who completed MicroMasters and XSeries programs on edX.org.
     program_certificate_awarded_on might be null for some programs such as SCM
   columns:
-  - name: program_certificate_hashed_id
-    description: str, unique hash value used to identify the program certificate
-    tests:
-    - not_null
-    - unique
   - name: program_type
     description: str, the type of the program. The value are 'MicroMasters' and 'XSeries'
       for MITx programs on edX.org
@@ -426,3 +421,46 @@ models:
   tests:
   - dbt_expectations.expect_compound_columns_to_be_unique:
       column_list: ["user_id", "program_uuid"]
+
+- name: int__edxorg__mitx_program_enrollments
+  description: learners who enrolled in MicroMasters and XSeries programs on edX.org
+  columns:
+  - name: program_type
+    description: str, the type of the program. The value are 'MicroMasters' and 'XSeries'
+      for MITx programs on edX.org
+    tests:
+    - not_null
+  - name: program_uuid
+    description: str, the UUID of the program on edX.org. 'MIT Finance' and 'Finance'
+      are two different UUIDs, as they have different required courses. 'Statistics
+      and Data Science' is split into 'Statistics and Data Science' and 'Statistics
+      and Data Science (General track)', which are also two different program UUIDs.
+    tests:
+    - not_null
+  - name: program_title
+    description: str, title of the program on edX.org.
+    tests:
+    - not_null
+  - name: user_id
+    description: int, the edX learner ID in the LMS in a user's course run enrollment
+      record.
+    tests:
+    - not_null
+  - name: user_username
+    description: str, username of the user on edX.org
+    tests:
+    - not_null
+  - name: user_full_name
+    description: str, the full name of an edX learner in the LMS in a user's user
+      profile record. Retired users will have no full name available.
+    tests:
+    - not_null
+  - name: user_has_completed_program
+    description: boolean, whether the learner has passed each of the courses in the
+      program with a grade that qualifies them for a verified certificate.
+  - name: micromasters_program_id
+    description: int, foreign key to program in the MicroMasters database
+  tests:
+  - dbt_expectations.expect_compound_columns_to_be_unique:
+      column_list: ["user_id", "program_uuid"]
+

--- a/src/ol_dbt/models/intermediate/edxorg/_int_edxorg__models.yml
+++ b/src/ol_dbt/models/intermediate/edxorg/_int_edxorg__models.yml
@@ -378,6 +378,11 @@ models:
   description: learners who completed MicroMasters and XSeries programs on edX.org.
     program_certificate_awarded_on might be null for some programs such as SCM
   columns:
+  - name: program_certificate_hashed_id
+    description: str, unique hash value used to identify the program certificate
+    tests:
+    - not_null
+    - unique
   - name: program_type
     description: str, the type of the program. The value are 'MicroMasters' and 'XSeries'
       for MITx programs on edX.org
@@ -463,3 +468,4 @@ models:
   tests:
   - dbt_expectations.expect_compound_columns_to_be_unique:
       column_list: ["user_id", "program_uuid"]
+

--- a/src/ol_dbt/models/intermediate/edxorg/_int_edxorg__models.yml
+++ b/src/ol_dbt/models/intermediate/edxorg/_int_edxorg__models.yml
@@ -468,4 +468,3 @@ models:
   tests:
   - dbt_expectations.expect_compound_columns_to_be_unique:
       column_list: ["user_id", "program_uuid"]
-

--- a/src/ol_dbt/models/intermediate/edxorg/int__edxorg__mitx_program_enrollments.sql
+++ b/src/ol_dbt/models/intermediate/edxorg/int__edxorg__mitx_program_enrollments.sql
@@ -1,0 +1,32 @@
+with program_learners as (
+    select * from {{ ref('stg__edxorg__s3__program_learner_report') }}
+)
+
+, micromasters_programs as (
+    select * from {{ ref('int__mitx__programs') }}
+    where is_micromasters_program = true
+)
+
+, program_learners_sorted as (
+    select
+        *
+        , row_number() over (partition by user_id, program_uuid order by courserunenrollment_created_on desc) as row_num
+    from program_learners
+)
+
+select
+    program_learners_sorted.program_type
+    , program_learners_sorted.program_uuid
+    , program_learners_sorted.program_title
+    , program_learners_sorted.user_id
+    , program_learners_sorted.user_username
+    , program_learners_sorted.user_full_name
+    , program_learners_sorted.user_has_completed_program
+    , micromasters_programs.micromasters_program_id
+from program_learners_sorted
+left join micromasters_programs
+    on (
+        program_learners_sorted.program_title like micromasters_programs.program_title || '%'
+        or program_learners_sorted.program_title like '%' || micromasters_programs.program_title
+    )
+where program_learners_sorted.row_num = 1

--- a/src/ol_dbt/models/intermediate/edxorg/int__edxorg__mitx_program_enrollments.sql
+++ b/src/ol_dbt/models/intermediate/edxorg/int__edxorg__mitx_program_enrollments.sql
@@ -23,7 +23,7 @@ left join micromasters_programs
         program_learners.program_title like micromasters_programs.program_title || '%'
         or program_learners.program_title like '%' || micromasters_programs.program_title
     )
-group by 
+group by
     program_learners.program_type
     , program_learners.program_uuid
     , program_learners.program_title

--- a/src/ol_dbt/models/intermediate/edxorg/int__edxorg__mitx_program_enrollments.sql
+++ b/src/ol_dbt/models/intermediate/edxorg/int__edxorg__mitx_program_enrollments.sql
@@ -1,5 +1,6 @@
 with program_learners as (
-    select * from {{ ref('stg__edxorg__s3__program_learner_report') }}
+    select *
+    from {{ ref('stg__edxorg__s3__program_learner_report') }}
 )
 
 , micromasters_programs as (
@@ -7,26 +8,27 @@ with program_learners as (
     where is_micromasters_program = true
 )
 
-, program_learners_sorted as (
-    select
-        *
-        , row_number() over (partition by user_id, program_uuid order by courserunenrollment_created_on desc) as row_num
-    from program_learners
-)
-
 select
-    program_learners_sorted.program_type
-    , program_learners_sorted.program_uuid
-    , program_learners_sorted.program_title
-    , program_learners_sorted.user_id
-    , program_learners_sorted.user_username
-    , program_learners_sorted.user_full_name
-    , program_learners_sorted.user_has_completed_program
+    program_learners.program_type
+    , program_learners.program_uuid
+    , program_learners.program_title
+    , program_learners.user_id
+    , program_learners.user_username
+    , program_learners.user_full_name
+    , program_learners.user_has_completed_program
     , micromasters_programs.micromasters_program_id
-from program_learners_sorted
+from program_learners
 left join micromasters_programs
     on (
-        program_learners_sorted.program_title like micromasters_programs.program_title || '%'
-        or program_learners_sorted.program_title like '%' || micromasters_programs.program_title
+        program_learners.program_title like micromasters_programs.program_title || '%'
+        or program_learners.program_title like '%' || micromasters_programs.program_title
     )
-where program_learners_sorted.row_num = 1
+group by 
+    program_learners.program_type
+    , program_learners.program_uuid
+    , program_learners.program_title
+    , program_learners.user_id
+    , program_learners.user_username
+    , program_learners.user_full_name
+    , program_learners.user_has_completed_program
+    , micromasters_programs.micromasters_program_id


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/3765

### Description (What does it do?)
Adds a new int__edxorg__mitx_program_enrollments table that contains program enrollment data from edx.

### How can this be tested?
dbt build --select int__edxorg__mitx_program_enrollments  
