### PR TITLE
fix test failure on program enrollment model

### DIFF
--- a/src/ol_dbt/models/intermediate/edxorg/int__edxorg__mitx_program_enrollments.sql
+++ b/src/ol_dbt/models/intermediate/edxorg/int__edxorg__mitx_program_enrollments.sql
@@ -8,27 +8,29 @@ with program_learners as (
     where is_micromasters_program = true
 )
 
+, program_learners_sorted as (
+    select
+        *
+        , row_number() over (
+            partition by user_id, program_uuid
+            order by program_certificate_awarded_on desc, courserunenrollment_created_on desc
+        ) as row_num
+    from program_learners
+)
+
 select
-    program_learners.program_type
-    , program_learners.program_uuid
-    , program_learners.program_title
-    , program_learners.user_id
-    , program_learners.user_username
-    , program_learners.user_full_name
-    , program_learners.user_has_completed_program
+    program_learners_sorted.program_type
+    , program_learners_sorted.program_uuid
+    , program_learners_sorted.program_title
+    , program_learners_sorted.user_id
+    , program_learners_sorted.user_username
+    , program_learners_sorted.user_full_name
+    , program_learners_sorted.user_has_completed_program
     , micromasters_programs.micromasters_program_id
-from program_learners
+from program_learners_sorted
 left join micromasters_programs
     on (
-        program_learners.program_title like micromasters_programs.program_title || '%'
-        or program_learners.program_title like '%' || micromasters_programs.program_title
+        program_learners_sorted.program_title like micromasters_programs.program_title || '%'
+        or program_learners_sorted.program_title like '%' || micromasters_programs.program_title
     )
-group by
-    program_learners.program_type
-    , program_learners.program_uuid
-    , program_learners.program_title
-    , program_learners.user_id
-    , program_learners.user_username
-    , program_learners.user_full_name
-    , program_learners.user_has_completed_program
-    , micromasters_programs.micromasters_program_id
+where program_learners_sorted.row_num = 1


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
NA

### Description (What does it do?)
<!--- Describe your changes in detail -->
This fixes dbt test failure on `int__edxorg__mitx_program_enrollments`. https://pipelines.odl.mit.edu/runs/bdbaf769-bb9c-491b-9a36-62043881ecd4
```
Warning in test dbt_expectations_expect_compound_columns_to_be_unique_int__edxorg__mitx_program_enrollments_user_id__program_uuid (models/intermediate/edxorg/_int_edxorg__models.yml)
Got 6 results, configured to warn if != 0


Warning in test dbt_expectations_expect_compound_columns_to_be_unique_marts__combined_program_enrollment_detail_program_title__user_username__programenrollment_created_on (models/marts/combined/_marts__combined__models.yml)
```

```
select count(*), program_uuid, user_id 
from "ol_data_lake_production"."ol_warehouse_production_intermediate".int__edxorg__mitx_program_enrollments
group by user_id,program_uuid
having count(*) > 1
```
These duplicated rows are due to different `user_username` for the same `user_id` (e.g. retired user) in stg__edxorg__s3__program_learner_report. In this intermediate, it's grouped by both user_id and user_username  so it failed on unique test  ["user_id", "program_uuid"] because of different `user_username` values.



### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->
Run these commands and the test should all pass now
```
dbt run --select stg__edxorg__s3__program_learner_report
dbt build --select int__edxorg__mitx_program_enrollments
dbt build --select marts__combined_program_enrollment_detail
```
