### PR TITLE
fix dbt failure

### DIFF
--- a/src/ol_dbt/models/intermediate/bootcamps/_int_bootcamps__models.yml
+++ b/src/ol_dbt/models/intermediate/bootcamps/_int_bootcamps__models.yml
@@ -292,10 +292,10 @@ models:
   - name: user_address_postal_code
     description: str, user postal code
   - name: user_gender
-    description: str, user gender
+    description: str, user gender. May be null if user didn't specify.
     tests:
     - accepted_values:
-        values: ['Male', 'Female', 'Other/Prefer Not to Say', '']
+        values: ['Male', 'Female', 'Other/Prefer Not to Say']
   - name: user_birth_year
     description: int, user birth year
   - name: user_company

--- a/src/ol_dbt/models/intermediate/mitxonline/_int_mitxonline__models.yml
+++ b/src/ol_dbt/models/intermediate/mitxonline/_int_mitxonline__models.yml
@@ -1344,7 +1344,7 @@ models:
   - name: user_leadership_level
     description: str, user leadership level
   - name: user_gender
-    description: str, user gender
+    description: str, user gender. May be null if user didn't specify.
     tests:
     - accepted_values:
         values: '{{ var("gender_values") }}'

--- a/src/ol_dbt/models/intermediate/mitxpro/_int_mitxpro__models.yml
+++ b/src/ol_dbt/models/intermediate/mitxpro/_int_mitxpro__models.yml
@@ -1330,7 +1330,7 @@ models:
   - name: user_address_postal_code
     description: str, user postal code
   - name: user_gender
-    description: str, user gender
+    description: str, user gender. May be null if user didn't specify.
     tests:
     - accepted_values:
         values: ['Male', 'Female', 'Other/Prefer Not to Say', '']

--- a/src/ol_dbt/models/staging/bootcamps/_stg_bootcamps__models.yml
+++ b/src/ol_dbt/models/staging/bootcamps/_stg_bootcamps__models.yml
@@ -295,11 +295,10 @@ models:
     tests:
     - not_null
   - name: user_gender
-    description: str, user gender
+    description: str, user gender. May be null if user didn't specify.
     tests:
     - accepted_values:
-        values: ['Male', 'Female', 'Other/Prefer Not to Say', '']
-    - not_null
+        values: ['Male', 'Female', 'Other/Prefer Not to Say']
   - name: user_birth_year
     description: int, user birth year
   - name: user_company

--- a/src/ol_dbt/models/staging/edxorg/_stg__edxorg__models.yml
+++ b/src/ol_dbt/models/staging/edxorg/_stg__edxorg__models.yml
@@ -783,13 +783,9 @@ models:
   - name: courseruncertificate_created_on
     description: timestamp, date and time string indicating when the certificate was
       created
-    tests:
-    - not_null
   - name: courseruncertificate_updated_on
     description: timestamp, date and time string indicating when the certificate was
       last modified
-    tests:
-    - not_null
   tests:
   - dbt_expectations.expect_compound_columns_to_be_unique:
       column_list: ["courserun_readable_id", "user_id"]

--- a/src/ol_dbt/models/staging/edxorg/stg__edxorg__s3__courserun_certificate.sql
+++ b/src/ol_dbt/models/staging/edxorg/stg__edxorg__s3__courserun_certificate.sql
@@ -18,8 +18,14 @@ with source as (
         , verify_uuid as courseruncertificate_verify_uuid
         , status as courseruncertificate_status
         , try_cast(grade as decimal(38, 2)) as courseruncertificate_grade
-        , to_iso8601(date_parse(created_date, '%Y-%m-%d %H:%i:%s')) as courseruncertificate_created_on
-        , to_iso8601(date_parse(modified_date, '%Y-%m-%d %H:%i:%s')) as courseruncertificate_updated_on
+        , case
+            when lower(created_date) = 'null' or lower(created_date) = 'none' then null
+            else to_iso8601(date_parse(created_date, '%Y-%m-%d %H:%i:%s'))
+        end as courseruncertificate_created_on
+        , case
+            when lower(modified_date) = 'null' or lower(modified_date) = 'none' then null
+            else to_iso8601(date_parse(modified_date, '%Y-%m-%d %H:%i:%s'))
+        end as courseruncertificate_updated_on
     from most_recent_source
 )
 

--- a/src/ol_dbt/models/staging/edxorg/stg__edxorg__s3__user.sql
+++ b/src/ol_dbt/models/staging/edxorg/stg__edxorg__s3__user.sql
@@ -17,7 +17,7 @@ with source as (
             regexp_replace(date_joined, '(\d{4}-\d{2}-\d{2})[ ](\d{2}:\d{2}:\d{2})(.*?)', '$1T$2$3')
         )) as user_joined_on
         , case
-            when lower(last_login) = 'null' then null
+            when lower(last_login) = 'null' or lower(last_login) = 'none' then null
             else to_iso8601(from_iso8601_timestamp_nanos(
                 regexp_replace(last_login, '(\d{4}-\d{2}-\d{2})[ ](\d{2}:\d{2}:\d{2})(.*?)', '$1T$2$3')
             ))

--- a/src/ol_dbt/models/staging/mitxpro/_stg_mitxpro__models.yml
+++ b/src/ol_dbt/models/staging/mitxpro/_stg_mitxpro__models.yml
@@ -994,11 +994,10 @@ models:
     - unique
     - not_null
   - name: user_gender
-    description: str, user gender
+    description: str, user gender. May be null if user didn't specify.
     tests:
     - accepted_values:
         values: ['Male', 'Female', 'Other/Prefer Not to Say', '']
-    - not_null
   - name: user_birth_year
     description: int, user birth year
   - name: user_company

--- a/src/ol_dbt/models/staging/mitxpro/_stg_mitxpro__models.yml
+++ b/src/ol_dbt/models/staging/mitxpro/_stg_mitxpro__models.yml
@@ -997,7 +997,7 @@ models:
     description: str, user gender. May be null if user didn't specify.
     tests:
     - accepted_values:
-        values: ['Male', 'Female', 'Other/Prefer Not to Say', '']
+        values: ['Male', 'Female', 'Other/Prefer Not to Say']
   - name: user_birth_year
     description: int, user birth year
   - name: user_company


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
NA
3 dbt failed tests https://pipelines.odl.mit.edu/runs/d91320ed-9dca-45fa-b8d6-6a9e5600229d

### Description (What does it do?)
<!--- Describe your changes in detail -->
- fixing the not_null test for user_gender field in stg__bootcamps__app__postgres__profiles_profile and stg__mitxpro__app__postgres__users_profile since there are user profiles missing user_gender in Bootcamps and xPro. 
   -  Gender fields are from a controlled list 'Male', 'Female', 'Other/Prefer Not to Say' in Bootcamps and xPro. Any missing values are converted to Null for consistency
- Converting the literal string`None` to null for courseruncertificate_created_on and courseruncertificate_updated_on in stg__edxorg__s3__courserun_certificate since these are date fields


### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

Run the following commands and there should be no failed tests now

dbt test --select stg__bootcamps__app__postgres__profiles_profile --target production
dbt test --select stg__mitxpro__app__postgres__users_profile --target production
dbt build --select stg__edxorg__s3__courserun_certificate 
dbt build --select stg__edxorg__s3__user 

### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->


<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
