### PR TITLE
Bugfix for dagster asset selection

### DIFF
--- a/src/ol_orchestrate/definitions/lakehouse/elt.py
+++ b/src/ol_orchestrate/definitions/lakehouse/elt.py
@@ -66,7 +66,9 @@ dbt_assets = load_assets_from_dbt_manifest(
 
 airbyte_asset_job = define_asset_job(
     name="airbyte_asset_sync",
-    selection=AssetSelection.assets(*dbt_assets).upstream(),
+    selection=AssetSelection.assets(*dbt_assets)
+    .upstream()
+    .required_multi_asset_neighbors(),
 )
 
 airbyte_update_schedule = ScheduleDefinition(


### PR DESCRIPTION
### What are the relevant tickets?
Tobias made [the following changes](https://github.com/mitodl/ol-data-platform/commit/3251cde232b13d3bf7648496ac2d0dfd3c825a06#diff-fa0bca61d46fa3a38e841b24932619f14976c5f896367ff439c053243abe4ff6L71-R77) to refactor how we are creating the AssetSelection for the elt pipeline.

Instead of using the "ol_warehouse_raw" group and collecting all the downstream assets:
`selection=AssetSelection.groups("ol_warehouse_raw").downstream(),`
We are now using "dbt_assets" loaded from the manifest.json to figure out what assets are upstream,
`selection=AssetSelection.assets(*dbt_assets).upstream(),`

### Description (What does it do?)
Both the error handling suggestion and a few examples online suggest adding required_multi_asset_neighbors() to select any remaining assets to resolve this error. This will make sure that all the required keys for the given airbyte sync are included in that selection.

### How can this be tested?
Deploy to QA
Check for error when loading code location in Dagster