### PR TITLE
Add courserun_is_current to combined course runs and enrollment mart

### DIFF
--- a/src/ol_dbt/models/intermediate/combined/_combined_models.yml
+++ b/src/ol_dbt/models/intermediate/combined/_combined_models.yml
@@ -211,3 +211,9 @@ models:
   - name: courserun_is_live
     description: boolean, indicating whether the course run is available to users
       on MITx Online and xPro. Null for Bootcamps and edx.org.
+  - name: courserun_is_current
+    description: boolean, indicating if the course run is currently running. True
+      if courserun_start_on is in the past and blank courserun_end_on, or courserun_start_on
+      is in the past and courserun_end_on is in the future.
+    tests:
+    - not_null

--- a/src/ol_dbt/models/intermediate/combined/_combined_models.yml
+++ b/src/ol_dbt/models/intermediate/combined/_combined_models.yml
@@ -205,9 +205,9 @@ models:
     - dbt_expectations.expect_column_values_to_not_be_null:
         row_condition: "platform != 'edX.org'"
   - name: courserun_start_on
-    description: timestamp, specifying when the course run begins
+    description: timestamp, specifying when the course run begins. May be Null.
   - name: courserun_end_on
-    description: timestamp, specifying when the course run ends
+    description: timestamp, specifying when the course run ends. May be Null.
   - name: courserun_is_live
     description: boolean, indicating whether the course run is available to users
       on MITx Online and xPro. Null for Bootcamps and edx.org.

--- a/src/ol_dbt/models/intermediate/combined/int__combined__course_runs.sql
+++ b/src/ol_dbt/models/intermediate/combined/int__combined__course_runs.sql
@@ -39,6 +39,17 @@ with mitx_courses as (
         , mitxonline_runs.courserun_start_on
         , mitxonline_runs.courserun_end_on
         , mitxonline_runs.courserun_is_live
+        , case
+            when
+                mitxonline_runs.courserun_end_on is null
+                and from_iso8601_timestamp(mitxonline_runs.courserun_start_on) <= current_date
+                then true
+            when
+                from_iso8601_timestamp(mitxonline_runs.courserun_start_on) <= current_date
+                and from_iso8601_timestamp(mitxonline_runs.courserun_end_on) > current_date
+                then true
+            else false
+        end as courserun_is_current
     from mitxonline_runs
     left join mitx_courses on mitxonline_runs.course_number = mitx_courses.course_number
     where mitxonline_runs.courserun_platform = '{{ var("mitxonline") }}'
@@ -55,6 +66,17 @@ with mitx_courses as (
         , edxorg_runs.courserun_start_date as courserun_start_on
         , edxorg_runs.courserun_end_date as courserun_end_on
         , null as courserun_is_live
+        , case
+            when
+                edxorg_runs.courserun_end_date is null
+                and from_iso8601_timestamp(edxorg_runs.courserun_start_date) <= current_date
+                then true
+            when
+                from_iso8601_timestamp(edxorg_runs.courserun_start_date) <= current_date
+                and from_iso8601_timestamp(edxorg_runs.courserun_end_date) > current_date
+                then true
+            else false
+        end as courserun_is_current
     from edxorg_runs
     left join mitx_courses on edxorg_runs.course_number = mitx_courses.course_number
 
@@ -70,6 +92,17 @@ with mitx_courses as (
         , mitxpro_runs.courserun_start_on
         , mitxpro_runs.courserun_end_on
         , mitxpro_runs.courserun_is_live
+        , case
+            when
+                mitxpro_runs.courserun_end_on is null
+                and from_iso8601_timestamp(mitxpro_runs.courserun_start_on) <= current_date
+                then true
+            when
+                from_iso8601_timestamp(mitxpro_runs.courserun_start_on) <= current_date
+                and from_iso8601_timestamp(mitxpro_runs.courserun_end_on) > current_date
+                then true
+            else false
+        end as courserun_is_current
     from mitxpro_runs
     left join mitxpro_courses on mitxpro_runs.course_id = mitxpro_courses.course_id
 
@@ -85,6 +118,17 @@ with mitx_courses as (
         , bootcamps_runs.courserun_start_on
         , bootcamps_runs.courserun_end_on
         , null as courserun_is_live
+        , case
+            when
+                bootcamps_runs.courserun_end_on is null
+                and from_iso8601_timestamp(bootcamps_runs.courserun_start_on) <= current_date
+                then true
+            when
+                from_iso8601_timestamp(bootcamps_runs.courserun_start_on) <= current_date
+                and from_iso8601_timestamp(bootcamps_runs.courserun_end_on) > current_date
+                then true
+            else false
+        end as courserun_is_current
     from bootcamps_runs
     left join bootcamps_courses on bootcamps_runs.course_id = bootcamps_courses.course_id
 

--- a/src/ol_dbt/models/marts/combined/_marts__combined__models.yml
+++ b/src/ol_dbt/models/marts/combined/_marts__combined__models.yml
@@ -162,7 +162,13 @@ models:
     description: str, unique string to identify a course run on the corresponding
       platform
   - name: courserun_start_on
-    description: timestamp, date and time when the course starts
+    description: timestamp, date and time when the course run starts
+  - name: courserun_end_on
+    description: timestamp, date and time when the course run ends
+  - name: courserun_is_current
+    description: boolean, indicating if the course run is currently running. True
+      if courserun_start_on is in the past and blank courserun_end_on, or courserun_start_on
+      is in the past and courserun_end_on is in the future.
   - name: user_username
     description: string, username to identify a user on the corresponding platform
     tests:

--- a/src/ol_dbt/models/marts/combined/_marts__combined__models.yml
+++ b/src/ol_dbt/models/marts/combined/_marts__combined__models.yml
@@ -169,6 +169,8 @@ models:
     description: boolean, indicating if the course run is currently running. True
       if courserun_start_on is in the past and blank courserun_end_on, or courserun_start_on
       is in the past and courserun_end_on is in the future.
+    tests:
+    - not_null
   - name: user_username
     description: string, username to identify a user on the corresponding platform
     tests:

--- a/src/ol_dbt/models/marts/combined/_marts__combined__models.yml
+++ b/src/ol_dbt/models/marts/combined/_marts__combined__models.yml
@@ -162,9 +162,9 @@ models:
     description: str, unique string to identify a course run on the corresponding
       platform
   - name: courserun_start_on
-    description: timestamp, date and time when the course run starts
+    description: timestamp, date and time when the course run starts. May be Null.
   - name: courserun_end_on
-    description: timestamp, date and time when the course run ends
+    description: timestamp, date and time when the course run ends. May be Null.
   - name: courserun_is_current
     description: boolean, indicating if the course run is currently running. True
       if courserun_start_on is in the past and blank courserun_end_on, or courserun_start_on

--- a/src/ol_dbt/models/marts/combined/marts__combined_course_enrollment_detail.sql
+++ b/src/ol_dbt/models/marts/combined/marts__combined_course_enrollment_detail.sql
@@ -90,7 +90,9 @@ with mitx_enrollments as (
         , mitx_enrollments.courserun_id
         , mitx_enrollments.courserun_title
         , mitx_enrollments.courserun_readable_id
-        , mitx_enrollments.courserun_start_on
+        , combined_courseruns.courserun_start_on
+        , combined_courseruns.courserun_end_on
+        , combined_courseruns.courserun_is_current
         , mitx_enrollments.user_username
         , mitx_enrollments.user_email
         , mitx_enrollments.user_full_name
@@ -166,7 +168,9 @@ with mitx_enrollments as (
         , mitx_enrollments.courserun_id
         , mitx_enrollments.courserun_title
         , mitx_enrollments.courserun_readable_id
-        , mitx_enrollments.courserun_start_on
+        , combined_courseruns.courserun_start_on
+        , combined_courseruns.courserun_end_on
+        , combined_courseruns.courserun_is_current
         , mitx_enrollments.user_username
         , mitx_enrollments.user_email
         , mitx_enrollments.user_full_name
@@ -245,7 +249,9 @@ with mitx_enrollments as (
         , mitxpro_enrollments.courserun_id
         , mitxpro_enrollments.courserun_title
         , mitxpro_enrollments.courserun_readable_id
-        , mitxpro_enrollments.courserun_start_on
+        , combined_courseruns.courserun_start_on
+        , combined_courseruns.courserun_end_on
+        , combined_courseruns.courserun_is_current
         , mitxpro_enrollments.user_username
         , mitxpro_enrollments.user_email
         , mitxpro_enrollments.user_full_name
@@ -324,7 +330,9 @@ with mitx_enrollments as (
         , bootcamps_enrollments.courserun_id
         , bootcamps_enrollments.courserun_title
         , bootcamps_enrollments.courserun_readable_id
-        , bootcamps_enrollments.courserun_start_on
+        , combined_courseruns.courserun_start_on
+        , combined_courseruns.courserun_end_on
+        , combined_courseruns.courserun_is_current
         , bootcamps_enrollments.user_username
         , bootcamps_enrollments.user_email
         , bootcamps_enrollments.user_full_name


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
The last code change for https://github.com/mitodl/hq/issues/3875

### Description (What does it do?)
<!--- Describe your changes in detail -->
Adding `courserun_is_current` and the relevant date fields to int__combined__course_runs and marts__combined_course_enrollment_detail
  - `courserun_is_current` is true if courserun_start_on is in the past and blank courserun_end_on, OR courserun_start_on
      is in the past and courserun_end_on is in the future.
  -  there are some old edx.org runs e.g.  MITx/8.02.2x/2T2019 where blank courserun_end_on with courserun_start_on is in the past, but that is data issue we get from BigQuery

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->
dbt build --select int__combined__course_runs
dbt build --select marts__combined_course_enrollment_detail
