### PR TITLE
Update MITx Online verified enrollment mode to count for change_status

### DIFF
--- a/src/ol_dbt/models/intermediate/mitxonline/int__mitxonline__courserunenrollments.sql
+++ b/src/ol_dbt/models/intermediate/mitxonline/int__mitxonline__courserunenrollments.sql
@@ -118,7 +118,9 @@ with enrollments as (
         , case
             when
                 dedp_enrollments_verified.user_id is not null
-                and dedp_enrollments_verified.courserun_id is not null then 'verified'
+                and dedp_enrollments_verified.courserun_id is not null
+                and enrollments.courserunenrollment_enrollment_status is null
+                then 'verified'
             else enrollments.courserunenrollment_enrollment_mode
         end as courserunenrollment_enrollment_mode
     from enrollments


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
NA

### Description (What does it do?)
<!--- Describe your changes in detail -->
Fixing the 'verified' enrollment mode in int__mitxonline__courserunenrollments to exclude the enrollment change status is modified, e.g., deferred or refunded status. These should not count as verified.

I noted this issue when looking at the deferred status at https://bi.ol.mit.edu/superset/dashboard/p/Pkj5M8GqADe/. In this example, this learner has deferred the verified enrollment from course-v1:MITxT+14.73x+1T2024 to course-v1:MITxT+14.73x+3T2024, but in the dashboard, it showed both enrollments are verified. It should have been verified for course-v1:MITxT+14.73x+3T2024.

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

dbt build --select int__mitxonline__courserunenrollments

The new count for MITx Online verified enrollments is 13218, 341 less than production
```
select count(*) from  "ol_data_lake_production"."ol_warehouse_production_rlougee_intermediate"."int__mitxonline__courserunenrollments"
 where courserunenrollment_enrollment_mode='verified'
  and courserunenrollment_platform='MITx Online'
```

