### PR TITLE
remove b2b and fix pk of orders mart

### DIFF
--- a/src/ol_dbt/models/marts/combined/_marts__combined__models.yml
+++ b/src/ol_dbt/models/marts/combined/_marts__combined__models.yml
@@ -83,8 +83,8 @@ models:
   description: B2B and regular orders combined into one table
   columns:
   - name: combined_orders_hash_id
-    description: int, primary key for this table. At the grain of order id, line id, 
-      and platform. 
+    description: int, primary key for this table. At the grain of order id, line id,
+      and platform.
   - name: platform
     description: string, describes platform associated with the order (edX.org, mitxonline,
       mitxpro, or bootcamps).

--- a/src/ol_dbt/models/marts/combined/marts__combined__orders.sql
+++ b/src/ol_dbt/models/marts/combined/marts__combined__orders.sql
@@ -51,7 +51,7 @@ with bootcamps__ecommerce_order as (
         , mitxpro__ecommerce_order.order_tax_amount
         , mitxpro__ecommerce_order.order_total_price_paid_plus_tax
         , mitxpro__ecommerce_allorders.coupon_id
-        , mitxpro__ecommerce_allorders.order_id 
+        , mitxpro__ecommerce_allorders.order_id
         , mitxpro__ecommerce_order.order_total_price_paid
         , mitxpro__ecommerce_order.couponpaymentversion_discount_amount_text as discount
         , concat('xpro-b2c-production-', cast(mitxpro__ecommerce_allorders.order_id as varchar))
@@ -207,8 +207,8 @@ with bootcamps__ecommerce_order as (
 )
 
 select
-    {{ generate_hash_id('cast(order_id as varchar) 
-        || cast(coalesce(line_id, 9) as varchar) 
+    {{ generate_hash_id('cast(order_id as varchar)
+        || cast(coalesce(line_id, 9) as varchar)
         || platform') }} as combined_orders_hash_id
     , platform
     , order_id


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/4296

### Description (What does it do?)
This changes the code so that the primary key of the marts__combined__orders table is generated via a reusable macro that can easily be added to other tables for joining. It also removed the b2b records and columns which will be put in a seperate table since they are not very common and only applicable to one platform.

### How can this be tested?
dbt build --select marts__combined__orders