### PR TITLE
simplify Micromasters dedp indicator in intermediate and mart tables

### DIFF
--- a/src/ol_dbt/models/intermediate/micromasters/_int_micromasters__models.yml
+++ b/src/ol_dbt/models/intermediate/micromasters/_int_micromasters__models.yml
@@ -297,9 +297,6 @@ models:
       created
     tests:
     - not_null
-  - name: program_is_dedp
-    description: boolean, specifying if the program is DEDP from the mixonline program
-      id
   tests:
   - dbt_expectations.expect_compound_columns_to_be_unique:
       column_list: ["user_email", "courserun_readable_id", "micromasters_program_id",

--- a/src/ol_dbt/models/intermediate/micromasters/int__micromasters__course_certificates.sql
+++ b/src/ol_dbt/models/intermediate/micromasters/int__micromasters__course_certificates.sql
@@ -119,7 +119,6 @@ with course_certificates_dedp_from_micromasters as (
         , courseruncertificate_uuid
         , courseruncertificate_url
         , courseruncertificate_created_on
-        , if(mitxonline_program_id in (1, 2, 3), true, false) as program_is_dedp
     from dedp_course_certificates
 
     union all
@@ -140,7 +139,6 @@ with course_certificates_dedp_from_micromasters as (
         , courseruncertificate_download_uuid as courseruncertificate_uuid
         , courseruncertificate_download_url as courseruncertificate_url
         , courseruncertificate_created_on
-        , false as program_is_dedp
     from course_certificates_non_dedp_program
 )
 

--- a/src/ol_dbt/models/intermediate/micromasters/int__micromasters__course_enrollments.sql
+++ b/src/ol_dbt/models/intermediate/micromasters/int__micromasters__course_enrollments.sql
@@ -24,7 +24,7 @@ select
     , mitx_enrollments.courserunenrollment_is_active
     , mitx_enrollments.courserun_title
     , mitx_enrollments.courserunenrollment_enrollment_mode
-    , if(mitx_enrollments.mitxonline_program_id in (1, 2, 3), true, false) as program_is_dedp
+    , programs.is_dedp_program as program_is_dedp
 from mitx_enrollments
 inner join programs
     on

--- a/src/ol_dbt/models/marts/micromasters/marts__micromasters_summary.sql
+++ b/src/ol_dbt/models/marts/micromasters/marts__micromasters_summary.sql
@@ -21,9 +21,12 @@ with micromasters_enrollments as (
 , enrollments as (
     select
         case when
-            micromasters_enrollments.program_is_dedp = true then 'Data, Economics, and Design of Policy'
+            mitx_programs.is_dedp_program = true then 'Data, Economics, and Design of Policy'
         else micromasters_enrollments.program_title end as program_title
-        , count(distinct micromasters_enrollments.courserun_readable_id || user_email) as total_enrollments
+        , count(
+            distinct micromasters_enrollments.courserun_readable_id 
+            || micromasters_enrollments.user_email
+        ) as total_enrollments
         , count(distinct micromasters_enrollments.user_email) as unique_users
         , count(distinct micromasters_enrollments.user_address_country) as unique_countries
         , count(distinct case
@@ -35,13 +38,17 @@ with micromasters_enrollments as (
                 then micromasters_enrollments.user_email
         end) as unique_verified_users
     from micromasters_enrollments
+    inner join mitx_programs
+        on 
+            micromasters_enrollments.micromasters_program_id = mitx_programs.micromasters_program_id
+            or micromasters_enrollments.mitxonline_program_id = mitx_programs.mitxonline_program_id
     group by 1
 )
 
 , course_certs as (
     select
         case when
-            micromasters_course_certificates.program_is_dedp = true then 'Data, Economics, and Design of Policy'
+            mitx_programs.is_dedp_program = true then 'Data, Economics, and Design of Policy'
         else micromasters_course_certificates.program_title end as program_title
         , count(
             distinct
@@ -50,6 +57,10 @@ with micromasters_enrollments as (
         ) as course_certificates
         , count(distinct micromasters_course_certificates.user_email) as unique_course_certificate_earners
     from micromasters_course_certificates
+    inner join mitx_programs
+        on 
+            micromasters_course_certificates.micromasters_program_id = mitx_programs.micromasters_program_id
+            or micromasters_course_certificates.mitxonline_program_id = mitx_programs.mitxonline_program_id
     group by 1
 )
 

--- a/src/ol_dbt/models/marts/micromasters/marts__micromasters_summary.sql
+++ b/src/ol_dbt/models/marts/micromasters/marts__micromasters_summary.sql
@@ -24,7 +24,7 @@ with micromasters_enrollments as (
             mitx_programs.is_dedp_program = true then 'Data, Economics, and Design of Policy'
         else micromasters_enrollments.program_title end as program_title
         , count(
-            distinct micromasters_enrollments.courserun_readable_id 
+            distinct micromasters_enrollments.courserun_readable_id
             || micromasters_enrollments.user_email
         ) as total_enrollments
         , count(distinct micromasters_enrollments.user_email) as unique_users
@@ -39,7 +39,7 @@ with micromasters_enrollments as (
         end) as unique_verified_users
     from micromasters_enrollments
     inner join mitx_programs
-        on 
+        on
             micromasters_enrollments.micromasters_program_id = mitx_programs.micromasters_program_id
             or micromasters_enrollments.mitxonline_program_id = mitx_programs.mitxonline_program_id
     group by 1
@@ -58,7 +58,7 @@ with micromasters_enrollments as (
         , count(distinct micromasters_course_certificates.user_email) as unique_course_certificate_earners
     from micromasters_course_certificates
     inner join mitx_programs
-        on 
+        on
             micromasters_course_certificates.micromasters_program_id = mitx_programs.micromasters_program_id
             or micromasters_course_certificates.mitxonline_program_id = mitx_programs.mitxonline_program_id
     group by 1

--- a/src/ol_dbt/models/marts/micromasters/marts__micromasters_summary.sql
+++ b/src/ol_dbt/models/marts/micromasters/marts__micromasters_summary.sql
@@ -24,7 +24,7 @@ with micromasters_enrollments as (
             mitx_programs.is_dedp_program = true then 'Data, Economics, and Design of Policy'
         else micromasters_enrollments.program_title end as program_title
         , count(
-            distinct micromasters_enrollments.courserun_readable_id
+            distinct micromasters_enrollments.courserun_readable_id 
             || micromasters_enrollments.user_email
         ) as total_enrollments
         , count(distinct micromasters_enrollments.user_email) as unique_users
@@ -39,7 +39,7 @@ with micromasters_enrollments as (
         end) as unique_verified_users
     from micromasters_enrollments
     inner join mitx_programs
-        on
+        on 
             micromasters_enrollments.micromasters_program_id = mitx_programs.micromasters_program_id
             or micromasters_enrollments.mitxonline_program_id = mitx_programs.mitxonline_program_id
     group by 1
@@ -58,7 +58,7 @@ with micromasters_enrollments as (
         , count(distinct micromasters_course_certificates.user_email) as unique_course_certificate_earners
     from micromasters_course_certificates
     inner join mitx_programs
-        on
+        on 
             micromasters_course_certificates.micromasters_program_id = mitx_programs.micromasters_program_id
             or micromasters_course_certificates.mitxonline_program_id = mitx_programs.mitxonline_program_id
     group by 1
@@ -66,7 +66,9 @@ with micromasters_enrollments as (
 
 , program_certs as (
     select
-        mitx_programs.program_title
+        case when
+            mitx_programs.is_dedp_program = true then 'Data, Economics, and Design of Policy'
+        else micromasters_program_certificates.program_title end as program_title
         , count(distinct micromasters_program_certificates.user_email) as program_certificates
     from micromasters_program_certificates
     inner join mitx_programs


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/3934

### Description (What does it do?)
Eliminate dedp indicator field from int__micromasters__course_certificates it's only used in the marts__micromasters_summary and there we added code to pull it from int__mitx__programs there. Replaced complicated if statement on int__micromasters__course_enrollments with the is_dedp_program field on int__mitx__programs.  These changes are based on feedback from Rachel as well.

### How can this be tested?
dbt build --select int__micromasters__course_certificates
dbt build --select int__micromasters__course_enrollments
dbt build --select marts__micromasters_summary


