### PR TITLE
fix hash id column on enrollment mart

### DIFF
--- a/src/ol_dbt/models/marts/combined/marts__combined_course_enrollment_detail.sql
+++ b/src/ol_dbt/models/marts/combined/marts__combined_course_enrollment_detail.sql
@@ -288,7 +288,7 @@ select
     , combined_enrollment_detail.user_username
 from combined_enrollment_detail
 left join mart_order
-    on 
+    on
         combined_enrollment_detail.platform = mart_order.platform
         and combined_enrollment_detail.order_id = mart_order.order_id
         and combined_enrollment_detail.line_id = mart_order.line_id


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/5088

### Description (What does it do?)
fixes the combined_orders_hash_id column on the marts__combined_course_enrollment_detail table to make it in-sync with the value on the marts__combined__orders table

### How can this be tested?
dbt build --select marts__combined_course_enrollment_detail