### PR TITLE
staging edxorg course enrollment and grade

### DIFF
--- a/src/ol_dbt/macros/apply_deduplication_query.sql
+++ b/src/ol_dbt/macros/apply_deduplication_query.sql
@@ -1,15 +1,15 @@
-{% macro deduplicate_query(cte_name1='source', cte_name2='most_recent_source') %}
+{% macro deduplicate_query(cte_name1='source', cte_name2='most_recent_source', partition_columns='id') %}
     /*
         Add additional queries to handle duplicated data introduced by airbyte sync mode "Incremental Sync - Append"
         where cursor is set to a timestamp field. The deduplication logic works like this:
-        - If there are multiple copies of the same record based on primary key id, we will use the record from most
+        - If there are multiple copies of the same record based on partition_columns, we will use the record from most
           recent sync in the source table.
-        - If there is only one record for the same primary key id, it will just load that record as it is.
+        - If there is only one record for the same partition_columns, it will just load that record as it is.
     */
    , source_sorted as (
         select
             *
-            , row_number() over ( partition by id order by _airbyte_emitted_at desc) as row_num
+            , row_number() over ( partition by {{ partition_columns }} order by _airbyte_emitted_at desc) as row_num
         from {{ cte_name1 }}
     )
 

--- a/src/ol_dbt/models/staging/edxorg/_edxorg_sources.yml
+++ b/src/ol_dbt/models/staging/edxorg/_edxorg_sources.yml
@@ -82,8 +82,8 @@ sources:
       description: str
 
   - name: raw__irx__edxorg__bigquery__mitx_person_course
-    description: source table contains user activities from edX.org, MITxOnline/xPro
-      open edx and certain enrollment/certificate fields from edx.org
+    description: IRx source table contains user activities from edX.org, MITxOnline/xPro
+      open edx and certain enrollment/certificate fields
     columns:
     - name: course_id
       description: str, The canonical ID of the course in the format as {org}/{course
@@ -430,9 +430,9 @@ sources:
         handle
 
   - name: raw__irx__edxorg__bigquery__email_opt_in
-    description: It contains email opt-in preferences for edX.org courses. If users
-      enroll in multiple courses, the email and username in this table are expected
-      to be the most recent data.
+    description: It contains email opt-in preferences for edX.org courses provided
+      by IRx. If users enroll in multiple courses, the email and username in this
+      table are expected to be the most recent data.
     columns:
     - name: course_id
       description: str, The canonical ID of the course in the format as {org}/{course}/{run}.
@@ -596,3 +596,49 @@ sources:
       description: str, internal used field for log file location
     - name: _ab_source_file_url
       description: str, url path for the raw log file
+
+  - name: raw__edxorg__s3__tables__student_courseenrollment
+    description: edX.org course enrollments ingested from CSV files on OL S3 bucket
+    columns:
+    - name: id
+      description: str, primary key for course run enrollment
+    - name: course_id
+      description: str, open edX Course Key formatted as course-v1:org+course_number+run.
+    - name: user_id
+      description: str, user ID on edX.org
+    - name: mode
+      description: str, indicating what kind of enrollment it is. Possible values
+        are honor, audit, credit, verified, unpaid-executive-education, professional,
+        no-id-professional.
+    - name: is_active
+      description: str, indicating whether this enrollment is active
+    - name: created
+      description: str, time when this enrollment was created
+
+  - name: raw__edxorg__s3__tables__grades_persistentcoursegrade
+    description: edx.org course grades ingested from CSV files on OL S3 bucket
+    columns:
+    - name: course_id
+      description: str, open edX Course Key formatted as course-v1:org+course_number+run.
+    - name: user_id
+      description: str, user ID on edX.org
+    - name: grading_policy_hash
+      description: str, a SHA-1 digest of the course grading policy, used to detect
+        and update grades whenever the policy changes
+    - name: percent_grade
+      description: str, calculated course grade as a decimal percentage, per grading
+        policy. e.g. 0.91 means 91%
+    - name: letter_grade
+      description: str, calculated course grade as a letter value (e.g., A-D, Pass),
+        per grading policy If the learner's grade is Fail or F, this value is empty.
+    - name: passed_timestamp
+      description: timestamp, date and time when the learner first passed the course.
+        If this value is empty, the learner never passed the course. If this value
+        is non-empty but the letter_grade value is empty, the learner transitioned
+        from passing to not passing.
+    - name: created
+      description: str, time when the course grade was first calculated for this user
+        for this course run.
+    - name: modified
+      description: str, time when the course grade was was last updated for this user
+        for this course run

--- a/src/ol_dbt/models/staging/edxorg/_stg__edxorg__models.yml
+++ b/src/ol_dbt/models/staging/edxorg/_stg__edxorg__models.yml
@@ -516,3 +516,79 @@ models:
   - dbt_expectations.expect_compound_columns_to_be_unique:
       column_list: ["user_username", "useractivity_context_object", "useractivity_event_source",
         "useractivity_event_type", "useractivity_event_object", "useractivity_timestamp"]
+
+- name: stg__edxorg__s3__courserun_enrollment
+  description: edX.org course run enrollments
+  columns:
+  - name: courserunenrollment_id
+    description: int, primary key for course enrollment
+    tests:
+    - unique
+    - not_null
+  - name: courserun_readable_id
+    description: str, open edX Course Key formatted as course-v1:org+course_number+run.
+    tests:
+    - not_null
+  - name: user_id
+    description: int, user ID on edX.org
+    tests:
+    - not_null
+  - name: courserunenrollment_mode
+    description: str, indicating what kind of enrollment it is. Possible values are
+      honor, audit, credit, verified, unpaid-executive-education, professional, no-id-professional.
+    tests:
+    - not_null
+  - name: courserunenrollment_is_active
+    description: str, indicating whether this enrollment is active
+    tests:
+    - not_null
+  - name: courserunenrollment_created_on
+    description: timestamp, time when this enrollment was created
+    tests:
+    - not_null
+  tests:
+  - dbt_expectations.expect_compound_columns_to_be_unique:
+      column_list: ["user_id", "courserun_readable_id"]
+
+- name: stg__edxorg__s3__courserun_grade
+  description: edx.org course grades ingested from CSV files on OL S3 bucket
+  columns:
+  - name: courserun_readable_id
+    description: str, open edX Course Key formatted as course-v1:org+course_number+run.
+    tests:
+    - not_null
+  - name: user_id
+    description: int, user ID on edX.org
+    tests:
+    - not_null
+  - name: courserungrade_grading_policy_hash
+    description: str, a SHA-1 digest of the course grading policy, used to detect
+      and update grades whenever the policy changes
+    tests:
+    - not_null
+  - name: courserungrade_grade
+    description: float, calculated course grade as a decimal percentage, per grading
+      policy. e.g. 0.91 means 91%
+    tests:
+    - not_null
+  - name: courserungrade_letter_grade
+    description: str, calculated course grade as a letter value (e.g., A-D, Pass),
+      per grading policy If the learner's grade is Fail or F, this value is empty.
+  - name: courserungrade_first_passed_on
+    description: timestamp, date and time when the learner first passed the course.
+      If this value is empty, the learner never passed the course. If this value is
+      non-empty but the letter_grade value is empty, the learner transitioned from
+      passing to not passing.
+  - name: courserungrade_created_on
+    description: timestamp, time when the course grade was first calculated for this
+      user for this course run.
+    tests:
+    - not_null
+  - name: courserungrade_updated_on
+    description: timestamp, time when the course grade was was last updated for this
+      user for this course run
+    tests:
+    - not_null
+  tests:
+  - dbt_expectations.expect_compound_columns_to_be_unique:
+      column_list: ["user_id", "courserun_readable_id"]

--- a/src/ol_dbt/models/staging/edxorg/_stg__edxorg__models.yml
+++ b/src/ol_dbt/models/staging/edxorg/_stg__edxorg__models.yml
@@ -539,11 +539,11 @@ models:
     tests:
     - not_null
   - name: courserunenrollment_is_active
-    description: str, indicating whether this enrollment is active
+    description: boolean, indicating whether this enrollment is active
     tests:
     - not_null
   - name: courserunenrollment_created_on
-    description: timestamp, time when this enrollment was created
+    description: timestamp, date and time when this enrollment was created
     tests:
     - not_null
   tests:
@@ -580,13 +580,13 @@ models:
       non-empty but the letter_grade value is empty, the learner transitioned from
       passing to not passing.
   - name: courserungrade_created_on
-    description: timestamp, time when the course grade was first calculated for this
-      user for this course run.
+    description: timestamp, date and time when the course grade was first calculated
+      for this user for this course run.
     tests:
     - not_null
   - name: courserungrade_updated_on
-    description: timestamp, time when the course grade was was last updated for this
-      user for this course run
+    description: timestamp, date and time when the course grade was was last updated
+      for this user for this course run
     tests:
     - not_null
   tests:

--- a/src/ol_dbt/models/staging/edxorg/stg__edxorg__s3__courserun_enrollment.sql
+++ b/src/ol_dbt/models/staging/edxorg/stg__edxorg__s3__courserun_enrollment.sql
@@ -1,0 +1,19 @@
+with source as (
+    select * from {{ source('ol_warehouse_raw_data', 'raw__edxorg__s3__tables__student_courseenrollment') }}
+)
+
+{{ deduplicate_query(cte_name1='source', cte_name2='most_recent_source', partition_columns='id') }}
+
+, cleaned as (
+    --- all values are ingested as string, so we need to cast here to match other data sources
+    select
+        cast(id as integer) as courserunenrollment_id
+        , course_id as courserun_readable_id
+        , cast(user_id as integer) as user_id
+        , cast(is_active as integer) as courserunenrollment_is_active
+        , mode as courserunenrollment_mode
+        , to_iso8601(date_parse(created, '%Y-%m-%d %H:%i:%s')) as courserunenrollment_created_on
+    from most_recent_source
+)
+
+select * from cleaned

--- a/src/ol_dbt/models/staging/edxorg/stg__edxorg__s3__courserun_enrollment.sql
+++ b/src/ol_dbt/models/staging/edxorg/stg__edxorg__s3__courserun_enrollment.sql
@@ -10,7 +10,7 @@ with source as (
         cast(id as integer) as courserunenrollment_id
         , course_id as courserun_readable_id
         , cast(user_id as integer) as user_id
-        , cast(is_active as integer) as courserunenrollment_is_active
+        , cast(is_active as boolean) as courserunenrollment_is_active
         , mode as courserunenrollment_mode
         , to_iso8601(date_parse(created, '%Y-%m-%d %H:%i:%s')) as courserunenrollment_created_on
     from most_recent_source

--- a/src/ol_dbt/models/staging/edxorg/stg__edxorg__s3__courserun_grade.sql
+++ b/src/ol_dbt/models/staging/edxorg/stg__edxorg__s3__courserun_grade.sql
@@ -1,0 +1,31 @@
+with source as (
+    select * from {{ source('ol_warehouse_raw_data','raw__edxorg__s3__tables__grades_persistentcoursegrade') }}
+)
+
+{{ deduplicate_query(cte_name1='source', cte_name2='most_recent_source' , partition_columns = 'course_id, user_id') }}
+
+, cleaned as (
+    select
+        ---all values are ingested as string, so we need to cast here to match other data sources
+        course_id as courserun_readable_id
+        , cast(user_id as integer) as user_id
+        , cast(percent_grade as decimal(38, 2)) as courserungrade_grade
+        , letter_grade as courserungrade_letter_grade
+        , grading_policy_hash as courserungrade_grading_policy_hash
+        , case
+            when passed_timestamp = 'NULL' then null
+            else to_iso8601(from_iso8601_timestamp_nanos(
+                regexp_replace(passed_timestamp, '(\d{4}-\d{2}-\d{2})[ ](\d{2}:\d{2}:\d{2})(.*?)', '$1T$2$3')
+            ))
+        end as courserungrade_first_passed_on
+        --- use regex here to preserve the faction of second if value uses nanosecond
+        , to_iso8601(from_iso8601_timestamp_nanos(
+            regexp_replace(created, '(\d{4}-\d{2}-\d{2})[ ](\d{2}:\d{2}:\d{2})(.*?)', '$1T$2$3')
+        )) as courserungrade_created_on
+        , to_iso8601(from_iso8601_timestamp_nanos(
+            regexp_replace(modified, '(\d{4}-\d{2}-\d{2})[ ](\d{2}:\d{2}:\d{2})(.*?)', '$1T$2$3')
+        )) as courserungrade_updated_on
+    from most_recent_source
+)
+
+select * from cleaned


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
Part of https://github.com/mitodl/hq/issues/4067, the rest of the raw tables mentioned in the issue are not ready yet

### Description (What does it do?)
<!--- Describe your changes in detail -->
Adding `stg__edxorg__s3__courserun_grade` and `stg__edxorg__s3__courserun_enrollment` 
  - fields are converted to the proper data types as raw fields are all ingested as string
  - data is deduplicated

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

 dbt build --select stg__edxorg__s3__courserun_enrollment
 dbt build --select stg__edxorg__s3__courserun_grade
