### PR TITLE
populate xPro enrollment_mode with upstream changes

### DIFF
--- a/src/ol_dbt/models/intermediate/combined/int__combined__courserun_enrollments.sql
+++ b/src/ol_dbt/models/intermediate/combined/int__combined__courserun_enrollments.sql
@@ -40,7 +40,7 @@ with mitx_enrollments as (
         '{{ var("mitxpro") }}' as platform
         , courserunenrollment_is_active
         , courserunenrollment_created_on
-        , null as courserunenrollment_enrollment_mode
+        , courserunenrollment_enrollment_mode
         , courserunenrollment_enrollment_status
         , user_id
         , courserun_id

--- a/src/ol_dbt/models/intermediate/mitxpro/_int_mitxpro__models.yml
+++ b/src/ol_dbt/models/intermediate/mitxpro/_int_mitxpro__models.yml
@@ -999,6 +999,11 @@ models:
     - accepted_values:
         values: ['deferred', 'transferred', 'refunded', 'enrolled', 'unenrolled',
           '', null]
+  - name: courserunenrollment_enrollment_mode
+    description: str, indicating what kind of enrollment this is. Possible values
+      are audit or no-id-professional.
+    tests:
+    - not_null
   - name: courserunenrollment_is_edx_enrolled
     description: boolean, indicating whether the user is enrolled on edx
     tests:

--- a/src/ol_dbt/models/intermediate/mitxpro/_int_mitxpro__models.yml
+++ b/src/ol_dbt/models/intermediate/mitxpro/_int_mitxpro__models.yml
@@ -1001,9 +1001,13 @@ models:
           '', null]
   - name: courserunenrollment_enrollment_mode
     description: str, indicating what kind of enrollment this is. Possible values
-      are audit or no-id-professional.
+      are audit or no-id-professional. For 'audit' enrollments on edx platform, they
+      are populated as no-id-professional if there are orders associated with the
+      enrollments.
     tests:
     - not_null
+    - accepted_values:
+        values: ['audit', 'no-id-professional']
   - name: courserunenrollment_is_edx_enrolled
     description: boolean, indicating whether the user is enrolled on edx
     tests:

--- a/src/ol_dbt/models/marts/combined/marts__combined_course_enrollment_detail.sql
+++ b/src/ol_dbt/models/marts/combined/marts__combined_course_enrollment_detail.sql
@@ -243,7 +243,7 @@ with mitx_enrollments as (
         , mitxpro_enrollments.courserunenrollment_id
         , mitxpro_enrollments.courserunenrollment_is_active
         , mitxpro_enrollments.courserunenrollment_created_on
-        , null as courserunenrollment_enrollment_mode
+        , mitxpro_enrollments.courserunenrollment_enrollment_mode
         , mitxpro_enrollments.courserunenrollment_enrollment_status
         , mitxpro_enrollments.courserunenrollment_is_edx_enrolled
         , mitxpro_enrollments.user_id

--- a/src/ol_dbt/models/staging/mitxpro/_mitxpro__sources.yml
+++ b/src/ol_dbt/models/staging/mitxpro/_mitxpro__sources.yml
@@ -1422,17 +1422,20 @@ sources:
     description: Stores the mapping of students to the courses they are enrolled in.
     columns:
     - name: course_id
-      description: string, unique ID representing a single MITx Pro course run
+      description: string, Open edX Course ID in the format course-v1:xPro+{course
+        code}+{run_tag}
     - name: mode
-      description: string, the mode in which the user took the course (eg. audit)
+      description: string, indicating what kind of enrollment this is. Possible values
+        are audit or no-id-professional
     - name: id
       description: int, the auto-incremented ID for this table
     - name: is_active
       description: boolean, whether the user has been active in a course
     - name: created
-      description: timestamp, specifying when the user first enrolled in the course
+      description: timestamp, date and time when this enrollment was initially created
+        on xPro open edx platform.
     - name: user_id
-      description: int, the foreign key to the users_user table
+      description: int, user ID on xPro open edx platform
 
   - name: raw__xpro__openedx__mysql__teams_courseteam
     description: Stores unique course teams

--- a/src/ol_dbt/models/staging/mitxpro/_stg_mitxpro__models.yml
+++ b/src/ol_dbt/models/staging/mitxpro/_stg_mitxpro__models.yml
@@ -2027,6 +2027,8 @@ models:
       are audit or no-id-professional
     tests:
     - not_null
+    - accepted_values:
+        values: ['audit', 'no-id-professional']
   - name: courserunenrollment_is_active
     description: boolean, indicating whether this enrollment is active on xPro open
       edx platform.

--- a/src/ol_dbt/models/staging/mitxpro/_stg_mitxpro__models.yml
+++ b/src/ol_dbt/models/staging/mitxpro/_stg_mitxpro__models.yml
@@ -2010,3 +2010,33 @@ models:
   tests:
   - dbt_expectations.expect_compound_columns_to_be_unique:
       column_list: ["courserun_readable_id", "openedx_user_id", "courseaccess_role"]
+
+- name: stg__mitxpro__openedx__mysql__courserun_enrollment
+  description: course run enrollments from xPro open edx platform
+  columns:
+  - name: courserun_readable_id
+    description: str, Open edX Course ID in the format course-v1:xPro+{course code}+{run_tag}
+    tests:
+    - not_null
+  - name: openedx_user_id
+    description: int, user ID on xPro open edx platform
+    tests:
+    - not_null
+  - name: courserunenrollment_enrollment_mode
+    description: str, indicating what kind of enrollment this is. Possible values
+      are audit or no-id-professional
+    tests:
+    - not_null
+  - name: courserunenrollment_is_active
+    description: boolean, indicating whether this enrollment is active on xPro open
+      edx platform.
+    tests:
+    - not_null
+  - name: courserunenrollment_created_on
+    description: timestamp, date and time when this enrollment was initially created
+      on xPro open edx platform.
+    tests:
+    - not_null
+  tests:
+  - dbt_expectations.expect_compound_columns_to_be_unique:
+      column_list: ["courserun_readable_id", "openedx_user_id"]

--- a/src/ol_dbt/models/staging/mitxpro/stg__mitxpro__openedx__mysql__courserun_enrollment.sql
+++ b/src/ol_dbt/models/staging/mitxpro/stg__mitxpro__openedx__mysql__courserun_enrollment.sql
@@ -1,0 +1,15 @@
+with source as (
+    select * from {{ source('ol_warehouse_raw_data','raw__xpro__openedx__mysql__student_courseenrollment') }}
+)
+
+, cleaned as (
+    select
+        course_id as courserun_readable_id
+        , user_id as openedx_user_id
+        , is_active as courserunenrollment_is_active
+        , mode as courserunenrollment_enrollment_mode
+        , to_iso8601(from_iso8601_timestamp_nanos(created)) as courserunenrollment_created_on
+    from source
+)
+
+select * from cleaned


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
https://github.com/mitodl/hq/issues/4132

### Description (What does it do?)
<!--- Describe your changes in detail -->
- Adding `stg__mitxpro__openedx__mysql__courserun_enrollment` since enrollment mode is not captured in xPro application database
- Populating courserunenrollment_enrollment_mode in int__mitxpro__courserunenrollments, int__combined__courserun_enrollments and marts__combined_course_enrollment_detail
   - For some `audit` enrollments, it is overwritten by 'no-id-professional' if learner has paid for 

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->
I tested changes under my namespace but if you want to validate these changes in your schema, I recommend running the following commands 
```
dbt build stg__mitxpro__openedx__mysql__courserun_enrollment
dbt build int__mitxpro__courserunenrollments

# the following models just need the run command since no test for the column
dbt run int__combined__courserun_enrollments 
dbt run marts__combined_course_enrollment_detail
```
