### PR TITLE
add block index to video mart for sorting in reports

### DIFF
--- a/src/ol_dbt/models/marts/mitxonline/_marts__mitxonline__models.yml
+++ b/src/ol_dbt/models/marts/mitxonline/_marts__mitxonline__models.yml
@@ -242,6 +242,9 @@ models:
     description: str, title of this video.
   - name: section_title
     description: str, title of section (aka chapter) this video belongs to.
+  - name: coursestructure_block_index
+    description: int, sequence number giving order in which this block content appears
+      within the course
   - name: video_duration
     description: float, The length of the video file, in seconds. Populated with data
       from ODL Video Service (OVS) or tracking log. May be null or 0.0 for small amounts

--- a/src/ol_dbt/models/marts/mitxonline/marts__mitxonline_video_engagements.sql
+++ b/src/ol_dbt/models/marts/mitxonline/marts__mitxonline_video_engagements.sql
@@ -30,6 +30,7 @@ select
     , mitxonline_videos.video_edx_uuid
     , video_structure.coursestructure_block_title as video_title
     , video_structure.coursestructure_chapter_title as section_title
+    , video_structure.coursestructure_block_index
     , video.useractivity_page_url as page_url
     , video.useractivity_event_type as video_event_type
     , video.useractivity_timestamp as video_event_timestamp


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/4617

### Description (What does it do?)
adds the coursestructure_block_index column to marts__mitxonline_video_engagements for easier sorting in the front end reports and dashboards

### How can this be tested?
dbt build --select marts__mitxonline_video_engagements 