### PR TITLE
Add user profile fields to enrollment mart and micromasters intermediate

### DIFF
--- a/src/ol_dbt/models/intermediate/micromasters/_int_micromasters__models.yml
+++ b/src/ol_dbt/models/intermediate/micromasters/_int_micromasters__models.yml
@@ -407,9 +407,9 @@ models:
   - name: user_nationality
     description: str, user's nationality (stored as country code)
   - name: user_birth_country
-    description: str, country where user was born pulling from MicroMasters profile.
+    description: str, country code where user was born pulling from MicroMasters profile.
   - name: user_address_country
-    description: str, country where user lives in
+    description: str, country code where user lives in
   - name: user_address_city
     description: str, city where user lives in
   - name: user_address_state_or_territory

--- a/src/ol_dbt/models/intermediate/micromasters/_int_micromasters__models.yml
+++ b/src/ol_dbt/models/intermediate/micromasters/_int_micromasters__models.yml
@@ -406,6 +406,8 @@ models:
     description: str, user's Nickname / Preferred name
   - name: user_nationality
     description: str, user's nationality (stored as country code)
+  - name: user_birth_country
+    description: str, country where user was born pulling from MicroMasters profile.
   - name: user_address_country
     description: str, country where user lives in
   - name: user_address_city

--- a/src/ol_dbt/models/intermediate/micromasters/int__micromasters__users.sql
+++ b/src/ol_dbt/models/intermediate/micromasters/int__micromasters__users.sql
@@ -50,6 +50,7 @@ select
     , users.user_full_name
     , users.user_first_name
     , users.user_last_name
+    , users.user_birth_country
     , users.user_address_country
     , users.user_address_city
     , users.user_address_state_or_territory

--- a/src/ol_dbt/models/intermediate/micromasters/subqueries/__int_micromasters_subqueries__models.yml
+++ b/src/ol_dbt/models/intermediate/micromasters/subqueries/__int_micromasters_subqueries__models.yml
@@ -26,6 +26,8 @@ models:
     description: timestamp, specifying when a user account was initially created
   - name: user_last_login
     description: timestamp, specifying when a user last logged in
+  - name: user_birth_country
+    description: str, country where user was born, pulling from MicroMasters profile.
   - name: user_address_country
     description: str, country code for the user's address
   - name: user_is_active

--- a/src/ol_dbt/models/intermediate/micromasters/subqueries/__micromasters__users.sql
+++ b/src/ol_dbt/models/intermediate/micromasters/subqueries/__micromasters__users.sql
@@ -60,6 +60,7 @@ select
     , profiles.user_full_name
     , profiles.user_first_name
     , profiles.user_last_name
+    , profiles.user_birth_country
     , profiles.user_address_country
     , profiles.user_address_city
     , profiles.user_address_state_or_territory

--- a/src/ol_dbt/models/marts/combined/_marts__combined__models.yml
+++ b/src/ol_dbt/models/marts/combined/_marts__combined__models.yml
@@ -174,11 +174,13 @@ models:
   - name: user_full_name
     description: str, user full name on the platform user enrolled
   - name: user_country_code
-    description: str, country code on the platform user enrolled
+    description: str, country code on the platform user enrolled. May be blank.
   - name: user_highest_education
-    description: str, user's highest education on the platform user enrolled
+    description: str, user's highest education on the platform user enrolled. May
+      be blank.
   - name: user_company
-    description: str, user's company pulled on the platform user enrolled
+    description: str, user's company pulled on the platform user enrolled. May be
+      blank.
   - name: courseruncertificate_is_earned
     description: boolean, indicating if learner has earned the certificate on mitxonline.mit.edu,
       micromasters.mit.edu (legacy), edX.org or xpro.mit.edu.

--- a/src/ol_dbt/models/marts/combined/_marts__combined__models.yml
+++ b/src/ol_dbt/models/marts/combined/_marts__combined__models.yml
@@ -172,9 +172,13 @@ models:
     tests:
     - not_null
   - name: user_full_name
-    description: str, user full name from user's profile on the corresponding platform
+    description: str, user full name on the platform user enrolled
   - name: user_country_code
-    description: str, country code from the user's address on the corresponding platform
+    description: str, country code on the platform user enrolled
+  - name: user_highest_education
+    description: str, user's highest education on the platform user enrolled
+  - name: user_company
+    description: str, user's company pulled on the platform user enrolled
   - name: courseruncertificate_is_earned
     description: boolean, indicating if learner has earned the certificate on mitxonline.mit.edu,
       micromasters.mit.edu (legacy), edX.org or xpro.mit.edu.

--- a/src/ol_dbt/models/marts/combined/marts__combined_course_enrollment_detail.sql
+++ b/src/ol_dbt/models/marts/combined/marts__combined_course_enrollment_detail.sql
@@ -50,6 +50,10 @@ with mitx_enrollments as (
     select * from {{ ref('int__mitxpro__courses') }}
 )
 
+, combined_users as (
+    select * from {{ ref('int__combined__users') }}
+)
+
 , mitxonline_completed_orders as (
     select
         *
@@ -106,7 +110,9 @@ with mitx_enrollments as (
         , mitx_enrollments.user_username
         , mitx_enrollments.user_email
         , mitx_enrollments.user_full_name
-        , mitx_enrollments.user_address_country as user_country_code
+        , combined_users.user_address_country as user_country_code
+        , combined_users.user_highest_education
+        , combined_users.user_company
         , if(mitx_certificates.courseruncertificate_url is not null, true, false) as courseruncertificate_is_earned
         , mitx_certificates.courseruncertificate_created_on
         , mitx_certificates.courseruncertificate_url
@@ -141,6 +147,10 @@ with mitx_enrollments as (
         , mitx_courses.course_title
         , mitx_courses.course_readable_id
     from mitx_enrollments
+    left join combined_users
+        on
+            mitx_enrollments.user_mitxonline_username = combined_users.user_username
+            and mitx_enrollments.platform = combined_users.platform
     left join mitx_certificates
         on
             mitx_enrollments.user_mitxonline_username = mitx_certificates.user_mitxonline_username
@@ -176,7 +186,9 @@ with mitx_enrollments as (
         , mitx_enrollments.user_username
         , mitx_enrollments.user_email
         , mitx_enrollments.user_full_name
-        , mitx_enrollments.user_address_country as user_country_code
+        , combined_users.user_address_country as user_country_code
+        , combined_users.user_highest_education
+        , combined_users.user_company
         , if(mitx_certificates.courseruncertificate_url is not null, true, false) as courseruncertificate_is_earned
         , mitx_certificates.courseruncertificate_created_on
         , mitx_certificates.courseruncertificate_url
@@ -211,6 +223,10 @@ with mitx_enrollments as (
         , mitx_courses.course_title
         , mitx_courses.course_readable_id
     from mitx_enrollments
+    left join combined_users
+        on
+            mitx_enrollments.user_edxorg_username = combined_users.user_username
+            and mitx_enrollments.platform = combined_users.platform
     left join mitx_certificates
         on
             mitx_enrollments.user_edxorg_username = mitx_certificates.user_edxorg_username
@@ -249,7 +265,9 @@ with mitx_enrollments as (
         , mitxpro_enrollments.user_username
         , mitxpro_enrollments.user_email
         , mitxpro_enrollments.user_full_name
-        , mitxpro_enrollments.user_address_country as user_country_code
+        , combined_users.user_address_country as user_country_code
+        , combined_users.user_highest_education
+        , combined_users.user_company
         , if(mitxpro_certificates.courseruncertificate_url is not null, true, false) as courseruncertificate_is_earned
         , mitxpro_certificates.courseruncertificate_created_on
         , mitxpro_certificates.courseruncertificate_url
@@ -288,6 +306,10 @@ with mitx_enrollments as (
         , mitxpro_courses.course_title
         , mitxpro_courses.course_readable_id
     from mitxpro_enrollments
+    left join combined_users
+        on
+            mitxpro_enrollments.user_username = combined_users.user_username
+            and combined_users.platform = '{{ var("mitxpro") }}'
     left join mitxpro_certificates
         on
             mitxpro_enrollments.user_id = mitxpro_certificates.user_id
@@ -324,7 +346,9 @@ with mitx_enrollments as (
         , bootcamps_enrollments.user_username
         , bootcamps_enrollments.user_email
         , bootcamps_enrollments.user_full_name
-        , bootcamps_enrollments.user_address_country as user_country_code
+        , combined_users.user_address_country as user_country_code
+        , combined_users.user_highest_education
+        , combined_users.user_company
         , if(bootcamps_certificates.courseruncertificate_url is not null, true, false) as courseruncertificate_is_earned
         , bootcamps_certificates.courseruncertificate_created_on
         , bootcamps_certificates.courseruncertificate_url
@@ -359,6 +383,10 @@ with mitx_enrollments as (
         , bootcamps_courses.course_title
         , null as course_readable_id  --- to be populated after we add to bootcamp app
     from bootcamps_enrollments
+    left join combined_users
+        on
+            bootcamps_enrollments.user_username = combined_users.user_username
+            and combined_users.platform = '{{ var("bootcamps") }}'
     left join bootcamps_certificates
         on
             bootcamps_enrollments.user_id = bootcamps_certificates.user_id

--- a/src/ol_dbt/models/staging/micromasters/_stg_micromasters__models.yml
+++ b/src/ol_dbt/models/staging/micromasters/_stg_micromasters__models.yml
@@ -503,9 +503,10 @@ models:
   - name: user_birth_date
     description: timestamp, user's date of birth
   - name: user_birth_country
-    description: str, country where user was born, pulling from MicroMasters profile.
+    description: str, country code where user was born, pulling from MicroMasters
+      profile.
   - name: user_address_country
-    description: str, country where user lives in
+    description: str, country code where user lives in
   - name: user_address_city
     description: str, city where user lives in
   - name: user_address_state_or_territory

--- a/src/ol_dbt/models/staging/micromasters/_stg_micromasters__models.yml
+++ b/src/ol_dbt/models/staging/micromasters/_stg_micromasters__models.yml
@@ -502,6 +502,8 @@ models:
     description: str, user's Nickname / Preferred name
   - name: user_birth_date
     description: timestamp, user's date of birth
+  - name: user_birth_country
+    description: str, country where user was born, pulling from MicroMasters profile.
   - name: user_address_country
     description: str, country where user lives in
   - name: user_address_city

--- a/src/ol_dbt/models/staging/micromasters/stg__micromasters__app__postgres__profiles_profile.sql
+++ b/src/ol_dbt/models/staging/micromasters/stg__micromasters__app__postgres__profiles_profile.sql
@@ -9,6 +9,7 @@ with source as (
         id as user_profile_id
         , user_id
         , country as user_address_country
+        , birth_country as user_birth_country
         , city as user_address_city
         , state_or_territory as user_address_state_or_territory
         , postal_code as user_address_postal_code


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
Part of https://github.com/mitodl/hq/issues/3875

### Description (What does it do?)
<!--- Describe your changes in detail -->
- adding `user_birth_country` to int__micromasters__users and its upstream model (This field is only on MM at the moment)
- Adding a few user profile fields like user_highest_education, user_company and user_address_country to `marts__combined_course_enrollment_detail`

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->
```
dbt run --select int__micromasters__users
dbt run --select +marts__combined_course_enrollment_detail
```
