### PR TITLE
Standarlize profiles in micromasters intermediate

### DIFF
--- a/src/ol_dbt/models/intermediate/micromasters/_int_micromasters__models.yml
+++ b/src/ol_dbt/models/intermediate/micromasters/_int_micromasters__models.yml
@@ -85,7 +85,8 @@ models:
 
 - name: int__micromasters__course_enrollments
   description: MicroMasters enrollments. Enrollments in courses that satisfy the requirements
-    for multiple programs appear in multiple rows.
+    for multiple programs appear in multiple rows. User's profile fields are chosen
+    in the order of MITx Online, MicroMasters, and edX.org, whichever is not null.
   columns:
   - name: program_title
     description: str, title of micromasters program the course is part of
@@ -104,15 +105,14 @@ models:
   - name: user_edxorg_username
     description: str, edxorg username for the user
   - name: user_address_country
-    description: str, country code for the user's address
+    description: str, country code on user's profile from MITx Online, MicroMasters,
+      or edX.org
   - name: user_email
-    description: str, user email
+    description: str, current user email on MITxOnline or edX.org.
     tests:
     - not_null
   - name: user_full_name
-    description: str, user full name on edX.org or MITxOnline. Very small number of
-      edX.org users have blank full name, their names aren't populated unless they
-      have their accounts linked on MicroMasters.
+    description: str, user's full name from MITx Online, MicroMasters, or edX.org.
   - name: courserun_readable_id
     description: str, course ID on edx.org or openedx
     tests:
@@ -174,9 +174,7 @@ models:
   - dbt_expectations.expect_table_row_count_to_equal_other_table:
       compare_model: ref('stg__micromasters__app__postgres__courses_program')
 - name: int__micromasters__program_requirements
-  description: Intermediate model for program requirements in MicroMasters. The profile
-    data are selected in the order of MITx Online, MicroMasters, and edX.org, whichever
-    is not null.
+  description: Intermediate model for program requirements in MicroMasters
   columns:
   - name: program_id
     description: int, foreign key to courses_program
@@ -205,8 +203,11 @@ models:
     description: int, indicating the number of required courses to earn certificate
     tests:
     - not_null
+
 - name: int__micromasters__program_certificates
-  description: MicroMasters program certificate earners
+  description: MicroMasters program certificate earners. User's profile fields are
+    chosen in the order of MITx Online, MicroMasters, and edX.org, whichever is not
+    null.
   columns:
   - name: user_edxorg_username
     description: str, The username of the learner on the edX platform. For users who
@@ -243,7 +244,7 @@ models:
     - accepted_values:
         values: '{{ var("gender_values") }}'
   - name: user_first_name
-    description: str, first name on user's profile from MITx Online or MicroMasters
+    description: str, first name on user's profile from MITx Online or MicroMasters.
   - name: user_last_name
     description: str, last name from user's profile on MITx Online or MicroMasters.
   - name: user_full_name
@@ -255,11 +256,14 @@ models:
     description: str, country code on user's profile from MITx Online, MicroMasters,
       or edX.org
   - name: user_address_postal_code
-    description: str, postal code on user's profile from MicroMasters
+    description: str, postal code on user's profile from MicroMasters. MITx Online
+      and edX.org don't collect this data.
   - name: user_street_address
-    description: str, street address on user's profile from MicroMasters
+    description: str, street address on user's profile from MicroMasters. MITx Online
+      and edX.org don't collect this data.
   - name: user_address_city
-    description: str,  address city on user's profile from MicroMasters
+    description: str,  address city on user's profile from MicroMasters. MITx Online
+      and edX.org don't collect this data.
   - name: user_address_state_or_territory
     description: str, state code or territory on user's profile from MITx Online or
       MicroMasters
@@ -273,7 +277,8 @@ models:
   description: course certificates earned for MicroMasters programs. This include
     certificates are downloadable and not revoked from MITx Online, MicroMaster and
     edX.org. Certificates earned for courses that satisfy the requirements for multiple
-    programs appear in multiple rows for each program
+    programs appear in multiple rows for each program. User's profile fields are chosen
+    in the order of MITx Online, MicroMasters, and edX.org, whichever is not null.
   columns:
   - name: program_title
     description: str, title of the program the course is part of
@@ -306,13 +311,14 @@ models:
   - name: user_mitxonline_username
     description: str, username on MITxOnline
   - name: user_email
-    description: str, user email on edX.org or MITxOnline
+    description: str, user's email address from MITx Online, MicroMasters, or edX.org
     tests:
     - not_null
   - name: user_full_name
-    description: str, user full name on edX.org or MITxOnline
+    description: str, user's full name from MITx Online, MicroMasters, or edX.org.
   - name: user_country
-    description: str, user country on edX.org or MITxOnline
+    description: str, country code on user's profile from MITx Online, MicroMasters,
+      or edX.org
   - name: courseruncertificate_uuid
     description: str, unique identifier for the certificate on MITx Online, MicroMasters
       or edX.org
@@ -331,7 +337,9 @@ models:
 
 - name: int__micromasters__course_grades
   description: course grades for MicroMasters programs. Grades for courses that satisfy
-    the requirements for multiple programs appear in multiple rows
+    the requirements for multiple programs appear in multiple rows. User's profile
+    fields are chosen in the order of MITx Online, MicroMasters, and edX.org, whichever
+    is not null.
   columns:
   - name: program_title
     description: str, title of program the course is part of
@@ -364,13 +372,14 @@ models:
   - name: user_mitxonline_username
     description: str, username on MITxOnline
   - name: user_email
-    description: str, user email on edX.org or MITxOnline.
+    description: str, user's email address from MITx Online, MicroMasters, or edX.org
     tests:
     - not_null
   - name: user_full_name
-    description: str, user full name on edX.org or MITxOnline
+    description: str, user's full name from MITx Online, MicroMasters, or edX.org.
   - name: user_country
-    description: str, user country on edX.org or MITxOnline
+    description: str, country code on user's profile from MITx Online, MicroMasters,
+      or edX.org
   - name: grade
     description: float, course grade on edX.org or MITxOnline range from 0 to 1, maybe
       blank on edX.org

--- a/src/ol_dbt/models/intermediate/micromasters/_int_micromasters__models.yml
+++ b/src/ol_dbt/models/intermediate/micromasters/_int_micromasters__models.yml
@@ -141,8 +141,7 @@ models:
     tests:
     - not_null
   - name: program_is_dedp
-    description: boolean, specifying if the program is DEDP from the mixonline program
-      id
+    description: boolean, specifying if the program is DEDP
   tests:
   - dbt_expectations.expect_compound_columns_to_be_unique:
       column_list: ["user_id", "platform", "courserun_readable_id", "micromasters_program_id",
@@ -175,7 +174,9 @@ models:
   - dbt_expectations.expect_table_row_count_to_equal_other_table:
       compare_model: ref('stg__micromasters__app__postgres__courses_program')
 - name: int__micromasters__program_requirements
-  description: Intermediate model for program requirements in MicroMasters
+  description: Intermediate model for program requirements in MicroMasters. The profile
+    data are selected in the order of MITx Online, MicroMasters, and edX.org, whichever
+    is not null.
   columns:
   - name: program_id
     description: int, foreign key to courses_program
@@ -214,7 +215,7 @@ models:
   - name: user_mitxonline_username
     description: str, username on MITx Online
   - name: user_email
-    description: str, The email address of the learner on the edX platform
+    description: str, user's email address from MITx Online, MicroMasters, or edX.org
     tests:
     - not_null
   - name: program_title
@@ -236,37 +237,34 @@ models:
     description: timestamp, timestamp of the course certificate that completed the
       program
   - name: user_gender
-    description: str, user's gender from user's profile on MITx Online or edX.org.
-      blank means user did not specify a gender. Null means this student signed up
-      before this information was collected
+    description: str, gender on user's profile from MITx Online, MicroMasters, or
+      edX.org
     tests:
     - accepted_values:
         values: '{{ var("gender_values") }}'
-  - name: user_address_city
-    description: str, city where user lives in from user's profile on MicroMasters.
-      Note that this data isn't available on MITx Online.
   - name: user_first_name
-    description: str, first name from user's profile on MITx Online or MicroMasters.
+    description: str, first name on user's profile from MITx Online or MicroMasters
   - name: user_last_name
     description: str, last name from user's profile on MITx Online or MicroMasters.
   - name: user_full_name
-    description: str, The full name from user's profile on MITx Online or MicroMasters.
+    description: str, user's full name from MITx Online, MicroMasters, or edX.org.
   - name: user_year_of_birth
-    description: str, user's birth year from user's profile on MITx Online or MicroMasters.
+    description: int, birth year on user's profile from MITx Online, MicroMasters,
+      or edX.org
   - name: user_country
-    description: str, Country from user's profile on MITx Online or MicroMasters
+    description: str, country code on user's profile from MITx Online, MicroMasters,
+      or edX.org
   - name: user_address_postal_code
-    description: str, postal code where user lives in from the profile on MicroMasters.
-      Note that this data isn't available on MITx Online.
+    description: str, postal code on user's profile from MicroMasters
   - name: user_street_address
-    description: str, street address where user lives in from user's profile on MicroMasters.
-      Note that this data isn't available on MITx Online.
+    description: str, street address on user's profile from MicroMasters
+  - name: user_address_city
+    description: str,  address city on user's profile from MicroMasters
   - name: user_address_state_or_territory
-    description: str,  state or territory where user lives in from user's profile
-      on MITx Online or MicroMasters.
+    description: str, state code or territory on user's profile from MITx Online or
+      MicroMasters
   - name: program_is_dedp
-    description: boolean, specifying if the program is DEDP from the mixonline program
-      id
+    description: boolean, specifying if the program is DEDP
   tests:
   - dbt_expectations.expect_compound_columns_to_be_unique:
       column_list: ["user_email", "micromasters_program_id", "mitxonline_program_id"]

--- a/src/ol_dbt/models/intermediate/micromasters/int__micromasters__course_certificates.sql
+++ b/src/ol_dbt/models/intermediate/micromasters/int__micromasters__course_certificates.sql
@@ -66,7 +66,7 @@ with course_certificates_dedp_from_micromasters as (
         , course_certificates_dedp_from_mitxonline.courseruncertificate_created_on
     from course_certificates_dedp_from_mitxonline
     left join mitx_users
-        on course_certificates_dedp_from_mitxonline.user_mitxonline_username = mitx_users.user_mitxonline_username
+        on course_certificates_dedp_from_mitxonline.user_mitxonline_id = mitx_users.user_mitxonline_id
     where course_certificates_dedp_from_mitxonline.courserun_platform = '{{ var("mitxonline") }}'
 
 )
@@ -128,7 +128,7 @@ with course_certificates_dedp_from_micromasters as (
         , coalesce(mitx_users.user_edxorg_email, mitx_users.user_micromasters_email) as user_email
     from course_certificates_non_dedp_program
     left join mitx_users
-        on course_certificates_non_dedp_program.user_edxorg_username = mitx_users.user_edxorg_username
+        on course_certificates_non_dedp_program.user_edxorg_id = mitx_users.user_edxorg_id
 )
 
 

--- a/src/ol_dbt/models/intermediate/micromasters/int__micromasters__course_certificates.sql
+++ b/src/ol_dbt/models/intermediate/micromasters/int__micromasters__course_certificates.sql
@@ -13,6 +13,10 @@ with course_certificates_dedp_from_micromasters as (
     from {{ ref('__micromasters_course_certificates_non_dedp_from_edxorg') }}
 )
 
+, mitx_users as (
+    select * from {{ ref('int__mitx__users') }}
+)
+
 -- DEDP course certificates come from MicroMasters and MITxOnline. We've migrated some learners data from
 -- MicroMasters to MITxOnline around Oct 2022, but only for those users who have MITxOnline account.
 -- To avoid data overlapping, we deduplicate based on their social auth account linked on MicroMasters.
@@ -22,44 +26,48 @@ with course_certificates_dedp_from_micromasters as (
 
 , dedp_course_certificates_combined as (
     select
-        program_title
-        , micromasters_program_id
-        , mitxonline_program_id
-        , courserun_title
-        , courserun_readable_id
-        , courserun_platform
-        , course_number
-        , user_edxorg_username
-        , user_mitxonline_username
-        , user_full_name
-        , user_country
-        , user_email
-        , coursecertificate_hash as courseruncertificate_uuid
-        , coursecertificate_url as courseruncertificate_url
-        , coursecertificate_created_on as courseruncertificate_created_on
+        course_certificates_dedp_from_micromasters.program_title
+        , course_certificates_dedp_from_micromasters.micromasters_program_id
+        , course_certificates_dedp_from_micromasters.mitxonline_program_id
+        , course_certificates_dedp_from_micromasters.courserun_title
+        , course_certificates_dedp_from_micromasters.courserun_readable_id
+        , course_certificates_dedp_from_micromasters.courserun_platform
+        , course_certificates_dedp_from_micromasters.course_number
+        , mitx_users.user_edxorg_username
+        , mitx_users.user_mitxonline_username
+        , mitx_users.user_full_name
+        , mitx_users.user_address_country as user_country
+        , mitx_users.user_micromasters_email as user_email
+        , course_certificates_dedp_from_micromasters.coursecertificate_hash as courseruncertificate_uuid
+        , course_certificates_dedp_from_micromasters.coursecertificate_url as courseruncertificate_url
+        , course_certificates_dedp_from_micromasters.coursecertificate_created_on as courseruncertificate_created_on
     from course_certificates_dedp_from_micromasters
-    where courserun_platform = '{{ var("edxorg") }}'
+    left join mitx_users
+        on course_certificates_dedp_from_micromasters.user_micromasters_id = mitx_users.user_micromasters_id
+    where course_certificates_dedp_from_micromasters.courserun_platform = '{{ var("edxorg") }}'
 
     union all
 
     select
-        program_title
-        , micromasters_program_id
-        , mitxonline_program_id
-        , courserun_title
-        , courserun_readable_id
-        , courserun_platform
-        , course_number
-        , user_edxorg_username
-        , user_mitxonline_username
-        , user_full_name
-        , user_country
-        , user_email
-        , courseruncertificate_uuid
-        , courseruncertificate_url
-        , courseruncertificate_created_on
+        course_certificates_dedp_from_mitxonline.program_title
+        , course_certificates_dedp_from_mitxonline.micromasters_program_id
+        , course_certificates_dedp_from_mitxonline.mitxonline_program_id
+        , course_certificates_dedp_from_mitxonline.courserun_title
+        , course_certificates_dedp_from_mitxonline.courserun_readable_id
+        , course_certificates_dedp_from_mitxonline.courserun_platform
+        , course_certificates_dedp_from_mitxonline.course_number
+        , mitx_users.user_edxorg_username
+        , mitx_users.user_mitxonline_username
+        , mitx_users.user_full_name
+        , mitx_users.user_address_country as user_country
+        , mitx_users.user_mitxonline_email as user_email
+        , course_certificates_dedp_from_mitxonline.courseruncertificate_uuid
+        , course_certificates_dedp_from_mitxonline.courseruncertificate_url
+        , course_certificates_dedp_from_mitxonline.courseruncertificate_created_on
     from course_certificates_dedp_from_mitxonline
-    where courserun_platform = '{{ var("mitxonline") }}'
+    left join mitx_users
+        on course_certificates_dedp_from_mitxonline.user_mitxonline_username = mitx_users.user_mitxonline_username
+    where course_certificates_dedp_from_mitxonline.courserun_platform = '{{ var("mitxonline") }}'
 
 )
 
@@ -101,6 +109,28 @@ with course_certificates_dedp_from_micromasters as (
     where row_num = 1
 )
 
+, non_dedp_course_certificates as (
+    select
+        course_certificates_non_dedp_program.program_title
+        , course_certificates_non_dedp_program.mitxonline_program_id
+        , course_certificates_non_dedp_program.micromasters_program_id
+        , course_certificates_non_dedp_program.courserun_title
+        , course_certificates_non_dedp_program.courserun_readable_id
+        , course_certificates_non_dedp_program.courserun_platform
+        , course_certificates_non_dedp_program.course_number
+        , mitx_users.user_edxorg_username
+        , mitx_users.user_mitxonline_username
+        , mitx_users.user_full_name
+        , mitx_users.user_address_country as user_country
+        , course_certificates_non_dedp_program.courseruncertificate_download_uuid as courseruncertificate_uuid
+        , course_certificates_non_dedp_program.courseruncertificate_download_url as courseruncertificate_url
+        , course_certificates_non_dedp_program.courseruncertificate_created_on
+        , coalesce(mitx_users.user_edxorg_email, mitx_users.user_micromasters_email) as user_email
+    from course_certificates_non_dedp_program
+    left join mitx_users
+        on course_certificates_non_dedp_program.user_edxorg_username = mitx_users.user_edxorg_username
+)
+
 
 , course_certificates as (
     select
@@ -136,10 +166,10 @@ with course_certificates_dedp_from_micromasters as (
         , user_full_name
         , user_country
         , user_email
-        , courseruncertificate_download_uuid as courseruncertificate_uuid
-        , courseruncertificate_download_url as courseruncertificate_url
+        , courseruncertificate_uuid
+        , courseruncertificate_url
         , courseruncertificate_created_on
-    from course_certificates_non_dedp_program
+    from non_dedp_course_certificates
 )
 
 select *

--- a/src/ol_dbt/models/intermediate/micromasters/int__micromasters__course_grades.sql
+++ b/src/ol_dbt/models/intermediate/micromasters/int__micromasters__course_grades.sql
@@ -13,6 +13,10 @@ with course_grades_dedp_from_micromasters as (
     from {{ ref('__micromasters_course_grades_non_dedp_from_edxorg') }}
 )
 
+, mitx_users as (
+    select * from {{ ref('int__mitx__users') }}
+)
+
 -- DEDP course grades come from MicroMasters and MITxOnline. We've migrated some learners data from
 -- MicroMasters to MITxOnline around Oct 2022, but only for those users who have MITxOnline account.
 -- To avoid data overlapping, we deduplicate based on their social auth account linked on MicroMasters.
@@ -21,44 +25,48 @@ with course_grades_dedp_from_micromasters as (
 
 , dedp_course_grades_combined as (
     select
-        program_title
-        , mitxonline_program_id
-        , micromasters_program_id
-        , courserun_title
-        , courserun_readable_id
-        , courserun_platform
-        , course_number
-        , user_edxorg_username
-        , user_mitxonline_username
-        , user_full_name
-        , user_country
-        , user_email
-        , coursegrade_grade as grade
+        course_grades_dedp_from_micromasters.program_title
+        , course_grades_dedp_from_micromasters.mitxonline_program_id
+        , course_grades_dedp_from_micromasters.micromasters_program_id
+        , course_grades_dedp_from_micromasters.courserun_title
+        , course_grades_dedp_from_micromasters.courserun_readable_id
+        , course_grades_dedp_from_micromasters.courserun_platform
+        , course_grades_dedp_from_micromasters.course_number
+        , mitx_users.user_edxorg_username
+        , mitx_users.user_mitxonline_username
+        , mitx_users.user_full_name
+        , mitx_users.user_address_country as user_country
+        , mitx_users.user_micromasters_email as user_email
+        , course_grades_dedp_from_micromasters.coursegrade_grade as grade
         , true as is_passing
-        , coursegrade_created_on as created_on
+        , course_grades_dedp_from_micromasters.coursegrade_created_on as created_on
     from course_grades_dedp_from_micromasters
-    where courserun_platform = '{{ var("edxorg") }}'
+    left join mitx_users
+        on course_grades_dedp_from_micromasters.user_micromasters_id = mitx_users.user_micromasters_id
+    where course_grades_dedp_from_micromasters.courserun_platform = '{{ var("edxorg") }}'
 
     union all
 
     select
-        program_title
-        , mitxonline_program_id
-        , micromasters_program_id
-        , courserun_title
-        , courserun_readable_id
-        , courserun_platform
-        , course_number
-        , user_edxorg_username
-        , user_mitxonline_username
-        , user_full_name
-        , user_country
-        , user_email
-        , courserungrade_grade as grade
-        , courserungrade_is_passing as is_passing
-        , courserungrade_created_on as created_on
+        course_grades_dedp_from_mitxonline.program_title
+        , course_grades_dedp_from_mitxonline.mitxonline_program_id
+        , course_grades_dedp_from_mitxonline.micromasters_program_id
+        , course_grades_dedp_from_mitxonline.courserun_title
+        , course_grades_dedp_from_mitxonline.courserun_readable_id
+        , course_grades_dedp_from_mitxonline.courserun_platform
+        , course_grades_dedp_from_mitxonline.course_number
+        , mitx_users.user_edxorg_username
+        , mitx_users.user_mitxonline_username
+        , mitx_users.user_full_name
+        , mitx_users.user_address_country as user_country
+        , mitx_users.user_mitxonline_email as user_email
+        , course_grades_dedp_from_mitxonline.courserungrade_grade as grade
+        , course_grades_dedp_from_mitxonline.courserungrade_is_passing as is_passing
+        , course_grades_dedp_from_mitxonline.courserungrade_created_on as created_on
     from course_grades_dedp_from_mitxonline
-    where courserun_platform = '{{ var("mitxonline") }}'
+    left join mitx_users
+        on course_grades_dedp_from_mitxonline.user_mitxonline_username = mitx_users.user_mitxonline_username
+    where course_grades_dedp_from_mitxonline.courserun_platform = '{{ var("mitxonline") }}'
 
 )
 
@@ -98,6 +106,27 @@ with course_grades_dedp_from_micromasters as (
     where row_num = 1
 )
 
+, non_dedp_course_grades as (
+    select
+        course_grades_non_dedp_program.program_title
+        , course_grades_non_dedp_program.mitxonline_program_id
+        , course_grades_non_dedp_program.micromasters_program_id
+        , course_grades_non_dedp_program.courserun_title
+        , course_grades_non_dedp_program.courserun_readable_id
+        , course_grades_non_dedp_program.courserun_platform
+        , course_grades_non_dedp_program.course_number
+        , mitx_users.user_edxorg_username
+        , mitx_users.user_mitxonline_username
+        , mitx_users.user_full_name
+        , mitx_users.user_address_country as user_country
+        , course_grades_non_dedp_program.courserungrade_user_grade as grade
+        , course_grades_non_dedp_program.courserungrade_is_passing as is_passing
+        , coalesce(mitx_users.user_edxorg_email, mitx_users.user_micromasters_email) as user_email
+    from course_grades_non_dedp_program
+    left join mitx_users
+        on course_grades_non_dedp_program.user_edxorg_username = mitx_users.user_edxorg_username
+)
+
 , program_course_grades as (
     select
         program_title
@@ -131,9 +160,9 @@ with course_grades_dedp_from_micromasters as (
         , user_full_name
         , user_country
         , user_email
-        , courserungrade_user_grade as grade
-        , courserungrade_is_passing as is_passing
-    from course_grades_non_dedp_program
+        , grade
+        , is_passing
+    from non_dedp_course_grades
 )
 
 select * from program_course_grades

--- a/src/ol_dbt/models/intermediate/micromasters/int__micromasters__course_grades.sql
+++ b/src/ol_dbt/models/intermediate/micromasters/int__micromasters__course_grades.sql
@@ -65,7 +65,7 @@ with course_grades_dedp_from_micromasters as (
         , course_grades_dedp_from_mitxonline.courserungrade_created_on as created_on
     from course_grades_dedp_from_mitxonline
     left join mitx_users
-        on course_grades_dedp_from_mitxonline.user_mitxonline_username = mitx_users.user_mitxonline_username
+        on course_grades_dedp_from_mitxonline.user_mitxonline_id = mitx_users.user_mitxonline_id
     where course_grades_dedp_from_mitxonline.courserun_platform = '{{ var("mitxonline") }}'
 
 )
@@ -124,7 +124,7 @@ with course_grades_dedp_from_micromasters as (
         , coalesce(mitx_users.user_edxorg_email, mitx_users.user_micromasters_email) as user_email
     from course_grades_non_dedp_program
     left join mitx_users
-        on course_grades_non_dedp_program.user_edxorg_username = mitx_users.user_edxorg_username
+        on course_grades_non_dedp_program.user_edxorg_id = mitx_users.user_edxorg_id
 )
 
 , program_course_grades as (

--- a/src/ol_dbt/models/intermediate/micromasters/int__micromasters__program_certificates.sql
+++ b/src/ol_dbt/models/intermediate/micromasters/int__micromasters__program_certificates.sql
@@ -75,7 +75,7 @@ with program_certificates_dedp_from_micromasters as (
         , true as program_is_dedp
     from program_certificates_dedp_from_mitxonline
     left join mitx_users
-        on program_certificates_dedp_from_mitxonline.user_mitxonline_username = mitx_users.user_mitxonline_username
+        on program_certificates_dedp_from_mitxonline.user_mitxonline_id = mitx_users.user_mitxonline_id
     where program_certificates_dedp_from_mitxonline.program_completion_timestamp >= '2022-10-01'
 
     union all
@@ -103,7 +103,7 @@ with program_certificates_dedp_from_micromasters as (
         , false as program_is_dedp
     from program_certificates_non_dedp
     left join mitx_users
-        on program_certificates_non_dedp.user_edxorg_username = mitx_users.user_edxorg_username
+        on program_certificates_non_dedp.user_edxorg_id = mitx_users.user_edxorg_id
 )
 
 

--- a/src/ol_dbt/models/intermediate/micromasters/int__micromasters__program_certificates.sql
+++ b/src/ol_dbt/models/intermediate/micromasters/int__micromasters__program_certificates.sql
@@ -26,13 +26,13 @@ with program_certificates_dedp_from_micromasters as (
 , report as (
     select
         program_certificates_dedp_from_micromasters.program_certificate_hashed_id
-        , program_certificates_dedp_from_micromasters.user_edxorg_username
-        , program_certificates_dedp_from_micromasters.user_mitxonline_username
         , program_certificates_dedp_from_micromasters.program_title
         , program_certificates_dedp_from_micromasters.micromasters_program_id
         , program_certificates_dedp_from_micromasters.mitxonline_program_id
-        , program_certificates_dedp_from_micromasters.user_edxorg_id
         , program_certificates_dedp_from_micromasters.program_completion_timestamp
+        , mitx_users.user_edxorg_id
+        , mitx_users.user_edxorg_username
+        , mitx_users.user_mitxonline_username
         , mitx_users.user_micromasters_email as user_email
         , mitx_users.user_first_name
         , mitx_users.user_last_name
@@ -47,20 +47,20 @@ with program_certificates_dedp_from_micromasters as (
         , true as program_is_dedp
     from program_certificates_dedp_from_micromasters
     left join mitx_users
-        on program_certificates_dedp_from_micromasters.micromasters_user_id = mitx_users.user_micromasters_id
+        on program_certificates_dedp_from_micromasters.user_micromasters_id = mitx_users.user_micromasters_id
     where program_certificates_dedp_from_micromasters.program_completion_timestamp < '2022-10-01'
 
     union all
 
     select
         program_certificates_dedp_from_mitxonline.program_certificate_hashed_id
-        , program_certificates_dedp_from_mitxonline.user_edxorg_username
-        , program_certificates_dedp_from_mitxonline.user_mitxonline_username
         , program_certificates_dedp_from_mitxonline.program_title
         , program_certificates_dedp_from_mitxonline.micromasters_program_id
         , program_certificates_dedp_from_mitxonline.mitxonline_program_id
-        , program_certificates_dedp_from_mitxonline.user_edxorg_id
         , program_certificates_dedp_from_mitxonline.program_completion_timestamp
+        , mitx_users.user_edxorg_id
+        , mitx_users.user_edxorg_username
+        , mitx_users.user_mitxonline_username
         , mitx_users.user_mitxonline_email as user_email
         , mitx_users.user_first_name
         , mitx_users.user_last_name
@@ -82,13 +82,13 @@ with program_certificates_dedp_from_micromasters as (
 
     select
         program_certificates_non_dedp.program_certificate_hashed_id
-        , program_certificates_non_dedp.user_edxorg_username
-        , program_certificates_non_dedp.user_mitxonline_username
         , program_certificates_non_dedp.program_title
         , program_certificates_non_dedp.micromasters_program_id
         , program_certificates_non_dedp.mitxonline_program_id
-        , program_certificates_non_dedp.user_edxorg_id
         , program_certificates_non_dedp.program_completion_timestamp
+        , mitx_users.user_edxorg_id
+        , mitx_users.user_edxorg_username
+        , mitx_users.user_mitxonline_username
         , mitx_users.user_edxorg_email as user_email
         , mitx_users.user_first_name
         , mitx_users.user_last_name

--- a/src/ol_dbt/models/intermediate/micromasters/int__micromasters__program_certificates.sql
+++ b/src/ol_dbt/models/intermediate/micromasters/int__micromasters__program_certificates.sql
@@ -13,6 +13,10 @@ with program_certificates_dedp_from_micromasters as (
     from {{ ref('__micromasters_program_certificates_non_dedp') }}
 )
 
+, mitx_users as (
+    select * from {{ ref('int__mitx__users') }}
+)
+
 -- Some micromasters learners from previous semesters don't have mitxonline logins. The mitxonline
 -- database does not include the certificates for those users. However, for future semesters,
 -- the mitxonline  database will be the source for dedp program certificates and the table in
@@ -21,76 +25,85 @@ with program_certificates_dedp_from_micromasters as (
 
 , report as (
     select
-        program_certificate_hashed_id
-        , user_edxorg_username
-        , user_mitxonline_username
-        , user_email
-        , program_title
-        , micromasters_program_id
-        , mitxonline_program_id
-        , user_edxorg_id
-        , program_completion_timestamp
-        , user_gender
-        , user_address_city
-        , user_first_name
-        , user_last_name
-        , user_full_name
-        , user_year_of_birth
-        , user_country
-        , user_address_postal_code
-        , user_street_address
-        , user_address_state_or_territory
+        program_certificates_dedp_from_micromasters.program_certificate_hashed_id
+        , program_certificates_dedp_from_micromasters.user_edxorg_username
+        , program_certificates_dedp_from_micromasters.user_mitxonline_username
+        , program_certificates_dedp_from_micromasters.program_title
+        , program_certificates_dedp_from_micromasters.micromasters_program_id
+        , program_certificates_dedp_from_micromasters.mitxonline_program_id
+        , program_certificates_dedp_from_micromasters.user_edxorg_id
+        , program_certificates_dedp_from_micromasters.program_completion_timestamp
+        , mitx_users.user_micromasters_email as user_email
+        , mitx_users.user_first_name
+        , mitx_users.user_last_name
+        , mitx_users.user_full_name
+        , mitx_users.user_gender
+        , mitx_users.user_birth_year as user_year_of_birth
+        , mitx_users.user_address_country as user_country
+        , mitx_users.user_address_state as user_address_state_or_territory
+        , mitx_users.user_address_city
+        , mitx_users.user_address_postal_code
+        , mitx_users.user_street_address
+        , true as program_is_dedp
     from program_certificates_dedp_from_micromasters
-    where program_completion_timestamp < '2022-10-01'
+    left join mitx_users
+        on program_certificates_dedp_from_micromasters.micromasters_user_id = mitx_users.user_micromasters_id
+    where program_certificates_dedp_from_micromasters.program_completion_timestamp < '2022-10-01'
 
     union all
 
     select
-        program_certificate_hashed_id
-        , user_edxorg_username
-        , user_mitxonline_username
-        , user_email
-        , program_title
-        , micromasters_program_id
-        , mitxonline_program_id
-        , user_edxorg_id
-        , program_completion_timestamp
-        , user_gender
-        , user_address_city
-        , user_first_name
-        , user_last_name
-        , user_full_name
-        , user_year_of_birth
-        , user_country
-        , user_address_postal_code
-        , user_street_address
-        , user_address_state_or_territory
+        program_certificates_dedp_from_mitxonline.program_certificate_hashed_id
+        , program_certificates_dedp_from_mitxonline.user_edxorg_username
+        , program_certificates_dedp_from_mitxonline.user_mitxonline_username
+        , program_certificates_dedp_from_mitxonline.program_title
+        , program_certificates_dedp_from_mitxonline.micromasters_program_id
+        , program_certificates_dedp_from_mitxonline.mitxonline_program_id
+        , program_certificates_dedp_from_mitxonline.user_edxorg_id
+        , program_certificates_dedp_from_mitxonline.program_completion_timestamp
+        , mitx_users.user_mitxonline_email as user_email
+        , mitx_users.user_first_name
+        , mitx_users.user_last_name
+        , mitx_users.user_full_name
+        , mitx_users.user_gender
+        , mitx_users.user_birth_year as user_year_of_birth
+        , mitx_users.user_address_country as user_country
+        , mitx_users.user_address_state as user_address_state_or_territory
+        , mitx_users.user_address_city
+        , mitx_users.user_address_postal_code
+        , mitx_users.user_street_address
+        , true as program_is_dedp
     from program_certificates_dedp_from_mitxonline
-    where program_completion_timestamp >= '2022-10-01'
+    left join mitx_users
+        on program_certificates_dedp_from_mitxonline.user_mitxonline_username = mitx_users.user_mitxonline_username
+    where program_certificates_dedp_from_mitxonline.program_completion_timestamp >= '2022-10-01'
 
     union all
 
     select
-        program_certificate_hashed_id
-        , user_edxorg_username
-        , user_mitxonline_username
-        , user_email
-        , program_title
-        , micromasters_program_id
-        , mitxonline_program_id
-        , user_edxorg_id
-        , program_completion_timestamp
-        , user_gender
-        , user_address_city
-        , user_first_name
-        , user_last_name
-        , user_full_name
-        , user_year_of_birth
-        , user_country
-        , user_address_postal_code
-        , user_street_address
-        , user_address_state_or_territory
+        program_certificates_non_dedp.program_certificate_hashed_id
+        , program_certificates_non_dedp.user_edxorg_username
+        , program_certificates_non_dedp.user_mitxonline_username
+        , program_certificates_non_dedp.program_title
+        , program_certificates_non_dedp.micromasters_program_id
+        , program_certificates_non_dedp.mitxonline_program_id
+        , program_certificates_non_dedp.user_edxorg_id
+        , program_certificates_non_dedp.program_completion_timestamp
+        , mitx_users.user_edxorg_email as user_email
+        , mitx_users.user_first_name
+        , mitx_users.user_last_name
+        , mitx_users.user_full_name
+        , mitx_users.user_gender
+        , mitx_users.user_birth_year as user_year_of_birth
+        , mitx_users.user_address_country as user_country
+        , mitx_users.user_address_state as user_address_state_or_territory
+        , mitx_users.user_address_city
+        , mitx_users.user_address_postal_code
+        , mitx_users.user_street_address
+        , false as program_is_dedp
     from program_certificates_non_dedp
+    left join mitx_users
+        on program_certificates_non_dedp.user_edxorg_username = mitx_users.user_edxorg_username
 )
 
 
@@ -105,15 +118,15 @@ select
     , report.user_edxorg_id
     , report.program_completion_timestamp
     , report.user_gender
-    , report.user_address_city
     , report.user_first_name
     , report.user_last_name
     , report.user_full_name
     , report.user_year_of_birth
     , report.user_country
     , report.user_address_postal_code
+    , report.user_address_city
     , report.user_street_address
     , report.user_address_state_or_territory
-    , if(report.mitxonline_program_id in (1, 2, 3), true, false) as program_is_dedp
+    , report.program_is_dedp
 from report
 order by report.program_completion_timestamp desc

--- a/src/ol_dbt/models/intermediate/micromasters/int__micromasters__program_enrollments.sql
+++ b/src/ol_dbt/models/intermediate/micromasters/int__micromasters__program_enrollments.sql
@@ -88,15 +88,11 @@ with micromasters_program_enrollments as (
         on mm_program_enrollments.user_id = mitx_users.user_micromasters_id
     left join mitxonline_dedp_records
         on
-            mm_program_enrollments.user_id = mitxonline_dedp_records.micromasters_user_id
+            mitx_users.user_micromasters_email = mitxonline_dedp_records.user_email
             and programs.program_title = mitxonline_dedp_records.program_title
     where
         programs.is_dedp_program = true
         and mitxonline_dedp_records.user_email is null
-        and (
-            mitx_users.user_mitxonline_username is not null
-            or mitx_users.user_edxorg_username is not null
-        )
 )
 
 , non_dedp_records as (

--- a/src/ol_dbt/models/intermediate/micromasters/subqueries/__int_micromasters_subqueries__models.yml
+++ b/src/ol_dbt/models/intermediate/micromasters/subqueries/__int_micromasters_subqueries__models.yml
@@ -146,6 +146,10 @@ models:
     description: str, username on MITx Online
     tests:
     - not_null
+  - name: user_mitxonline_id
+    description: int, user ID on MITx Online
+    tests:
+    - not_null
   - name: micromasters_program_id
     description: int, sequential ID representing a program in MicroMasters
   - name: mitxonline_program_id
@@ -294,6 +298,10 @@ models:
     description: str, username on MITxOnline
     tests:
     - not_null
+  - name: user_mitxonline_id
+    description: int, user ID on MITx Online
+    tests:
+    - not_null
   - name: courseruncertificate_uuid
     description: str, unique identifier for the certificate on MITx Online
     tests:
@@ -346,6 +354,10 @@ models:
     - not_null
   - name: user_edxorg_username
     description: str, username on edX.org
+    tests:
+    - not_null
+  - name: user_edxorg_id
+    description: int, user ID on edX.org
     tests:
     - not_null
   - name: courseruncertificate_download_url
@@ -444,6 +456,10 @@ models:
     description: str, username on MITxOnline
     tests:
     - not_null
+  - name: user_mitxonline_id
+    description: int, user ID on MITx Online
+    tests:
+    - not_null
   - name: courserungrade_grade
     description: float, course grade range from 0 to 1
     tests:
@@ -489,6 +505,10 @@ models:
     - not_null
   - name: user_edxorg_username
     description: str, username on edX.org
+    tests:
+    - not_null
+  - name: user_edxorg_id
+    description: int, user ID on edX.org
     tests:
     - not_null
   - name: courserungrade_user_grade

--- a/src/ol_dbt/models/intermediate/micromasters/subqueries/__int_micromasters_subqueries__models.yml
+++ b/src/ol_dbt/models/intermediate/micromasters/subqueries/__int_micromasters_subqueries__models.yml
@@ -110,13 +110,10 @@ models:
   tests:
   - dbt_expectations.expect_table_row_count_to_equal_other_table:
       compare_model: ref('stg__micromasters__app__postgres__auth_user')
+
 - name: __micromasters_program_certificates_dedp_from_micromasters
   description: DEDP program certificate earners according to the micromasters database
   columns:
-  - name: user_edxorg_username
-    description: str, The username of the learner on the edX platform
-    tests:
-    - not_null
   - name: user_mitxonline_username
     description: str, username on MITx Online
   - name: micromasters_program_id
@@ -127,8 +124,6 @@ models:
     description: str, title of the program
     tests:
     - not_null
-  - name: user_edxorg_id
-    description: int, Numerical user ID of a learner on the edX platform
   - name: program_certificate_hashed_id
     description: str, unique hash used to identify the program certificate
     tests:
@@ -139,14 +134,14 @@ models:
       program
     tests:
     - not_null
-  - name: micromasters_user_id
+  - name: user_micromasters_id
     description: str, user id in the micromasters database
+    tests:
+    - not_null
 
 - name: __micromasters_program_certificates_dedp_from_mitxonline
   description: DEDP program certificate earners according to the mitxonline database
   columns:
-  - name: user_edxorg_username
-    description: str, The username of the learner on the edX platform
   - name: user_mitxonline_username
     description: str, username on MITx Online
     tests:
@@ -159,8 +154,6 @@ models:
     description: str, title of the program
     tests:
     - not_null
-  - name: user_edxorg_id
-    description: int, Numerical user ID of a learner on the edX platform
   - name: program_certificate_hashed_id
     description: str, unique hash used to identify the program certificate
     tests:
@@ -171,8 +164,8 @@ models:
       program
     tests:
     - not_null
-  - name: micromasters_user_id
-    description: str, user id in the micromasters database
+  - name: user_micromasters_id
+    description: int, user id in the micromasters database
 
 - name: __micromasters_program_certificates_non_dedp
   description: Non DEDP program certificate earners. Data come from learners report
@@ -184,8 +177,6 @@ models:
     description: str, The username of the learner on the edX platform
     tests:
     - not_null
-  - name: user_mitxonline_username
-    description: str, username on MITx Online
   - name: micromasters_program_id
     description: int, sequential ID representing a program in MicroMasters
   - name: mitxonline_program_id
@@ -206,8 +197,6 @@ models:
   - name: program_completion_timestamp
     description: timestamp, timestamp of the course certificate that completed the
       program
-  - name: micromasters_user_id
-    description: str, user id in the micromasters database
   tests:
   - dbt_expectations.expect_compound_columns_to_be_unique:
       column_list: ["user_edxorg_username", "micromasters_program_id"]
@@ -223,6 +212,10 @@ models:
     description: int, sequential ID representing a program in MicroMasters
   - name: mitxonline_program_id
     description: int, sequential ID representing a program in Mitxonline
+  - name: user_micromasters_id
+    description: int, user id in MicroMasters
+    tests:
+    - not_null
   - name: courserun_title
     description: str, title of the course run
     tests:
@@ -245,18 +238,6 @@ models:
     description: str, unique string for the course e.g. 14.009x
     tests:
     - not_null
-  - name: user_edxorg_username
-    description: str, username on edX.org
-  - name: user_mitxonline_username
-    description: str, username on MITxOnline
-  - name: user_email
-    description: str, user email on edX.org
-    tests:
-    - not_null
-  - name: user_full_name
-    description: str, user full name on edX.org
-  - name: user_country
-    description: str, user country on edX.org
   - name: coursecertificate_hash
     description: str, unique hash used to identify this DEDP course certificate
     tests:
@@ -277,7 +258,7 @@ models:
     - not_null
   tests:
   - dbt_expectations.expect_compound_columns_to_be_unique:
-      column_list: ["user_email", "courserun_readable_id"]
+      column_list: ["user_micromasters_id", "courserun_readable_id"]
   - dbt_expectations.expect_table_row_count_to_equal_other_table:
       compare_model: ref('stg__micromasters__app__postgres__grades_coursecertificate')
 
@@ -309,20 +290,10 @@ models:
     description: str, unique string for the course e.g. 14.009x
     tests:
     - not_null
-  - name: user_edxorg_username
-    description: str, username on edX.org
   - name: user_mitxonline_username
     description: str, username on MITxOnline
     tests:
     - not_null
-  - name: user_email
-    description: str, user email on MITx Online
-    tests:
-    - not_null
-  - name: user_full_name
-    description: str, user full name on MITx Online
-  - name: user_country
-    description: str, user country on MITx Online
   - name: courseruncertificate_uuid
     description: str, unique identifier for the certificate on MITx Online
     tests:
@@ -377,16 +348,6 @@ models:
     description: str, username on edX.org
     tests:
     - not_null
-  - name: user_mitxonline_username
-    description: str, username on MITxOnline
-  - name: user_email
-    description: str, user email on edX.org
-    tests:
-    - not_null
-  - name: user_full_name
-    description: str, user full name on edX.org
-  - name: user_country
-    description: str, user country on edX.org
   - name: courseruncertificate_download_url
     description: str, the full URL to the certificate
   - name: courseruncertificate_download_uuid
@@ -434,18 +395,10 @@ models:
     description: str, unique string for the course e.g. 14.009x
     tests:
     - not_null
-  - name: user_edxorg_username
-    description: str, username on edX.org
-  - name: user_mitxonline_username
-    description: str, username on MITxOnline
-  - name: user_email
-    description: str, user email on edX.org
+  - name: user_micromasters_id
+    description: int, user id in MicroMasters
     tests:
     - not_null
-  - name: user_full_name
-    description: str, user full name on edX.org
-  - name: user_country
-    description: str, user country on edX.org
   - name: coursegrade_grade
     description: float, course grade on edX.org range from 0 to 1
     tests:
@@ -454,7 +407,7 @@ models:
     description: timestamp, date and time when this grade was initially calculated
   tests:
   - dbt_expectations.expect_compound_columns_to_be_unique:
-      column_list: ["user_email", "courserun_readable_id"]
+      column_list: ["user_micromasters_id", "courserun_readable_id"]
   - dbt_expectations.expect_table_row_count_to_equal_other_table:
       compare_model: ref('stg__micromasters__app__postgres__grades_combinedcoursegrade')
 
@@ -487,20 +440,10 @@ models:
     description: str, unique string for the course e.g. 14.009x
     tests:
     - not_null
-  - name: user_edxorg_username
-    description: str, username on edX.org
   - name: user_mitxonline_username
     description: str, username on MITxOnline
     tests:
     - not_null
-  - name: user_email
-    description: str, user email on MITx Online
-    tests:
-    - not_null
-  - name: user_full_name
-    description: str, user full name on MITx Online
-  - name: user_country
-    description: str, user country on MITx Online
   - name: courserungrade_grade
     description: float, course grade range from 0 to 1
     tests:
@@ -548,16 +491,6 @@ models:
     description: str, username on edX.org
     tests:
     - not_null
-  - name: user_mitxonline_username
-    description: str, username on MITxOnline
-  - name: user_email
-    description: str, user email on edX.org
-    tests:
-    - not_null
-  - name: user_full_name
-    description: str, user full name on edX.org
-  - name: user_country
-    description: str, user country on edX.org
   - name: courserungrade_user_grade
     description: float, course grade range from 0 to 1, maybe blank
   - name: courserungrade_is_passing

--- a/src/ol_dbt/models/intermediate/micromasters/subqueries/__int_micromasters_subqueries__models.yml
+++ b/src/ol_dbt/models/intermediate/micromasters/subqueries/__int_micromasters_subqueries__models.yml
@@ -119,10 +119,6 @@ models:
     - not_null
   - name: user_mitxonline_username
     description: str, username on MITx Online
-  - name: user_email
-    description: str, The email address of the learner on the edX platform
-    tests:
-    - not_null
   - name: micromasters_program_id
     description: int, sequential ID representing a program in MicroMasters
   - name: mitxonline_program_id
@@ -133,32 +129,6 @@ models:
     - not_null
   - name: user_edxorg_id
     description: int, Numerical user ID of a learner on the edX platform
-  - name: user_gender
-    description: str, user's gender from edxorg - blank means user did not specify
-      a gender. Null means this student signed up before this information was collected
-    tests:
-    - accepted_values:
-        values: ['Male', 'Female', 'Other/Prefer Not to Say', '', null]
-  - name: user_country
-    description: str, Country provided by the user on the edX platform
-  - name: user_address_city
-    description: str, city where user lives in, collected from the micromasters database
-  - name: user_first_name
-    description: str, first from the micromasters profile
-  - name: user_last_name
-    description: str, last name from the micromasters profile
-  - name: user_year_of_birth
-    description: str, user's birth year from the profile in the micromasters database
-  - name: user_address_postal_code
-    description: str, postal code where user lives in from the profile in micromasters
-  - name: user_street_address
-    description: str, street address where user lives in from the profile in the micromasters
-      database
-  - name: user_address_state_or_territory
-    description: str,  state or territory where user lives in from the profile in
-      the micromasters database
-  - name: user_full_name
-    description: str, The full name of the user on the edX platform
   - name: program_certificate_hashed_id
     description: str, unique hash used to identify the program certificate
     tests:
@@ -181,10 +151,6 @@ models:
     description: str, username on MITx Online
     tests:
     - not_null
-  - name: user_email
-    description: str, user's email address on MITx Online
-    tests:
-    - not_null
   - name: micromasters_program_id
     description: int, sequential ID representing a program in MicroMasters
   - name: mitxonline_program_id
@@ -195,35 +161,6 @@ models:
     - not_null
   - name: user_edxorg_id
     description: int, Numerical user ID of a learner on the edX platform
-  - name: user_gender
-    description: str, user's gender from user's profile on MITx Online or MicroMasters.
-      blank means user did not specify a gender. Null means this student signed up
-      before this information was collected
-    tests:
-    - accepted_values:
-        values: '{{ var("gender_values") }}'
-  - name: user_country
-    description: str, Country from user's profile on MITx Online or MicroMasters.
-  - name: user_address_city
-    description: str, city where user lives in from user's profile on MicroMasters.
-      Note that this data isn't available on MITx Online.
-  - name: user_first_name
-    description: str, first name from user's profile on MITx Online.
-  - name: user_last_name
-    description: str, last name from user's profile on MITx Online.
-  - name: user_year_of_birth
-    description: str, user's birth year from user's profile on MITx Online or MicroMasters.
-  - name: user_address_postal_code
-    description: str, postal code where user lives in from user's profile on MicroMasters.
-      Note that this data isn't available on MITx Online.
-  - name: user_street_address
-    description: str, street address where user lives in from user's profile on MicroMasters.
-      Note that this data isn't available on MITx Online.
-  - name: user_address_state_or_territory
-    description: str,  state or territory where user lives in from user's profile
-      on MITx Online or MicroMasters.
-  - name: user_full_name
-    description: str, The full name from user's profile on MITx Online
   - name: program_certificate_hashed_id
     description: str, unique hash used to identify the program certificate
     tests:
@@ -249,10 +186,6 @@ models:
     - not_null
   - name: user_mitxonline_username
     description: str, username on MITx Online
-  - name: user_email
-    description: str, The email address of the learner on the edX platform
-    tests:
-    - not_null
   - name: micromasters_program_id
     description: int, sequential ID representing a program in MicroMasters
   - name: mitxonline_program_id
@@ -265,32 +198,6 @@ models:
     description: int, Numerical user ID of a learner on the edX platform
     tests:
     - not_null
-  - name: user_gender
-    description: str, user's gender from edxorg - blank means user did not specify
-      a gender. Null means this student signed up before this information was collected
-    tests:
-    - accepted_values:
-        values: ['Male', 'Female', 'Other/Prefer Not to Say', '', null]
-  - name: user_country
-    description: str, Country provided by the user on the edX platform
-  - name: user_address_city
-    description: str, city where user lives in, collected from the micromasters database
-  - name: user_first_name
-    description: str, first from the micromasters profile
-  - name: user_last_name
-    description: str, last name from the micromasters profile
-  - name: user_year_of_birth
-    description: str, user's birth year from the profile in the micromasters database
-  - name: user_address_postal_code
-    description: str, postal code where user lives in from the profile in micromasters
-  - name: user_street_address
-    description: str, street address where user lives in from the profile in the micromasters
-      database
-  - name: user_address_state_or_territory
-    description: str,  state or territory where user lives in from the profile in
-      the micromasters database
-  - name: user_full_name
-    description: str, The full name of the user on the edX platform
   - name: program_certificate_hashed_id
     description: str, unique hash used to identify the program certificate
     tests:

--- a/src/ol_dbt/models/intermediate/micromasters/subqueries/__micromasters_course_certificates_dedp_from_micromasters.sql
+++ b/src/ol_dbt/models/intermediate/micromasters/subqueries/__micromasters_course_certificates_dedp_from_micromasters.sql
@@ -50,11 +50,6 @@ with dedp_course_certificates as (
     select * from {{ ref('int__mitx__programs') }}
 )
 
-, mm_users as (
-    select * from {{ ref('__micromasters__users') }}
-)
-
-
 select
     programs.program_title
     , programs.micromasters_program_id
@@ -64,11 +59,7 @@ select
     , courseruns.courserun_edxorg_readable_id
     , courseruns.courserun_platform
     , courses.course_number
-    , mm_users.user_edxorg_username
-    , mm_users.user_mitxonline_username
-    , mm_users.user_email
-    , mm_users.user_full_name
-    , mm_users.user_address_country as user_country
+    , dedp_course_certificates.user_id as user_micromasters_id
     , dedp_course_certificates.coursecertificate_hash
     , dedp_course_certificates.coursecertificate_url
     , dedp_course_certificates.coursecertificate_created_on
@@ -81,4 +72,3 @@ inner join highest_courserun_grades
 inner join courseruns on highest_courserun_grades.courserun_id = courseruns.courserun_id
 inner join courses on dedp_course_certificates.course_id = courses.course_id
 inner join programs on courses.program_id = programs.micromasters_program_id
-inner join mm_users on dedp_course_certificates.user_id = mm_users.user_id

--- a/src/ol_dbt/models/intermediate/micromasters/subqueries/__micromasters_course_certificates_dedp_from_mitxonline.sql
+++ b/src/ol_dbt/models/intermediate/micromasters/subqueries/__micromasters_course_certificates_dedp_from_mitxonline.sql
@@ -4,10 +4,6 @@ with courserun_certificates as (
     where courseruncertificate_is_revoked = false
 )
 
-, mitxonline_users as (
-    select * from {{ ref('int__mitxonline__users') }}
-)
-
 , courseruns as (
     select * from {{ ref('int__mitxonline__course_runs') }}
 )
@@ -28,11 +24,7 @@ select
     , courseruns.courserun_readable_id
     , courseruns.courserun_platform
     , courses.course_number
-    , enrollments_with_program.user_edxorg_username
-    , mitxonline_users.user_username as user_mitxonline_username
-    , mitxonline_users.user_full_name
-    , mitxonline_users.user_address_country as user_country
-    , mitxonline_users.user_email
+    , courserun_certificates.user_username as user_mitxonline_username
     , courserun_certificates.courseruncertificate_uuid
     , courserun_certificates.courseruncertificate_url
     , courserun_certificates.courseruncertificate_created_on
@@ -40,7 +32,6 @@ select
 from courserun_certificates
 inner join courseruns on courserun_certificates.courserun_id = courseruns.courserun_id
 inner join courses on courserun_certificates.course_id = courses.course_id
-inner join mitxonline_users on courserun_certificates.user_id = mitxonline_users.user_id
 inner join enrollments_with_program
     on
         courseruns.courserun_id = enrollments_with_program.courserun_id

--- a/src/ol_dbt/models/intermediate/micromasters/subqueries/__micromasters_course_certificates_dedp_from_mitxonline.sql
+++ b/src/ol_dbt/models/intermediate/micromasters/subqueries/__micromasters_course_certificates_dedp_from_mitxonline.sql
@@ -25,6 +25,7 @@ select
     , courseruns.courserun_platform
     , courses.course_number
     , courserun_certificates.user_username as user_mitxonline_username
+    , courserun_certificates.user_id as user_mitxonline_id
     , courserun_certificates.courseruncertificate_uuid
     , courserun_certificates.courseruncertificate_url
     , courserun_certificates.courseruncertificate_created_on

--- a/src/ol_dbt/models/intermediate/micromasters/subqueries/__micromasters_course_certificates_non_dedp_from_edxorg.sql
+++ b/src/ol_dbt/models/intermediate/micromasters/subqueries/__micromasters_course_certificates_non_dedp_from_edxorg.sql
@@ -2,14 +2,6 @@ with courserun_certificates as (
     select * from {{ ref('int__edxorg__mitx_courserun_certificates') }}
 )
 
-, edxorg_users as (
-    select * from {{ ref('int__edxorg__mitx_users') }}
-)
-
-, micromasters_users as (
-    select * from {{ ref('__micromasters__users') }}
-)
-
 , courseruns as (
     select * from {{ ref('int__edxorg__mitx_courseruns') }}
 )
@@ -26,11 +18,7 @@ select
     , courseruns.courserun_readable_id
     , '{{ var("edxorg") }}' as courserun_platform
     , courseruns.course_number
-    , edxorg_users.user_username as user_edxorg_username
-    , micromasters_users.user_mitxonline_username
-    , edxorg_users.user_full_name
-    , edxorg_users.user_country
-    , edxorg_users.user_email
+    , courserun_certificates.user_username as user_edxorg_username
     , courserun_certificates.courseruncertificate_download_url
     , courserun_certificates.courseruncertificate_download_uuid
     , courserun_certificates.courseruncertificate_created_on
@@ -38,6 +26,4 @@ select
 from courserun_certificates
 inner join courseruns on courserun_certificates.courserun_readable_id = courseruns.courserun_readable_id
 inner join programs on courseruns.micromasters_program_id = programs.micromasters_program_id
-inner join edxorg_users on courserun_certificates.user_id = edxorg_users.user_id
-left join micromasters_users on edxorg_users.user_username = micromasters_users.user_edxorg_username
 where programs.is_dedp_program = false

--- a/src/ol_dbt/models/intermediate/micromasters/subqueries/__micromasters_course_certificates_non_dedp_from_edxorg.sql
+++ b/src/ol_dbt/models/intermediate/micromasters/subqueries/__micromasters_course_certificates_non_dedp_from_edxorg.sql
@@ -19,6 +19,7 @@ select
     , '{{ var("edxorg") }}' as courserun_platform
     , courseruns.course_number
     , courserun_certificates.user_username as user_edxorg_username
+    , courserun_certificates.user_id as user_edxorg_id
     , courserun_certificates.courseruncertificate_download_url
     , courserun_certificates.courseruncertificate_download_uuid
     , courserun_certificates.courseruncertificate_created_on

--- a/src/ol_dbt/models/intermediate/micromasters/subqueries/__micromasters_course_grades_dedp_from_micromasters.sql
+++ b/src/ol_dbt/models/intermediate/micromasters/subqueries/__micromasters_course_grades_dedp_from_micromasters.sql
@@ -56,14 +56,6 @@ with dedp_course_grades as (
     select * from {{ ref('int__mitx__programs') }}
 )
 
-, mm_users as (
-    select * from {{ ref('__micromasters__users') }}
-)
-
-, edx_users as (
-    select * from {{ ref('int__edxorg__mitx_users') }}
-)
-
 select
     programs.program_title
     , programs.micromasters_program_id
@@ -72,11 +64,7 @@ select
     , courseruns.courserun_readable_id
     , courseruns.courserun_platform
     , courses.course_number
-    , mm_users.user_edxorg_username
-    , mm_users.user_mitxonline_username
-    , mm_users.user_full_name
-    , mm_users.user_address_country as user_country
-    , mm_users.user_email
+    , dedp_course_grades.user_id as user_micromasters_id
     , cast(dedp_course_grades.coursegrade_grade / 100 as decimal(5, 3)) as coursegrade_grade
     , dedp_course_grades.coursegrade_created_on
 from dedp_course_grades
@@ -87,6 +75,3 @@ inner join highest_courserun_grades
 inner join courseruns on highest_courserun_grades.courserun_id = courseruns.courserun_id
 inner join courses on dedp_course_grades.course_id = courses.course_id
 inner join programs on courses.program_id = programs.micromasters_program_id
-inner join mm_users on dedp_course_grades.user_id = mm_users.user_id
----not all MM users can match with edx using edxorg username
-left join edx_users on mm_users.user_edxorg_username = edx_users.user_username

--- a/src/ol_dbt/models/intermediate/micromasters/subqueries/__micromasters_course_grades_dedp_from_mitxonline.sql
+++ b/src/ol_dbt/models/intermediate/micromasters/subqueries/__micromasters_course_grades_dedp_from_mitxonline.sql
@@ -23,6 +23,7 @@ select
     , courseruns.courserun_platform
     , courses.course_number
     , courserun_grades.user_username as user_mitxonline_username
+    , courserun_grades.user_id as user_mitxonline_id
     , courserun_grades.courserungrade_grade
     , courserun_grades.courserungrade_is_passing
     , courserun_grades.courserungrade_created_on

--- a/src/ol_dbt/models/intermediate/micromasters/subqueries/__micromasters_course_grades_dedp_from_mitxonline.sql
+++ b/src/ol_dbt/models/intermediate/micromasters/subqueries/__micromasters_course_grades_dedp_from_mitxonline.sql
@@ -2,21 +2,6 @@ with courserun_grades as (
     select * from {{ ref('int__mitxonline__courserun_grades') }}
 )
 
-, mitxonline_users as (
-    select * from {{ ref('int__mitxonline__users') }}
-)
-
-, micromasters_users as (
-    select *
-    from {{ ref('__micromasters__users') }}
-)
-
-, edx_users as (
-    select *
-    from {{ ref('int__edxorg__mitx_users') }}
-)
-
-
 , courseruns as (
     select * from {{ ref('int__mitxonline__course_runs') }}
 )
@@ -37,11 +22,7 @@ select
     , courseruns.courserun_readable_id
     , courseruns.courserun_platform
     , courses.course_number
-    , micromasters_users.user_edxorg_username
-    , mitxonline_users.user_username as user_mitxonline_username
-    , mitxonline_users.user_full_name
-    , mitxonline_users.user_address_country as user_country
-    , mitxonline_users.user_email
+    , courserun_grades.user_username as user_mitxonline_username
     , courserun_grades.courserungrade_grade
     , courserun_grades.courserungrade_is_passing
     , courserun_grades.courserungrade_created_on
@@ -52,8 +33,4 @@ inner join enrollments_with_program
     on
         courseruns.courserun_id = enrollments_with_program.courserun_id
         and courserun_grades.user_id = enrollments_with_program.user_id
-inner join mitxonline_users on courserun_grades.user_id = mitxonline_users.user_id
-left join micromasters_users
-    on mitxonline_users.user_micromasters_profile_id = micromasters_users.user_profile_id
-left join edx_users on micromasters_users.user_edxorg_username = edx_users.user_username
 where enrollments_with_program.is_dedp_program = true

--- a/src/ol_dbt/models/intermediate/micromasters/subqueries/__micromasters_course_grades_non_dedp_from_edxorg.sql
+++ b/src/ol_dbt/models/intermediate/micromasters/subqueries/__micromasters_course_grades_non_dedp_from_edxorg.sql
@@ -2,14 +2,6 @@ with courserun_grades as (
     select * from {{ ref('int__edxorg__mitx_courserun_grades') }}
 )
 
-, edxorg_users as (
-    select * from {{ ref('int__edxorg__mitx_users') }}
-)
-
-, micromasters_users as (
-    select * from {{ ref('__micromasters__users') }}
-)
-
 , courseruns as (
     select * from {{ ref('int__edxorg__mitx_courseruns') }}
 )
@@ -26,16 +18,10 @@ select
     , courseruns.courserun_readable_id
     , '{{ var("edxorg") }}' as courserun_platform
     , courseruns.course_number
-    , edxorg_users.user_username as user_edxorg_username
-    , micromasters_users.user_mitxonline_username
-    , edxorg_users.user_full_name
-    , edxorg_users.user_country
-    , edxorg_users.user_email
+    , courserun_grades.user_username as user_edxorg_username
     , courserun_grades.courserungrade_is_passing
     , courserun_grades.courserungrade_user_grade
 from courserun_grades
 inner join courseruns on courserun_grades.courserun_readable_id = courseruns.courserun_readable_id
 inner join programs on courseruns.micromasters_program_id = programs.micromasters_program_id
-inner join edxorg_users on courserun_grades.user_id = edxorg_users.user_id
-left join micromasters_users on edxorg_users.user_username = micromasters_users.user_edxorg_username
 where programs.is_dedp_program = false

--- a/src/ol_dbt/models/intermediate/micromasters/subqueries/__micromasters_course_grades_non_dedp_from_edxorg.sql
+++ b/src/ol_dbt/models/intermediate/micromasters/subqueries/__micromasters_course_grades_non_dedp_from_edxorg.sql
@@ -19,6 +19,7 @@ select
     , '{{ var("edxorg") }}' as courserun_platform
     , courseruns.course_number
     , courserun_grades.user_username as user_edxorg_username
+    , courserun_grades.user_id as user_edxorg_id
     , courserun_grades.courserungrade_is_passing
     , courserun_grades.courserungrade_user_grade
 from courserun_grades

--- a/src/ol_dbt/models/intermediate/micromasters/subqueries/__micromasters_program_certificates_dedp_from_micromasters.sql
+++ b/src/ol_dbt/models/intermediate/micromasters/subqueries/__micromasters_program_certificates_dedp_from_micromasters.sql
@@ -24,24 +24,13 @@ with mm_program_certificates as (
 select
     micromasters_users.user_edxorg_username
     , micromasters_users.user_mitxonline_username
-    , micromasters_users.user_email
     , programs.micromasters_program_id
     , programs.program_title
     , programs.mitxonline_program_id
     , edx_users.user_id as user_edxorg_id
-    , edx_users.user_gender
-    , edx_users.user_country
-    , micromasters_users.user_address_city
-    , micromasters_users.user_first_name
-    , micromasters_users.user_last_name
-    , micromasters_users.user_address_postal_code
-    , micromasters_users.user_street_address
-    , micromasters_users.user_address_state_or_territory
-    , edx_users.user_full_name
     , {{ generate_hash_id('mm_program_certificates.programcertificate_hash') }} as program_certificate_hashed_id
     , mm_program_certificates.programcertificate_created_on as program_completion_timestamp
     , micromasters_users.user_id as micromasters_user_id
-    , substring(micromasters_users.user_birth_date, 1, 4) as user_year_of_birth
 from mm_program_certificates
 left join micromasters_users on mm_program_certificates.user_id = micromasters_users.user_id
 left join programs

--- a/src/ol_dbt/models/intermediate/micromasters/subqueries/__micromasters_program_certificates_dedp_from_micromasters.sql
+++ b/src/ol_dbt/models/intermediate/micromasters/subqueries/__micromasters_program_certificates_dedp_from_micromasters.sql
@@ -5,35 +5,20 @@ with mm_program_certificates as (
     from {{ ref('stg__micromasters__app__postgres__grades_programcertificate') }}
 )
 
-, micromasters_users as (
-    select *
-    from {{ ref('__micromasters__users') }}
-)
-
-
 , programs as (
     select *
     from {{ ref('int__mitx__programs') }}
 )
 
-, edx_users as (
-    select *
-    from {{ ref('int__edxorg__mitx_users') }}
-)
 
 select
-    micromasters_users.user_edxorg_username
-    , micromasters_users.user_mitxonline_username
-    , programs.micromasters_program_id
+    programs.micromasters_program_id
     , programs.program_title
     , programs.mitxonline_program_id
-    , edx_users.user_id as user_edxorg_id
     , {{ generate_hash_id('mm_program_certificates.programcertificate_hash') }} as program_certificate_hashed_id
     , mm_program_certificates.programcertificate_created_on as program_completion_timestamp
-    , micromasters_users.user_id as micromasters_user_id
+    , mm_program_certificates.user_id as user_micromasters_id
 from mm_program_certificates
-left join micromasters_users on mm_program_certificates.user_id = micromasters_users.user_id
 left join programs
     on mm_program_certificates.program_id = programs.micromasters_program_id
-left join edx_users on micromasters_users.user_edxorg_username = edx_users.user_username
 where programs.is_dedp_program = true

--- a/src/ol_dbt/models/intermediate/micromasters/subqueries/__micromasters_program_certificates_dedp_from_mitxonline.sql
+++ b/src/ol_dbt/models/intermediate/micromasters/subqueries/__micromasters_program_certificates_dedp_from_mitxonline.sql
@@ -30,28 +30,13 @@ with mitxonline_program_certificates as (
 select
     micromasters_users.user_edxorg_username
     , mitxonline_users.user_username as user_mitxonline_username
-    , mitxonline_users.user_email
     , mitx_programs.micromasters_program_id
     , mitx_programs.program_title
     , mitx_programs.mitxonline_program_id
     , edx_users.user_id as user_edxorg_id
-    , micromasters_users.user_address_city
-    , mitxonline_users.user_first_name
-    , mitxonline_users.user_last_name
-    , micromasters_users.user_address_postal_code
-    , micromasters_users.user_street_address
     , {{ generate_hash_id('mitxonline_program_certificates.programcertificate_uuid') }} as program_certificate_hashed_id
     , mitxonline_program_certificates.programcertificate_created_on as program_completion_timestamp
     , micromasters_users.user_id as micromasters_user_id
-    , mitxonline_users.user_full_name
-    , coalesce(mitxonline_users.user_gender, micromasters_users.user_gender) as user_gender
-    , coalesce(mitxonline_users.user_address_state, micromasters_users.user_address_state_or_territory)
-    as user_address_state_or_territory
-    , coalesce(mitxonline_users.user_address_country, micromasters_users.user_address_country) as user_country
-    , coalesce(
-        cast(mitxonline_users.user_birth_year as varchar)
-        , substring(micromasters_users.user_birth_date, 1, 4)
-    ) as user_year_of_birth
 from mitxonline_program_certificates
 left join mitxonline_users on mitxonline_program_certificates.user_id = mitxonline_users.user_id
 left join micromasters_users on mitxonline_users.user_micromasters_profile_id = micromasters_users.user_profile_id

--- a/src/ol_dbt/models/intermediate/micromasters/subqueries/__micromasters_program_certificates_dedp_from_mitxonline.sql
+++ b/src/ol_dbt/models/intermediate/micromasters/subqueries/__micromasters_program_certificates_dedp_from_mitxonline.sql
@@ -12,6 +12,7 @@ with mitxonline_program_certificates as (
 
 select
     mitxonline_program_certificates.user_username as user_mitxonline_username
+    , mitxonline_program_certificates.user_id as user_mitxonline_id
     , mitx_programs.micromasters_program_id
     , mitx_programs.program_title
     , mitx_programs.mitxonline_program_id

--- a/src/ol_dbt/models/intermediate/micromasters/subqueries/__micromasters_program_certificates_dedp_from_mitxonline.sql
+++ b/src/ol_dbt/models/intermediate/micromasters/subqueries/__micromasters_program_certificates_dedp_from_mitxonline.sql
@@ -5,42 +5,19 @@ with mitxonline_program_certificates as (
     from {{ ref('int__mitxonline__program_certificates') }}
 )
 
-, edx_users as (
-    select *
-    from {{ ref('int__edxorg__mitx_users') }}
-)
-
-, micromasters_users as (
-    select *
-    from {{ ref('__micromasters__users') }}
-)
-
-
 , mitx_programs as (
     select *
     from {{ ref('int__mitx__programs') }}
 )
 
-
-, mitxonline_users as (
-    select *
-    from {{ ref('int__mitxonline__users') }}
-)
-
 select
-    micromasters_users.user_edxorg_username
-    , mitxonline_users.user_username as user_mitxonline_username
+    mitxonline_program_certificates.user_username as user_mitxonline_username
     , mitx_programs.micromasters_program_id
     , mitx_programs.program_title
     , mitx_programs.mitxonline_program_id
-    , edx_users.user_id as user_edxorg_id
     , {{ generate_hash_id('mitxonline_program_certificates.programcertificate_uuid') }} as program_certificate_hashed_id
     , mitxonline_program_certificates.programcertificate_created_on as program_completion_timestamp
-    , micromasters_users.user_id as micromasters_user_id
 from mitxonline_program_certificates
-left join mitxonline_users on mitxonline_program_certificates.user_id = mitxonline_users.user_id
-left join micromasters_users on mitxonline_users.user_micromasters_profile_id = micromasters_users.user_profile_id
-left join edx_users on micromasters_users.user_edxorg_username = edx_users.user_username
 left join mitx_programs on mitxonline_program_certificates.program_id = mitx_programs.mitxonline_program_id
 where
     mitx_programs.is_dedp_program = true

--- a/src/ol_dbt/models/intermediate/micromasters/subqueries/__micromasters_program_certificates_non_dedp.sql
+++ b/src/ol_dbt/models/intermediate/micromasters/subqueries/__micromasters_program_certificates_non_dedp.sql
@@ -38,24 +38,13 @@ with micromasters_program_certificates as (
     select
         edx_users.user_username as user_edxorg_username
         , micromasters_users.user_mitxonline_username
-        , edx_users.user_email
         , programs.micromasters_program_id
         , micromasters_program_certificates.program_title
         , programs.mitxonline_program_id
         , micromasters_program_certificates.user_id as user_edxorg_id
-        , edx_users.user_gender
-        , edx_users.user_country
-        , micromasters_users.user_address_city
-        , micromasters_users.user_first_name
-        , micromasters_users.user_last_name
-        , micromasters_users.user_address_postal_code
-        , micromasters_users.user_street_address
-        , micromasters_users.user_address_state_or_territory
-        , edx_users.user_full_name
         , micromasters_program_certificates.program_certificate_hashed_id
         , micromasters_program_certificates.program_certificate_awarded_on as program_completion_timestamp
         , micromasters_users.user_id as micromasters_user_id
-        , substring(micromasters_users.user_birth_date, 1, 4) as user_year_of_birth
     from micromasters_program_certificates
     left join edx_users
         on micromasters_program_certificates.user_id = edx_users.user_id
@@ -75,24 +64,13 @@ with micromasters_program_certificates as (
     select
         edx_users.user_username as user_edxorg_username
         , micromasters_users.user_mitxonline_username
-        , edx_users.user_email
         , programs.micromasters_program_id
         , programs.program_title
         , programs.mitxonline_program_id
         , edx_users.user_id as user_edxorg_id
-        , edx_users.user_gender
-        , edx_users.user_country
-        , micromasters_users.user_address_city
-        , micromasters_users.user_first_name
-        , micromasters_users.user_last_name
-        , micromasters_users.user_address_postal_code
-        , micromasters_users.user_street_address
-        , micromasters_users.user_address_state_or_territory
-        , edx_users.user_full_name
         , program_certificates_override_list.program_certificate_hashed_id
         , null as program_completion_timestamp
         , micromasters_users.user_id as micromasters_user_id
-        , substring(micromasters_users.user_birth_date, 1, 4) as user_year_of_birth
     from program_certificates_override_list
     inner join edx_users
         on program_certificates_override_list.user_edxorg_id = edx_users.user_id

--- a/src/ol_dbt/models/intermediate/micromasters/subqueries/__micromasters_program_certificates_non_dedp.sql
+++ b/src/ol_dbt/models/intermediate/micromasters/subqueries/__micromasters_program_certificates_non_dedp.sql
@@ -18,11 +18,6 @@ with micromasters_program_certificates as (
     from {{ ref('int__edxorg__mitx_users') }}
 )
 
-, micromasters_users as (
-    select *
-    from {{ ref('__micromasters__users') }}
-)
-
 , programs as (
     select *
     from {{ ref('int__mitx__programs') }}
@@ -37,19 +32,15 @@ with micromasters_program_certificates as (
 , non_dedp_certificates as (
     select
         edx_users.user_username as user_edxorg_username
-        , micromasters_users.user_mitxonline_username
         , programs.micromasters_program_id
         , micromasters_program_certificates.program_title
         , programs.mitxonline_program_id
         , micromasters_program_certificates.user_id as user_edxorg_id
         , micromasters_program_certificates.program_certificate_hashed_id
         , micromasters_program_certificates.program_certificate_awarded_on as program_completion_timestamp
-        , micromasters_users.user_id as micromasters_user_id
     from micromasters_program_certificates
     left join edx_users
         on micromasters_program_certificates.user_id = edx_users.user_id
-    left join micromasters_users
-        on micromasters_program_certificates.user_username = micromasters_users.user_edxorg_username
     left join programs
         on micromasters_program_certificates.micromasters_program_id = programs.micromasters_program_id
     where micromasters_program_certificates.row_num = 1
@@ -63,19 +54,15 @@ with micromasters_program_certificates as (
 , non_dedp_overides as (
     select
         edx_users.user_username as user_edxorg_username
-        , micromasters_users.user_mitxonline_username
         , programs.micromasters_program_id
         , programs.program_title
         , programs.mitxonline_program_id
         , edx_users.user_id as user_edxorg_id
         , program_certificates_override_list.program_certificate_hashed_id
         , null as program_completion_timestamp
-        , micromasters_users.user_id as micromasters_user_id
     from program_certificates_override_list
     inner join edx_users
         on program_certificates_override_list.user_edxorg_id = edx_users.user_id
-    left join micromasters_users
-        on edx_users.user_username = micromasters_users.user_edxorg_username
     inner join programs
         on program_certificates_override_list.micromasters_program_id = programs.micromasters_program_id
     left join non_dedp_certificates

--- a/src/ol_dbt/models/intermediate/mitx/_int_mitx__models.yml
+++ b/src/ol_dbt/models/intermediate/mitx/_int_mitx__models.yml
@@ -116,7 +116,7 @@ models:
 - name: int__mitx__users
   description: MITx users combined from MITx Online and edX.org. For users who exist
     on both platforms, their profile data are selected in the order of MITx Online,
-    MicroMasters, and edX.org, whichever is not null
+    MicroMasters, and edX.org, whichever is not null.
   columns:
   - name: is_mitxonline_user
     description: boolean, indicating if this user is MITx Online user
@@ -128,6 +128,10 @@ models:
     - unique
   - name: user_edxorg_id
     description: int, user ID on edX.org
+    tests:
+    - unique
+  - name: user_micromasters_id
+    description: int, user ID on MicroMasters
     tests:
     - unique
   - name: user_mitxonline_username
@@ -145,6 +149,8 @@ models:
   - name: user_edxorg_email
     description: str, user email on edX.org. Not unique as some edxorg users found
       with same email for different username and user ID
+  - name: user_micromasters_email
+    description: str, user email on MicroMasters
   - name: user_joined_on_mitxonline
     description: timestamp, user join timestamp on MITx Online
   - name: user_joined_on_edxorg
@@ -159,26 +165,38 @@ models:
     description: boolean, indicating if user's account is active on edx.org. A user
       is inactive when their username or email is hashed.
   - name: user_full_name
-    description: str, user full name on edX.org or MITxOnline. Very small number of
-      edX.org users have blank full name, their name couldn't be populated from other
-      sources if they don't have their accounts linked on MicroMasters.
+    description: str, user's full name from MITx Online, MicroMasters, or edX.org.
+  - name: user_first_name
+    description: str, first name on user's profile from MITx Online or MicroMasters
+  - name: user_last_name
+    description: str, last name on user's profile from MITx Online or MicroMasters
   - name: user_address_country
-    description: str, country code provided by the user from MITx Online, MicroMasters,
+    description: str, country code on user's profile from MITx Online, MicroMasters,
       or edX.org
+  - name: user_address_state
+    description: str,  state code or territory on user's profile from MITx Online
+      or MicroMasters
+  - name: user_address_postal_code
+    description: str, postal code on user's profile from MicroMasters
+  - name: user_street_address
+    description: str, street address on user's profile from MicroMasters
+  - name: user_address_city
+    description: str, address city on user's profile from MicroMasters
   - name: user_highest_education
-    description: str, user's level of education from MITx Online, MicroMasters, or
-      edX.org
+    description: str, level of education on user's profile from MITx Online, MicroMasters,
+      or edX.org
   - name: user_gender
-    description: str, Gender selected by the user on their profile from MITx Online,
-      MicroMasters, or edX.org
+    description: str, gender on user's profile from MITx Online, MicroMasters, or
+      edX.org
   - name: user_birth_year
-    description: int, user's birth year from MITx Online, MicroMasters, or edX.org
+    description: int, birth year on user's profile from MITx Online, MicroMasters,
+      or edX.org
   - name: user_company
-    description: str, user's company pulled from MITx Online or MicroMasters
-  - name: user_job_title
-    description: str, user's job title pulled from MITx Online or MicroMasters
+    description: str, company or employer on user's profile from MITx Online or MicroMasters
   - name: user_industry
-    description: str, user's job industry pulled from MITx Online or MicroMasters
+    description: str, job industry on user's profile from MITx Online or MicroMasters
+  - name: user_job_title
+    description: str, job title on user's profile from MITx Online or MicroMasters
 
 - name: int__mitx__courserun_enrollments
   description: MITx courserun enrollments combined from MITx Online and edX.org

--- a/src/ol_dbt/models/intermediate/mitx/_int_mitx__models.yml
+++ b/src/ol_dbt/models/intermediate/mitx/_int_mitx__models.yml
@@ -114,9 +114,9 @@ models:
     - not_null
 
 - name: int__mitx__users
-  description: MITx users from MITx Online and edX.org. For users who exist on both
-    platforms, their data are combined from into one row per user, where MITx Online
-    profile data take precedent over edx.org if field not null
+  description: MITx users combined from MITx Online and edX.org. For users who exist
+    on both platforms, their profile data are selected in the order of MITx Online,
+    MicroMasters, and edX.org, whichever is not null
   columns:
   - name: is_mitxonline_user
     description: boolean, indicating if this user is MITx Online user
@@ -163,14 +163,16 @@ models:
       edX.org users have blank full name, their name couldn't be populated from other
       sources if they don't have their accounts linked on MicroMasters.
   - name: user_address_country
-    description: str, country code provided by the user from MITx Online or edX.org
-  - name: user_highest_education
-    description: str, user's level of education from MITx Online or edX.org
-  - name: user_gender
-    description: str, Gender selected by the user on their profile from MITx Online
+    description: str, country code provided by the user from MITx Online, MicroMasters,
       or edX.org
+  - name: user_highest_education
+    description: str, user's level of education from MITx Online, MicroMasters, or
+      edX.org
+  - name: user_gender
+    description: str, Gender selected by the user on their profile from MITx Online,
+      MicroMasters, or edX.org
   - name: user_birth_year
-    description: int, user's birth year from MITx Online or edX.org
+    description: int, user's birth year from MITx Online, MicroMasters, or edX.org
   - name: user_company
     description: str, user's company pulled from MITx Online or MicroMasters
   - name: user_job_title

--- a/src/ol_dbt/models/intermediate/mitx/_int_mitx__models.yml
+++ b/src/ol_dbt/models/intermediate/mitx/_int_mitx__models.yml
@@ -119,9 +119,9 @@ models:
     MicroMasters, and edX.org, whichever is not null.
   columns:
   - name: is_mitxonline_user
-    description: boolean, indicating if this user is MITx Online user
+    description: boolean, indicating if this user has an account on MITx Online
   - name: is_edxorg_user
-    description: boolean, indicating if this user is edX.org user
+    description: boolean, indicating if this user has an account on edX.org
   - name: user_mitxonline_id
     description: int, user ID on MITx Online
     tests:

--- a/src/ol_dbt/models/intermediate/mitx/_int_mitx__models.yml
+++ b/src/ol_dbt/models/intermediate/mitx/_int_mitx__models.yml
@@ -114,9 +114,9 @@ models:
     - not_null
 
 - name: int__mitx__users
-  description: MITx users combined from MITx Online and edX.org. For users who exist
-    on both platforms, their profile fields are selected in the order of MITx Online,
-    MicroMasters, and edX.org, whichever is not null.
+  description: MITx users combined from MITx Online, MicroMasters, and edX.org. For
+    users who exist on both platforms, their profile fields are selected in the order
+    of MITx Online, MicroMasters, and edX.org, whichever is not null.
   columns:
   - name: is_mitxonline_user
     description: boolean, indicating if this user has an account on MITx Online

--- a/src/ol_dbt/models/intermediate/mitx/_int_mitx__models.yml
+++ b/src/ol_dbt/models/intermediate/mitx/_int_mitx__models.yml
@@ -115,7 +115,7 @@ models:
 
 - name: int__mitx__users
   description: MITx users combined from MITx Online and edX.org. For users who exist
-    on both platforms, their profile data are selected in the order of MITx Online,
+    on both platforms, their profile fields are selected in the order of MITx Online,
     MicroMasters, and edX.org, whichever is not null.
   columns:
   - name: is_mitxonline_user
@@ -167,9 +167,11 @@ models:
   - name: user_full_name
     description: str, user's full name from MITx Online, MicroMasters, or edX.org.
   - name: user_first_name
-    description: str, first name on user's profile from MITx Online or MicroMasters
+    description: str, first name on user's profile from MITx Online or MicroMasters.
+      EdX collects fullname but doesn't breakdown into first/last name.
   - name: user_last_name
-    description: str, last name on user's profile from MITx Online or MicroMasters
+    description: str, last name on user's profile from MITx Online or MicroMasters.
+      EdX collects fullname but doesn't breakdown into first/last name.
   - name: user_address_country
     description: str, country code on user's profile from MITx Online, MicroMasters,
       or edX.org
@@ -177,11 +179,14 @@ models:
     description: str,  state code or territory on user's profile from MITx Online
       or MicroMasters
   - name: user_address_postal_code
-    description: str, postal code on user's profile from MicroMasters
+    description: str, postal code on user's profile from MicroMasters. MITx Online
+      and edX.org don't collect this data.
   - name: user_street_address
-    description: str, street address on user's profile from MicroMasters
+    description: str, street address on user's profile from MicroMasters. MITx Online
+      and edX.org don't collect this data.
   - name: user_address_city
-    description: str, address city on user's profile from MicroMasters
+    description: str, address city on user's profile from MicroMasters. MITx Online
+      and edX.org don't collect this data.
   - name: user_highest_education
     description: str, level of education on user's profile from MITx Online, MicroMasters,
       or edX.org
@@ -288,7 +293,8 @@ models:
 - name: int__mitx__courserun_enrollments_with_programs
   description: MITx courserun enrollments combined from MITx Online and edX.org. For
     courses that satisfy the requirements for multiple programs, the same enrollment
-    will have multiple rows
+    will have multiple rows. User's profile fields are chosen in the order of MITx
+    Online, MicroMasters, and edX.org, whichever is not null.
   columns:
   - name: platform
     description: str, indicating the platform where course runs on. It's either MITx
@@ -350,14 +356,13 @@ models:
     description: str, username in edx.org. For the very small number of users with
       multiple edx usernames, this is the username with the latest logins
   - name: user_full_name
-    description: str, user full name on edX.org or MITxOnline. Very small number of
-      edX.org users have blank full name, their name couldn't be populated from other
-      sources if they don't have their accounts linked on MicroMasters.
+    description: str, user's full name from MITx Online, MicroMasters, or edX.org.
   - name: course_number
     description: str, unique string for the course. It can contain letters, numbers,
       or periods. e.g. 6.002.1x
   - name: user_address_country
-    description: str, country code provided by the user from MITx Online or edX.org
+    description: str, country code on user's profile from MITx Online, MicroMasters,
+      or edX.org
   - name: program_title
     description: str, title of the program
   - name: mitxonline_program_id

--- a/src/ol_dbt/models/intermediate/mitx/int__mitx__courserun_enrollments_with_programs.sql
+++ b/src/ol_dbt/models/intermediate/mitx/int__mitx__courserun_enrollments_with_programs.sql
@@ -4,6 +4,10 @@ with edx_enrollments as (
     where platform = '{{ var("edxorg") }}'
 )
 
+, mitx_users as (
+    select * from {{ ref('int__mitx__users') }}
+)
+
 , mitxonline_enrollments_with_program as (
     select *
     from {{ ref('int__mitxonline__courserunenrollments_with_programs') }}
@@ -25,43 +29,47 @@ with edx_enrollments as (
         , edx_enrollments.courserun_title
         , edx_enrollments.courserun_readable_id
         , edx_enrollments.course_number
-        , edx_enrollments.user_id
-        , edx_enrollments.user_email
-        , edx_enrollments.user_full_name
-        , edx_enrollments.user_username
-        , edx_enrollments.user_edxorg_username
-        , edx_enrollments.user_mitxonline_username
-        , edx_enrollments.user_address_country
+        , mitx_users.user_edxorg_id as user_id
+        , mitx_users.user_edxorg_email as user_email
+        , mitx_users.user_full_name
+        , mitx_users.user_edxorg_username as user_username
+        , mitx_users.user_edxorg_username
+        , mitx_users.user_mitxonline_username
+        , mitx_users.user_address_country
         , program_requirements.micromasters_program_id
         , program_requirements.mitxonline_program_id
         , program_requirements.program_title
     from edx_enrollments
+    left join mitx_users
+        on edx_enrollments.user_edxorg_id = mitx_users.user_edxorg_id
     inner join program_requirements on edx_enrollments.course_number = program_requirements.course_number
 )
 
 , mitxonline_query as (
     select
-        courserunenrollment_platform as platform
-        , courserunenrollment_is_active
-        , courserunenrollment_created_on
-        , courserunenrollment_enrollment_mode
-        , courserunenrollment_enrollment_status
-        , courserun_id
-        , courserun_title
-        , courserun_readable_id
-        , course_number
-        , user_id
-        , user_email
-        , user_full_name
-        , user_username
-        , user_edxorg_username
-        , user_username as user_mitxonline_username
-        , user_address_country
-        , micromasters_program_id
-        , mitxonline_program_id
-        , program_title
+        mitxonline_enrollments_with_program.courserunenrollment_platform as platform
+        , mitxonline_enrollments_with_program.courserunenrollment_is_active
+        , mitxonline_enrollments_with_program.courserunenrollment_created_on
+        , mitxonline_enrollments_with_program.courserunenrollment_enrollment_mode
+        , mitxonline_enrollments_with_program.courserunenrollment_enrollment_status
+        , mitxonline_enrollments_with_program.courserun_id
+        , mitxonline_enrollments_with_program.courserun_title
+        , mitxonline_enrollments_with_program.courserun_readable_id
+        , mitxonline_enrollments_with_program.course_number
+        , mitx_users.user_mitxonline_id as user_id
+        , mitx_users.user_mitxonline_email as user_email
+        , mitx_users.user_full_name
+        , mitx_users.user_mitxonline_username as user_username
+        , mitx_users.user_edxorg_username
+        , mitx_users.user_mitxonline_username
+        , mitx_users.user_address_country
+        , mitxonline_enrollments_with_program.micromasters_program_id
+        , mitxonline_enrollments_with_program.mitxonline_program_id
+        , mitxonline_enrollments_with_program.program_title
     from mitxonline_enrollments_with_program
-    where courserunenrollment_platform = '{{ var("mitxonline") }}'
+    left join mitx_users
+        on mitxonline_enrollments_with_program.user_mitxonline_id = mitx_users.user_mitxonline_id
+    where mitxonline_enrollments_with_program.courserunenrollment_platform = '{{ var("mitxonline") }}'
 )
 
 select *

--- a/src/ol_dbt/models/intermediate/mitx/int__mitx__courserun_enrollments_with_programs.sql
+++ b/src/ol_dbt/models/intermediate/mitx/int__mitx__courserun_enrollments_with_programs.sql
@@ -41,7 +41,7 @@ with edx_enrollments as (
         , program_requirements.program_title
     from edx_enrollments
     left join mitx_users
-        on edx_enrollments.user_edxorg_id = mitx_users.user_edxorg_id
+        on edx_enrollments.user_id = mitx_users.user_edxorg_id
     inner join program_requirements on edx_enrollments.course_number = program_requirements.course_number
 )
 
@@ -68,7 +68,7 @@ with edx_enrollments as (
         , mitxonline_enrollments_with_program.program_title
     from mitxonline_enrollments_with_program
     left join mitx_users
-        on mitxonline_enrollments_with_program.user_mitxonline_id = mitx_users.user_mitxonline_id
+        on mitxonline_enrollments_with_program.user_id = mitx_users.user_mitxonline_id
     where mitxonline_enrollments_with_program.courserunenrollment_platform = '{{ var("mitxonline") }}'
 )
 

--- a/src/ol_dbt/models/intermediate/mitx/int__mitx__users.sql
+++ b/src/ol_dbt/models/intermediate/mitx/int__mitx__users.sql
@@ -42,10 +42,6 @@ with mitxonline_users as (
         , edxorg_users.user_username as user_edxorg_username
         , edxorg_users.user_email as user_edxorg_email
         , edxorg_users.user_full_name
-        , edxorg_users.user_country as user_address_country
-        , edxorg_users.user_highest_education
-        , edxorg_users.user_gender
-        , edxorg_users.user_birth_year
         , edxorg_users.user_joined_on
         , edxorg_users.user_last_login
         , edxorg_users.user_is_active
@@ -53,6 +49,14 @@ with mitxonline_users as (
         , micromasters_users.user_company_industry
         , micromasters_users.user_job_position
         , true as is_edxorg_user
+        , coalesce(micromasters_users.user_address_country, edxorg_users.user_country) as user_address_country
+        , coalesce(
+            micromasters_users.user_highest_education, edxorg_users.user_highest_education
+        ) as user_highest_education
+        , coalesce(micromasters_users.user_gender, edxorg_users.user_gender) as user_gender
+        , coalesce(
+            cast(substring(micromasters_users.user_birth_date, 1, 4) as int), edxorg_users.user_birth_year
+        ) as user_birth_year
     from edxorg_users
     left join micromasters_users on edxorg_users.user_username = micromasters_users.user_edxorg_username
 )

--- a/src/ol_dbt/models/intermediate/mitx/int__mitx__users.sql
+++ b/src/ol_dbt/models/intermediate/mitx/int__mitx__users.sql
@@ -22,7 +22,10 @@ with mitxonline_users as (
         , mitxonline_users.user_edxorg_username
         , mitxonline_users.user_email as user_mitxonline_email
         , mitxonline_users.user_full_name
+        , mitxonline_users.user_first_name
+        , mitxonline_users.user_last_name
         , mitxonline_users.user_address_country
+        , mitxonline_users.user_address_state
         , mitxonline_users.user_highest_education
         , mitxonline_users.user_gender
         , mitxonline_users.user_birth_year
@@ -36,19 +39,28 @@ with mitxonline_users as (
     from mitxonline_users
 )
 
+---augment edxorg users profile with MicroMasters
 , edxorg_users_view as (
     select
         edxorg_users.user_id as user_edxorg_id
         , edxorg_users.user_username as user_edxorg_username
         , edxorg_users.user_email as user_edxorg_email
-        , edxorg_users.user_full_name
+        , micromasters_users.user_email as user_micromasters_email
+        , micromasters_users.user_id as user_micromasters_id
+        , micromasters_users.user_first_name
+        , micromasters_users.user_last_name
         , edxorg_users.user_joined_on
         , edxorg_users.user_last_login
         , edxorg_users.user_is_active
         , micromasters_users.user_company_name
         , micromasters_users.user_company_industry
         , micromasters_users.user_job_position
+        , micromasters_users.user_address_state_or_territory
+        , micromasters_users.user_address_postal_code
+        , micromasters_users.user_street_address
+        , micromasters_users.user_address_city
         , true as is_edxorg_user
+        , coalesce(micromasters_users.user_full_name, edxorg_users.user_full_name) as user_full_name
         , coalesce(micromasters_users.user_address_country, edxorg_users.user_country) as user_address_country
         , coalesce(
             micromasters_users.user_highest_education, edxorg_users.user_highest_education
@@ -65,21 +77,30 @@ with mitxonline_users as (
     select
         mitxonline_users_view.user_mitxonline_id
         , edxorg_users_view.user_edxorg_id
+        , edxorg_users_view.user_micromasters_id
         , mitxonline_users_view.user_mitxonline_username
         , edxorg_users_view.user_edxorg_username
         , mitxonline_users_view.user_mitxonline_email
         , edxorg_users_view.user_edxorg_email
+        , edxorg_users_view.user_micromasters_email
         , mitxonline_users_view.user_joined_on as user_joined_on_mitxonline
         , edxorg_users_view.user_joined_on as user_joined_on_edxorg
         , mitxonline_users_view.user_last_login as user_last_login_on_mitxonline
         , edxorg_users_view.user_last_login as user_last_login_on_edxorg
         , mitxonline_users_view.user_is_active as user_is_active_on_mitxonline
         , edxorg_users_view.user_is_active as user_is_active_on_edxorg
+        , edxorg_users_view.user_address_postal_code
+        , edxorg_users_view.user_street_address
+        , edxorg_users_view.user_address_city
         , coalesce(mitxonline_users_view.is_mitxonline_user is not null, false) as is_mitxonline_user
         , coalesce(edxorg_users_view.is_edxorg_user is not null, false) as is_edxorg_user
         , coalesce(mitxonline_users_view.user_full_name, edxorg_users_view.user_full_name) as user_full_name
+        , coalesce(mitxonline_users_view.user_first_name, edxorg_users_view.user_first_name) as user_first_name
+        , coalesce(mitxonline_users_view.user_last_name, edxorg_users_view.user_last_name) as user_last_name
         , coalesce(mitxonline_users_view.user_address_country, edxorg_users_view.user_address_country)
         as user_address_country
+        , coalesce(mitxonline_users_view.user_address_state, edxorg_users_view.user_address_state_or_territory)
+        as user_address_state
         , coalesce(mitxonline_users_view.user_highest_education, edxorg_users_view.user_highest_education)
         as user_highest_education
         , coalesce(mitxonline_users_view.user_gender, edxorg_users_view.user_gender) as user_gender
@@ -92,4 +113,35 @@ with mitxonline_users as (
         on mitxonline_users_view.user_edxorg_username = edxorg_users_view.user_edxorg_username
 )
 
-select * from mitx_users_combined
+select
+    is_mitxonline_user
+    , is_edxorg_user
+    , user_mitxonline_id
+    , user_edxorg_id
+    , user_micromasters_id
+    , user_mitxonline_username
+    , user_edxorg_username
+    , user_mitxonline_email
+    , user_edxorg_email
+    , user_micromasters_email
+    , user_joined_on_mitxonline
+    , user_joined_on_edxorg
+    , user_last_login_on_mitxonline
+    , user_last_login_on_edxorg
+    , user_is_active_on_mitxonline
+    , user_is_active_on_edxorg
+    , user_full_name
+    , user_first_name
+    , user_last_name
+    , user_address_country
+    , user_address_state
+    , user_address_city
+    , user_address_postal_code
+    , user_street_address
+    , user_highest_education
+    , user_gender
+    , user_birth_year
+    , user_company
+    , user_industry
+    , user_job_title
+from mitx_users_combined

--- a/src/ol_dbt/models/intermediate/mitx/int__mitx__users.sql
+++ b/src/ol_dbt/models/intermediate/mitx/int__mitx__users.sql
@@ -1,8 +1,6 @@
 ---MITx users from MITx Online and edX with dedup
 ---For users exist on both MITx Online and edX.org, profile data are COALESCE from MITx Online, MicroMasters or edX.org
 
-{{ config(materialized='view') }}
-
 with mitxonline_users as (
     select * from {{ ref('int__mitxonline__users') }}
 )
@@ -21,22 +19,33 @@ with mitxonline_users as (
         , mitxonline_users.user_username as user_mitxonline_username
         , mitxonline_users.user_edxorg_username
         , mitxonline_users.user_email as user_mitxonline_email
+        , micromasters_users.user_email as user_micromasters_email
+        , micromasters_users.user_id as user_micromasters_id
         , mitxonline_users.user_full_name
         , mitxonline_users.user_first_name
         , mitxonline_users.user_last_name
-        , mitxonline_users.user_address_country
-        , mitxonline_users.user_address_state
-        , mitxonline_users.user_highest_education
-        , mitxonline_users.user_gender
-        , mitxonline_users.user_birth_year
-        , mitxonline_users.user_company
-        , mitxonline_users.user_job_title
-        , mitxonline_users.user_industry
         , mitxonline_users.user_joined_on
         , mitxonline_users.user_last_login
         , mitxonline_users.user_is_active
         , true as is_mitxonline_user
+        , coalesce(mitxonline_users.user_company, micromasters_users.user_company_name) as user_company
+        , coalesce(mitxonline_users.user_industry, micromasters_users.user_company_industry) as user_industry
+        , coalesce(mitxonline_users.user_job_title, micromasters_users.user_job_position) as user_job_title
+        , coalesce(
+            mitxonline_users.user_address_country, micromasters_users.user_address_country
+        ) as user_address_country
+        , coalesce(
+            mitxonline_users.user_address_state, micromasters_users.user_address_state_or_territory
+        ) as user_address_state
+        , coalesce(
+            mitxonline_users.user_highest_education, micromasters_users.user_highest_education
+        ) as user_highest_education
+        , coalesce(mitxonline_users.user_gender, micromasters_users.user_gender) as user_gender
+        , coalesce(
+            mitxonline_users.user_birth_year, cast(substring(micromasters_users.user_birth_date, 1, 4) as int)
+        ) as user_birth_year
     from mitxonline_users
+    left join micromasters_users on mitxonline_users.user_username = micromasters_users.user_mitxonline_username
 )
 
 ---augment edxorg users profile with MicroMasters
@@ -73,16 +82,14 @@ with mitxonline_users as (
     left join micromasters_users on edxorg_users.user_username = micromasters_users.user_edxorg_username
 )
 
-, mitx_users_combined as (
+, mitxonline_edxorg_users as (
     select
         mitxonline_users_view.user_mitxonline_id
         , edxorg_users_view.user_edxorg_id
-        , edxorg_users_view.user_micromasters_id
         , mitxonline_users_view.user_mitxonline_username
         , edxorg_users_view.user_edxorg_username
         , mitxonline_users_view.user_mitxonline_email
         , edxorg_users_view.user_edxorg_email
-        , edxorg_users_view.user_micromasters_email
         , mitxonline_users_view.user_joined_on as user_joined_on_mitxonline
         , edxorg_users_view.user_joined_on as user_joined_on_edxorg
         , mitxonline_users_view.user_last_login as user_last_login_on_mitxonline
@@ -108,6 +115,12 @@ with mitxonline_users as (
         , coalesce(mitxonline_users_view.user_company, edxorg_users_view.user_company_name) as user_company
         , coalesce(mitxonline_users_view.user_job_title, edxorg_users_view.user_job_position) as user_job_title
         , coalesce(mitxonline_users_view.user_industry, edxorg_users_view.user_company_industry) as user_industry
+        , coalesce(
+            mitxonline_users_view.user_micromasters_id, edxorg_users_view.user_micromasters_id
+        ) as user_micromasters_id
+        , coalesce(
+            mitxonline_users_view.user_micromasters_email, edxorg_users_view.user_micromasters_email
+        ) as user_micromasters_email
     from mitxonline_users_view
     full outer join edxorg_users_view
         on mitxonline_users_view.user_edxorg_username = edxorg_users_view.user_edxorg_username
@@ -144,4 +157,42 @@ select
     , user_company
     , user_industry
     , user_job_title
-from mitx_users_combined
+from mitxonline_edxorg_users
+
+union distinct
+--- append micromasters users who don't exist in mitxonline_edxorg_users
+select
+    if(micromasters_users.user_mitxonline_username is not null, true, false) as is_mitxonline_user
+    , if(micromasters_users.user_edxorg_username is not null, true, false) as is_edxorg_user
+    , null as user_mitxonline_id
+    , null as user_edxorg_id
+    , micromasters_users.user_id as user_micromasters_id
+    , micromasters_users.user_mitxonline_username
+    , micromasters_users.user_edxorg_username
+    , null as user_mitxonline_email
+    , null as user_edxorg_email
+    , micromasters_users.user_email as user_micromasters_email
+    , null as user_joined_on_mitxonline
+    , null as user_joined_on_edxorg
+    , null as user_last_login_on_mitxonline
+    , null as user_last_login_on_edxorg
+    , null as user_is_active_on_mitxonline
+    , null as user_is_active_on_edxorg
+    , micromasters_users.user_full_name
+    , micromasters_users.user_first_name
+    , micromasters_users.user_last_name
+    , micromasters_users.user_address_country
+    , micromasters_users.user_address_state_or_territory as user_address_state
+    , micromasters_users.user_address_city
+    , micromasters_users.user_address_postal_code
+    , micromasters_users.user_street_address
+    , micromasters_users.user_highest_education
+    , micromasters_users.user_gender
+    , cast(substring(micromasters_users.user_birth_date, 1, 4) as int) as user_birth_year
+    , micromasters_users.user_company_name as user_company
+    , micromasters_users.user_company_industry as user_industry
+    , micromasters_users.user_job_position as user_job_title
+from micromasters_users
+left join mitxonline_edxorg_users
+    on micromasters_users.user_id = mitxonline_edxorg_users.user_micromasters_id
+where mitxonline_edxorg_users.user_micromasters_id is null

--- a/src/ol_dbt/models/marts/micromasters/_marts_micromasters__models.yml
+++ b/src/ol_dbt/models/marts/micromasters/_marts_micromasters__models.yml
@@ -87,9 +87,10 @@ models:
     tests:
     - not_null
   - name: user_full_name
-    description: str, user full name on edX.org or MITxOnline
+    description: str, user's full name from MITx Online, MicroMasters, or edX.org.
   - name: user_country
-    description: str, user country on edX.org or MITxOnline
+    description: str, country code on user's profile from MITx Online, MicroMasters,
+      or edX.org
   - name: courseruncertificate_url
     description: str, the full URL to this DEDP course certificate on MITx Online
   - name: courseruncertificate_created_on
@@ -204,8 +205,9 @@ models:
     description: int, count of program certificates earned for the the program
 
 - name: marts__micromasters_program_certificates
-  description: MicroMasters program certificate earners. The profile data are selected
-    in the order of MITx Online, MicroMasters, and edX.org, whichever is not null.
+  description: MicroMasters program certificate earners. User's profile fields are
+    selected in the order of MITx Online, MicroMasters, and edX.org, whichever is
+    not null.
   config:
     grants:
       select: ['mit_irx']
@@ -251,11 +253,14 @@ models:
     description: str, country code on user's profile from MITx Online, MicroMasters,
       or edX.org
   - name: user_address_postal_code
-    description: str, postal code on user's profile from MicroMasters
+    description: str, postal code on user's profile from MicroMasters. MITx Online
+      and edX.org don't collect this data.
   - name: user_street_address
-    description: str, street address on user's profile from MicroMasters
+    description: str, street address on user's profile from MicroMasters. MITx Online
+      and edX.org don't collect this data.
   - name: user_address_city
-    description: str, address city on user's profile from MicroMasters
+    description: str, address city on user's profile from MicroMasters. MITx Online
+      and edX.org don't collect this data.
   - name: user_address_state_or_territory
     description: str, state code or territory on user's profile from MITx Online or
       MicroMasters

--- a/src/ol_dbt/models/marts/micromasters/_marts_micromasters__models.yml
+++ b/src/ol_dbt/models/marts/micromasters/_marts_micromasters__models.yml
@@ -204,7 +204,8 @@ models:
     description: int, count of program certificates earned for the the program
 
 - name: marts__micromasters_program_certificates
-  description: MicroMasters program certificate earners
+  description: MicroMasters program certificate earners. The profile data are selected
+    in the order of MITx Online, MicroMasters, and edX.org, whichever is not null.
   config:
     grants:
       select: ['mit_irx']
@@ -232,15 +233,11 @@ models:
     description: timestamp, timestamp of the course certificate that completed the
       program
   - name: user_gender
-    description: str, user's gender from user's profile on MITx Online or MicroMasters.
-      blank means user did not specify a gender. Null means this student signed up
-      before this information was collected
+    description: str, gender on user's profile from MITx Online, MicroMasters, or
+      edX.org
     tests:
     - accepted_values:
         values: '{{ var("gender_values") }}'
-  - name: user_address_city
-    description: str,  city where user lives in from user's profile on MicroMasters.
-      Note that this data isn't available on MITx Online.
   - name: user_first_name
     description: str, first name from user's profile on MITx Online or MicroMasters
   - name: user_last_name
@@ -248,18 +245,20 @@ models:
   - name: user_full_name
     description: str, The full name from user's profile on MITx Online or MicroMasters
   - name: user_year_of_birth
-    description: str, user's birth year from user's profile on MITx Online or MicroMasters
+    description: int, birth year on user's profile from MITx Online, MicroMasters,
+      or edX.org
   - name: user_country
-    description: str, Country from user's profile on MITx Online or MicroMasters
+    description: str, country code on user's profile from MITx Online, MicroMasters,
+      or edX.org
   - name: user_address_postal_code
-    description: str, postal code where user lives in from the profile on MicroMasters.
-      Note that this data isn't available on MITx Online.
+    description: str, postal code on user's profile from MicroMasters
   - name: user_street_address
-    description: str, street address where user lives in from user's profile on MicroMasters.
-      Note that this data isn't available on MITx Online.
+    description: str, street address on user's profile from MicroMasters
+  - name: user_address_city
+    description: str, address city on user's profile from MicroMasters
   - name: user_address_state_or_territory
-    description: str,  state or territory where user lives in from user's profile
-      on MITx Online or MicroMasters.
+    description: str, state code or territory on user's profile from MITx Online or
+      MicroMasters
   - name: micromasters_program_id
     description: int, id of the program in the micromasters database
   - name: mitxonline_program_id


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
close https://github.com/mitodl/hq/issues/4118

### Description (What does it do?)
<!--- Describe your changes in detail -->
- Update the profile fields in `int__mitx__users` to coalesce MITx Online, MicroMasters, and edx.org
- Update the profile fields in `int__micromasters__*` and `int__mitx__courserun_enrollments_with_programs`(int__micromasters__course_enrollments use it)  to use the above model
- Update field description in these models and upstream marts

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->
Run the following should cover all the changes:

dbt build --select int__mitx__users --full-refresh
dbt build --select int__mitx__courserun_enrollments_with_programs
dbt build --select intermediate.micromasters
