### PR TITLE
fix dbt test not_null on courserun_is_current in combined enrollment mart

### DIFF
--- a/src/ol_dbt/models/marts/combined/marts__combined_course_enrollment_detail.sql
+++ b/src/ol_dbt/models/marts/combined/marts__combined_course_enrollment_detail.sql
@@ -170,7 +170,8 @@ with mitx_enrollments as (
         , mitx_enrollments.courserun_readable_id
         , combined_courseruns.courserun_start_on
         , combined_courseruns.courserun_end_on
-        , combined_courseruns.courserun_is_current
+        , if(combined_courseruns.courserun_is_current is null, false, combined_courseruns.courserun_is_current)
+        as courserun_is_current
         , mitx_enrollments.user_username
         , mitx_enrollments.user_email
         , mitx_enrollments.user_full_name


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
NA

### Description (What does it do?)
<!--- Describe your changes in detail -->
This is to address the is_null test on `courserun_is_current` in marts__combined_course_enrollment_detail https://pipelines.odl.mit.edu/runs/d97dcabe-ada3-499b-887c-87cca6cecdf8. A few edx.org course runs don't have courserun_is_current populated in the mart due to missing data from BigQuery. We can assume these runs are not current.

MITx/Launch.x_3/1T2017
MITx/20.305x/1T2019
MITx/CTL.CFx/1T18U1
MITx/CTL.CFx/1T18U5
MITx/CTL.CFx/1T18U8
MITx/14.100PEx/3T2020

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

Tests should all pass now

dbt build --select marts__combined_course_enrollment_detail


### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->


<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
