### PR TITLE
add columns to edx learners

### DIFF
--- a/src/ol_dbt/models/staging/edxorg/_stg__edxorg__models.yml
+++ b/src/ol_dbt/models/staging/edxorg/_stg__edxorg__models.yml
@@ -438,6 +438,12 @@ models:
   - name: courserunenrollment_upgraded_on
     description: timestamp, the date in ISO-8601 format that the learner first upgraded
       to the verified track course mode.
+  - name: latest_program_cert_award_on
+    description: timestamp, the latest date and time that the learner has passed
+      each of the courses in the program and was awarded a program certificate.
+  - name: ever_completed_program
+    description: boolean, whether the learner at any point has passed each of the 
+      courses in the program with a grade that qualifies them for a verified certificate.
   tests:
   - dbt_expectations.expect_compound_columns_to_be_unique:
       column_list: ["user_id", "courserun_readable_id", "program_uuid"]

--- a/src/ol_dbt/models/staging/edxorg/_stg__edxorg__models.yml
+++ b/src/ol_dbt/models/staging/edxorg/_stg__edxorg__models.yml
@@ -439,10 +439,10 @@ models:
     description: timestamp, the date in ISO-8601 format that the learner first upgraded
       to the verified track course mode.
   - name: latest_program_cert_award_on
-    description: timestamp, the latest date and time that the learner has passed
-      each of the courses in the program and was awarded a program certificate.
+    description: timestamp, the latest date and time that the learner has passed each
+      of the courses in the program and was awarded a program certificate.
   - name: ever_completed_program
-    description: boolean, whether the learner at any point has passed each of the 
+    description: boolean, whether the learner at any point has passed each of the
       courses in the program with a grade that qualifies them for a verified certificate.
   tests:
   - dbt_expectations.expect_compound_columns_to_be_unique:

--- a/src/ol_dbt/models/staging/edxorg/_stg__edxorg__models.yml
+++ b/src/ol_dbt/models/staging/edxorg/_stg__edxorg__models.yml
@@ -439,10 +439,10 @@ models:
     description: timestamp, the date in ISO-8601 format that the learner first upgraded
       to the verified track course mode.
   - name: latest_program_cert_award_on
-    description: timestamp, the latest date and time that the learner has passed each
-      of the courses in the program and was awarded a program certificate.
+    description: timestamp, the latest date and time that the learner has passed
+      each of the courses in the program and was awarded a program certificate.
   - name: ever_completed_program
-    description: boolean, whether the learner at any point has passed each of the
+    description: boolean, whether the learner at any point has passed each of the 
       courses in the program with a grade that qualifies them for a verified certificate.
   tests:
   - dbt_expectations.expect_compound_columns_to_be_unique:

--- a/src/ol_dbt/models/staging/edxorg/_stg__edxorg__models.yml
+++ b/src/ol_dbt/models/staging/edxorg/_stg__edxorg__models.yml
@@ -438,12 +438,6 @@ models:
   - name: courserunenrollment_upgraded_on
     description: timestamp, the date in ISO-8601 format that the learner first upgraded
       to the verified track course mode.
-  - name: latest_program_cert_award_on
-    description: timestamp, the latest date and time that the learner has passed each
-      of the courses in the program and was awarded a program certificate.
-  - name: ever_completed_program
-    description: boolean, whether the learner at any point has passed each of the
-      courses in the program with a grade that qualifies them for a verified certificate.
   tests:
   - dbt_expectations.expect_compound_columns_to_be_unique:
       column_list: ["user_id", "courserun_readable_id", "program_uuid"]

--- a/src/ol_dbt/models/staging/edxorg/stg__edxorg__s3__program_learner_report.sql
+++ b/src/ol_dbt/models/staging/edxorg/stg__edxorg__s3__program_learner_report.sql
@@ -21,7 +21,7 @@ with source as (
         "user id" as user_id
         , "program uuid" as program_uuid
         , max(program_certificate_awarded_dt) as latest_program_cert_award_on
-        , max("completed program") as ever_completed_program        
+        , max("completed program") as ever_completed_program
     from source_sorted
     group by 1, 2
 )
@@ -81,12 +81,12 @@ with source as (
 
 )
 
-select 
-    cleaned.* 
+select
+    cleaned.*
     , add_program_cert_latest.latest_program_cert_award_on
     , add_program_cert_latest.ever_completed_program
 from cleaned
 left join add_program_cert_latest
-    on 
+    on
         cleaned.user_id = add_program_cert_latest.user_id
         and cleaned.program_uuid = add_program_cert_latest.program_uuid

--- a/src/ol_dbt/models/staging/edxorg/stg__edxorg__s3__program_learner_report.sql
+++ b/src/ol_dbt/models/staging/edxorg/stg__edxorg__s3__program_learner_report.sql
@@ -21,7 +21,7 @@ with source as (
         cast("user id" as integer) as user_id
         , "program uuid" as program_uuid
         , max(program_certificate_awarded_dt) as latest_program_cert_award_on
-        , max("completed program") as ever_completed_program
+        , max("completed program") as ever_completed_program        
     from source_sorted
     group by 1, 2
 )
@@ -81,12 +81,12 @@ with source as (
 
 )
 
-select
-    cleaned.*
+select 
+    cleaned.* 
     , add_program_cert_latest.latest_program_cert_award_on
     , add_program_cert_latest.ever_completed_program
 from cleaned
 left join add_program_cert_latest
-    on
+    on 
         cleaned.user_id = add_program_cert_latest.user_id
         and cleaned.program_uuid = add_program_cert_latest.program_uuid

--- a/src/ol_dbt/models/staging/edxorg/stg__edxorg__s3__program_learner_report.sql
+++ b/src/ol_dbt/models/staging/edxorg/stg__edxorg__s3__program_learner_report.sql
@@ -21,7 +21,7 @@ with source as (
         cast("user id" as integer) as user_id
         , "program uuid" as program_uuid
         , max(program_certificate_awarded_dt) as latest_program_cert_award_on
-        , max("completed program") as ever_completed_program        
+        , max("completed program") as ever_completed_program
     from source_sorted
     group by 1, 2
 )
@@ -78,7 +78,7 @@ with source as (
 
 )
 
-select 
+select
     cleaned.org_id
     , cleaned.program_type
     , cleaned.program_uuid
@@ -105,6 +105,6 @@ select
     , add_program_cert_latest.latest_program_cert_award_on as program_certificate_awarded_on
 from cleaned
 left join add_program_cert_latest
-    on 
+    on
         cleaned.user_id = add_program_cert_latest.user_id
         and cleaned.program_uuid = add_program_cert_latest.program_uuid

--- a/src/ol_dbt/models/staging/edxorg/stg__edxorg__s3__program_learner_report.sql
+++ b/src/ol_dbt/models/staging/edxorg/stg__edxorg__s3__program_learner_report.sql
@@ -21,7 +21,7 @@ with source as (
         cast("user id" as integer) as user_id
         , "program uuid" as program_uuid
         , max(program_certificate_awarded_dt) as latest_program_cert_award_on
-        , max("completed program") as ever_completed_program
+        , max("completed program") as ever_completed_program        
     from source_sorted
     group by 1, 2
 )
@@ -78,12 +78,33 @@ with source as (
 
 )
 
-select
-    cleaned.*
-    , add_program_cert_latest.latest_program_cert_award_on
-    , cast(add_program_cert_latest.ever_completed_program as boolean) as ever_completed_program
+select 
+    cleaned.org_id
+    , cleaned.program_type
+    , cleaned.program_uuid
+    , cleaned.user_username
+    , cleaned.user_full_name
+    , cleaned.courserun_readable_id
+    , cleaned.course_title
+    , cleaned.courserunenrollment_enrollment_mode
+    , cleaned.user_id
+    , cleaned.user_has_completed_course
+    , cast(add_program_cert_latest.ever_completed_program as boolean) as user_has_completed_program
+    , cleaned.courserunenrollment_is_active
+    , cleaned.user_has_purchased_as_bundle
+    , cleaned.user_roles
+    , cleaned.courserungrade_letter_grade
+    , cleaned.courserungrade_grade
+    , cleaned.program_title
+    , cleaned.courserun_start_on
+    , cleaned.courserunenrollment_created_on
+    , cleaned.completed_course_on
+    , cleaned.courseactivity_last_activity_date
+    , cleaned.courserunenrollment_unenrolled_on
+    , cleaned.courserunenrollment_upgraded_on
+    , add_program_cert_latest.latest_program_cert_award_on as program_certificate_awarded_on
 from cleaned
 left join add_program_cert_latest
-    on
+    on 
         cleaned.user_id = add_program_cert_latest.user_id
         and cleaned.program_uuid = add_program_cert_latest.program_uuid

--- a/src/ol_dbt/models/staging/edxorg/stg__edxorg__s3__program_learner_report.sql
+++ b/src/ol_dbt/models/staging/edxorg/stg__edxorg__s3__program_learner_report.sql
@@ -21,7 +21,7 @@ with source as (
         cast("user id" as integer) as user_id
         , "program uuid" as program_uuid
         , max(program_certificate_awarded_dt) as latest_program_cert_award_on
-        , max("completed program") as ever_completed_program        
+        , max("completed program") as ever_completed_program
     from source_sorted
     group by 1, 2
 )
@@ -81,12 +81,12 @@ with source as (
 
 )
 
-select 
-    cleaned.* 
+select
+    cleaned.*
     , add_program_cert_latest.latest_program_cert_award_on
     , add_program_cert_latest.ever_completed_program
 from cleaned
 left join add_program_cert_latest
-    on 
+    on
         cleaned.user_id = add_program_cert_latest.user_id
         and cleaned.program_uuid = add_program_cert_latest.program_uuid

--- a/src/ol_dbt/models/staging/edxorg/stg__edxorg__s3__program_learner_report.sql
+++ b/src/ol_dbt/models/staging/edxorg/stg__edxorg__s3__program_learner_report.sql
@@ -21,7 +21,7 @@ with source as (
         cast("user id" as integer) as user_id
         , "program uuid" as program_uuid
         , max(program_certificate_awarded_dt) as latest_program_cert_award_on
-        , max("completed program") as ever_completed_program
+        , max("completed program") as ever_completed_program        
     from source_sorted
     group by 1, 2
 )
@@ -73,20 +73,17 @@ with source as (
             when "date first upgraded to verified" = 'null' then null
             else to_iso8601(date_parse("date first upgraded to verified", '%Y-%m-%d %H:%i:%s Z'))
         end as courserunenrollment_upgraded_on
-        , case
-            when "date program certificate awarded" = 'null' then null
-            else to_iso8601(date_parse("date program certificate awarded", '%Y-%m-%dT%H:%i:%sZ'))
-        end as program_certificate_awarded_on
+        , program_certificate_awarded_dt as program_certificate_awarded_on
     from dedup_source
 
 )
 
-select
-    cleaned.*
+select 
+    cleaned.* 
     , add_program_cert_latest.latest_program_cert_award_on
-    , add_program_cert_latest.ever_completed_program
+    , cast(add_program_cert_latest.ever_completed_program as boolean) as ever_completed_program
 from cleaned
 left join add_program_cert_latest
-    on
+    on 
         cleaned.user_id = add_program_cert_latest.user_id
         and cleaned.program_uuid = add_program_cert_latest.program_uuid

--- a/src/ol_dbt/models/staging/edxorg/stg__edxorg__s3__program_learner_report.sql
+++ b/src/ol_dbt/models/staging/edxorg/stg__edxorg__s3__program_learner_report.sql
@@ -21,7 +21,7 @@ with source as (
         cast("user id" as integer) as user_id
         , "program uuid" as program_uuid
         , max(program_certificate_awarded_dt) as latest_program_cert_award_on
-        , max("completed program") as ever_completed_program        
+        , max("completed program") as ever_completed_program
     from source_sorted
     group by 1, 2
 )
@@ -78,12 +78,12 @@ with source as (
 
 )
 
-select 
-    cleaned.* 
+select
+    cleaned.*
     , add_program_cert_latest.latest_program_cert_award_on
     , cast(add_program_cert_latest.ever_completed_program as boolean) as ever_completed_program
 from cleaned
 left join add_program_cert_latest
-    on 
+    on
         cleaned.user_id = add_program_cert_latest.user_id
         and cleaned.program_uuid = add_program_cert_latest.program_uuid

--- a/src/ol_dbt/models/staging/edxorg/stg__edxorg__s3__program_learner_report.sql
+++ b/src/ol_dbt/models/staging/edxorg/stg__edxorg__s3__program_learner_report.sql
@@ -21,7 +21,7 @@ with source as (
         "user id" as user_id
         , "program uuid" as program_uuid
         , max(program_certificate_awarded_dt) as latest_program_cert_award_on
-        , max("completed program") as ever_completed_program
+        , max("completed program") as ever_completed_program        
     from source_sorted
     group by 1, 2
 )
@@ -81,12 +81,12 @@ with source as (
 
 )
 
-select
-    cleaned.*
+select 
+    cleaned.* 
     , add_program_cert_latest.latest_program_cert_award_on
     , add_program_cert_latest.ever_completed_program
 from cleaned
 left join add_program_cert_latest
-    on
-        dedup_source.user_id = add_program_cert_latest.user_id
-        and dedup_source.program_uuid = add_program_cert_latest.program_uuid
+    on 
+        cleaned.user_id = add_program_cert_latest.user_id
+        and cleaned.program_uuid = add_program_cert_latest.program_uuid

--- a/src/ol_dbt/models/staging/edxorg/stg__edxorg__s3__program_learner_report.sql
+++ b/src/ol_dbt/models/staging/edxorg/stg__edxorg__s3__program_learner_report.sql
@@ -21,7 +21,7 @@ with source as (
         "user id" as user_id
         , "program uuid" as program_uuid
         , max(program_certificate_awarded_dt) as latest_program_cert_award_on
-        , max("completed program") as ever_completed_program        
+        , max("completed program") as ever_completed_program
     from source
     group by 1, 2
 )
@@ -81,12 +81,12 @@ with source as (
 
 )
 
-select 
-    cleaned.* 
+select
+    cleaned.*
     , add_program_cert_latest.latest_program_cert_award_on
     , add_program_cert_latest.ever_completed_program
 from cleaned
 left join add_program_cert_latest
-    on 
+    on
         dedup_source.user_id = add_program_cert_latest.user_id
         and dedup_source.program_uuid = add_program_cert_latest.program_uuid

--- a/src/ol_dbt/models/staging/edxorg/stg__edxorg__s3__program_learner_report.sql
+++ b/src/ol_dbt/models/staging/edxorg/stg__edxorg__s3__program_learner_report.sql
@@ -21,8 +21,8 @@ with source as (
         "user id" as user_id
         , "program uuid" as program_uuid
         , max(program_certificate_awarded_dt) as latest_program_cert_award_on
-        , max("completed program") as ever_completed_program
-    from source
+        , max("completed program") as ever_completed_program        
+    from source_sorted
     group by 1, 2
 )
 
@@ -81,12 +81,12 @@ with source as (
 
 )
 
-select
-    cleaned.*
+select 
+    cleaned.* 
     , add_program_cert_latest.latest_program_cert_award_on
     , add_program_cert_latest.ever_completed_program
 from cleaned
 left join add_program_cert_latest
-    on
+    on 
         dedup_source.user_id = add_program_cert_latest.user_id
         and dedup_source.program_uuid = add_program_cert_latest.program_uuid

--- a/src/ol_dbt/models/staging/edxorg/stg__edxorg__s3__program_learner_report.sql
+++ b/src/ol_dbt/models/staging/edxorg/stg__edxorg__s3__program_learner_report.sql
@@ -18,10 +18,10 @@ with source as (
 
 , add_program_cert_latest as (
     select
-        "user id" as user_id
+        cast("user id" as integer) as user_id
         , "program uuid" as program_uuid
         , max(program_certificate_awarded_dt) as latest_program_cert_award_on
-        , max("completed program") as ever_completed_program
+        , max("completed program") as ever_completed_program        
     from source_sorted
     group by 1, 2
 )
@@ -81,12 +81,12 @@ with source as (
 
 )
 
-select
-    cleaned.*
+select 
+    cleaned.* 
     , add_program_cert_latest.latest_program_cert_award_on
     , add_program_cert_latest.ever_completed_program
 from cleaned
 left join add_program_cert_latest
-    on
+    on 
         cleaned.user_id = add_program_cert_latest.user_id
         and cleaned.program_uuid = add_program_cert_latest.program_uuid

--- a/src/ol_dbt/models/staging/edxorg/stg__edxorg__s3__program_learner_report.sql
+++ b/src/ol_dbt/models/staging/edxorg/stg__edxorg__s3__program_learner_report.sql
@@ -21,7 +21,7 @@ with source as (
         "user id" as user_id
         , "program uuid" as program_uuid
         , max(program_certificate_awarded_dt) as latest_program_cert_award_on
-        , max("completed program") as ever_completed_program        
+        , max("completed program") as ever_completed_program
     from source_sorted
     group by 1, 2
 )
@@ -81,12 +81,12 @@ with source as (
 
 )
 
-select 
-    cleaned.* 
+select
+    cleaned.*
     , add_program_cert_latest.latest_program_cert_award_on
     , add_program_cert_latest.ever_completed_program
 from cleaned
 left join add_program_cert_latest
-    on 
+    on
         dedup_source.user_id = add_program_cert_latest.user_id
         and dedup_source.program_uuid = add_program_cert_latest.program_uuid


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/4460
https://github.com/mitodl/hq/issues/4425

### Description (What does it do?)
This adds the columns latest_program_cert_award_on and ever_completed_program to the stg__edxorg__s3__program_learner_report table. Currently only 4 records are making it into the intermediate program cert table (see https://github.com/mitodl/hq/issues/4460) because the current record program completion boolean is just set to 'false' when the person actually completed the program. We need a way to identify if they ever completed a program.

there will also be other intermediate changes following this PR

### How can this be tested?
dbt build --select stg__edxorg__s3__program_learner_report 