### PR TITLE
update design of enrollment and order marts

### DIFF
--- a/src/ol_dbt/models/marts/combined/_marts__combined__models.yml
+++ b/src/ol_dbt/models/marts/combined/_marts__combined__models.yml
@@ -123,144 +123,6 @@ models:
       or a unique uuid
   - name: req_reference_number
     description: str, cybersource req reference number for a payment
-  tests:
-  - dbt_expectations.expect_compound_columns_to_be_unique:
-      column_list: ["order_id", "line_id", "b2b_only_indicator", "platform", "coupon_id"]
-
-- name: marts__combined_course_enrollment_detail
-  description: course enrollment detail with certificates, orders and coupons from
-    OL platforms. No order data for edX.org course purchase.
-  config:
-    grants:
-      select: ['finance']
-  columns:
-  - name: platform
-    description: string, application where the data is from
-    tests:
-    - not_null
-    - accepted_values:
-        values: '{{ var("platforms") }}'
-  - name: courserunenrollment_id
-    description: int, internal ID and foreign key to courserunenrollments on the corresponding
-      platform. Null for enrollments on edX.org.
-  - name: courserunenrollment_is_active
-    description: boolean, indicating whether the enrollment is active
-    tests:
-    - not_null
-  - name: user_id
-    description: int, user ID on the corresponding platform
-    tests:
-    - not_null
-  - name: courserun_id
-    description: int, primary key representing a single course run on the corresponding
-      platform. Null for course runs from edx.org
-  - name: courserunenrollment_created_on
-    description: timestamp, specifying when the enrollment was initially
-    tests:
-    - not_null
-  - name: courserunenrollment_enrollment_mode
-    description: string, enrollment mode for user on the corresponding platform
-  - name: courserunenrollment_enrollment_status
-    description: string, enrollment status for users whose enrollment changed on the
-      corresponding platform
-  - name: courserunenrollment_is_edx_enrolled
-    description: boolean, indicating whether the user is enrolled on edX platform.
-      For edx.org course enrollment, it would always be true. Null for Bootcamps as
-      it doesn't apply.
-  - name: courserun_title
-    description: string, title of the course run on the corresponding platform. Maybe
-      blank for a few edX.org runs missing in int__edxorg__mitx_courseruns.
-  - name: courserun_readable_id
-    description: str, unique string to identify a course run on the corresponding
-      platform
-  - name: courserun_start_on
-    description: timestamp, date and time when the course run starts. May be Null.
-  - name: courserun_end_on
-    description: timestamp, date and time when the course run ends. May be Null.
-  - name: courserun_is_current
-    description: boolean, indicating if the course run is currently running. True
-      if courserun_start_on is in the past and blank courserun_end_on, or courserun_start_on
-      is in the past and courserun_end_on is in the future.
-    tests:
-    - not_null
-  - name: user_username
-    description: string, username to identify a user on the corresponding platform
-    tests:
-    - not_null
-  - name: user_email
-    description: string, user email that user registered on the corresponding platform
-    tests:
-    - not_null
-  - name: user_full_name
-    description: str, user full name on the platform user enrolled
-  - name: user_country_code
-    description: str, country code on the platform user enrolled. May be blank.
-  - name: user_highest_education
-    description: str, user's highest education on the platform user enrolled. May
-      be blank.
-  - name: user_company
-    description: str, user's company pulled on the platform user enrolled. May be
-      blank.
-  - name: courseruncertificate_is_earned
-    description: boolean, indicating if learner has earned the certificate on mitxonline.mit.edu,
-      micromasters.mit.edu (legacy), edX.org or xpro.mit.edu.
-    tests:
-    - not_null
-  - name: courseruncertificate_uuid
-    description: str, unique identifier for the certificate on the corresponding platform
-  - name: courseruncertificate_url
-    description: str, URL to the course certificate for users who earned the certificate
-      on mitxonline.mit.edu, micromasters.mit.edu (legacy), edX.org or xpro.mit.edu.
-      It doesn't include the revoked certificates.
-  - name: courseruncertificate_created_on
-    description: timestamp, date and time when the course certificate was initially
-      created
-  - name: order_id
-    description: int, unique identifier/foreign key to ecommerce orders from the corresponding
-      platform. Note that this doesn't include orders from edX.org, which we don't
-      have data for them
-  - name: order_state
-    description: string, order state from the corresponding platform. It doesn't include
-      'created' order state
-  - name: order_created_on
-    description: timestamp, specifying when the order was initially created
-  - name: order_reference_number
-    description: string, order reference number to identify an order on the corresponding
-      platform, e.g. mitxonline-production-20
-  - name: order_total_price_paid
-    description: number, total order amount for the order
-  - name: unit_price
-    description: numeric, price for the order line item before discount
-  - name: discount
-    description: str, discount in readable format. e.g. $100 off, 30% off, etc
-  - name: discount_amount
-    description: numeric, actual discount dollar amount. For percent-discount coupon,
-      this is calculated as line_price * percentage off
-  - name: payment_type
-    description: str, for xPro, the possible values are "staff", "marketing", "credit_card",
-      "purchase_order", "sales". For MITx Online, it's one of "marketing", "sales",
-      "financial-assistance", "customer-support", "staff", "legacy". Null for Bootcamps
-      or MicroMasters orders.
-  - name: coupon_type
-    description: str, type of the coupon which describes what circumstances the coupon
-      can be redeemed.
-  - name: coupon_code
-    description: str, discount code for the redeemed coupon if applicable
-  - name: coupon_redeemed_on
-    description: timestamp, specifying when the discount was redeemed by the user
-  - name: receipt_transaction_id
-    description: str, transaction ID from cybersource receipt
-  - name: receipt_authorization_code
-    description: str, authorization code from cybersource receipt
-  - name: receipt_payment_method
-    description: str, payment method from cybersource receipt. Value could be 'paypal'
-      or 'card'.
-  - name: receipt_req_reference_number
-    description: str, req_reference_number from cybersource receipt
-  - name: receipt_bill_to_address_state
-    description: str, address state from cybersource receipt
-  - name: receipt_bill_to_address_country
-    description: str, address country from cybersource receipt
   - name: order_tax_country_code
     description: str, the country code where the tax was applied. Only applicable
       for xPro for now.
@@ -275,30 +137,158 @@ models:
     description: numeric, total order amount plus the amount of tax paid. For xPro,
       this is calculated order_total_price_paid+order_tax_amount. For other platform,
       this is the same as order_total_price_paid
-  - name: product_id
-    description: int, unique identifier/foreign key to ecommerce products on MITx
-      Online or xPro.
-  - name: product_program_readable_id
-    description: str, open edX program readable ID associated to ecommerce products
-      on MITx Online or xPro. Blank means that the product is course run.
+  tests:
+  - dbt_expectations.expect_compound_columns_to_be_unique:
+      column_list: ["order_id", "line_id", "b2b_only_indicator", "platform", "coupon_id"]
+
+- name: marts__combined_course_enrollment_detail
+  description: course enrollment detail with certificates, orders and coupons from
+    OL platforms. No order data for edX.org course purchase.
+  config:
+    grants:
+      select: ['finance']
+  columns:
+  - name: coupon_code
+    description: str, discount code for the redeemed coupon if applicable
+  - name: coupon_redeemed_on
+    description: timestamp, specifying when the discount was redeemed by the user
+  - name: coupon_type
+    description: str, type of the coupon which describes what circumstances the coupon
+      can be redeemed.
+  - name: course_readable_id
+    description: str, Open edX ID formatted as course-v1:{org}+{course code} for MITx
+      Online and xPro courses, and {org}/{course} for edX.org courses. May be null
+      for some old edX.org runs and Bootcamps courses. Examples include MITx/6.00.2x
+      and course-v1:MITxT+14.740x.
+    tests:
+    - dbt_expectations.expect_column_values_to_not_be_null:
+        row_condition: "platform != 'Bootcamps' and platform != 'edX.org'"
+  - name: course_title
+    description: str, title of the course. May be null for some old edX.org runs.
+    tests:
+    - dbt_expectations.expect_column_values_to_not_be_null:
+        row_condition: "platform != 'edX.org'"
+  - name: courserun_end_on
+    description: timestamp, date and time when the course run ends. May be Null.
+  - name: courserun_id
+    description: int, primary key representing a single course run on the corresponding
+      platform. Null for course runs from edx.org
+  - name: courserun_is_current
+    description: boolean, indicating if the course run is currently running. True
+      if courserun_start_on is in the past and blank courserun_end_on, or courserun_start_on
+      is in the past and courserun_end_on is in the future.
+    tests:
+    - not_null
+  - name: courserun_readable_id
+    description: str, unique string to identify a course run on the corresponding
+      platform
+  - name: courserun_start_on
+    description: timestamp, date and time when the course run starts. May be Null.
+  - name: courserun_title
+    description: string, title of the course run on the corresponding platform. Maybe
+      blank for a few edX.org runs missing in int__edxorg__mitx_courseruns.
+  - name: courseruncertificate_created_on
+    description: timestamp, date and time when the course certificate was initially
+      created
+  - name: courseruncertificate_is_earned
+    description: boolean, indicating if learner has earned the certificate on mitxonline.mit.edu,
+      micromasters.mit.edu (legacy), edX.org or xpro.mit.edu.
+    tests:
+    - not_null
+  - name: courseruncertificate_url
+    description: str, URL to the course certificate for users who earned the certificate
+      on mitxonline.mit.edu, micromasters.mit.edu (legacy), edX.org or xpro.mit.edu.
+      It doesn't include the revoked certificates.
+  - name: courseruncertificate_uuid
+    description: str, unique identifier for the certificate on the corresponding platform
+  - name: courserunenrollment_created_on
+    description: timestamp, specifying when the enrollment was initially
+    tests:
+    - not_null
+  - name: courserunenrollment_enrollment_mode
+    description: string, enrollment mode for user on the corresponding platform
+  - name: courserunenrollment_enrollment_status
+    description: string, enrollment status for users whose enrollment changed on the
+      corresponding platform
+  - name: courserunenrollment_id
+    description: int, internal ID and foreign key to courserunenrollments on the corresponding
+      platform. Null for enrollments on edX.org.
+  - name: courserunenrollment_is_active
+    description: boolean, indicating whether the enrollment is active
+    tests:
+    - not_null
+  - name: courserunenrollment_is_edx_enrolled
+    description: boolean, indicating whether the user is enrolled on edX platform.
+      For edx.org course enrollment, it would always be true. Null for Bootcamps as
+      it doesn't apply.
   - name: courserungrade_grade
     description: float, course grade on edX.org or MITxOnline or xPro range from 0
       to 1
   - name: courserungrade_is_passing
     description: boolean, indicating whether the user has passed the passing score
       set for this course on edX.org or MITxOnline or xPro
-  - name: course_title
-    description: str, title of the course. May be null for some old edX.org runs.
+  - name: discount
+    description: str, discount in readable format. e.g. $100 off, 30% off, etc
+  - name: discount_amount
+    description: numeric, actual discount dollar amount. For percent-discount coupon,
+      this is calculated as line_price * percentage off
+  - name: order_id
+    description: int, unique identifier/foreign key to ecommerce orders from the corresponding
+      platform. Note that this doesn't include orders from edX.org, which we don't
+      have data for them
+  - name: order_reference_number
+    description: string, order reference number to identify an order on the corresponding
+      platform, e.g. mitxonline-production-20
+  - name: payment_bill_to_address_country
+    description: str, address country from most recent cybersource payment
+  - name: payment_bill_to_address_state
+    description: str, address state from most recent cybersource payment
+  - name: payment_method
+    description: str, payment method from cybersource receipt. Value could be 'paypal'
+      or 'card'.
+  - name: payment_transaction_id
+    description: str, unique identifier from most recent cybersource payment or UUID.
+  - name: payment_type
+    description: str, for xPro, the possible values are "staff", "marketing", "credit_card",
+      "purchase_order", "sales". For MITx Online, it's one of "marketing", "sales",
+      "financial-assistance", "customer-support", "staff", "legacy". Null for Bootcamps
+      or MicroMasters orders.
+  - name: platform
+    description: string, application where the data is from
     tests:
-    - dbt_expectations.expect_column_values_to_not_be_null:
-        row_condition: "platform != 'edX.org'"
-  - name: course_readable_id
-    description: str, Open edX ID formatted as course-v1:{org}+{course code} for MITx
-      Online and xPro courses, and {org}/{course} for edX.org courses. May be null
-      for some old edX.org runs and Bootcamps courses.
+    - not_null
+    - accepted_values:
+        values: '{{ var("platforms") }}'
+  - name: product_id
+    description: int, unique identifier/foreign key to ecommerce products on MITx
+      Online or xPro.
+  - name: product_program_readable_id
+    description: str, open edX program readable ID associated to ecommerce products
+      on MITx Online or xPro. Blank means that the product is course run.
+  - name: unit_price
+    description: numeric, price for the order line item before discount
+  - name: user_company
+    description: str, user's company pulled on the platform user enrolled. May be
+      blank.
+  - name: user_country_code
+    description: str, country code on the platform user enrolled. May be blank.
+  - name: user_email
+    description: string, user email that user registered on the corresponding platform
     tests:
-    - dbt_expectations.expect_column_values_to_not_be_null:
-        row_condition: "platform != 'Bootcamps' and platform != 'edX.org'"
+    - not_null
+  - name: user_full_name
+    description: str, user full name on the platform user enrolled
+  - name: user_highest_education
+    description: str, user's highest education on the platform user enrolled. May
+      be blank.
+  - name: user_id
+    description: int, user ID on the corresponding platform
+    tests:
+    - not_null
+  - name: user_username
+    description: string, username to identify a user on the corresponding platform
+    tests:
+    - not_null
   tests:
   - dbt_expectations.expect_compound_columns_to_be_unique:
       column_list: ["user_username", "courserun_readable_id"]

--- a/src/ol_dbt/models/marts/combined/_marts__combined__models.yml
+++ b/src/ol_dbt/models/marts/combined/_marts__combined__models.yml
@@ -89,6 +89,14 @@ models:
     description: int, foreign key for order table
   - name: line_id
     description: int, foreign key for line table
+  - name: b2b_only_indicator
+    description: str, indicates whether the record is only related to a b2b order
+  - name: coupon_id
+    description: int, foreign key referencing ecommerce_coupon or the b2b coupon table
+  - name: coupon_name
+    description: string, human readable name for the coupon payment
+  - name: courserun_id
+    description: int, foreign key in courses_courserun
   - name: order_created_on
     description: timestamp, specifying when the order was initially created. If this
       is a b2b order it will be the timestamp that order was created otherwise it
@@ -96,33 +104,8 @@ models:
   - name: order_state
     description: string, order state. Options are "fulfilled", "failed", "created"
       "refunded"
-  - name: courserun_id
-    description: int, foreign key in courses_courserun
-  - name: order_total_price_paid
-    description: number, total order amount
-  - name: product_id
-    description: int, foreign key for product table
-  - name: product_type
-    description: string, readable product type
-  - name: user_email
-    description: str, user email associated with their account
-  - name: user_id
-    description: int, foreign key to the user table
-  - name: user_id
-    description: int, foreign key to the user table
-  - name: b2b_only_indicator
-    description: str, indicates whether the record is only related to a b2b order
-  - name: coupon_id
-    description: int, foreign key referencing ecommerce_coupon or the b2b coupon table
-  - name: coupon_name
-    description: string, human readable name for the coupon payment
-  - name: receipt_authorization_code
-    description: str, authorization code from cybersource payment
-  - name: receipt_transaction_id
-    description: string, unique identifier. Either the transaction_id from cybersource
-      or a unique uuid
-  - name: req_reference_number
-    description: str, cybersource req reference number for a payment
+  - name: order_tax_amount
+    description: numeric, the amount of tax paid. Only applicable for xPro for now.
   - name: order_tax_country_code
     description: str, the country code where the tax was applied. Only applicable
       for xPro for now.
@@ -131,12 +114,27 @@ models:
   - name: order_tax_rate_name
     description: string, name of the tax rate assessed. Only applicable for xPro for
       now.
-  - name: order_tax_amount
-    description: numeric, the amount of tax paid. Only applicable for xPro for now.
   - name: order_total_price_paid_plus_tax
     description: numeric, total order amount plus the amount of tax paid. For xPro,
       this is calculated order_total_price_paid+order_tax_amount. For other platform,
       this is the same as order_total_price_paid
+  - name: order_total_price_paid
+    description: number, total order amount
+  - name: product_id
+    description: int, foreign key for product table
+  - name: product_type
+    description: string, readable product type
+  - name: receipt_authorization_code
+    description: str, authorization code from cybersource payment
+  - name: receipt_transaction_id
+    description: string, unique identifier. Either the transaction_id from cybersource
+      or a unique uuid
+  - name: req_reference_number
+    description: str, cybersource req reference number for a payment
+  - name: user_email
+    description: str, user email associated with their account
+  - name: user_id
+    description: int, foreign key to the user table
   tests:
   - dbt_expectations.expect_compound_columns_to_be_unique:
       column_list: ["order_id", "line_id", "b2b_only_indicator", "platform", "coupon_id"]

--- a/src/ol_dbt/models/marts/combined/marts__combined__orders.sql
+++ b/src/ol_dbt/models/marts/combined/marts__combined__orders.sql
@@ -49,6 +49,11 @@ with bootcamps__ecommerce_order as (
         , mitxpro__ecommerce_allorders.receipt_authorization_code
         , mitxpro__ecommerce_allorders.receipt_transaction_id
         , mitxpro__ecommerce_allorders.req_reference_number
+        , mitxpro__ecommerce_order.order_tax_country_code
+        , mitxpro__ecommerce_order.order_tax_rate
+        , mitxpro__ecommerce_order.order_tax_rate_name
+        , mitxpro__ecommerce_order.order_tax_amount
+        , mitxpro__ecommerce_order.order_total_price_paid_plus_tax
         , coalesce(mitxpro__ecommerce_allorders.coupon_id, mitxpro__ecommerce_allorders.b2bcoupon_id) as coupon_id
         , coalesce(mitxpro__ecommerce_allorders.order_id, mitxpro__ecommerce_allorders.b2border_id) as order_id
         , case
@@ -103,6 +108,11 @@ with bootcamps__ecommerce_order as (
         , payment_authorization_code as receipt_authorization_code
         , payment_transaction_id as receipt_transaction_id
         , order_reference_number as req_reference_number
+        , null as order_tax_country_code
+        , null as order_tax_rate
+        , null as order_tax_rate_name
+        , null as order_tax_amount
+        , null as order_total_price_paid_plus_tax
     from mitxonline__ecommerce_order
 
     union all
@@ -125,6 +135,11 @@ with bootcamps__ecommerce_order as (
         , receipt_authorization_code
         , receipt_transaction_id
         , req_reference_number
+        , order_tax_country_code
+        , order_tax_rate
+        , order_tax_rate_name
+        , order_tax_amount
+        , order_total_price_paid_plus_tax
     from mitxpro_orders
 
     union all
@@ -147,6 +162,11 @@ with bootcamps__ecommerce_order as (
         , receipt_authorization_code
         , receipt_transaction_id
         , req_reference_number
+        , null as order_tax_country_code
+        , null as order_tax_rate
+        , null as order_tax_rate_name
+        , null as order_tax_amount
+        , null as order_total_price_paid_plus_tax
     from bootcamps_orders
 
 )

--- a/src/ol_dbt/models/marts/combined/marts__combined__orders.sql
+++ b/src/ol_dbt/models/marts/combined/marts__combined__orders.sql
@@ -171,7 +171,7 @@ with bootcamps__ecommerce_order as (
 
 )
 
-select 
+select
     platform
     , order_id
     , line_id

--- a/src/ol_dbt/models/marts/combined/marts__combined__orders.sql
+++ b/src/ol_dbt/models/marts/combined/marts__combined__orders.sql
@@ -112,7 +112,7 @@ with bootcamps__ecommerce_order as (
         , null as order_tax_rate
         , null as order_tax_rate_name
         , null as order_tax_amount
-        , null as order_total_price_paid_plus_tax
+        , order_total_price_paid as order_total_price_paid_plus_tax
     from mitxonline__ecommerce_order
 
     union all
@@ -166,9 +166,32 @@ with bootcamps__ecommerce_order as (
         , null as order_tax_rate
         , null as order_tax_rate_name
         , null as order_tax_amount
-        , null as order_total_price_paid_plus_tax
+        , order_total_price_paid as order_total_price_paid_plus_tax
     from bootcamps_orders
 
 )
 
-select * from combined_orders
+select 
+    platform
+    , order_id
+    , line_id
+    , b2b_only_indicator
+    , coupon_id
+    , coupon_name
+    , courserun_id
+    , order_created_on
+    , order_state
+    , order_tax_amount
+    , order_tax_country_code
+    , order_tax_rate
+    , order_tax_rate_name
+    , order_total_price_paid_plus_tax
+    , order_total_price_paid
+    , product_id
+    , product_type
+    , receipt_authorization_code
+    , receipt_transaction_id
+    , req_reference_number
+    , user_email
+    , user_id
+from combined_orders

--- a/src/ol_dbt/models/marts/combined/marts__combined_course_enrollment_detail.sql
+++ b/src/ol_dbt/models/marts/combined/marts__combined_course_enrollment_detail.sql
@@ -342,7 +342,7 @@ with combined_enrollments as (
     where combined_enrollments.platform = '{{ var("bootcamps") }}'
 )
 
-select 
+select
     platform
     , courserunenrollment_id
     , coupon_code

--- a/src/ol_dbt/models/marts/combined/marts__combined_course_enrollment_detail.sql
+++ b/src/ol_dbt/models/marts/combined/marts__combined_course_enrollment_detail.sql
@@ -342,8 +342,10 @@ with combined_enrollments as (
     where combined_enrollments.platform = '{{ var("bootcamps") }}'
 )
 
-select
-    coupon_code
+select 
+    platform
+    , courserunenrollment_id
+    , coupon_code
     , coupon_redeemed_on
     , coupon_type
     , course_readable_id
@@ -361,7 +363,6 @@ select
     , courserunenrollment_created_on
     , courserunenrollment_enrollment_mode
     , courserunenrollment_enrollment_status
-    , courserunenrollment_id
     , courserunenrollment_is_active
     , courserunenrollment_is_edx_enrolled
     , courserungrade_grade
@@ -375,7 +376,6 @@ select
     , payment_method
     , payment_transaction_id
     , payment_type
-    , platform
     , product_id
     , product_program_readable_id
     , unit_price

--- a/src/ol_dbt/models/marts/combined/marts__combined_course_enrollment_detail.sql
+++ b/src/ol_dbt/models/marts/combined/marts__combined_course_enrollment_detail.sql
@@ -158,12 +158,12 @@ with combined_enrollments as (
         , micromasters_completed_orders.coupon_type
         , micromasters_completed_orders.coupon_code
         , micromasters_completed_orders.redeemedcoupon_created_on as coupon_redeemed_on
-        , micromasters_completed_orders.receipt_transaction_id
-        , micromasters_completed_orders.receipt_authorization_code
-        , micromasters_completed_orders.receipt_payment_method
-        , micromasters_completed_orders.receipt_reference_number as receipt_req_reference_number
-        , micromasters_completed_orders.receipt_bill_to_address_state
-        , micromasters_completed_orders.receipt_bill_to_address_country
+        , micromasters_completed_orders.receipt_transaction_id as payment_transaction_id
+        , micromasters_completed_orders.receipt_authorization_code as payment_authorization_code
+        , micromasters_completed_orders.receipt_payment_method as payment_method
+        , micromasters_completed_orders.receipt_reference_number as payment_req_reference_number
+        , micromasters_completed_orders.receipt_bill_to_address_state as payment_bill_to_address_state
+        , micromasters_completed_orders.receipt_bill_to_address_country as payment_bill_to_address_country
         , null as order_tax_country_code
         , null as order_tax_rate
         , null as order_tax_rate_name
@@ -231,12 +231,12 @@ with combined_enrollments as (
         , mitxpro_completed_orders.couponpaymentversion_coupon_type as coupon_type
         , mitxpro_completed_orders.coupon_code
         , mitxpro_completed_orders.couponredemption_created_on as coupon_redeemed_on
-        , mitxpro_completed_orders.receipt_transaction_id
-        , mitxpro_completed_orders.receipt_authorization_code
-        , mitxpro_completed_orders.receipt_payment_method
-        , mitxpro_completed_orders.receipt_reference_number as receipt_req_reference_number
-        , mitxpro_completed_orders.receipt_bill_to_address_state
-        , mitxpro_completed_orders.receipt_bill_to_address_country
+        , mitxpro_completed_orders.receipt_transaction_id as payment_transaction_id
+        , mitxpro_completed_orders.receipt_authorization_code as payment_authorization_code
+        , mitxpro_completed_orders.receipt_payment_method as payment_method
+        , mitxpro_completed_orders.receipt_reference_number as payment_req_reference_number
+        , mitxpro_completed_orders.receipt_bill_to_address_state as payment_bill_to_address_state
+        , mitxpro_completed_orders.receipt_bill_to_address_country as payment_bill_to_address_country
         , mitxpro_completed_orders.order_tax_country_code
         , mitxpro_completed_orders.order_tax_rate
         , mitxpro_completed_orders.order_tax_rate_name
@@ -307,12 +307,12 @@ with combined_enrollments as (
         , null as coupon_type
         , null as coupon_code
         , null as coupon_redeemed_on
-        , bootcamps_completed_orders.receipt_transaction_id
-        , bootcamps_completed_orders.receipt_authorization_code
-        , bootcamps_completed_orders.receipt_payment_method
-        , bootcamps_completed_orders.receipt_reference_number as receipt_req_reference_number
-        , bootcamps_completed_orders.receipt_bill_to_address_state
-        , bootcamps_completed_orders.receipt_bill_to_address_country
+        , bootcamps_completed_orders.receipt_transaction_id as payment_transaction_id
+        , bootcamps_completed_orders.receipt_authorization_code as payment_authorization_code
+        , bootcamps_completed_orders.receipt_payment_method as payment_method
+        , bootcamps_completed_orders.receipt_reference_number as payment_req_reference_number
+        , bootcamps_completed_orders.receipt_bill_to_address_state as payment_bill_to_address_state
+        , bootcamps_completed_orders.receipt_bill_to_address_country as payment_bill_to_address_country
         , null as order_tax_country_code
         , null as order_tax_rate
         , null as order_tax_rate_name
@@ -342,4 +342,48 @@ with combined_enrollments as (
     where combined_enrollments.platform = '{{ var("bootcamps") }}'
 )
 
-select * from combined_enrollment_detail
+select 
+    coupon_code
+    , coupon_redeemed_on
+    , coupon_type
+    , course_readable_id
+    , course_title
+    , courserun_end_on
+    , courserun_id
+    , courserun_is_current
+    , courserun_readable_id
+    , courserun_start_on
+    , courserun_title
+    , courseruncertificate_created_on
+    , courseruncertificate_is_earned
+    , courseruncertificate_url
+    , courseruncertificate_uuid
+    , courserunenrollment_created_on
+    , courserunenrollment_enrollment_mode
+    , courserunenrollment_enrollment_status
+    , courserunenrollment_id
+    , courserunenrollment_is_active
+    , courserunenrollment_is_edx_enrolled
+    , courserungrade_grade
+    , courserungrade_is_passing
+    , discount
+    , discount_amount
+    , order_id
+    , order_reference_number
+    , payment_bill_to_address_country
+    , payment_bill_to_address_state
+    , payment_method
+    , payment_transaction_id
+    , payment_type
+    , platform
+    , product_id
+    , product_program_readable_id
+    , unit_price
+    , user_company
+    , user_country_code
+    , user_email
+    , user_full_name
+    , user_highest_education
+    , user_id
+    , user_username
+from combined_enrollment_detail

--- a/src/ol_dbt/models/marts/combined/marts__combined_course_enrollment_detail.sql
+++ b/src/ol_dbt/models/marts/combined/marts__combined_course_enrollment_detail.sql
@@ -342,7 +342,7 @@ with combined_enrollments as (
     where combined_enrollments.platform = '{{ var("bootcamps") }}'
 )
 
-select 
+select
     coupon_code
     , coupon_redeemed_on
     , coupon_type


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/4296

### Description (What does it do?)
Changed order of enrollment mart to alphabetical for readability. Moved order columns to orders mart from enrollment mart it makes more sense there design wise. Improved definition.

### How can this be tested?
dbt build --select marts__combined__orders
dbt build --select marts__combined_course_enrollment_detail

