### PR TITLE
add number_of_passed_courses to user mart and upstream

### DIFF
--- a/src/ol_dbt/models/intermediate/combined/_combined_models.yml
+++ b/src/ol_dbt/models/intermediate/combined/_combined_models.yml
@@ -100,6 +100,12 @@ models:
       on the corresponding platform.
     tests:
     - not_null
+  - name: courserungrade_grade
+    description: float, course grade on edX.org or MITxOnline or xPro range from 0
+      to 1. Null for bootcamps
+  - name: courserungrade_is_passing
+    description: boolean, indicating whether the user has passed the passing score
+      set for this course on edX.org or MITxOnline or xPro. Null for bootcamps
 
 - name: int__combined__courserun_certificates
   description: course certificates model combined from different platforms. It excludes

--- a/src/ol_dbt/models/intermediate/combined/_combined_models.yml
+++ b/src/ol_dbt/models/intermediate/combined/_combined_models.yml
@@ -106,6 +106,12 @@ models:
   - name: courserungrade_is_passing
     description: boolean, indicating whether the user has passed the passing score
       set for this course on edX.org or MITxOnline or xPro. Null for bootcamps
+  - name: course_title
+    description: str, title of the course. May be null for some old edX.org runs.
+  - name: course_readable_id
+    description: str, open edX ID formatted as course-v1:{org}+{course code} for MITx
+      Online and xPro courses, and {org}/{course} for edX.org courses. May be null
+      for some old edX.org runs and Bootcamps courses.
 
 - name: int__combined__courserun_certificates
   description: course certificates model combined from different platforms. It excludes

--- a/src/ol_dbt/models/intermediate/combined/int__combined__courserun_enrollments.sql
+++ b/src/ol_dbt/models/intermediate/combined/int__combined__courserun_enrollments.sql
@@ -1,7 +1,3 @@
---- This model combines intermediate enrollments from different platform,
--- it's built as view with no additional data is stored
-{{ config(materialized='view') }}
-
 with mitx_enrollments as (
     select * from {{ ref('int__mitx__courserun_enrollments') }}
 )
@@ -25,6 +21,11 @@ with mitx_enrollments as (
 , combined_certificates as (
     select * from {{ ref('int__combined__courserun_certificates') }}
 )
+
+, combined_courseruns as (
+    select * from {{ ref('int__combined__course_runs') }}
+)
+
 
 , combined_enrollments as (
     select
@@ -96,8 +97,12 @@ with mitx_enrollments as (
 
 select
     combined_enrollments.*
+    , combined_courseruns.course_title
+    , combined_courseruns.course_readable_id
     , if(combined_certificates.platform is not null, true, false) as user_has_certificate
 from combined_enrollments
+left join combined_courseruns
+    on combined_enrollments.courserun_readable_id = combined_courseruns.courserun_readable_id
 left join combined_certificates
     on
         combined_enrollments.platform = combined_certificates.platform

--- a/src/ol_dbt/models/intermediate/combined/int__combined__courserun_enrollments.sql
+++ b/src/ol_dbt/models/intermediate/combined/int__combined__courserun_enrollments.sql
@@ -14,42 +14,65 @@ with mitx_enrollments as (
     select * from {{ ref('int__bootcamps__courserunenrollments') }}
 )
 
+, mitx_grades as (
+    select * from {{ ref('int__mitx__courserun_grades') }}
+)
+
+, mitxpro_grades as (
+    select * from {{ ref('int__mitxpro__courserun_grades') }}
+)
+
 , combined_certificates as (
     select * from {{ ref('int__combined__courserun_certificates') }}
 )
 
 , combined_enrollments as (
     select
-        platform
-        , courserunenrollment_is_active
-        , courserunenrollment_created_on
-        , courserunenrollment_enrollment_mode
-        , courserunenrollment_enrollment_status
-        , user_id
-        , courserun_id
-        , courserun_title
-        , courserun_readable_id
-        , user_username
-        , user_email
-        , user_full_name
+        mitx_enrollments.platform
+        , mitx_enrollments.courserunenrollment_is_active
+        , mitx_enrollments.courserunenrollment_created_on
+        , mitx_enrollments.courserunenrollment_enrollment_mode
+        , mitx_enrollments.courserunenrollment_enrollment_status
+        , mitx_enrollments.user_id
+        , mitx_enrollments.courserun_id
+        , mitx_enrollments.courserun_title
+        , mitx_enrollments.courserun_readable_id
+        , mitx_enrollments.user_username
+        , mitx_enrollments.user_email
+        , mitx_enrollments.user_full_name
+        , mitx_grades.courserungrade_grade
+        , mitx_grades.courserungrade_is_passing
     from mitx_enrollments
+    left join mitx_grades
+        on
+            mitx_enrollments.courserun_readable_id = mitx_grades.courserun_readable_id
+            and (
+                mitx_enrollments.user_mitxonline_username = mitx_grades.user_mitxonline_username
+                or mitx_enrollments.user_edxorg_username = mitx_grades.user_edxorg_username
+            )
 
     union all
 
     select
         '{{ var("mitxpro") }}' as platform
-        , courserunenrollment_is_active
-        , courserunenrollment_created_on
-        , courserunenrollment_enrollment_mode
-        , courserunenrollment_enrollment_status
-        , user_id
-        , courserun_id
-        , courserun_title
-        , courserun_readable_id
-        , user_username
-        , user_email
-        , user_full_name
+        , mitxpro_enrollments.courserunenrollment_is_active
+        , mitxpro_enrollments.courserunenrollment_created_on
+        , mitxpro_enrollments.courserunenrollment_enrollment_mode
+        , mitxpro_enrollments.courserunenrollment_enrollment_status
+        , mitxpro_enrollments.user_id
+        , mitxpro_enrollments.courserun_id
+        , mitxpro_enrollments.courserun_title
+        , mitxpro_enrollments.courserun_readable_id
+        , mitxpro_enrollments.user_username
+        , mitxpro_enrollments.user_email
+        , mitxpro_enrollments.user_full_name
+        , mitxpro_grades.courserungrade_grade
+        , mitxpro_grades.courserungrade_is_passing
     from mitxpro_enrollments
+    left join mitxpro_grades
+        on
+            mitxpro_enrollments.courserun_readable_id = mitxpro_grades.courserun_readable_id
+            and mitxpro_enrollments.user_username = mitxpro_grades.user_username
 
     union all
 
@@ -66,6 +89,8 @@ with mitx_enrollments as (
         , user_username
         , user_email
         , user_full_name
+        , null as courserungrade_grade
+        , null as courserungrade_is_passing
     from bootcamps_enrollments
 )
 

--- a/src/ol_dbt/models/marts/combined/_marts__combined__models.yml
+++ b/src/ol_dbt/models/marts/combined/_marts__combined__models.yml
@@ -10,6 +10,8 @@ models:
       bootcamps, edX.org, or MITx Online. If the user is on edX.org and MITx Online
       then the email will be chosen from the last platform they joined if their account
       is active
+    tests:
+    - not_null
   - name: user_joined_on
     description: timestamp, user join timestamp on the corresponding platform including
       xpro, bootcamps, edX.org, or MITx Online. If the user is on edX.org and MITx
@@ -27,6 +29,8 @@ models:
       is active, otherwise it will default to their edX.org account active status.
   - name: platforms
     description: string, application where the data is from
+    tests:
+    - not_null
   - name: user_full_name
     description: str, user full name. Very small number of edX.org users have blank
       full name, their name couldn't be populated from other sources if they don't
@@ -62,9 +66,17 @@ models:
     description: string, username on MITxPRO
   - name: user_bootcamps_username
     description: string, username on bootcamps
+  - name: num_of_course_enrolled
+    description: number, the number of courses learner enrolled based on their emails
+      so this counts as same person if they use the email to register on different
+      platforms
+  - name: num_of_course_passed
+    description: number, the number of courses learner passed based on their emails
+      so this counts as same person if they use the email to register on different
+      platforms
   tests:
   - dbt_expectations.expect_compound_columns_to_be_unique:
-      column_list: ["user_mitxonline_id", "user_edxorg_id", "user_mitxpro_id", "user_bootcamps_id",
+      column_list: ["user_email", "user_edxorg_id", "user_mitxpro_id", "user_bootcamps_id",
         "platforms"]
 
 - name: marts__combined__orders

--- a/src/ol_dbt/models/marts/combined/_marts__combined__models.yml
+++ b/src/ol_dbt/models/marts/combined/_marts__combined__models.yml
@@ -76,7 +76,7 @@ models:
       platforms
   tests:
   - dbt_expectations.expect_compound_columns_to_be_unique:
-      column_list: ["user_email", "user_edxorg_id", "user_mitxpro_id", "user_bootcamps_id",
+      column_list: ["user_mitxonline_id", "user_edxorg_id", "user_mitxpro_id", "user_bootcamps_id",
         "platforms"]
 
 - name: marts__combined__orders

--- a/src/ol_dbt/models/marts/combined/marts__combined__users.sql
+++ b/src/ol_dbt/models/marts/combined/marts__combined__users.sql
@@ -16,24 +16,18 @@ with mitx__users as (
     select * from {{ ref('int__combined__courserun_enrollments') }}
 )
 
-, combined_courseruns as (
-    select * from {{ ref('int__combined__course_runs') }}
-)
-
 , course_stats as (
     select
-        combined_enrollments.user_email
-        , count(distinct combined_courseruns.course_title) as num_of_course_enrolled
+        user_email
+        , count(distinct course_title) as num_of_course_enrolled
         , count(
             distinct
             case
-                when combined_enrollments.courserungrade_is_passing = true then combined_courseruns.course_title
+                when courserungrade_is_passing = true then course_title
             end
         ) as num_of_course_passed
     from combined_enrollments
-    inner join combined_courseruns
-        on combined_enrollments.courserun_readable_id = combined_courseruns.courserun_readable_id
-    group by combined_enrollments.user_email
+    group by user_email
 )
 
 , combined_users as (


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
NA but related to https://bi.ol.mit.edu/superset/dashboard/11/ 

### Description (What does it do?)
<!--- Describe your changes in detail -->
Adding  `num_of_course_passed` and `num_of_course_enrolled` to `marts__combined__users` and its upstream changes so that the filter # of courses passed used on https://bi.ol.mit.edu/superset/dashboard/11/ can directly come from dbt model rather than calculating it on the superset

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->
dbt build int__combined__courserun_enrollments
dbt build marts__combined__users
