### PR TITLE
Refactoring metadata parsing

### DIFF
--- a/src/ol_orchestrate/lib/openedx.py
+++ b/src/ol_orchestrate/lib/openedx.py
@@ -221,8 +221,6 @@ def parse_course_xml(metadata_file: str) -> dict[str, Any]:
     self_paced = bool(metadata_root.attrib.get("self_paced", None))
     start = metadata_root.attrib.get("start", None)
     video_upload_pipeline = metadata_root.attrib.get("video_upload_pipeline", None)
-    wiki = metadata_root.find("wiki", None)
-    slug = wiki.attrib.get("slug", None) if wiki else None
     chapters = metadata_root.findall("chapter", None)
     # if there is chapter data
     chapter_ids = (
@@ -252,6 +250,5 @@ def parse_course_xml(metadata_file: str) -> dict[str, Any]:
         "self_paced": self_paced,
         "start": start,
         "video_upload_pipeline": video_upload_pipeline,
-        "slug": slug,
         "chapter_ids": chapter_ids,
     }


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/4067

### Description (What does it do?)
After setting up the new metadata stream _raw__edxorg__s3__course_structure__course_metadata_ in the **edx.org Production Course Structure** Airbyte connection, we were seeing Trino errors when trying to query the table in Starburst>
`Glue table 'ol_warehouse_production_raw.raw__edxorg__s3__course_structure__course_metadata' column 'slug' has invalid data type: null`. Rachel mentioned that most of these elements/attributes are not necessary for us right now, so we should just drop it if it's causing issues.

### How can this be tested?
Once deployed, allow the metadata files to be reprocesses, and then try querying the tables in Starburst again. Confirm that there are no longer any issues/errors that pop up.

