### PR TITLE
add product_readable_id to combined order mart

### DIFF
--- a/src/ol_dbt/models/marts/combined/_marts__combined__models.yml
+++ b/src/ol_dbt/models/marts/combined/_marts__combined__models.yml
@@ -80,7 +80,7 @@ models:
         "user_bootcamps_username", "platforms"]
 
 - name: marts__combined__orders
-  description: B2B and regular orders combined into one table
+  description: ecommerce regular b2c orders
   columns:
   - name: combined_orders_hash_id
     description: int, primary key for this table. At the grain of order id, line id,
@@ -153,9 +153,20 @@ models:
   - name: order_total_price_paid
     description: number, total order amount
   - name: product_id
-    description: int, foreign key for product table
+    description: int, foreign key for product table. May be null for bootcamps and
+      edX.org.
+    tests:
+    - dbt_expectations.expect_column_values_to_not_be_null:
+        row_condition: "platform != 'Bootcamps' and platform != 'edX.org'"
+  - name: product_readable_id
+    description: string, the product identifier either referring to courserun_readable_id
+      or program_readable_id. May be null for bootcamps and edX.org.
+    tests:
+    - dbt_expectations.expect_column_values_to_not_be_null:
+        row_condition: "platform != 'Bootcamps' and platform != 'edX.org'"
   - name: product_type
-    description: string, readable product type
+    description: string, readable product type - either course run or program. May
+      be null for bootcamps and edX.org
   - name: receipt_authorization_code
     description: str, either the authorization code from cybersource payment transaction,
       or approvalCode from cybersource refund transaction (MITx Online only).

--- a/src/ol_dbt/models/marts/combined/marts__combined__orders.sql
+++ b/src/ol_dbt/models/marts/combined/marts__combined__orders.sql
@@ -171,6 +171,10 @@ with bootcamps__ecommerce_order as (
         , mitxpro__ecommerce_order.couponpaymentversion_discount_amount_text as discount
         , concat('xpro-b2c-production-', cast(mitxpro__ecommerce_allorders.order_id as varchar))
         as order_reference_number
+        , coalesce(
+            mitxpro__ecommerce_allorders.courserun_readable_id
+            , mitxpro__ecommerce_allorders.program_readable_id
+        ) as product_readable_id
     from mitxpro__ecommerce_allorders
     left join mitxpro__ecommerce_order
         on mitxpro__ecommerce_allorders.order_id = mitxpro__ecommerce_order.order_id
@@ -191,6 +195,7 @@ with bootcamps__ecommerce_order as (
         , courserun_id
         , courserun_readable_id
         , product_id
+        , courserun_readable_id as product_readable_id
         , product_type
         , product_price as unit_price
         , user_email
@@ -237,6 +242,7 @@ with bootcamps__ecommerce_order as (
         , courserun_id
         , courserun_readable_id
         , product_id
+        , product_readable_id
         , product_type
         , product_price as unit_price
         , user_email
@@ -283,6 +289,7 @@ with bootcamps__ecommerce_order as (
         , courserun_id
         , courserun_readable_id
         , null as product_id
+        , null as product_readable_id
         , null as product_type
         , line_price as unit_price
         , user_email
@@ -329,6 +336,7 @@ with bootcamps__ecommerce_order as (
         , null as courserun_id
         , courserun_readable_id
         , null as product_id
+        , null as product_readable_id
         , null as product_type
         , line_price as unit_price
         , user_edxorg_email as user_email
@@ -394,6 +402,7 @@ select
     , order_total_price_paid_plus_tax
     , order_total_price_paid
     , product_id
+    , product_readable_id
     , product_type
     , receipt_authorization_code
     , receipt_bill_to_address_state


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
NA
I noted this when creating https://bi.ol.mit.edu/superset/dashboard/21/

e.g. https://bi.ol.mit.edu/superset/dashboard/7b9f141d-14d2-40c6-aa01-fef8a0375ce8/?native_filters_key=rAQccwWFOGMQ7d_Hhl7vgisLgmMoMkxYluKFvTk1wbu_-FqhMc1t3g2QtVUnmXMA

### Description (What does it do?)
<!--- Describe your changes in detail -->
Adding product_readable_id to marts__combined__orders. Currently, there are program and courserun orders from xPro, but we don't have the program identifier in this table. The new product_readable_id corresponds to product_type in marts__combined__orders, which is now populated for program and courserun.

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

dbt build --select marts__combined__orders

```
select * from "ol_data_lake_production"."ol_warehouse_production_rlougee_mart".marts__combined__orders
where product_type ='program'
```
