### PR TITLE
Add residential to combined enrollment mart

### DIFF
--- a/src/ol_dbt/dbt_project.yml
+++ b/src/ol_dbt/dbt_project.yml
@@ -29,7 +29,8 @@ vars:
   schema_suffix: dev
 
   open_learning:
-    platforms: ['Bootcamps', 'xPro', 'MITx Online', 'MicroMasters', 'edX.org']
+    platforms: ['Bootcamps', 'xPro', 'MITx Online', 'MicroMasters', 'edX.org', 'Residential
+        MITx']
     bootcamps: 'Bootcamps'
     edxorg: 'edX.org'
     mitxpro: 'xPro'

--- a/src/ol_dbt/macros/extract_course_id.sql
+++ b/src/ol_dbt/macros/extract_course_id.sql
@@ -19,3 +19,19 @@
               then regexp_extract(page, '{{ course_id_regex }}')
       end
 {% endmacro %}
+
+
+{% macro extract_course_readable_id(courserun_readable_id) %}
+    ---Output: course_readable_id in course-v1:{org}+{course number} format
+    ---Input: courserun_readable_id in course-v1:{org}+{course number}+{run tag} for courses created since Fall 2014,
+    --- {org}/{course number}/{run tag} for courses created before Fall 2014
+     case
+          when position('course-v' in {{ courserun_readable_id }} ) > 0
+             then regexp_extract({{ courserun_readable_id }}, 'course-v(\d{1}):([\w\.\-]+)\+([a-zA-Z0-9.-]+)')
+          else
+             concat(
+                  'course-v1:'
+                  , replace(regexp_extract({{ courserun_readable_id }}, '([\w]+)/([a-zA-Z0-9.-]+)'), '/', '+')
+             )
+      end
+{% endmacro %}

--- a/src/ol_dbt/models/intermediate/combined/_combined_models.yml
+++ b/src/ol_dbt/models/intermediate/combined/_combined_models.yml
@@ -121,7 +121,7 @@ models:
       to 1. Null for bootcamps
   - name: courserungrade_is_passing
     description: boolean, indicating whether the user has passed the passing score
-      set for this course on edX.org or MITxOnline or xPro. Null for bootcamps
+      set for this course on the corresponding platform. Null for bootcamps
   - name: course_title
     description: str, title of the course. May be null for some old edX.org runs.
   - name: course_readable_id

--- a/src/ol_dbt/models/intermediate/combined/_combined_models.yml
+++ b/src/ol_dbt/models/intermediate/combined/_combined_models.yml
@@ -123,11 +123,12 @@ models:
     description: boolean, indicating whether the user has passed the passing score
       set for this course on the corresponding platform. Null for bootcamps
   - name: course_title
-    description: str, title of the course. May be null for some old edX.org runs.
+    description: str, title of the course. May be null for some edX.org and Residential
+      courses.
   - name: course_readable_id
     description: str, open edX ID formatted as course-v1:{org}+{course code} for MITx
       Online and xPro courses, and {org}/{course} for edX.org courses. May be null
-      for some old edX.org runs and Bootcamps courses.
+      for some Bootcamps courses.
 
 - name: int__combined__courserun_certificates
   description: course certificates model combined from different platforms. It excludes

--- a/src/ol_dbt/models/intermediate/combined/int__combined__course_runs.sql
+++ b/src/ol_dbt/models/intermediate/combined/int__combined__course_runs.sql
@@ -29,11 +29,7 @@ with mitx_courses as (
 , residential_runs as (
     select
         *
-        , concat(
-            element_at(split(courserun_readable_id, '+'), 1)
-            , '+'
-            , element_at(split(courserun_readable_id, '+'), 2)
-        ) as course_readable_id
+        , {{ extract_course_readable_id('courserun_readable_id') }} as course_readable_id
     from {{ ref('int__mitxresidential__courseruns') }}
 )
 

--- a/src/ol_dbt/models/intermediate/combined/int__combined__courserun_enrollments.sql
+++ b/src/ol_dbt/models/intermediate/combined/int__combined__courserun_enrollments.sql
@@ -165,8 +165,11 @@ with mitx_enrollments as (
 
 select
     combined_enrollments.*
-    , combined_courseruns.course_title
-    , combined_courseruns.course_readable_id
+    , coalesce(combined_courseruns.course_title, combined_enrollments.courserun_title) as course_title
+    , coalesce(
+        combined_courseruns.course_readable_id
+        , {{ extract_course_readable_id('combined_enrollments.courserun_readable_id') }}
+    ) as course_readable_id
     , combined_certificates.courseruncertificate_created_on
     , combined_certificates.courseruncertificate_url
     , combined_certificates.courseruncertificate_uuid

--- a/src/ol_dbt/models/intermediate/combined/int__combined__courserun_enrollments.sql
+++ b/src/ol_dbt/models/intermediate/combined/int__combined__courserun_enrollments.sql
@@ -146,6 +146,7 @@ with mitx_enrollments as (
         , residential_enrollments.courserunenrollment_enrollment_mode
         , null as courserunenrollment_enrollment_status
         , true as courserunenrollment_is_edx_enrolled
+        , null as courserun_upgrade_deadline
         , residential_enrollments.user_id
         , null as courserun_id
         , residential_enrollments.courserun_title
@@ -154,7 +155,7 @@ with mitx_enrollments as (
         , residential_enrollments.user_email
         , residential_enrollments.user_full_name
         , residential_grades.courserungrade_grade
-        , null as courserungrade_is_passing
+        , if(residential_grades.courserungrade_letter_grade != '', true, false) as courserungrade_is_passing
     from residential_enrollments
     left join residential_grades
         on
@@ -172,7 +173,9 @@ select
     , if(combined_certificates.courseruncertificate_url is not null, true, false) as courseruncertificate_is_earned
 from combined_enrollments
 left join combined_courseruns
-    on combined_enrollments.courserun_readable_id = combined_courseruns.courserun_readable_id
+    on
+        combined_enrollments.courserun_readable_id = combined_courseruns.courserun_readable_id
+        and combined_enrollments.platform = combined_courseruns.platform
 left join combined_certificates
     on
         combined_enrollments.platform = combined_certificates.platform

--- a/src/ol_dbt/models/intermediate/combined/int__combined__courserun_enrollments.sql
+++ b/src/ol_dbt/models/intermediate/combined/int__combined__courserun_enrollments.sql
@@ -10,6 +10,14 @@ with mitx_enrollments as (
     select * from {{ ref('int__bootcamps__courserunenrollments') }}
 )
 
+, residential_enrollments as (
+    select * from {{ ref('int__mitxresidential__courserun_enrollments') }}
+)
+
+, residential_grades as (
+    select * from {{ ref('int__mitxresidential__courserun_grades') }}
+)
+
 , mitx_grades as (
     select * from {{ ref('int__mitx__courserun_grades') }}
 )
@@ -127,6 +135,31 @@ with mitx_enrollments as (
         , null as courserungrade_grade
         , null as courserungrade_is_passing
     from bootcamps_enrollments
+
+    union all
+
+    select
+        '{{ var("residential") }}' as platform
+        , residential_enrollments.courserunenrollment_id
+        , residential_enrollments.courserunenrollment_is_active
+        , residential_enrollments.courserunenrollment_created_on
+        , residential_enrollments.courserunenrollment_enrollment_mode
+        , null as courserunenrollment_enrollment_status
+        , true as courserunenrollment_is_edx_enrolled
+        , residential_enrollments.user_id
+        , null as courserun_id
+        , residential_enrollments.courserun_title
+        , residential_enrollments.courserun_readable_id
+        , residential_enrollments.user_username
+        , residential_enrollments.user_email
+        , residential_enrollments.user_full_name
+        , residential_grades.courserungrade_grade
+        , null as courserungrade_is_passing
+    from residential_enrollments
+    left join residential_grades
+        on
+            residential_enrollments.courserun_readable_id = residential_grades.courserun_readable_id
+            and residential_enrollments.user_id = residential_grades.user_id
 )
 
 select

--- a/src/ol_dbt/models/intermediate/combined/int__combined__users.sql
+++ b/src/ol_dbt/models/intermediate/combined/int__combined__users.sql
@@ -18,6 +18,10 @@ with mitxonline_users as (
     select * from {{ ref('int__edxorg__mitx_users') }}
 )
 
+, residential_users as (
+    select * from {{ ref('int__mitxresidential__users') }}
+)
+
 , micromasters_users as (
     select * from {{ ref('int__micromasters__users') }}
 )
@@ -97,6 +101,25 @@ with mitxonline_users as (
         , edxorg_users.user_is_active
     from edxorg_users
     left join micromasters_users on edxorg_users.user_username = micromasters_users.user_edxorg_username
+
+    union all
+
+    select
+        '{{ var("residential") }}' as platform
+        , user_id
+        , user_username
+        , user_email
+        , user_address_country
+        , user_highest_education
+        , user_gender
+        , user_birth_year
+        , null as user_company
+        , null as user_job_title
+        , null as user_industry
+        , user_joined_on
+        , user_last_login
+        , user_is_active
+    from residential_users
 )
 
 select * from combined_users

--- a/src/ol_dbt/models/intermediate/mitxresidential/_int_mitxresidential__models.yml
+++ b/src/ol_dbt/models/intermediate/mitxresidential/_int_mitxresidential__models.yml
@@ -126,6 +126,8 @@ models:
     description: str, user's email associated with their account
     tests:
     - not_null
+  - name: user_full_name
+    description: str, user's full name on Residential MITx open edx platform.
   tests:
   - dbt_expectations.expect_table_row_count_to_equal_other_table:
       compare_model: ref('stg__mitxresidential__openedx__courserun_enrollment')

--- a/src/ol_dbt/models/intermediate/mitxresidential/_int_mitxresidential__models.yml
+++ b/src/ol_dbt/models/intermediate/mitxresidential/_int_mitxresidential__models.yml
@@ -18,12 +18,10 @@ models:
     - not_null
   - name: user_first_name
     description: str, user's first name
-    tests:
-    - not_null
   - name: user_last_name
     description: str, user's last name
-    tests:
-    - not_null
+  - name: user_full_name
+    description: str, user's full name. May be null for a few users.
   - name: user_email
     description: str, user's email associated with their account
     tests:
@@ -39,6 +37,16 @@ models:
     - not_null
   - name: user_last_login
     description: timestamp, date and time when user last login
+  - name: user_address_city
+    description: string, user city. May be null.
+  - name: user_address_country
+    description: string, user country code. May be null.
+  - name: user_gender
+    description: str, user gender. May be null.
+  - name: user_birth_year
+    description: int, user birth year. May be null.
+  - name: user_highest_education
+    description: str, user highest education. May be null.
   tests:
   - dbt_expectations.expect_table_row_count_to_equal_other_table:
       compare_model: ref('stg__mitxresidential__openedx__auth_user')
@@ -101,9 +109,6 @@ models:
     description: int, user ID on Residential MITx open edx platform
     tests:
     - not_null
-    - relationships:
-        to: ref('int__mitxresidential__users')
-        field: user_id
   - name: courserunenrollment_enrollment_mode
     description: str, enrollment mode e.g. honor or audit
     tests:

--- a/src/ol_dbt/models/intermediate/mitxresidential/int__mitxresidential__courserun_enrollments.sql
+++ b/src/ol_dbt/models/intermediate/mitxresidential/int__mitxresidential__courserun_enrollments.sql
@@ -7,7 +7,7 @@ with enrollments as (
 )
 
 , users as (
-    select * from {{ ref('stg__mitxresidential__openedx__auth_user') }}
+    select * from {{ ref('int__mitxresidential__users') }}
 )
 
 , courserun_enrollments as (

--- a/src/ol_dbt/models/intermediate/mitxresidential/int__mitxresidential__courserun_enrollments.sql
+++ b/src/ol_dbt/models/intermediate/mitxresidential/int__mitxresidential__courserun_enrollments.sql
@@ -21,6 +21,7 @@ with enrollments as (
         , runs.courserun_title
         , users.user_username
         , users.user_email
+        , users.user_full_name
     from enrollments
     left join runs on enrollments.courserun_readable_id = runs.courserun_readable_id
     left join users on enrollments.user_id = users.user_id

--- a/src/ol_dbt/models/intermediate/mitxresidential/int__mitxresidential__users.sql
+++ b/src/ol_dbt/models/intermediate/mitxresidential/int__mitxresidential__users.sql
@@ -2,6 +2,10 @@ with users as (
     select * from {{ ref('stg__mitxresidential__openedx__auth_user') }}
 )
 
+, profiles as (
+    select * from {{ ref('stg__mitxresidential__openedx__auth_userprofile') }}
+)
+
 select
     users.user_id
     , users.user_username
@@ -11,4 +15,11 @@ select
     , users.user_joined_on
     , users.user_last_login
     , users.user_is_active
+    , profiles.user_address_city
+    , profiles.user_address_country
+    , profiles.user_birth_year
+    , profiles.user_gender
+    , profiles.user_highest_education
+    , coalesce(users.user_full_name, profiles.user_full_name) as user_full_name
 from users
+left join profiles on users.user_id = profiles.user_id

--- a/src/ol_dbt/models/marts/combined/_marts__combined__models.yml
+++ b/src/ol_dbt/models/marts/combined/_marts__combined__models.yml
@@ -59,8 +59,6 @@ models:
     description: int, user ID on MITxPRO
   - name: user_bootcamps_id
     description: int, user ID on bootcamps
-  - name: user_mitx_id
-    description: int, open user ID on Residential MITx
   - name: user_mitxonline_username
     description: string, username on MITxOnline
   - name: user_edxorg_username
@@ -69,8 +67,6 @@ models:
     description: string, username on MITxPRO
   - name: user_bootcamps_username
     description: string, username on bootcamps
-  - name: user_mitx_username
-    description: string, username on Residential MITx
   - name: num_of_course_enrolled
     description: number, the number of courses learner enrolled based on their emails
       so this counts as same person if they use the email to register on different
@@ -82,7 +78,7 @@ models:
   tests:
   - dbt_expectations.expect_compound_columns_to_be_unique:
       column_list: ["user_mitxonline_username", "user_edxorg_username", "user_mitxpro_username",
-        "user_bootcamps_username", "user_mitx_username", "platforms"]
+        "user_bootcamps_username", "platforms"]
 
 - name: marts__combined__orders
   description: ecommerce regular b2c orders

--- a/src/ol_dbt/models/marts/combined/_marts__combined__models.yml
+++ b/src/ol_dbt/models/marts/combined/_marts__combined__models.yml
@@ -246,12 +246,14 @@ models:
       and platform.
   - name: course_readable_id
     description: str, Open edX ID formatted as course-v1:{org}+{course code} for MITx
-      Online and xPro courses, and {org}/{course} for edX.org courses. May be null
-      for some old edX.org runs, Bootcamps or Residential MITx courses. Examples include
-      MITx/6.00.2x and course-v1:MITxT+14.740x.
+      Online, xPro or Residential courses, and {org}/{course} for edX.org courses.
+      May be null for some Bootcamps courses. Examples include MITx/6.00.2x and course-v1:MITxT+14.740x.
+    tests:
+    - dbt_expectations.expect_column_values_to_not_be_null:
+        row_condition: "platform != 'Bootcamps'"
   - name: course_title
-    description: str, title of the course. May be null for some old edX.org runs or
-      Residential MITx courses
+    description: str, title of the course. May be null for some edX.org and Residential
+      courses
   - name: courserun_end_on
     description: timestamp, date and time when the course run ends. May be Null.
   - name: courserun_id

--- a/src/ol_dbt/models/marts/combined/_marts__combined__models.yml
+++ b/src/ol_dbt/models/marts/combined/_marts__combined__models.yml
@@ -7,26 +7,27 @@ models:
   columns:
   - name: user_email
     description: string, user email on the corresponding platform including xpro,
-      bootcamps, edX.org, or MITx Online. If the user is on edX.org and MITx Online
-      then the email will be chosen from the last platform they joined if their account
-      is active
+      bootcamps, edX.org, MITx Online, and Residential MITx. If the user is on edX.org
+      and MITx Online then the email will be chosen from the last platform they joined
+      if their account is active
     tests:
     - not_null
   - name: user_joined_on
     description: timestamp, user join timestamp on the corresponding platform including
-      xpro, bootcamps, edX.org, or MITx Online. If the user is on edX.org and MITx
-      Online then the timestamp will be chosen from the latest platform they joined
-      if their account is active
+      xpro, bootcamps, edX.org, MITx Online, and Residential MITx. If the user is
+      on edX.org and MITx Online then the timestamp will be chosen from the latest
+      platform they joined if their account is active
   - name: user_last_login
     description: timestamp, user last login on the corresponding platform including
-      xpro, bootcamps, edX.org, or MITx Online. If the user is on edX.org and MITx
-      Online then the timestamp will be chosen from the latest login if their account
-      is active
+      xpro, bootcamps, edX.org, MITx Online, and Residential MITx. If the user is
+      on edX.org and MITx Online then the timestamp will be chosen from the latest
+      login if their account is active
   - name: user_is_active
     description: boolean, indicating if user's account is active on the corresponding
-      platform including xpro, bootcamps, edX.org, or MITx Online. If the user is
-      on edX.org and MITx Online then it will be true if their MITx Online account
-      is active, otherwise it will default to their edX.org account active status.
+      platform including xpro, bootcamps, edX.org, MITx Online, and Residential MITx.
+      If the user is on edX.org and MITx Online then it will be true if their MITx
+      Online account is active, otherwise it will default to their edX.org account
+      active status.
   - name: platforms
     description: string, application where the data is from
     tests:
@@ -58,6 +59,8 @@ models:
     description: int, user ID on MITxPRO
   - name: user_bootcamps_id
     description: int, user ID on bootcamps
+  - name: user_mitx_id
+    description: int, open user ID on Residential MITx
   - name: user_mitxonline_username
     description: string, username on MITxOnline
   - name: user_edxorg_username
@@ -66,6 +69,8 @@ models:
     description: string, username on MITxPRO
   - name: user_bootcamps_username
     description: string, username on bootcamps
+  - name: user_mitx_username
+    description: string, username on Residential MITx
   - name: num_of_course_enrolled
     description: number, the number of courses learner enrolled based on their emails
       so this counts as same person if they use the email to register on different
@@ -77,7 +82,7 @@ models:
   tests:
   - dbt_expectations.expect_compound_columns_to_be_unique:
       column_list: ["user_mitxonline_username", "user_edxorg_username", "user_mitxpro_username",
-        "user_bootcamps_username", "platforms"]
+        "user_bootcamps_username", "user_mitx_username", "platforms"]
 
 - name: marts__combined__orders
   description: ecommerce regular b2c orders
@@ -242,16 +247,11 @@ models:
   - name: course_readable_id
     description: str, Open edX ID formatted as course-v1:{org}+{course code} for MITx
       Online and xPro courses, and {org}/{course} for edX.org courses. May be null
-      for some old edX.org runs and Bootcamps courses. Examples include MITx/6.00.2x
-      and course-v1:MITxT+14.740x.
-    tests:
-    - dbt_expectations.expect_column_values_to_not_be_null:
-        row_condition: "platform != 'Bootcamps' and platform != 'edX.org'"
+      for some old edX.org runs, Bootcamps or Residential MITx courses. Examples include
+      MITx/6.00.2x and course-v1:MITxT+14.740x.
   - name: course_title
-    description: str, title of the course. May be null for some old edX.org runs.
-    tests:
-    - dbt_expectations.expect_column_values_to_not_be_null:
-        row_condition: "platform != 'edX.org'"
+    description: str, title of the course. May be null for some old edX.org runs or
+      Residential MITx courses
   - name: courserun_end_on
     description: timestamp, date and time when the course run ends. May be Null.
   - name: courserun_id
@@ -356,6 +356,9 @@ models:
   - dbt_expectations.expect_compound_columns_to_be_unique:
       column_list: ["courserunenrollment_id", "order_reference_number"]
       row_condition: "platform='Bootcamps'"
+  - dbt_expectations.expect_compound_columns_to_be_unique:
+      column_list: ["courserunenrollment_id"]
+      row_condition: "platform ='Residential MITx'"
 
 - name: marts__combined_program_enrollment_detail
   description: Mart model for program enrollments and certificates from different

--- a/src/ol_dbt/models/marts/combined/_marts__combined__models.yml
+++ b/src/ol_dbt/models/marts/combined/_marts__combined__models.yml
@@ -333,6 +333,8 @@ models:
   - name: user_highest_education
     description: str, user's highest education on the platform user enrolled. May
       be blank.
+  - name: user_gender
+    description: str, gender on the platform user enrolled
   - name: user_id
     description: int, user ID on the corresponding platform
     tests:

--- a/src/ol_dbt/models/marts/combined/marts__combined__users.sql
+++ b/src/ol_dbt/models/marts/combined/marts__combined__users.sql
@@ -12,6 +12,11 @@ with mitx__users as (
     select * from {{ ref('int__bootcamps__users') }}
 )
 
+, residential_users as (
+    select * from {{ ref('int__mitxresidential__users') }}
+)
+
+
 , combined_enrollments as (
     select * from {{ ref('int__combined__courserun_enrollments') }}
 )
@@ -130,6 +135,34 @@ with mitx__users as (
         , user_job_title
         , user_industry
     from bootcamps_users
+
+    union all
+
+    select
+        null as user_mitxonline_id
+        , null as user_edxorg_id
+        , null as user_mitxpro_id
+        , null as user_bootcamps_id
+        , user_id as user_mitx_id
+        , null as user_mitxonline_username
+        , null as user_edxorg_username
+        , null as user_mitxpro_username
+        , null as user_bootcamps_username
+        , user_username as user_mitx_username
+        , user_email
+        , user_joined_on
+        , user_last_login
+        , user_is_active
+        , '{{ var("residential") }}' as platforms
+        , user_full_name
+        , user_address_country
+        , user_highest_education
+        , user_gender
+        , user_birth_year
+        , user_company
+        , user_job_title
+        , user_industry
+    from residential_users
 )
 
 select
@@ -150,10 +183,12 @@ select
     , combined_users.user_edxorg_id
     , combined_users.user_mitxpro_id
     , combined_users.user_bootcamps_id
+    , combined_users.user_mitx_id
     , combined_users.user_mitxonline_username
     , combined_users.user_edxorg_username
     , combined_users.user_mitxpro_username
     , combined_users.user_bootcamps_username
+    , combined_users.user_mitx_username
     , course_stats.num_of_course_enrolled
     , course_stats.num_of_course_passed
 from combined_users

--- a/src/ol_dbt/models/marts/combined/marts__combined__users.sql
+++ b/src/ol_dbt/models/marts/combined/marts__combined__users.sql
@@ -41,10 +41,12 @@ with mitx__users as (
         , user_edxorg_id
         , null as user_mitxpro_id
         , null as user_bootcamps_id
+        , null as user_mitx_id
         , user_mitxonline_username
         , user_edxorg_username
         , null as user_mitxpro_username
         , null as user_bootcamps_username
+        , null as user_mitx_username
         , case
             when user_is_active_on_mitxonline and user_joined_on_mitxonline > user_joined_on_edxorg
                 then user_mitxonline_email
@@ -91,10 +93,12 @@ with mitx__users as (
         , null as user_edxorg_id
         , user_id as user_mitxpro_id
         , null as user_bootcamps_id
+        , null as user_mitx_id
         , null as user_mitxonline_username
         , null as user_edxorg_username
         , user_username as user_mitxpro_username
         , null as user_bootcamps_username
+        , null as user_mitx_username
         , user_email
         , user_joined_on
         , user_last_login
@@ -117,10 +121,12 @@ with mitx__users as (
         , null as user_edxorg_id
         , null as user_mitxpro_id
         , user_id as user_bootcamps_id
+        , null as user_mitx_id
         , null as user_mitxonline_username
         , null as user_edxorg_username
         , null as user_mitxpro_username
         , user_username as user_bootcamps_username
+        , null as user_mitx_username
         , user_email
         , user_joined_on
         , user_last_login
@@ -159,9 +165,9 @@ with mitx__users as (
         , user_highest_education
         , user_gender
         , user_birth_year
-        , user_company
-        , user_job_title
-        , user_industry
+        , null as user_company
+        , null as user_job_title
+        , null as user_industry
     from residential_users
 )
 

--- a/src/ol_dbt/models/marts/combined/marts__combined__users.sql
+++ b/src/ol_dbt/models/marts/combined/marts__combined__users.sql
@@ -12,11 +12,6 @@ with mitx__users as (
     select * from {{ ref('int__bootcamps__users') }}
 )
 
-, residential_users as (
-    select * from {{ ref('int__mitxresidential__users') }}
-)
-
-
 , combined_enrollments as (
     select * from {{ ref('int__combined__courserun_enrollments') }}
 )
@@ -41,12 +36,10 @@ with mitx__users as (
         , user_edxorg_id
         , null as user_mitxpro_id
         , null as user_bootcamps_id
-        , null as user_mitx_id
         , user_mitxonline_username
         , user_edxorg_username
         , null as user_mitxpro_username
         , null as user_bootcamps_username
-        , null as user_mitx_username
         , case
             when user_is_active_on_mitxonline and user_joined_on_mitxonline > user_joined_on_edxorg
                 then user_mitxonline_email
@@ -93,12 +86,10 @@ with mitx__users as (
         , null as user_edxorg_id
         , user_id as user_mitxpro_id
         , null as user_bootcamps_id
-        , null as user_mitx_id
         , null as user_mitxonline_username
         , null as user_edxorg_username
         , user_username as user_mitxpro_username
         , null as user_bootcamps_username
-        , null as user_mitx_username
         , user_email
         , user_joined_on
         , user_last_login
@@ -121,12 +112,10 @@ with mitx__users as (
         , null as user_edxorg_id
         , null as user_mitxpro_id
         , user_id as user_bootcamps_id
-        , null as user_mitx_id
         , null as user_mitxonline_username
         , null as user_edxorg_username
         , null as user_mitxpro_username
         , user_username as user_bootcamps_username
-        , null as user_mitx_username
         , user_email
         , user_joined_on
         , user_last_login
@@ -141,34 +130,6 @@ with mitx__users as (
         , user_job_title
         , user_industry
     from bootcamps_users
-
-    union all
-
-    select
-        null as user_mitxonline_id
-        , null as user_edxorg_id
-        , null as user_mitxpro_id
-        , null as user_bootcamps_id
-        , user_id as user_mitx_id
-        , null as user_mitxonline_username
-        , null as user_edxorg_username
-        , null as user_mitxpro_username
-        , null as user_bootcamps_username
-        , user_username as user_mitx_username
-        , user_email
-        , user_joined_on
-        , user_last_login
-        , user_is_active
-        , '{{ var("residential") }}' as platforms
-        , user_full_name
-        , user_address_country
-        , user_highest_education
-        , user_gender
-        , user_birth_year
-        , null as user_company
-        , null as user_job_title
-        , null as user_industry
-    from residential_users
 )
 
 select
@@ -189,12 +150,10 @@ select
     , combined_users.user_edxorg_id
     , combined_users.user_mitxpro_id
     , combined_users.user_bootcamps_id
-    , combined_users.user_mitx_id
     , combined_users.user_mitxonline_username
     , combined_users.user_edxorg_username
     , combined_users.user_mitxpro_username
     , combined_users.user_bootcamps_username
-    , combined_users.user_mitx_username
     , course_stats.num_of_course_enrolled
     , course_stats.num_of_course_passed
 from combined_users

--- a/src/ol_dbt/models/marts/combined/marts__combined_course_enrollment_detail.sql
+++ b/src/ol_dbt/models/marts/combined/marts__combined_course_enrollment_detail.sql
@@ -74,6 +74,7 @@ with combined_enrollments as (
         , combined_users.user_address_country as user_country_code
         , combined_users.user_highest_education
         , combined_users.user_company
+        , combined_users.user_gender
         , combined_enrollments.courseruncertificate_is_earned
         , combined_enrollments.courseruncertificate_created_on
         , combined_enrollments.courseruncertificate_url
@@ -126,6 +127,7 @@ with combined_enrollments as (
         , combined_users.user_address_country as user_country_code
         , combined_users.user_highest_education
         , combined_users.user_company
+        , combined_users.user_gender
         , combined_enrollments.courseruncertificate_is_earned
         , combined_enrollments.courseruncertificate_created_on
         , combined_enrollments.courseruncertificate_url
@@ -180,6 +182,7 @@ with combined_enrollments as (
         , combined_users.user_address_country as user_country_code
         , combined_users.user_highest_education
         , combined_users.user_company
+        , combined_users.user_gender
         , combined_enrollments.courseruncertificate_is_earned
         , combined_enrollments.courseruncertificate_created_on
         , combined_enrollments.courseruncertificate_url
@@ -231,6 +234,7 @@ with combined_enrollments as (
         , combined_users.user_address_country as user_country_code
         , combined_users.user_highest_education
         , combined_users.user_company
+        , combined_users.user_gender
         , combined_enrollments.courseruncertificate_is_earned
         , combined_enrollments.courseruncertificate_created_on
         , combined_enrollments.courseruncertificate_url
@@ -282,6 +286,7 @@ with combined_enrollments as (
         , combined_users.user_address_country as user_country_code
         , combined_users.user_highest_education
         , combined_users.user_company
+        , combined_users.user_gender
         , combined_enrollments.courseruncertificate_is_earned
         , combined_enrollments.courseruncertificate_created_on
         , combined_enrollments.courseruncertificate_url
@@ -340,6 +345,7 @@ select
     , user_email
     , user_full_name
     , user_highest_education
+    , user_gender
     , user_id
     , user_username
 from combined_enrollment_detail

--- a/src/ol_dbt/models/marts/combined/marts__combined_course_enrollment_detail.sql
+++ b/src/ol_dbt/models/marts/combined/marts__combined_course_enrollment_detail.sql
@@ -83,8 +83,8 @@ with combined_enrollments as (
         , mitxonline_completed_orders.order_reference_number
         , combined_enrollments.courserungrade_grade
         , combined_enrollments.courserungrade_is_passing
-        , combined_courseruns.course_title
-        , combined_courseruns.course_readable_id
+        , combined_enrollments.course_title
+        , combined_enrollments.course_readable_id
         , combined_enrollments.courserun_upgrade_deadline
     from combined_enrollments
     left join combined_users
@@ -135,8 +135,8 @@ with combined_enrollments as (
         , micromasters_completed_orders.order_reference_number
         , combined_enrollments.courserungrade_grade
         , combined_enrollments.courserungrade_is_passing
-        , combined_courseruns.course_title
-        , combined_courseruns.course_readable_id
+        , combined_enrollments.course_title
+        , combined_enrollments.course_readable_id
         , combined_enrollments.courserun_upgrade_deadline
     from combined_enrollments
     left join combined_users
@@ -189,8 +189,8 @@ with combined_enrollments as (
         , mitxpro_completed_orders.receipt_reference_number as order_reference_number
         , combined_enrollments.courserungrade_grade
         , combined_enrollments.courserungrade_is_passing
-        , combined_courseruns.course_title
-        , combined_courseruns.course_readable_id
+        , combined_enrollments.course_title
+        , combined_enrollments.course_readable_id
         , combined_enrollments.courserun_upgrade_deadline
     from mitxpro_enrollments
     inner join combined_enrollments
@@ -240,8 +240,8 @@ with combined_enrollments as (
         , bootcamps_completed_orders.order_reference_number
         , combined_enrollments.courserungrade_grade
         , combined_enrollments.courserungrade_is_passing
-        , combined_courseruns.course_title
-        , combined_courseruns.course_readable_id
+        , combined_enrollments.course_title
+        , combined_enrollments.course_readable_id
         , combined_enrollments.courserun_upgrade_deadline
     from combined_enrollments
     left join combined_users
@@ -291,15 +291,8 @@ with combined_enrollments as (
         , null as order_reference_number
         , combined_enrollments.courserungrade_grade
         , combined_enrollments.courserungrade_is_passing
-        , coalesce(combined_courseruns.course_title, combined_enrollments.courserun_title) as course_title
-        , coalesce(
-            combined_courseruns.course_readable_id
-            , concat(
-                element_at(split(combined_courseruns.course_readable_id, '+'), 1)
-                , '+'
-                , element_at(split(combined_courseruns.course_readable_id, '+'), 2)
-            )
-        ) as course_readable_id
+        , combined_enrollments.course_title
+        , combined_enrollments.course_readable_id
         , combined_enrollments.courserun_upgrade_deadline
     from combined_enrollments
     left join combined_users

--- a/src/ol_dbt/models/staging/mitxresidential/_stg_mitxresidential__models.yml
+++ b/src/ol_dbt/models/staging/mitxresidential/_stg_mitxresidential__models.yml
@@ -18,14 +18,10 @@ models:
     - not_null
   - name: user_first_name
     description: str, user's first name
-    tests:
-    - not_null
   - name: user_last_name
     description: str, user's last name
-    tests:
-    - not_null
   - name: user_full_name
-    description: str, user's full name on Residential open edx platform if applicable
+    description: str, user's full name
   - name: user_email
     description: str, user's email associated with their account
     tests:
@@ -50,6 +46,38 @@ models:
     - not_null
   - name: user_last_login
     description: timestamp, date and time when user last login
+
+- name: stg__mitxresidential__openedx__auth_userprofile
+  description: Residential MITx open edX user profile
+  columns:
+  - name: user_profile_id
+    description: int, primary key in auth_userprofile
+    tests:
+    - unique
+    - not_null
+  - name: user_id
+    description: int, foreign key to auth_user
+    tests:
+    - not_null
+  - name: user_full_name
+    description: str, user full name
+  - name: user_birth_year
+    description: int, user birth year. May be null.
+  - name: user_address_city
+    description: string, user city. May be null.
+  - name: user_address_country
+    description: string, user country code. May be null.
+  - name: user_gender
+    description: str, user gender. May be null.
+    tests:
+    - accepted_values:
+        values: ['Male', 'Female', 'Other/Prefer Not to Say']
+  - name: user_highest_education
+    description: str, user highest education. May be null.
+    tests:
+    - accepted_values:
+        values: '{{ var("highest_education_values") }}'
+
 
 - name: stg__mitxresidential__openedx__user_courseaccessrole
   description: This table lists the users who have a privileged role or roles for

--- a/src/ol_dbt/models/staging/mitxresidential/stg__mitxresidential__openedx__auth_user.sql
+++ b/src/ol_dbt/models/staging/mitxresidential/stg__mitxresidential__openedx__auth_user.sql
@@ -7,12 +7,12 @@ with source as (
         id as user_id
         , username as user_username
         , email as user_email
-        , first_name as user_first_name
-        , last_name as user_last_name
         , is_active as user_is_active
         , is_staff as user_is_staff
         , is_superuser as user_is_superuser
-        , concat_ws(' ', first_name, last_name) as user_full_name
+        , nullif(first_name, '') as user_first_name
+        , nullif(last_name, '') as user_last_name
+        , concat(nullif(first_name, ''), ' ', nullif(last_name, '')) as user_full_name
         , to_iso8601(from_iso8601_timestamp_nanos(date_joined)) as user_joined_on
         , to_iso8601(from_iso8601_timestamp_nanos(last_login)) as user_last_login
     from source

--- a/src/ol_dbt/models/staging/mitxresidential/stg__mitxresidential__openedx__auth_userprofile.sql
+++ b/src/ol_dbt/models/staging/mitxresidential/stg__mitxresidential__openedx__auth_userprofile.sql
@@ -1,0 +1,18 @@
+with source as (
+    select * from {{ source('ol_warehouse_raw_data','raw__mitx__openedx__mysql__auth_userprofile') }}
+)
+
+, cleaned as (
+    select
+        id as user_profile_id
+        , user_id
+        , name as user_full_name
+        , year_of_birth as user_birth_year
+        , nullif(city, '') as user_address_city
+        , nullif(country, '') as user_address_country
+        , {{ transform_gender_value('gender') }} as user_gender
+        , {{ transform_education_value('level_of_education') }} as user_highest_education
+    from source
+)
+
+select * from cleaned


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
Close https://github.com/mitodl/hq/issues/5219

### Description (What does it do?)
<!--- Describe your changes in detail -->
Adding Residential MITx enrollments and grades to `marts__combined_course_enrollment_detail`
  
### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->
dbt build --select +int__mitxresidential__users
dbt build --select +int__mitxresidential__courserun_enrollments
dbt build --select int__combined__courserun_enrollments
dbt build --select int__combined__users
dbt build --select marts__combined_course_enrollment_detail

or 

dbt build --select +marts__combined_course_enrollment_detail

but you may get some warnings about table count not match
