### PR TITLE
Reverting changes to the airbyte connection_filter

### DIFF
--- a/src/ol_orchestrate/definitions/lakehouse/elt.py
+++ b/src/ol_orchestrate/definitions/lakehouse/elt.py
@@ -44,21 +44,13 @@ dbt_config = {
 }
 configured_dbt_cli = dbt_cli_resource.configured(dbt_config)
 
-
-def filter_active_connections(connection) -> bool:
-    if "S3 Glue Data Lake" in connection.name:
-        pass
-    return connection.status == "active"
-
-
 airbyte_assets = load_assets_from_airbyte_instance(
     configured_airbyte_resource,
     # This key_prefix is how Dagster knows to map the Airbyte outputs to the dbt
     # sources, since they are defined as ol_warehouse_raw_data in the
     # sources.yml files. (TMM 2023-01-18)
     key_prefix="ol_warehouse_raw_data",
-    # connections that should be excluded from the output assets
-    connection_filter=filter_active_connections,
+    connection_filter=lambda conn: "S3 Glue Data Lake" in conn.name,
     connection_to_group_fn=(
         lambda conn_name: "ol_warehouse_raw"
         if "S3 Glue Data Lake" in conn_name


### PR DESCRIPTION
### What are the relevant tickets?
Reverting the changes from these commits:
https://github.com/mitodl/ol-data-platform/pull/1106
https://github.com/mitodl/ol-data-platform/pull/1113
https://github.com/mitodl/ol-data-platform/pull/1117

### Description (What does it do?)
Reverting to the original code. Tobias has addressed the filtering by utilizing the dbt_assets to generate the list of airbyte assets upstream instead of trying to get everything downstream of the ol_warehouse_raw db. https://github.com/mitodl/ol-data-platform/commit/3251cde232b13d3bf7648496ac2d0dfd3c825a06#diff-fa0bca61d46fa3a38e841b24932619f14976c5f896367ff439c053243abe4ff6L71-R77

### How can this be tested?
Deploy to QA, check for error when loading code location in Dagster