### PR TITLE
add missing mart program enroll records

### DIFF
--- a/src/ol_dbt/models/intermediate/micromasters/_int_micromasters__models.yml
+++ b/src/ol_dbt/models/intermediate/micromasters/_int_micromasters__models.yml
@@ -583,9 +583,8 @@ models:
   - name: user_year_of_birth
     description: str, user's birth year from user's profile on MITx Online or MicroMasters.
   - name: platform_name
-    description: str, a field indicating if the data is pulled from MITx Online or
-      edx.org.
+    description: str, a field indicating if the data is pulled from MITx Online or edx.org.
   tests:
   - dbt_expectations.expect_compound_columns_to_be_unique:
       column_list: ["user_edxorg_username", "micromasters_program_id", "mitxonline_program_id",
-        "user_mitxonline_username", "micromasters_user_id"]
+        "user_mitxonline_username", "micromasters_user_id", "user_email"]

--- a/src/ol_dbt/models/intermediate/micromasters/_int_micromasters__models.yml
+++ b/src/ol_dbt/models/intermediate/micromasters/_int_micromasters__models.yml
@@ -583,8 +583,7 @@ models:
   - name: user_year_of_birth
     description: str, user's birth year from user's profile on MITx Online or MicroMasters.
   - name: platform_name
-    description: str, a field indicating if the data is pulled from MITx Online or
-      edx.org.
+    description: str, a field indicating if the data is pulled from MITx Online or edx.org.
   tests:
   - dbt_expectations.expect_compound_columns_to_be_unique:
       column_list: ["user_edxorg_username", "program_title", "user_email"]

--- a/src/ol_dbt/models/intermediate/micromasters/_int_micromasters__models.yml
+++ b/src/ol_dbt/models/intermediate/micromasters/_int_micromasters__models.yml
@@ -583,7 +583,8 @@ models:
   - name: user_year_of_birth
     description: str, user's birth year from user's profile on MITx Online or MicroMasters.
   - name: platform_name
-    description: str, a field indicating if the data is pulled from MITx Online or edx.org.
+    description: str, a field indicating if the data is pulled from MITx Online or
+      edx.org.
   tests:
   - dbt_expectations.expect_compound_columns_to_be_unique:
       column_list: ["user_edxorg_username", "program_title", "user_email"]

--- a/src/ol_dbt/models/intermediate/micromasters/_int_micromasters__models.yml
+++ b/src/ol_dbt/models/intermediate/micromasters/_int_micromasters__models.yml
@@ -583,9 +583,7 @@ models:
   - name: user_year_of_birth
     description: str, user's birth year from user's profile on MITx Online or MicroMasters.
   - name: platform_name
-    description: str, a field indicating if the data is pulled from MITx Online or
-      edx.org.
+    description: str, a field indicating if the data is pulled from MITx Online or edx.org.
   tests:
   - dbt_expectations.expect_compound_columns_to_be_unique:
-      column_list: ["user_edxorg_username", "micromasters_program_id", "mitxonline_program_id",
-        "user_mitxonline_username", "micromasters_user_id", "user_email"]
+      column_list: ["user_edxorg_username", "program_title", "user_email"]

--- a/src/ol_dbt/models/intermediate/micromasters/_int_micromasters__models.yml
+++ b/src/ol_dbt/models/intermediate/micromasters/_int_micromasters__models.yml
@@ -582,6 +582,8 @@ models:
     description: int, sequential ID representing a user in MicroMasters
   - name: user_year_of_birth
     description: str, user's birth year from user's profile on MITx Online or MicroMasters.
+  - name: platform_name
+    description: str, a field indicating if the data is pulled from MITx Online or edx.org.
   tests:
   - dbt_expectations.expect_compound_columns_to_be_unique:
       column_list: ["user_edxorg_username", "micromasters_program_id", "mitxonline_program_id",

--- a/src/ol_dbt/models/intermediate/micromasters/_int_micromasters__models.yml
+++ b/src/ol_dbt/models/intermediate/micromasters/_int_micromasters__models.yml
@@ -583,7 +583,8 @@ models:
   - name: user_year_of_birth
     description: str, user's birth year from user's profile on MITx Online or MicroMasters.
   - name: platform_name
-    description: str, a field indicating if the data is pulled from MITx Online or edx.org.
+    description: str, a field indicating if the data is pulled from MITx Online or
+      edx.org.
   tests:
   - dbt_expectations.expect_compound_columns_to_be_unique:
       column_list: ["user_edxorg_username", "micromasters_program_id", "mitxonline_program_id",

--- a/src/ol_dbt/models/intermediate/micromasters/int__micromasters__program_enrollments.sql
+++ b/src/ol_dbt/models/intermediate/micromasters/int__micromasters__program_enrollments.sql
@@ -98,10 +98,10 @@ with micromasters_program_enrollments as (
         , micromasters_users.user_address_state_or_territory
         , edx_users.user_full_name
         , micromasters_users.user_id as micromasters_user_id
-        , case 
-            when micromasters_users.user_mitxonline_username is not null 
-                then '{{ var("mitxonline") }}' 
-            else '{{ var("edxorg") }}' 
+        , case
+            when micromasters_users.user_mitxonline_username is not null
+                then '{{ var("mitxonline") }}'
+            else '{{ var("edxorg") }}'
         end as platform_name
         , substring(micromasters_users.user_birth_date, 1, 4) as user_year_of_birth
     from mm_program_enrollments
@@ -119,7 +119,7 @@ with micromasters_program_enrollments as (
         programs.is_dedp_program = true
         and mitxonline_dedp_records.user_email is null
         and (
-            micromasters_users.user_mitxonline_username is not null 
+            micromasters_users.user_mitxonline_username is not null
             or micromasters_users.user_edxorg_username is not null
         )
 )

--- a/src/ol_dbt/models/intermediate/micromasters/int__micromasters__program_enrollments.sql
+++ b/src/ol_dbt/models/intermediate/micromasters/int__micromasters__program_enrollments.sql
@@ -58,7 +58,7 @@ with micromasters_program_enrollments as (
         , micromasters_users.user_street_address
         , mitxonline_users.user_full_name
         , micromasters_users.user_id as micromasters_user_id
-        , 'mitxonline' as platform_name
+        , '{{ var("mitxonline") }}' as platform_name
         , coalesce(
             cast(mitxonline_users.user_birth_year as varchar)
             , substring(micromasters_users.user_birth_date, 1, 4)
@@ -98,7 +98,7 @@ with micromasters_program_enrollments as (
         , micromasters_users.user_address_state_or_territory
         , edx_users.user_full_name
         , micromasters_users.user_id as micromasters_user_id
-        , 'edxorg' as platform_name
+        , '{{ var("edxorg") }}' as platform_name
         , substring(micromasters_users.user_birth_date, 1, 4) as user_year_of_birth
     from mm_program_enrollments
     inner join micromasters_users
@@ -135,7 +135,7 @@ with micromasters_program_enrollments as (
         , micromasters_users.user_address_state_or_territory
         , micromasters_program_enrollments.user_full_name
         , micromasters_users.user_id as micromasters_user_id
-        , 'edxorg' as platform_name
+        , '{{ var("edxorg") }}' as platform_name
         , substring(micromasters_users.user_birth_date, 1, 4) as user_year_of_birth
     from micromasters_program_enrollments
     inner join edx_users

--- a/src/ol_dbt/models/intermediate/micromasters/int__micromasters__program_enrollments.sql
+++ b/src/ol_dbt/models/intermediate/micromasters/int__micromasters__program_enrollments.sql
@@ -46,7 +46,7 @@ with micromasters_program_enrollments as (
     select
         micromasters_users.user_edxorg_username
         , mitxonline_programenrollments.user_username as user_mitxonline_username
-        , micromasters_users.user_email
+        , mitxonline_programenrollments.user_email
         , programs.micromasters_program_id
         , programs.program_title
         , mitxonline_programenrollments.program_id as mitxonline_program_id

--- a/src/ol_dbt/models/intermediate/micromasters/int__micromasters__program_enrollments.sql
+++ b/src/ol_dbt/models/intermediate/micromasters/int__micromasters__program_enrollments.sql
@@ -98,7 +98,7 @@ with micromasters_program_enrollments as (
         , micromasters_users.user_address_state_or_territory
         , edx_users.user_full_name
         , micromasters_users.user_id as micromasters_user_id
-        , 'micromasters' as platform_name
+        , 'edxorg' as platform_name
         , substring(micromasters_users.user_birth_date, 1, 4) as user_year_of_birth
     from mm_program_enrollments
     inner join micromasters_users

--- a/src/ol_dbt/models/intermediate/micromasters/int__micromasters__program_enrollments.sql
+++ b/src/ol_dbt/models/intermediate/micromasters/int__micromasters__program_enrollments.sql
@@ -98,7 +98,11 @@ with micromasters_program_enrollments as (
         , micromasters_users.user_address_state_or_territory
         , edx_users.user_full_name
         , micromasters_users.user_id as micromasters_user_id
-        , '{{ var("edxorg") }}' as platform_name
+        , case 
+            when micromasters_users.user_mitxonline_username is not null 
+                then '{{ var("mitxonline") }}' 
+            else '{{ var("edxorg") }}' 
+        end as platform_name
         , substring(micromasters_users.user_birth_date, 1, 4) as user_year_of_birth
     from mm_program_enrollments
     inner join micromasters_users
@@ -114,6 +118,10 @@ with micromasters_program_enrollments as (
     where
         programs.is_dedp_program = true
         and mitxonline_dedp_records.user_email is null
+        and (
+            micromasters_users.user_mitxonline_username is not null 
+            or micromasters_users.user_edxorg_username is not null
+        )
 )
 
 , non_dedp_records as (

--- a/src/ol_dbt/models/intermediate/micromasters/int__micromasters__program_enrollments.sql
+++ b/src/ol_dbt/models/intermediate/micromasters/int__micromasters__program_enrollments.sql
@@ -46,7 +46,7 @@ with micromasters_program_enrollments as (
     select
         micromasters_users.user_edxorg_username
         , mitxonline_programenrollments.user_username as user_mitxonline_username
-        , mitxonline_users.user_email
+        , micromasters_users.user_email
         , programs.micromasters_program_id
         , programs.program_title
         , mitxonline_programenrollments.program_id as mitxonline_program_id

--- a/src/ol_dbt/models/intermediate/micromasters/int__micromasters__program_enrollments.sql
+++ b/src/ol_dbt/models/intermediate/micromasters/int__micromasters__program_enrollments.sql
@@ -58,6 +58,7 @@ with micromasters_program_enrollments as (
         , micromasters_users.user_street_address
         , mitxonline_users.user_full_name
         , micromasters_users.user_id as micromasters_user_id
+        , 'mitxonline' as platform_name
         , coalesce(
             cast(mitxonline_users.user_birth_year as varchar)
             , substring(micromasters_users.user_birth_date, 1, 4)
@@ -97,6 +98,7 @@ with micromasters_program_enrollments as (
         , micromasters_users.user_address_state_or_territory
         , edx_users.user_full_name
         , micromasters_users.user_id as micromasters_user_id
+        , 'micromasters' as platform_name
         , substring(micromasters_users.user_birth_date, 1, 4) as user_year_of_birth
     from mm_program_enrollments
     inner join micromasters_users
@@ -107,11 +109,11 @@ with micromasters_program_enrollments as (
         on micromasters_users.user_edxorg_username = edx_users.user_username
     left join mitxonline_dedp_records
         on
-            micromasters_users.user_mitxonline_username = mitxonline_dedp_records.user_mitxonline_username
-            and programs.mitxonline_program_id = mitxonline_dedp_records.mitxonline_program_id
+            micromasters_users.user_email = mitxonline_dedp_records.user_email
+            and programs.program_title = mitxonline_dedp_records.program_title
     where
         programs.is_dedp_program = true
-        and mitxonline_dedp_records.user_mitxonline_username is null
+        and mitxonline_dedp_records.user_email is null
 )
 
 , non_dedp_records as (
@@ -133,6 +135,7 @@ with micromasters_program_enrollments as (
         , micromasters_users.user_address_state_or_territory
         , micromasters_program_enrollments.user_full_name
         , micromasters_users.user_id as micromasters_user_id
+        , 'edxorg' as platform_name
         , substring(micromasters_users.user_birth_date, 1, 4) as user_year_of_birth
     from micromasters_program_enrollments
     inner join edx_users
@@ -165,6 +168,7 @@ select
     , user_full_name
     , micromasters_user_id
     , user_year_of_birth
+    , platform_name
 from mitxonline_dedp_records
 
 union distinct
@@ -188,6 +192,7 @@ select
     , user_full_name
     , micromasters_user_id
     , user_year_of_birth
+    , platform_name
 from mm_dedp_records
 
 union distinct
@@ -211,4 +216,5 @@ select
     , user_full_name
     , micromasters_user_id
     , user_year_of_birth
+    , platform_name
 from non_dedp_records

--- a/src/ol_dbt/models/marts/combined/_marts__combined__models.yml
+++ b/src/ol_dbt/models/marts/combined/_marts__combined__models.yml
@@ -339,4 +339,4 @@ models:
     description: str, unique identifier for the program certificate
   tests:
   - dbt_expectations.expect_compound_columns_to_be_unique:
-      column_list: ["program_title", "user_username", "programenrollment_created_on"]
+      column_list: ["program_title", "user_username", "user_email", "programenrollment_created_on"]

--- a/src/ol_dbt/models/marts/combined/_marts__combined__models.yml
+++ b/src/ol_dbt/models/marts/combined/_marts__combined__models.yml
@@ -339,4 +339,4 @@ models:
     description: str, unique identifier for the program certificate
   tests:
   - dbt_expectations.expect_compound_columns_to_be_unique:
-      column_list: ["program_title", "user_username", "user_email", "programenrollment_created_on"]
+      column_list: ["program_title", "user_username", "platform_name", "programenrollment_created_on"]

--- a/src/ol_dbt/models/marts/combined/marts__combined_program_enrollment_detail.sql
+++ b/src/ol_dbt/models/marts/combined/marts__combined_program_enrollment_detail.sql
@@ -118,7 +118,7 @@ with mitxpro__programenrollments as (
 )
 
 , mm_no_dups as (
-    select
+    select 
         micromasters__program_enrollments.platform_name
         , micromasters__program_enrollments.micromasters_program_id as program_id
         , micromasters__program_enrollments.program_title
@@ -137,16 +137,16 @@ with mitxpro__programenrollments as (
     inner join micromasters__users
         on micromasters__program_enrollments.micromasters_user_id = micromasters__users.user_id
     left join combined_programs
-        on
+        on 
             micromasters__program_enrollments.user_email = combined_programs.user_email
             and micromasters__program_enrollments.program_title = combined_programs.program_title
-    where
+    where 
         combined_programs.user_email is null
         and combined_programs.program_title is null
         and micromasters__program_enrollments.platform_name = 'micromasters'
 )
 
-select
+select 
     combined_programs.platform_name
     , combined_programs.program_id
     , combined_programs.program_title
@@ -165,7 +165,7 @@ from combined_programs
 
 union all
 
-select
+select 
     mm_no_dups.platform_name
     , mm_no_dups.program_id
     , mm_no_dups.program_title

--- a/src/ol_dbt/models/marts/combined/marts__combined_program_enrollment_detail.sql
+++ b/src/ol_dbt/models/marts/combined/marts__combined_program_enrollment_detail.sql
@@ -118,7 +118,7 @@ with mitxpro__programenrollments as (
 )
 
 , mm_no_dups as (
-    select 
+    select
         micromasters__program_enrollments.platform_name
         , micromasters__program_enrollments.micromasters_program_id as program_id
         , micromasters__program_enrollments.program_title
@@ -137,16 +137,16 @@ with mitxpro__programenrollments as (
     inner join micromasters__users
         on micromasters__program_enrollments.micromasters_user_id = micromasters__users.user_id
     left join combined_programs
-        on 
+        on
             micromasters__program_enrollments.user_email = combined_programs.user_email
             and micromasters__program_enrollments.program_title = combined_programs.program_title
-    where 
+    where
         combined_programs.user_email is null
         and combined_programs.program_title is null
         and micromasters__program_enrollments.platform_name = 'micromasters'
 )
 
-select 
+select
     combined_programs.platform_name
     , combined_programs.program_id
     , combined_programs.program_title
@@ -165,7 +165,7 @@ from combined_programs
 
 union all
 
-select 
+select
     mm_no_dups.platform_name
     , mm_no_dups.program_id
     , mm_no_dups.program_title

--- a/src/ol_dbt/models/marts/combined/marts__combined_program_enrollment_detail.sql
+++ b/src/ol_dbt/models/marts/combined/marts__combined_program_enrollment_detail.sql
@@ -126,22 +126,22 @@ with mitxpro__programenrollments as (
 )
 
 , mm_no_dups as (
-    select 
+    select
         micromasters__program_enrollments.platform_name
         , micromasters__program_enrollments.micromasters_program_id as program_id
         , micromasters__program_enrollments.program_title
         , null as program_is_live
         , null as program_readable_id
-        , case 
+        , case
             when micromasters__program_enrollments.platform_name = '{{ var("mitxonline") }}'
                 then mitxonline__users.user_id
-            else micromasters__program_enrollments.user_edxorg_id 
+            else micromasters__program_enrollments.user_edxorg_id
         end as user_id
         , micromasters__program_enrollments.user_email
-        , case 
-            when micromasters__program_enrollments.platform_name = '{{ var("mitxonline") }}' 
-                then micromasters__program_enrollments.user_mitxonline_username 
-            else micromasters__program_enrollments.user_edxorg_username 
+        , case
+            when micromasters__program_enrollments.platform_name = '{{ var("mitxonline") }}'
+                then micromasters__program_enrollments.user_mitxonline_username
+            else micromasters__program_enrollments.user_edxorg_username
         end as user_username
         , null as programenrollment_is_active
         , null as programenrollment_created_on
@@ -153,24 +153,24 @@ with mitxpro__programenrollments as (
     inner join micromasters__users
         on micromasters__program_enrollments.micromasters_user_id = micromasters__users.user_id
     left join micromasters__certs
-        on 
-            micromasters__program_enrollments.micromasters_program_id 
+        on
+            micromasters__program_enrollments.micromasters_program_id
             = micromasters__certs.micromasters_program_id
             and micromasters__program_enrollments.user_email = micromasters__certs.user_email
     left join combined_programs
-        on 
+        on
             micromasters__program_enrollments.user_email = combined_programs.user_email
             and micromasters__program_enrollments.program_title = combined_programs.program_title
     left join mitxonline__users
-        on 
-            micromasters__program_enrollments.user_mitxonline_username 
+        on
+            micromasters__program_enrollments.user_mitxonline_username
             = mitxonline__users.user_username
-    where 
+    where
         combined_programs.user_email is null
         and combined_programs.program_title is null
 )
 
-select 
+select
     combined_programs.platform_name
     , combined_programs.program_id
     , combined_programs.program_title
@@ -189,7 +189,7 @@ from combined_programs
 
 union all
 
-select 
+select
     mm_no_dups.platform_name
     , mm_no_dups.program_id
     , mm_no_dups.program_title

--- a/src/ol_dbt/models/marts/combined/marts__combined_program_enrollment_detail.sql
+++ b/src/ol_dbt/models/marts/combined/marts__combined_program_enrollment_detail.sql
@@ -122,7 +122,7 @@ with mitxpro__programenrollments as (
 )
 
 , mm_no_dups as (
-    select 
+    select
         micromasters__program_enrollments.platform_name
         , micromasters__program_enrollments.micromasters_program_id as program_id
         , micromasters__program_enrollments.program_title
@@ -141,21 +141,21 @@ with mitxpro__programenrollments as (
     inner join micromasters__users
         on micromasters__program_enrollments.micromasters_user_id = micromasters__users.user_id
     left join micromasters__certs
-        on 
-            micromasters__program_enrollments.micromasters_program_id 
+        on
+            micromasters__program_enrollments.micromasters_program_id
             = micromasters__certs.micromasters_program_id
             and micromasters__program_enrollments.user_email = micromasters__certs.user_email
     left join combined_programs
-        on 
+        on
             micromasters__program_enrollments.user_email = combined_programs.user_email
             and micromasters__program_enrollments.program_title = combined_programs.program_title
-    where 
+    where
         combined_programs.user_email is null
         and combined_programs.program_title is null
         and micromasters__program_enrollments.platform_name = '{{ var("edxorg") }}'
 )
 
-select 
+select
     combined_programs.platform_name
     , combined_programs.program_id
     , combined_programs.program_title
@@ -174,7 +174,7 @@ from combined_programs
 
 union all
 
-select 
+select
     mm_no_dups.platform_name
     , mm_no_dups.program_id
     , mm_no_dups.program_title

--- a/src/ol_dbt/models/marts/combined/marts__combined_program_enrollment_detail.sql
+++ b/src/ol_dbt/models/marts/combined/marts__combined_program_enrollment_detail.sql
@@ -122,15 +122,15 @@ with mitxpro__programenrollments as (
 )
 
 , mm_no_dups as (
-    select
+    select 
         micromasters__program_enrollments.platform_name
         , micromasters__program_enrollments.micromasters_program_id as program_id
         , micromasters__program_enrollments.program_title
         , null as program_is_live
         , null as program_readable_id
-        , micromasters__users.user_id
+        , micromasters__program_enrollments.user_edxorg_id as user_id
         , micromasters__program_enrollments.user_email
-        , micromasters__users.user_username
+        , micromasters__program_enrollments.user_edxorg_username as user_username
         , null as programenrollment_is_active
         , null as programenrollment_created_on
         , null as programenrollment_enrollment_status
@@ -141,21 +141,21 @@ with mitxpro__programenrollments as (
     inner join micromasters__users
         on micromasters__program_enrollments.micromasters_user_id = micromasters__users.user_id
     left join micromasters__certs
-        on
-            micromasters__program_enrollments.micromasters_program_id
+        on 
+            micromasters__program_enrollments.micromasters_program_id 
             = micromasters__certs.micromasters_program_id
             and micromasters__program_enrollments.user_email = micromasters__certs.user_email
     left join combined_programs
-        on
+        on 
             micromasters__program_enrollments.user_email = combined_programs.user_email
             and micromasters__program_enrollments.program_title = combined_programs.program_title
-    where
+    where 
         combined_programs.user_email is null
         and combined_programs.program_title is null
-        and micromasters__program_enrollments.platform_name = 'micromasters'
+        and micromasters__program_enrollments.platform_name = '{{ var("edxorg") }}'
 )
 
-select
+select 
     combined_programs.platform_name
     , combined_programs.program_id
     , combined_programs.program_title
@@ -174,7 +174,7 @@ from combined_programs
 
 union all
 
-select
+select 
     mm_no_dups.platform_name
     , mm_no_dups.program_id
     , mm_no_dups.program_title

--- a/src/ol_dbt/models/marts/combined/marts__combined_program_enrollment_detail.sql
+++ b/src/ol_dbt/models/marts/combined/marts__combined_program_enrollment_detail.sql
@@ -46,6 +46,10 @@ with mitxpro__programenrollments as (
     select * from {{ ref('int__micromasters__program_certificates') }}
 )
 
+, mitxonline__users as (
+    select * from {{ ref('int__mitxonline__users') }}
+)
+
 , combined_programs as (
     select
         mitxpro__programs.platform_name
@@ -122,15 +126,23 @@ with mitxpro__programenrollments as (
 )
 
 , mm_no_dups as (
-    select
+    select 
         micromasters__program_enrollments.platform_name
         , micromasters__program_enrollments.micromasters_program_id as program_id
         , micromasters__program_enrollments.program_title
         , null as program_is_live
         , null as program_readable_id
-        , micromasters__program_enrollments.user_edxorg_id as user_id
+        , case 
+            when micromasters__program_enrollments.platform_name = '{{ var("mitxonline") }}'
+                then mitxonline__users.user_id
+            else micromasters__program_enrollments.user_edxorg_id 
+        end as user_id
         , micromasters__program_enrollments.user_email
-        , micromasters__program_enrollments.user_edxorg_username as user_username
+        , case 
+            when micromasters__program_enrollments.platform_name = '{{ var("mitxonline") }}' 
+                then micromasters__program_enrollments.user_mitxonline_username 
+            else micromasters__program_enrollments.user_edxorg_username 
+        end as user_username
         , null as programenrollment_is_active
         , null as programenrollment_created_on
         , null as programenrollment_enrollment_status
@@ -141,21 +153,24 @@ with mitxpro__programenrollments as (
     inner join micromasters__users
         on micromasters__program_enrollments.micromasters_user_id = micromasters__users.user_id
     left join micromasters__certs
-        on
-            micromasters__program_enrollments.micromasters_program_id
+        on 
+            micromasters__program_enrollments.micromasters_program_id 
             = micromasters__certs.micromasters_program_id
             and micromasters__program_enrollments.user_email = micromasters__certs.user_email
     left join combined_programs
-        on
+        on 
             micromasters__program_enrollments.user_email = combined_programs.user_email
             and micromasters__program_enrollments.program_title = combined_programs.program_title
-    where
+    left join mitxonline__users
+        on 
+            micromasters__program_enrollments.user_mitxonline_username 
+            = mitxonline__users.user_username
+    where 
         combined_programs.user_email is null
         and combined_programs.program_title is null
-        and micromasters__program_enrollments.platform_name = '{{ var("edxorg") }}'
 )
 
-select
+select 
     combined_programs.platform_name
     , combined_programs.program_id
     , combined_programs.program_title
@@ -174,7 +189,7 @@ from combined_programs
 
 union all
 
-select
+select 
     mm_no_dups.platform_name
     , mm_no_dups.program_id
     , mm_no_dups.program_title

--- a/src/ol_dbt/models/marts/combined/marts__combined_program_enrollment_detail.sql
+++ b/src/ol_dbt/models/marts/combined/marts__combined_program_enrollment_detail.sql
@@ -122,7 +122,7 @@ with mitxpro__programenrollments as (
 )
 
 , mm_no_dups as (
-    select 
+    select
         micromasters__program_enrollments.platform_name
         , micromasters__program_enrollments.micromasters_program_id as program_id
         , micromasters__program_enrollments.program_title
@@ -141,21 +141,21 @@ with mitxpro__programenrollments as (
     inner join micromasters__users
         on micromasters__program_enrollments.micromasters_user_id = micromasters__users.user_id
     left join micromasters__certs
-        on 
-            micromasters__program_enrollments.micromasters_program_id 
+        on
+            micromasters__program_enrollments.micromasters_program_id
             = micromasters__certs.micromasters_program_id
             and micromasters__program_enrollments.user_email = micromasters__certs.user_email
     left join combined_programs
-        on 
+        on
             micromasters__program_enrollments.user_email = combined_programs.user_email
             and micromasters__program_enrollments.program_title = combined_programs.program_title
-    where 
+    where
         combined_programs.user_email is null
         and combined_programs.program_title is null
         and micromasters__program_enrollments.platform_name = 'micromasters'
 )
 
-select 
+select
     combined_programs.platform_name
     , combined_programs.program_id
     , combined_programs.program_title
@@ -174,7 +174,7 @@ from combined_programs
 
 union all
 
-select 
+select
     mm_no_dups.platform_name
     , mm_no_dups.program_id
     , mm_no_dups.program_title

--- a/src/ol_dbt/models/marts/combined/marts__combined_program_enrollment_detail.sql
+++ b/src/ol_dbt/models/marts/combined/marts__combined_program_enrollment_detail.sql
@@ -39,7 +39,7 @@ with mitxpro__programenrollments as (
 )
 
 , micromasters__users as (
-    select * from {{ ref('stg__micromasters__app__postgres__auth_user') }}
+    select * from {{ ref('__micromasters__users') }}
 )
 
 , combined_programs as (
@@ -118,7 +118,7 @@ with mitxpro__programenrollments as (
 )
 
 , mm_no_dups as (
-    select
+    select 
         micromasters__program_enrollments.platform_name
         , micromasters__program_enrollments.micromasters_program_id as program_id
         , micromasters__program_enrollments.program_title
@@ -137,16 +137,16 @@ with mitxpro__programenrollments as (
     inner join micromasters__users
         on micromasters__program_enrollments.micromasters_user_id = micromasters__users.user_id
     left join combined_programs
-        on
+        on 
             micromasters__program_enrollments.user_email = combined_programs.user_email
             and micromasters__program_enrollments.program_title = combined_programs.program_title
-    where
+    where 
         combined_programs.user_email is null
         and combined_programs.program_title is null
         and micromasters__program_enrollments.platform_name = 'micromasters'
 )
 
-select
+select 
     combined_programs.platform_name
     , combined_programs.program_id
     , combined_programs.program_title
@@ -165,7 +165,7 @@ from combined_programs
 
 union all
 
-select
+select 
     mm_no_dups.platform_name
     , mm_no_dups.program_id
     , mm_no_dups.program_title


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/4061

### Description (What does it do?)
Adds old DEDP enrollment data to the marts__combined_program_enrollment_detail. And adds a new platform name field to  the int__micromasters__program_enrollments table.

### How can this be tested?
dbt build --select +marts__combined_program_enrollment_detail