### PR TITLE
remove test for micromasters users without profiles

### DIFF
--- a/src/ol_dbt/models/intermediate/micromasters/subqueries/__int_micromasters_subqueries__models.yml
+++ b/src/ol_dbt/models/intermediate/micromasters/subqueries/__int_micromasters_subqueries__models.yml
@@ -99,8 +99,8 @@ models:
     description: str, user's Nickname / Preferred name
   - name: user_profile_id
     description: int, foreign key to profiles_profile
-    tests:
-    - not_null
+#    tests: #some users don't have info on the profile table
+#    - not_null
   - name: user_profile_is_filled_out
     description: boolean, whether user filled out the profile
   - name: user_profile_parental_consent_is_required


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/4062

### Description (What does it do?)
There is currently a test to check if user_profile_id on __micromasters__users is null. However, users can exist without profiles so we should remove the test.

### How can this be tested?
dbt build --select __micromasters__users