### PR TITLE
add fk to orders in enrollment mart

### DIFF
--- a/src/ol_dbt/models/marts/combined/_marts__combined__models.yml
+++ b/src/ol_dbt/models/marts/combined/_marts__combined__models.yml
@@ -83,8 +83,8 @@ models:
   description: B2B and regular orders combined into one table
   columns:
   - name: combined_orders_hash_id
-    description: int, primary key for this table. At the grain of order id, line id, 
-      and platform. 
+    description: int, primary key for this table. At the grain of order id, line id,
+      and platform.
   - name: platform
     description: string, describes platform associated with the order (edX.org, mitxonline,
       mitxpro, or bootcamps).
@@ -195,8 +195,8 @@ models:
     description: int, internal ID and foreign key to courserunenrollments on the corresponding
       platform. Null for enrollments on edX.org.
   - name: combined_orders_hash_id
-    description: int, primary key for this table. At the grain of order id, line id, 
-      and platform. 
+    description: int, primary key for this table. At the grain of order id, line id,
+      and platform.
   - name: course_readable_id
     description: str, Open edX ID formatted as course-v1:{org}+{course code} for MITx
       Online and xPro courses, and {org}/{course} for edX.org courses. May be null

--- a/src/ol_dbt/models/marts/combined/marts__combined_course_enrollment_detail.sql
+++ b/src/ol_dbt/models/marts/combined/marts__combined_course_enrollment_detail.sql
@@ -252,8 +252,8 @@ with combined_enrollments as (
 select
     platform
     , courserunenrollment_id
-    , {{ generate_hash_id('cast(order_id as varchar) 
-        || cast(coalesce(line_id, 9) as varchar) 
+    , {{ generate_hash_id('cast(order_id as varchar)
+        || cast(coalesce(line_id, 9) as varchar)
         || platform') }} as combined_orders_hash_id
     , course_readable_id
     , course_title


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/4296

### Description (What does it do?)
Adds a line id column and a pk to orders mart into marts__combined_course_enrollment_detail

### How can this be tested?
dbt build --select marts__combined_course_enrollment_detail