### PR TITLE
Add Dagster Assets to Extract Open edX Course Structures data

### DIFF
--- a/src/ol_orchestrate/assets/openedx.py
+++ b/src/ol_orchestrate/assets/openedx.py
@@ -1,0 +1,166 @@
+# - Query the openedx api to get course structures and course blocks data
+# - Model the different asset objects according to their type
+
+import hashlib
+import json
+from datetime import UTC, datetime
+from pathlib import Path
+
+import jsonlines
+from dagster import (
+    AssetExecutionContext,
+    AssetIn,
+    AssetKey,
+    AssetOut,
+    AutoMaterializePolicy,
+    Config,
+    DagsterEventType,
+    DataVersion,
+    EventRecordsFilter,
+    Output,
+    asset,
+    multi_asset,
+)
+from flatten_dict import flatten
+from flatten_dict.reducers import make_reducer
+from pydantic import Field
+from upath import UPath
+
+from ol_orchestrate.lib.openedx import un_nest_course_structure
+
+
+@asset(
+    key=AssetKey(("openedx", "raw_data", "course_list_config")),
+    # partitions_def=,
+    group_name="openedx",
+)
+class CourseListConfig(Config):
+    edx_course_api_page_size: int = Field(
+        default=100,
+        description="The number of records to return per API request. This can be "
+        "modified to address issues with rate limiting.",
+    )
+
+
+@asset(
+    # partitions_def=,
+    key=AssetKey(("openedx", "raw_data", "course_list")),
+    group_name="openedx",
+    io_manager_key="s3file_io_manager",
+    # todo: best practice for passing in the config for page_size?
+    ins={
+        "course_list_config": AssetIn(
+            key=AssetKey(("openedx", "raw_data", "course_list_config"))
+        )
+    },
+    auto_materialize_policy=AutoMaterializePolicy.eager(
+        max_materializations_per_minute=None
+    ),
+)
+def course_list(
+    context: AssetExecutionContext, config: Config
+):
+    course_ids = []
+    course_id_generator = context.resources.openedx.get_edx_course_ids(
+        page_size=config.edx_course_api_page_size,
+    )
+    for result_set in course_id_generator:
+        course_ids.extend([course["id"] for course in result_set])
+    yield Output(course_ids)
+
+@multi_asset(
+    outs={
+        "course_structure": AssetOut(
+            key=AssetKey(("openedx", "raw_data", "course_structure")),
+            io_manager_key="s3file_io_manager",
+            description=(
+                "A json file with the course structure information."
+            ),
+            auto_materialize_policy=AutoMaterializePolicy.eager(
+                max_materializations_per_minute=None
+            ),
+        ),
+        "course_blocks": AssetOut(
+            key=AssetKey(("openedx", "raw_data", "course_blocks")),
+            io_manager_key="s3file_io_manager",
+            description=(
+                "A json file containing the hierarchical representation"
+                "of the course structure information with course blocks."
+            ),
+            auto_materialize_policy=AutoMaterializePolicy.eager(
+                max_materializations_per_minute=None
+            ),
+        ),
+    },
+    ins={
+        "course_list": AssetIn(
+            key=AssetKey(("openedx", "raw_data", "course_list"))
+        )
+    },
+    # partitions_def=,
+    group_name="openedx",
+)
+def course_structure(
+    context: AssetExecutionContext, course_list: list[str],
+):
+    dagster_instance = context.instance
+    ## TODO: Is this correctly iterating over the list of course_ids?
+    input_asset_materialization_event =  dagster_instance.get_event_records(
+        event_records_filter=EventRecordsFilter(
+            asset_key=context.asset_key_for_input("course_list"),
+            event_type=DagsterEventType.ASSET_MATERIALIZATION,
+            asset_partitions=[context.partiton_key],
+        ),
+        limit=1,
+    )[0]
+    course_id = input_asset_materialization_event.asset_materialization.metadata[
+        "course_id"
+    ]
+    course_structure = context.resources.openedx.get_course_structure_document(
+        course_id
+    )
+    course_structure_document = json.load(course_structure.open())
+    data_version = hashlib.sha256(
+        json.dumps(course_structure_document).encode("utf-8")
+    ).hexdigest()
+    structures_file = Path(f"course_structures_{data_version}.json")
+    blocks_file = Path(f"course_blocks_{data_version}.json")
+    data_retrieval_timestamp = datetime.now(tz=UTC).isoformat()
+    with (
+        jsonlines.open(structures_file, mode="w") as structures,
+        jsonlines.open(blocks_file, mode="w") as blocks,
+    ):
+        table_row = {
+            "content_hash": hashlib.sha256(
+                json.dumps(course_structure_document).encode("utf-8")
+            ).hexdigest(),
+            "course_id": context.partition_key,
+            "course_structure": course_structure_document,
+            "course_structure_flattened": flatten(
+                course_structure_document,
+                reducer=make_reducer("__"),
+            ),
+            "retrieved_at": data_retrieval_timestamp,
+        }
+        structures.write(table_row)
+        for block in un_nest_course_structure(
+            course_id, course_structure_document, data_retrieval_timestamp
+        ):
+            blocks.write(block)
+    # todo: How do i get the open_edx_deployment from the context? instance?
+    structure_object_key = f"{context.open_edx_deployment}_openedx_extracts/course_structure/{context.partition_key}/course_structures_{data_version}.json" # noqa: E501
+    blocks_object_key = f"{context.open_edx_deployment}_openedx_extracts/course_blocks/{context.partition_key}/course_blocks_{data_version}.json" # noqa: E501
+    yield Output(
+        (structures_file, structure_object_key),
+        output_name="flattened_course_structure",
+        data_version=DataVersion(data_version),
+        metadata={"course_id": course_id, "object_key": structure_object_key},
+    )
+    yield Output(
+        (blocks_file, blocks_object_key),
+        output_name="course_blocks",
+        data_version=DataVersion(data_version),
+        metadata={
+            "course_id": course_id, "object_key": blocks_object_key,
+        },
+    )

--- a/src/ol_orchestrate/assets/openedx.py
+++ b/src/ol_orchestrate/assets/openedx.py
@@ -23,14 +23,10 @@ from flatten_dict import flatten
 from flatten_dict.reducers import make_reducer
 
 from ol_orchestrate.lib.openedx import un_nest_course_structure
-from ol_orchestrate.partitions.openedx import (
-    OPENEDX_COURSE_RUN_PARTITION,
-)
 
 
 @asset(
     key=AssetKey(["openedx", "courseware"]),
-    partitions_def=OPENEDX_COURSE_RUN_PARTITION,
     required_resource_keys={"openedx"},
     description=("An instance of courseware running in an Open edX environment."),
     automation_condition=AutomationCondition.on_cron(
@@ -74,7 +70,6 @@ def openedx_live_courseware(context: AssetExecutionContext):
         ),
     },
     ins={"courseware": AssetIn(key=AssetKey(["openedx", "courseware"]))},
-    partitions_def=OPENEDX_COURSE_RUN_PARTITION,
     group_name="openedx",
     required_resource_keys={"openedx"},
 )

--- a/src/ol_orchestrate/assets/openedx.py
+++ b/src/ol_orchestrate/assets/openedx.py
@@ -24,16 +24,12 @@ from dagster import (
 from flatten_dict import flatten
 from flatten_dict.reducers import make_reducer
 from pydantic import Field
-from upath import UPath
 
 from ol_orchestrate.lib.openedx import un_nest_course_structure
 
+course_list_asset_key = AssetKey(("openedx", "raw_data", "course_list")),
 
-@asset(
-    key=AssetKey(("openedx", "raw_data", "course_list_config")),
-    # partitions_def=,
-    group_name="openedx",
-)
+
 class CourseListConfig(Config):
     edx_course_api_page_size: int = Field(
         default=100,
@@ -44,22 +40,14 @@ class CourseListConfig(Config):
 
 @asset(
     # partitions_def=,
-    key=AssetKey(("openedx", "raw_data", "course_list")),
+    key=course_list_asset_key,
     group_name="openedx",
     io_manager_key="s3file_io_manager",
-    # todo: best practice for passing in the config for page_size?
-    ins={
-        "course_list_config": AssetIn(
-            key=AssetKey(("openedx", "raw_data", "course_list_config"))
-        )
-    },
     auto_materialize_policy=AutoMaterializePolicy.eager(
         max_materializations_per_minute=None
     ),
 )
-def course_list(
-    context: AssetExecutionContext, config: Config
-):
+def course_list(context: AssetExecutionContext, config: CourseListConfig):
     course_ids = []
     course_id_generator = context.resources.openedx.get_edx_course_ids(
         page_size=config.edx_course_api_page_size,
@@ -68,14 +56,13 @@ def course_list(
         course_ids.extend([course["id"] for course in result_set])
     yield Output(course_ids)
 
+
 @multi_asset(
     outs={
         "course_structure": AssetOut(
             key=AssetKey(("openedx", "raw_data", "course_structure")),
             io_manager_key="s3file_io_manager",
-            description=(
-                "A json file with the course structure information."
-            ),
+            description=("A json file with the course structure information."),
             auto_materialize_policy=AutoMaterializePolicy.eager(
                 max_materializations_per_minute=None
             ),
@@ -92,20 +79,17 @@ def course_list(
             ),
         ),
     },
-    ins={
-        "course_list": AssetIn(
-            key=AssetKey(("openedx", "raw_data", "course_list"))
-        )
-    },
+    ins={"course_list": AssetIn(key=AssetKey(("openedx", "raw_data", "course_list")))},
     # partitions_def=,
     group_name="openedx",
 )
 def course_structure(
-    context: AssetExecutionContext, course_list: list[str],
+    context: AssetExecutionContext,
+    course_list: list[str],
 ):
     dagster_instance = context.instance
     ## TODO: Is this correctly iterating over the list of course_ids?
-    input_asset_materialization_event =  dagster_instance.get_event_records(
+    input_asset_materialization_event = dagster_instance.get_event_records(
         event_records_filter=EventRecordsFilter(
             asset_key=context.asset_key_for_input("course_list"),
             event_type=DagsterEventType.ASSET_MATERIALIZATION,
@@ -147,9 +131,9 @@ def course_structure(
             course_id, course_structure_document, data_retrieval_timestamp
         ):
             blocks.write(block)
-    # todo: How do i get the open_edx_deployment from the context? instance?
-    structure_object_key = f"{context.open_edx_deployment}_openedx_extracts/course_structure/{context.partition_key}/course_structures_{data_version}.json" # noqa: E501
-    blocks_object_key = f"{context.open_edx_deployment}_openedx_extracts/course_blocks/{context.partition_key}/course_blocks_{data_version}.json" # noqa: E501
+    # TODO: How do i get the open_edx_deployment from the context? instance?
+    structure_object_key = f"{context.open_edx_deployment}_openedx_extracts/course_structure/{context.partition_key}/course_structures_{data_version}.json"  # noqa: E501
+    blocks_object_key = f"{context.open_edx_deployment}_openedx_extracts/course_blocks/{context.partition_key}/course_blocks_{data_version}.json"  # noqa: E501
     yield Output(
         (structures_file, structure_object_key),
         output_name="flattened_course_structure",
@@ -161,6 +145,7 @@ def course_structure(
         output_name="course_blocks",
         data_version=DataVersion(data_version),
         metadata={
-            "course_id": course_id, "object_key": blocks_object_key,
+            "course_id": course_id,
+            "object_key": blocks_object_key,
         },
     )

--- a/src/ol_orchestrate/assets/openedx.py
+++ b/src/ol_orchestrate/assets/openedx.py
@@ -74,13 +74,11 @@ def openedx_live_courseware(context: AssetExecutionContext):
     required_resource_keys={"openedx"},
 )
 def course_structure(context: AssetExecutionContext, courseware):  # noqa: ARG001
-    partition_dimensions = context.partition_key.keys_by_dimension()
     source_system = context.resources.openedx.deployment
-    course_id = partition_dimensions["course_key"]
-    course_structure = context.resources.openedx.client.get_course_structure_document(
-        course_id
+    course_id = context.partition_key
+    course_structure_document = (
+        context.resources.openedx.client.get_course_structure_document(course_id)
     )
-    course_structure_document = json.load(course_structure.open())
     data_version = hashlib.sha256(
         json.dumps(course_structure_document).encode("utf-8")
     ).hexdigest()
@@ -112,7 +110,7 @@ def course_structure(context: AssetExecutionContext, courseware):  # noqa: ARG00
     blocks_object_key = f"{source_system}_openedx_extracts/course_blocks/{course_id}/course_blocks_{data_version}.json"  # noqa: E501
     yield Output(
         (structures_file, structure_object_key),
-        output_name="flattened_course_structure",
+        output_name="course_structure",
         data_version=DataVersion(data_version),
         metadata={"course_id": course_id, "object_key": structure_object_key},
     )

--- a/src/ol_orchestrate/assets/openedx.py
+++ b/src/ol_orchestrate/assets/openedx.py
@@ -24,12 +24,17 @@ from dagster import (
 from flatten_dict import flatten
 from flatten_dict.reducers import make_reducer
 from pydantic import Field
+from upath import UPath
 
 from ol_orchestrate.lib.openedx import un_nest_course_structure
 
 course_list_asset_key = AssetKey(("openedx", "raw_data", "course_list")),
 
-
+@asset(
+    key=AssetKey(("openedx", "raw_data", "course_list_config")),
+    # partitions_def=,
+    group_name="openedx",
+)
 class CourseListConfig(Config):
     edx_course_api_page_size: int = Field(
         default=100,
@@ -56,13 +61,14 @@ def course_list(context: AssetExecutionContext, config: CourseListConfig):
         course_ids.extend([course["id"] for course in result_set])
     yield Output(course_ids)
 
-
 @multi_asset(
     outs={
         "course_structure": AssetOut(
             key=AssetKey(("openedx", "raw_data", "course_structure")),
             io_manager_key="s3file_io_manager",
-            description=("A json file with the course structure information."),
+            description=(
+                "A json file with the course structure information."
+            ),
             auto_materialize_policy=AutoMaterializePolicy.eager(
                 max_materializations_per_minute=None
             ),
@@ -79,17 +85,20 @@ def course_list(context: AssetExecutionContext, config: CourseListConfig):
             ),
         ),
     },
-    ins={"course_list": AssetIn(key=AssetKey(("openedx", "raw_data", "course_list")))},
+    ins={
+        "course_list": AssetIn(
+            key=AssetKey(("openedx", "raw_data", "course_list"))
+        )
+    },
     # partitions_def=,
     group_name="openedx",
 )
 def course_structure(
-    context: AssetExecutionContext,
-    course_list: list[str],
+    context: AssetExecutionContext, course_list: list[str],
 ):
     dagster_instance = context.instance
     ## TODO: Is this correctly iterating over the list of course_ids?
-    input_asset_materialization_event = dagster_instance.get_event_records(
+    input_asset_materialization_event =  dagster_instance.get_event_records(
         event_records_filter=EventRecordsFilter(
             asset_key=context.asset_key_for_input("course_list"),
             event_type=DagsterEventType.ASSET_MATERIALIZATION,
@@ -131,9 +140,9 @@ def course_structure(
             course_id, course_structure_document, data_retrieval_timestamp
         ):
             blocks.write(block)
-    # TODO: How do i get the open_edx_deployment from the context? instance?
-    structure_object_key = f"{context.open_edx_deployment}_openedx_extracts/course_structure/{context.partition_key}/course_structures_{data_version}.json"  # noqa: E501
-    blocks_object_key = f"{context.open_edx_deployment}_openedx_extracts/course_blocks/{context.partition_key}/course_blocks_{data_version}.json"  # noqa: E501
+    # todo: How do i get the open_edx_deployment from the context? instance?
+    structure_object_key = f"{context.open_edx_deployment}_openedx_extracts/course_structure/{context.partition_key}/course_structures_{data_version}.json" # noqa: E501
+    blocks_object_key = f"{context.open_edx_deployment}_openedx_extracts/course_blocks/{context.partition_key}/course_blocks_{data_version}.json" # noqa: E501
     yield Output(
         (structures_file, structure_object_key),
         output_name="flattened_course_structure",
@@ -145,7 +154,6 @@ def course_structure(
         output_name="course_blocks",
         data_version=DataVersion(data_version),
         metadata={
-            "course_id": course_id,
-            "object_key": blocks_object_key,
+            "course_id": course_id, "object_key": blocks_object_key,
         },
     )

--- a/src/ol_orchestrate/definitions/edx/openedx_data_extract.py
+++ b/src/ol_orchestrate/definitions/edx/openedx_data_extract.py
@@ -1,26 +1,16 @@
 from typing import Literal
 
-from dagster import (
-AssetSelection,
-    Definitions,
-    ScheduleDefinition,
-define_asset_job
-)
-from dagster_aws.s3 import S3Resource
+from dagster import AssetSelection, Definitions, ScheduleDefinition, define_asset_job
 
-from ol_orchestrate.assets.edxorg_archive import (
-    CourseListConfig,
+from ol_orchestrate.assets.openedx import (
     course_list,
     course_structure,
 )
-
 from ol_orchestrate.io_managers.filepath import (
     S3FileObjectIOManager,
 )
-from ol_orchestrate.jobs.open_edx import extract_open_edx_data_to_ol_data_platform
 from ol_orchestrate.lib.constants import DAGSTER_ENV, VAULT_ADDRESS
 from ol_orchestrate.resources.openedx import OpenEdxApiClient
-from ol_orchestrate.resources.outputs import DailyResultsDir
 from ol_orchestrate.resources.secrets.vault import Vault
 
 if DAGSTER_ENV == "dev":
@@ -64,30 +54,6 @@ def open_edx_extract_job_config(
     }
 
 
-ol_extract_jobs = [
-    extract_open_edx_data_to_ol_data_platform.to_job(
-        resource_defs={
-            "results_dir": DailyResultsDir(),
-            "s3_upload": S3Resource(),
-            "s3": S3Resource(),
-            "openedx": OpenEdxApiClient.configure_at_launch(),
-        },
-        name=f"extract_{deployment}_open_edx_data_to_data_platform",
-        config=open_edx_extract_job_config(deployment, DAGSTER_ENV),  # type: ignore[arg-type]
-    )
-    for deployment in ("residential", "xpro", "mitxonline")
-]
-
-openedx_data_extracts = Definitions(
-    jobs=ol_extract_jobs,
-    schedules=[
-        ScheduleDefinition(
-            name=f"{job.name}_nightly", cron_schedule="0 0 * * *", job=job
-        )
-        for job in ol_extract_jobs
-    ],
-)
-
 def s3_uploads_bucket(
     dagster_env: Literal["dev", "qa", "production"],
 ) -> dict[str, Any]:
@@ -100,6 +66,7 @@ def s3_uploads_bucket(
         },
     }
     return bucket_map[dagster_env]
+
 
 def edxorg_data_archive_config(dagster_env):
     return {
@@ -114,26 +81,35 @@ def edxorg_data_archive_config(dagster_env):
     }
 
 
-openedx_course_structures_job = extract_open_edx_data_to_ol_data_platform.to_job(
+openedx_course_structures_job = define_asset_job(
     name="extract_open_edx_data_to_ol_data_platform",
-    config=edxorg_data_archive_config(DAGSTER_ENV),
-    selection=AssetSelection.assets(CourseListConfig, course_list, course_structure),
+    config=open_edx_extract_job_config(DAGSTER_ENV),
+    selection=AssetSelection.assets(course_list).downstream(),
+    # only include direct descendants
+    depth=1,
+    include_self=True,
 )
+
 
 retrieve_openedx_course_data = Definitions(
     resources={
-        "s3": S3Resource(),
-        "exports_dir": DailyResultsDir.configure_at_launch(),
-        "s3file_io_manager": S3FileObjectIOManager(
+        "io_manager": S3FileObjectIOManager(
             bucket=s3_uploads_bucket(DAGSTER_ENV)["bucket"],
             path_prefix=s3_uploads_bucket(DAGSTER_ENV)["prefix"],
         ),
         "vault": vault,
+        "openedx": OpenEdxApiClient.configure_at_launch(),
     },
     jobs=[openedx_course_structures_job],
     assets=[
-        CourseListConfig,
         course_list,
         course_structure,
+    ],
+    schedules=[
+        ScheduleDefinition(
+            name=f"{openedx_course_structures_job.name}_nightly",
+            cron_schedule="0 0 * * *",
+            job=openedx_course_structures_job,
+        )
     ],
 )

--- a/src/ol_orchestrate/definitions/edx/openedx_data_extract.py
+++ b/src/ol_orchestrate/definitions/edx/openedx_data_extract.py
@@ -1,16 +1,26 @@
 from typing import Literal
 
-from dagster import AssetSelection, Definitions, ScheduleDefinition, define_asset_job
+from dagster import (
+AssetSelection,
+    Definitions,
+    ScheduleDefinition,
+define_asset_job
+)
+from dagster_aws.s3 import S3Resource
 
-from ol_orchestrate.assets.openedx import (
+from ol_orchestrate.assets.edxorg_archive import (
+    CourseListConfig,
     course_list,
     course_structure,
 )
+
 from ol_orchestrate.io_managers.filepath import (
     S3FileObjectIOManager,
 )
+from ol_orchestrate.jobs.open_edx import extract_open_edx_data_to_ol_data_platform
 from ol_orchestrate.lib.constants import DAGSTER_ENV, VAULT_ADDRESS
 from ol_orchestrate.resources.openedx import OpenEdxApiClient
+from ol_orchestrate.resources.outputs import DailyResultsDir
 from ol_orchestrate.resources.secrets.vault import Vault
 
 if DAGSTER_ENV == "dev":
@@ -54,6 +64,30 @@ def open_edx_extract_job_config(
     }
 
 
+ol_extract_jobs = [
+    extract_open_edx_data_to_ol_data_platform.to_job(
+        resource_defs={
+            "results_dir": DailyResultsDir(),
+            "s3_upload": S3Resource(),
+            "s3": S3Resource(),
+            "openedx": OpenEdxApiClient.configure_at_launch(),
+        },
+        name=f"extract_{deployment}_open_edx_data_to_data_platform",
+        config=open_edx_extract_job_config(deployment, DAGSTER_ENV),  # type: ignore[arg-type]
+    )
+    for deployment in ("residential", "xpro", "mitxonline")
+]
+
+openedx_data_extracts = Definitions(
+    jobs=ol_extract_jobs,
+    schedules=[
+        ScheduleDefinition(
+            name=f"{job.name}_nightly", cron_schedule="0 0 * * *", job=job
+        )
+        for job in ol_extract_jobs
+    ],
+)
+
 def s3_uploads_bucket(
     dagster_env: Literal["dev", "qa", "production"],
 ) -> dict[str, Any]:
@@ -66,7 +100,6 @@ def s3_uploads_bucket(
         },
     }
     return bucket_map[dagster_env]
-
 
 def edxorg_data_archive_config(dagster_env):
     return {
@@ -81,35 +114,26 @@ def edxorg_data_archive_config(dagster_env):
     }
 
 
-openedx_course_structures_job = define_asset_job(
+openedx_course_structures_job = extract_open_edx_data_to_ol_data_platform.to_job(
     name="extract_open_edx_data_to_ol_data_platform",
-    config=open_edx_extract_job_config(DAGSTER_ENV),
-    selection=AssetSelection.assets(course_list).downstream(),
-    # only include direct descendants
-    depth=1,
-    include_self=True,
+    config=edxorg_data_archive_config(DAGSTER_ENV),
+    selection=AssetSelection.assets(CourseListConfig, course_list, course_structure),
 )
-
 
 retrieve_openedx_course_data = Definitions(
     resources={
-        "io_manager": S3FileObjectIOManager(
+        "s3": S3Resource(),
+        "exports_dir": DailyResultsDir.configure_at_launch(),
+        "s3file_io_manager": S3FileObjectIOManager(
             bucket=s3_uploads_bucket(DAGSTER_ENV)["bucket"],
             path_prefix=s3_uploads_bucket(DAGSTER_ENV)["prefix"],
         ),
         "vault": vault,
-        "openedx": OpenEdxApiClient.configure_at_launch(),
     },
     jobs=[openedx_course_structures_job],
     assets=[
+        CourseListConfig,
         course_list,
         course_structure,
-    ],
-    schedules=[
-        ScheduleDefinition(
-            name=f"{openedx_course_structures_job.name}_nightly",
-            cron_schedule="0 0 * * *",
-            job=openedx_course_structures_job,
-        )
     ],
 )

--- a/src/ol_orchestrate/definitions/edx/openedx_data_extract.py
+++ b/src/ol_orchestrate/definitions/edx/openedx_data_extract.py
@@ -8,7 +8,8 @@ from ol_orchestrate.assets.openedx import course_structure, openedx_live_coursew
 from ol_orchestrate.io_managers.filepath import (
     S3FileObjectIOManager,
 )
-from ol_orchestrate.lib.constants import DAGSTER_ENV, VAULT_ADDRESS
+from ol_orchestrate.lib.assets_helper import add_prefix_to_asset_keys
+from ol_orchestrate.lib.constants import DAGSTER_ENV, OPENEDX_DEPLOYMENTS, VAULT_ADDRESS
 from ol_orchestrate.resources.openedx import OpenEdxApiClientFactory
 from ol_orchestrate.resources.secrets.vault import Vault
 from ol_orchestrate.sensors.openedx import course_run_sensor
@@ -24,7 +25,7 @@ else:
 
 
 def open_edx_extract_job_config(
-    open_edx_deployment: Literal["mitx", "mitxonline", "xpro"],
+    open_edx_deployment: OPENEDX_DEPLOYMENTS,
     dagster_env: Literal["qa", "production"],
 ):
     client = vault.client.secrets.kv.v1.read_secret(
@@ -81,12 +82,12 @@ def edxorg_data_archive_config(dagster_env):
     }
 
 
-for deployment_name in ["mitx", "mitxonline", "xpro"]:
+for deployment_name in OPENEDX_DEPLOYMENTS:
     locals()[f"{deployment_name}_openedx_assets_definition"] = (
         create_repository_using_definitions_args(
             name=f"{deployment_name}_openedx_assets",
             resources={
-                "io_manager": S3FileObjectIOManager(
+                "s3file_io_manager": S3FileObjectIOManager(
                     bucket=s3_uploads_bucket(DAGSTER_ENV)["bucket"],
                     path_prefix=s3_uploads_bucket(DAGSTER_ENV)["prefix"],
                 ),
@@ -96,8 +97,8 @@ for deployment_name in ["mitx", "mitxonline", "xpro"]:
                 ),
             },
             assets=[
-                openedx_live_courseware,
-                course_structure,
+                add_prefix_to_asset_keys(openedx_live_courseware, deployment_name),
+                add_prefix_to_asset_keys(course_structure, deployment_name),
             ],
             sensors=[course_run_sensor],
         )

--- a/src/ol_orchestrate/definitions/edx/openedx_data_extract.py
+++ b/src/ol_orchestrate/definitions/edx/openedx_data_extract.py
@@ -8,8 +8,12 @@ from ol_orchestrate.assets.openedx import course_structure, openedx_live_coursew
 from ol_orchestrate.io_managers.filepath import (
     S3FileObjectIOManager,
 )
-from ol_orchestrate.lib.assets_helper import add_prefix_to_asset_keys
+from ol_orchestrate.lib.assets_helper import (
+    add_prefix_to_asset_keys,
+    late_bind_partition_to_asset,
+)
 from ol_orchestrate.lib.constants import DAGSTER_ENV, OPENEDX_DEPLOYMENTS, VAULT_ADDRESS
+from ol_orchestrate.partitions.openedx import OPENEDX_COURSE_RUN_PARTITIONS
 from ol_orchestrate.resources.openedx import OpenEdxApiClientFactory
 from ol_orchestrate.resources.secrets.vault import Vault
 from ol_orchestrate.sensors.openedx import course_run_sensor
@@ -97,8 +101,14 @@ for deployment_name in OPENEDX_DEPLOYMENTS:
                 ),
             },
             assets=[
-                add_prefix_to_asset_keys(openedx_live_courseware, deployment_name),
-                add_prefix_to_asset_keys(course_structure, deployment_name),
+                late_bind_partition_to_asset(
+                    add_prefix_to_asset_keys(openedx_live_courseware, deployment_name),
+                    OPENEDX_COURSE_RUN_PARTITIONS[deployment_name],
+                ),
+                late_bind_partition_to_asset(
+                    add_prefix_to_asset_keys(course_structure, deployment_name),
+                    OPENEDX_COURSE_RUN_PARTITIONS[deployment_name],
+                ),
             ],
             sensors=[course_run_sensor],
         )

--- a/src/ol_orchestrate/jobs/open_edx.py
+++ b/src/ol_orchestrate/jobs/open_edx.py
@@ -4,24 +4,17 @@ from ol_orchestrate.lib.hooks import (
     notify_healthchecks_io_on_failure,
     notify_healthchecks_io_on_success,
 )
-from ol_orchestrate.ops.object_storage import upload_files_to_s3
 from ol_orchestrate.ops.open_edx import (
     course_enrollments,
     course_roles,
     enrolled_users,
     export_edx_courses,
     export_edx_forum_database,
-    fetch_edx_course_structure_from_api,
     list_courses,
     student_submissions,
     upload_extracted_data,
     user_roles,
     write_course_list_csv,
-)
-from ol_orchestrate.assets.open_edx import (
-    course_list,
-    course_structure,
-    course_list_asset_key,
 )
 
 
@@ -58,20 +51,3 @@ def edx_course_pipeline():
             notify_healthchecks_io_on_failure,
         }
     )(course_list, extracts_upload)
-
-
-@graph(
-    name="mitol_openedx_data_extracts",
-    description=(
-        "Extract data from Open edX installations for consumption by the "
-        "Open Learning data platform."
-    ),
-    tags={
-        "source": "Open edX",
-        "destination": "s3",
-        "owner": "platform-engineering",
-        "consumer": "ol-data-platform",
-    },
-)
-def extract_open_edx_data_to_ol_data_platform():
-    course_structure(course_list())

--- a/src/ol_orchestrate/jobs/open_edx.py
+++ b/src/ol_orchestrate/jobs/open_edx.py
@@ -1,9 +1,5 @@
 from dagster import graph
 
-from ol_orchestrate.assets.open_edx import (
-    course_list,
-    course_structure,
-)
 from ol_orchestrate.lib.hooks import (
     notify_healthchecks_io_on_failure,
     notify_healthchecks_io_on_success,

--- a/src/ol_orchestrate/jobs/open_edx.py
+++ b/src/ol_orchestrate/jobs/open_edx.py
@@ -18,6 +18,11 @@ from ol_orchestrate.ops.open_edx import (
     user_roles,
     write_course_list_csv,
 )
+from ol_orchestrate.assets.open_edx import (
+    course_list,
+    course_structure,
+    course_list_asset_key,
+)
 
 
 @graph(
@@ -69,6 +74,4 @@ def edx_course_pipeline():
     },
 )
 def extract_open_edx_data_to_ol_data_platform():
-    fetch_edx_course_structure_from_api(list_courses()).map(
-        lambda fpath: upload_files_to_s3(fpath)
-    )
+    course_structure(course_list())

--- a/src/ol_orchestrate/jobs/open_edx.py
+++ b/src/ol_orchestrate/jobs/open_edx.py
@@ -1,5 +1,9 @@
 from dagster import graph
 
+from ol_orchestrate.assets.open_edx import (
+    course_list,
+    course_structure,
+)
 from ol_orchestrate.lib.hooks import (
     notify_healthchecks_io_on_failure,
     notify_healthchecks_io_on_success,

--- a/src/ol_orchestrate/lib/assets_helper.py
+++ b/src/ol_orchestrate/lib/assets_helper.py
@@ -1,0 +1,25 @@
+from dagster import AssetsDefinition, PartitionsDefinition
+
+
+def late_bind_partition_to_asset(
+    asset_def: AssetsDefinition, partition_def: PartitionsDefinition
+) -> AssetsDefinition:
+    asset_def._partitions_def = partition_def  # noqa: SLF001
+    return asset_def
+
+
+def add_prefix_to_asset_keys(
+    asset_def: AssetsDefinition, asset_key_prefix: str
+) -> AssetsDefinition:
+    in_key_map = {
+        dep_key: dep_key.with_prefix(asset_key_prefix)
+        for dep_key in asset_def.dependency_keys
+    }
+    out_key_map = {
+        out_key: out_key.with_prefix(asset_key_prefix) for out_key in asset_def.keys
+    }
+
+    return asset_def.with_attributes(
+        output_asset_key_replacements=out_key_map,
+        input_asset_key_replacements=in_key_map,
+    )

--- a/src/ol_orchestrate/lib/constants.py
+++ b/src/ol_orchestrate/lib/constants.py
@@ -9,3 +9,5 @@ if DAGSTER_ENV == "dev":
     VAULT_ADDRESS = os.getenv("VAULT_ADDR", "https://vault-qa.odl.mit.edu")
 else:
     VAULT_ADDRESS = os.getenv("VAULT_ADDR", f"https://vault-{DAGSTER_ENV}.odl.mit.edu")
+
+OPENEDX_DEPLOYMENTS = ["mitx", "mitxonline", "xpro"]

--- a/src/ol_orchestrate/lib/dagster_helpers.py
+++ b/src/ol_orchestrate/lib/dagster_helpers.py
@@ -1,5 +1,11 @@
 import re
 
+from dagster._core.definitions.partition import INVALID_PARTITION_SUBSTRINGS
+
 
 def sanitize_mapping_key(mapping_key: str, replacement: str = "__") -> str:
     return re.sub(r"[^A-Za-z0-9_]", replacement, mapping_key)
+
+
+def contains_invalid_partition_strings(partition_key: str) -> bool:
+    return any(substr in partition_key for substr in INVALID_PARTITION_SUBSTRINGS)

--- a/src/ol_orchestrate/partitions/openedx.py
+++ b/src/ol_orchestrate/partitions/openedx.py
@@ -1,16 +1,12 @@
 from dagster import (
     DynamicPartitionsDefinition,
-    MultiPartitionsDefinition,
     StaticPartitionsDefinition,
 )
 
-OPENEDX_DEPLOYMENT_PARTITION = StaticPartitionsDefinition(
-    ["mitxonline", "xpro", "mitx"]
-)
-OPENEDX_COURSE_RUN_PARTITION = DynamicPartitionsDefinition(name="openedx_course_run")
-OPENEDX_COURSE_AND_SOURCE_PARTITION = MultiPartitionsDefinition(
-    {
-        "source_system": OPENEDX_DEPLOYMENT_PARTITION,
-        "course_key": OPENEDX_COURSE_RUN_PARTITION,
-    }
-)
+from ol_orchestrate.lib.constants import OPENEDX_DEPLOYMENTS
+
+OPENEDX_DEPLOYMENT_PARTITION = StaticPartitionsDefinition(OPENEDX_DEPLOYMENTS)
+OPENEDX_COURSE_RUN_PARTITIONS = {
+    deployment: DynamicPartitionsDefinition(name=f"{deployment}_openedx_course_run")
+    for deployment in OPENEDX_DEPLOYMENTS
+}

--- a/src/ol_orchestrate/partitions/openedx.py
+++ b/src/ol_orchestrate/partitions/openedx.py
@@ -1,0 +1,16 @@
+from dagster import (
+    DynamicPartitionsDefinition,
+    MultiPartitionsDefinition,
+    StaticPartitionsDefinition,
+)
+
+OPENEDX_DEPLOYMENT_PARTITION = StaticPartitionsDefinition(
+    ["mitxonline", "xpro", "mitx"]
+)
+OPENEDX_COURSE_RUN_PARTITION = DynamicPartitionsDefinition(name="openedx_course_run")
+OPENEDX_COURSE_AND_SOURCE_PARTITION = MultiPartitionsDefinition(
+    {
+        "source_system": OPENEDX_DEPLOYMENT_PARTITION,
+        "course_key": OPENEDX_COURSE_RUN_PARTITION,
+    }
+)

--- a/src/ol_orchestrate/sensors/openedx.py
+++ b/src/ol_orchestrate/sensors/openedx.py
@@ -6,7 +6,7 @@ from dagster import (
 
 from ol_orchestrate.lib.dagster_helpers import contains_invalid_partition_strings
 from ol_orchestrate.partitions.openedx import (
-    OPENEDX_COURSE_RUN_PARTITION,
+    OPENEDX_COURSE_RUN_PARTITIONS,
 )
 from ol_orchestrate.resources.openedx import OpenEdxApiClientFactory
 
@@ -33,14 +33,14 @@ def course_run_sensor(
             ]
         )
     existing_keys = set(
-        OPENEDX_COURSE_RUN_PARTITION.get_partition_keys(
+        OPENEDX_COURSE_RUN_PARTITIONS[openedx.deployment].get_partition_keys(
             dynamic_partitions_store=context.instance
         )
     )
     new_course_run_ids = set(course_run_ids) - existing_keys
     return SensorResult(
         dynamic_partitions_requests=[
-            OPENEDX_COURSE_RUN_PARTITION.build_add_request(
+            OPENEDX_COURSE_RUN_PARTITIONS[openedx.deployment].build_add_request(
                 partition_keys=list(new_course_run_ids)
             )
         ],

--- a/src/ol_orchestrate/sensors/openedx.py
+++ b/src/ol_orchestrate/sensors/openedx.py
@@ -1,0 +1,77 @@
+import httpx
+from dagster import (
+    AssetKey,
+    AssetMaterialization,
+    MultiPartitionKey,
+    SensorEvaluationContext,
+    SensorResult,
+    sensor,
+)
+from dagster._core.definitions.data_version import DATA_VERSION_TAG
+
+from ol_orchestrate.partitions.openedx import (
+    OPENEDX_COURSE_RUN_PARTITION,
+)
+from ol_orchestrate.resources.openedx import OpenEdxApiClientFactory
+
+
+@sensor(
+    name="openedx_courseware_sensor",
+    minimum_interval_seconds=60 * 60,
+    description="Query a running Open edX system for courseware definitions "
+    "and version changes.",
+)
+def course_run_sensor(
+    context: SensorEvaluationContext,
+    openedx: OpenEdxApiClientFactory,
+):
+    # Enumerate the course-run IDs from edX via the API
+    course_id_generator = openedx.client.get_edx_course_ids()
+    course_run_ids = []
+    for result_set in course_id_generator:
+        course_run_ids.extend([course["id"] for course in result_set])
+    existing_keys = set(
+        OPENEDX_COURSE_RUN_PARTITION.get_partition_keys(
+            dynamic_partitions_store=context.instance
+        )
+    )
+
+    # For each courserun ID retrieve the last published timestamp from
+    # /learning_sequences/v1/course_outline/{course_key_str}. Yield an
+    # AssetMaterialization event for each course key, using the last published
+    # information as the data version
+    assets = []
+    for courserun_id in set(course_run_ids).difference(existing_keys):
+        try:
+            course_outline = openedx.client.get_course_outline(courserun_id)
+        except httpx.HTTPStatusError:
+            context.log.info(
+                "Unable to retrieve the course outline for %s", courserun_id
+            )
+            continue
+        course_asset = AssetMaterialization(
+            asset_key=AssetKey(["openedx", "courseware"]),
+            description=(
+                f"An instance of courseware running in an Open edX environment located at {openedx.client.lms_url}"  # noqa: E501
+            ),
+            partition=MultiPartitionKey(
+                {"source_system": openedx.deployment, "course_key": courserun_id}
+            ),
+            tags={
+                DATA_VERSION_TAG: course_outline["published_version"],
+            },
+            metadata={
+                "course_key": courserun_id,
+                "course_title": course_outline["title"],
+                "courseware_published_version": course_outline["published_version"],
+                "courseware_published_at": course_outline["published_at"],
+            },
+        )
+        assets.append(course_asset)
+
+    return SensorResult(
+        assets=assets,
+        dynamic_partitions_requests=OPENEDX_COURSE_RUN_PARTITION.build_add_request(
+            partition_keys=course_run_ids
+        ),
+    )

--- a/src/ol_orchestrate/sensors/openedx.py
+++ b/src/ol_orchestrate/sensors/openedx.py
@@ -1,14 +1,10 @@
-import httpx
 from dagster import (
-    AssetKey,
-    AssetMaterialization,
-    MultiPartitionKey,
     SensorEvaluationContext,
     SensorResult,
     sensor,
 )
-from dagster._core.definitions.data_version import DATA_VERSION_TAG
 
+from ol_orchestrate.lib.dagster_helpers import contains_invalid_partition_strings
 from ol_orchestrate.partitions.openedx import (
     OPENEDX_COURSE_RUN_PARTITION,
 )
@@ -29,49 +25,23 @@ def course_run_sensor(
     course_id_generator = openedx.client.get_edx_course_ids()
     course_run_ids = []
     for result_set in course_id_generator:
-        course_run_ids.extend([course["id"] for course in result_set])
+        course_run_ids.extend(
+            [
+                course["id"]
+                for course in result_set
+                if not contains_invalid_partition_strings(course["id"])
+            ]
+        )
     existing_keys = set(
         OPENEDX_COURSE_RUN_PARTITION.get_partition_keys(
             dynamic_partitions_store=context.instance
         )
     )
-
-    # For each courserun ID retrieve the last published timestamp from
-    # /learning_sequences/v1/course_outline/{course_key_str}. Yield an
-    # AssetMaterialization event for each course key, using the last published
-    # information as the data version
-    assets = []
-    for courserun_id in set(course_run_ids).difference(existing_keys):
-        try:
-            course_outline = openedx.client.get_course_outline(courserun_id)
-        except httpx.HTTPStatusError:
-            context.log.info(
-                "Unable to retrieve the course outline for %s", courserun_id
-            )
-            continue
-        course_asset = AssetMaterialization(
-            asset_key=AssetKey(["openedx", "courseware"]),
-            description=(
-                f"An instance of courseware running in an Open edX environment located at {openedx.client.lms_url}"  # noqa: E501
-            ),
-            partition=MultiPartitionKey(
-                {"source_system": openedx.deployment, "course_key": courserun_id}
-            ),
-            tags={
-                DATA_VERSION_TAG: course_outline["published_version"],
-            },
-            metadata={
-                "course_key": courserun_id,
-                "course_title": course_outline["title"],
-                "courseware_published_version": course_outline["published_version"],
-                "courseware_published_at": course_outline["published_at"],
-            },
-        )
-        assets.append(course_asset)
-
+    new_course_run_ids = set(course_run_ids) - existing_keys
     return SensorResult(
-        assets=assets,
-        dynamic_partitions_requests=OPENEDX_COURSE_RUN_PARTITION.build_add_request(
-            partition_keys=course_run_ids
-        ),
+        dynamic_partitions_requests=[
+            OPENEDX_COURSE_RUN_PARTITION.build_add_request(
+                partition_keys=list(new_course_run_ids)
+            )
+        ],
     )


### PR DESCRIPTION
Refactoring the openedx course structures pipeline code to Dagster assets.
Added a course_list asset and a course_structure multi asset that will produce the course_blocks and course_structures files. Utilizing the existing s3 io_manager to handle the asset oriented files and using data versioning to better organize the uploaded files. Still need to update the actual job to call these new components. Leaving the existing openedx ops alone since the edx_course_pipeline graph job still requires them and we do not want to disrupt downstream consumers of that data like Jon.

### What are the relevant tickets?
Addresses https://github.com/mitodl/hq/issues/4465

### Description (What does it do?)
We are seeing a mix of data from different openedx deployments in the course_structures and course_blocks data in our data lake. As it is, we are pulling a list of course_ids and using that to query the Open edX REST API to retrieve the course_structure and course_blocks data. It appears that both mitxonline and xpro courses are being pulled when this happens as the files in both mitxonline_openedx_extracts and xpro_openedx_extracts in S3 (ol-data-lake-landing-zone-production) are identical.

Without modifying the existing code that handles generating the list of courses and queries the Open edX instances for the course structures data (because we have other downstream consumers of the data produced by the edx_course_pipeline), we want to put up new Dagster assets to handle generating the list of courses and pulling and flattening the course_structures data. This PR adds a new file that contains openedx Dagster assets.

### How can this be tested?
Try running the pipeline locally.
```
export GITHUB_TOKEN=<your_token>
dagster dev -f src/ol_orchestrate/definitions/edx/openedx_data_extract.py
```
Once the code is merged, test on Dagster QA.

### Checklist:
- [ ] Update the extract_open_edx_data_to_ol_data_platform graph in jobs/open_edx.py