### PR TITLE
Residential MITx staging and intermediate course engagement models

### DIFF
--- a/src/ol_dbt/models/intermediate/mitxresidential/_int_mitxresidential__models.yml
+++ b/src/ol_dbt/models/intermediate/mitxresidential/_int_mitxresidential__models.yml
@@ -496,13 +496,6 @@ models:
     description: str, username on Residential MITx
     tests:
     - not_null
-  - name: user_id
-    description: int, the edX user ID extracted from context field in tracking log.
-      This id doesn't always match with the id in auth_user. There could be multiple
-      user_ids for the same user_username. For those cases, use user_id from source
-      table auth_user for that user_username.
-    tests:
-    - not_null
   - name: courserun_readable_id
     description: str, Open edX Course ID formatted as course-v1:{org}+{course code}+{run_tag}.
     tests:

--- a/src/ol_dbt/models/intermediate/mitxresidential/_int_mitxresidential__models.yml
+++ b/src/ol_dbt/models/intermediate/mitxresidential/_int_mitxresidential__models.yml
@@ -241,7 +241,7 @@ models:
   tests:
   - dbt_expectations.expect_compound_columns_to_be_unique:
       column_list: ["user_username", "courserun_readable_id", "useractivity_problem_id",
-        "useractivity_timestamp"]
+        "useractivity_problem_student_answers", "useractivity_problem_attempts", "useractivity_timestamp"]
 
 - name: int__mitxresidential__user_courseactivity_problemsubmitted
   description: Residential MITx learners problem submission activities within a course
@@ -445,6 +445,11 @@ models:
       internal_data_formats/tracking_logs/student_event_types.html#video-interaction-events
     tests:
     - not_null
+  - name: useractivity_event_object
+    description: object, it includes member fields that identify the specific video
+      event. Example, id, code, new_time, old_time, etc.
+    tests:
+    - not_null
   - name: useractivity_page_url
     description: str, url of the page the user was visiting when the event was emitted.
   - name: useractivity_video_id
@@ -459,10 +464,8 @@ models:
       Null for load_video or seek_video events.
   - name: useractivity_video_old_time
     description: number, time in the video, in seconds, at which the user chose to
-      go to a different point in time for seek_video event
-    tests:
-    - dbt_expectations.expect_column_values_to_not_be_null:
-        row_condition: "useractivity_event_type = 'seek_video'"
+      go to a different point in time for seek_video event. Small seek_video events
+      may not have old time recorded in this dataset.
   - name: useractivity_video_new_time
     description: number, time in the video, in seconds, that the user selected as
       the destination point for seek_video event
@@ -524,8 +527,6 @@ models:
     description: int, number of play_video events
   - name: courseactivity_num_unique_play_video
     description: int, number of unique videos played within a course
-  - name: courseactivity_num_chapters_visited
-    description: int, number of unique chapters visited within a course
   - name: courseactivity_last_play_video_timestamp
     description: timestamp, timestamp of user's last play_video event within a course
   - name: courseactivity_last_problem_check_timestamp

--- a/src/ol_dbt/models/intermediate/mitxresidential/_int_mitxresidential__models.yml
+++ b/src/ol_dbt/models/intermediate/mitxresidential/_int_mitxresidential__models.yml
@@ -180,3 +180,381 @@ models:
   tests:
   - dbt_expectations.expect_table_row_count_to_equal_other_table:
       compare_model: ref('stg__mitxresidential__openedx__courserun_grade')
+
+- name: int__mitxresidential__user_courseactivity_problemcheck
+  description: Residential MITx users problem_check activities within a course
+  columns:
+  - name: user_username
+    description: str, username on Residential MITx
+    tests:
+    - not_null
+  - name: user_id
+    description: int, the edX user ID extracted from context field in tracking log.
+      This id doesn't always match with the id in auth_user. There could be multiple
+      user_ids for the same user_username. For those cases, use user_id from source
+      table auth_user for that user_username.
+    tests:
+    - not_null
+  - name: courserun_readable_id
+    description: str, open edX Course ID formatted as course-v1:{org}+{course}+{run}
+      for course runs since Fall 2014, {org}/{course number}/{run} for older runs
+    tests:
+    - not_null
+  - name: useractivity_event_type
+    description: str, problem_check - when a problem is successfully checked.
+    tests:
+    - not_null
+  - name: useractivity_problem_id
+    description: str, Unique ID for this problem in a course. It's recorded as a URL
+      format - block-v1:{org)+{course ID}+type@problem+block@{hash code}
+    tests:
+    - not_null
+  - name: useractivity_problem_name
+    description: str, display name of this problem in a course
+    tests:
+    - not_null
+  - name: useractivity_problem_attempts
+    description: number, The number of times the user attempted to answer this problem
+    tests:
+    - not_null
+  - name: useractivity_problem_student_answers
+    description: json, student answers to this problem in problem_id and internal
+      answer pair. For multiple questions, it lists every question and answer.
+    tests:
+    - not_null
+  - name: useractivity_problem_success
+    description: str, It's either 'correct' or 'incorrect'
+    tests:
+    - not_null
+  - name: useractivity_problem_current_grade
+    description: number, current grade value for this user
+    tests:
+    - not_null
+  - name: useractivity_problem_max_grade
+    description: number, Maximum possible grade value for this problem
+    tests:
+    - not_null
+  - name: useractivity_timestamp
+    description: timestamp, time when this event was emitted
+    tests:
+    - not_null
+  tests:
+  - dbt_expectations.expect_compound_columns_to_be_unique:
+      column_list: ["user_username", "courserun_readable_id", "useractivity_problem_id",
+        "useractivity_timestamp"]
+
+- name: int__mitxresidential__user_courseactivity_problemsubmitted
+  description: Residential MITx learners problem submission activities within a course
+  columns:
+  - name: useractivity_event_id
+    description: str, The unique identifier for tracing this problem submitted event
+    tests:
+    - not_null
+    - unique
+  - name: user_username
+    description: str, username on Residential MITx
+    tests:
+    - not_null
+  - name: user_id
+    description: int, the edX user ID extracted from context field in tracking log.
+      This id doesn't always match with the id in auth_user. There could be multiple
+      user_ids for the same user_username. For those cases, use user_id from source
+      table auth_user for that user_username.
+    tests:
+    - not_null
+  - name: courserun_readable_id
+    description: str, open edX Course ID formatted as course-v1:{org}+{course}+{run}
+      for course runs since Fall 2014, {org}/{course number}/{run} for older runs
+    tests:
+    - not_null
+  - name: useractivity_event_source
+    description: str, specifies the source of the interaction that triggered the event.
+      The value is server for this event.
+    tests:
+    - not_null
+  - name: useractivity_event_type
+    description: str, edx.grades.problem.submitted - when a problem is submitted and
+      successfully saved
+    tests:
+    - not_null
+  - name: useractivity_path
+    description: str, relative url path of page that generated the problem submitted
+      event.
+  - name: useractivity_problem_id
+    description: str, Unique ID for this problem in a course, formatted as block-v1:{org)+{course
+      ID}+type@problem+block@{hash code}.
+    tests:
+    - not_null
+  - name: useractivity_problem_name
+    description: str, display name of this problem in a course
+  - name: useractivity_problem_weight
+    description: number, the weight of this problem
+  - name: useractivity_problem_earned_score
+    description: str, learner’s weighted score for this problem.
+  - name: useractivity_problem_max_score
+    description: number, weighted maximum possible score for this problem.
+  - name: useractivity_timestamp
+    description: timestamp, time when this event was emitted
+    tests:
+    - not_null
+
+- name: int__mitxresidential__user_courseactivity_discussion
+  description: Residential MITx learners discussion forum activities within a course
+  columns:
+  - name: user_username
+    description: str, username on Residential MITx
+    tests:
+    - not_null
+  - name: user_id
+    description: int, the edX user ID extracted from context field in tracking log.
+      This id doesn't always match with the id in auth_user. There could be multiple
+      user_ids for the same user_username. For those cases, use user_id from source
+      table auth_user for that user_username.
+    tests:
+    - not_null
+  - name: courserun_readable_id
+    description: str, open edX Course ID formatted as course-v1:{org}+{course}+{run}
+      for course runs since Fall 2014, {org}/{course number}/{run} for older runs
+    tests:
+    - not_null
+  - name: useractivity_event_source
+    description: str, specifies the source of the interaction that triggered the event.
+      The value is server for the discussion events.
+    tests:
+    - not_null
+  - name: useractivity_event_type
+    description: >
+      str, type of discussion forum event triggered. Values can be edx.forum.comment.created,
+      edx.forum.comment.edited, edx.forum.response.created, edx.forum.response.voted,
+      edx.forum.thread.created, edx.forum.thread.viewed, edx.forum.thread.voted, edx.forum.searched,
+      etc.
+      A list of discussion events can be found https://edx.readthedocs.io/projects/devdata/en/latest/
+      internal_data_formats/tracking_logs/student_event_types.html#discussion-forum-events
+    tests:
+    - not_null
+  - name: useractivity_path
+    description: str, relative url path of page that generated this discussion event.
+      e.g. for edx.forum.response.voted events, it indicates if this event is unvote
+      or upvote
+  - name: useractivity_discussion_post_id
+    description: str, unique identifier for the discussion post learner engaged in.
+      May be Null for edx.forum.searched event
+    tests:
+    - dbt_expectations.expect_column_values_to_not_be_null:
+        row_condition: "useractivity_event_type != 'edx.forum.searched'"
+  - name: useractivity_discussion_post_title
+    description: str, title for the specific discussion post. May be Null for edx.forum.searched
+      event.
+  - name: useractivity_discussion_block_id
+    description: str, identifier for the specific discussion component. e.g. discussion_ps2A-tab5.
+      Value is the last part of 'coursestructure_block_id' string. May be Null for
+      edx.forum.searched event.
+  - name: useractivity_discussion_block_name
+    description: str, display name for the specific discussion component. This value
+      consists of the unit name and 'coursestructure_block_title' of this discussion
+      component.
+  - name: useractivity_discussion_page_url
+    description: str, URL of the page from which the discussion thread can be viewed.
+  - name: useractivity_discussion_search_query
+    description: str, the query text searched by the learner on the course discussion
+      page. Applicable for edx.forum.searched event.
+    tests:
+    - dbt_expectations.expect_column_values_to_not_be_null:
+        row_condition: "useractivity_event_type = 'edx.forum.searched'"
+  - name: useractivity_discussion_roles
+    description: >
+      array, Identifies a user who doesn't have discussion management privileges
+      as a 'Student', or a user who has discussion management privileges as a course
+      'Community TA', 'Moderator', or 'Administrator'.
+      The value of role refers to name field in django_comment_client_role_users.
+      https://edx.readthedocs.io/projects/devdata/en/latest/internal_data_formats/sql_schema.html#id12
+  - name: useractivity_timestamp
+    description: timestamp, time when this event was emitted
+    tests:
+    - not_null
+  tests:
+  - dbt_expectations.expect_compound_columns_to_be_unique:
+      column_list: ["user_username", "courserun_readable_id", "useractivity_event_type",
+        "useractivity_discussion_post_id", "useractivity_timestamp"]
+
+- name: int__mitxresidential__user_courseactivity_showanswer
+  description: Residential MITx learners show answer events within a course
+  columns:
+  - name: user_username
+    description: str, username on Residential MITx
+    tests:
+    - not_null
+  - name: user_id
+    description: int, the edX user ID extracted from context field in tracking log.
+      This id doesn't always match with the id in auth_user. There could be multiple
+      user_ids for the same user_username. For those cases, use user_id from source
+      table auth_user for that user_username.
+    tests:
+    - not_null
+  - name: courserun_readable_id
+    description: str, Open edX Course ID formatted as course-v1:{org}+{course code}+{run_tag}
+    tests:
+    - not_null
+  - name: useractivity_path
+    description: str, relative url path of page when the answer to a problem is shown
+      event.
+  - name: useractivity_problem_id
+    description: str, Unique ID for this problem in a course, formatted as block-v1:{org)+{course
+      ID}+type@problem+block@{hash code}.
+    tests:
+    - not_null
+  - name: useractivity_timestamp
+    description: timestamp, time for this show answer event
+    tests:
+    - not_null
+  tests:
+  - dbt_expectations.expect_compound_columns_to_be_unique:
+      column_list: ["user_username", "courserun_readable_id", "useractivity_problem_id",
+        "useractivity_timestamp"]
+
+- name: int__mitxresidential__user_courseactivity_video
+  description: Residential MITx learners discussion forum activities within a course
+  columns:
+  - name: user_username
+    description: str, username on Residential MITx
+    tests:
+    - not_null
+  - name: user_id
+    description: int, the edX user ID extracted from context field. This id doesn't
+      always match with the id in auth_user. There could be multiple user_ids for
+      the same user_username. For those cases, use user_id from source table auth_user
+      for that user_username.
+    tests:
+    - not_null
+  - name: courserun_readable_id
+    description: str, open edX Course ID formatted as course-v1:{org}+{course}+{run}
+      for course runs since Fall 2014, {org}/{course number}/{run} for older runs
+    tests:
+    - not_null
+  - name: useractivity_event_source
+    description: str, specifies the source of the interaction that triggered the event.
+      The value can only be browser for video event as MITx Online doesn't have a
+      mobile app at this time.
+    tests:
+    - not_null
+  - name: useractivity_event_type
+    description: >
+      str, type of video event triggered. e.g. play_video, pause_video, stop_video,
+      complete_video, etc.
+      A list of video events can be found https://edx.readthedocs.io/projects/devdata/en/latest/
+      internal_data_formats/tracking_logs/student_event_types.html#video-interaction-events
+    tests:
+    - not_null
+  - name: useractivity_page_url
+    description: str, url of the page the user was visiting when the event was emitted.
+  - name: useractivity_video_id
+    description: str, hash code for the video being watched. This value is the last
+      part of coursestructure_block_id string
+    tests:
+    - not_null
+  - name: useractivity_video_duration
+    description: number, The length of the video file, in seconds.
+  - name: useractivity_video_currenttime
+    description: number, The time in the video when this event was emitted. May be
+      Null for load_video or seek_video events.
+  - name: useractivity_video_old_time
+    description: number, time in the video, in seconds, at which the user chose to
+      go to a different point in time for seek_video event
+    tests:
+    - dbt_expectations.expect_column_values_to_not_be_null:
+        row_condition: "useractivity_event_type = 'seek_video'"
+  - name: useractivity_video_new_time
+    description: number, time in the video, in seconds, that the user selected as
+      the destination point for seek_video event
+    tests:
+    - dbt_expectations.expect_column_values_to_not_be_null:
+        row_condition: "useractivity_event_type = 'seek_video'"
+  - name: useractivity_video_new_speed
+    description: number, new speed that the user selected for the video to play for
+      speed_change_video event. e.g. 0.75, 1.0, 1.25, 1.50.
+    tests:
+    - dbt_expectations.expect_column_values_to_not_be_null:
+        row_condition: "useractivity_event_type = 'speed_change_video'"
+  - name: useractivity_video_old_speed
+    description: number, old speed at which the video was playing for speed_change_video
+      event.
+    tests:
+    - dbt_expectations.expect_column_values_to_not_be_null:
+        row_condition: "useractivity_event_type = 'speed_change_video'"
+  - name: useractivity_timestamp
+    description: timestamp, time when this event was emitted
+    tests:
+    - not_null
+
+- name: int__mitxresidential__user_courseactivities
+  description: Residential MITx learners activities aggregated statistics per course
+  columns:
+  - name: user_username
+    description: str, username on Residential MITx
+    tests:
+    - not_null
+  - name: user_id
+    description: int, the edX user ID extracted from context field in tracking log.
+      This id doesn't always match with the id in auth_user. There could be multiple
+      user_ids for the same user_username. For those cases, use user_id from source
+      table auth_user for that user_username.
+    tests:
+    - not_null
+  - name: courserun_readable_id
+    description: str, Open edX Course ID formatted as course-v1:{org}+{course code}+{run_tag}.
+    tests:
+    - not_null
+  - name: courseactivity_num_events
+    description: int, number of tracking log events
+    tests:
+    - not_null
+  - name: courseactivity_num_days_activity
+    description: int, number of days with activity
+    tests:
+    - not_null
+  - name: courseactivity_first_event_timestamp
+    description: timestamp, timestamp of user's first event within a course
+    tests:
+    - not_null
+  - name: courseactivity_last_event_timestamp
+    description: timestamp, timestamp of user's last event within a course
+    tests:
+    - not_null
+  - name: courseactivity_num_play_video
+    description: int, number of play_video events
+  - name: courseactivity_num_unique_play_video
+    description: int, number of unique videos played within a course
+  - name: courseactivity_num_chapters_visited
+    description: int, number of unique chapters visited within a course
+  - name: courseactivity_last_play_video_timestamp
+    description: timestamp, timestamp of user's last play_video event within a course
+  - name: courseactivity_last_problem_check_timestamp
+    description: timestamp, timestamp of user's last problem_check event within a
+      course
+  tests:
+  - dbt_expectations.expect_compound_columns_to_be_unique:
+      column_list: ["user_username", "courserun_readable_id"]
+
+- name: int__mitxresidential__user_courseactivities_daily
+  description: Residential MITx learners activities aggregated daily per course
+  columns:
+  - name: user_username
+    description: str, username on Residential MITx
+    tests:
+    - not_null
+  - name: courserun_readable_id
+    description: str, open edX Course ID formatted as course-v1:{org}+{course}+{run}
+      for course runs since Fall 2014, {org}/{course number}/{run} for older runs
+    tests:
+    - not_null
+  - name: courseactivity_num_events
+    description: int, number of tracking log events (including all course activities)
+    tests:
+    - not_null
+  - name: courseactivity_date
+    description: date, date that user has any kind of activities in the course
+    tests:
+    - not_null
+  tests:
+  - dbt_expectations.expect_compound_columns_to_be_unique:
+      column_list: ["user_username", "courserun_readable_id", "courseactivity_date"]

--- a/src/ol_dbt/models/intermediate/mitxresidential/int__mitxresidential__user_courseactivities.sql
+++ b/src/ol_dbt/models/intermediate/mitxresidential/int__mitxresidential__user_courseactivities.sql
@@ -1,0 +1,94 @@
+with course_activities as (
+    select * from {{ ref('stg__mitxresidential__openedx__tracking_logs__user_activity') }}
+    where courserun_readable_id is not null
+)
+
+, course_activities_video as (
+    select * from {{ ref('int__mitxresidential__user_courseactivity_video') }}
+)
+
+, problem_check as (
+    select * from {{ ref('int__mitxresidential__user_courseactivity_problemcheck') }}
+)
+
+, course_state as (
+    select * from {{ ref('stg__mitxonline__openedx__mysql__courseware_studentmodule') }}
+)
+
+, course_chapters_stats as (
+    select
+        course_state.user_id
+        , course_state.courserun_readable_id
+        , count(distinct course_structure.coursestructure_chapter_id) as courseactivity_num_chapters_visited
+    from course_state
+    inner join course_structure
+        on
+            course_state.courserun_readable_id = course_structure.courserun_readable_id
+            and course_state.coursestructure_block_id = course_structure.coursestructure_block_id
+    group by course_state.user_id, course_state.courserun_readable_id
+)
+
+, problem_check_stats as (
+    select
+        user_username
+        , courserun_readable_id
+        , max(useractivity_timestamp) as courseactivity_last_problem_check_timestamp
+    from problem_check
+    group by user_username, courserun_readable_id
+)
+
+, play_video_stats as (
+    select
+        user_username
+        , courserun_readable_id
+        , count(distinct useractivity_video_id) as courseactivity_num_unique_play_video
+        , count(*) as courseactivity_num_play_video
+        , max(useractivity_timestamp) as courseactivity_last_play_video_timestamp
+    from course_activities_video
+    where useractivity_event_type = 'play_video'
+    group by user_username, courserun_readable_id
+)
+
+
+, all_course_activities_stats as (
+    select
+        course_activities.user_username
+        , course_activities.user_id
+        , course_activities.courserun_readable_id
+        , count(distinct date(from_iso8601_timestamp(course_activities.useractivity_timestamp)))
+        as courseactivity_num_days_activity
+        , count(*) as courseactivity_num_events
+        , min(course_activities.useractivity_timestamp) as courseactivity_first_event_timestamp
+        , max(course_activities.useractivity_timestamp) as courseactivity_last_event_timestamp
+    from course_activities
+    group by
+        course_activities.user_username
+        , course_activities.user_id
+        , course_activities.courserun_readable_id
+)
+
+select
+    all_course_activities_stats.user_username
+    , all_course_activities_stats.courserun_readable_id
+    , all_course_activities_stats.courseactivity_num_days_activity
+    , all_course_activities_stats.courseactivity_num_events
+    , play_video_stats.courseactivity_num_unique_play_video
+    , play_video_stats.courseactivity_num_play_video
+    , play_video_stats.courseactivity_last_play_video_timestamp
+    , problem_check_stats.courseactivity_last_problem_check_timestamp
+    , course_chapters_stats.courseactivity_num_chapters_visited
+    , all_course_activities_stats.courseactivity_first_event_timestamp
+    , all_course_activities_stats.courseactivity_last_event_timestamp
+from all_course_activities_stats
+left join play_video_stats
+    on
+        all_course_activities_stats.user_username = play_video_stats.user_username
+        and all_course_activities_stats.courserun_readable_id = play_video_stats.courserun_readable_id
+left join problem_check_stats
+    on
+        all_course_activities_stats.user_username = problem_check_stats.user_username
+        and all_course_activities_stats.courserun_readable_id = problem_check_stats.courserun_readable_id
+left join course_chapters_stats
+    on
+        all_course_activities_stats.user_id = course_chapters_stats.user_id
+        and all_course_activities_stats.courserun_readable_id = course_chapters_stats.courserun_readable_id

--- a/src/ol_dbt/models/intermediate/mitxresidential/int__mitxresidential__user_courseactivities.sql
+++ b/src/ol_dbt/models/intermediate/mitxresidential/int__mitxresidential__user_courseactivities.sql
@@ -11,23 +11,6 @@ with course_activities as (
     select * from {{ ref('int__mitxresidential__user_courseactivity_problemcheck') }}
 )
 
-, course_state as (
-    select * from {{ ref('stg__mitxonline__openedx__mysql__courseware_studentmodule') }}
-)
-
-, course_chapters_stats as (
-    select
-        course_state.user_id
-        , course_state.courserun_readable_id
-        , count(distinct course_structure.coursestructure_chapter_id) as courseactivity_num_chapters_visited
-    from course_state
-    inner join course_structure
-        on
-            course_state.courserun_readable_id = course_structure.courserun_readable_id
-            and course_state.coursestructure_block_id = course_structure.coursestructure_block_id
-    group by course_state.user_id, course_state.courserun_readable_id
-)
-
 , problem_check_stats as (
     select
         user_username
@@ -76,7 +59,6 @@ select
     , play_video_stats.courseactivity_num_play_video
     , play_video_stats.courseactivity_last_play_video_timestamp
     , problem_check_stats.courseactivity_last_problem_check_timestamp
-    , course_chapters_stats.courseactivity_num_chapters_visited
     , all_course_activities_stats.courseactivity_first_event_timestamp
     , all_course_activities_stats.courseactivity_last_event_timestamp
 from all_course_activities_stats
@@ -88,7 +70,3 @@ left join problem_check_stats
     on
         all_course_activities_stats.user_username = problem_check_stats.user_username
         and all_course_activities_stats.courserun_readable_id = problem_check_stats.courserun_readable_id
-left join course_chapters_stats
-    on
-        all_course_activities_stats.user_id = course_chapters_stats.user_id
-        and all_course_activities_stats.courserun_readable_id = course_chapters_stats.courserun_readable_id

--- a/src/ol_dbt/models/intermediate/mitxresidential/int__mitxresidential__user_courseactivities.sql
+++ b/src/ol_dbt/models/intermediate/mitxresidential/int__mitxresidential__user_courseactivities.sql
@@ -36,7 +36,6 @@ with course_activities as (
 , all_course_activities_stats as (
     select
         course_activities.user_username
-        , course_activities.user_id
         , course_activities.courserun_readable_id
         , count(distinct date(from_iso8601_timestamp(course_activities.useractivity_timestamp)))
         as courseactivity_num_days_activity
@@ -46,7 +45,6 @@ with course_activities as (
     from course_activities
     group by
         course_activities.user_username
-        , course_activities.user_id
         , course_activities.courserun_readable_id
 )
 

--- a/src/ol_dbt/models/intermediate/mitxresidential/int__mitxresidential__user_courseactivities_daily.sql
+++ b/src/ol_dbt/models/intermediate/mitxresidential/int__mitxresidential__user_courseactivities_daily.sql
@@ -1,0 +1,19 @@
+with course_activities as (
+    select * from {{ ref('stg__mitxresidential__openedx__tracking_logs__user_activity') }}
+    where courserun_readable_id is not null
+)
+
+, daily_activities_stats as (
+    select
+        user_username
+        , courserun_readable_id
+        , date(from_iso8601_timestamp(useractivity_timestamp)) as courseactivity_date
+        , count(*) as courseactivity_num_events
+    from course_activities
+    group by
+        user_username
+        , courserun_readable_id
+        , date(from_iso8601_timestamp(useractivity_timestamp))
+)
+
+select * from daily_activities_stats

--- a/src/ol_dbt/models/intermediate/mitxresidential/int__mitxresidential__user_courseactivity_discussion.sql
+++ b/src/ol_dbt/models/intermediate/mitxresidential/int__mitxresidential__user_courseactivity_discussion.sql
@@ -1,0 +1,24 @@
+{{ config(materialized='view') }}
+
+with course_activities as (
+    select * from {{ ref('stg__mitxresidential__openedx__tracking_logs__user_activity') }}
+    where courserun_readable_id is not null
+)
+
+select
+    user_username
+    , courserun_readable_id
+    , user_id
+    , useractivity_event_source
+    , useractivity_event_type
+    , useractivity_path
+    , useractivity_timestamp
+    , json_query(useractivity_event_object, 'lax $.id' omit quotes) as useractivity_discussion_post_id
+    , json_query(useractivity_event_object, 'lax $.title' omit quotes) as useractivity_discussion_post_title
+    , json_query(useractivity_event_object, 'lax $.category_id' omit quotes) as useractivity_discussion_block_id
+    , json_query(useractivity_event_object, 'lax $.category_name' omit quotes) as useractivity_discussion_block_name
+    , json_query(useractivity_event_object, 'lax $.url' omit quotes) as useractivity_discussion_page_url
+    , json_query(useractivity_event_object, 'lax $.query' omit quotes) as useractivity_discussion_search_query
+    , json_query(useractivity_event_object, 'lax $.user_forums_roles' omit quotes) as useractivity_discussion_roles
+from course_activities
+where useractivity_event_type like 'edx.forum.%'

--- a/src/ol_dbt/models/intermediate/mitxresidential/int__mitxresidential__user_courseactivity_problemcheck.sql
+++ b/src/ol_dbt/models/intermediate/mitxresidential/int__mitxresidential__user_courseactivity_problemcheck.sql
@@ -1,0 +1,25 @@
+{{ config(materialized='view') }}
+
+with course_activities as (
+    select * from {{ ref('stg__mitxresidential__openedx__tracking_logs__user_activity') }}
+    where courserun_readable_id is not null
+)
+
+select
+    user_username
+    , courserun_readable_id
+    , user_id
+    , useractivity_event_type
+    , useractivity_timestamp
+    , json_query(useractivity_context_object, 'lax $.module.display_name' omit quotes) as useractivity_problem_name
+    , json_query(useractivity_event_object, 'lax $.problem_id' omit quotes) as useractivity_problem_id
+    , json_query(useractivity_event_object, 'lax $.answers' omit quotes) as useractivity_problem_student_answers
+    , json_query(useractivity_event_object, 'lax $.attempts' omit quotes) as useractivity_problem_attempts
+    , json_query(useractivity_event_object, 'lax $.success' omit quotes) as useractivity_problem_success
+    , json_query(useractivity_event_object, 'lax $.grade' omit quotes) as useractivity_problem_current_grade
+    , json_query(useractivity_event_object, 'lax $.max_grade' omit quotes) as useractivity_problem_max_grade
+from course_activities
+where useractivity_event_type = 'problem_check'
+--- This event emitted by the browser contain all of the GET parameters,
+--  only events emitted by the server are useful
+and useractivity_event_source = 'server'

--- a/src/ol_dbt/models/intermediate/mitxresidential/int__mitxresidential__user_courseactivity_problemcheck.sql
+++ b/src/ol_dbt/models/intermediate/mitxresidential/int__mitxresidential__user_courseactivity_problemcheck.sql
@@ -5,7 +5,7 @@ with course_activities as (
     where courserun_readable_id is not null
 )
 
-select
+select distinct
     user_username
     , courserun_readable_id
     , user_id

--- a/src/ol_dbt/models/intermediate/mitxresidential/int__mitxresidential__user_courseactivity_problemsubmitted.sql
+++ b/src/ol_dbt/models/intermediate/mitxresidential/int__mitxresidential__user_courseactivity_problemsubmitted.sql
@@ -1,0 +1,23 @@
+{{ config(materialized='view') }}
+
+with course_activities as (
+    select * from {{ ref('stg__mitxresidential__openedx__tracking_logs__user_activity') }}
+    where courserun_readable_id is not null
+)
+
+select
+    user_username
+    , courserun_readable_id
+    , user_id
+    , useractivity_event_source
+    , useractivity_event_type
+    , useractivity_path
+    , useractivity_timestamp
+    , json_query(useractivity_event_object, 'lax $.event_transaction_id' omit quotes) as useractivity_event_id
+    , json_query(useractivity_context_object, 'lax $.module.display_name' omit quotes) as useractivity_problem_name
+    , json_query(useractivity_event_object, 'lax $.problem_id' omit quotes) as useractivity_problem_id
+    , json_query(useractivity_event_object, 'lax $.weight' omit quotes) as useractivity_problem_weight
+    , json_query(useractivity_event_object, 'lax $.weighted_earned' omit quotes) as useractivity_problem_earned_score
+    , json_query(useractivity_event_object, 'lax $.weighted_possible' omit quotes) as useractivity_problem_max_score
+from course_activities
+where useractivity_event_type = 'edx.grades.problem.submitted'

--- a/src/ol_dbt/models/intermediate/mitxresidential/int__mitxresidential__user_courseactivity_showanswer.sql
+++ b/src/ol_dbt/models/intermediate/mitxresidential/int__mitxresidential__user_courseactivity_showanswer.sql
@@ -1,0 +1,16 @@
+{{ config(materialized='view') }}
+
+with course_activities as (
+    select * from {{ ref('stg__mitxresidential__openedx__tracking_logs__user_activity') }}
+    where courserun_readable_id is not null
+)
+
+select
+    user_username
+    , courserun_readable_id
+    , user_id
+    , useractivity_path
+    , useractivity_timestamp
+    , json_query(useractivity_event_object, 'lax $.problem_id' omit quotes) as useractivity_problem_id
+from course_activities
+where useractivity_event_type = 'showanswer'

--- a/src/ol_dbt/models/intermediate/mitxresidential/int__mitxresidential__user_courseactivity_video.sql
+++ b/src/ol_dbt/models/intermediate/mitxresidential/int__mitxresidential__user_courseactivity_video.sql
@@ -11,6 +11,7 @@ select
     , user_id
     , useractivity_event_source
     , useractivity_event_type
+    , useractivity_event_object
     , useractivity_page_url
     , useractivity_timestamp
     , json_query(useractivity_event_object, 'lax $.id' omit quotes) as useractivity_video_id

--- a/src/ol_dbt/models/intermediate/mitxresidential/int__mitxresidential__user_courseactivity_video.sql
+++ b/src/ol_dbt/models/intermediate/mitxresidential/int__mitxresidential__user_courseactivity_video.sql
@@ -1,0 +1,27 @@
+{{ config(materialized='view') }}
+
+with course_activities as (
+    select * from {{ ref('stg__mitxresidential__openedx__tracking_logs__user_activity') }}
+    where courserun_readable_id is not null
+)
+
+select
+    user_username
+    , courserun_readable_id
+    , user_id
+    , useractivity_event_source
+    , useractivity_event_type
+    , useractivity_page_url
+    , useractivity_timestamp
+    , json_query(useractivity_event_object, 'lax $.id' omit quotes) as useractivity_video_id
+    , json_query(useractivity_event_object, 'lax $.duration' omit quotes) as useractivity_video_duration
+    , json_query(useractivity_event_object, 'lax $.currentTime' omit quotes) as useractivity_video_currenttime
+    , json_query(useractivity_event_object, 'lax $.old_time' omit quotes) as useractivity_video_old_time
+    , json_query(useractivity_event_object, 'lax $.new_time' omit quotes) as useractivity_video_new_time
+    , json_query(useractivity_event_object, 'lax $.new_speed' omit quotes) as useractivity_video_new_speed
+    , json_query(useractivity_event_object, 'lax $.old_speed' omit quotes) as useractivity_video_old_speed
+from course_activities
+where
+    regexp_like(useractivity_event_type, '(^[\w]+)_video') = true
+    or regexp_like(useractivity_event_type, '(^[\w]+)_transcript') = true
+    or useractivity_event_type like 'edx.video.%'

--- a/src/ol_dbt/models/staging/mitxresidential/_mitxresidential__sources.yml
+++ b/src/ol_dbt/models/staging/mitxresidential/_mitxresidential__sources.yml
@@ -922,3 +922,53 @@ sources:
       description: str, the name of the assessment workflow step
     - name: submitter_completed_at
       description: timestamp, specifying when assessment workflow step was completed
+
+  - name: raw__mitx__openedx__tracking_logs
+    description: Residential MITx event data that are emitted by server, the browser,
+      or the mobile device to capture information about user's interactions with a
+      course
+    columns:
+    - name: username
+      description: str, username of the open edX user who caused the event to be emitted.
+        Some events are recorded with a blank username. This can occur when a user
+        logs out, or the login session times out, while a browser window remains open.
+        EdX recommends to ignore these events.
+    - name: context
+      description: object, it includes member fields that provide contextual information.
+        Common fields apply to all events are course_id, org_id, path, user_id. Other
+        member fields for applicable events are course_user_tags, module.
+    - name: event_source
+      description: str, specifies the source of the interaction that triggered the
+        event. The values are - browser, mobile, server, task
+    - name: event_type
+      description: str, type of event triggered. Values depend on event_source.
+    - name: name
+      description: str, type of event triggered. When this field is present for an
+        event, it supersedes the event_type field.
+    - name: event
+      description: object, it includes member fields that identify specifics of each
+        triggered event. Different member fields are supplied for different events.
+    - name: page
+      description: str, url of the page the user was visiting when the event was emitted.
+    - name: session
+      description: str, 32-character value to identify the user’s session. All browser
+        events and the server 'enrollment' events include a session value. Other server
+        events and mobile events do not include a session value.
+    - name: ip
+      description: str, IP address of the user who triggered the event. Empty for
+        mobile events.
+    - name: host
+      description: str, the site visited by the user, e.g., lms.mitx.mit.edu
+    - name: time
+      description: str, time at which the event was emitted in YYYY-MM-dd HH:mm:ss.SSSSSS
+        format
+    - name: agent
+      description: str, browser agent string of the user who triggered the event.
+    - name: accept_language
+      description: str, value from the HTTP Accept-Language request-header field
+    - name: referer
+      description: str, URI from the HTTP Referer request-header field
+    - name: log_file
+      description: str, internal used field for log file location
+    - name: _ab_source_file_url
+      description: str, url path for the raw log file

--- a/src/ol_dbt/models/staging/mitxresidential/_mitxresidential__sources.yml
+++ b/src/ol_dbt/models/staging/mitxresidential/_mitxresidential__sources.yml
@@ -924,9 +924,8 @@ sources:
       description: timestamp, specifying when assessment workflow step was completed
 
   - name: raw__mitx__openedx__tracking_logs
-    description: Residential MITx event data that are emitted by server, the browser,
-      or the mobile device to capture information about user's interactions with a
-      course
+    description: Residential MITx event data that are emitted by server and the browser
+      to capture information about user's interactions with a course.
     columns:
     - name: username
       description: str, username of the open edX user who caused the event to be emitted.
@@ -939,7 +938,7 @@ sources:
         member fields for applicable events are course_user_tags, module.
     - name: event_source
       description: str, specifies the source of the interaction that triggered the
-        event. The values are - browser, mobile, server, task
+        event. The possible values are - browser, server, task
     - name: event_type
       description: str, type of event triggered. Values depend on event_source.
     - name: name
@@ -953,10 +952,9 @@ sources:
     - name: session
       description: str, 32-character value to identify the user’s session. All browser
         events and the server 'enrollment' events include a session value. Other server
-        events and mobile events do not include a session value.
+        events do not include a session value.
     - name: ip
-      description: str, IP address of the user who triggered the event. Empty for
-        mobile events.
+      description: str, IP address of the user who triggered the event
     - name: host
       description: str, the site visited by the user, e.g., lms.mitx.mit.edu
     - name: time
@@ -972,3 +970,36 @@ sources:
       description: str, internal used field for log file location
     - name: _ab_source_file_url
       description: str, url path for the raw log file
+
+  - name: raw__mitx__openedx__mysql__courseware_studentmodule
+    columns:
+    - name: id
+      description: str, primary key in courseware_studentmodule
+    - name: student_id
+      description: str, reference user id in auth_user from open edX
+    - name: course_id
+      description: str, Open edX Course ID in the format course-v1:{org}+{course code}+{run_tag}
+    - name: module_id
+      description: str, block ID for a distinct piece of content in a course, referencing
+        course_structure
+    - name: module_type
+      description: str, category/type of the block, referencing course_structure.
+    - name: state
+      description: str, JSON text indicating the learner's last known state within
+        a course.
+    - name: done
+      description: str, not used. The value is 'na' in every row
+    - name: grade
+      description: str, floating point value indicating the total unweighted grade
+        for this problem that the learner has scored. e.g. how many responses they
+        got right within the problem. This data is also available in courseactivity_problemcheck
+    - name: max_grade
+      description: str, floating point value indicating the total possible unweighted
+        grade for this problem, or basically the number of responses that are in this
+        problem. This data is also available in courseactivity_problemcheck
+    - name: created
+      description: timestamp, datetime when this row was created, which is typically
+        when the learner first accesses this piece of content.
+    - name: modified
+      description: timestamp, datetime when this row was last updated. A change in
+        this field implies that there was a state change.

--- a/src/ol_dbt/models/staging/mitxresidential/_stg_mitxresidential__models.yml
+++ b/src/ol_dbt/models/staging/mitxresidential/_stg_mitxresidential__models.yml
@@ -220,10 +220,9 @@ models:
       column_list: ["courserun_readable_id", "user_id"]
 
 - name: stg__mitxresidential__openedx__tracking_logs__user_activity
-  description: Residential MITx event data that are emitted by server, the browser,
-    or the mobile device to capture information about user's interactions with a course.
-    This table filters out events that don't supply user identifiers like username
-    and user_id.
+  description: Residential MITx event data that are emitted by server and the browser
+    to capture information about user's interactions with a course. This table filters
+    out events that don't supply user identifiers like username and user_id.
   columns:
   - name: user_username
     description: str, username of a learner on Residential MITx open edx platform
@@ -251,7 +250,7 @@ models:
       member fields for applicable events are course_user_tags, module.
   - name: useractivity_event_source
     description: str, specifies the source of the interaction that triggered the event.
-      The values are - browser, mobile, server, task
+      The possible values are - browser, server, task.
     tests:
     - not_null
   - name: useractivity_event_type
@@ -268,10 +267,9 @@ models:
   - name: useractivity_session_id
     description: str, 32-character value to identify the user’s session. All browser
       events and the server 'enrollment' events include session value. Other server
-      events and mobile events do not include a session value.
+      events do not include a session value.
   - name: useractivity_ip
-    description: str, IP address of the user who triggered the event. Empty for mobile
-      events.
+    description: str, IP address of the user who triggered the event.
   - name: useractivity_http_host
     description: str, The site visited by the user, e.g., lms.mitx.mit.edu
     tests:
@@ -291,3 +289,56 @@ models:
   - dbt_expectations.expect_compound_columns_to_be_unique:
       column_list: ["user_username", "useractivity_context_object", "useractivity_event_source",
         "useractivity_event_type", "useractivity_event_object", "useractivity_timestamp"]
+
+- name: stg__mitxresidential__openedx__courseware_studentmodule
+  description: It holds the most current course state and score per course section
+    for learners on Residential MITx . There is a separate row for every piece of
+    content that a learner accesses.
+  columns:
+  - name: studentmodule_id
+    description: int, primary key in courseware_studentmodule
+    tests:
+    - not_null
+    - unique
+  - name: user_id
+    description: int, reference user id in auth_user
+    tests:
+    - not_null
+  - name: courserun_readable_id
+    description: str, open edX Course ID formatted as course-v1:{org}+{course}+{run}
+    tests:
+    - not_null
+  - name: coursestructure_block_id
+    description: str, block ID for a distinct piece of content in a course, referencing
+      course_structure
+    tests:
+    - not_null
+  - name: coursestructure_block_category
+    description: str, category/type of the block, referencing course_structure.
+    tests:
+    - not_null
+  - name: studentmodule_state_data
+    description: json, JSON object indicating the user’s last known state in the course.
+      It may contain any attributes for different module types - course, chapter,
+      sequential, etc.
+  - name: studentmodule_problem_grade
+    description: float, floating point value indicating the total unweighted grade
+      for this problem that the learner has scored. e.g. how many responses they got
+      right within the problem. This data is also available in courseactivity_problemcheck
+  - name: studentmodule_problem_max_grade
+    description: float, floating point value indicating the total possible unweighted
+      grade for this problem, or basically the number of responses that are in this
+      problem. This data is also available in courseactivity_problemcheck
+  - name: studentmodule_created_on
+    description: timestamp, datetime when this row was created, which is typically
+      when the learner first accesses this piece of content.
+    tests:
+    - not_null
+  - name: studentmodule_updated_on
+    description: timestamp, datetime when this row was last updated. A change in this
+      field implies that there was a state change.
+    tests:
+    - not_null
+  tests:
+  - dbt_expectations.expect_compound_columns_to_be_unique:
+      column_list: ["user_id", "courserun_readable_id", "coursestructure_block_id"]

--- a/src/ol_dbt/models/staging/mitxresidential/_stg_mitxresidential__models.yml
+++ b/src/ol_dbt/models/staging/mitxresidential/_stg_mitxresidential__models.yml
@@ -218,3 +218,76 @@ models:
   tests:
   - dbt_expectations.expect_compound_columns_to_be_unique:
       column_list: ["courserun_readable_id", "user_id"]
+
+- name: stg__mitxresidential__openedx__tracking_logs__user_activity
+  description: Residential MITx event data that are emitted by server, the browser,
+    or the mobile device to capture information about user's interactions with a course.
+    This table filters out events that don't supply user identifiers like username
+    and user_id.
+  columns:
+  - name: user_username
+    description: str, username of a learner on Residential MITx open edx platform
+    tests:
+    - not_null
+  - name: user_id
+    description: int, learner's user ID on edX.org. Extracted from context field.
+    tests:
+    - not_null
+  - name: courserun_readable_id
+    description: str, open edX Course ID formatted as course-v1:{org}+{course}+{run}
+      for course runs since Fall 2014, {org}/{course number}/{run} for older runs.
+      Extracted from various fields - context.course_id, context.path, event_type
+      and page. Note that the course ID extracted from context field may not be a
+      valid. This field could be blank for any events that are not for any specific
+      course .e.g. user login/out.
+  - name: org_id
+    description: str, reference name in organizations_organization from open edX.
+      e.g. MITx . Extracted from context field.
+  - name: useractivity_path
+    description: str, URL that generated this event. Extracted from context field
+  - name: useractivity_context_object
+    description: object, it includes member fields that provide contextual information.
+      Common fields apply to all events are course_id, org_id, path, user_id. Other
+      member fields for applicable events are course_user_tags, module.
+  - name: useractivity_event_source
+    description: str, specifies the source of the interaction that triggered the event.
+      The values are - browser, mobile, server, task
+    tests:
+    - not_null
+  - name: useractivity_event_type
+    description: str, type of event triggered. Values depend on event_source.
+    tests:
+    - not_null
+  - name: useractivity_event_object
+    description: object,it includes member fields that identify specifics of each
+      triggered event. Different member fields are supplied for different events.
+    tests:
+    - not_null
+  - name: useractivity_page_url
+    description: str, url of the page the user was visiting when the event was emitted.
+  - name: useractivity_session_id
+    description: str, 32-character value to identify the user’s session. All browser
+      events and the server 'enrollment' events include session value. Other server
+      events and mobile events do not include a session value.
+  - name: useractivity_ip
+    description: str, IP address of the user who triggered the event. Empty for mobile
+      events.
+  - name: useractivity_http_host
+    description: str, The site visited by the user, e.g., lms.mitx.mit.edu
+    tests:
+    - not_null
+  - name: useractivity_http_user_agent
+    description: str, browser agent string of the user who triggered the event.
+  - name: useractivity_http_accept_language
+    description: str, value from the HTTP Accept-Language request-header field
+  - name: useractivity_http_referer
+    description: str, URI from the HTTP Referer request-header field
+  - name: useractivity_timestamp
+    description: timestamp, time at which the event was emitted, formatted as ISO
+      8601 string
+    tests:
+    - not_null
+  tests:
+  - dbt_expectations.expect_compound_columns_to_be_unique:
+      column_list: ["user_username", "useractivity_context_object", "useractivity_event_source",
+        "useractivity_event_type", "useractivity_event_object", "useractivity_timestamp"]

--- a/src/ol_dbt/models/staging/mitxresidential/_stg_mitxresidential__models.yml
+++ b/src/ol_dbt/models/staging/mitxresidential/_stg_mitxresidential__models.yml
@@ -225,11 +225,11 @@ models:
     out events that don't supply user identifiers like username and user_id.
   columns:
   - name: user_username
-    description: str, username of a learner on Residential MITx open edx platform
+    description: str, username on Residential MITx
     tests:
     - not_null
   - name: user_id
-    description: int, learner's user ID on edX.org. Extracted from context field.
+    description: int, the edX user ID extracted from context field in tracking log
     tests:
     - not_null
   - name: courserun_readable_id

--- a/src/ol_dbt/models/staging/mitxresidential/_stg_mitxresidential__models.yml
+++ b/src/ol_dbt/models/staging/mitxresidential/_stg_mitxresidential__models.yml
@@ -233,8 +233,7 @@ models:
     tests:
     - not_null
   - name: courserun_readable_id
-    description: str, open edX Course ID formatted as course-v1:{org}+{course}+{run}
-      for course runs since Fall 2014, {org}/{course number}/{run} for older runs.
+    description: str, open edX Course ID formatted as course-v1:{org}+{course}+{run}.
       Extracted from various fields - context.course_id, context.path, event_type
       and page. Note that the course ID extracted from context field may not be a
       valid. This field could be blank for any events that are not for any specific

--- a/src/ol_dbt/models/staging/mitxresidential/stg__mitxresidential__openedx__courserun_enrollment.sql
+++ b/src/ol_dbt/models/staging/mitxresidential/stg__mitxresidential__openedx__courserun_enrollment.sql
@@ -9,7 +9,7 @@ with source as (
         , user_id
         , is_active as courserunenrollment_is_active
         , mode as courserunenrollment_enrollment_mode
-        ,{{ cast_timestamp_to_iso8601('created') }} as courserunenrollment_created_on
+        , to_iso8601(from_iso8601_timestamp_nanos(created)) as courserunenrollment_created_on
     from source
 )
 

--- a/src/ol_dbt/models/staging/mitxresidential/stg__mitxresidential__openedx__courseware_studentmodule.sql
+++ b/src/ol_dbt/models/staging/mitxresidential/stg__mitxresidential__openedx__courseware_studentmodule.sql
@@ -1,0 +1,28 @@
+with source as (
+    select * from {{ source('ol_warehouse_raw_data', 'raw__mitx__openedx__mysql__courseware_studentmodule') }}
+)
+
+{{ deduplicate_query(
+   cte_name1='source',
+   cte_name2='most_recent_source' ,
+   partition_columns = 'course_id, student_id, module_id'
+   )
+}}
+
+, cleaned as (
+
+    select
+        id as studentmodule_id
+        , course_id as courserun_readable_id
+        , module_id as coursestructure_block_id
+        , module_type as coursestructure_block_category
+        , student_id as user_id
+        , state as studentmodule_state_data
+        , grade as studentmodule_problem_grade
+        , max_grade as studentmodule_problem_max_grade
+        , to_iso8601(from_iso8601_timestamp_nanos(created)) as studentmodule_created_on
+        , to_iso8601(from_iso8601_timestamp_nanos(modified)) as studentmodule_updated_on
+    from most_recent_source
+)
+
+select * from cleaned

--- a/src/ol_dbt/models/staging/mitxresidential/stg__mitxresidential__openedx__tracking_logs__user_activity.sql
+++ b/src/ol_dbt/models/staging/mitxresidential/stg__mitxresidential__openedx__tracking_logs__user_activity.sql
@@ -47,7 +47,7 @@ with source as (
         , accept_language as useractivity_http_accept_language
         , referer as useractivity_http_referer
         , coalesce(name, event_type) as useractivity_event_type
-        , {{ extract_course_id_from_tracking_log(course_id_has_old_format=true) }} as courserun_readable_id
+        , {{ extract_course_id_from_tracking_log(course_id_has_old_format=false) }} as courserun_readable_id
         , cast(json_query(context, 'lax $.user_id' omit quotes) as integer) as user_id
         , json_query(context, 'lax $.org_id' omit quotes) as org_id
         , json_query(context, 'lax $.path' omit quotes) as useractivity_path

--- a/src/ol_dbt/models/staging/mitxresidential/stg__mitxresidential__openedx__tracking_logs__user_activity.sql
+++ b/src/ol_dbt/models/staging/mitxresidential/stg__mitxresidential__openedx__tracking_logs__user_activity.sql
@@ -1,0 +1,61 @@
+{{ config(
+    materialized='incremental',
+    unique_key = ['user_username', 'useractivity_context_object', 'useractivity_event_source',
+    'useractivity_event_type', 'useractivity_event_object', 'useractivity_timestamp'],
+    incremental_strategy='delete+insert',
+    views_enabled=false,
+  )
+}}
+
+with source as (
+    select * from {{ source('ol_warehouse_raw_data','raw__mitx__openedx__tracking_logs') }}
+    where
+        username != ''
+        and json_query(context, 'lax $.user_id' omit quotes) is not null
+
+        {% if is_incremental() %}
+            and "time" > (select max(this.useractivity_timestamp) from {{ this }} as this)
+        {% endif %}
+)
+
+, source_sorted as (
+    select
+        *
+        , row_number() over (
+            partition by username, context, event_source, event_type, event, "time"
+            order by _airbyte_emitted_at desc, _ab_source_file_last_modified desc, "time" desc
+        ) as row_num
+    from source
+)
+
+, dedup_source as (
+    select * from source_sorted
+    where row_num = 1
+)
+
+, cleaned as (
+    select
+        username as user_username
+        , context as useractivity_context_object
+        , event as useractivity_event_object
+        , event_source as useractivity_event_source
+        , page as useractivity_page_url
+        , session as useractivity_session_id
+        , ip as useractivity_ip
+        , host as useractivity_http_host
+        , agent as useractivity_http_user_agent
+        , accept_language as useractivity_http_accept_language
+        , referer as useractivity_http_referer
+        , coalesce(name, event_type) as useractivity_event_type
+        , {{ extract_course_id_from_tracking_log(course_id_has_old_format=true) }} as courserun_readable_id
+        , cast(json_query(context, 'lax $.user_id' omit quotes) as integer) as user_id
+        , json_query(context, 'lax $.org_id' omit quotes) as org_id
+        , json_query(context, 'lax $.path' omit quotes) as useractivity_path
+        --- use regex here to preserve the nanoseconds
+        , to_iso8601(from_iso8601_timestamp_nanos(
+            regexp_replace("time", '(\d{4}-\d{2}-\d{2})[ ](\d{2}:\d{2}:\d{2}\.\d+)(.*?)', '$1T$2$3')
+        )) as useractivity_timestamp
+    from dedup_source
+)
+
+select * from cleaned

--- a/src/ol_dbt/models/staging/mitxresidential/stg__mitxresidential__openedx__tracking_logs__user_activity.sql
+++ b/src/ol_dbt/models/staging/mitxresidential/stg__mitxresidential__openedx__tracking_logs__user_activity.sql
@@ -51,7 +51,6 @@ with source as (
         , cast(json_query(context, 'lax $.user_id' omit quotes) as integer) as user_id
         , json_query(context, 'lax $.org_id' omit quotes) as org_id
         , json_query(context, 'lax $.path' omit quotes) as useractivity_path
-        --- use regex here to preserve the nanoseconds
         , to_iso8601(from_iso8601_timestamp_nanos(
             regexp_replace("time", '(\d{4}-\d{2}-\d{2})[ ](\d{2}:\d{2}:\d{2}\.\d+)(.*?)', '$1T$2$3')
         )) as useractivity_timestamp


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
https://github.com/mitodl/hq/issues/5219

### Description (What does it do?)
<!--- Describe your changes in detail -->
This adds a bunch of staging and intermediate models for Residential MITx mostly from tracking log.

We also need the course structure table which is currently waiting for https://github.com/mitodl/ol-data-platform/pull/1233. But we can add that later when it's ready.

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

dbt build --select stg__mitxresidential__openedx__tracking_logs__user_activity
dbt build --select stg__mitxresidential__openedx__courseware_studentmodule
dbt build --select intermediate.mitxresidential

or 

dbt build --select staging.mitxresidential
dbt build --select intermediate.mitxresidential

If you have never run dbt locally for residential

