### PR TITLE
add courseruncertificate_is_earned to combined enrollment mart

### DIFF
--- a/src/ol_dbt/models/marts/combined/_marts__combined__models.yml
+++ b/src/ol_dbt/models/marts/combined/_marts__combined__models.yml
@@ -175,6 +175,11 @@ models:
     description: str, user full name from user's profile on the corresponding platform
   - name: user_country_code
     description: str, country code from the user's address on the corresponding platform
+  - name: courseruncertificate_is_earned
+    description: boolean, indicating if learner has earned the certificate on mitxonline.mit.edu,
+      micromasters.mit.edu (legacy), edX.org or xpro.mit.edu.
+    tests:
+    - not_null
   - name: courseruncertificate_uuid
     description: str, unique identifier for the certificate on the corresponding platform
   - name: courseruncertificate_url

--- a/src/ol_dbt/models/marts/combined/marts__combined_course_enrollment_detail.sql
+++ b/src/ol_dbt/models/marts/combined/marts__combined_course_enrollment_detail.sql
@@ -107,6 +107,7 @@ with mitx_enrollments as (
         , mitx_enrollments.user_email
         , mitx_enrollments.user_full_name
         , mitx_enrollments.user_address_country as user_country_code
+        , if(mitx_certificates.courseruncertificate_url is not null, true, false) as courseruncertificate_is_earned
         , mitx_certificates.courseruncertificate_created_on
         , mitx_certificates.courseruncertificate_url
         , mitx_certificates.courseruncertificate_uuid
@@ -176,6 +177,7 @@ with mitx_enrollments as (
         , mitx_enrollments.user_email
         , mitx_enrollments.user_full_name
         , mitx_enrollments.user_address_country as user_country_code
+        , if(mitx_certificates.courseruncertificate_url is not null, true, false) as courseruncertificate_is_earned
         , mitx_certificates.courseruncertificate_created_on
         , mitx_certificates.courseruncertificate_url
         , mitx_certificates.courseruncertificate_uuid
@@ -248,6 +250,7 @@ with mitx_enrollments as (
         , mitxpro_enrollments.user_email
         , mitxpro_enrollments.user_full_name
         , mitxpro_enrollments.user_address_country as user_country_code
+        , if(mitxpro_certificates.courseruncertificate_url is not null, true, false) as courseruncertificate_is_earned
         , mitxpro_certificates.courseruncertificate_created_on
         , mitxpro_certificates.courseruncertificate_url
         , mitxpro_certificates.courseruncertificate_uuid
@@ -322,6 +325,7 @@ with mitx_enrollments as (
         , bootcamps_enrollments.user_email
         , bootcamps_enrollments.user_full_name
         , bootcamps_enrollments.user_address_country as user_country_code
+        , if(bootcamps_certificates.courseruncertificate_url is not null, true, false) as courseruncertificate_is_earned
         , bootcamps_certificates.courseruncertificate_created_on
         , bootcamps_certificates.courseruncertificate_url
         , bootcamps_certificates.courseruncertificate_uuid


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
part of https://github.com/mitodl/hq/issues/3875

### Description (What does it do?)
<!--- Describe your changes in detail -->
Adding `courseruncertificate_is_earned` to marts__combined_course_enrollment_detail for certificate indicator to be used in combined learners dashboard


### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

dbt build --select marts__combined_course_enrollment_detail