### PR TITLE
Stage MITx Online and xPro edx course video tables

### DIFF
--- a/src/ol_dbt/models/staging/mitxonline/_mitxonline__sources.yml
+++ b/src/ol_dbt/models/staging/mitxonline/_mitxonline__sources.yml
@@ -1698,3 +1698,33 @@ sources:
       description: str, the name of the assessment workflow step
     - name: submitter_completed_at
       description: timestamp, specifying when assessment workflow step was completed
+
+  - name: raw__mitxonline__openedx__mysql__edxval_video
+    description: video content on MITx Online open edx platform
+    columns:
+    - name: id
+      description: int, primary key in edxval_video.
+    - name: edx_video_id
+      description: str, video hashed ID.
+    - name: client_video_id
+      description: str, human readable name for video. e.g. 14.310x_Lect9_Seg8_Final.mp4
+    - name: status
+      description: str, values are external, imported, file_complete, and upload_failed.
+        The videos with 'external' and 'imported' status are not managed from ODL
+        Video Service (OVS) application.
+    - name: duration
+      description: int, the length of the video, in seconds. Default to 0.0
+    - name: created
+      description: timestamp, date and time when the record was created.
+
+  - name: raw__mitxonline__openedx__mysql__edxval_coursevideo
+    description: course ID and video association on MITx Online open edx platform
+    columns:
+    - name: id
+      description: int, primary key in edxval_coursevideo.
+    - name: course_id
+      description: str, open edX Course ID formatted as course-v1:{org}+{course code}+{run_tag}
+    - name: video_id
+      description: int, foreign key in edxval_video
+    - name: is_hidden
+      description: boolean, indicating if the video is hidden for the course.

--- a/src/ol_dbt/models/staging/mitxonline/_stg_mitxonline__models.yml
+++ b/src/ol_dbt/models/staging/mitxonline/_stg_mitxonline__models.yml
@@ -1567,3 +1567,57 @@ models:
   tests:
   - dbt_expectations.expect_compound_columns_to_be_unique:
       column_list: ["courserun_readable_id", "openedx_user_id", "courseaccess_role"]
+
+- name: stg__mitxonline__openedx__mysql__edxval_video
+  description: video content on MITx Online open edx
+  columns:
+  - name: video_id
+    description: int, primary key in edxval_video.
+    tests:
+    - unique
+    - not_null
+  - name: video_edx_uuid
+    description: str, hashed ID for the edx video
+    tests:
+    - unique
+    - not_null
+  - name: video_client_id
+    description: str, human readable name for video. e.g. 14.310x_Lect9_Seg8_Final.mp4
+  - name: video_status
+    description: str, values are external, imported, file_complete, and upload_failed.
+      The videos with 'external' and 'imported' status are not managed from ODL Video
+      Service (OVS) application.
+    tests:
+    - not_null
+  - name: video_duration
+    description: float, the length of the video, in seconds. Default to 0.0
+    tests:
+    - not_null
+  - name: video_created_on
+    description: timestamp, date and time when the record was created.
+    tests:
+    - not_null
+
+- name: stg__mitxonline__openedx__mysql__edxval_coursevideo
+  description: course ID and video association on MITx Online open edx
+  columns:
+  - name: coursevideo_id
+    description: int, primary key in edxval_coursevideo.
+    tests:
+    - unique
+    - not_null
+  - name: courserun_readable_id
+    description: str, open edX Course ID formatted as course-v1:{org}+{course code}+{run_tag}
+    tests:
+    - not_null
+  - name: video_id
+    description: int, foreign key in edxval_video
+    tests:
+    - not_null
+  - name: coursevideo_is_hidden
+    description: boolean, indicating if the video is hidden for the course.
+    tests:
+    - not_null
+  tests:
+  - dbt_expectations.expect_compound_columns_to_be_unique:
+      column_list: ["courserun_readable_id", "video_id"]

--- a/src/ol_dbt/models/staging/mitxonline/stg__mitxonline__openedx__mysql__edxval_coursevideo.sql
+++ b/src/ol_dbt/models/staging/mitxonline/stg__mitxonline__openedx__mysql__edxval_coursevideo.sql
@@ -1,0 +1,16 @@
+with source as (
+    select * from {{ source('ol_warehouse_raw_data', 'raw__mitxonline__openedx__mysql__edxval_coursevideo') }}
+)
+
+, cleaned as (
+
+    select
+        id as coursevideo_id
+        , course_id as courserun_readable_id
+        , video_id
+        , is_hidden as coursevideo_is_hidden
+
+    from source
+)
+
+select * from cleaned

--- a/src/ol_dbt/models/staging/mitxonline/stg__mitxonline__openedx__mysql__edxval_video.sql
+++ b/src/ol_dbt/models/staging/mitxonline/stg__mitxonline__openedx__mysql__edxval_video.sql
@@ -1,0 +1,18 @@
+with source as (
+    select * from {{ source('ol_warehouse_raw_data', 'raw__mitxonline__openedx__mysql__edxval_video') }}
+)
+
+, cleaned as (
+
+    select
+        id as video_id
+        , edx_video_id as video_edx_uuid
+        , client_video_id as video_client_id
+        , status as video_status
+        , duration as video_duration
+        , {{ cast_timestamp_to_iso8601('created') }} as video_created_on
+
+    from source
+)
+
+select * from cleaned

--- a/src/ol_dbt/models/staging/mitxpro/_mitxpro__sources.yml
+++ b/src/ol_dbt/models/staging/mitxpro/_mitxpro__sources.yml
@@ -2223,3 +2223,33 @@ sources:
     - name: modified
       description: timestamp, datetime when this row was last updated. A change in
         this field implies that there was a state change.
+
+  - name: raw__xpro__openedx__mysql__edxval_video
+    description: video content on MIT xPro open edx platform
+    columns:
+    - name: id
+      description: int, primary key in edxval_video.
+    - name: edx_video_id
+      description: str, video hashed ID.
+    - name: client_video_id
+      description: str, human readable name for video. e.g. AMx_R3_DDV16_EBM.mp4
+    - name: status
+      description: str, values are external, imported, file_complete, and upload_failed.
+        The videos with 'external' and 'imported' status are not managed from ODL
+        Video Service (OVS) application.
+    - name: duration
+      description: int, the length of the video, in seconds. Default to 0.0
+    - name: created
+      description: timestamp, date and time when the record was created.
+
+  - name: raw__xpro__openedx__mysql__edxval_coursevideo
+    description: course ID and video association on MIT xPro edx platform
+    columns:
+    - name: id
+      description: int, primary key in edxval_coursevideo.
+    - name: course_id
+      description: str, open edX Course ID formatted as course-v1:{org}+{course code}+{run_tag}
+    - name: video_id
+      description: int, foreign key in edxval_video
+    - name: is_hidden
+      description: boolean, indicating if the video is hidden for the course.

--- a/src/ol_dbt/models/staging/mitxpro/_stg_mitxpro__models.yml
+++ b/src/ol_dbt/models/staging/mitxpro/_stg_mitxpro__models.yml
@@ -2041,3 +2041,57 @@ models:
   tests:
   - dbt_expectations.expect_compound_columns_to_be_unique:
       column_list: ["courserun_readable_id", "openedx_user_id"]
+
+- name: stg__mitxpro__openedx__mysql__edxval_video
+  description: video content on MIT xPro open edx platform
+  columns:
+  - name: video_id
+    description: int, primary key in edxval_video.
+    tests:
+    - unique
+    - not_null
+  - name: video_edx_uuid
+    description: str, hashed ID for the edx video
+    tests:
+    - unique
+    - not_null
+  - name: video_client_id
+    description: str, human readable name for video. e.g. 14.310x_Lect9_Seg8_Final.mp4
+  - name: video_status
+    description: str, values are external, imported, file_complete, and upload_failed.
+      The videos with 'external' and 'imported' status are not managed from ODL Video
+      Service (OVS) application.
+    tests:
+    - not_null
+  - name: video_duration
+    description: float, the length of the video, in seconds. Default to 0.0
+    tests:
+    - not_null
+  - name: video_created_on
+    description: timestamp, date and time when the record was created.
+    tests:
+    - not_null
+
+- name: stg__mitxpro__openedx__mysql__edxval_coursevideo
+  description: course ID and video association on MIT xPro open edx platform
+  columns:
+  - name: coursevideo_id
+    description: int, primary key in edxval_coursevideo.
+    tests:
+    - unique
+    - not_null
+  - name: courserun_readable_id
+    description: str, open edX Course ID formatted as course-v1:{org}+{course code}+{run_tag}
+    tests:
+    - not_null
+  - name: video_id
+    description: int, foreign key in edxval_video
+    tests:
+    - not_null
+  - name: coursevideo_is_hidden
+    description: boolean, indicating if the video is hidden for the course.
+    tests:
+    - not_null
+  tests:
+  - dbt_expectations.expect_compound_columns_to_be_unique:
+      column_list: ["courserun_readable_id", "video_id"]

--- a/src/ol_dbt/models/staging/mitxpro/stg__mitxpro__openedx__mysql__edxval_coursevideo.sql
+++ b/src/ol_dbt/models/staging/mitxpro/stg__mitxpro__openedx__mysql__edxval_coursevideo.sql
@@ -1,0 +1,16 @@
+with source as (
+    select * from {{ source('ol_warehouse_raw_data', 'raw__xpro__openedx__mysql__edxval_coursevideo') }}
+)
+
+, cleaned as (
+
+    select
+        id as coursevideo_id
+        , course_id as courserun_readable_id
+        , video_id
+        , is_hidden as coursevideo_is_hidden
+
+    from source
+)
+
+select * from cleaned

--- a/src/ol_dbt/models/staging/mitxpro/stg__mitxpro__openedx__mysql__edxval_video.sql
+++ b/src/ol_dbt/models/staging/mitxpro/stg__mitxpro__openedx__mysql__edxval_video.sql
@@ -1,0 +1,18 @@
+with source as (
+    select * from {{ source('ol_warehouse_raw_data', 'raw__xpro__openedx__mysql__edxval_video') }}
+)
+
+, cleaned as (
+
+    select
+        id as video_id
+        , edx_video_id as video_edx_uuid
+        , client_video_id as video_client_id
+        , status as video_status
+        , duration as video_duration
+        , {{ cast_timestamp_to_iso8601('created') }} as video_created_on
+
+    from source
+)
+
+select * from cleaned


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
Part of https://github.com/mitodl/hq/issues/4234

### Description (What does it do?)
<!--- Describe your changes in detail -->
Creating the following staging models from MITx Online and xPro open edx sources

stg__mitxonline__openedx__mysql__edxval_video
stg__mitxonline__openedx__mysql__edxval_coursevideo
stg__mitxpro__openedx__mysql__edxval_video
stg__mitxpro__openedx__mysql__edxval_coursevideo

These will be used with OVS tables (created in https://github.com/mitodl/ol-data-platform/pull/1140) to populate video duration of the course videos used on MITx Online and xPro open edx

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->
Run

dbt build --select stg__mitxonline__openedx__mysql__edxval_video
dbt build --select stg__mitxonline__openedx__mysql__edxval_coursevideo
dbt build --select stg__mitxpro__openedx__mysql__edxval_video
dbt build --select stg__mitxpro__openedx__mysql__edxval_coursevideo