### PR TITLE
Create combined product mart

### DIFF
--- a/src/ol_dbt/models/intermediate/mitxpro/_int_mitxpro__models.yml
+++ b/src/ol_dbt/models/intermediate/mitxpro/_int_mitxpro__models.yml
@@ -985,6 +985,12 @@ models:
     description: boolean, Public product is purchasable through the bulk form at /ecommerce/bulk
     tests:
     - not_null
+  - name: product_list_price
+    description: numeric, the latest list price for the product.
+    tests:
+    - not_null
+  - name: product_description
+    description: str, product description from the latest product version
   - name: courserun_id
     description: int, primary key representing a single xPro course run
   - name: courserun_readable_id

--- a/src/ol_dbt/models/intermediate/mitxpro/int__mitxpro__ecommerce_product.sql
+++ b/src/ol_dbt/models/intermediate/mitxpro/int__mitxpro__ecommerce_product.sql
@@ -18,6 +18,17 @@ with products as (
     from {{ ref('stg__mitxpro__app__postgres__courses_program') }}
 )
 
+, latest_productversion as (
+    select * from
+        (
+            select
+                *
+                , row_number() over (partition by product_id order by productversion_updated_on desc) as row_num
+            from {{ ref('stg__mitxpro__app__postgres__ecommerce_productversion') }}
+        ) as product
+    where row_num = 1
+)
+
 , product_subquery as (
     select
         products.product_id
@@ -42,9 +53,12 @@ with products as (
 
 select
     product_subquery.*
+    , latest_productversion.productversion_price as product_list_price
+    , latest_productversion.productversion_description as product_description
     , courseruns.course_id
     , courseruns.courserun_readable_id
     , programs.program_readable_id
 from product_subquery
+left join latest_productversion on product_subquery.product_id = latest_productversion.product_id
 left join courseruns on product_subquery.courserun_id = courseruns.courserun_id
 left join programs on product_subquery.program_id = programs.program_id

--- a/src/ol_dbt/models/marts/combined/_marts__combined__models.yml
+++ b/src/ol_dbt/models/marts/combined/_marts__combined__models.yml
@@ -398,7 +398,12 @@ models:
   description: combined course or program products from MITx Online and xPro
   columns:
   - name: platform
-    description: str, MITx Online or xPro
+    description: str, application where data is from - MITx Online or xPro
+    tests:
+    - not_null
+  - name: product_platform
+    description: str, indicating the partners for course/program. The possible values
+      are Emeritus, xPRO, Simplilearn, Global Alumni, WHU, Susskind and MITx Online.
     tests:
     - not_null
   - name: product_readable_id
@@ -410,27 +415,33 @@ models:
   - name: product_name
     description: str, title of the course run or program run
   - name: product_id
-    description: int, primary key from ecommerce_product on MITx Online and xPro
+    description: int, primary key from ecommerce_product on MITx Online or xPro
   - name: product_type
     description: str, either 'course run' or 'program run'
   - name: product_description
     description: str, product description
-  - name: product_platform
-    description: str, indicating the partners for course/program. The possible values
-      are Emeritus, xPRO, Simplilearn, Global Alumni, WHU, Susskind and MITx Online.
-    tests:
-    - not_null
-  - name: product_is_private
-    description: boolean, public product is purchasable
   - name: list_price
     description: numeric, the latest list price for the product.
     tests:
     - not_null
+  - name: product_is_active
+    description: boolean, indicating whether the product is visible at the checkout
+      page on MITx Online or xPro
+    tests:
+    - not_null
+  - name: product_is_private
+    description: boolean, indicating whether the product is public or private. Public
+      products are listed in the product drop-down on the bulk purchase form for xPro.
+    tests:
+    - not_null
+  - name: product_created_on
+    description: timestamp, date and time when the product was created on MITx Online
+      or xPro
   - name: start_date
-    description: timestamp, specifying when the course or program starts
+    description: timestamp, date and time when the course or program starts
   - name: end_date
-    description: timestamp, specifying when the course or program ends
+    description: timestamp, date and time when the course or program ends
   - name: enrollment_start
-    description: timestamp, specifying when the course or program enrollment starts
+    description: timestamp, date and time when the course or program enrollment starts
   - name: enrollment_end
-    description: timestamp, specifying when the course or program enrollment ends
+    description: timestamp, date and time when the course or program enrollment ends

--- a/src/ol_dbt/models/marts/combined/_marts__combined__models.yml
+++ b/src/ol_dbt/models/marts/combined/_marts__combined__models.yml
@@ -393,3 +393,44 @@ models:
   tests:
   - dbt_expectations.expect_compound_columns_to_be_unique:
       column_list: ["program_title", "user_username", "platform_name", "programenrollment_created_on"]
+
+- name: marts__combined__products
+  description: combined course or program products from MITx Online and xPro
+  columns:
+  - name: platform
+    description: str, MITx Online or xPro
+    tests:
+    - not_null
+  - name: product_readable_id
+    description: str, unique open edX Course ID formatted as course-v1:{org}+{course
+      code}+{run_tag} or program run ID formatted as program-v1:{org}+{program code}+{run_tag}
+    tests:
+    - not_null
+    - unique
+  - name: product_id
+    description: int, primary key from ecommerce_product on MITx Online and xPro
+  - name: product_description
+    description: str, product description
+  - name: product_name
+    description: str, title of the course run or program run
+  - name: product_type
+    description: str, either 'course run' or 'program run'
+  - name: product_platform
+    description: str, indicating the partners for course/program. The possible values
+      are Emeritus, xPRO, Simplilearn, Global Alumni, WHU, Susskind and MITx Online.
+    tests:
+    - not_null
+  - name: product_is_private
+    description: boolean, public product is purchasable
+  - name: list_price
+    description: numeric, the latest list price for the product.
+    tests:
+    - not_null
+  - name: start_date
+    description: timestamp, specifying when the course or program starts
+  - name: end_date
+    description: timestamp, specifying when the course or program ends
+  - name: enrollment_start
+    description: timestamp, specifying when the course or program enrollment starts
+  - name: enrollment_end
+    description: timestamp, specifying when the course or program enrollment ends

--- a/src/ol_dbt/models/marts/combined/_marts__combined__models.yml
+++ b/src/ol_dbt/models/marts/combined/_marts__combined__models.yml
@@ -407,14 +407,14 @@ models:
     tests:
     - not_null
     - unique
-  - name: product_id
-    description: int, primary key from ecommerce_product on MITx Online and xPro
-  - name: product_description
-    description: str, product description
   - name: product_name
     description: str, title of the course run or program run
+  - name: product_id
+    description: int, primary key from ecommerce_product on MITx Online and xPro
   - name: product_type
     description: str, either 'course run' or 'program run'
+  - name: product_description
+    description: str, product description
   - name: product_platform
     description: str, indicating the partners for course/program. The possible values
       are Emeritus, xPRO, Simplilearn, Global Alumni, WHU, Susskind and MITx Online.

--- a/src/ol_dbt/models/marts/combined/marts__combined__products.sql
+++ b/src/ol_dbt/models/marts/combined/marts__combined__products.sql
@@ -74,10 +74,10 @@ with mitxonline_product as (
 select
     '{{ var("mitxonline") }}' as platform
     , product_readable_id
-    , product_id
-    , product_description
     , product_name
+    , product_id
     , product_type
+    , product_description
     , '{{ var("mitxonline") }}' as product_platform
     , false as product_is_private
     , list_price
@@ -92,10 +92,10 @@ union all
 select
     '{{ var("mitxpro") }}' as platform
     , product_readable_id
-    , product_id
-    , product_description
     , product_name
+    , product_id
     , product_type
+    , product_description
     , product_platform
     , product_is_private
     , list_price

--- a/src/ol_dbt/models/marts/combined/marts__combined__products.sql
+++ b/src/ol_dbt/models/marts/combined/marts__combined__products.sql
@@ -1,0 +1,46 @@
+with mitxonline_product as (
+    select * from {{ ref('int__mitxonline__ecommerce_product') }}
+)
+
+, mitxonline_runs as (
+    select * from {{ ref('int__mitxonline__course_runs') }}
+)
+
+, mitxpro_product as (
+    select * from {{ ref('int__mitxpro__ecommerce_product') }}
+)
+
+, mitxpro_runs as (
+    select * from {{ ref('int__mitxpro__course_runs') }}
+)
+
+
+select
+    '{{ var("mitxonline") }}' as platform
+    , mitxonline_product.product_id
+    , mitxonline_product.product_type
+    , mitxonline_product.product_readable_id
+    , mitxonline_product.product_price
+    , mitxonline_runs.courserun_start_on
+    , mitxonline_runs.courserun_end_on
+    , mitxonline_runs.courserun_enrollment_start_on
+    , mitxonline_runs.courserun_enrollment_end_on
+from mitxonline_product
+left join mitxonline_runs
+    on mitxonline_product.courserun_id = mitxonline_runs.courserun_id
+
+union all
+
+select
+    '{{ var("mitxpro") }}' as platform
+    , mitxpro_product.product_id
+    , mitxpro_product.pproduct_type
+    , mitxpro_product.pproduct_readable_id
+    , null as pproduct_price
+    , mitxpro_runs.courserun_start_on
+    , mitxpro_runs.courserun_end_on
+    , mitxpro_runs.courserun_enrollment_start_on
+    , mitxpro_runs.courserun_enrollment_end_on
+from mitxpro_product
+left join mitxpro_runs
+    on mitxpro_product.courserun_id = mitxpro_runs.courserun_id

--- a/src/ol_dbt/models/marts/combined/marts__combined__products.sql
+++ b/src/ol_dbt/models/marts/combined/marts__combined__products.sql
@@ -33,6 +33,8 @@ with mitxonline_product as (
         , mitxonline_product.courserun_readable_id as product_readable_id
         , mitxonline_product.product_price as list_price
         , mitxonline_product.product_description
+        , mitxonline_product.product_is_active
+        , mitxonline_product.product_created_on
         , mitxonline_course_runs.courserun_title as product_name
         , mitxonline_course_runs.courserun_start_on as start_on
         , mitxonline_course_runs.courserun_end_on as end_on
@@ -49,6 +51,8 @@ with mitxonline_product as (
         , mitxpro_product.product_list_price as list_price
         , mitxpro_product.product_description
         , mitxpro_product.product_is_private
+        , mitxpro_product.product_is_active
+        , mitxpro_product.product_created_on
         , mitxpro_course_runs.courserun_enrollment_start_on as enrollment_start_on
         , mitxpro_course_runs.courserun_enrollment_end_on as enrollment_end_on
         , if(mitxpro_product.product_type = 'program', 'program run', mitxpro_product.product_type) as product_type
@@ -73,14 +77,16 @@ with mitxonline_product as (
 
 select
     '{{ var("mitxonline") }}' as platform
+    , '{{ var("mitxonline") }}' as product_platform
     , product_readable_id
     , product_name
     , product_id
     , product_type
     , product_description
-    , '{{ var("mitxonline") }}' as product_platform
-    , false as product_is_private
     , list_price
+    , product_is_active
+    , false as product_is_private
+    , product_created_on
     , start_on
     , end_on
     , enrollment_start_on
@@ -91,14 +97,16 @@ union all
 
 select
     '{{ var("mitxpro") }}' as platform
+    , product_platform
     , product_readable_id
     , product_name
     , product_id
     , product_type
     , product_description
-    , product_platform
-    , product_is_private
     , list_price
+    , product_is_active
+    , product_is_private
+    , product_created_on
     , start_on
     , end_on
     , enrollment_start_on

--- a/src/ol_dbt/models/marts/combined/marts__combined__products.sql
+++ b/src/ol_dbt/models/marts/combined/marts__combined__products.sql
@@ -2,7 +2,7 @@ with mitxonline_product as (
     select * from {{ ref('int__mitxonline__ecommerce_product') }}
 )
 
-, mitxonline_runs as (
+, mitxonline_course_runs as (
     select * from {{ ref('int__mitxonline__course_runs') }}
 )
 
@@ -10,37 +10,97 @@ with mitxonline_product as (
     select * from {{ ref('int__mitxpro__ecommerce_product') }}
 )
 
-, mitxpro_runs as (
+, mitxpro_course_runs as (
     select * from {{ ref('int__mitxpro__course_runs') }}
 )
 
+, mitxpro_courses as (
+    select * from {{ ref('int__mitxpro__courses') }}
+)
+
+, mitxpro_programs as (
+    select * from {{ ref('int__mitxpro__programs') }}
+)
+
+, mitxpro_program_runs as (
+    select * from {{ ref('int__mitxpro__program_runs') }}
+)
+
+, mitxonline_product_view as (
+    select
+        mitxonline_product.product_id
+        , mitxonline_product.product_type
+        , mitxonline_product.courserun_readable_id as product_readable_id
+        , mitxonline_product.product_price as list_price
+        , mitxonline_product.product_description
+        , mitxonline_course_runs.courserun_title as product_name
+        , mitxonline_course_runs.courserun_start_on as start_on
+        , mitxonline_course_runs.courserun_end_on as end_on
+        , mitxonline_course_runs.courserun_enrollment_start_on as enrollment_start_on
+        , mitxonline_course_runs.courserun_enrollment_end_on as enrollment_end_on
+    from mitxonline_product
+    left join mitxonline_course_runs
+        on mitxonline_product.courserun_id = mitxonline_course_runs.courserun_id
+)
+
+, mitxpro_product_view as (
+    select
+        mitxpro_product.product_id
+        , mitxpro_product.product_list_price as list_price
+        , mitxpro_product.product_description
+        , mitxpro_product.product_is_private
+        , mitxpro_course_runs.courserun_enrollment_start_on as enrollment_start_on
+        , mitxpro_course_runs.courserun_enrollment_end_on as enrollment_end_on
+        , if(mitxpro_product.product_type = 'program', 'program run', mitxpro_product.product_type) as product_type
+        , coalesce(mitxpro_courses.platform_name, mitxpro_programs.platform_name) as product_platform
+        , coalesce(
+            mitxpro_course_runs.courserun_readable_id, mitxpro_program_runs.programrun_readable_id
+        ) as product_readable_id
+        , coalesce(mitxpro_course_runs.courserun_title, mitxpro_program_runs.program_title) as product_name
+        , coalesce(mitxpro_course_runs.courserun_start_on, mitxpro_program_runs.programrun_start_on) as start_on
+        , coalesce(mitxpro_course_runs.courserun_end_on, mitxpro_program_runs.programrun_end_on) as end_on
+    from mitxpro_product
+    left join mitxpro_course_runs
+        on mitxpro_product.courserun_id = mitxpro_course_runs.courserun_id
+    left join mitxpro_courses
+        on mitxpro_course_runs.course_id = mitxpro_courses.course_id
+    left join mitxpro_program_runs
+        on mitxpro_product.program_id = mitxpro_program_runs.program_id
+    left join mitxpro_programs
+        on mitxpro_program_runs.program_id = mitxpro_programs.program_id
+    where mitxpro_product.product_type in ('program', 'course run')
+)
 
 select
     '{{ var("mitxonline") }}' as platform
-    , mitxonline_product.product_id
-    , mitxonline_product.product_type
-    , mitxonline_product.product_readable_id
-    , mitxonline_product.product_price
-    , mitxonline_runs.courserun_start_on
-    , mitxonline_runs.courserun_end_on
-    , mitxonline_runs.courserun_enrollment_start_on
-    , mitxonline_runs.courserun_enrollment_end_on
-from mitxonline_product
-left join mitxonline_runs
-    on mitxonline_product.courserun_id = mitxonline_runs.courserun_id
+    , product_readable_id
+    , product_id
+    , product_description
+    , product_name
+    , product_type
+    , '{{ var("mitxonline") }}' as product_platform
+    , false as product_is_private
+    , list_price
+    , start_on
+    , end_on
+    , enrollment_start_on
+    , enrollment_end_on
+from mitxonline_product_view
 
 union all
 
 select
     '{{ var("mitxpro") }}' as platform
-    , mitxpro_product.product_id
-    , mitxpro_product.pproduct_type
-    , mitxpro_product.pproduct_readable_id
-    , null as pproduct_price
-    , mitxpro_runs.courserun_start_on
-    , mitxpro_runs.courserun_end_on
-    , mitxpro_runs.courserun_enrollment_start_on
-    , mitxpro_runs.courserun_enrollment_end_on
-from mitxpro_product
-left join mitxpro_runs
-    on mitxpro_product.courserun_id = mitxpro_runs.courserun_id
+    , product_readable_id
+    , product_id
+    , product_description
+    , product_name
+    , product_type
+    , product_platform
+    , product_is_private
+    , list_price
+    , start_on
+    , end_on
+    , enrollment_start_on
+    , enrollment_end_on
+from mitxpro_product_view

--- a/src/ol_dbt/models/marts/mitxpro/_marts__mitxpro__models.yml
+++ b/src/ol_dbt/models/marts/mitxpro/_marts__mitxpro__models.yml
@@ -32,8 +32,8 @@ models:
       the program code. Examples include ML, QCF, AIPS, and DSBD.
   - name: list_price
     description: numeric, the product price for this version
-  - name: Product_description
-    description: string, product version discriptiom
+  - name: product_description
+    description: str, product description from the latest product version
   - name: start_date
     description: date, specifying when the course or program begins
   - name: end_date


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
https://github.com/mitodl/hq/issues/5104

### Description (What does it do?)
<!--- Describe your changes in detail -->

- adding product_list_price and product_description to int__mitxpro__ecommerce_product
- creating marts__combined__products from xPro and MITx Online

    platform
    product_readable_id
    product_name
    product_id
    product_type
    product_description
    product_platform
    product_is_private
    list_price
    start_on
    end_on
    enrollment_start_on
    enrollment_end_on

The course/program metadata such as duration, time_commitment, etc, which are sourced from CMS, will be added later because we haven't staged CMS tables for MITx Online.


### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->
dbt build --select int__mitxpro__ecommerce_product
dbt build --select marts__combined__products
