### PR TITLE
Update OCW external resources report

### DIFF
--- a/src/ol_dbt/models/intermediate/ocw/_int_ocw__models.yml
+++ b/src/ol_dbt/models/intermediate/ocw/_int_ocw__models.yml
@@ -228,6 +228,10 @@ models:
     description: boolean, whether the external resource has a license warning
   - name: external_resource_is_broken
     description: boolean, whether the external resource link is broken
+  - name: content_type
+    description: str, websitecontent type of the resource (e.g., resource, external-resource)
+    tests:
+    - not_null
   tests:
   - dbt_expectations.expect_compound_columns_to_be_unique:
       column_list: ["course_uuid", "resource_uuid"]

--- a/src/ol_dbt/models/intermediate/ocw/int__ocw__resources.sql
+++ b/src/ol_dbt/models/intermediate/ocw/int__ocw__resources.sql
@@ -20,6 +20,7 @@ select
     , websitecontents.metadata_draft as resource_draft
     , websites.primary_course_number as course_number
     , websitecontents.websitecontent_metadata as metadata --noqa: disable=RF04
+    , websitecontents.websitecontent_type as content_type
     -- image_metadata for image resources; could be in metadata or image_metadata
     -- noqa: disable=RF02
     , cast(


### PR DESCRIPTION
### What are the relevant tickets?
Related to https://github.com/mitodl/hq/issues/4023.

### Description (What does it do?)
This PR allows for the intermediate OCW resources table to properly pull in external resources, which are identified by the `websitecontent_type = external-resource`.

### How can this be tested?

Run the following commands; the tests should all pass
```
dbt build --select staging.ocw  --vars 'schema_suffix: <your name>' --target dev_production
dbt build --select intermediate.ocw --vars 'schema_suffix: <your name>' --target dev_production
```

Run the following query in https://mitol.galaxy.starburst.io/query-editor to see the result of the above tables:
```
SELECT * FROM ol_data_lake_production.ol_warehouse_production_<your name>_intermediate.int__ocw__resources
```

Then, verify that external resources are properly pulled in, using a query like

```
select course_name, resource_uuid, studio_url, external_resource_url from ol_data_lake_production.ol_warehouse_production_<your name>_intermediate.int__ocw__resources
where external_resource_is_broken = true
```

Also, verify that it is possible to get a list of all external resources, using a query like

```
select * from ol_data_lake_production.ol_warehouse_production_<your name>_intermediate.int__ocw__resources
where content_type = 'external-resource'
```