### PR TITLE
Update intermediate combined view materialization to reduce number of stages in the mart query

### DIFF
--- a/src/ol_dbt/models/intermediate/combined/int__combined__course_runs.sql
+++ b/src/ol_dbt/models/intermediate/combined/int__combined__course_runs.sql
@@ -1,5 +1,3 @@
-{{ config(materialized='view') }}
-
 with mitx_courses as (
     select * from {{ ref('int__mitx__courses') }}
 )

--- a/src/ol_dbt/models/intermediate/combined/int__combined__courserun_enrollments.sql
+++ b/src/ol_dbt/models/intermediate/combined/int__combined__courserun_enrollments.sql
@@ -1,7 +1,3 @@
---- This model combines intermediate enrollments from different platform,
--- it's built as view with no additional data is stored
-{{ config(materialized='view') }}
-
 with mitx_enrollments as (
     select * from {{ ref('int__mitx__courserun_enrollments') }}
 )


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
NA

### Description (What does it do?)
<!--- Describe your changes in detail -->
fixing the second error in https://pipelines.odl.mit.edu/runs/8887a580-4d2f-4b6b-827d-5ccff5791cd4?logs=error mostly due to the referenced intermediate models are `views` instead of `tables`
```
 TrinoUserError(type=USER_ERROR, name=QUERY_HAS_TOO_MANY_STAGES, message="Number of stages in the query (164) exceeds the allowed maximum (150). If the query contains multiple aggregates with DISTINCT over different columns, please set the 'distinct_aggregations_strategy' session property to 'single_step'. If the query contains WITH clauses that are referenced more than once, please create temporary table(s) for the queries in those clauses.", query_id=20240521_150636_45393_m3ypf)
```

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

Run the full refresh on the following intermediate models:

> dbt run --select int__combined__courserun_enrollments --full-refresh
> dbt run --select int__combined__course_runs --full-refresh

Then run `dbt compile --select marts__combined_course_enrollment_detail` to compile the query
Then run `EXPLAIN ANALYZE <compiled query from above step>`, you should notice the number of steps is reduced to 24 from 115 
https://mitol.galaxy.starburst.io/query-history/20240521_165655_27128_tsyr4 is the query detail from my test


