### PR TITLE
add new combined program enrollment mart

### DIFF
--- a/src/ol_dbt/models/marts/combined/_marts__combined__models.yml
+++ b/src/ol_dbt/models/marts/combined/_marts__combined__models.yml
@@ -250,6 +250,14 @@ models:
   - name: product_program_readable_id
     description: str, open edX program readable ID associated to ecommerce products
       on MITx Online or xPro. Blank means that the product is course run.
+  - name: courserungrade_grade
+    description: float, course grade on edX.org or MITxOnline or xPro range from 0
+      to 1
+  - name: courserungrade_is_passing
+    description: boolean, indicating whether the user has passed the passing score
+      set for this course on edX.org or MITxOnline or xPro
+  - name: course_title
+    description: str, title of the course
   tests:
   - dbt_expectations.expect_compound_columns_to_be_unique:
       column_list: ["user_username", "courserun_readable_id"]

--- a/src/ol_dbt/models/marts/combined/_marts__combined__models.yml
+++ b/src/ol_dbt/models/marts/combined/_marts__combined__models.yml
@@ -250,14 +250,6 @@ models:
   - name: product_program_readable_id
     description: str, open edX program readable ID associated to ecommerce products
       on MITx Online or xPro. Blank means that the product is course run.
-  - name: courserungrade_grade
-    description: float, course grade on edX.org or MITxOnline or xPro range from 0
-      to 1
-  - name: courserungrade_is_passing
-    description: boolean, indicating whether the user has passed the passing score
-      set for this course on edX.org or MITxOnline or xPro
-  - name: course_title
-    description: str, title of the course
   tests:
   - dbt_expectations.expect_compound_columns_to_be_unique:
       column_list: ["user_username", "courserun_readable_id"]
@@ -271,3 +263,43 @@ models:
   - dbt_expectations.expect_compound_columns_to_be_unique:
       column_list: ["courserunenrollment_id", "order_reference_number"]
       row_condition: "platform='Bootcamps'"
+
+- name: marts__combined_program_enrollment_detail
+  description: Mart model for program enrollments and certificates from different
+    platforms
+  columns:
+  - name: platform_name
+    description: str, name of the platform
+    tests:
+    - not_null
+  - name: program_id
+    description: int, id representing a single program on a particular platform
+  - name: program_title
+    description: str, title of the program
+  - name: program_is_live
+    description: boolean, indicating whether the program is available to users on
+      the MITxOnline website or MITxPro website
+  - name: program_readable_id
+    description: str, readable ID from xpro or mitxonline formatted as program-v1:{org}+{program
+      code} e.g.program-v1:xPRO+MLx
+  - name: user_id
+    description: int, unique id assigned to the user
+  - name: user_email
+    description: string, email
+  - name: user_username
+    description: string, username
+  - name: programenrollment_is_active
+    description: boolean, indicating whether the user is still enrolled in the program
+  - name: programenrollment_created_on
+    description: timestamp, specifying when an enrollment was initially created
+  - name: programenrollment_enrollment_status
+    description: str, enrollment status for users whose enrollment changed
+  - name: programcertificate_created_on
+    description: timestamp, specifying when a certificate was initially created
+  - name: programcertificate_is_revoked
+    description: boolean, indicating whether the certificate is revoked and invalid
+  - name: programcertificate_uuid
+    description: str, unique identifier for the program certificate
+  tests:
+  - dbt_expectations.expect_compound_columns_to_be_unique:
+      column_list: ["platform_name", "program_title", "user_username", "programenrollment_created_on"]

--- a/src/ol_dbt/models/marts/combined/_marts__combined__models.yml
+++ b/src/ol_dbt/models/marts/combined/_marts__combined__models.yml
@@ -310,4 +310,4 @@ models:
     description: str, unique identifier for the program certificate
   tests:
   - dbt_expectations.expect_compound_columns_to_be_unique:
-      column_list: ["platform_name", "program_title", "user_username", "programenrollment_created_on"]
+      column_list: ["program_title", "user_username", "programenrollment_created_on"]

--- a/src/ol_dbt/models/marts/combined/marts__combined_program_enrollment_detail.sql
+++ b/src/ol_dbt/models/marts/combined/marts__combined_program_enrollment_detail.sql
@@ -85,7 +85,7 @@ with mitxpro__programenrollments as (
 
     union all
 
-    select
+    select 
         'edxorg' as platform_name
         , edx_program_enrollments.micromasters_program_id as program_id
         , edx_program_enrollments.program_title
@@ -99,13 +99,13 @@ with mitxpro__programenrollments as (
         , null as programenrollment_enrollment_status
         , edx_program_certificates.program_certificate_awarded_on as programcertificate_created_on
         , null as programcertificate_is_revoked
-        , null as programcertificate_uuid
+        , edx_program_certificates.program_certificate_hashed_id as programcertificate_uuid
     from edx_program_enrollments
     left join mitx__users
         on edx_program_enrollments.user_id = mitx__users.user_id
     left join edx_program_certificates
-        on
-            edx_program_enrollments.program_uuid = edx_program_certificates.program_uuid
+        on 
+            edx_program_enrollments.program_uuid = edx_program_certificates.program_uuid 
             and edx_program_enrollments.user_id = edx_program_certificates.user_id
 )
 

--- a/src/ol_dbt/models/marts/combined/marts__combined_program_enrollment_detail.sql
+++ b/src/ol_dbt/models/marts/combined/marts__combined_program_enrollment_detail.sql
@@ -1,0 +1,112 @@
+with mitxpro__programenrollments as (
+    select * from {{ ref('int__mitxpro__programenrollments') }}
+)
+
+, mitxpro__programs as (
+    select * from {{ ref('int__mitxpro__programs') }}
+)
+
+, mitxpro__program_certificates as (
+    select * from {{ ref('int__mitxpro__program_certificates') }}
+)
+
+, mitxonline__programenrollments as (
+    select * from {{ ref('int__mitxonline__programenrollments') }}
+)
+
+, mitxonline__programs as (
+    select * from {{ ref('int__mitxonline__programs') }}
+)
+
+, mitxonline__program_certificates as (
+    select * from {{ ref('int__mitxonline__program_certificates') }}
+)
+
+, edx_program_certificates as (
+    select * from {{ ref('int__edxorg__mitx_program_certificates') }}
+)
+
+, edx_program_enrollments as (
+    select * from {{ ref('int__edxorg__mitx_program_enrollments') }}
+)
+
+, mitx__users as (
+    select * from {{ ref('int__edxorg__mitx_users') }}
+)
+
+, combined_programs as (
+    select
+        mitxpro__programs.platform_name
+        , mitxpro__programs.program_id
+        , mitxpro__programs.program_title
+        , mitxpro__programs.program_is_live
+        , mitxpro__programs.program_readable_id
+        , mitxpro__programenrollments.user_id
+        , mitxpro__programenrollments.user_email
+        , mitxpro__programenrollments.user_username
+        , mitxpro__programenrollments.programenrollment_is_active
+        , mitxpro__programenrollments.programenrollment_created_on
+        , mitxpro__programenrollments.programenrollment_enrollment_status
+        , mitxpro__program_certificates.programcertificate_created_on
+        , mitxpro__program_certificates.programcertificate_is_revoked
+        , mitxpro__program_certificates.programcertificate_uuid
+    from mitxpro__programenrollments
+    inner join mitxpro__programs
+        on mitxpro__programenrollments.program_id = mitxpro__programs.program_id
+    left join mitxpro__program_certificates
+        on
+            mitxpro__programenrollments.program_id = mitxpro__program_certificates.program_id
+            and mitxpro__programenrollments.user_id = mitxpro__program_certificates.user_id
+
+    union all
+
+    select
+        'mitxonline' as platform_name
+        , mitxonline__programs.program_id
+        , mitxonline__programs.program_title
+        , mitxonline__programs.program_is_live
+        , mitxonline__programs.program_readable_id
+        , mitxonline__programenrollments.user_id
+        , mitxonline__programenrollments.user_email
+        , mitxonline__programenrollments.user_username
+        , mitxonline__programenrollments.programenrollment_is_active
+        , mitxonline__programenrollments.programenrollment_created_on
+        , mitxonline__programenrollments.programenrollment_enrollment_status
+        , mitxonline__program_certificates.programcertificate_created_on
+        , mitxonline__program_certificates.programcertificate_is_revoked
+        , mitxonline__program_certificates.programcertificate_uuid
+    from mitxonline__programenrollments
+    inner join mitxonline__programs
+        on mitxonline__programenrollments.program_id = mitxonline__programs.program_id
+    left join mitxonline__program_certificates
+        on
+            mitxonline__programenrollments.user_id = mitxonline__program_certificates.user_id
+            and mitxonline__programenrollments.program_id = mitxonline__program_certificates.program_id
+
+    union all
+
+    select 
+        'edxorg' as platform_name
+        , edx_program_enrollments.micromasters_program_id as program_id
+        , edx_program_enrollments.program_title
+        , null as program_is_live
+        , null as program_readable_id
+        , edx_program_enrollments.user_id
+        , mitx__users.user_email
+        , edx_program_enrollments.user_username
+        , null as programenrollment_is_active
+        , null as programenrollment_created_on
+        , null as programenrollment_enrollment_status
+        , edx_program_certificates.program_certificate_awarded_on as programcertificate_created_on
+        , null as programcertificate_is_revoked
+        , null as programcertificate_uuid
+    from edx_program_enrollments
+    left join mitx__users
+        on edx_program_enrollments.user_id = mitx__users.user_id
+    left join edx_program_certificates
+        on 
+            edx_program_enrollments.program_uuid = edx_program_certificates.program_uuid 
+            and edx_program_enrollments.user_id = edx_program_certificates.user_id
+)
+
+select * from combined_programs

--- a/src/ol_dbt/models/marts/combined/marts__combined_program_enrollment_detail.sql
+++ b/src/ol_dbt/models/marts/combined/marts__combined_program_enrollment_detail.sql
@@ -85,7 +85,7 @@ with mitxpro__programenrollments as (
 
     union all
 
-    select 
+    select
         'edxorg' as platform_name
         , edx_program_enrollments.micromasters_program_id as program_id
         , edx_program_enrollments.program_title
@@ -104,8 +104,8 @@ with mitxpro__programenrollments as (
     left join mitx__users
         on edx_program_enrollments.user_id = mitx__users.user_id
     left join edx_program_certificates
-        on 
-            edx_program_enrollments.program_uuid = edx_program_certificates.program_uuid 
+        on
+            edx_program_enrollments.program_uuid = edx_program_certificates.program_uuid
             and edx_program_enrollments.user_id = edx_program_certificates.user_id
 )
 

--- a/src/ol_dbt/models/marts/combined/marts__combined_program_enrollment_detail.sql
+++ b/src/ol_dbt/models/marts/combined/marts__combined_program_enrollment_detail.sql
@@ -85,7 +85,7 @@ with mitxpro__programenrollments as (
 
     union all
 
-    select
+    select 
         'edxorg' as platform_name
         , edx_program_enrollments.micromasters_program_id as program_id
         , edx_program_enrollments.program_title
@@ -104,8 +104,8 @@ with mitxpro__programenrollments as (
     left join mitx__users
         on edx_program_enrollments.user_id = mitx__users.user_id
     left join edx_program_certificates
-        on
-            edx_program_enrollments.program_uuid = edx_program_certificates.program_uuid
+        on 
+            edx_program_enrollments.program_uuid = edx_program_certificates.program_uuid 
             and edx_program_enrollments.user_id = edx_program_certificates.user_id
 )
 


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/3765

### Description (What does it do?)
Adds a new marts__combined_program_enrollment_detail table that contains program, enrollment, and certificate data from xpro, mixonline, and edx.

### How can this be tested?
dbt build --select marts__combined_program_enrollment_detail  
