### PR TITLE
Fix blank micromaster dedp certificate in combined enrollment mart

### DIFF
--- a/src/ol_dbt/models/intermediate/combined/_combined_models.yml
+++ b/src/ol_dbt/models/intermediate/combined/_combined_models.yml
@@ -90,8 +90,8 @@ models:
     description: string, title of the course run on the corresponding platform. Maybe
       blank for a few edX.org runs missing in int__edxorg__mitx_courseruns.
   - name: courserun_readable_id
-    description: str, unique string to identify a course run on the corresponding
-      platform
+    description: str, Open edX course ID formatted as course-v1:{org}+{course code}+{run_tag}
+      for MITx Online and xPro courses, {org}/{course}/{run_tag} for edX.org courses
   - name: user_username
     description: string, username on the corresponding platform
     tests:
@@ -140,8 +140,8 @@ models:
     description: string, title of the course run on the corresponding platform. Maybe
       blank for a few edX.org runs missing in int__edxorg__mitx_courseruns.
   - name: courserun_readable_id
-    description: str, unique string to identify a course run on the corresponding
-      platform
+    description: str, Open edX course ID formatted as course-v1:{org}+{course code}+{run_tag}
+      for MITx Online and xPro courses, {org}/{course}/{run_tag} for edX.org courses
     tests:
     - not_null
   - name: user_username

--- a/src/ol_dbt/models/intermediate/combined/int__combined__courserun_certificates.sql
+++ b/src/ol_dbt/models/intermediate/combined/int__combined__courserun_certificates.sql
@@ -2,7 +2,22 @@
 
 with mitx_certificates as (
     --revoked certificates are already filtered
-    select * from {{ ref('int__mitx__courserun_certificates') }}
+    select
+        platform
+        , courseruncertificate_uuid
+        , courseruncertificate_url
+        , courseruncertificate_created_on
+        , courserun_title
+        , user_mitxonline_username
+        , user_edxorg_username
+        , user_email
+        , user_full_name
+        , if(
+            platform = '{{ var("edxorg") }}'
+            , replace(replace(courserun_readable_id, 'course-v1:', ''), '+', '/')
+            , courserun_readable_id
+        ) as courserun_readable_id
+    from {{ ref('int__mitx__courserun_certificates') }}
 )
 
 , mitxpro_certificates as (

--- a/src/ol_dbt/models/marts/combined/_marts__combined__models.yml
+++ b/src/ol_dbt/models/marts/combined/_marts__combined__models.yml
@@ -264,8 +264,8 @@ models:
     tests:
     - not_null
   - name: courserun_readable_id
-    description: str, unique string to identify a course run on the corresponding
-      platform
+    description: str, Open edX course ID formatted as course-v1:{org}+{course code}+{run_tag}
+      for MITxOnline and xPro courses, {org}/{course}/{run_tag} for edX.org courses
   - name: courserun_start_on
     description: timestamp, date and time when the course run starts. May be Null.
   - name: courserun_title


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
NA

### Description (What does it do?)
<!--- Describe your changes in detail -->
This fixes the certificate-related fields such as`courseruncertificate_is_earned`, `courseruncertificate_url` in marts__combined_course_enrollment_detail for MicroMasters DEDP certificates.

Due to the courserun_readable_id being in different format in upstream models `int__combined__courserun_certificates` and  
`int__combined__courserun_enrollments` for these legacy DEDP courses, caused the join to drop these MicroMasters certificates, for example, `MITx/JPAL102x/2T2020`. 

For edx.org enrollments, we get data from BigQuery which are all in {org}/{course}/{run_tag} format. But for the certificates, since these DEDP are from MicroMasters, they are in course-v1:{org}+{course code}+{run_tag} format. I updated courserun_readable_id to be consistent between the two upstream models

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->
You can run these separately if you don't want to refresh all the upstream models:
dbt build --select int__combined__courserun_certificates
dbt build --select int__combined__courserun_enrollments
dbt build --select marts__combined_course_enrollment_detail

Then check the certificate count should be increased now
```
select count(*) from  "ol_data_lake_production"."ol_warehouse_production_rlougee_intermediate"."int__combined__courserun_enrollments"
where courseruncertificate_is_earned = true
```
Then verify this learner https://bi.ol.mit.edu/superset/dashboard/p/Xb250JwEJvB/ should now `courseruncertificate_is_earned = true` for these runs

MITx/14.740x/3T2016
MITx/JPAL102x/2T2020
MITx/14.750x/1T2020

### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->
Related to https://github.com/mitodl/hq/issues/5234#issuecomment-2297398631


<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
