### PR TITLE
Removing AirbyteConnectionMetadata import

### DIFF
--- a/src/ol_orchestrate/definitions/lakehouse/elt.py
+++ b/src/ol_orchestrate/definitions/lakehouse/elt.py
@@ -12,7 +12,6 @@ from dagster import (
     load_assets_from_current_module,
 )
 from dagster_airbyte import airbyte_resource, load_assets_from_airbyte_instance
-from dagster_airbyte.asset_defs import AirbyteConnectionMetadata
 from dagster_dbt import (
     dbt_cli_resource,
     load_assets_from_dbt_manifest,
@@ -46,11 +45,10 @@ dbt_config = {
 configured_dbt_cli = dbt_cli_resource.configured(dbt_config)
 
 
-def filter_active_connections(connection_metadata: AirbyteConnectionMetadata) -> bool:
-    if "S3 Glue Data Lake" in connection_metadata.name:
+def filter_active_connections(connection) -> bool:
+    if "S3 Glue Data Lake" in connection.name:
         pass
-    # Confirm the existence of this field in AirbyteConnectionMetadata
-    return connection_metadata.status == "active"
+    return connection.get("status") == "active"
 
 
 airbyte_assets = load_assets_from_airbyte_instance(


### PR DESCRIPTION
### What are the relevant tickets?
See previous PRs where AirbyteConnectionMetadata was imported:
https://github.com/mitodl/ol-data-platform/pull/1106/files
https://github.com/mitodl/ol-data-platform/pull/1113/files

### Description (What does it do?)
The most recent change is still causing an error:
`AttributeError: 'AirbyteConnectionMetadata' object has no attribute 'status'`
We should be able to execute the filter logic without the need for the AirbyteConnectionMetadata object and by using the existing connection object.

### How can this be tested?
Deploy to QA 
Check for errors when loading https://pipelines-qa.odl.mit.edu/locations