### PR TITLE
Create open edx course video models and populate video duration to the mart

### DIFF
--- a/src/ol_dbt/models/intermediate/mitxonline/_int_mitxonline__models.yml
+++ b/src/ol_dbt/models/intermediate/mitxonline/_int_mitxonline__models.yml
@@ -1420,7 +1420,8 @@ models:
     tests:
     - not_null
   - name: useractivity_video_duration
-    description: number, The length of the video file, in seconds.
+    description: number, The length of the video file, in seconds. This is extracted
+      from event field in tracking log.
     tests:
     - not_null
   - name: useractivity_video_currenttime
@@ -1875,3 +1876,34 @@ models:
   tests:
   - dbt_expectations.expect_compound_columns_to_be_unique:
       column_list: ["openedx_user_id", "courserun_readable_id", "coursestructure_block_id"]
+
+- name: int__mitxonline__courserun_videos
+  description: course videos on MITx Online open edx
+  columns:
+  - name: courserun_readable_id
+    description: str, open edX Course ID formatted as course-v1:{org}+{course code}+{run_tag}
+    tests:
+    - not_null
+  - name: coursevideo_is_hidden
+    description: boolean, indicating if the video is hidden for the course.
+    tests:
+    - not_null
+  - name: video_edx_uuid
+    description: str, hashed ID for the edx video
+    tests:
+    - not_null
+  - name: video_client_id
+    description: str, human readable name for video. e.g. 14.310x_Lect9_Seg8_Final.mp4
+  - name: video_status
+    description: str, values are external, imported, file_complete, and upload_failed.
+    tests:
+    - not_null
+  - name: video_duration
+    description: float, the length of the video, in seconds. Populated with data from
+      ODL Video Service (OVS) if the video is uploaded there. May be 0.0 for small
+      amounts of videos.
+    tests:
+    - not_null
+  tests:
+  - dbt_expectations.expect_compound_columns_to_be_unique:
+      column_list: ["courserun_readable_id", "video_edx_uuid"]

--- a/src/ol_dbt/models/intermediate/mitxonline/_int_mitxonline__models.yml
+++ b/src/ol_dbt/models/intermediate/mitxonline/_int_mitxonline__models.yml
@@ -1420,10 +1420,8 @@ models:
     tests:
     - not_null
   - name: useractivity_video_duration
-    description: number, The length of the video file, in seconds. This is extracted
+    description: float, The length of the video file, in seconds. This is extracted
       from event field in tracking log.
-    tests:
-    - not_null
   - name: useractivity_video_currenttime
     description: number, The time in the video when this event was emitted. May be
       Null for load_video or seek_video events.

--- a/src/ol_dbt/models/intermediate/mitxonline/int__mitxonline__courserun_videos.sql
+++ b/src/ol_dbt/models/intermediate/mitxonline/int__mitxonline__courserun_videos.sql
@@ -1,0 +1,30 @@
+with mitxonline_coursevideos as (
+    select *
+    from {{ ref('stg__mitxonline__openedx__mysql__edxval_coursevideo') }}
+)
+
+, mitxonline_videos as (
+    select * from {{ ref('stg__mitxonline__openedx__mysql__edxval_video') }}
+)
+
+, ovs_videos as (
+    select
+        *
+        , row_number() over (partition by video_title order by video_created_on desc) as video_rank
+    from {{ ref('int__ovs__videos') }}
+    where platform = '{{ var("mitxonline") }}'
+)
+
+
+select
+    mitxonline_coursevideos.courserun_readable_id
+    , mitxonline_coursevideos.coursevideo_is_hidden
+    , mitxonline_videos.video_edx_uuid
+    , mitxonline_videos.video_client_id
+    , mitxonline_videos.video_status
+    , coalesce(cast(ovs_videos.video_duration as decimal(38, 4)), mitxonline_videos.video_duration) as video_duration
+from mitxonline_coursevideos
+inner join mitxonline_videos on mitxonline_coursevideos.video_id = mitxonline_videos.video_id
+--- the relationship between OVS videos and MITx Online videos are linked via video title and client video ID
+-- e.g. 14.310x_Lect9_Seg8_Final.mp4. If there are multiple videos with same title on OVS, use the latest one.
+left join ovs_videos on mitxonline_videos.video_client_id = ovs_videos.video_title and ovs_videos.video_rank = 1

--- a/src/ol_dbt/models/intermediate/mitxonline/int__mitxonline__user_courseactivity_video.sql
+++ b/src/ol_dbt/models/intermediate/mitxonline/int__mitxonline__user_courseactivity_video.sql
@@ -14,7 +14,10 @@ select
     , useractivity_page_url
     , useractivity_timestamp
     , json_query(useractivity_event_object, 'lax $.id' omit quotes) as useractivity_video_id
-    , json_query(useractivity_event_object, 'lax $.duration' omit quotes) as useractivity_video_duration
+    , case
+        when lower(json_query(useractivity_event_object, 'lax $.duration' omit quotes)) = 'null' then null
+        else cast(json_query(useractivity_event_object, 'lax $.duration' omit quotes) as decimal(38, 4))
+    end as useractivity_video_duration
     , json_query(useractivity_event_object, 'lax $.currentTime' omit quotes) as useractivity_video_currenttime
     , json_query(useractivity_event_object, 'lax $.old_time' omit quotes) as useractivity_video_old_time
     , json_query(useractivity_event_object, 'lax $.new_time' omit quotes) as useractivity_video_new_time

--- a/src/ol_dbt/models/intermediate/mitxpro/_int_mitxpro__models.yml
+++ b/src/ol_dbt/models/intermediate/mitxpro/_int_mitxpro__models.yml
@@ -1666,10 +1666,8 @@ models:
     tests:
     - not_null
   - name: useractivity_video_duration
-    description: number, The length of the video file, in seconds. This is extracted
+    description: float, The length of the video file, in seconds. This is extracted
       from event field in tracking log.
-    tests:
-    - not_null
   - name: useractivity_video_currenttime
     description: number, The time in the video when this event was emitted
   - name: useractivity_video_old_time

--- a/src/ol_dbt/models/intermediate/mitxpro/_int_mitxpro__models.yml
+++ b/src/ol_dbt/models/intermediate/mitxpro/_int_mitxpro__models.yml
@@ -1666,7 +1666,8 @@ models:
     tests:
     - not_null
   - name: useractivity_video_duration
-    description: number, The length of the video file, in seconds.
+    description: number, The length of the video file, in seconds. This is extracted
+      from event field in tracking log.
     tests:
     - not_null
   - name: useractivity_video_currenttime
@@ -2069,3 +2070,34 @@ models:
   tests:
   - dbt_expectations.expect_compound_columns_to_be_unique:
       column_list: ["user_username", "courserun_readable_id", "courseactivity_date"]
+
+- name: int__mitxpro__courserun_videos
+  description: course videos on MIT xPro open edx
+  columns:
+  - name: courserun_readable_id
+    description: str, open edX Course ID formatted as course-v1:{org}+{course code}+{run_tag}
+    tests:
+    - not_null
+  - name: coursevideo_is_hidden
+    description: boolean, indicating if the video is hidden for the course.
+    tests:
+    - not_null
+  - name: video_edx_uuid
+    description: str, hashed ID for the edx video
+    tests:
+    - not_null
+  - name: video_client_id
+    description: str, human readable name for video. e.g. TTSBSV3_Web3_BVB_FINAL.mp4
+  - name: video_status
+    description: str, values are external, imported, file_complete, and upload_failed.
+    tests:
+    - not_null
+  - name: video_duration
+    description: float, the length of the video, in seconds. Populated with data from
+      ODL Video Service (OVS) if the video is uploaded there. May be 0.0 for small
+      amounts of videos.
+    tests:
+    - not_null
+  tests:
+  - dbt_expectations.expect_compound_columns_to_be_unique:
+      column_list: ["courserun_readable_id", "video_edx_uuid"]

--- a/src/ol_dbt/models/intermediate/mitxpro/int__mitxpro__courserun_videos.sql
+++ b/src/ol_dbt/models/intermediate/mitxpro/int__mitxpro__courserun_videos.sql
@@ -1,0 +1,30 @@
+with mitxpro_coursevideos as (
+    select *
+    from {{ ref('stg__mitxpro__openedx__mysql__edxval_coursevideo') }}
+)
+
+, mitxpro_videos as (
+    select * from {{ ref('stg__mitxpro__openedx__mysql__edxval_video') }}
+)
+
+, ovs_videos as (
+    select
+        *
+        , row_number() over (partition by video_title order by video_created_on desc) as video_rank
+    from {{ ref('int__ovs__videos') }}
+    where platform = '{{ var("mitxpro") }}'
+)
+
+
+select
+    mitxpro_coursevideos.courserun_readable_id
+    , mitxpro_coursevideos.coursevideo_is_hidden
+    , mitxpro_videos.video_edx_uuid
+    , mitxpro_videos.video_client_id
+    , mitxpro_videos.video_status
+    , coalesce(cast(ovs_videos.video_duration as decimal(38, 4)), mitxpro_videos.video_duration) as video_duration
+from mitxpro_coursevideos
+inner join mitxpro_videos on mitxpro_coursevideos.video_id = mitxpro_videos.video_id
+--- the relationship between OVS videos and xPro videos are linked via video title and client video ID
+-- e.g. TTSBSV3_Web3_BVB_FINAL.mp4. If there are multiple videos with same title on OVS, use the latest one.
+left join ovs_videos on mitxpro_videos.video_client_id = ovs_videos.video_title and ovs_videos.video_rank = 1

--- a/src/ol_dbt/models/intermediate/mitxpro/int__mitxpro__user_courseactivity_video.sql
+++ b/src/ol_dbt/models/intermediate/mitxpro/int__mitxpro__user_courseactivity_video.sql
@@ -14,7 +14,10 @@ select
     , useractivity_page_url
     , useractivity_timestamp
     , json_query(useractivity_event_object, 'lax $.id' omit quotes) as useractivity_video_id
-    , json_query(useractivity_event_object, 'lax $.duration' omit quotes) as useractivity_video_duration
+    , case
+        when lower(json_query(useractivity_event_object, 'lax $.duration' omit quotes)) = 'null' then null
+        else cast(json_query(useractivity_event_object, 'lax $.duration' omit quotes) as decimal(38, 4))
+    end as useractivity_video_duration
     , json_query(useractivity_event_object, 'lax $.currentTime' omit quotes) as useractivity_video_currenttime
     , json_query(useractivity_event_object, 'lax $.old_time' omit quotes) as useractivity_video_old_time
     , json_query(useractivity_event_object, 'lax $.new_time' omit quotes) as useractivity_video_new_time

--- a/src/ol_dbt/models/intermediate/ovs/_int_ovs__models.yml
+++ b/src/ol_dbt/models/intermediate/ovs/_int_ovs__models.yml
@@ -28,11 +28,15 @@ models:
     - not_null
     - unique
   - name: video_title
-    description: str, title of the video.
+    description: str, title of the video. e.g. 14.310x_Lect9_Seg8_Final.mp4
     tests:
     - not_null
   - name: video_duration
     description: int, the length of the video, in seconds.
+    tests:
+    - not_null
+  - name: video_created_on
+    description: timestamp, date and time when the record was created.
     tests:
     - not_null
   - name: edxendpoint_base_url

--- a/src/ol_dbt/models/intermediate/ovs/int__ovs__videos.sql
+++ b/src/ol_dbt/models/intermediate/ovs/int__ovs__videos.sql
@@ -32,6 +32,7 @@ select
     , videos.video_uuid
     , videos.video_title
     , videos.video_status
+    , videos.video_created_on
     , video_encodejobs.video_duration
     , case
         when edxendpoints.edxendpoint_base_url = '{{ var("mitxonline_openedx_url") }}'

--- a/src/ol_dbt/models/marts/mitxonline/_marts__mitxonline__models.yml
+++ b/src/ol_dbt/models/marts/mitxonline/_marts__mitxonline__models.yml
@@ -236,12 +236,16 @@ models:
     description: str, hash code for the video being watched.
     tests:
     - not_null
+  - name: video_edx_uuid
+    description: str, the video ID from MITx Online open edx.
   - name: video_title
     description: str, title of this video.
   - name: section_title
     description: str, title of section (aka chapter) this video belongs to.
   - name: video_duration
-    description: number, The length of the video file, in seconds.
+    description: float, The length of the video file, in seconds. Populated with data
+      from ODL Video Service (OVS) or tracking log. May be 0.0 for small amounts of
+      videos.
     tests:
     - not_null
   - name: video_currenttime

--- a/src/ol_dbt/models/marts/mitxonline/_marts__mitxonline__models.yml
+++ b/src/ol_dbt/models/marts/mitxonline/_marts__mitxonline__models.yml
@@ -244,10 +244,8 @@ models:
     description: str, title of section (aka chapter) this video belongs to.
   - name: video_duration
     description: float, The length of the video file, in seconds. Populated with data
-      from ODL Video Service (OVS) or tracking log. May be 0.0 for small amounts of
-      videos.
-    tests:
-    - not_null
+      from ODL Video Service (OVS) or tracking log. May be null or 0.0 for small amounts
+      of videos.
   - name: video_currenttime
     description: number, The time in the video when this event was emitted. May be
       Null for seek_video

--- a/src/ol_dbt/models/marts/mitxonline/marts__mitxonline_video_engagements.sql
+++ b/src/ol_dbt/models/marts/mitxonline/marts__mitxonline_video_engagements.sql
@@ -42,9 +42,7 @@ select
     , course_runs.course_number
     , course_runs.courserun_start_on
     , course_runs.courserun_end_on
-    , coalesce(
-        mitxonline_videos.video_duration, cast(video.useractivity_video_duration as decimal(38, 4))
-    ) as video_duration
+    , coalesce(mitxonline_videos.video_duration, video.useractivity_video_duration) as video_duration
 from video
 inner join course_runs on video.courserun_readable_id = course_runs.courserun_readable_id
 left join video_structure

--- a/src/ol_dbt/models/marts/mitxonline/marts__mitxonline_video_engagements.sql
+++ b/src/ol_dbt/models/marts/mitxonline/marts__mitxonline_video_engagements.sql
@@ -5,9 +5,14 @@ with video as (
 , video_structure as (
     select
         *
+        , json_query(coursestructure_block_metadata, 'lax $.edx_video_id' omit quotes) as video_edx_uuid
         , element_at(split(coursestructure_block_id, '@'), -1) as video_id
     from {{ ref('int__mitxonline__course_structure') }}
     where coursestructure_block_category = 'video' and coursestructure_is_latest = true
+)
+
+, mitxonline_videos as (
+    select * from {{ ref('int__mitxonline__courserun_videos') }}
 )
 
 , course_runs as (
@@ -22,12 +27,12 @@ select
     video.user_username
     , video.courserun_readable_id
     , video.useractivity_video_id as video_id
+    , mitxonline_videos.video_edx_uuid
     , video_structure.coursestructure_block_title as video_title
     , video_structure.coursestructure_chapter_title as section_title
     , video.useractivity_page_url as page_url
     , video.useractivity_event_type as video_event_type
     , video.useractivity_timestamp as video_event_timestamp
-    , video.useractivity_video_duration as video_duration
     , video.useractivity_video_currenttime as video_currenttime
     , video.useractivity_video_old_time as video_old_time
     , video.useractivity_video_new_time as video_new_time
@@ -37,11 +42,18 @@ select
     , course_runs.course_number
     , course_runs.courserun_start_on
     , course_runs.courserun_end_on
+    , coalesce(
+        mitxonline_videos.video_duration, cast(video.useractivity_video_duration as decimal(38, 4))
+    ) as video_duration
 from video
 inner join course_runs on video.courserun_readable_id = course_runs.courserun_readable_id
 left join video_structure
     on
         video.courserun_readable_id = video_structure.courserun_readable_id
         and video.useractivity_video_id = video_structure.video_id
+left join mitxonline_videos
+    on
+        video_structure.courserun_readable_id = mitxonline_videos.courserun_readable_id
+        and video_structure.video_edx_uuid = mitxonline_videos.video_edx_uuid
 left join users on video.user_username = users.user_username
 where video.useractivity_event_type in ('play_video', 'seek_video', 'complete_video', 'pause_video', 'stop_video')

--- a/src/ol_dbt/models/staging/mitxonline/_stg_mitxonline__models.yml
+++ b/src/ol_dbt/models/staging/mitxonline/_stg_mitxonline__models.yml
@@ -1585,7 +1585,7 @@ models:
     description: str, human readable name for video. e.g. 14.310x_Lect9_Seg8_Final.mp4
   - name: video_status
     description: str, values are external, imported, file_complete, and upload_failed.
-      The videos with 'external' and 'imported' status are not managed from ODL Video
+      Videos with 'external' and 'imported' status may be not managed from ODL Video
       Service (OVS) application.
     tests:
     - not_null


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
close https://github.com/mitodl/hq/issues/3227 


### Description (What does it do?)
<!--- Describe your changes in detail -->

- Adding `int__mitxonline__courserun_videos` and `int__mitxpro__courserun_videos` to populate the video duration with the data in `int__ovs__videos` .

- Modifying `video_duration` in `marts__mitxonline_video_engagements` to populate from the above tables. If it can't be populated from OVS (e.g. due to some data issues with course structure https://github.com/mitodl/hq/issues/4465), use the tracking log duration as default.

No need to create a new mart for the moment as the video structure is incorporated in `marts__mitxonline_video_engagements` 


### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

dbt build --select int__mitxonline__courserun_videos
dbt build --select int__mitxpro__courserun_videos
dbt build --select marts__mitxonline_video_engagements
