### PR TITLE
add edxorg course access roles to intermediate

### DIFF
--- a/src/ol_dbt/models/intermediate/combined/_combined_models.yml
+++ b/src/ol_dbt/models/intermediate/combined/_combined_models.yml
@@ -179,7 +179,9 @@ models:
     - not_null
   - name: courserun_readable_id
     description: str, the open edX Course ID formatted as course-v1:{org}+{course
-      number}+{run_tag}
+      number}+{run_tag} for MITx Online, xPro and Residential MITx. For edx.org platform,
+      it is formatted as {org}/{course number}/{run_tag} so it can be used to match
+      with other edx.org datasets.
     tests:
     - not_null
   - name: user_username
@@ -203,7 +205,7 @@ models:
     - not_null
   tests:
   - dbt_expectations.expect_compound_columns_to_be_unique:
-      column_list: ["platform", "user_username", "courserun_readable_id", "courseaccess_role"]
+      column_list: ["platform", "user_email", "courserun_readable_id", "courseaccess_role"]
 
 - name: int__combined__course_runs
   description: Intermediate combined model for courses and runs from different platforms

--- a/src/ol_dbt/models/intermediate/combined/_combined_models.yml
+++ b/src/ol_dbt/models/intermediate/combined/_combined_models.yml
@@ -203,7 +203,7 @@ models:
     - not_null
   tests:
   - dbt_expectations.expect_compound_columns_to_be_unique:
-      column_list: ["user_username", "courserun_readable_id", "courseaccess_role"]
+      column_list: ["platform", "user_username", "courserun_readable_id", "courseaccess_role"]
 
 - name: int__combined__course_runs
   description: Intermediate combined model for courses and runs from different platforms

--- a/src/ol_dbt/models/intermediate/combined/int__combined__user_course_roles.sql
+++ b/src/ol_dbt/models/intermediate/combined/int__combined__user_course_roles.sql
@@ -66,7 +66,7 @@ with mitxonline_courseroles as (
         , edxorg_users.user_username
         , edxorg_users.user_email
         , edxorg_profiles.user_full_name
-        , edxorg_courseroles.courserun_readable_id
+        , edxorg_courseroles.courserun_edx_readable_id as courserun_readable_id
         , edxorg_courseroles.organization
         , edxorg_courseroles.courseaccess_role
     from edxorg_courseroles

--- a/src/ol_dbt/models/intermediate/combined/int__combined__user_course_roles.sql
+++ b/src/ol_dbt/models/intermediate/combined/int__combined__user_course_roles.sql
@@ -30,6 +30,18 @@ with mitxonline_courseroles as (
     select * from {{ ref('stg__mitxresidential__openedx__auth_user') }}
 )
 
+, edxorg_courseroles as (
+    select * from {{ ref('stg__edxorg__s3__user_courseaccessrole') }}
+)
+
+, edxorg_users as (
+    select * from {{ ref('stg__edxorg__s3__user') }}
+)
+
+, edxorg_profiles as (
+    select * from {{ ref('stg__edxorg__s3__user_profile') }}
+)
+
 , combined_courseroles as (
     select
         '{{ var("mitxonline") }}' as platform
@@ -46,6 +58,22 @@ with mitxonline_courseroles as (
         on
             mitxonline_openedx_users.user_username = mitxonline_app_users.user_username
             or mitxonline_openedx_users.user_email = mitxonline_app_users.user_email
+
+    union all
+
+    select
+        '{{ var("edxorg") }}' as platform
+        , edxorg_users.user_username
+        , edxorg_users.user_email
+        , edxorg_profiles.user_full_name
+        , edxorg_courseroles.courserun_readable_id
+        , edxorg_courseroles.organization
+        , edxorg_courseroles.courseaccess_role
+    from edxorg_courseroles
+    inner join edxorg_users
+        on edxorg_courseroles.user_id = edxorg_users.user_id
+    left join edxorg_profiles
+        on edxorg_courseroles.user_id = edxorg_profiles.user_id
 
     union all
 

--- a/src/ol_dbt/models/staging/edxorg/_stg__edxorg__models.yml
+++ b/src/ol_dbt/models/staging/edxorg/_stg__edxorg__models.yml
@@ -804,6 +804,11 @@ models:
       runs.
     tests:
     - not_null
+  - name: courserun_edx_readable_id
+    description: str, open edX Course ID formatted as {org}/{course number}/{run}
+      for all runs.
+    tests:
+    - not_null
   - name: organization
     description: str, the organization the course belongs to. e.g. MITx
   - name: courseaccess_role

--- a/src/ol_dbt/models/staging/edxorg/stg__edxorg__s3__user_courseaccessrole.sql
+++ b/src/ol_dbt/models/staging/edxorg/stg__edxorg__s3__user_courseaccessrole.sql
@@ -14,6 +14,7 @@ with source as (
         course_id as courserun_readable_id
         , cast(user_id as integer) as user_id
         , role as courseaccess_role
+        , replace(replace(course_id, 'course-v1:', ''), '+', '/') as courserun_edx_readable_id
         , if(lower(org) = 'mitxt', 'MITxT', org) as organization
     from most_recent_source
 )


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
NA but related to https://github.com/mitodl/hq/issues/4067

### Description (What does it do?)
<!--- Describe your changes in detail -->
Adding courserun_edx_readable_id to stg__edxorg__s3__user_courseaccessrole for consistent format
Adding edX.org course access roles to int__combined__user_course_roles


### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->
dbt build --select stg__edxorg__s3__user_courseaccessrole
dbt build --select int__combined__user_course_roles
