### PR TITLE
Add course and resource live URLs to OCW resource report

### DIFF
--- a/src/ol_dbt/models/intermediate/ocw/_int_ocw__models.yml
+++ b/src/ol_dbt/models/intermediate/ocw/_int_ocw__models.yml
@@ -30,10 +30,10 @@ models:
     description: str, indicating which courses were imported and which ones were authored
       in the app. Possible values are 'studio', 'ocw-import', or blank
   - name: course_url_path
-    description: str, unique url relative path to the OCW course website. e.g. courses/my-site-fall-2020.
+    description: str, unique URL relative path to the OCW course website. e.g., courses/my-site-fall-2020.
       For draft courses, it can be used to preview on https://draft.ocw.mit.edu/
   - name: course_live_url
-    description: str, url to the OCW course on production.
+    description: str, URL of the OCW course on production.
   - name: course_is_live
     description: boolean, indicating if the course website is currently published
       on OCW production.
@@ -172,6 +172,8 @@ models:
     description: str, websitecontent type of the resource (e.g., resource, external-resource)
     tests:
     - not_null
+  - name: course_live_url
+    description: str, url of the course on production
   - name: course_name
     description: str, name of the course
     tests:
@@ -214,6 +216,8 @@ models:
     description: str, filename of the resource file
     tests:
     - not_null
+  - name: resource_live_url
+    description: str, live URL of the resource on production
   - name: resource_title
     description: str, title of the resource
   - name: resource_type

--- a/src/ol_dbt/models/intermediate/ocw/int__ocw__resources.sql
+++ b/src/ol_dbt/models/intermediate/ocw/int__ocw__resources.sql
@@ -23,6 +23,7 @@ with websites as (
 
 select
     websites.website_name as course_name
+    , websites.website_live_url as course_live_url
     , websites.website_uuid as course_uuid
     , websitecontents.websitecontent_type as content_type
     , websitecontents.learning_resource_types
@@ -47,6 +48,7 @@ select
     , coalesce(sitemetadata.sitemetadata_course_term, websites.metadata_course_term) as course_term
     , coalesce(sitemetadata.sitemetadata_course_title, websites.metadata_course_title) as course_title
     , coalesce(sitemetadata.sitemetadata_course_year, websites.metadata_course_year) as course_year
+    , websites.website_live_url || '/resources/' || websitecontents.websitecontent_filename as resource_live_url
     , 'https://ocw-studio.odl.mit.edu/sites/'
     || websites.website_name
     || '/type/'


### PR DESCRIPTION
### What are the relevant tickets?
Related to https://github.com/mitodl/hq/issues/5163 and https://github.com/mitodl/hq/issues/3185#issuecomment-2291747615.

### Description (What does it do?)
This PR adds the `course_live_url` and `resource_live_url` fields to the OCW resource report. For each resource, these correspond to the URL of the course website containing the resource and a direct link to the webpage containing the resource, respectively. 

### How can this be tested?
Run the following commands; the tests should all pass.
```
dbt build --select staging.ocw  --vars 'schema_suffix: <your name>' --target dev_production
dbt build --select intermediate.ocw --vars 'schema_suffix: <your name>' --target dev_production
```

Run the following query in https://mitol.galaxy.starburst.io/query-editor to see the result of the above tables:
```
SELECT * FROM ol_data_lake_production.ol_warehouse_production_<your name>_intermediate.int__ocw__resources
```

Verify that the new fields defined in this PR actually contain data, and that the links work as expected.
