### PR TITLE
Refactoring import for AirbyteConnectionMetadata to resolve import error.

### DIFF
--- a/src/ol_orchestrate/definitions/lakehouse/elt.py
+++ b/src/ol_orchestrate/definitions/lakehouse/elt.py
@@ -11,11 +11,8 @@ from dagster import (
     define_asset_job,
     load_assets_from_current_module,
 )
-from dagster_airbyte import (
-    AirbyteConnectionMetadata,
-    airbyte_resource,
-    load_assets_from_airbyte_instance,
-)
+from dagster_airbyte import airbyte_resource, load_assets_from_airbyte_instance
+from dagster_airbyte.asset_defs import AirbyteConnectionMetadata
 from dagster_dbt import (
     dbt_cli_resource,
     load_assets_from_dbt_manifest,


### PR DESCRIPTION
### What are the relevant tickets?
This PR was created to address a bug from [these changes to exclude paused Airbyte syncs](https://github.com/mitodl/ol-data-platform/pull/1106). The changes require the AirbyteConnectionMetadata class, which stores the status of the existing Airbyte connections. The import statement is not pulling from the correct package (dagster_airbyte.asset_defs) and we are seeing the following import error when dagster attempts to load the [pipeline definitions](https://pipelines.odl.mit.edu/locations).
`ImportError: cannot import name 'AirbyteConnectionMetadata' from 'dagster_airbyte'`

### Description (What does it do?)
There are examples of the correct way to import AirbyteConnectionMetadata online:
https://github.com/dagster-io/dagster/issues/15733
The import statement has been revised to pull the metadata class from dagster_airbyte.asset_defs.

### How can this be tested?
Make sure connections are paused in QA.
Initiate a new airbyte_asset_sync job.
Confirm that the pipeline run didn't fail due to the paused connections.