### PR TITLE
add readable_id and make it unique in bootcamps course staging model

### DIFF
--- a/src/ol_dbt/models/intermediate/bootcamps/_int_bootcamps__models.yml
+++ b/src/ol_dbt/models/intermediate/bootcamps/_int_bootcamps__models.yml
@@ -228,6 +228,8 @@ models:
     description: str, readable ID formatted as bootcamp-v1:{type}+{topic}-{format}.
       type is either 'public' or 'private', format is either ol (online) or f2f (face
       to face). May be null until data is populated in bootcamps application database.
+    tests:
+    - unique
 
 - name: int__bootcamps__course_runs
   description: Intermediate model for Bootcamps course runs

--- a/src/ol_dbt/models/staging/bootcamps/_bootcamps__sources.yml
+++ b/src/ol_dbt/models/staging/bootcamps/_bootcamps__sources.yml
@@ -131,6 +131,10 @@ sources:
     - name: legacy
       description: boolean, used to distinguish the older bootcamp courses from the
         newer ones
+    - name: readable_id
+      description: str, readable ID formatted as bootcamp-v1:{type}+{topic}-{format}.
+        type is either 'public' or 'private', format is either ol (online) or f2f
+        (face to face).
 
   - name: raw__bootcamps__app__postgres__klasses_bootcamprun
     columns:

--- a/src/ol_dbt/models/staging/bootcamps/_stg_bootcamps__models.yml
+++ b/src/ol_dbt/models/staging/bootcamps/_stg_bootcamps__models.yml
@@ -357,7 +357,10 @@ models:
   - name: course_readable_id
     description: str, readable ID formatted as bootcamp-v1:{type}+{topic}-{format}.
       type is either 'public' or 'private', format is either ol (online) or f2f (face
-      to face). May be null until data is populated in bootcamps application database.
+      to face). May be null until data is back-populated in bootcamps application
+      database.
+    tests:
+    - unique
 
 - name: stg__bootcamps__app__postgres__courses_courserun
   description: staging model for Bootcamps course runs

--- a/src/ol_dbt/models/staging/bootcamps/stg__bootcamps__app__postgres__courses_course.sql
+++ b/src/ol_dbt/models/staging/bootcamps/stg__bootcamps__app__postgres__courses_course.sql
@@ -8,7 +8,7 @@ with source as (
     select
         id as course_id
         , title as course_title
-        , '' as course_readable_id --- placeholder to add course_readable_id from bootcamps application
+        , readable_id as course_readable_id
     from source
 )
 


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
Close https://github.com/mitodl/hq/issues/3905

### Description (What does it do?)
<!--- Describe your changes in detail -->
Updating `readable_id` with source data to stg__bootcamps__app__postgres__courses_course, and making it unique field in dbt test
Note that there is currently no data for this field until back-populating is done in bootcamps repo. But data will just flow through at that point



### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->
dbt build --select stg__bootcamps__app__postgres__courses_course