### PR TITLE
Create problem and video activities intermediate models for edX.org

### DIFF
--- a/src/ol_dbt/models/intermediate/edxorg/_int_edxorg__models.yml
+++ b/src/ol_dbt/models/intermediate/edxorg/_int_edxorg__models.yml
@@ -472,3 +472,197 @@ models:
   tests:
   - dbt_expectations.expect_compound_columns_to_be_unique:
       column_list: ["user_id", "program_uuid"]
+
+- name: int__edxorg__mitx_user_courseactivities
+  description: users' video activities within a course on edX.org
+  columns:
+  - name: user_username
+    description: str, username of the edX.org user
+    tests:
+    - not_null
+  - name: user_id
+    description: int, the edX user ID extracted from context field. This id doesn't
+      always match with the id in auth_user. There could be multiple user_ids for
+      the same user_username. For those cases, use user_id from source table auth_user
+      for that user_username.
+    tests:
+    - not_null
+  - name: courserun_readable_id
+    description: str, open edX Course ID formatted as {org}/{course number}/{run}
+      for older runs prior to 3T2015, and course-v1:{org}+{course}+{run} for newer
+      runs.
+    tests:
+    - not_null
+  - name: useractivity_event_source
+    description: str, specifies the source of the interaction that triggered the event.
+    tests:
+    - not_null
+  - name: useractivity_event_type
+    description: >
+      str, type of video event triggered. e.g. play_video, pause_video, stop_video,
+      complete_video, etc.
+      A list of video events can be found https://edx.readthedocs.io/projects/devdata/en/latest/
+      internal_data_formats/tracking_logs/student_event_types.html#video-interaction-events
+    tests:
+    - not_null
+  - name: useractivity_page_url
+    description: str, url of the page the user was visiting when the event was emitted.
+  - name: useractivity_video_id
+    description: str, hash code for the video being watched. This value is the last
+      part of coursestructure_block_id string
+    tests:
+    - not_null
+  - name: useractivity_video_duration
+    description: number, The length of the video file, in seconds.
+    tests:
+    - not_null
+  - name: useractivity_video_currenttime
+    description: number, The time in the video when this event was emitted. May be
+      Null for load_video or seek_video events.
+  - name: useractivity_video_old_time
+    description: number, time in the video, in seconds, at which the user chose to
+      go to a different point in time for seek_video event
+    tests:
+    - dbt_expectations.expect_column_values_to_not_be_null:
+        row_condition: "useractivity_event_type = 'seek_video'"
+  - name: useractivity_video_new_time
+    description: number, time in the video, in seconds, that the user selected as
+      the destination point for seek_video event
+    tests:
+    - dbt_expectations.expect_column_values_to_not_be_null:
+        row_condition: "useractivity_event_type = 'seek_video'"
+  - name: useractivity_video_new_speed
+    description: number, new speed that the user selected for the video to play for
+      speed_change_video event. e.g. 0.75, 1.0, 1.25, 1.50.
+    tests:
+    - dbt_expectations.expect_column_values_to_not_be_null:
+        row_condition: "useractivity_event_type = 'speed_change_video'"
+  - name: useractivity_video_old_speed
+    description: number, old speed at which the video was playing for speed_change_video
+      event.
+    tests:
+    - dbt_expectations.expect_column_values_to_not_be_null:
+        row_condition: "useractivity_event_type = 'speed_change_video'"
+  - name: useractivity_timestamp
+    description: timestamp, time when this event was emitted
+    tests:
+    - not_null
+
+- name: int__edxorg__user_courseactivity_problemcheck
+  description: users' problem_check activities within a course on edX.org
+  columns:
+  - name: user_username
+    description: str, username of the edX.org user
+    tests:
+    - not_null
+  - name: user_id
+    description: int, the edX user ID extracted from context field. This id doesn't
+      always match with the id in auth_user. There could be multiple user_ids for
+      the same user_username. For those cases, use user_id from source table auth_user
+      for that user_username.
+    tests:
+    - not_null
+  - name: courserun_readable_id
+    description: str, open edX Course ID formatted as {org}/{course number}/{run}
+      for older runs prior to 3T2015, and course-v1:{org}+{course}+{run} for newer
+      runs.
+    tests:
+    - not_null
+  - name: useractivity_event_type
+    description: str, problem_check - when a problem is successfully checked.
+    tests:
+    - not_null
+  - name: useractivity_problem_id
+    description: str, Unique ID for this problem in a course. It's recorded as a URL
+      format - block-v1:{org)+{course ID}+type@problem+block@{hash code}
+    tests:
+    - not_null
+  - name: useractivity_problem_name
+    description: str, display name of this problem in a course
+    tests:
+    - not_null
+  - name: useractivity_problem_attempts
+    description: number, The number of times the user attempted to answer this problem
+    tests:
+    - not_null
+  - name: useractivity_problem_student_answers
+    description: json, student answers to this problem in problem_id and internal
+      answer pair. For multiple questions, it lists every question and answer.
+    tests:
+    - not_null
+  - name: useractivity_problem_success
+    description: str, It's either 'correct' or 'incorrect'
+    tests:
+    - not_null
+  - name: useractivity_problem_current_grade
+    description: number, current grade value for this user
+    tests:
+    - not_null
+  - name: useractivity_problem_max_grade
+    description: number, Maximum possible grade value for this problem
+    tests:
+    - not_null
+  - name: useractivity_timestamp
+    description: timestamp, time when this event was emitted
+    tests:
+    - not_null
+  tests:
+  - dbt_expectations.expect_compound_columns_to_be_unique:
+      column_list: ["user_username", "courserun_readable_id", "useractivity_problem_id",
+        "useractivity_timestamp"]
+
+- name: int__edxorg__user_courseactivity_problemsubmitted
+  description: users' problem submission activities within a course on edX.org
+  columns:
+  - name: useractivity_event_id
+    description: str, The unique identifier for tracing this problem submitted event
+    tests:
+    - not_null
+    - unique
+  - name: user_username
+    description: str, username of the edX.org user
+    tests:
+    - not_null
+  - name: user_id
+    description: int, the edX user ID extracted from context field. This id doesn't
+      always match with the id in auth_user. There could be multiple user_ids for
+      the same user_username. For those cases, use user_id from source table auth_user
+      for that user_username.
+    tests:
+    - not_null
+  - name: courserun_readable_id
+    description: str, open edX Course ID formatted as {org}/{course number}/{run}
+      for older runs prior to 3T2015, and course-v1:{org}+{course}+{run} for newer
+      runs.
+    tests:
+    - not_null
+  - name: useractivity_event_source
+    description: str, specifies the source of the interaction that triggered the event.
+      The value is server for this event.
+    tests:
+    - not_null
+  - name: useractivity_event_type
+    description: str, edx.grades.problem.submitted - when a problem is submitted and
+      successfully saved
+    tests:
+    - not_null
+  - name: useractivity_path
+    description: str, relative url path of page that generated the problem submitted
+      event.
+  - name: useractivity_problem_id
+    description: str, Unique ID for this problem in a course, formatted as block-v1:{org)+{course
+      ID}+type@problem+block@{hash code}.
+    tests:
+    - not_null
+  - name: useractivity_problem_name
+    description: str, display name of this problem in a course
+  - name: useractivity_problem_weight
+    description: number, the weight of this problem
+  - name: useractivity_problem_earned_score
+    description: str, learner’s weighted score for this problem.
+  - name: useractivity_problem_max_score
+    description: number, weighted maximum possible score for this problem.
+  - name: useractivity_timestamp
+    description: timestamp, time when this event was emitted
+    tests:
+    - not_null

--- a/src/ol_dbt/models/intermediate/edxorg/int__edxorg__user_courseactivity_problemcheck.sql
+++ b/src/ol_dbt/models/intermediate/edxorg/int__edxorg__user_courseactivity_problemcheck.sql
@@ -1,0 +1,25 @@
+{{ config(materialized='view') }}
+
+with course_activities as (
+    select * from {{ ref('stg__edxorg__s3__tracking_logs__user_activity') }}
+    where courserun_readable_id is not null
+)
+
+select
+    user_username
+    , courserun_readable_id
+    , user_id
+    , useractivity_event_type
+    , useractivity_timestamp
+    , json_query(useractivity_context_object, 'lax $.module.display_name' omit quotes) as useractivity_problem_name
+    , json_query(useractivity_event_object, 'lax $.problem_id' omit quotes) as useractivity_problem_id
+    , json_query(useractivity_event_object, 'lax $.answers' omit quotes) as useractivity_problem_student_answers
+    , json_query(useractivity_event_object, 'lax $.attempts' omit quotes) as useractivity_problem_attempts
+    , json_query(useractivity_event_object, 'lax $.success' omit quotes) as useractivity_problem_success
+    , json_query(useractivity_event_object, 'lax $.grade' omit quotes) as useractivity_problem_current_grade
+    , json_query(useractivity_event_object, 'lax $.max_grade' omit quotes) as useractivity_problem_max_grade
+from course_activities
+where useractivity_event_type = 'problem_check'
+--- This event emitted by the browser contain all of the GET parameters,
+--  only events emitted by the server are useful
+and useractivity_event_source = 'server'

--- a/src/ol_dbt/models/intermediate/edxorg/int__edxorg__user_courseactivity_problemsubmitted.sql
+++ b/src/ol_dbt/models/intermediate/edxorg/int__edxorg__user_courseactivity_problemsubmitted.sql
@@ -1,0 +1,23 @@
+{{ config(materialized='view') }}
+
+with course_activities as (
+    select * from {{ ref('stg__edxorg__s3__tracking_logs__user_activity') }}
+    where courserun_readable_id is not null
+)
+
+select
+    user_username
+    , courserun_readable_id
+    , user_id
+    , useractivity_event_source
+    , useractivity_event_type
+    , useractivity_path
+    , useractivity_timestamp
+    , json_query(useractivity_event_object, 'lax $.event_transaction_id' omit quotes) as useractivity_event_id
+    , json_query(useractivity_context_object, 'lax $.module.display_name' omit quotes) as useractivity_problem_name
+    , json_query(useractivity_event_object, 'lax $.problem_id' omit quotes) as useractivity_problem_id
+    , json_query(useractivity_event_object, 'lax $.weight' omit quotes) as useractivity_problem_weight
+    , json_query(useractivity_event_object, 'lax $.weighted_earned' omit quotes) as useractivity_problem_earned_score
+    , json_query(useractivity_event_object, 'lax $.weighted_possible' omit quotes) as useractivity_problem_max_score
+from course_activities
+where useractivity_event_type = 'edx.grades.problem.submitted'

--- a/src/ol_dbt/models/intermediate/edxorg/int__edxorg__user_courseactivity_video.sql
+++ b/src/ol_dbt/models/intermediate/edxorg/int__edxorg__user_courseactivity_video.sql
@@ -1,0 +1,24 @@
+{{ config(materialized='view') }}
+
+with course_activities as (
+    select * from {{ ref('stg__edxorg__s3__tracking_logs__user_activity') }}
+    where courserun_readable_id is not null
+)
+
+select
+    user_username
+    , courserun_readable_id
+    , user_id
+    , useractivity_event_source
+    , useractivity_event_type
+    , useractivity_page_url
+    , useractivity_timestamp
+    , json_query(useractivity_event_object, 'lax $.id' omit quotes) as useractivity_video_id
+    , json_query(useractivity_event_object, 'lax $.duration' omit quotes) as useractivity_video_duration
+    , json_query(useractivity_event_object, 'lax $.currentTime' omit quotes) as useractivity_video_currenttime
+    , json_query(useractivity_event_object, 'lax $.old_time' omit quotes) as useractivity_video_old_time
+    , json_query(useractivity_event_object, 'lax $.new_time' omit quotes) as useractivity_video_new_time
+    , json_query(useractivity_event_object, 'lax $.new_speed' omit quotes) as useractivity_video_new_speed
+    , json_query(useractivity_event_object, 'lax $.old_speed' omit quotes) as useractivity_video_old_speed
+from course_activities
+where useractivity_event_type like '%\_video' escape '\' or useractivity_event_type like 'edx.video.%' --noqa


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
https://github.com/mitodl/hq/issues/3713

### Description (What does it do?)
<!--- Describe your changes in detail -->
- This adds a few user course activity models sourced from edx.org tracking logs. These are similar to MITx Online.
- Update `int__edxorg__mitx_user_courseactivities` to use our edx.org tracking logs. No upstream model uses it, so there should be no impact.


### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

