### PR TITLE
Combined course engagement marts and its upstream models

### DIFF
--- a/src/ol_dbt/models/intermediate/combined/_combined_models.yml
+++ b/src/ol_dbt/models/intermediate/combined/_combined_models.yml
@@ -23,6 +23,8 @@ models:
     description: string, user email on the corresponding platform
     tests:
     - not_null
+  - name: user_full_name
+    description: str, user full name collected on the corresponding platform
   - name: user_address_country
     description: str, country code provided by the user on the corresponding platform
   - name: user_highest_education
@@ -355,6 +357,8 @@ models:
     - not_null
   - name: chapter_id
     description: str, block id of chapter within which this video belongs to.
+    tests:
+    - not_null
   - name: chapter_title
     description: str, title of chapter this video belongs to.
   - name: video_duration

--- a/src/ol_dbt/models/intermediate/combined/_combined_models.yml
+++ b/src/ol_dbt/models/intermediate/combined/_combined_models.yml
@@ -252,3 +252,113 @@ models:
       is in the past and courserun_end_on is in the future.
     tests:
     - not_null
+
+- name: int__combined__course_structure
+  description: this table contains the latest course structure of the courses from
+    MITx Online ,xPro and edX.org.
+  columns:
+  - name: platform
+    description: str, MITx Online, xPro, edX.org
+    tests:
+    - not_null
+    - accepted_values:
+        values: '{{ var("platforms") }}'
+  - name: courserun_readable_id
+    description: str, the open edX course ID formatted as course-v1:{org}+{course
+      code}+{run_tag} for MITxOnline and xPro courses, {org}/{course}/{run_tag} for
+      edX.org courses
+    tests:
+    - not_null
+  - name: coursestructure_block_id
+    description: str, Unique ID for a distinct piece of content in a course, formatted
+      as block-v1:{org}+{course}+{run}type@{block type}+block@{hash code}
+    tests:
+    - not_null
+  - name: coursestructure_parent_block_id
+    description: str, parent block ID, same format as block_id
+  - name: coursestructure_block_index
+    description: int, sequence number giving order in which this block content appears
+      within the course
+    tests:
+    - not_null
+  - name: coursestructure_block_category
+    description: str, category/type of the block, it identifies core structural elements
+      of a course. Value includes but not limited to course, chapter, sequential,
+      vertical, discussion, html, problem, video, etc.
+    tests:
+    - not_null
+  - name: coursestructure_block_title
+    description: str, title of the block extracted from the metadata of the block.
+      This field comes from name field for the section, subsection, or unit on the
+      Studio 'Course Outline' page.
+  - name: coursestructure_block_metadata
+    description: str, json string of the metadata field for the block. It provides
+      additional information about this block, different block type may have different
+      member fields inside metadata.
+    tests:
+    - not_null
+  - name: courserun_title
+    description: str, title of the course extracted from the metadata of 'course'
+      block
+  - name: coursestructure_retrieved_at
+    description: timestamp, indicating when this course structure was initially retrieved
+      from S3
+    tests:
+    - not_null
+  - name: coursestructure_chapter_id
+    description: str, block id of chapter within which this child block belongs to.
+      Null for the 'course' block as it's the top block that doesn't belong to any
+      chapter.
+  - name: coursestructure_chapter_title
+    description: str, title of chapter within which this child block belongs to.
+  tests:
+  - dbt_expectations.expect_compound_columns_to_be_unique:
+      column_list: ["platform", "courserun_readable_id", "coursestructure_block_index"]
+
+- name: int__combined__course_videos
+  description: this table contains video structure and metadata for MITx Online, xPro
+    and edX.org courses.
+  columns:
+  - name: courserun_readable_id
+    description: str, the open edX course ID formatted as course-v1:{org}+{course
+      code}+{run_tag} for MITxOnline and xPro courses, {org}/{course}/{run_tag} for
+      edX.org courses.
+    tests:
+    - not_null
+  - name: video_id
+    description: str, hash code for the video. This value is the last part of video_block_id
+      string.
+    tests:
+    - not_null
+  - name: video_edx_id
+    description: str, the video ID on the open edx platform. edx_video_id extracted
+      from the video metadata.
+  - name: video_block_id
+    description: str, Unique ID for the video, formatted as block-v1:{org}+{course}+{run}type@{block
+      type}+block@{hash code}
+    tests:
+    - not_null
+  - name: video_parent_block_id
+    description: str, parent block ID, same format as block_id.
+  - name: video_index
+    description: int, sequence number giving order in which the video appears within
+      the course
+    tests:
+    - not_null
+  - name: video_title
+    description: str, title of the video extracted from the metadata of the block.
+      This field comes from name field for the section, subsection, or unit on the
+      Studio 'Course Outline' page.
+  - name: video_metadata
+    description: str, json string of the video metadata, e.g., display_name, edx_video_id
+    tests:
+    - not_null
+  - name: chapter_id
+    description: str, block id of chapter within which this video belongs to.
+  - name: chapter_title
+    description: str, title of chapter this video belongs to.
+  - name: video_duration
+    description: float, the length of the video, in seconds. May be 0.0.
+  tests:
+  - dbt_expectations.expect_compound_columns_to_be_unique:
+      column_list: ["platform", "courserun_readable_id", "video_index"]

--- a/src/ol_dbt/models/intermediate/combined/_combined_models.yml
+++ b/src/ol_dbt/models/intermediate/combined/_combined_models.yml
@@ -357,8 +357,6 @@ models:
     - not_null
   - name: chapter_id
     description: str, block id of chapter within which this video belongs to.
-    tests:
-    - not_null
   - name: chapter_title
     description: str, title of chapter this video belongs to.
   - name: video_duration

--- a/src/ol_dbt/models/intermediate/combined/int__combined__course_structure.sql
+++ b/src/ol_dbt/models/intermediate/combined/int__combined__course_structure.sql
@@ -1,0 +1,68 @@
+with mitxonline_course_structure as (
+    select * from {{ ref('int__mitxonline__course_structure') }}
+)
+
+, edxorg_course_structure as (
+    select * from {{ ref('int__edxorg__mitx_course_structure') }}
+)
+
+, xpro_course_structure as (
+    select * from {{ ref('int__mitxpro__course_structure') }}
+)
+
+
+, combined as (
+    select
+        '{{ var("mitxonline") }}' as platform
+        , courserun_readable_id
+        , courserun_title
+        , coursestructure_block_index
+        , coursestructure_block_id
+        , coursestructure_parent_block_id
+        , coursestructure_block_category
+        , coursestructure_block_title
+        , coursestructure_block_metadata
+        , coursestructure_retrieved_at
+        , coursestructure_chapter_id
+        , coursestructure_chapter_title
+    from mitxonline_course_structure
+    where coursestructure_is_latest = true
+
+    union all
+
+    select
+        '{{ var("edxorg") }}' as platform
+        , courserun_readable_id
+        , courserun_title
+        , coursestructure_block_index
+        , coursestructure_block_id
+        , coursestructure_parent_block_id
+        , coursestructure_block_category
+        , coursestructure_block_title
+        , coursestructure_block_metadata
+        , coursestructure_retrieved_at
+        , coursestructure_chapter_id
+        , coursestructure_chapter_title
+    from edxorg_course_structure
+    where coursestructure_is_latest = true
+
+    union all
+
+    select
+        '{{ var("mitxpro") }}' as platform
+        , courserun_readable_id
+        , courserun_title
+        , coursestructure_block_index
+        , coursestructure_block_id
+        , coursestructure_parent_block_id
+        , coursestructure_block_category
+        , coursestructure_block_title
+        , coursestructure_block_metadata
+        , coursestructure_retrieved_at
+        , coursestructure_chapter_id
+        , coursestructure_chapter_title
+    from xpro_course_structure
+    where coursestructure_is_latest = true
+)
+
+select * from combined

--- a/src/ol_dbt/models/intermediate/combined/int__combined__course_videos.sql
+++ b/src/ol_dbt/models/intermediate/combined/int__combined__course_videos.sql
@@ -1,0 +1,81 @@
+with video_structure as (
+    select
+        *
+        , json_query(coursestructure_block_metadata, 'lax $.edx_video_id' omit quotes) as video_edx_uuid
+        , element_at(split(coursestructure_block_id, '@'), -1) as video_id
+    from {{ ref('int__combined__course_structure') }}
+    where coursestructure_block_category = 'video'
+)
+
+, mitxonline_videos as (
+    select * from {{ ref('int__mitxonline__courserun_videos') }}
+)
+
+, xpro_videos as (
+    select * from {{ ref('int__mitxpro__courserun_videos') }}
+)
+
+, combined as (
+    select
+        '{{ var("mitxonline") }}' as platform
+        , video_structure.courserun_readable_id
+        , video_structure.video_id
+        , mitxonline_videos.video_edx_uuid as video_edx_id
+        , video_structure.coursestructure_block_id as video_block_id
+        , video_structure.coursestructure_parent_block_id as video_parent_block_id
+        , video_structure.coursestructure_block_metadata as video_metadata
+        , video_structure.coursestructure_block_title as video_title
+        , video_structure.coursestructure_block_index as video_index
+        , video_structure.coursestructure_chapter_title as chapter_title
+        , video_structure.coursestructure_chapter_id as chapter_id
+        , mitxonline_videos.video_duration
+    from video_structure
+    left join mitxonline_videos
+        on
+            video_structure.courserun_readable_id = mitxonline_videos.courserun_readable_id
+            and video_structure.video_edx_uuid = mitxonline_videos.video_edx_uuid
+    where video_structure.platform = '{{ var("mitxonline") }}'
+
+    union all
+
+    select
+        '{{ var("edxorg") }}' as platform
+        , courserun_readable_id
+        , video_id
+        , video_edx_uuid as video_edx_id
+        , coursestructure_block_id as video_block_id
+        , coursestructure_parent_block_id as video_parent_block_id
+        , coursestructure_block_metadata as video_metadata
+        , coursestructure_block_title as video_title
+        , coursestructure_block_index as video_index
+        , coursestructure_chapter_title as chapter_title
+        , coursestructure_chapter_id as chapter_id
+        --- null until we parse it from course xml for edxorg
+        , null as video_duration
+    from video_structure
+    where video_structure.platform = '{{ var("edxorg") }}'
+
+    union all
+
+    select
+        '{{ var("mitxpro") }}' as platform
+        , video_structure.courserun_readable_id
+        , video_structure.video_id
+        , xpro_videos.video_edx_uuid as video_edx_id
+        , video_structure.coursestructure_block_id as video_block_id
+        , video_structure.coursestructure_parent_block_id as video_parent_block_id
+        , video_structure.coursestructure_block_metadata as video_metadata
+        , video_structure.coursestructure_block_title as video_title
+        , video_structure.coursestructure_block_index as video_index
+        , video_structure.coursestructure_chapter_title as chapter_title
+        , video_structure.coursestructure_chapter_id as chapter_id
+        , xpro_videos.video_duration
+    from video_structure
+    left join xpro_videos
+        on
+            video_structure.courserun_readable_id = xpro_videos.courserun_readable_id
+            and video_structure.video_edx_uuid = xpro_videos.video_edx_uuid
+    where video_structure.platform = '{{ var("mitxpro") }}'
+)
+
+select * from combined

--- a/src/ol_dbt/models/intermediate/combined/int__combined__users.sql
+++ b/src/ol_dbt/models/intermediate/combined/int__combined__users.sql
@@ -32,6 +32,7 @@ with mitxonline_users as (
         , user_id
         , user_username
         , user_email
+        , user_full_name
         , user_address_country
         , user_highest_education
         , user_gender
@@ -51,6 +52,7 @@ with mitxonline_users as (
         , user_id
         , user_username
         , user_email
+        , user_full_name
         , user_address_country
         , user_highest_education
         , user_gender
@@ -70,6 +72,7 @@ with mitxonline_users as (
         , user_id
         , user_username
         , user_email
+        , user_full_name
         , user_address_country
         , user_highest_education
         , user_gender
@@ -89,6 +92,7 @@ with mitxonline_users as (
         , edxorg_users.user_id
         , edxorg_users.user_username
         , edxorg_users.user_email
+        , edxorg_users.user_full_name
         , edxorg_users.user_country as user_address_country
         , edxorg_users.user_highest_education
         , edxorg_users.user_gender
@@ -109,6 +113,7 @@ with mitxonline_users as (
         , user_id
         , user_username
         , user_email
+        , user_full_name
         , user_address_country
         , user_highest_education
         , user_gender

--- a/src/ol_dbt/models/intermediate/edxorg/_int_edxorg__models.yml
+++ b/src/ol_dbt/models/intermediate/edxorg/_int_edxorg__models.yml
@@ -724,3 +724,68 @@ models:
   tests:
   - dbt_expectations.expect_compound_columns_to_be_unique:
       column_list: ["user_username", "courserun_readable_id", "courseactivity_date"]
+
+- name: int__edxorg__mitx_course_structure
+  description: this table contains historical changes to edX.org course content data.
+    It adds coursestructure_chapter_id that identifies chapter each subsection belongs
+    to
+  columns:
+  - name: courserun_readable_id
+    description: str, Open edX Course ID formatted as {org}/{course code}/{run_tag}.
+    tests:
+    - not_null
+  - name: coursestructure_content_hash
+    description: str, sha256 hashed string of the course content.
+    tests:
+    - not_null
+  - name: coursestructure_block_content_hash
+    description: str, sha256 hashed string of the block content in a course
+    tests:
+    - not_null
+  - name: coursestructure_block_id
+    description: str, Unique ID for a distinct piece of content in a course, formatted
+      as block-v1:{org}+{course}+{run}type@{block type}+block@{hash code}
+    tests:
+    - not_null
+  - name: coursestructure_parent_block_id
+    description: str, parent block ID, same format as block_id
+  - name: coursestructure_block_index
+    description: int, sequence number giving order in which this block content appears
+      within the course
+    tests:
+    - not_null
+  - name: coursestructure_block_category
+    description: str, category/type of the block, it identifies core structural elements
+      of a course. Value includes but not limited to course, chapter, sequential,
+      vertical, discussion, html, problem, video, etc.
+    tests:
+    - not_null
+  - name: coursestructure_block_title
+    description: str, title of the block extracted from the metadata of the block.
+      This field comes from name field for the section, subsection, or unit on the
+      Studio 'Course Outline' page.
+  - name: coursestructure_block_metadata
+    description: str, json string of the metadata field for the block. It provides
+      additional information about this block, different block type may have different
+      member fields inside metadata.
+    tests:
+    - not_null
+  - name: courserun_title
+    description: str, title of the course extracted from the metadata of 'course'
+      block
+  - name: coursestructure_retrieved_at
+    description: timestamp, indicating when this course structure was initially retrieved
+      from S3
+    tests:
+    - not_null
+  - name: coursestructure_chapter_id
+    description: str, block id of chapter within which this child block belongs to.
+      Null for the 'course' block as it's the top block that doesn't belong to any
+      chapter.
+  - name: coursestructure_chapter_title
+    description: str, title of chapter within which this child block belongs to.
+  - name: coursestructure_is_latest
+    description: boolean, indicating if the course content is the latest version
+  tests:
+  - dbt_expectations.expect_table_row_count_to_equal_other_table:
+      compare_model: ref('stg__edxorg__s3__course_structure')

--- a/src/ol_dbt/models/intermediate/edxorg/_int_edxorg__models.yml
+++ b/src/ol_dbt/models/intermediate/edxorg/_int_edxorg__models.yml
@@ -668,7 +668,7 @@ models:
     tests:
     - not_null
   - name: useractivity_video_duration
-    description: number, The length of the video file, in seconds.
+    description: float, The length of the video file, in seconds.
   - name: useractivity_video_currenttime
     description: number, The time in the video when this event was emitted. May be
       Null for load_video or seek_video events.

--- a/src/ol_dbt/models/intermediate/edxorg/int__edxorg__mitx_course_structure.sql
+++ b/src/ol_dbt/models/intermediate/edxorg/int__edxorg__mitx_course_structure.sql
@@ -1,0 +1,65 @@
+with course_structure as (
+    select * from {{ ref('stg__edxorg__s3__course_structure') }}
+    order by courserun_readable_id, coursestructure_retrieved_at, coursestructure_block_index
+
+)
+
+, latest_course_structure_date as (
+    select
+        courserun_readable_id
+        , max(coursestructure_retrieved_at) as max_retrieved_date
+    from course_structure
+    group by courserun_readable_id
+)
+
+, chapters as (
+    select * from course_structure
+    where coursestructure_block_category = 'chapter'
+)
+
+, course_structure_with_chapters as (
+    select
+        course_structure.*
+        , chapters.coursestructure_block_id as coursestructure_chapter_id
+        , chapters.coursestructure_block_title as coursestructure_chapter_title
+        , row_number() over (
+            partition by
+                course_structure.courserun_readable_id
+                , course_structure.coursestructure_block_index
+                , course_structure.coursestructure_retrieved_at
+            order by chapters.coursestructure_block_index desc
+        ) as row_num
+    from course_structure
+    inner join chapters
+        on
+            course_structure.courserun_readable_id = chapters.courserun_readable_id
+            and course_structure.coursestructure_retrieved_at = chapters.coursestructure_retrieved_at
+            and course_structure.coursestructure_block_index >= chapters.coursestructure_block_index
+)
+
+select
+    course_structure.courserun_readable_id
+    , course_structure.courserun_title
+    , course_structure.coursestructure_block_index
+    , course_structure.coursestructure_block_id
+    , course_structure.coursestructure_parent_block_id
+    , course_structure.coursestructure_block_category
+    , course_structure.coursestructure_block_title
+    , course_structure.coursestructure_content_hash
+    , course_structure.coursestructure_block_content_hash
+    , course_structure.coursestructure_block_metadata
+    , course_structure.coursestructure_retrieved_at
+    , course_structure_with_chapters.coursestructure_chapter_id
+    , course_structure_with_chapters.coursestructure_chapter_title
+    , if(latest_course_structure_date.max_retrieved_date is not null, true, false) as coursestructure_is_latest
+from course_structure
+left join latest_course_structure_date
+    on
+        course_structure.courserun_readable_id = latest_course_structure_date.courserun_readable_id
+        and course_structure.coursestructure_retrieved_at = latest_course_structure_date.max_retrieved_date
+left join course_structure_with_chapters
+    on
+        course_structure.courserun_readable_id = course_structure_with_chapters.courserun_readable_id
+        and course_structure.coursestructure_block_id = course_structure_with_chapters.coursestructure_block_id
+        and course_structure.coursestructure_retrieved_at = course_structure_with_chapters.coursestructure_retrieved_at
+        and course_structure_with_chapters.row_num = 1

--- a/src/ol_dbt/models/intermediate/edxorg/int__edxorg__mitx_user_courseactivity_video.sql
+++ b/src/ol_dbt/models/intermediate/edxorg/int__edxorg__mitx_user_courseactivity_video.sql
@@ -14,7 +14,10 @@ select
     , useractivity_page_url
     , useractivity_timestamp
     , json_query(useractivity_event_object, 'lax $.id' omit quotes) as useractivity_video_id
-    , json_query(useractivity_event_object, 'lax $.duration' omit quotes) as useractivity_video_duration
+    , case
+        when lower(json_query(useractivity_event_object, 'lax $.duration' omit quotes)) = 'null' then null
+        else cast(json_query(useractivity_event_object, 'lax $.duration' omit quotes) as decimal(38, 4))
+    end as useractivity_video_duration
     , json_query(useractivity_event_object, 'lax $.currentTime' omit quotes) as useractivity_video_currenttime
     , json_query(useractivity_event_object, 'lax $.old_time' omit quotes) as useractivity_video_old_time
     , json_query(useractivity_event_object, 'lax $.new_time' omit quotes) as useractivity_video_new_time

--- a/src/ol_dbt/models/intermediate/mitxresidential/_int_mitxresidential__models.yml
+++ b/src/ol_dbt/models/intermediate/mitxresidential/_int_mitxresidential__models.yml
@@ -559,3 +559,32 @@ models:
   tests:
   - dbt_expectations.expect_compound_columns_to_be_unique:
       column_list: ["user_username", "courserun_readable_id", "courseactivity_date"]
+
+- name: int__mitxresidential__courserun_videos
+  description: course videos on Residential MITx open edx
+  columns:
+  - name: courserun_readable_id
+    description: str, open edX Course ID formatted as course-v1:{org}+{course code}+{run_tag}
+    tests:
+    - not_null
+  - name: coursevideo_is_hidden
+    description: boolean, indicating if the video is hidden for the course.
+    tests:
+    - not_null
+  - name: video_edx_uuid
+    description: str, hashed ID for the edx video
+    tests:
+    - not_null
+  - name: video_client_id
+    description: str, human readable name for video. e.g. 14.310x_Lect9_Seg8_Final.mp4
+  - name: video_status
+    description: str, values are external, imported, file_complete, and upload_failed.
+    tests:
+    - not_null
+  - name: video_duration
+    description: float, the length of the video, in seconds. May be 0.0.
+    tests:
+    - not_null
+  tests:
+  - dbt_expectations.expect_compound_columns_to_be_unique:
+      column_list: ["courserun_readable_id", "video_edx_uuid"]

--- a/src/ol_dbt/models/intermediate/mitxresidential/int__mitxresidential__courserun_videos.sql
+++ b/src/ol_dbt/models/intermediate/mitxresidential/int__mitxresidential__courserun_videos.sql
@@ -1,0 +1,17 @@
+with coursevideos as (
+    select * from {{ ref('stg__mitxresidential__openedx__edxval_coursevideo') }}
+)
+
+, videos as (
+    select * from {{ ref('stg__mitxresidential__openedx__edxval_video') }}
+)
+
+select
+    coursevideos.courserun_readable_id
+    , coursevideos.coursevideo_is_hidden
+    , videos.video_edx_uuid
+    , videos.video_client_id
+    , videos.video_status
+    , videos.video_duration
+from coursevideos
+inner join videos on coursevideos.video_id = videos.video_id

--- a/src/ol_dbt/models/intermediate/mitxresidential/int__mitxresidential__user_courseactivity_video.sql
+++ b/src/ol_dbt/models/intermediate/mitxresidential/int__mitxresidential__user_courseactivity_video.sql
@@ -15,7 +15,10 @@ select
     , useractivity_page_url
     , useractivity_timestamp
     , json_query(useractivity_event_object, 'lax $.id' omit quotes) as useractivity_video_id
-    , json_query(useractivity_event_object, 'lax $.duration' omit quotes) as useractivity_video_duration
+    , case
+        when lower(json_query(useractivity_event_object, 'lax $.duration' omit quotes)) = 'null' then null
+        else cast(json_query(useractivity_event_object, 'lax $.duration' omit quotes) as decimal(38, 4))
+    end as useractivity_video_duration
     , json_query(useractivity_event_object, 'lax $.currentTime' omit quotes) as useractivity_video_currenttime
     , json_query(useractivity_event_object, 'lax $.old_time' omit quotes) as useractivity_video_old_time
     , json_query(useractivity_event_object, 'lax $.new_time' omit quotes) as useractivity_video_new_time

--- a/src/ol_dbt/models/marts/combined/_marts__combined__models.yml
+++ b/src/ol_dbt/models/marts/combined/_marts__combined__models.yml
@@ -451,3 +451,130 @@ models:
     description: timestamp, date and time when the course or program enrollment starts
   - name: enrollment_end
     description: timestamp, date and time when the course or program enrollment ends
+
+- name: marts__combined_video_engagements
+  description: Learners video engagements - play, pause, seek, or stop video actions
+    from MITx Online, xPro, edX.org, Residential MITx.
+  columns:
+  - name: platform
+    description: str, open edx platform, e.g., MITx Online, edX.org, xPro, Residential
+      MITx.
+    tests:
+    - not_null
+  - name: courserun_readable_id
+    description: str, the open edX course ID formatted as course-v1:{org}+{course
+      code}+{run_tag} for MITxOnline, xPro, Residential courses, {org}/{course}/{run_tag}
+      for edX.org courses.
+    tests:
+    - not_null
+  - name: user_username
+    description: str, open edx username on the corresponding platform
+    tests:
+    - not_null
+  - name: video_event_type
+    description: str, type of this video event. The value is one of play_video, seek_video,
+      pause_video, stop_video, complete_video.
+    tests:
+    - not_null
+  - name: page_url
+    description: str, url of the page the user was visiting when this video event
+      was emitted.
+  - name: video_id
+    description: str, hash code for the video being watched. This value is the last
+      part of video_block_id string.
+    tests:
+    - not_null
+  - name: video_edx_id
+    description: str, the video ID on the open edx platform.
+  - name: video_title
+    description: str, title of this video. Null for Residential MITx until we populate
+      the course structure data.
+  - name: video_index
+    description: int, sequence number giving order in which this block content appears
+      within the course. Null for Residential MITx until we populate the course structure
+      data.
+  - name: chapter_title
+    description: str, title of chapter this video belongs to. Null for Residential
+      MITx until we populate the course structure data.
+  - name: chapter_id
+    description: str, block id of chapter within which this video belongs to.
+  - name: video_duration
+    description: float, The length of the video file, in seconds. Populated with data
+      from ODL Video Service (OVS) or tracking log. May be 0.0.
+  - name: video_currenttime
+    description: number, The time in the video when this event was emitted. May be
+      Null for seek_video
+  - name: video_old_time
+    description: number, time in the video, in seconds, at which the user chose to
+      go to a different point in time for 'seek_video' event
+  - name: video_new_time
+    description: number, time in the video, in seconds, that the user selected as
+      the destination point for 'seek_video' event
+  - name: video_event_timestamp
+    description: timestamp, time of this video event
+    tests:
+    - not_null
+  - name: user_full_name
+    description: str, user full name on the corresponding platform
+  - name: user_email
+    description: str, user email on the corresponding platform
+  - name: courserun_title
+    description: str, title of the course run
+  - name: courserun_start_on
+    description: timestamp, datetime on when the course begins
+  - name: courserun_end_on
+    description: timestamp, datetime on when the course ends
+  - name: courserun_is_current
+    description: boolean, indicating if the course run is currently running. True
+      if courserun_start_on is in the past and blank courserun_end_on, or courserun_start_on
+      is in the past and courserun_end_on is in the future.
+
+- name: marts__combined_course_engagements
+  description: Learners daily course engagement statistics from MITx Online, xPro,
+    edX.org, Residential MITx.
+  columns:
+  - name: platform
+    description: str, open edx platform, e.g., MITx Online, edX.org, xPro, Residential
+      MITx.
+    tests:
+    - not_null
+  - name: courserun_readable_id
+    description: str, the open edX course ID formatted as course-v1:{org}+{course
+      code}+{run_tag} for MITxOnline, xPro, Residential courses, {org}/{course}/{run_tag}
+      for edX.org courses.
+    tests:
+    - not_null
+  - name: user_username
+    description: str, open edx username on the corresponding platform
+    tests:
+    - not_null
+  - name: courseactivity_date
+    description: date, date that user has any interactions within a course
+    tests:
+    - not_null
+  - name: num_events
+    description: int, number of course activity events for the user
+  - name: num_problem_submitted
+    description: int, number of problem submitted events in a course for the user
+  - name: num_video_played
+    description: int, number of play video events in a course for the user
+  - name: num_discussion_participated
+    description: int, number of discussion participated in a course including creating
+      a post, creating a comment about a response, or creating a reply to a post.
+  - name: user_full_name
+    description: str, user full name on the corresponding platform
+  - name: user_email
+    description: str, user email on the corresponding platform
+  - name: courserun_title
+    description: str, title of the course run
+  - name: courserun_start_on
+    description: timestamp, datetime on when the course begins
+  - name: courserun_end_on
+    description: timestamp, datetime on when the course ends
+  - name: courserun_is_current
+    description: boolean, indicating if the course run is currently running. True
+      if courserun_start_on is in the past and blank courserun_end_on, or courserun_start_on
+      is in the past and courserun_end_on is in the future.
+  tests:
+  - dbt_expectations.expect_compound_columns_to_be_unique:
+      column_list: ["platform", "user_username", "courserun_readable_id", "courseactivity_date"]

--- a/src/ol_dbt/models/marts/combined/marts__combined_course_engagements.sql
+++ b/src/ol_dbt/models/marts/combined/marts__combined_course_engagements.sql
@@ -1,0 +1,262 @@
+with combined_course_activities_daily as (
+    select
+        '{{ var("mitxonline") }}' as platform
+        , user_username
+        , courserun_readable_id
+        , courseactivity_date
+        , courseactivity_num_events
+    from {{ ref('int__mitxonline__user_courseactivities_daily') }}
+
+    union all
+
+    select
+        '{{ var("edxorg") }}' as platform
+        , user_username
+        , courserun_readable_id
+        , courseactivity_date
+        , courseactivity_num_events
+    from {{ ref('int__edxorg__mitx_user_courseactivities_daily') }}
+
+    union all
+
+    select
+        '{{ var("mitxpro") }}' as platform
+        , user_username
+        , courserun_readable_id
+        , courseactivity_date
+        , courseactivity_num_events
+    from {{ ref('int__mitxpro__user_courseactivities_daily') }}
+
+    union all
+
+    select
+        '{{ var("residential") }}' as platform
+        , user_username
+        , courserun_readable_id
+        , courseactivity_date
+        , courseactivity_num_events
+    from {{ ref('int__mitxresidential__user_courseactivities_daily') }}
+
+)
+
+, combined_play_video as (
+
+    select
+        '{{ var("mitxonline") }}' as platform
+        , user_username
+        , courserun_readable_id
+        , date(from_iso8601_timestamp(useractivity_timestamp)) as courseactivity_date
+    from {{ ref('int__mitxonline__user_courseactivity_video') }}
+    where useractivity_event_type = 'play_video'
+
+    union all
+
+    select
+        '{{ var("edxorg") }}' as platform
+        , user_username
+        , courserun_readable_id
+        , date(from_iso8601_timestamp(useractivity_timestamp)) as courseactivity_date
+    from {{ ref('int__edxorg__mitx_user_courseactivity_video') }}
+    where useractivity_event_type = 'play_video'
+
+    union all
+
+    select
+        '{{ var("mitxpro") }}' as platform
+        , user_username
+        , courserun_readable_id
+        , date(from_iso8601_timestamp(useractivity_timestamp)) as courseactivity_date
+    from {{ ref('int__mitxpro__user_courseactivity_video') }}
+    where useractivity_event_type = 'play_video'
+
+    union all
+
+    select
+        '{{ var("residential") }}' as platform
+        , user_username
+        , courserun_readable_id
+        , date(from_iso8601_timestamp(useractivity_timestamp)) as courseactivity_date
+    from {{ ref('int__mitxresidential__user_courseactivity_video') }}
+    where useractivity_event_type = 'play_video'
+)
+
+, combined_problem_submitted as (
+
+    select
+        '{{ var("mitxonline") }}' as platform
+        , user_username
+        , courserun_readable_id
+        , date(from_iso8601_timestamp(useractivity_timestamp)) as courseactivity_date
+    from {{ ref('int__mitxonline__user_courseactivity_problemsubmitted') }}
+
+    union all
+
+    select
+        '{{ var("edxorg") }}' as platform
+        , user_username
+        , courserun_readable_id
+        , date(from_iso8601_timestamp(useractivity_timestamp)) as courseactivity_date
+    from {{ ref('int__edxorg__mitx_user_courseactivity_problemsubmitted') }}
+
+    union all
+
+    select
+        '{{ var("mitxpro") }}' as platform
+        , user_username
+        , courserun_readable_id
+        , date(from_iso8601_timestamp(useractivity_timestamp)) as courseactivity_date
+    from {{ ref('int__mitxpro__user_courseactivity_problemsubmitted') }}
+
+    union all
+
+    select
+        '{{ var("residential") }}' as platform
+        , user_username
+        , courserun_readable_id
+        , date(from_iso8601_timestamp(useractivity_timestamp)) as courseactivity_date
+    from {{ ref('int__mitxresidential__user_courseactivity_problemsubmitted') }}
+)
+
+, combined_discussion as (
+
+    select
+        '{{ var("mitxonline") }}' as platform
+        , user_username
+        , courserun_readable_id
+        , date(from_iso8601_timestamp(useractivity_timestamp)) as courseactivity_date
+    from {{ ref('int__mitxonline__user_courseactivity_discussion') }}
+    -- edx.forum.comment.created, edx.forum.response.created, edx.forum.thread.created
+    where useractivity_event_type like 'edx.forum.%.created'
+
+    union all
+
+    select
+        '{{ var("edxorg") }}' as platform
+        , user_username
+        , courserun_readable_id
+        , date(from_iso8601_timestamp(useractivity_timestamp)) as courseactivity_date
+    from {{ ref('int__edxorg__mitx_user_courseactivity_discussion') }}
+    -- edx.forum.comment.created, edx.forum.response.created, edx.forum.thread.created
+    where useractivity_event_type like 'edx.forum.%.created'
+
+    union all
+
+    select
+        '{{ var("mitxpro") }}' as platform
+        , user_username
+        , courserun_readable_id
+        , date(from_iso8601_timestamp(useractivity_timestamp)) as courseactivity_date
+    from {{ ref('int__mitxpro__user_courseactivity_discussion') }}
+    -- edx.forum.comment.created, edx.forum.response.created, edx.forum.thread.created
+    where useractivity_event_type like 'edx.forum.%.created'
+
+    union all
+
+    select
+        '{{ var("residential") }}' as platform
+        , user_username
+        , courserun_readable_id
+        , date(from_iso8601_timestamp(useractivity_timestamp)) as courseactivity_date
+    from {{ ref('int__mitxresidential__user_courseactivity_discussion') }}
+    -- edx.forum.comment.created, edx.forum.response.created, edx.forum.thread.created
+    where useractivity_event_type like 'edx.forum.%.created'
+)
+
+, combined_users as (
+    select * from {{ ref('int__combined__users') }}
+)
+
+, combined_runs as (
+    select * from {{ ref('int__combined__course_runs') }}
+)
+
+, combined_play_video_daily as (
+    select
+        platform
+        , user_username
+        , courserun_readable_id
+        , courseactivity_date
+        , count(*) as num_video_played
+    from combined_play_video
+    group by
+        platform
+        , user_username
+        , courserun_readable_id
+        , courseactivity_date
+)
+
+
+, combined_problem_submitted_daily as (
+    select
+        platform
+        , user_username
+        , courserun_readable_id
+        , courseactivity_date
+        , count(*) as num_problem_submitted
+    from combined_problem_submitted
+    group by
+        platform
+        , user_username
+        , courserun_readable_id
+        , courseactivity_date
+)
+
+, combined_discussion_daily as (
+    select
+        platform
+        , user_username
+        , courserun_readable_id
+        , courseactivity_date
+        , count(*) as num_discussion_participated
+    from combined_discussion
+    group by
+        platform
+        , user_username
+        , courserun_readable_id
+        , courseactivity_date
+)
+
+select
+    combined_course_activities_daily.platform
+    , combined_course_activities_daily.user_username
+    , combined_course_activities_daily.courserun_readable_id
+    , combined_course_activities_daily.courseactivity_date
+    , combined_course_activities_daily.courseactivity_num_events as num_events
+    , combined_problem_submitted_daily.num_problem_submitted
+    , combined_play_video_daily.num_video_played
+    , combined_discussion_daily.num_discussion_participated
+    , combined_users.user_full_name
+    , combined_users.user_email
+    , combined_users.user_address_country as user_country_code
+    , combined_users.user_highest_education
+    , combined_users.user_gender
+    , combined_runs.courserun_title
+    , combined_runs.course_readable_id
+    , combined_runs.courserun_is_current
+    , combined_runs.courserun_start_on
+    , combined_runs.courserun_end_on
+from combined_course_activities_daily
+inner join combined_runs
+    on
+        combined_course_activities_daily.courserun_readable_id = combined_runs.courserun_readable_id
+        and combined_course_activities_daily.platform = combined_runs.platform
+left join combined_users
+    on
+        combined_course_activities_daily.user_username = combined_users.user_username
+        and combined_course_activities_daily.platform = combined_users.platform
+left join combined_problem_submitted_daily
+    on
+        combined_course_activities_daily.courseactivity_date = combined_problem_submitted_daily.courseactivity_date
+        and combined_course_activities_daily.courserun_readable_id
+        = combined_problem_submitted_daily.courserun_readable_id
+        and combined_course_activities_daily.user_username = combined_problem_submitted_daily.user_username
+left join combined_play_video_daily
+    on
+        combined_course_activities_daily.courseactivity_date = combined_play_video_daily.courseactivity_date
+        and combined_course_activities_daily.courserun_readable_id = combined_play_video_daily.courserun_readable_id
+        and combined_course_activities_daily.user_username = combined_play_video_daily.user_username
+left join combined_discussion_daily
+    on
+        combined_course_activities_daily.courseactivity_date = combined_discussion_daily.courseactivity_date
+        and combined_course_activities_daily.courserun_readable_id = combined_discussion_daily.courserun_readable_id
+        and combined_course_activities_daily.user_username = combined_discussion_daily.user_username

--- a/src/ol_dbt/models/marts/combined/marts__combined_video_engagements.sql
+++ b/src/ol_dbt/models/marts/combined/marts__combined_video_engagements.sql
@@ -1,17 +1,65 @@
-with mitxonline_video_engagements as (
-    select * from {{ ref('int__mitxonline__user_courseactivity_video') }}
-)
+with combined_video_engagements as (
+    select
+        '{{ var("mitxonline") }}' as platform
+        , user_username
+        , courserun_readable_id
+        , useractivity_video_id
+        , useractivity_page_url
+        , useractivity_event_type
+        , useractivity_timestamp
+        , useractivity_video_duration
+        , useractivity_video_currenttime
+        , useractivity_video_old_time
+        , useractivity_video_new_time
+    from {{ ref('int__mitxonline__user_courseactivity_video') }}
 
-, edxorg_video_engagements as (
-    select * from {{ ref('int__edxorg__mitx_user_courseactivity_video') }}
-)
+    union all
 
-, xpro_video_engagements as (
-    select * from {{ ref('int__edxorg__mitx_user_courseactivity_video') }}
-)
+    select
+        '{{ var("edxorg") }}' as platform
+        , user_username
+        , courserun_readable_id
+        , useractivity_video_id
+        , useractivity_page_url
+        , useractivity_event_type
+        , useractivity_timestamp
+        , useractivity_video_duration
+        , useractivity_video_currenttime
+        , useractivity_video_old_time
+        , useractivity_video_new_time
+    from {{ ref('int__edxorg__mitx_user_courseactivity_video') }}
 
-, residential_video_engagements as (
-    select * from {{ ref('int__mitxresidential__user_courseactivity_video') }}
+    union all
+
+    select
+        '{{ var("mitxpro") }}' as platform
+        , user_username
+        , courserun_readable_id
+        , useractivity_video_id
+        , useractivity_page_url
+        , useractivity_event_type
+        , useractivity_timestamp
+        , useractivity_video_duration
+        , useractivity_video_currenttime
+        , useractivity_video_old_time
+        , useractivity_video_new_time
+    from {{ ref('int__mitxpro__user_courseactivity_video') }}
+
+    union all
+
+    select
+        '{{ var("residential") }}' as platform
+        , user_username
+        , courserun_readable_id
+        , useractivity_video_id
+        , useractivity_page_url
+        , useractivity_event_type
+        , useractivity_timestamp
+        , useractivity_video_duration
+        , useractivity_video_currenttime
+        , useractivity_video_old_time
+        , useractivity_video_new_time
+    from {{ ref('int__mitxresidential__user_courseactivity_video') }}
 )
 
 , combined_video_structure as (
@@ -27,74 +75,16 @@ with mitxonline_video_engagements as (
 
 )
 
-, combined_video_engagements as (
-    select
-        '{{ var("mitxonline") }}' as platform
-        , user_username
-        , courserun_readable_id
-        , useractivity_video_id
-        , useractivity_page_url
-        , useractivity_event_type
-        , useractivity_timestamp
-        , useractivity_video_currenttime
-        , useractivity_video_old_time
-        , useractivity_video_new_time
-    from mitxonline_video_engagements
-
-    union all
-
-    select
-        '{{ var("edxorg") }}' as platform
-        , user_username
-        , courserun_readable_id
-        , useractivity_video_id
-        , useractivity_page_url
-        , useractivity_event_type
-        , useractivity_timestamp
-        , useractivity_video_currenttime
-        , useractivity_video_old_time
-        , useractivity_video_new_time
-    from edxorg_video_engagements
-
-    union all
-
-    select
-        '{{ var("mitxpro") }}' as platform
-        , user_username
-        , courserun_readable_id
-        , useractivity_video_id
-        , useractivity_page_url
-        , useractivity_event_type
-        , useractivity_timestamp
-        , useractivity_video_currenttime
-        , useractivity_video_old_time
-        , useractivity_video_new_time
-    from xpro_video_engagements
-
-    union all
-
-    select
-        '{{ var("residential") }}' as platform
-        , user_username
-        , courserun_readable_id
-        , useractivity_video_id
-        , useractivity_page_url
-        , useractivity_event_type
-        , useractivity_timestamp
-        , useractivity_video_currenttime
-        , useractivity_video_old_time
-        , useractivity_video_new_time
-    from residential_video_engagements
-)
-
 select
-    combined_video_engagements.user_username
+    combined_video_engagements.platform
+    , combined_video_engagements.user_username
     , combined_video_engagements.courserun_readable_id
-    , combined_video_structure.video_id
+    , combined_video_engagements.useractivity_video_id as video_id
     , combined_video_structure.video_edx_id
     , combined_video_structure.video_title
     , combined_video_structure.video_index
     , combined_video_structure.chapter_title
+    , combined_video_structure.chapter_id
     , combined_video_engagements.useractivity_page_url as page_url
     , combined_video_engagements.useractivity_event_type as video_event_type
     , combined_video_engagements.useractivity_timestamp as video_event_timestamp
@@ -107,7 +97,6 @@ select
     , combined_users.user_highest_education
     , combined_users.user_gender
     , combined_runs.courserun_title
-    , combined_runs.course_number
     , combined_runs.course_readable_id
     , combined_runs.courserun_is_current
     , combined_runs.courserun_start_on

--- a/src/ol_dbt/models/marts/combined/marts__combined_video_engagements.sql
+++ b/src/ol_dbt/models/marts/combined/marts__combined_video_engagements.sql
@@ -1,0 +1,135 @@
+with mitxonline_video_engagements as (
+    select * from {{ ref('int__mitxonline__user_courseactivity_video') }}
+)
+
+, edxorg_video_engagements as (
+    select * from {{ ref('int__edxorg__mitx_user_courseactivity_video') }}
+)
+
+, xpro_video_engagements as (
+    select * from {{ ref('int__edxorg__mitx_user_courseactivity_video') }}
+)
+
+, residential_video_engagements as (
+    select * from {{ ref('int__mitxresidential__user_courseactivity_video') }}
+)
+
+, combined_video_structure as (
+    select * from {{ ref('int__combined__course_videos') }}
+)
+
+, combined_runs as (
+    select * from {{ ref('int__combined__course_runs') }}
+)
+
+, combined_users as (
+    select * from {{ ref('int__combined__users') }}
+
+)
+
+, combined_video_engagements as (
+    select
+        '{{ var("mitxonline") }}' as platform
+        , user_username
+        , courserun_readable_id
+        , useractivity_video_id
+        , useractivity_page_url
+        , useractivity_event_type
+        , useractivity_timestamp
+        , useractivity_video_currenttime
+        , useractivity_video_old_time
+        , useractivity_video_new_time
+    from mitxonline_video_engagements
+
+    union all
+
+    select
+        '{{ var("edxorg") }}' as platform
+        , user_username
+        , courserun_readable_id
+        , useractivity_video_id
+        , useractivity_page_url
+        , useractivity_event_type
+        , useractivity_timestamp
+        , useractivity_video_currenttime
+        , useractivity_video_old_time
+        , useractivity_video_new_time
+    from edxorg_video_engagements
+
+    union all
+
+    select
+        '{{ var("mitxpro") }}' as platform
+        , user_username
+        , courserun_readable_id
+        , useractivity_video_id
+        , useractivity_page_url
+        , useractivity_event_type
+        , useractivity_timestamp
+        , useractivity_video_currenttime
+        , useractivity_video_old_time
+        , useractivity_video_new_time
+    from xpro_video_engagements
+
+    union all
+
+    select
+        '{{ var("residential") }}' as platform
+        , user_username
+        , courserun_readable_id
+        , useractivity_video_id
+        , useractivity_page_url
+        , useractivity_event_type
+        , useractivity_timestamp
+        , useractivity_video_currenttime
+        , useractivity_video_old_time
+        , useractivity_video_new_time
+    from residential_video_engagements
+)
+
+select
+    combined_video_engagements.user_username
+    , combined_video_engagements.courserun_readable_id
+    , combined_video_structure.video_id
+    , combined_video_structure.video_edx_id
+    , combined_video_structure.video_title
+    , combined_video_structure.video_index
+    , combined_video_structure.chapter_title
+    , combined_video_engagements.useractivity_page_url as page_url
+    , combined_video_engagements.useractivity_event_type as video_event_type
+    , combined_video_engagements.useractivity_timestamp as video_event_timestamp
+    , combined_video_engagements.useractivity_video_currenttime as video_currenttime
+    , combined_video_engagements.useractivity_video_old_time as video_old_time
+    , combined_video_engagements.useractivity_video_new_time as video_new_time
+    , combined_users.user_full_name
+    , combined_users.user_email
+    , combined_users.user_address_country as user_country_code
+    , combined_users.user_highest_education
+    , combined_users.user_gender
+    , combined_runs.courserun_title
+    , combined_runs.course_number
+    , combined_runs.course_readable_id
+    , combined_runs.courserun_is_current
+    , combined_runs.courserun_start_on
+    , combined_runs.courserun_end_on
+    , coalesce(
+        combined_video_structure.video_duration
+        , combined_video_engagements.useractivity_video_duration
+    ) as video_duration
+from combined_video_engagements
+inner join combined_runs
+    on
+        combined_video_engagements.courserun_readable_id = combined_runs.courserun_readable_id
+        and combined_video_engagements.platform = combined_runs.platform
+left join combined_video_structure
+    on
+        combined_video_engagements.courserun_readable_id = combined_video_structure.courserun_readable_id
+        and combined_video_engagements.useractivity_video_id = combined_video_structure.video_id
+        and combined_video_engagements.platform = combined_video_structure.platform
+left join combined_users
+    on
+        combined_video_engagements.user_username = combined_users.user_username
+        and combined_video_engagements.platform = combined_users.platform
+where
+    combined_video_engagements.useractivity_event_type
+    in ('play_video', 'seek_video', 'complete_video', 'pause_video', 'stop_video')

--- a/src/ol_dbt/models/staging/mitxresidential/_mitxresidential__sources.yml
+++ b/src/ol_dbt/models/staging/mitxresidential/_mitxresidential__sources.yml
@@ -1003,3 +1003,31 @@ sources:
     - name: modified
       description: timestamp, datetime when this row was last updated. A change in
         this field implies that there was a state change.
+
+  - name: raw__mitx__openedx__mysql__edxval_video
+    description: video content on Residential MITx open edx platform
+    columns:
+    - name: id
+      description: int, primary key in edxval_video.
+    - name: edx_video_id
+      description: str, video hashed ID.
+    - name: client_video_id
+      description: str, human readable name for video. e.g. 14.310x_Lect9_Seg8_Final.mp4
+    - name: status
+      description: str, values are external and imported.
+    - name: duration
+      description: int, the length of the video, in seconds. Default to 0.0
+    - name: created
+      description: timestamp, date and time when the record was created.
+
+  - name: raw__mitx__openedx__mysql__edxval_coursevideo
+    description: course ID and video association on MITx Online open edx platform
+    columns:
+    - name: id
+      description: int, primary key in edxval_coursevideo.
+    - name: course_id
+      description: str, open edX Course ID formatted as course-v1:{org}+{course code}+{run_tag}
+    - name: video_id
+      description: int, foreign key in edxval_video
+    - name: is_hidden
+      description: boolean, indicating if the video is hidden for the course.

--- a/src/ol_dbt/models/staging/mitxresidential/_stg_mitxresidential__models.yml
+++ b/src/ol_dbt/models/staging/mitxresidential/_stg_mitxresidential__models.yml
@@ -369,3 +369,55 @@ models:
   tests:
   - dbt_expectations.expect_compound_columns_to_be_unique:
       column_list: ["user_id", "courserun_readable_id", "coursestructure_block_id"]
+
+- name: stg__mitxresidential__openedx__edxval_video
+  description: video content on the Residential MITx open edx platform
+  columns:
+  - name: video_id
+    description: int, primary key in edxval_video.
+    tests:
+    - unique
+    - not_null
+  - name: video_edx_uuid
+    description: str, hashed ID for the edx video
+    tests:
+    - unique
+    - not_null
+  - name: video_client_id
+    description: str, human readable name for video. e.g. 14.310x_Lect9_Seg8_Final.mp4
+  - name: video_status
+    description: str, values are external and imported.
+    tests:
+    - not_null
+  - name: video_duration
+    description: float, the length of the video, in seconds. Default to 0.0
+    tests:
+    - not_null
+  - name: video_created_on
+    description: timestamp, date and time when the record was created.
+    tests:
+    - not_null
+
+- name: stg__mitxresidential__openedx__edxval_coursevideo
+  description: course ID and video association on the Residential MITx open edx platform
+  columns:
+  - name: coursevideo_id
+    description: int, primary key in edxval_coursevideo.
+    tests:
+    - unique
+    - not_null
+  - name: courserun_readable_id
+    description: str, open edX Course ID formatted as course-v1:{org}+{course code}+{run_tag}
+    tests:
+    - not_null
+  - name: video_id
+    description: int, foreign key in edxval_video
+    tests:
+    - not_null
+  - name: coursevideo_is_hidden
+    description: boolean, indicating if the video is hidden for the course.
+    tests:
+    - not_null
+  tests:
+  - dbt_expectations.expect_compound_columns_to_be_unique:
+      column_list: ["courserun_readable_id", "video_id"]

--- a/src/ol_dbt/models/staging/mitxresidential/stg__mitxresidential__openedx__edxval_coursevideo.sql
+++ b/src/ol_dbt/models/staging/mitxresidential/stg__mitxresidential__openedx__edxval_coursevideo.sql
@@ -1,0 +1,16 @@
+with source as (
+    select * from {{ source('ol_warehouse_raw_data', 'raw__mitx__openedx__mysql__edxval_coursevideo') }}
+)
+
+, cleaned as (
+
+    select
+        id as coursevideo_id
+        , course_id as courserun_readable_id
+        , video_id
+        , is_hidden as coursevideo_is_hidden
+
+    from source
+)
+
+select * from cleaned

--- a/src/ol_dbt/models/staging/mitxresidential/stg__mitxresidential__openedx__edxval_video.sql
+++ b/src/ol_dbt/models/staging/mitxresidential/stg__mitxresidential__openedx__edxval_video.sql
@@ -1,0 +1,17 @@
+with source as (
+    select * from {{ source('ol_warehouse_raw_data', 'raw__mitx__openedx__mysql__edxval_video') }}
+)
+
+, cleaned as (
+
+    select
+        id as video_id
+        , edx_video_id as video_edx_uuid
+        , client_video_id as video_client_id
+        , status as video_status
+        , duration as video_duration
+        , to_iso8601(from_iso8601_timestamp_nanos(created)) as video_created_on
+    from source
+)
+
+select * from cleaned


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
https://github.com/mitodl/hq/issues/5052

### Description (What does it do?)
<!--- Describe your changes in detail -->
Creating two marts and a couple of intermediate models, combining from xPro, MITx Online, edX.org, and Residential
- `marts__combined_course_engagements`  - e.g. num_problem_submitted, num_video_played, num_discussion_participated aggregated 
- `marts__combined_video_engagements` - play_video, seek_video, pause_video, stop_video, complete_video.

We are still waiting for the Residential course structure, some of the fields - video_title, chapter_title, etc in marts__combined_video_engagements are null for Residential

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->
dbt build --select +int__combined__course_structure
dbt build --select +int__combined__course_videos
dbt build --select. int__combined__users
dbt build --select marts__combined_video_engagements
dbt build --select marts__combined_course_engagements
