### PR TITLE
fix dbt error on int__edxorg__mitx_courserun_certificates

### DIFF
--- a/src/ol_dbt/models/intermediate/edxorg/_int_edxorg__models.yml
+++ b/src/ol_dbt/models/intermediate/edxorg/_int_edxorg__models.yml
@@ -81,9 +81,7 @@ models:
     tests:
     - not_null
   - name: user_full_name
-    description: str, The full name of the user on edx.org. Very small number of edX.org
-      users have blank full name, their names aren't populated unless they have their
-      accounts linked on MicroMasters.
+    description: str, The full name from user's profile on MicroMasters or edx.org
   - name: courseruncertificate_created_on
     description: timestamp, Timestamp indicating when the certificate was created
   - name: courseruncertificate_updated_on

--- a/src/ol_dbt/models/intermediate/edxorg/int__edxorg__mitx_courserun_certificates.sql
+++ b/src/ol_dbt/models/intermediate/edxorg/int__edxorg__mitx_courserun_certificates.sql
@@ -74,7 +74,7 @@ with person_courses as (
         , dedp_edxorg_certificates_from_micromasters.coursecertificate_url as courseruncertificate_download_url
         , dedp_edxorg_certificates_from_micromasters.coursecertificate_hash as courseruncertificate_download_uuid
         , dedp_edxorg_certificates_from_micromasters.coursecertificate_hash as courseruncertificate_verify_uuid
-        , dedp_edxorg_certificates_from_micromasters.user_full_name as courseruncertificate_name
+        , micromasters_users.user_full_name as courseruncertificate_name
         , 'downloadable' as courseruncertificate_status
         , dedp_edxorg_certificates_from_micromasters.coursecertificate_created_on as courseruncertificate_created_on
         , dedp_edxorg_certificates_from_micromasters.coursecertificate_updated_on as courseruncertificate_updated_on
@@ -84,9 +84,11 @@ with person_courses as (
         , edxorg_enrollments.user_mitxonline_username
         , runs.courserun_title
         , runs.course_number
-        , coalesce(users.user_full_name, dedp_edxorg_certificates_from_micromasters.user_full_name) as user_full_name
+        , coalesce(micromasters_users.user_full_name, users.user_full_name) as user_full_name
     from dedp_edxorg_certificates_from_micromasters
-    inner join users on dedp_edxorg_certificates_from_micromasters.user_edxorg_username = users.user_username
+    inner join micromasters_users
+        on dedp_edxorg_certificates_from_micromasters.user_micromasters_id = micromasters_users.user_id
+    inner join users on micromasters_users.user_edxorg_username = users.user_username
     left join
         runs
         on dedp_edxorg_certificates_from_micromasters.courserun_edxorg_readable_id = runs.courserun_readable_id
@@ -94,12 +96,13 @@ with person_courses as (
         on
             dedp_edxorg_certificates_from_micromasters.courserun_readable_id
             = dedp_edxorg_grades_from_micromasters.courserun_readable_id
-            and dedp_edxorg_certificates_from_micromasters.user_email = dedp_edxorg_grades_from_micromasters.user_email
+            and dedp_edxorg_certificates_from_micromasters.user_micromasters_id
+            = dedp_edxorg_grades_from_micromasters.user_micromasters_id
     left join edxorg_enrollments
         on
             dedp_edxorg_certificates_from_micromasters.courserun_edxorg_readable_id
             = edxorg_enrollments.courserun_readable_id
-            and dedp_edxorg_certificates_from_micromasters.user_edxorg_username = edxorg_enrollments.user_username
+            and micromasters_users.user_edxorg_username = edxorg_enrollments.user_username
 )
 
 , edxorg_non_dedp_certificates as (


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
NA
This is related to my previous PR https://github.com/mitodl/ol-data-platform/pull/1181, in which I forgot that the subqueries are used in nt__edxorg__mitx_courserun_certificates

### Description (What does it do?)
<!--- Describe your changes in detail -->
This fixes the database error in today's run https://pipelines.odl.mit.edu/runs/4b3a8ca7-7961-4567-b2c6-645cbfe43d99
```
 Database Error in model int__edxorg__mitx_courserun_certificates (models/intermediate/edxorg/int__edxorg__mitx_courserun_certificates.sql)
  TrinoUserError(type=USER_ERROR, name=COLUMN_NOT_FOUND, message="line 98:25: Column 'dedp_edxorg_certificates_from_micromasters.user_edxorg_username' cannot be resolved", query_id=20240702_085829_07390_vvmzp)
```

The other database error on stg__micromasters__app__postgres__profiles_employment is intermittent and nothing to fix


### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->
dbt build --select int__edxorg__mitx_courserun_certificates