### PR TITLE
Staging edxorg users, profiles, courseaccessroles and certificates

### DIFF
--- a/src/ol_dbt/dbt_project.yml
+++ b/src/ol_dbt/dbt_project.yml
@@ -46,9 +46,10 @@ vars:
     highest_education_values: ['Doctorate', "Master''s or professional degree", "Bachelor''s\
         \ degree", 'Associate degree', 'Secondary/high school', 'Junior secondary/junior
         high/middle school', 'Elementary/primary school', 'No formal education', 'Other
-        education', '']
+        education', "Doctorate in science or engineering", "Doctorate in another field",
+      '']
     gender_values: ['Male', 'Female', 'Transgender', 'Non-binary/non-conforming',
-      'Other/Prefer Not to Say', '']
+      'Binary', 'Other/Prefer Not to Say', '']
 
 # Configuring models
 # Full documentation: https://docs.getdbt.com/docs/configuring-models

--- a/src/ol_dbt/macros/transform_code_to_readable_values.sql
+++ b/src/ol_dbt/macros/transform_code_to_readable_values.sql
@@ -3,9 +3,10 @@
             when {{ column_name }} = 'm' then 'Male'
             when {{ column_name }} = 'f' then 'Female'
             when {{ column_name }} = 't' then 'Transgender'
+            when {{ column_name }} = 'b' then 'Binary'
             when {{ column_name }} = 'nb' then 'Non-binary/non-conforming'
             when {{ column_name }} = 'o' then 'Other/Prefer Not to Say'
-            else {{ column_name }}
+            else null
         end
 {% endmacro %}
 
@@ -23,7 +24,7 @@
         --- the following two are no longer used, but there are still users' profiles with these values
         when {{ column_name }} = 'p_se' then 'Doctorate in science or engineering'
         when {{ column_name }} = 'p_oth' then 'Doctorate in another field'
-        else {{ column_name }}
+        else null
     end
 {% endmacro %}
 

--- a/src/ol_dbt/models/staging/edxorg/_edxorg_sources.yml
+++ b/src/ol_dbt/models/staging/edxorg/_edxorg_sources.yml
@@ -831,7 +831,9 @@ sources:
     - name: user_id
       description: str, foreign key to auth_user.id
     - name: course_id
-      description: str, open edX Course Key formatted as {org}/{course code}/{run_tag}
+      description: str, open edX Course ID formatted as {org}/{course number}/{run}
+        for older runs prior to 3T2015, and course-v1:{org}+{course}+{run} for newer
+        runs.
     - name: download_url
       description: str, url location for the generated certificate. Used internally
         only.
@@ -866,3 +868,20 @@ sources:
     - name: modified_date
       description: str, date and time string indicating when the certificate was last
         modified
+
+  - name: raw__edxorg__s3__tables__student_courseaccessrole
+    description: edX.org student course access roles that lists the users who have
+      a privileged role or roles for working in a course
+    columns:
+    - name: course_id
+      description: str, open edX Course ID formatted as {org}/{course number}/{run}
+        for older runs prior to 3T2015, and course-v1:{org}+{course}+{run} for newer
+        runs.
+    - name: org
+      description: str, the organization the course belongs to. e.g. MITx
+    - name: role
+      description: str, the privilege level assigned to the user for working in this
+        course. Possible values are instructor, staff, beta_testers, data_researcher,
+        ccx_coach, limited_staff, sales_admin, beta_testers, finance_admin
+    - name: user_id
+      description: str, foreign key to auth_user.id

--- a/src/ol_dbt/models/staging/edxorg/_edxorg_sources.yml
+++ b/src/ol_dbt/models/staging/edxorg/_edxorg_sources.yml
@@ -680,3 +680,189 @@ sources:
     - name: retrieved_at
       description: timestamp, time indicating when this block was initially retrieved
         from S3
+
+  - name: raw__edxorg__s3__tables__auth_user
+    description: edx.org user data
+    columns:
+    - name: id
+      description: str, primary key for this user table
+    - name: username
+      description: str, the unique username for a user on edX.org.
+    - name: first_name
+      description: str, not used; a user’s full name is stored in auth_userprofile.name
+        instead.
+    - name: last_name
+      description: str, not used; a user’s full name is stored in auth_userprofile.name
+        instead.
+    - name: email
+      description: str, the user’s email address, which is the primary mechanism users
+        use to log in.
+    - name: password
+      description: str, the hashed version of the user’s password
+    - name: is_staff
+      description: str, set to '1' if the user is a staff member of edx, who have
+        Admin privileges in the LMS
+    - name: is_active
+      description: str, set to '1' if the user has clicked on the activation link
+        that was sent to them when they created their account, and false if user hasn't
+        activated the account or the account is soft deleted
+    - name: is_superuser
+      description: str, controls access to django_admin views. Set to '1' only for
+        site admins. '0' for almost everybody.
+    - name: last_login
+      description: str, date and time string of the user’s last login. Should not
+        be used as a proxy for activity, since people can use the site all the time
+        and go days between logging in and out.
+    - name: date_joined
+      description: str, date and time string indicating when the account was created.
+        This is not the date that the user activated the account.
+    - name: status
+      description: str, obsolete column that was added by an application called Askbot,
+        a discussion forum package that is no longer part of the system. Only users
+        who were part of the prototype 6.002x course run in Spring 2012 may have any
+        information in these columns.
+    - name: email_key
+      description: str, obsolete column that was added by an application called Askbot,
+        a discussion forum package that is no longer part of the system. Only users
+        who were part of the prototype 6.002x course run in Spring 2012 may have any
+        information in these columns.
+    - name: avatar_type
+      description: str, obsolete column that was added by an application called Askbot,
+        a discussion forum package that is no longer part of the system. Only users
+        who were part of the prototype 6.002x course run in Spring 2012 may have any
+        information in these columns.
+    - name: country
+      description: str, obsolete column that was added by an application called Askbot,
+        a discussion forum package that is no longer part of the system. Only users
+        who were part of the prototype 6.002x course run in Spring 2012 may have any
+        information in these columns.
+    - name: show_country
+      description: str, obsolete column that was added by an application called Askbot,
+        a discussion forum package that is no longer part of the system. Only users
+        who were part of the prototype 6.002x course run in Spring 2012 may have any
+        information in these columns.
+    - name: date_of_birth
+      description: str, obsolete column that was added by an application called Askbot,
+        a discussion forum package that is no longer part of the system. Only users
+        who were part of the prototype 6.002x course run in Spring 2012 may have any
+        information in these columns.
+    - name: interesting_tags
+      description: str, obsolete column that was added by an application called Askbot,
+        a discussion forum package that is no longer part of the system. Only users
+        who were part of the prototype 6.002x course run in Spring 2012 may have any
+        information in these columns.
+    - name: ignored_tags
+      description: str, obsolete column that was added by an application called Askbot,
+        a discussion forum package that is no longer part of the system. Only users
+        who were part of the prototype 6.002x course run in Spring 2012 may have any
+        information in these columns.
+    - name: email_tag_filter_strategy
+      description: str, obsolete column that was added by an application called Askbot,
+        a discussion forum package that is no longer part of the system. Only users
+        who were part of the prototype 6.002x course run in Spring 2012 may have any
+        information in these columns.
+    - name: display_tag_filter_strategy
+      description: str, obsolete column that was added by an application called Askbot,
+        a discussion forum package that is no longer part of the system. Only users
+        who were part of the prototype 6.002x course run in Spring 2012 may have any
+        information in these columns.
+    - name: consecutive_days_visit_count
+      description: str, obsolete column that was added by an application called Askbot,
+        a discussion forum package that is no longer part of the system. Only users
+        who were part of the prototype 6.002x course run in Spring 2012 may have any
+        information in these columns.
+
+  - name: raw__edxorg__s3__tables__auth_userprofile
+    description: edx.org user profile data
+    columns:
+    - name: id
+      description: str, primary key for user profile table
+    - name: user_id
+      description: str, foreign key to auth_user.id
+    - name: name
+      description: str, a user’s full name. Name changes are logged in the meta field.
+    - name: meta
+      description: str, freeform text field that stores arbitrary JSON metadata e.g.
+        old_names, old_emails for the user
+    - name: gender
+      description: str, possible values are m, f, o, t, b, blank, or NULL
+    - name: level_of_education
+      description: str, learner's Level of education in one or two letters.
+    - name: year_of_birth
+      description: str, learner's birth year.
+    - name: goals
+      description: text, collected during registration to answer question "Tell us
+        why you’re interested in edX"
+    - name: country
+      description: str, two digit country code. Null for user profiles created before
+        18 Sep 2014.
+    - name: bio
+      description: text, one or more paragraphs of biographical information that the
+        learner enters as profile information. Added 22 Apr 2015.
+    - name: profile_image_uploaded_at
+      description: str, the date and time when a learner uploaded a profile image
+        to show with profile information. Added 22 Apr 2015.
+    - name: city
+      description: str, not currently used. NULL for all user profiles except a few
+        rows that may have incomplete or bad data
+    - name: language
+      description: str, no longer used. User’s preferred language, asked during the
+        sign up process for the 6.002x prototype course given in Spring 2012. EdX
+        stopped collecting this data after MITx transitioned to edX
+    - name: location
+      description: str, no longer used. User’s location, asked during the sign up
+        process for the 6.002x prototype course given in Spring 2012. Like language,
+        edX stopped collecting this column after MITx transitioned to edX, so it is
+        only available for the first batch of learners.
+    - name: courseware
+      description: str, no longer used. This column was added for use with an A/B
+        testing feature, but it has not been used for anything meaningful since the
+        prototype course concluded in Spring 2012.
+    - name: mailing_address
+      description: str, no longer used. This column contains NULL for learners who
+        register after 17 May 2016 as well as for learners who registered accounts
+        for the prototype course.
+
+  - name: raw__edxorg__s3__tables__certificates_generatedcertificate
+    description: edx.org course runs certificate data
+    columns:
+    - name: id
+      description: str, primary key for certificates_generatedcertificate table
+    - name: user_id
+      description: str, foreign key to auth_user.id
+    - name: course_id
+      description: str, open edX Course Key formatted as {org}/{course code}/{run_tag}
+    - name: download_url
+      description: str, url location for the generated certificate. Used internally
+        only.
+    - name: download_uuid
+      description: str, the unique identifier for the generated certificate. Used
+        internally only.
+    - name: verify_uuid
+      description: str, a hash code that verifies the validity of a certificate. Included
+        on the certificate itself as part of a URL.
+    - name: grade
+      description: str, the grade ranged from '0' to '1' computed the at the time
+        of certificate generation. It is suggested that the grades_persistentcoursegrade
+        table be used instead of this grade.
+    - name: mode
+      description: str, contains the value in student_courseenrollment.mode field
+        at the time the certificate was generated
+    - name: status
+      description: str, after certificates have been issued, the status will be one
+        of the possible values- audit_notpassing, audit_passing, deleted, deleting,
+        downloadable, error, generating, notpassing, restricted , unavailable, unverified
+    - name: error_reason
+      description: st, used internally only
+    - name: distinction
+      description: str, not used. currently all '0'
+    - name: name
+      description: str, the name of the learner that was set at the time the certificate
+        was generated.
+    - name: key
+      description: str, used internally only.
+    - name: created_date
+      description: str, date and time string indicating when the certificate was created
+    - name: modified_date
+      description: str, date and time string indicating when the certificate was last
+        modified

--- a/src/ol_dbt/models/staging/edxorg/_stg__edxorg__models.yml
+++ b/src/ol_dbt/models/staging/edxorg/_stg__edxorg__models.yml
@@ -648,3 +648,144 @@ models:
   - dbt_expectations.expect_compound_columns_to_be_unique:
       column_list: ["courserun_readable_id", "coursestructure_block_id", "coursestructure_content_hash",
         "coursestructure_retrieved_at"]
+
+- name: stg__edxorg__s3__user
+  description: edx.org user data
+  columns:
+  - name: user_id
+    description: int, primary key for this user table
+    tests:
+    - unique
+    - not_null
+  - name: user_username
+    description: str, the unique username for a user on edX.org.
+    tests:
+    - unique
+    - not_null
+  - name: user_email
+    description: str, the user’s email address, which is the primary mechanism users
+      use to log in.
+    tests:
+    - not_null
+  - name: user_is_staff
+    description: boolean, set to true if the user is a staff member of edx, who have
+      Admin privileges in the LMS
+    tests:
+    - not_null
+  - name: user_is_active
+    description: boolean, set to true if the user has clicked on the activation link
+      that was sent to them when they created their account, and false if user hasn't
+      activated the account or the account is soft deleted
+    tests:
+    - not_null
+  - name: user_is_superuser
+    description: boolean, controls access to django_admin views. Set to true only
+      for site admins. false for almost everybody.
+    tests:
+    - not_null
+  - name: user_last_login
+    description: timestamp, date and time of the user’s last login. Should not be
+      used as a proxy for activity, since people can use the site all the time and
+      go days between logging in and out.
+  - name: user_joined_on
+    description: timestamp, date and time indicating when the account was created.
+      This is not the date that the user activated the account.
+
+- name: stg__edxorg__s3__user_profile
+  description: edx.org user profile data
+  columns:
+  - name: user_profile_id
+    description: str, primary key for user profile table
+    tests:
+    - unique
+    - not_null
+  - name: user_id
+    description: str, foreign key to auth_user.id
+    tests:
+    - unique
+    - not_null
+  - name: user_full_name
+    description: str, a user’s full name. Name changes are logged in the meta field.
+  - name: user_gender
+    description: str, learner's gender in readable text
+    tests:
+    - accepted_values:
+        values: '{{ var("gender_values") }}'
+  - name: user_highest_education
+    description: str, learner's Level of education in readable text.
+    tests:
+    - accepted_values:
+        values: '{{ var("highest_education_values") }}'
+  - name: user_year_of_birth
+    description: int, learner's birth year.
+  - name: user_address_country
+    description: str, two digit country code. Null for user profiles created before
+      18 Sep 2014.
+  - name: user_profile_metadata
+    description: text, freeform text field that stores arbitrary JSON metadata e.g.
+      old_names, old_emails for the user
+  - name: user_goals
+    description: text, collected during registration to answer question "Tell us why
+      you’re interested in edX"
+  - name: user_bio
+    description: text, one or more paragraphs of biographical information that the
+      learner enters as profile information. Added 22 Apr 2015.
+
+- name: stg__edxorg__s3__courserun_certificate
+  description: edx.org course runs certificate data
+  columns:
+  - name: courseruncertificate_id
+    description: str, primary key for certificates_generatedcertificate table
+    tests:
+    - unique
+    - not_null
+  - name: user_id
+    description: int, foreign key to auth_user.id
+    tests:
+    - not_null
+  - name: courserun_readable_id
+    description: str, open edX Course Key formatted as {org}/{course code}/{run_tag}
+    tests:
+    - not_null
+  - name: courseruncertificate_status
+    description: str, after certificates have been issued, the status will be one
+      of the possible values- audit_notpassing, audit_passing, deleted, deleting,
+      downloadable, error, generating, notpassing, restricted , unavailable, unverified
+    tests:
+    - accepted_values:
+        values: ["audit_notpassing", "audit_passing", "deleted", "deleting", "downloadable",
+          "error", "generating", "notpassing", "restricted", "unavailable", "unverified"]
+  - name: courseruncertificate_download_url
+    description: str, url location for the generated certificate. Used internally
+      only.
+  - name: courseruncertificate_download_uuid
+    description: str, the unique identifier for the generated certificate. Used internally
+      only.
+  - name: courseruncertificate_verify_uuid
+    description: str, a hash code that verifies the validity of a certificate. Included
+      on the certificate itself as part of a URL.
+  - name: courseruncertificate_grade
+    description: float, the grade ranged from '0' to '1' computed the at the time
+      of certificate generation. It is suggested that the grades_persistentcoursegrade
+      table be used instead of this grade.
+  - name: courseruncertificate_mode
+    description: str, contains the value in student_courseenrollment.mode field at
+      the time the certificate was generated
+  - name: courseruncertificate_user_full_name
+    description: str, the name of the learner that was set at the time the certificate
+      was generated.
+  - name: courseruncertificate_key
+    description: str, used internally only.
+  - name: courserunenrollment_created_on
+    description: timestamp, date and time string indicating when the certificate was
+      created
+    tests:
+    - not_null
+  - name: courserunenrollment_updated_on
+    description: timestamp, date and time string indicating when the certificate was
+      last modified
+    tests:
+    - not_null
+  tests:
+  - dbt_expectations.expect_compound_columns_to_be_unique:
+      column_list: ["courserun_readable_id", "user_id"]

--- a/src/ol_dbt/models/staging/edxorg/_stg__edxorg__models.yml
+++ b/src/ol_dbt/models/staging/edxorg/_stg__edxorg__models.yml
@@ -697,12 +697,12 @@ models:
   description: edx.org user profile data
   columns:
   - name: user_profile_id
-    description: str, primary key for user profile table
+    description: int, primary key for user profile table
     tests:
     - unique
     - not_null
   - name: user_id
-    description: str, foreign key to auth_user.id
+    description: int, foreign key to auth_user.id
     tests:
     - unique
     - not_null
@@ -737,7 +737,7 @@ models:
   description: edx.org course runs certificate data
   columns:
   - name: courseruncertificate_id
-    description: str, primary key for certificates_generatedcertificate table
+    description: int, primary key for certificates_generatedcertificate table
     tests:
     - unique
     - not_null

--- a/src/ol_dbt/models/staging/edxorg/_stg__edxorg__models.yml
+++ b/src/ol_dbt/models/staging/edxorg/_stg__edxorg__models.yml
@@ -744,7 +744,9 @@ models:
     tests:
     - not_null
   - name: courserun_readable_id
-    description: str, open edX Course Key formatted as {org}/{course code}/{run_tag}
+    description: str, open edX Course ID formatted as {org}/{course number}/{run}
+      for older runs prior to 3T2015, and course-v1:{org}+{course}+{run} for newer
+      runs.
     tests:
     - not_null
   - name: courseruncertificate_status
@@ -789,3 +791,32 @@ models:
   tests:
   - dbt_expectations.expect_compound_columns_to_be_unique:
       column_list: ["courserun_readable_id", "user_id"]
+
+- name: stg__edxorg__s3__user_courseaccessrole
+  description: edX.org student course access roles that lists the users who have a
+    privileged role or roles for working in a course
+  columns:
+  - name: user_id
+    description: int, foreign key to auth_user.id
+    tests:
+    - not_null
+  - name: courserun_readable_id
+    description: str, open edX Course ID formatted as {org}/{course number}/{run}
+      for older runs prior to 3T2015, and course-v1:{org}+{course}+{run} for newer
+      runs.
+    tests:
+    - not_null
+  - name: organization
+    description: str, the organization the course belongs to. e.g. MITx
+  - name: courseaccess_role
+    description: str, the privilege level assigned to the user for working in this
+      course. Possible values are instructor, staff, beta_testers, data_researcher,
+      ccx_coach, limited_staff, sales_admin, beta_testers, finance_admin
+    tests:
+    - not_null
+    - accepted_values:
+        values: ['staff', 'limited_staff', 'data_researcher', 'instructor', 'finance_admin',
+          'sales_admin', 'beta_testers', 'ccx_coach']
+  tests:
+  - dbt_expectations.expect_compound_columns_to_be_unique:
+      column_list: ["courserun_readable_id", "user_id", "courseaccess_role"]

--- a/src/ol_dbt/models/staging/edxorg/_stg__edxorg__models.yml
+++ b/src/ol_dbt/models/staging/edxorg/_stg__edxorg__models.yml
@@ -780,12 +780,12 @@ models:
       was generated.
   - name: courseruncertificate_key
     description: str, used internally only.
-  - name: courserunenrollment_created_on
+  - name: courseruncertificate_created_on
     description: timestamp, date and time string indicating when the certificate was
       created
     tests:
     - not_null
-  - name: courserunenrollment_updated_on
+  - name: courseruncertificate_updated_on
     description: timestamp, date and time string indicating when the certificate was
       last modified
     tests:

--- a/src/ol_dbt/models/staging/edxorg/_stg__edxorg__models.yml
+++ b/src/ol_dbt/models/staging/edxorg/_stg__edxorg__models.yml
@@ -690,6 +690,8 @@ models:
   - name: user_joined_on
     description: timestamp, date and time indicating when the account was created.
       This is not the date that the user activated the account.
+    tests:
+    - not_null
 
 - name: stg__edxorg__s3__user_profile
   description: edx.org user profile data

--- a/src/ol_dbt/models/staging/edxorg/stg__edxorg__s3__courserun_certificate.sql
+++ b/src/ol_dbt/models/staging/edxorg/stg__edxorg__s3__courserun_certificate.sql
@@ -18,8 +18,8 @@ with source as (
         , verify_uuid as courseruncertificate_verify_uuid
         , status as courseruncertificate_status
         , try_cast(grade as decimal(38, 2)) as courseruncertificate_grade
-        , to_iso8601(date_parse(created_date, '%Y-%m-%d %H:%i:%s')) as courserunenrollment_created_on
-        , to_iso8601(date_parse(modified_date, '%Y-%m-%d %H:%i:%s')) as courserunenrollment_updated_on
+        , to_iso8601(date_parse(created_date, '%Y-%m-%d %H:%i:%s')) as courseruncertificate_created_on
+        , to_iso8601(date_parse(modified_date, '%Y-%m-%d %H:%i:%s')) as courseruncertificate_updated_on
     from most_recent_source
 )
 

--- a/src/ol_dbt/models/staging/edxorg/stg__edxorg__s3__courserun_certificate.sql
+++ b/src/ol_dbt/models/staging/edxorg/stg__edxorg__s3__courserun_certificate.sql
@@ -1,0 +1,26 @@
+with source as (
+    select * from {{ source('ol_warehouse_raw_data', 'raw__edxorg__s3__tables__certificates_generatedcertificate') }}
+)
+
+{{ deduplicate_query(cte_name1='source', cte_name2='most_recent_source', partition_columns='id') }}
+
+, cleaned as (
+    --- all values are ingested as string, so we need to cast here to match other data sources
+    select
+        cast(id as integer) as courseruncertificate_id
+        , course_id as courserun_readable_id
+        , cast(user_id as integer) as user_id
+        , name as courseruncertificate_user_full_name
+        , key as courseruncertificate_key
+        , mode as courseruncertificate_mode
+        , download_url as courseruncertificate_download_url
+        , download_uuid as courseruncertificate_download_uuid
+        , verify_uuid as courseruncertificate_verify_uuid
+        , status as courseruncertificate_status
+        , try_cast(grade as decimal(38, 2)) as courseruncertificate_grade
+        , to_iso8601(date_parse(created_date, '%Y-%m-%d %H:%i:%s')) as courserunenrollment_created_on
+        , to_iso8601(date_parse(modified_date, '%Y-%m-%d %H:%i:%s')) as courserunenrollment_updated_on
+    from most_recent_source
+)
+
+select * from cleaned

--- a/src/ol_dbt/models/staging/edxorg/stg__edxorg__s3__user.sql
+++ b/src/ol_dbt/models/staging/edxorg/stg__edxorg__s3__user.sql
@@ -1,0 +1,28 @@
+with source as (
+    select * from {{ source('ol_warehouse_raw_data','raw__edxorg__s3__tables__auth_user') }}
+)
+
+{{ deduplicate_query(cte_name1='source', cte_name2='most_recent_source' , partition_columns = 'id') }}
+
+, cleaned as (
+    select
+        ---all values are ingested as string, so we need to cast here to match other data sources
+        cast(id as integer) as user_id
+        , username as user_username
+        , email as user_email
+        , cast(is_active as boolean) as user_is_active
+        , cast(is_staff as boolean) as user_is_staff
+        , cast(is_superuser as boolean) as user_is_superuser
+        , to_iso8601(from_iso8601_timestamp_nanos(
+            regexp_replace(date_joined, '(\d{4}-\d{2}-\d{2})[ ](\d{2}:\d{2}:\d{2})(.*?)', '$1T$2$3')
+        )) as user_joined_on
+        , case
+            when lower(last_login) = 'null' then null
+            else to_iso8601(from_iso8601_timestamp_nanos(
+                regexp_replace(last_login, '(\d{4}-\d{2}-\d{2})[ ](\d{2}:\d{2}:\d{2})(.*?)', '$1T$2$3')
+            ))
+        end as user_last_login
+    from most_recent_source
+)
+
+select * from cleaned

--- a/src/ol_dbt/models/staging/edxorg/stg__edxorg__s3__user_courseaccessrole.sql
+++ b/src/ol_dbt/models/staging/edxorg/stg__edxorg__s3__user_courseaccessrole.sql
@@ -1,0 +1,21 @@
+with source as (
+    select * from {{ source('ol_warehouse_raw_data','raw__edxorg__s3__tables__student_courseaccessrole') }}
+)
+
+{{ deduplicate_query (
+   cte_name1='source',
+   cte_name2='most_recent_source' ,
+   partition_columns = 'course_id, user_id, role')
+}}
+
+
+, cleaned as (
+    select
+        course_id as courserun_readable_id
+        , cast(user_id as integer) as user_id
+        , role as courseaccess_role
+        , if(lower(org) = 'mitxt', 'MITxT', org) as organization
+    from most_recent_source
+)
+
+select * from cleaned

--- a/src/ol_dbt/models/staging/edxorg/stg__edxorg__s3__user_profile.sql
+++ b/src/ol_dbt/models/staging/edxorg/stg__edxorg__s3__user_profile.sql
@@ -1,0 +1,45 @@
+with source as (
+    select * from {{ source('ol_warehouse_raw_data','raw__edxorg__s3__tables__auth_userprofile') }}
+)
+
+{{ deduplicate_query(cte_name1='source', cte_name2='most_recent_source' , partition_columns = 'id') }}
+
+, cleaned as (
+    select
+        ---all values are ingested as string, so we need to cast here to match other data sources
+        cast(id as integer) as user_profile_id
+        , cast(user_id as integer) as user_id
+        , meta as user_profile_metadata
+        , case
+            when lower(name) = 'null' then null
+            when name = '' then null
+            when name like '><%' then null
+            else name
+        end as user_full_name
+        , case
+            when lower(bio) = 'null' then null
+            when bio = '' then null
+            else bio
+        end as user_bio
+        , case
+            when lower(goals) = 'null' then null
+            when goals = '' then null
+            when goals like '><%' then null
+            else goals
+        end as user_goals
+        , case
+            when lower(year_of_birth) = 'null' then null
+            when year_of_birth = '' then null
+            else try_cast(year_of_birth as integer)
+        end as user_year_of_birth
+        , case
+            when lower(country) = 'null' then null
+            when country = '' then null
+            else country
+        end as user_address_country
+        , {{ transform_gender_value('gender') }} as user_gender
+        , {{ transform_education_value('level_of_education') }} as user_highest_education
+    from most_recent_source
+)
+
+select * from cleaned


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
remaining https://github.com/mitodl/hq/issues/4067

### Description (What does it do?)
<!--- Describe your changes in detail -->
Creating `stg__edxorg__s3__user` and `stg__edxorg__s3__user_profile`, `stg__edxorg__s3__user_courseaccessrole` and `stg__edxorg__s3__courserun_certificate`
- fields are converted to the proper data types and cleaned
- data is deduplicated

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->
Run these commands and there should be no errors

dbt build --select stg__edxorg__s3__user
dbt build --select stg__edxorg__s3__user_profile
dbt build --select stg__edxorg__s3__user_courseaccessrole
dbt build --select stg__edxorg__s3__courserun_certificate
