### PR TITLE
Update metadata fields parsed to match int__edxorg__mitx_courseruns

### DIFF
--- a/src/ol_orchestrate/lib/openedx.py
+++ b/src/ol_orchestrate/lib/openedx.py
@@ -214,8 +214,8 @@ def parse_course_xml(metadata_file: str) -> dict[str, Any]:
     return {
         "enrollment_start": enrollment_start,
         "enrollment_end": enrollment_end,
-        "start": start,
-        "end": end,
+        "course_start": start,
+        "course_end": end,
         "instructor_info": instructor_info,
         "self_paced": self_paced,
         "title": title,

--- a/src/ol_orchestrate/lib/openedx.py
+++ b/src/ol_orchestrate/lib/openedx.py
@@ -6,6 +6,8 @@ from pathlib import Path
 from typing import Any, Optional
 from xml.etree.ElementTree import ElementTree
 
+from pytz import utc
+
 
 def generate_block_indexes(
     course_structure: dict[str, Any], root_block_id: str
@@ -93,7 +95,9 @@ def process_video_xml(archive_path: Path) -> dict[str, Any]:
     with tarfile.open(archive_path, "r") as tf:
         tf.extractall(filter="data")
         for member in tf.getmembers():
-            course_id, course_number, run_tag = parse_course_id("course/course.xml")
+            course_id, course_number, run_tag, org = parse_course_id(
+                "course/course.xml"
+            )
             if not member.isdir() and member.path.startswith("course/video/"):
                 video_data = parse_video_xml(member.path)
                 video_data["course_id"] = course_id
@@ -101,7 +105,7 @@ def process_video_xml(archive_path: Path) -> dict[str, Any]:
     return json_data
 
 
-def parse_course_id(course_xml: str) -> tuple[str, str, str]:
+def parse_course_id(course_xml: str) -> tuple[str, str, str, str]:
     """
     Parse the attributes of the course.xml file in the root directory
     and generate a properly formatted course_id string.
@@ -117,9 +121,9 @@ def parse_course_id(course_xml: str) -> tuple[str, str, str]:
         tree.parse(course)
         course_root = tree.getroot()
         run_tag = str(course_root.attrib.get("url_name", None))
-        org = course_root.attrib.get("org", None)
+        org = str(course_root.attrib.get("org", None))
         course_number = str(course_root.attrib.get("course", None))
-    return f"course-v1:{org}+{course_number}+{run_tag}", course_number, run_tag
+    return f"course-v1:{org}+{course_number}+{run_tag}", course_number, run_tag, org
 
 
 def parse_video_xml(video_file: str) -> dict[str, Any]:
@@ -167,15 +171,18 @@ def process_course_xml(archive_path: Path) -> dict[str, Any]:
         tar_info_course = tf.getmember(f"{archive_root.name}/course.xml")
         course_xml_file = Path("course.xml")
         course_xml_file.write_bytes(tf.extractfile(tar_info_course).read())  # type: ignore[union-attr]
-        course_id, course_number, run_tag = parse_course_id(str(course_xml_file))
+        course_id, course_number, run_tag, org = parse_course_id(str(course_xml_file))
         # use the run_tag to find the course metadata file
         tar_info_metadata = tf.getmember(f"{archive_root.name}/course/{run_tag}.xml")
         course_metadata_file = Path("course_metadata.xml")
         course_metadata_file.write_bytes(tf.extractfile(tar_info_metadata).read())  # type: ignore[union-attr]
         course_metadata = parse_course_xml(str(course_metadata_file))
+        # add courserun data from the parse_course_id output
         course_metadata["course_id"] = course_id
         course_metadata["course_number"] = course_number
-        course_metadata["run_tag"] = run_tag
+        # courserun_semester is run_tag
+        course_metadata["semester"] = run_tag
+        course_metadata["institution"] = org
         course_xml_file.unlink()
         course_metadata_file.unlink()
     return course_metadata
@@ -192,63 +199,27 @@ def parse_course_xml(metadata_file: str) -> dict[str, Any]:
     :return: A dictionary with all of the course metadata attributes
     :rtype: dict[str, Any]
     """
+    DEFAULT_START_DATE = datetime(2030, 1, 1, tzinfo=utc)
     with Path(metadata_file).open("r") as metadata:
         tree = ElementTree()
         tree.parse(metadata)
         metadata_root = tree.getroot()
-    advertised_start = metadata_root.attrib.get("advertised_start", None)
-    allow_anonymous = metadata_root.attrib.get("allow_anonymous", None)
-    allow_unsupported_xblocks = metadata_root.attrib.get(
-        "allow_unsupported_xblocks", None
-    )
-    cert_html_view_enabled = metadata_root.attrib.get("cert_html_view_enabled", None)
-    course_image = metadata_root.attrib.get("course_image", None)
-    days_early_for_beta = metadata_root.attrib.get("days_early_for_beta", None)
-    display_name = metadata_root.attrib.get("display_name", None)
-    enable_subsection_gating = bool(
-        metadata_root.attrib.get("enable_subsection_gating", None)
-    )
-    end = metadata_root.attrib.get("end", None)
-    enrollment_end = metadata_root.attrib.get("enrollment_end", None)
-    enrollment_start = metadata_root.attrib.get("enrollment_start", None)
-    giturl = metadata_root.attrib.get("giturl", None)
-    graceperiod = metadata_root.attrib.get("graceperiod", None)
-    instructor_info = metadata_root.attrib.get("instructor_info", None)
-    language = metadata_root.attrib.get("language", None)
-    learning_info = metadata_root.attrib.get("learning_info", None)
-    minimum_grade_credit = metadata_root.attrib.get("minimum_grade_credit", None)
-    mobile_available = metadata_root.attrib.get("mobile_available", None)
-    self_paced = bool(metadata_root.attrib.get("self_paced", None))
-    start = metadata_root.attrib.get("start", None)
-    video_upload_pipeline = metadata_root.attrib.get("video_upload_pipeline", None)
-    chapters = metadata_root.findall("chapter", None)
-    # if there is chapter data
-    chapter_ids = (
-        [chapter.attrib.get("url_name", None) for chapter in chapters]
-        if len(chapters) > 0
-        else []
-    )
+    enrollment_start = metadata_root.attrib.get("enrollment_start")
+    enrollment_end = metadata_root.attrib.get("enrollment_end")
+    # Default value as defined in edx-platform code
+    # https://github.com/openedx/edx-platform/blob/master/xmodule/course_metadata_utils.py#L17
+    start = metadata_root.attrib.get("start", DEFAULT_START_DATE)
+    end = metadata_root.attrib.get("end")
+    # default to empty list
+    instructor_info = metadata_root.attrib.get("instructor_info")
+    self_paced = bool(metadata_root.attrib.get("self_paced", False))
+    title = metadata_root.attrib.get("display_name")
     return {
-        "advertised_start": advertised_start,
-        "allow_anonymous": allow_anonymous,
-        "allow_unsupported_xblocks": allow_unsupported_xblocks,
-        "cert_html_view_enabled": cert_html_view_enabled,
-        "course_image": course_image,
-        "days_early_for_beta": days_early_for_beta,
-        "display_name": display_name,
-        "enable_subsection_gating": enable_subsection_gating,
-        "end": end,
-        "enrollment_end": enrollment_end,
         "enrollment_start": enrollment_start,
-        "giturl": giturl,
-        "graceperiod": graceperiod,
-        "instructor_info": instructor_info,
-        "language": language,
-        "learning_info": learning_info,
-        "minimum_grade_credit": minimum_grade_credit,
-        "mobile_available": mobile_available,
-        "self_paced": self_paced,
+        "enrollment_end": enrollment_end,
         "start": start,
-        "video_upload_pipeline": video_upload_pipeline,
-        "chapter_ids": chapter_ids,
+        "end": end,
+        "instructor_info": instructor_info,
+        "self_paced": self_paced,
+        "title": title,
     }

--- a/src/ol_orchestrate/lib/openedx.py
+++ b/src/ol_orchestrate/lib/openedx.py
@@ -6,8 +6,6 @@ from pathlib import Path
 from typing import Any, Optional
 from xml.etree.ElementTree import ElementTree
 
-from pytz import utc
-
 
 def generate_block_indexes(
     course_structure: dict[str, Any], root_block_id: str
@@ -199,7 +197,6 @@ def parse_course_xml(metadata_file: str) -> dict[str, Any]:
     :return: A dictionary with all of the course metadata attributes
     :rtype: dict[str, Any]
     """
-    DEFAULT_START_DATE = datetime(2030, 1, 1, tzinfo=utc)
     with Path(metadata_file).open("r") as metadata:
         tree = ElementTree()
         tree.parse(metadata)
@@ -208,7 +205,7 @@ def parse_course_xml(metadata_file: str) -> dict[str, Any]:
     enrollment_end = metadata_root.attrib.get("enrollment_end")
     # Default value as defined in edx-platform code
     # https://github.com/openedx/edx-platform/blob/master/xmodule/course_metadata_utils.py#L17
-    start = metadata_root.attrib.get("start", DEFAULT_START_DATE)
+    start = metadata_root.attrib.get("start")
     end = metadata_root.attrib.get("end")
     # default to empty list
     instructor_info = metadata_root.attrib.get("instructor_info")


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/4067

### Description (What does it do?)
After setting up the new metadata stream _raw__edxorg__s3__course_structure__course_metadata_ in the **edx.org Production Course Structure** Airbyte connection, we were seeing Trino errors when trying to query the table in Starburst>
`Glue table 'ol_warehouse_production_raw.raw__edxorg__s3__course_structure__course_metadata' column 'allow_anonymous' has invalid data type: null`. Rachel mentioned that most of these elements/attributes are not necessary for us right now, so we should just drop it if it's causing issues. I've removed all of the extraneous fields and whittled the selection down to the courserun fields that are being processed in the [int__edxorg__mitx_courseruns dbt model](https://github.com/mitodl/ol-data-platform/blob/main/src/ol_dbt/models/intermediate/edxorg/int__edxorg__mitx_courseruns.sql#L24-L35) as recommended by Rachel (with the exception of the courserun_url).

### How can this be tested?
Once deployed, allow the metadata files to be reprocesses, and then try querying the tables in Starburst again. Confirm that there are no longer any issues/errors that pop up.

