### PR TITLE
add course readable id to combined enrollment mart and upstream models

### DIFF
--- a/src/ol_dbt/models/intermediate/edxorg/_int_edxorg__models.yml
+++ b/src/ol_dbt/models/intermediate/edxorg/_int_edxorg__models.yml
@@ -17,6 +17,10 @@ models:
   - name: course_number
     description: str, unique string for the course. It can contain letters, numbers,
       or periods. e.g. 6.002.1x
+  - name: course_readable_id
+    description: str, Open edX ID for the course formatted as {org}/{course}
+    tests:
+    - not_null
   - name: courserun_semester
     description: str, The semester during which the course was launched e.g Fall 2020
   - name: courserun_enrollment_start_date

--- a/src/ol_dbt/models/intermediate/edxorg/int__edxorg__mitx_courseruns.sql
+++ b/src/ol_dbt/models/intermediate/edxorg/int__edxorg__mitx_courseruns.sql
@@ -23,6 +23,7 @@ with runs as (
 select
     runs.courserun_readable_id
     , runs.course_number
+    , runs.course_readable_id
     , runs.courserun_title
     , runs.courserun_semester
     , runs.courserun_url

--- a/src/ol_dbt/models/intermediate/mitx/_int_mitx__models.yml
+++ b/src/ol_dbt/models/intermediate/mitx/_int_mitx__models.yml
@@ -38,6 +38,11 @@ models:
     tests:
     - unique
     - not_null
+  - name: course_readable_id
+    description: str, Open edX ID for the course formatted as course-v1:{org}+{course
+      code} for MITx Online and {org}/{course} for edX.org
+    tests:
+    - not_null
   - name: course_title
     description: str, title of the course
     tests:

--- a/src/ol_dbt/models/intermediate/mitx/int__mitx__courses.sql
+++ b/src/ol_dbt/models/intermediate/mitx/int__mitx__courses.sql
@@ -24,6 +24,7 @@ with mitxonline_courses as (
         , micromasters_program_id
         , micromasters_course_id
         , course_number
+        , course_readable_id
     from edx_courseruns
     where course_recency_rank = 1
 )
@@ -33,6 +34,7 @@ with mitxonline_courses as (
         mitxonline_courses.mitxonline_course_id
         , edx_courses.micromasters_course_id
         , coalesce(mitxonline_courses.course_number, edx_courses.course_number) as course_number
+        , coalesce(mitxonline_courses.course_readable_id, edx_courses.course_readable_id) as course_readable_id
         , coalesce(mitxonline_courses.course_title, edx_courses.course_title) as course_title
         , coalesce(mitxonline_courses.course_number is not null, false) as is_on_mitxonline
         , coalesce(edx_courses.course_number is not null, false) as is_on_edxorg

--- a/src/ol_dbt/models/marts/combined/_marts__combined__models.yml
+++ b/src/ol_dbt/models/marts/combined/_marts__combined__models.yml
@@ -257,7 +257,17 @@ models:
     description: boolean, indicating whether the user has passed the passing score
       set for this course on edX.org or MITxOnline or xPro
   - name: course_title
-    description: str, title of the course
+    description: str, title of the course. May be null for some old edX.org runs.
+    tests:
+    - dbt_expectations.expect_column_values_to_not_be_null:
+        row_condition: "platform != 'edX.org'"
+  - name: course_readable_id
+    description: str, Open edX ID formatted as course-v1:{org}+{course code} for MITx
+      Online and xPro courses, and {org}/{course} for edX.org courses. May be null
+      for some old edX.org runs and Bootcamps courses.
+    tests:
+    - dbt_expectations.expect_column_values_to_not_be_null:
+        row_condition: "platform != 'Bootcamps' and platform != 'edX.org'"
   tests:
   - dbt_expectations.expect_compound_columns_to_be_unique:
       column_list: ["user_username", "courserun_readable_id"]

--- a/src/ol_dbt/models/marts/combined/marts__combined_course_enrollment_detail.sql
+++ b/src/ol_dbt/models/marts/combined/marts__combined_course_enrollment_detail.sql
@@ -138,6 +138,7 @@ with mitx_enrollments as (
         , mitx_grades.courserungrade_grade
         , mitx_grades.courserungrade_is_passing
         , mitx_courses.course_title
+        , mitx_courses.course_readable_id
     from mitx_enrollments
     left join mitx_certificates
         on
@@ -206,6 +207,7 @@ with mitx_enrollments as (
         , mitx_grades.courserungrade_grade
         , mitx_grades.courserungrade_is_passing
         , mitx_courses.course_title
+        , mitx_courses.course_readable_id
     from mitx_enrollments
     left join mitx_certificates
         on
@@ -281,6 +283,7 @@ with mitx_enrollments as (
         , mitxpro_grades.courserungrade_grade
         , mitxpro_grades.courserungrade_is_passing
         , mitxpro_courses.course_title
+        , mitxpro_courses.course_readable_id
     from mitxpro_enrollments
     left join mitxpro_certificates
         on
@@ -350,6 +353,7 @@ with mitx_enrollments as (
         , null as courserungrade_grade
         , null as courserungrade_is_passing
         , bootcamps_courses.course_title
+        , null as course_readable_id  --- to be populated after we add to bootcamp app
     from bootcamps_enrollments
     left join bootcamps_certificates
         on

--- a/src/ol_dbt/models/staging/edxorg/_stg__edxorg__models.yml
+++ b/src/ol_dbt/models/staging/edxorg/_stg__edxorg__models.yml
@@ -38,6 +38,10 @@ models:
       MITProfessionalX, MITx, MITxPRO
   - name: courserun_instructors
     description: str, List of instructors associated with the course
+  - name: course_readable_id
+    description: str, Open edX ID for the course formatted as {org}/{course}
+    tests:
+    - not_null
 
 - name: stg__edxorg__bigquery__mitx_person_course
   description: It contains user activities from edX.org, MITxOnline/xPro open edx

--- a/src/ol_dbt/models/staging/edxorg/stg__edxorg__bigquery__mitx_courserun.sql
+++ b/src/ol_dbt/models/staging/edxorg/stg__edxorg__bigquery__mitx_courserun.sql
@@ -32,7 +32,8 @@ with source as (
             else institution
         end as courserun_institution
         , course_id as courserun_readable_id
-        ,{{ translate_course_id_to_platform('course_id') }} as courserun_platform
+        , concat(element_at(split(course_id, '/'), 1), '/', element_at(split(course_id, '/'), 2)) as course_readable_id
+        , {{ translate_course_id_to_platform('course_id') }} as courserun_platform
         , coalesce(self_paced = 1, false) as courserun_is_self_paced
     from source
 


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
Part of https://github.com/mitodl/hq/issues/3875

### Description (What does it do?)
<!--- Describe your changes in detail -->
Adding course_readable_id to marts__combined_course_enrollment_detail and upstream changes
-  some null for some old edx.org runs due to missing data from BigQuery mitx_course table. This hopefully will get resolved once we use our own edx.org data
- null bootcamps for now until we add it in bootcamps app https://github.com/mitodl/hq/issues/3905


### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

```
dbt build --select +marts__combined_course_enrollment_detail
```