### PR TITLE
Fix coupon redemption fields

### DIFF
--- a/src/ol_dbt/models/intermediate/micromasters/_int_micromasters__models.yml
+++ b/src/ol_dbt/models/intermediate/micromasters/_int_micromasters__models.yml
@@ -613,7 +613,8 @@ models:
   - name: coupon_code
     description: str, coupon code for the redeemed coupon
   - name: redeemedcoupon_created_on
-    description: timestamp, specifying when the coupon was redeemed for the order
+    description: timestamp, specifying when the coupon was redeemed by user for fulfilled
+      or refunded orders
   tests:
   - dbt_expectations.expect_table_row_count_to_equal_other_table:
       compare_model: ref('stg__micromasters__app__postgres__ecommerce_order')

--- a/src/ol_dbt/models/intermediate/micromasters/int__micromasters__orders.sql
+++ b/src/ol_dbt/models/intermediate/micromasters/int__micromasters__orders.sql
@@ -73,7 +73,10 @@ select
     , coupons.coupon_type
     , coupons.coupon_code
     , coupons.coupon_discount_amount_text
-    , redeemedcoupons.redeemedcoupon_created_on
+    , case
+        when orders.order_state in ('fulfilled', 'refunded')
+            then redeemedcoupons.redeemedcoupon_created_on
+    end as redeemedcoupon_created_on
     , case
         when coupons.coupon_amount_type = 'percent-discount'
             then cast(lines.line_price * coupons.coupon_amount as decimal(38, 2))

--- a/src/ol_dbt/models/intermediate/mitxonline/_int_mitxonline__models.yml
+++ b/src/ol_dbt/models/intermediate/mitxonline/_int_mitxonline__models.yml
@@ -385,7 +385,7 @@ models:
   - name: discountredemption_id
     description: int, primary key representing a discount redemption
   - name: discountredemption_timestamp
-    description: timestamp, specifying when the discount was redeemed by the user
+    description: timestamp, specifying when the discount redemption record was created.
   - name: user_id
     description: int, foreign key for users_user
   - name: discount_id
@@ -564,8 +564,8 @@ models:
     description: str, discount code from the most recent coupon redemption for the
       order
   - name: discountredemption_timestamp
-    description: timestamp, specifying when the discount was redeemed from the most
-      recent coupon redemption for the order
+    description: timestamp, specifying when the discount was last redeemed by user
+      for fulfilled or refunded orders
   - name: transaction_id
     description: int, foreign key to ecommerce_transaction referring to cybersource
       payment

--- a/src/ol_dbt/models/intermediate/mitxonline/int__mitxonline__ecommerce_order.sql
+++ b/src/ol_dbt/models/intermediate/mitxonline/int__mitxonline__ecommerce_order.sql
@@ -79,7 +79,6 @@ select
     , discounts.discount_redemption_type
     , discounts.discount_code
     , discounts.discount_amount_text
-    , discountredemptions.discountredemption_timestamp
     , payments.transaction_id
     , payments.transaction_authorization_code as payment_authorization_code
     , payments.transaction_payment_method as payment_method
@@ -87,6 +86,10 @@ select
     , payments.transaction_reference_number as payment_req_reference_number
     , payments.transaction_bill_to_address_state as payment_bill_to_address_state
     , payments.transaction_bill_to_address_country as payment_bill_to_address_country
+    , case
+        when orders.order_state in ('fulfilled', 'refunded')
+            then discountredemptions.discountredemption_timestamp
+    end as discountredemption_timestamp
     , case
         when discounts.discount_type = 'percent-off'
             then cast(intermediate_products_view.product_price * (discounts.discount_amount / 100) as decimal(38, 2))

--- a/src/ol_dbt/models/intermediate/mitxpro/_int_mitxpro__models.yml
+++ b/src/ol_dbt/models/intermediate/mitxpro/_int_mitxpro__models.yml
@@ -829,7 +829,7 @@ models:
     description: string, discount amount in readable format. It can be percent-off
       which is <dollar amount * 100>% off, dollars-off which is $<dollar amount> off
   - name: couponredemption_created_on
-    description: timestamp, specifying when the coupon was redeemed
+    description: timestamp, specifying when the coupon redemption record was created
   - name: receipt_reference_number
     description: str, transaction reference number from cybersource payment
   - name: receipt_transaction_id

--- a/src/ol_dbt/models/intermediate/mitxpro/_int_mitxpro__models.yml
+++ b/src/ol_dbt/models/intermediate/mitxpro/_int_mitxpro__models.yml
@@ -31,8 +31,8 @@ models:
   - name: b2border_discount
     description: numeric, dollar discount amount for the order
   - name: redeemed
-    description: boolean, when an order uses a coupon this field will be true otherwise
-      it will be null
+    description: boolean, when a fulfilled/refunded order uses a coupon this field
+      will be true otherwise it will be null
   - name: coupon_redeemed_on
     description: timestamp, specifying when the b2b or regular coupon was redeemed.
   - name: user_email
@@ -183,7 +183,7 @@ models:
     tests:
     - not_null
   - name: couponredemption_created_on
-    description: timestamp, specifying when the coupon was redeemed
+    description: timestamp, specifying when the coupon redemption record was created.
     tests:
     - not_null
   - name: couponredemption_updated_on
@@ -829,7 +829,8 @@ models:
     description: string, discount amount in readable format. It can be percent-off
       which is <dollar amount * 100>% off, dollars-off which is $<dollar amount> off
   - name: couponredemption_created_on
-    description: timestamp, specifying when the coupon redemption record was created
+    description: timestamp, specifying when the coupon was redeemed by user for fulfilled
+      or refunded orders
   - name: receipt_reference_number
     description: str, transaction reference number from cybersource payment
   - name: receipt_transaction_id

--- a/src/ol_dbt/models/intermediate/mitxpro/int__mitxpro__ecommerce_allorders.sql
+++ b/src/ol_dbt/models/intermediate/mitxpro/int__mitxpro__ecommerce_allorders.sql
@@ -140,8 +140,16 @@ with b2becommerce_b2border as (
         , b2becommerce_b2breceipt.b2breceipt_payment_method as receipt_payment_method
         , b2becommerce_b2breceipt.b2breceipt_bill_to_address_state as receipt_bill_to_address_state
         , b2becommerce_b2breceipt.b2breceipt_bill_to_address_country as receipt_bill_to_address_country
-        , b2becommerce_b2bcouponredemption.b2bcouponredemption_created_on as coupon_redeemed_on
-        , case when b2becommerce_b2bcouponredemption.b2bcouponredemption_id is not null then true end as redeemed
+        , case
+            when b2becommerce_b2border.b2border_status in ('fulfilled', 'refunded')
+                then b2becommerce_b2bcouponredemption.b2bcouponredemption_created_on
+        end as coupon_redeemed_on
+        , case
+            when
+                b2becommerce_b2bcouponredemption.b2bcouponredemption_id is not null
+                and b2becommerce_b2border.b2border_status in ('fulfilled', 'refunded')
+                then true
+        end as redeemed
     from b2becommerce_b2border
     left join ecommerce_couponpaymentversion
         on b2becommerce_b2border.couponpaymentversion_id = ecommerce_couponpaymentversion.couponpaymentversion_id

--- a/src/ol_dbt/models/intermediate/mitxpro/int__mitxpro__ecommerce_allorders.sql
+++ b/src/ol_dbt/models/intermediate/mitxpro/int__mitxpro__ecommerce_allorders.sql
@@ -79,8 +79,16 @@ with b2becommerce_b2border as (
         , ecommerce_order.receipt_payment_method
         , ecommerce_order.receipt_bill_to_address_state
         , ecommerce_order.receipt_bill_to_address_country
-        , ecommerce_couponredemption.couponredemption_created_on as coupon_redeemed_on
-        , case when ecommerce_couponredemption.couponredemption_id is not null then true end as redeemed
+        , case
+            when ecommerce_order.order_state in ('fulfilled', 'refunded')
+                then ecommerce_couponredemption.couponredemption_created_on
+        end as coupon_redeemed_on
+        , case
+            when
+                ecommerce_couponredemption.couponredemption_id is not null
+                and orders.order_state in ('fulfilled', 'refunded')
+                then true
+        end as redeemed
     from ecommerce_order
     inner join ecommerce_line
         on ecommerce_order.order_id = ecommerce_line.order_id

--- a/src/ol_dbt/models/intermediate/mitxpro/int__mitxpro__ecommerce_allorders.sql
+++ b/src/ol_dbt/models/intermediate/mitxpro/int__mitxpro__ecommerce_allorders.sql
@@ -86,7 +86,7 @@ with b2becommerce_b2border as (
         , case
             when
                 ecommerce_couponredemption.couponredemption_id is not null
-                and orders.order_state in ('fulfilled', 'refunded')
+                and ecommerce_order.order_state in ('fulfilled', 'refunded')
                 then true
         end as redeemed
     from ecommerce_order

--- a/src/ol_dbt/models/intermediate/mitxpro/int__mitxpro__ecommerce_order.sql
+++ b/src/ol_dbt/models/intermediate/mitxpro/int__mitxpro__ecommerce_order.sql
@@ -48,7 +48,6 @@ select
     , couponpaymentversion.couponpaymentversion_discount_amount_text
     , couponpaymentversion.couponpaymentversion_discount_type
     , couponpaymentversion.couponpaymentversion_discount_amount
-    , couponredemption.couponredemption_created_on
     , receipts.receipt_reference_number
     , receipts.receipt_authorization_code
     , receipts.receipt_payment_method
@@ -57,6 +56,10 @@ select
     , receipts.receipt_bill_to_address_country
     , orders.order_tax_amount
     , orders.order_total_price_paid_plus_tax
+    , case
+        when orders.order_state in ('fulfilled', 'refunded')
+            then couponredemption.couponredemption_created_on
+    end as couponredemption_created_on
 from orders
 left join couponredemption on orders.order_id = couponredemption.order_id
 left join couponversion on couponredemption.couponversion_id = couponversion.couponversion_id

--- a/src/ol_dbt/models/marts/combined/_marts__combined__models.yml
+++ b/src/ol_dbt/models/marts/combined/_marts__combined__models.yml
@@ -104,7 +104,8 @@ models:
   - name: coupon_name
     description: string, human readable name for the coupon payment
   - name: coupon_redeemed_on
-    description: timestamp, specifying when the coupon was redeemed.
+    description: timestamp, specifying when the coupon was redeemed by the user for
+      for fulfilled or refunded orders
   - name: coupon_type
     description: string, type of the coupon which describes what circumstances the
       coupon can be redeemed.
@@ -240,13 +241,6 @@ models:
     tests:
     - dbt_expectations.expect_column_values_to_not_be_null:
         row_condition: "platform != 'edX.org'"
-  - name: coupon_code
-    description: str, discount code for the redeemed coupon if applicable
-  - name: coupon_redeemed_on
-    description: timestamp, specifying when the discount was redeemed by the user
-  - name: coupon_type
-    description: str, type of the coupon which describes what circumstances the coupon
-      can be redeemed.
   - name: courserun_end_on
     description: timestamp, date and time when the course run ends. May be Null.
   - name: courserun_id
@@ -303,11 +297,6 @@ models:
   - name: courserungrade_is_passing
     description: boolean, indicating whether the user has passed the passing score
       set for this course on edX.org or MITxOnline or xPro
-  - name: discount
-    description: str, discount in readable format. e.g. $100 off, 30% off, etc
-  - name: discount_amount
-    description: numeric, actual discount dollar amount. For percent-discount coupon,
-      this is calculated as line_price * percentage off
   - name: line_id
     description: int, foreign key for line table. For edX.org, it refers to line table
       in MicroMasters application.

--- a/src/ol_dbt/models/marts/combined/marts__combined__orders.sql
+++ b/src/ol_dbt/models/marts/combined/marts__combined__orders.sql
@@ -75,10 +75,6 @@ with bootcamps__ecommerce_order as (
         , mitxonline__ecommerce_order.order_reference_number
         , mitxonline__ecommerce_order.order_state
         , mitxonline__ecommerce_order.order_total_price_paid
-        , case
-            when mitxonline__ecommerce_order.order_state in ('fulfilled', 'refunded')
-                then mitxonline__ecommerce_order.discountredemption_timestamp
-        end as discount_redeemed_on
         ----In MITx Online, there are two transactions for an refunded order.
         ----Here we picked the refund transaction ID and auth code until we change the unique key
         , coalesce(
@@ -138,6 +134,7 @@ with bootcamps__ecommerce_order as (
         , mitxpro__ecommerce_allcoupons.coupon_code
         , mitxpro__ecommerce_allcoupons.coupon_name
         , mitxpro__ecommerce_allcoupons.coupon_type
+        , mitxpro__ecommerce_allorders.coupon_redeemed_on
         , mitxpro__ecommerce_allorders.order_created_on
         , mitxpro__ecommerce_allorders.order_state
         , mitxpro__ecommerce_allorders.product_id
@@ -172,10 +169,6 @@ with bootcamps__ecommerce_order as (
         , mitxpro__ecommerce_allorders.order_id
         , mitxpro__ecommerce_order.order_total_price_paid
         , mitxpro__ecommerce_order.couponpaymentversion_discount_amount_text as discount
-        , case
-            when mitxpro__ecommerce_order.order_state in ('fulfilled', 'refunded')
-                then mitxpro__ecommerce_order.couponredemption_created_on
-        end as coupon_redeemed_on
         , concat('xpro-b2c-production-', cast(mitxpro__ecommerce_allorders.order_id as varchar))
         as order_reference_number
     from mitxpro__ecommerce_allorders
@@ -206,7 +199,7 @@ with bootcamps__ecommerce_order as (
         , null as coupon_id
         , null as coupon_name
         , discount_redemption_type as coupon_type
-        , discount_redeemed_on as coupon_redeemed_on
+        , discountredemption_timestamp as coupon_redeemed_on
         , discount_amount_text as discount
         , transaction_authorization_code as receipt_authorization_code
         , transaction_bill_to_address_state as receipt_bill_to_address_state

--- a/src/ol_dbt/models/marts/combined/marts__combined__orders.sql
+++ b/src/ol_dbt/models/marts/combined/marts__combined__orders.sql
@@ -75,6 +75,10 @@ with bootcamps__ecommerce_order as (
         , mitxonline__ecommerce_order.order_reference_number
         , mitxonline__ecommerce_order.order_state
         , mitxonline__ecommerce_order.order_total_price_paid
+        , case
+            when mitxonline__ecommerce_order.order_state in ('fulfilled', 'refunded')
+                then mitxonline__ecommerce_order.discountredemption_timestamp
+        end as discount_redeemed_on
         ----In MITx Online, there are two transactions for an refunded order.
         ----Here we picked the refund transaction ID and auth code until we change the unique key
         , coalesce(
@@ -134,7 +138,6 @@ with bootcamps__ecommerce_order as (
         , mitxpro__ecommerce_allcoupons.coupon_code
         , mitxpro__ecommerce_allcoupons.coupon_name
         , mitxpro__ecommerce_allcoupons.coupon_type
-        , mitxpro__ecommerce_allorders.coupon_redeemed_on
         , mitxpro__ecommerce_allorders.order_created_on
         , mitxpro__ecommerce_allorders.order_state
         , mitxpro__ecommerce_allorders.product_id
@@ -169,6 +172,10 @@ with bootcamps__ecommerce_order as (
         , mitxpro__ecommerce_allorders.order_id
         , mitxpro__ecommerce_order.order_total_price_paid
         , mitxpro__ecommerce_order.couponpaymentversion_discount_amount_text as discount
+        , case
+            when mitxpro__ecommerce_order.order_state in ('fulfilled', 'refunded')
+                then mitxpro__ecommerce_order.couponredemption_created_on
+        end as coupon_redeemed_on
         , concat('xpro-b2c-production-', cast(mitxpro__ecommerce_allorders.order_id as varchar))
         as order_reference_number
     from mitxpro__ecommerce_allorders
@@ -199,7 +206,7 @@ with bootcamps__ecommerce_order as (
         , null as coupon_id
         , null as coupon_name
         , discount_redemption_type as coupon_type
-        , discountredemption_timestamp as coupon_redeemed_on
+        , discount_redeemed_on as coupon_redeemed_on
         , discount_amount_text as discount
         , transaction_authorization_code as receipt_authorization_code
         , transaction_bill_to_address_state as receipt_bill_to_address_state


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
https://github.com/mitodl/hq/issues/5001

### Description (What does it do?)
<!--- Describe your changes in detail -->
Updating the upstream `coupon_redeemed_on` in marts__combined__orders to be populated when the order is fulfilled or refunded 
Fixing `redeemed` in `int__mitxpro__ecommerce_allorders` as well

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->
dbt build --select int__micromasters__orders
dbt build --select int__mitxonline__ecommerce_order
dbt build --select int__mitxpro__ecommerce_order
dbt build --select int__mitxpro__ecommerce_allorders
dbt build --select marts__combined__orders

Then run the following query to verify the `redeemed` and `coupon_redeemed_on` are fixed
```
---null
select redeemed from "ol_data_lake_production"."ol_warehouse_production_rlougee_intermediate"."int__mitxpro__ecommerce_allorders"
where coupon_id=15905

--null
select coupon_redeemed_on from "ol_data_lake_production"."ol_warehouse_production_rlougee_mart"."marts__combined__orders"
where coupon_id=15905

```


