### PR TITLE
add payment timestamp to order mart

### DIFF
--- a/src/ol_dbt/models/marts/combined/_marts__combined__models.yml
+++ b/src/ol_dbt/models/marts/combined/_marts__combined__models.yml
@@ -176,6 +176,8 @@ models:
   - name: receipt_payment_method
     description: string, payment method from cybersource payment transaction. Value
       could be 'paypal' or 'card'.
+  - name: receipt_payment_timestamp
+    description: string, the signed_date_time from cybersource payment transaction
   - name: receipt_payment_transaction_type
     description: string, type of transaction - req_transaction_type from cybersource
       payment transaction, e.g., sale
@@ -192,9 +194,6 @@ models:
     description: string, unique identifier - either transaction_id from cybersource
       payment or refund transaction, e.g., 3735553783662130706689, OR unique UUID
       if no payment required.
-  - name: receipt_transaction_timestamp
-    description: string, either the signed_date_time from cybersource payment transaction,
-      or submitTimeUtc from cybersource refund transaction (MITx Online only).
   - name: req_reference_number
     description: string, cybersource req_reference_number from cybersource payment
       transaction, e.g., mitxonline-production-1

--- a/src/ol_dbt/models/marts/combined/marts__combined__orders.sql
+++ b/src/ol_dbt/models/marts/combined/marts__combined__orders.sql
@@ -69,6 +69,7 @@ with bootcamps__ecommerce_order as (
         , mitxonline__transaction.transaction_payer_email
         , mitxonline__transaction.transaction_payer_ip_address
         , mitxonline__transaction.transaction_payment_method
+        , mitxonline__transaction.transaction_timestamp as transaction_payment_timestamp
         , mitxonline__transaction.transaction_reference_number
         , mitxonline__ecommerce_order.order_created_on
         , mitxonline__ecommerce_order.order_reference_number
@@ -84,10 +85,6 @@ with bootcamps__ecommerce_order as (
             mitxonline__refund.transaction_authorization_code
             , mitxonline__transaction.transaction_authorization_code
         ) as transaction_authorization_code
-        , coalesce(
-            mitxonline__refund.transaction_timestamp
-            , mitxonline__transaction.transaction_timestamp
-        ) as transaction_timestamp
     from mitxonline__ecommerce_order
     left join mitxonline__transaction
         on mitxonline__ecommerce_order.transaction_id = mitxonline__transaction.transaction_id
@@ -217,9 +214,9 @@ with bootcamps__ecommerce_order as (
         , transaction_payer_email as receipt_payer_email
         , transaction_payer_ip_address as receipt_payer_ip_address
         , transaction_payment_method as receipt_payment_method
+        , transaction_payment_timestamp as receipt_payment_timestamp
         , transaction_readable_identifier as receipt_transaction_id
         , transaction_reference_number as req_reference_number
-        , transaction_timestamp as receipt_transaction_timestamp
         , order_created_on
         , order_reference_number
         , order_state
@@ -263,9 +260,9 @@ with bootcamps__ecommerce_order as (
         , receipt_payer_email
         , receipt_payer_ip_address
         , receipt_payment_method
+        , receipt_payment_timestamp
         , receipt_transaction_id
         , receipt_reference_number as req_reference_number
-        , receipt_payment_timestamp as receipt_transaction_timestamp
         , order_created_on
         , order_reference_number
         , order_state
@@ -309,9 +306,9 @@ with bootcamps__ecommerce_order as (
         , receipt_payer_email
         , receipt_payer_ip_address
         , receipt_payment_method
+        , receipt_payment_timestamp
         , receipt_transaction_id
         , receipt_reference_number as req_reference_number
-        , receipt_payment_timestamp as receipt_transaction_timestamp
         , order_created_on
         , order_reference_number
         , order_state
@@ -355,9 +352,9 @@ with bootcamps__ecommerce_order as (
         , receipt_payer_email
         , receipt_payer_ip_address
         , receipt_payment_method
+        , receipt_payment_timestamp
         , receipt_transaction_id
         , receipt_reference_number as req_reference_number
-        , receipt_payment_timestamp as receipt_transaction_timestamp
         , order_created_on
         , order_reference_number
         , order_state
@@ -406,13 +403,13 @@ select
     , receipt_payment_card_number
     , receipt_payment_card_type
     , receipt_payment_method
+    , receipt_payment_timestamp
     , receipt_payment_transaction_type
     , receipt_payment_transaction_uuid
     , receipt_payer_name
     , receipt_payer_email
     , receipt_payer_ip_address
     , receipt_transaction_id
-    , receipt_transaction_timestamp
     , req_reference_number
     , unit_price
     , user_email


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
follow up to https://github.com/mitodl/ol-data-platform/pull/1212

### Description (What does it do?)
<!--- Describe your changes in detail -->
This adds receipt_payment_timestamp instead of receipt_transaction_timestamp to the marts__combined__orders. It is used in https://bi.odl.mit.edu/queries/1189/source as payment_date

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->
dbt build --select marts__combined__orders

### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->


<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
