### PR TITLE
Update combined orders mart and upstream changes

### DIFF
--- a/src/ol_dbt/models/intermediate/bootcamps/_int_bootcamps__models.yml
+++ b/src/ol_dbt/models/intermediate/bootcamps/_int_bootcamps__models.yml
@@ -133,6 +133,9 @@ models:
     description: int, foreign key in courses_courserun of the purchased run
     tests:
     - not_null
+  - name: courserun_readable_id
+    description: str, unique string to identify a bootcamp course run (could be blank
+      for older runs)
   - name: line_price
     description: numeric, list price for the order line
     tests:
@@ -151,6 +154,16 @@ models:
     description: str, address state from cybersource payment
   - name: receipt_bill_to_address_country
     description: str, address country from cybersource payment
+  - name: user_username
+    description: str, username to login on Bootcamps
+    tests:
+    - not_null
+  - name: user_email
+    description: str, user email on Bootcamps
+    tests:
+    - not_null
+  - name: user_full_name
+    description: str, user full name on Bootcamps
   tests:
   - dbt_expectations.expect_table_row_count_to_equal_other_table:
       compare_model: ref('stg__bootcamps__app__postgres__ecommerce_order')

--- a/src/ol_dbt/models/intermediate/bootcamps/int__bootcamps__ecommerce_order.sql
+++ b/src/ol_dbt/models/intermediate/bootcamps/int__bootcamps__ecommerce_order.sql
@@ -12,6 +12,15 @@ with orders as (
     select * from {{ ref('stg__bootcamps__app__postgres__ecommerce_receipt') }}
 )
 
+, users as (
+    select * from {{ ref('int__bootcamps__users') }}
+)
+
+, runs as (
+    select * from {{ ref('stg__bootcamps__app__postgres__courses_courserun') }}
+)
+
+
 select
     orders.order_id
     , orders.order_reference_number
@@ -25,6 +34,7 @@ select
     , lines.line_id
     , lines.line_description
     , lines.courserun_id
+    , runs.courserun_readable_id
     , lines.line_price
     , receipts.receipt_transaction_id
     , receipts.receipt_reference_number
@@ -32,6 +42,11 @@ select
     , receipts.receipt_authorization_code
     , receipts.receipt_bill_to_address_state
     , receipts.receipt_bill_to_address_country
+    , users.user_username
+    , users.user_email
+    , users.user_full_name
 from lines
 inner join orders on lines.order_id = orders.order_id
+inner join users on orders.order_purchaser_user_id = users.user_id
+inner join runs on lines.courserun_id = runs.courserun_id
 left join receipts on orders.order_id = receipts.order_id

--- a/src/ol_dbt/models/intermediate/micromasters/_int_micromasters__models.yml
+++ b/src/ol_dbt/models/intermediate/micromasters/_int_micromasters__models.yml
@@ -510,10 +510,32 @@ models:
     description: int, primary key in users_user for the purchaser
     tests:
     - not_null
+  - name: user_username
+    description: str, username on MicroMasters
+    tests:
+    - not_null
+  - name: user_edxorg_username
+    description: str, username on edX.org
+  - name: user_edxorg_id
+    description: int, user ID on edX.org
+  - name: user_edxorg_email
+    description: str, user email on edX.org
+  - name: user_mitxonline_username
+    description: str, username on MITx Online
+  - name: user_full_name
+    description: str, user full name on MicroMasters
+  - name: user_email
+    description: str, user email on MicroMasters
+    tests:
+    - not_null
   - name: order_reference_number
     description: string, readable id for the order
     tests:
     - unique
+  - name: line_id
+    description: int, foreign key to ecommerce_line
+    tests:
+    - not_null
   - name: line_price
     description: numeric, list price for the order line
     tests:
@@ -525,6 +547,9 @@ models:
   - name: courserun_edxorg_readable_id
     description: str, courserun_readable_id formatted as {org}/{course code}/{run_tag}
       to match course in edxorg
+  - name: courserun_platform
+    description: str, indicating the platform where the course runs on. It's either
+      MITx Online or edX.org.
   - name: receipt_transaction_id
     description: str, transaction identifier from most recent cybersource payment
       for the order
@@ -548,6 +573,8 @@ models:
   - name: discount_amount
     description: numeric, actual discount dollar amount. For percent-discount coupon,
       this is calculated as line_price * percentage off
+  - name: coupon_id
+    description: int, foreign key to ecommerce_coupon
   - name: coupon_type
     description: str, type of the coupon which describes what circumstances the coupon
       can be redeemed. Possible values are "standard" or "discounted-previous-course".
@@ -558,6 +585,7 @@ models:
   tests:
   - dbt_expectations.expect_table_row_count_to_equal_other_table:
       compare_model: ref('stg__micromasters__app__postgres__ecommerce_order')
+
 - name: int__micromasters__program_enrollments
   description: MicroMasters program enrolled users
   columns:

--- a/src/ol_dbt/models/intermediate/micromasters/int__micromasters__orders.sql
+++ b/src/ol_dbt/models/intermediate/micromasters/int__micromasters__orders.sql
@@ -22,22 +22,44 @@ with orders as (
     where receipt_transaction_status != 'ERROR'
 )
 
+, users as (
+    select * from {{ ref('__micromasters__users') }}
+)
+
+, courseruns as (
+    select * from {{ ref('stg__micromasters__app__postgres__courses_courserun') }}
+)
+
+, edxorg_users as (
+    select * from {{ ref('int__edxorg__mitx_users') }}
+)
+
 select
     orders.order_id
     , orders.user_id
+    , users.user_username
+    , users.user_mitxonline_username
+    , users.user_edxorg_username
+    , edxorg_users.user_id as user_edxorg_id
+    , edxorg_users.user_email as user_edxorg_email
+    , users.user_full_name
+    , users.user_email
     , orders.order_state
     , orders.order_reference_number
     , orders.order_total_price_paid
     , orders.order_created_on
+    , lines.line_id
     , lines.line_price
     , lines.courserun_readable_id
     , lines.courserun_edxorg_readable_id
+    , courseruns.courserun_platform
     , receipts.receipt_reference_number
     , receipts.receipt_transaction_id
     , receipts.receipt_payment_method
     , receipts.receipt_authorization_code
     , receipts.receipt_bill_to_address_state
     , receipts.receipt_bill_to_address_country
+    , coupons.coupon_id
     , coupons.coupon_type
     , coupons.coupon_code
     , coupons.coupon_discount_amount_text
@@ -48,7 +70,10 @@ select
         else cast(coupons.coupon_amount as decimal(38, 2))
     end as coupon_amount
 from orders
+inner join users on orders.user_id = users.user_id
 inner join lines on orders.order_id = lines.order_id
+left join courseruns on lines.courserun_readable_id = courseruns.courserun_readable_id
 left join redeemedcoupons on orders.order_id = redeemedcoupons.order_id
 left join coupons on redeemedcoupons.coupon_id = coupons.coupon_id
 left join receipts on orders.order_id = receipts.order_id and receipts.row_num = 1
+left join edxorg_users on users.user_edxorg_username = edxorg_users.user_username

--- a/src/ol_dbt/models/intermediate/mitxpro/_int_mitxpro__models.yml
+++ b/src/ol_dbt/models/intermediate/mitxpro/_int_mitxpro__models.yml
@@ -37,6 +37,8 @@ models:
     description: str, user email associated with their account
   - name: product_type
     description: string, readable product type
+  - name: courserun_id
+    description: int, foreign key to courses_courserun
   - name: courserun_readable_id
     description: str, Open edX Course ID formatted as course-v1:{org}+{course code}+{run_tag}
       e.g. course-v1:xPRO+MLx1+R0

--- a/src/ol_dbt/models/intermediate/mitxpro/int__mitxpro__ecommerce_allorders.sql
+++ b/src/ol_dbt/models/intermediate/mitxpro/int__mitxpro__ecommerce_allorders.sql
@@ -70,6 +70,7 @@ with b2becommerce_b2border as (
         , b2becommerce_b2border.b2border_discount
         , users.user_email
         , ecommerce_line.product_type
+        , course_runs.courserun_id
         , course_runs.courserun_readable_id
         , programs.program_readable_id
         , ecommerce_order.coupon_id
@@ -115,6 +116,7 @@ with b2becommerce_b2border as (
         , ecommerce_couponpaymentversion.couponpaymentversion_payment_transaction
         , ecommerce_couponpaymentversion.couponpaymentversion_coupon_type
         , b2becommerce_b2border.b2border_discount
+        , course_runs.courserun_id
         , course_runs.courserun_readable_id
         , programs.program_readable_id
         , ecommerce_coupon.coupon_id
@@ -168,6 +170,7 @@ select
     , redeemed
     , user_email
     , product_type
+    , courserun_id
     , courserun_readable_id
     , program_readable_id
     , coupon_id
@@ -194,6 +197,7 @@ select
     , redeemed
     , user_email
     , product_type
+    , courserun_id
     , courserun_readable_id
     , program_readable_id
     , coupon_id

--- a/src/ol_dbt/models/marts/combined/_marts__combined__models.yml
+++ b/src/ol_dbt/models/marts/combined/_marts__combined__models.yml
@@ -83,27 +83,50 @@ models:
   description: B2B and regular orders combined into one table
   columns:
   - name: platform
-    description: string, describes which platform the data is from (mitxonline, mitxpro,
-      or bootcamps)
+    description: string, describes platform associated with the order (edX.org, mitxonline,
+      mitxpro, or bootcamps).
+    tests:
+    - not_null
   - name: order_id
-    description: int, foreign key for order table
+    description: int, foreign key for order table. For edX.org, it refers to order
+      table in MicroMasters application.
+    tests:
+    - not_null
   - name: line_id
-    description: int, foreign key for line table
+    description: int, foreign key for line table. For edX.org, it refers to line table
+      in MicroMasters application.
   - name: b2b_only_indicator
-    description: str, indicates whether the record is only related to a b2b order
+    description: string, 'Y' indicates the record is only related to a b2b order.
+      Only applicable for xPro.
   - name: coupon_id
-    description: int, foreign key referencing ecommerce_coupon or the b2b coupon table
+    description: int, foreign key referencing ecommerce_coupon or the b2b coupon table.
+      For edX.org, it refers to ecommerce_coupon table in MicroMasters application.
   - name: coupon_name
     description: string, human readable name for the coupon payment
   - name: courserun_id
-    description: int, foreign key in courses_courserun
+    description: int, foreign key in courses_courserun. Null for edX.org.
+  - name: courserun_readable_id
+    description: str, unique string to identify a course run on the corresponding
+      platform.
   - name: order_created_on
     description: timestamp, specifying when the order was initially created. If this
       is a b2b order it will be the timestamp that order was created otherwise it
-      will be when the regular order was created.
+      will be when the regular order was created. For edX.org, it is the timestamp
+      that order was created in MicroMasters application.
+    tests:
+    - not_null
+  - name: order_reference_number
+    description: string, order reference number to identify an order in the corresponding
+      application database, e.g., mitxonline-production-20. For edX.org, it refers
+      to the order in MicroMasters application.
+    tests:
+    - not_null
   - name: order_state
-    description: string, order state. Options are "fulfilled", "failed", "created"
-      "refunded"
+    description: string, order state. Options are "cancelled", "created", "declined",
+      "errored", "failed", "fulfilled", "refunded", "partially_refunded",  "pending",
+      "review".
+    tests:
+    - not_null
   - name: order_tax_amount
     description: numeric, the amount of tax paid. Only applicable for xPro for now.
   - name: order_tax_country_code
@@ -132,9 +155,10 @@ models:
   - name: req_reference_number
     description: str, cybersource req reference number for a payment
   - name: user_email
-    description: str, user email associated with their account
+    description: str, user email associated with their account on the corresponding
+      platform
   - name: user_id
-    description: int, foreign key to the user table
+    description: int, foreign key to the user table on the corresponding platform
   tests:
   - dbt_expectations.expect_compound_columns_to_be_unique:
       column_list: ["order_id", "line_id", "b2b_only_indicator", "platform", "coupon_id"]

--- a/src/ol_dbt/models/marts/combined/marts__combined__orders.sql
+++ b/src/ol_dbt/models/marts/combined/marts__combined__orders.sql
@@ -1,5 +1,4 @@
 --- This model combines intermediate orders from different platforms
----{{ config(materialized='view') }}
 
 with bootcamps__ecommerce_order as (
     select * from {{ ref('int__bootcamps__ecommerce_order') }}
@@ -9,16 +8,8 @@ with bootcamps__ecommerce_order as (
     select * from {{ ref('int__mitxpro__ecommerce_allorders') }}
 )
 
-, mitxpro__course_runs as (
-    select * from {{ ref('int__mitxpro__course_runs') }}
-)
-
 , mitxonline__ecommerce_order as (
     select * from {{ ref('int__mitxonline__ecommerce_order') }}
-)
-
-, bootcamps__users as (
-    select * from {{ ref('int__bootcamps__users') }}
 )
 
 , mitxpro__b2becommerce_b2border as (
@@ -33,6 +24,10 @@ with bootcamps__ecommerce_order as (
     select * from {{ ref('int__mitxpro__ecommerce_allcoupons') }}
 )
 
+, micromasters_orders as (
+    select * from {{ ref('int__micromasters__orders') }}
+)
+
 , mitxpro_orders as (
     select
         mitxpro__ecommerce_allorders.line_id
@@ -42,10 +37,9 @@ with bootcamps__ecommerce_order as (
         , mitxpro__ecommerce_allorders.product_id
         , mitxpro__ecommerce_allorders.product_type
         , mitxpro__ecommerce_allorders.user_email
-        , mitxpro__course_runs.courserun_id
+        , mitxpro__ecommerce_allorders.courserun_id
+        , mitxpro__ecommerce_allorders.courserun_readable_id
         , mitxpro__ecommerce_order.order_purchaser_user_id
-        , mitxpro__ecommerce_order.order_total_price_paid
-        , mitxpro__b2becommerce_b2border.b2border_total_price
         , mitxpro__ecommerce_allorders.receipt_authorization_code
         , mitxpro__ecommerce_allorders.receipt_transaction_id
         , mitxpro__ecommerce_allorders.req_reference_number
@@ -54,15 +48,23 @@ with bootcamps__ecommerce_order as (
         , mitxpro__ecommerce_order.order_tax_rate_name
         , mitxpro__ecommerce_order.order_tax_amount
         , mitxpro__ecommerce_order.order_total_price_paid_plus_tax
+        , coalesce(
+            mitxpro__ecommerce_order.order_total_price_paid, mitxpro__b2becommerce_b2border.b2border_total_price
+        ) as order_total_price_paid
         , coalesce(mitxpro__ecommerce_allorders.coupon_id, mitxpro__ecommerce_allorders.b2bcoupon_id) as coupon_id
         , coalesce(mitxpro__ecommerce_allorders.order_id, mitxpro__ecommerce_allorders.b2border_id) as order_id
+        , case
+            --- the order reference number prefixes use the same format as in xpro application codebase
+            when mitxpro__ecommerce_allorders.order_id is not null
+                then concat('xpro-b2c-production-', cast(mitxpro__ecommerce_allorders.order_id as varchar))
+            when mitxpro__ecommerce_allorders.b2border_id is not null
+                then concat('xpro-bulk-production-', cast(mitxpro__ecommerce_allorders.b2border_id as varchar))
+        end as order_reference_number
         , case
             when mitxpro__ecommerce_allorders.order_id is null
                 then 'Y'
         end as b2b_only_indicator
     from mitxpro__ecommerce_allorders
-    left join mitxpro__course_runs
-        on mitxpro__ecommerce_allorders.courserun_readable_id = mitxpro__course_runs.courserun_readable_id
     left join mitxpro__ecommerce_order
         on mitxpro__ecommerce_allorders.order_id = mitxpro__ecommerce_order.order_id
     left join mitxpro__b2becommerce_b2border
@@ -71,33 +73,13 @@ with bootcamps__ecommerce_order as (
         on mitxpro__ecommerce_allorders.coupon_id = mitxpro__ecommerce_allcoupons.coupon_id
 )
 
-, bootcamps_orders as (
-    select
-        bootcamps__ecommerce_order.order_id
-        , bootcamps__ecommerce_order.line_id
-        , bootcamps__ecommerce_order.order_created_on
-        , bootcamps__ecommerce_order.order_state
-        , bootcamps__ecommerce_order.courserun_id
-        , bootcamps__ecommerce_order.order_total_price_paid
-        , bootcamps__ecommerce_order.order_purchaser_user_id
-        , bootcamps__users.user_email
-        , bootcamps__ecommerce_order.receipt_authorization_code
-        , bootcamps__ecommerce_order.receipt_transaction_id
-        , bootcamps__ecommerce_order.receipt_reference_number as req_reference_number
-    from bootcamps__ecommerce_order
-    left join bootcamps__users
-        on bootcamps__ecommerce_order.order_purchaser_user_id = bootcamps__users.user_id
-)
-
 , combined_orders as (
     select
         '{{ var("mitxonline") }}' as platform
         , order_id
         , line_id
-        , order_created_on
-        , order_state
         , courserun_id
-        , order_total_price_paid
+        , courserun_readable_id
         , product_id
         , product_type
         , user_email
@@ -107,12 +89,16 @@ with bootcamps__ecommerce_order as (
         , null as coupon_name
         , payment_authorization_code as receipt_authorization_code
         , payment_transaction_id as receipt_transaction_id
-        , order_reference_number as req_reference_number
+        , payment_req_reference_number as req_reference_number
+        , order_created_on
+        , order_reference_number
+        , order_state
         , null as order_tax_country_code
         , null as order_tax_rate
         , null as order_tax_rate_name
         , null as order_tax_amount
         , order_total_price_paid as order_total_price_paid_plus_tax
+        , order_total_price_paid
     from mitxonline__ecommerce_order
 
     union all
@@ -121,10 +107,8 @@ with bootcamps__ecommerce_order as (
         '{{ var("mitxpro") }}' as platform
         , order_id
         , line_id
-        , order_created_on
-        , order_state
         , courserun_id
-        , coalesce(order_total_price_paid, b2border_total_price) as order_total_price_paid
+        , courserun_readable_id
         , product_id
         , product_type
         , user_email
@@ -135,11 +119,15 @@ with bootcamps__ecommerce_order as (
         , receipt_authorization_code
         , receipt_transaction_id
         , req_reference_number
+        , order_created_on
+        , order_reference_number
+        , order_state
         , order_tax_country_code
         , order_tax_rate
         , order_tax_rate_name
         , order_tax_amount
         , order_total_price_paid_plus_tax
+        , order_total_price_paid
     from mitxpro_orders
 
     union all
@@ -148,10 +136,8 @@ with bootcamps__ecommerce_order as (
         '{{ var("bootcamps") }}' as platform
         , order_id
         , line_id
-        , order_created_on
-        , order_state
         , courserun_id
-        , order_total_price_paid
+        , courserun_readable_id
         , null as product_id
         , null as product_type
         , user_email
@@ -161,13 +147,47 @@ with bootcamps__ecommerce_order as (
         , null as coupon_name
         , receipt_authorization_code
         , receipt_transaction_id
-        , req_reference_number
+        , receipt_reference_number as req_reference_number
+        , order_created_on
+        , order_reference_number
+        , order_state
         , null as order_tax_country_code
         , null as order_tax_rate
         , null as order_tax_rate_name
         , null as order_tax_amount
         , order_total_price_paid as order_total_price_paid_plus_tax
-    from bootcamps_orders
+        , order_total_price_paid
+    from bootcamps__ecommerce_order
+
+    union all
+
+    select
+        '{{ var("edxorg") }}' as platform
+        , order_id
+        , line_id
+        , null as courserun_id
+        , courserun_readable_id
+        , null as product_id
+        , null as product_type
+        , user_edxorg_email as user_email
+        , user_edxorg_id as user_id
+        , null as b2b_only_indicator
+        , coupon_id
+        , coupon_code as coupon_name
+        , receipt_authorization_code
+        , receipt_transaction_id
+        , receipt_reference_number as req_reference_number
+        , order_created_on
+        , order_reference_number
+        , order_state
+        , null as order_tax_country_code
+        , null as order_tax_rate
+        , null as order_tax_rate_name
+        , null as order_tax_amount
+        , order_total_price_paid as order_total_price_paid_plus_tax
+        , order_total_price_paid
+    from micromasters_orders
+    where courserun_platform = '{{ var("edxorg") }}'
 
 )
 
@@ -179,7 +199,9 @@ select
     , coupon_id
     , coupon_name
     , courserun_id
+    , courserun_readable_id
     , order_created_on
+    , order_reference_number
     , order_state
     , order_tax_amount
     , order_tax_country_code


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
Part of https://github.com/mitodl/hq/issues/4532

### Description (What does it do?)
<!--- Describe your changes in detail -->
A few changes to marts__combined__orders

- Added the MicroMasters orders for legacy edx.org courses
- Added order_reference_number and courserun_readable_id
- Removed some of the joins to intermediate to simplify the mart . The query for xPro orders should probably be moved to mitxpro__ecommerce_allorders but that is out of scope for this PR.

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

dbt build --select +int__bootcamps__ecommerce_order
dbt build --select int__micromasters__orders
dbt build --select marts__combined__orders