### PR TITLE
Create intermediate OVS videos to populate video duration

### DIFF
--- a/src/ol_dbt/dbt_project.yml
+++ b/src/ol_dbt/dbt_project.yml
@@ -42,6 +42,8 @@ vars:
     dedp_mitxonline_good_economics_for_hard_times_course_number: '14.009x'
     dedp_mitxonline_good_economics_for_hard_times_internation_development_cutoff: '2023-08-01'
     ocw_production_url: 'https://ocw.mit.edu/'
+    mitxonline_openedx_url: 'https://courses.mitxonline.mit.edu'
+    mitxpro_openedx_url: 'https://courses.xpro.mit.edu'
 
     highest_education_values: ['Doctorate', "Master''s or professional degree", "Bachelor''s\
         \ degree", 'Associate degree', 'Secondary/high school', 'Junior secondary/junior

--- a/src/ol_dbt/models/intermediate/ovs/_int_ovs__models.yml
+++ b/src/ol_dbt/models/intermediate/ovs/_int_ovs__models.yml
@@ -5,6 +5,17 @@ models:
 - name: int__ovs__videos
   description: OVS complete videos, collections, and their associated open edx endpoints
   columns:
+  - name: collection_uuid
+    description: str, UUID to identify this video collection.
+    tests:
+    - not_null
+  - name: collection_title
+    description: str, title of the video collection.
+    tests:
+    - not_null
+  - name: courserun_readable_id
+    description: str, the open edX course ID that the video collection associated
+      with. May be blank.
   - name: video_id
     description: int, primary key in ui_video.
     tests:
@@ -15,17 +26,6 @@ models:
     tests:
     - not_null
     - unique
-  - name: courserun_readable_id
-    description: str, the open edX course ID that the video collection associated
-      with. May be blank.
-  - name: collection_uuid
-    description: str, UUID to identify this video collection.
-    tests:
-    - not_null
-  - name: collection_title
-    description: str, title of the video collection.
-    tests:
-    - not_null
   - name: video_title
     description: str, title of the video.
     tests:

--- a/src/ol_dbt/models/intermediate/ovs/_int_ovs__models.yml
+++ b/src/ol_dbt/models/intermediate/ovs/_int_ovs__models.yml
@@ -1,0 +1,46 @@
+---
+version: 2
+
+models:
+- name: int__ovs__videos
+  description: OVS complete videos, collections, and their associated open edx endpoints
+  columns:
+  - name: video_id
+    description: int, primary key in ui_video.
+    tests:
+    - not_null
+    - unique
+  - name: video_uuid
+    description: str, UUID to identify this video on OVS
+    tests:
+    - not_null
+    - unique
+  - name: courserun_readable_id
+    description: str, the open edX course ID that the video collection associated
+      with. May be blank.
+  - name: collection_uuid
+    description: str, UUID to identify this video collection.
+    tests:
+    - not_null
+  - name: collection_title
+    description: str, title of the video collection.
+    tests:
+    - not_null
+  - name: video_title
+    description: str, title of the video.
+    tests:
+    - not_null
+  - name: video_duration
+    description: int, the length of the video, in seconds.
+    tests:
+    - not_null
+  - name: edxendpoint_base_url
+    description: str, base URL of the edx endpoint e.g. https://courses.mitxonline.mit.edu
+    tests:
+    - not_null
+  - name: platform
+    description: str, open edx platform where the video is posted to from OVS
+    tests:
+    - not_null
+    - accepted_values:
+        values: ['{{ var("mitxonline") }}', '{{ var("mitxpro") }}']

--- a/src/ol_dbt/models/intermediate/ovs/_int_ovs__models.yml
+++ b/src/ol_dbt/models/intermediate/ovs/_int_ovs__models.yml
@@ -3,7 +3,8 @@ version: 2
 
 models:
 - name: int__ovs__videos
-  description: OVS complete videos, collections, and their associated open edx endpoints
+  description: complete videos, collections, and their associated open edx endpoints
+    from ODL Video Service
   columns:
   - name: collection_uuid
     description: str, UUID to identify this video collection.
@@ -22,7 +23,7 @@ models:
     - not_null
     - unique
   - name: video_uuid
-    description: str, UUID to identify this video on OVS
+    description: str, UUID to identify this video on ODL Video Service
     tests:
     - not_null
     - unique
@@ -39,7 +40,8 @@ models:
     tests:
     - not_null
   - name: platform
-    description: str, open edx platform where the video is posted to from OVS
+    description: str, open edx platform where the video is posted to from ODL Video
+      Service
     tests:
     - not_null
     - accepted_values:

--- a/src/ol_dbt/models/intermediate/ovs/int__ovs__videos.sql
+++ b/src/ol_dbt/models/intermediate/ovs/int__ovs__videos.sql
@@ -1,0 +1,47 @@
+with video_encodejobs as (
+    select
+        *
+        --- there may be multiple encodejobs for the same video, but we only need the last one for video duration
+        , row_number() over (partition by video_id order by encodejob_created_on desc) as encodejob_rank
+    from {{ ref('stg__ovs__studio__postgres__dj_elastictranscoder_encodejob') }}
+)
+
+, videos as (
+    select * from {{ ref('stg__ovs__studio__postgres__ui_video') }}
+)
+
+, collections as (
+    select * from {{ ref('stg__ovs__studio__postgres__ui_collection') }}
+)
+
+, collection_edxendpoints as (
+    select * from {{ ref('stg__ovs__studio__postgres__ui_collectionedxendpoint') }}
+)
+
+, edxendpoints as (
+    select * from {{ ref('stg__ovs__studio__postgres__ui_edxendpoint') }}
+)
+
+select
+    collections.collection_id
+    , collections.collection_uuid
+    , collections.collection_title
+    , collections.courserun_readable_id
+    , edxendpoints.edxendpoint_base_url
+    , videos.video_id
+    , videos.video_uuid
+    , videos.video_title
+    , videos.video_status
+    , video_encodejobs.video_duration
+    , case
+        when edxendpoints.edxendpoint_base_url = '{{ var("mitxonline_openedx_url") }}'
+            then '{{ var("mitxonline") }}'
+        when edxendpoints.edxendpoint_base_url = '{{ var("mitxpro_openedx_url") }}'
+            then '{{ var("mitxpro") }}'
+    end as platform
+from videos
+inner join collections on videos.collection_id = collections.collection_id
+inner join collection_edxendpoints on collections.collection_id = collection_edxendpoints.collection_id
+inner join edxendpoints on collection_edxendpoints.edxendpoint_id = edxendpoints.edxendpoint_id
+left join video_encodejobs on videos.video_id = video_encodejobs.video_id and video_encodejobs.encodejob_rank = 1
+where videos.video_status = 'Complete'


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
Close https://github.com/mitodl/hq/issues/4234

### Description (What does it do?)
<!--- Describe your changes in detail -->
Creating `int__ovs__videos` so that it can be used to pull video duration from videos used on MITx Online and xPro

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

dbt build --select int__ovs__videos
