### PR TITLE
Update metadata object keys to organize raw metadata files

### DIFF
--- a/src/ol_orchestrate/assets/openedx_course_archives.py
+++ b/src/ol_orchestrate/assets/openedx_course_archives.py
@@ -47,7 +47,8 @@ def extract_edxorg_courserun_metadata(
     data_version = hashlib.file_digest(
         course_metadata_file.open("rb"), "sha256"
     ).hexdigest()
-    course_metadata_object_key = f"edxorg/processed_data/course_metadata/{context.partition_key}/{data_version}.json"  # noqa: E501
+    partition_dict = context.partition_key.keys_by_dimension
+    course_metadata_object_key = f"edxorg/processed_data/course_metadata/{partition_dict["source_system"]}/{partition_dict["course_id"]}/{data_version}.json"  # noqa: E501
     yield Output(
         (course_metadata_file, course_metadata_object_key),
         data_version=DataVersion(data_version),


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/4067

### Description (What does it do?)
With the way the object keys are currently configured, metadata filenames include both the source_system and course_id rather than creating a new path for each source_system and course_id pair. These changes update the course_metadata_object_key to make sure each source_system has its on unique destination path.


### How can this be tested?
Let the course metadata get processed in production, double check the file structure/path of the resulting files in S3.