### PR TITLE
Changes to int__micromasters__dedp_proctored_exam_grades and upstream models

### DIFF
--- a/src/ol_dbt/models/intermediate/micromasters/_int_micromasters__models.yml
+++ b/src/ol_dbt/models/intermediate/micromasters/_int_micromasters__models.yml
@@ -21,6 +21,9 @@ models:
   - name: examrun_readable_id
     description: str, edX exam run ID formatted as course-v1:{org}+{exam code}+{semester},
       e.g., course-v1:MITxT+14.100PEx+2T2022. May be null for exam runs before 2022.
+  - name: examrun_semester
+    description: str, semester for the exam run, e.g., 2T2022. May be null for exam
+      runs before 2022.
   - name: user_edxorg_username
     description: str, username on edX.org
   - name: user_mitxonline_username
@@ -33,20 +36,23 @@ models:
     - not_null
   - name: user_mitxonline_email
     description: str, current user email on mitxonline
+  - name: proctoredexamgrade_passing_score
+    description: float, passing score set for the proctored exam, range between 0
+      to 100
+    tests:
+    - not_null
   - name: proctoredexamgrade_score
     description: float, user score for the proctored exam, range between 0 to 100
+    tests:
+    - not_null
+  - name: proctoredexamgrade_percentage_grade
+    description: float, user percentage grade for the proctored exam, range between
+      0 to 1
     tests:
     - not_null
   - name: proctoredexamgrade_is_passing
     description: boolean, indicating whether the user has passed the passing score
       set for this proctored exam
-    tests:
-    - not_null
-  - name: proctoredexamgrade_passing_score
-    description: float, passing score for the proctored exam, range between 0 to 100
-  - name: proctoredexamgrade_percentage_grade
-    description: float, user percentage grade for the proctored exam, range between
-      0 to 1
     tests:
     - not_null
   - name: proctoredexamgrade_exam_on
@@ -69,7 +75,7 @@ models:
     - unique
   tests:
   - dbt_expectations.expect_compound_columns_to_be_unique:
-      column_list: ["user_micromasters_email", "examrun_readable_id"]
+      column_list: ["user_micromasters_email", "proctoredexamgrade_exam_on"]
 
 - name: int__micromasters__course_enrollments
   description: MicroMasters enrollments. Enrollments in courses that satisfy the requirements

--- a/src/ol_dbt/models/intermediate/micromasters/_int_micromasters__models.yml
+++ b/src/ol_dbt/models/intermediate/micromasters/_int_micromasters__models.yml
@@ -7,7 +7,7 @@ models:
     had any new data for this table since 2022-09.
   columns:
   - name: program_title
-    description: str, title of the program
+    description: str, title of the MicroMasters program
     tests:
     - not_null
   - name: micromasters_program_id
@@ -15,10 +15,12 @@ models:
   - name: mitxonline_program_id
     description: int, id of the program in the mitxonline database
   - name: course_title
-    description: str, title of the course for example Foundations of Modern Finance
-      I
+    description: str, title of the course, for example Data Analysis for Social Scientists
   - name: course_number
     description: str, course number, for example 14.73x or JPAL102x
+  - name: examrun_readable_id
+    description: str, edX exam run ID formatted as course-v1:{org}+{exam code}+{semester},
+      e.g., course-v1:MITxT+14.100PEx+2T2022. May be null for exam runs before 2022.
   - name: user_edxorg_username
     description: str, username on edX.org
   - name: user_mitxonline_username
@@ -32,27 +34,42 @@ models:
   - name: user_mitxonline_email
     description: str, current user email on mitxonline
   - name: proctoredexamgrade_score
-    description: float, user score for the course, range between 0 to 100
+    description: float, user score for the proctored exam, range between 0 to 100
+    tests:
+    - not_null
   - name: proctoredexamgrade_is_passing
     description: boolean, indicating whether the user has passed the passing score
-      set for this course
+      set for this proctored exam
+    tests:
+    - not_null
   - name: proctoredexamgrade_passing_score
-    description: float, passing score for the course, range between 0 to 100
+    description: float, passing score for the proctored exam, range between 0 to 100
   - name: proctoredexamgrade_percentage_grade
-    description: float, user percentage grade for the course, range between 0 to 1
+    description: float, user percentage grade for the proctored exam, range between
+      0 to 1
+    tests:
+    - not_null
   - name: proctoredexamgrade_exam_on
     description: timestamp, date and time the learner took the exam
+    tests:
+    - not_null
   - name: proctoredexamgrade_created_on
     description: timestamp, date and time when this grade was initially created
+    tests:
+    - not_null
   - name: proctoredexamgrade_updated_on
     description: timestamp, date and time when this grade was most recently updated
     tests:
     - not_null
   - name: proctoredexamgrade_id
-    description: int, sequential ID representing a DEDP proctor exam grade
+    description: int, sequential ID representing a DEDP proctored exam grade in MicroMasters
+      database
     tests:
     - not_null
     - unique
+  tests:
+  - dbt_expectations.expect_compound_columns_to_be_unique:
+      column_list: ["user_micromasters_email", "examrun_readable_id"]
 
 - name: int__micromasters__course_enrollments
   description: MicroMasters enrollments. Enrollments in courses that satisfy the requirements

--- a/src/ol_dbt/models/intermediate/micromasters/int__micromasters__dedp_proctored_exam_grades.sql
+++ b/src/ol_dbt/models/intermediate/micromasters/int__micromasters__dedp_proctored_exam_grades.sql
@@ -30,15 +30,16 @@ select
     , courses.course_title
     , courses.course_number
     , examruns.examrun_readable_id
+    , examruns.examrun_semester
     , micromasters_users.user_edxorg_username
     , micromasters_users.user_mitxonline_username
     , micromasters_users.user_full_name
     , micromasters_users.user_email as user_micromasters_email
     , mixonline_users.user_email as user_mitxonline_email
-    , exam_grades.proctoredexamgrade_score
-    , exam_grades.proctoredexamgrade_is_passing
     , exam_grades.proctoredexamgrade_passing_score
+    , exam_grades.proctoredexamgrade_score
     , exam_grades.proctoredexamgrade_percentage_grade
+    , exam_grades.proctoredexamgrade_is_passing
     , exam_grades.proctoredexamgrade_exam_on
     , exam_grades.proctoredexamgrade_created_on
     , exam_grades.proctoredexamgrade_updated_on

--- a/src/ol_dbt/models/intermediate/micromasters/int__micromasters__dedp_proctored_exam_grades.sql
+++ b/src/ol_dbt/models/intermediate/micromasters/int__micromasters__dedp_proctored_exam_grades.sql
@@ -3,6 +3,10 @@ with exam_grades as (
     from {{ ref('stg__micromasters__app__postgres__grades_proctoredexamgrade') }}
 )
 
+, examruns as (
+    select * from {{ ref('stg__micromasters__app__postgres__exams_examrun') }}
+)
+
 , programs as (
     select * from {{ ref('int__mitx__programs') }}
 )
@@ -11,7 +15,7 @@ with exam_grades as (
     select * from {{ ref('stg__micromasters__app__postgres__courses_course') }}
 )
 
-, mm_users as (
+, micromasters_users as (
     select * from {{ ref('__micromasters__users') }}
 )
 
@@ -25,10 +29,11 @@ select
     , programs.mitxonline_program_id
     , courses.course_title
     , courses.course_number
-    , mm_users.user_edxorg_username
-    , mm_users.user_mitxonline_username
-    , mm_users.user_full_name
-    , mm_users.user_email as user_micromasters_email
+    , examruns.examrun_readable_id
+    , micromasters_users.user_edxorg_username
+    , micromasters_users.user_mitxonline_username
+    , micromasters_users.user_full_name
+    , micromasters_users.user_email as user_micromasters_email
     , mixonline_users.user_email as user_mitxonline_email
     , exam_grades.proctoredexamgrade_score
     , exam_grades.proctoredexamgrade_is_passing
@@ -39,7 +44,8 @@ select
     , exam_grades.proctoredexamgrade_updated_on
     , exam_grades.proctoredexamgrade_id
 from exam_grades
+inner join examruns on exam_grades.examrun_id = examruns.examrun_id
 inner join courses on exam_grades.course_id = courses.course_id
 inner join programs on courses.program_id = programs.micromasters_program_id
-inner join mm_users on exam_grades.user_id = mm_users.user_id
-left join mixonline_users on mm_users.user_mitxonline_username = mixonline_users.user_username
+inner join micromasters_users on exam_grades.user_id = micromasters_users.user_id
+left join mixonline_users on micromasters_users.user_mitxonline_username = mixonline_users.user_username

--- a/src/ol_dbt/models/staging/micromasters/_micromasters__sources.yml
+++ b/src/ol_dbt/models/staging/micromasters/_micromasters__sources.yml
@@ -573,7 +573,7 @@ sources:
 
 
   - name: raw__micromasters__app__postgres__exams_examrun
-    description: Proctored exam individual runs from MicroMasters application database
+    description: DEDP proctored exam runs from MicroMasters application database
     columns:
     - name: id
       description: int, primary key in exams_examrun

--- a/src/ol_dbt/models/staging/micromasters/_micromasters__sources.yml
+++ b/src/ol_dbt/models/staging/micromasters/_micromasters__sources.yml
@@ -570,3 +570,44 @@ sources:
       description: int, foreign key to courses_program
     - name: share_hash
       description: str, share hash for the program enrollment example:72ff85f6-b88d-4636-830a-69cf59f896f5
+
+
+  - name: raw__micromasters__app__postgres__exams_examrun
+    description: Proctored exam individual runs from MicroMasters application database
+    columns:
+    - name: id
+      description: int, primary key in exams_examrun
+    - name: course_id
+      description: int, foreign key to courses_course
+    - name: exam_series_code
+      description: str, unique series code for the exam. e.g., MIT_14.100x
+    - name: edx_exam_course_key
+      description: str, edX exam run ID formatted as course-v1:{org}+{exam code}+{semester},
+        e.g., course-v1:MITxT+14.100PEx+2T2022. May be null for exam runs before 2022.
+    - name: semester
+      description: str, semester for the exam run, e.g., 2T2022
+    - name: description
+      description: str, description for the exam run
+    - name: authorized
+      description: boolean, indicating if the exam run has authorizations from Pearson
+    - name: passing_score
+      description: float, passing score for the exam run, range between 0 to 1.
+    - name: date_first_schedulable
+      description: timestamp, the first date and time a learner can start scheduling
+        the exam with Pearson.
+    - name: date_last_schedulable
+      description: timestamp, the last date and time a learner can start scheduling
+        the exam with Pearson.
+    - name: date_first_eligible
+      description: timestamp, the first date and time at which this exam run becomes
+        available
+    - name: date_last_eligible
+      description: timestamp, the last date and time at which this exam run becomes
+        available
+    - name: date_grades_available
+      description: timestamp, date and time when the grade becomes available to learners
+        on their dashboard
+    - name: created_on
+      description: timestamp, date and time when the exam run was initially created
+    - name: updated_on
+      description: timestamp, date and time when the exam run was most recently updated

--- a/src/ol_dbt/models/staging/micromasters/_stg_micromasters__models.yml
+++ b/src/ol_dbt/models/staging/micromasters/_stg_micromasters__models.yml
@@ -447,7 +447,8 @@ models:
     tests:
     - not_null
   - name: proctoredexamgrade_passing_score
-    description: float, passing score for the proctored exam, range between 0 to 100
+    description: float, passing score set for the proctored exam, range between 0
+      to 100
   - name: proctoredexamgrade_is_passing
     description: boolean, indicating whether the user has passed the passing score
       set for this proctored exam
@@ -949,32 +950,7 @@ models:
     tests:
     - not_null
   - name: examrun_passing_score
-    description: float, passing score for the exam run, range between 0 to 1.
-    tests:
-    - not_null
-  - name: examrun_first_schedulable_on
-    description: timestamp, the first date and time a learner can start scheduling
-      the exam with Pearson.
-    tests:
-    - not_null
-  - name: examrun_last_schedulable_on
-    description: timestamp, the last date and time a learner can start scheduling
-      the exam with Pearson.
-    tests:
-    - not_null
-  - name: examrun_first_eligible_on
-    description: timestamp, the first date and time at which this exam run becomes
-      available
-    tests:
-    - not_null
-  - name: examrun_last_eligible_on
-    description: timestamp, the last date and time at which this exam run becomes
-      available
-    tests:
-    - not_null
-  - name: examrun_grades_available_on
-    description: timestamp, date and time when the grade becomes available to learners
-      on their dashboard
+    description: float, passing score for the exam run, range between 0 to 100.
     tests:
     - not_null
   - name: examrun_created_on

--- a/src/ol_dbt/models/staging/micromasters/_stg_micromasters__models.yml
+++ b/src/ol_dbt/models/staging/micromasters/_stg_micromasters__models.yml
@@ -922,7 +922,7 @@ models:
       column_list: ["user_id", "program_id"]
 
 - name: stg__micromasters__app__postgres__exams_examrun
-  description: Proctored exam individual runs from MicroMasters application database
+  description: DEDP proctored exam runs from MicroMasters application database
   columns:
   - name: examrun_id
     description: int, primary key in exams_examrun

--- a/src/ol_dbt/models/staging/micromasters/_stg_micromasters__models.yml
+++ b/src/ol_dbt/models/staging/micromasters/_stg_micromasters__models.yml
@@ -426,33 +426,61 @@ models:
       column_list: ["courserun_id", "user_id"]
 
 - name: stg__micromasters__app__postgres__grades_proctoredexamgrade
-  description: DEDP proctor exam grades stored in MicroMasters database
+  description: DEDP proctored exam grades stored in MicroMasters database
   columns:
   - name: proctoredexamgrade_id
-    description: int, sequential ID representing a DEDP proctor exam grade
+    description: int, sequential ID representing a DEDP proctored exam grade
+    tests:
+    - not_null
+    - unique
   - name: course_id
     description: int, foreign key to courses_course
+    tests:
+    - not_null
   - name: user_id
     description: int, foreign key to auth_user
+    tests:
+    - not_null
   - name: proctoredexamgrade_letter_grade
-    description: str, letter grade indicating it's pass or fail
+    description: str, letter grade indicating it's pass or fail for the proctored
+      exam
+    tests:
+    - not_null
   - name: proctoredexamgrade_passing_score
-    description: float, passing score for the course, range between 0 to 100
+    description: float, passing score for the proctored exam, range between 0 to 100
   - name: proctoredexamgrade_is_passing
     description: boolean, indicating whether the user has passed the passing score
-      set for this course
+      set for this proctored exam
+    tests:
+    - not_null
   - name: proctoredexamgrade_percentage_grade
-    description: float, user percentage grade for the course, range between 0 to 1
+    description: float, user percentage grade for the proctored exam, range between
+      0 to 1
+    tests:
+    - not_null
   - name: proctoredexamgrade_score
-    description: float, user score for the course, range between 0 to 100
+    description: float, user score for the proctored exam, range between 0 to 100
+    tests:
+    - not_null
   - name: examrun_id
     description: int, foreign key to exams_examrun
+    tests:
+    - not_null
   - name: proctoredexamgrade_exam_on
-    description: timestamp, date and time for the exam
+    description: timestamp, date and time when this user took the exam
+    tests:
+    - not_null
   - name: proctoredexamgrade_created_on
     description: timestamp, date and time when this grade was initially created
+    tests:
+    - not_null
   - name: proctoredexamgrade_updated_on
     description: timestamp, date and time when this grade was most recently updated
+    tests:
+    - not_null
+  tests:
+  - dbt_expectations.expect_compound_columns_to_be_unique:
+      column_list: ["user_id", "examrun_id"]
 
 - name: stg__micromasters__app__postgres__auth_user
   columns:
@@ -880,7 +908,80 @@ models:
     - not_null
   - name: user_id
     description: int, foreign key for users_user
+    tests:
+    - not_null
   - name: program_id
     description: int, foreign key to courses_program
+    tests:
+    - not_null
   - name: share_hash
     description: str, share hash for the program enrollment
+  tests:
+  - dbt_expectations.expect_compound_columns_to_be_unique:
+      column_list: ["user_id", "program_id"]
+
+- name: stg__micromasters__app__postgres__exams_examrun
+  description: Proctored exam individual runs from MicroMasters application database
+  columns:
+  - name: examrun_id
+    description: int, primary key in exams_examrun
+    tests:
+    - not_null
+    - unique
+  - name: course_id
+    description: int, foreign key to courses_course
+    tests:
+    - not_null
+  - name: exam_series_code
+    description: str, unique series code for the exam. e.g., MIT_14.100x
+    tests:
+    - not_null
+  - name: examrun_readable_id
+    description: str, edX exam run ID formatted as course-v1:{org}+{exam code}+{semester},
+      e.g., course-v1:MITxT+14.100PEx+2T2022. May be null for exam runs before 2022.
+  - name: examrun_semester
+    description: str, semester for the exam run, e.g., 2T2022. May be null for exam
+      runs before 2022.
+  - name: examrun_description
+    description: str, description for the exam run
+  - name: examrun_is_authorized
+    description: boolean, indicating if the exam run has authorizations from Pearson
+    tests:
+    - not_null
+  - name: examrun_passing_score
+    description: float, passing score for the exam run, range between 0 to 1.
+    tests:
+    - not_null
+  - name: examrun_first_schedulable_on
+    description: timestamp, the first date and time a learner can start scheduling
+      the exam with Pearson.
+    tests:
+    - not_null
+  - name: examrun_last_schedulable_on
+    description: timestamp, the last date and time a learner can start scheduling
+      the exam with Pearson.
+    tests:
+    - not_null
+  - name: examrun_first_eligible_on
+    description: timestamp, the first date and time at which this exam run becomes
+      available
+    tests:
+    - not_null
+  - name: examrun_last_eligible_on
+    description: timestamp, the last date and time at which this exam run becomes
+      available
+    tests:
+    - not_null
+  - name: examrun_grades_available_on
+    description: timestamp, date and time when the grade becomes available to learners
+      on their dashboard
+    tests:
+    - not_null
+  - name: examrun_created_on
+    description: timestamp, date and time when the exam run was initially created
+    tests:
+    - not_null
+  - name: examrun_updated_on
+    description: timestamp, date and time when the exam run was most recently updated
+    tests:
+    - not_null

--- a/src/ol_dbt/models/staging/micromasters/stg__micromasters__app__postgres__exams_examrun.sql
+++ b/src/ol_dbt/models/staging/micromasters/stg__micromasters__app__postgres__exams_examrun.sql
@@ -14,12 +14,7 @@ with source as (
         , semester as examrun_semester
         , description as examrun_description
         , authorized as examrun_is_authorized
-        , passing_score as examrun_passing_score
-        ,{{ cast_timestamp_to_iso8601('date_first_schedulable') }} as examrun_first_schedulable_on
-        ,{{ cast_timestamp_to_iso8601('date_last_schedulable') }} as examrun_last_schedulable_on
-        ,{{ cast_timestamp_to_iso8601('date_first_eligible') }} as examrun_first_eligible_on
-        ,{{ cast_timestamp_to_iso8601('date_first_eligible') }} as examrun_last_eligible_on
-        ,{{ cast_timestamp_to_iso8601('date_grades_available') }} as examrun_grades_available_on
+        , passing_score * 100 as examrun_passing_score
         ,{{ cast_timestamp_to_iso8601('created_on') }} as examrun_created_on
         ,{{ cast_timestamp_to_iso8601('updated_on') }} as examrun_updated_on
     from source

--- a/src/ol_dbt/models/staging/micromasters/stg__micromasters__app__postgres__exams_examrun.sql
+++ b/src/ol_dbt/models/staging/micromasters/stg__micromasters__app__postgres__exams_examrun.sql
@@ -1,0 +1,29 @@
+with source as (
+
+    select * from {{ source('ol_warehouse_raw_data', 'raw__micromasters__app__postgres__exams_examrun') }}
+
+)
+
+, renamed as (
+
+    select
+        id as examrun_id
+        , course_id
+        , exam_series_code
+        , edx_exam_course_key as examrun_readable_id
+        , semester as examrun_semester
+        , description as examrun_description
+        , authorized as examrun_is_authorized
+        , passing_score as examrun_passing_score
+        ,{{ cast_timestamp_to_iso8601('date_first_schedulable') }} as examrun_first_schedulable_on
+        ,{{ cast_timestamp_to_iso8601('date_last_schedulable') }} as examrun_last_schedulable_on
+        ,{{ cast_timestamp_to_iso8601('date_first_eligible') }} as examrun_first_eligible_on
+        ,{{ cast_timestamp_to_iso8601('date_first_eligible') }} as examrun_last_eligible_on
+        ,{{ cast_timestamp_to_iso8601('date_grades_available') }} as examrun_grades_available_on
+        ,{{ cast_timestamp_to_iso8601('created_on') }} as examrun_created_on
+        ,{{ cast_timestamp_to_iso8601('updated_on') }} as examrun_updated_on
+    from source
+
+)
+
+select * from renamed

--- a/src/ol_dbt/models/staging/micromasters/stg__micromasters__app__postgres__grades_proctoredexamgrade.sql
+++ b/src/ol_dbt/models/staging/micromasters/stg__micromasters__app__postgres__grades_proctoredexamgrade.sql
@@ -10,7 +10,7 @@ with source as (
         id as proctoredexamgrade_id
         , user_id
         , course_id
-        , passing_score as proctoredexamgrade_passing_score
+        , if(passing_score < 1, passing_score * 100, passing_score) as proctoredexamgrade_passing_score
         , passed as proctoredexamgrade_is_passing
         , score as proctoredexamgrade_score
         , grade as proctoredexamgrade_letter_grade


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
Part of https://github.com/mitodl/hq/issues/4481 

### Description (What does it do?)
<!--- Describe your changes in detail -->
This PR includes the changes for MicroMasters' ProctoredExamGrade data.
- Adding stg__micromasters__app__postgres__exams_examrun
- Updating stg__micromasters__app__postgres__grades_proctoredexamgrade - field definitions and tests
- Adding `examrun_readable_id` and `examrun_semester` to int__micromasters__dedp_proctored_exam_grades -field definitions and tests

 I will have a separate PR to add the exam grades from MITx Online and update the `marts__micromasters_dedp_exam_grades` to have the completed data.

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

dbt build --select stg__micromasters__app__postgres__exams_examrun
dbt build --select stg__micromasters__app__postgres__grades_proctoredexamgrade
dbt build --select int__micromasters__dedp_proctored_exam_grades

