### PR TITLE
Treat string 'null' as null for OCW resources

### DIFF
--- a/src/ol_dbt/models/intermediate/ocw/int__ocw__resources.sql
+++ b/src/ol_dbt/models/intermediate/ocw/int__ocw__resources.sql
@@ -56,51 +56,67 @@ select
     || '/edit/'
     || websitecontents.websitecontent_text_id
     || '/' as studio_url
-    , nullif(json_query(
+    , nullif(nullif(json_query(
         websitecontents.websitecontent_metadata, 'lax $.backup_url' omit quotes
-    ), '') as external_resource_backup_url
-    , json_query(websitecontents.websitecontent_metadata, 'lax $.external_url' omit quotes) as external_resource_url
+    ), ''), 'null') as external_resource_backup_url
+    , nullif(
+        nullif(json_query(websitecontents.websitecontent_metadata, 'lax $.external_url' omit quotes), ''), 'null'
+    ) as external_resource_url
     -- image_metadata for image resources; could be in metadata or image_metadata
     , coalesce(
-        nullif(json_query(websitecontents.websitecontent_metadata, 'lax $.metadata.image_alt' omit quotes), '')
-        , nullif(
-            json_query(websitecontents.websitecontent_metadata, 'lax $.image_metadata."image-alt"' omit quotes), ''
+        nullif(
+            nullif(json_query(websitecontents.websitecontent_metadata, 'lax $.metadata.image_alt' omit quotes), '')
+            , 'null'
         )
+        , nullif(nullif(
+            json_query(websitecontents.websitecontent_metadata, 'lax $.image_metadata."image-alt"' omit quotes), ''
+        ), 'null')
     ) as image_alt_text
     , coalesce(
-        nullif(json_query(websitecontents.websitecontent_metadata, 'lax $.metadata.caption' omit quotes), '')
-        , nullif(json_query(websitecontents.websitecontent_metadata, 'lax $.image_metadata.caption' omit quotes), '')
+        nullif(
+            nullif(json_query(websitecontents.websitecontent_metadata, 'lax $.metadata.caption' omit quotes), '')
+            , 'null'
+        )
+        , nullif(
+            nullif(json_query(websitecontents.websitecontent_metadata, 'lax $.image_metadata.caption' omit quotes), '')
+            , 'null'
+        )
     ) as image_caption
     , coalesce(
-        nullif(json_query(websitecontents.websitecontent_metadata, 'lax $.metadata.credit' omit quotes), '')
-        , nullif(json_query(websitecontents.websitecontent_metadata, 'lax $.image_metadata.credit' omit quotes), '')
+        nullif(
+            nullif(json_query(websitecontents.websitecontent_metadata, 'lax $.metadata.credit' omit quotes), ''), 'null'
+        )
+        , nullif(
+            nullif(json_query(websitecontents.websitecontent_metadata, 'lax $.image_metadata.credit' omit quotes), '')
+            , 'null'
+        )
     ) as image_credit
     -- video_metadata for video resources
-    , nullif(json_query(
+    , nullif(nullif(json_query(
         websitecontents.websitecontent_metadata, 'lax $.video_metadata.youtube_description' omit quotes
-    ), '') as video_youtube_description
-    , nullif(json_query(
+    ), ''), 'null') as video_youtube_description
+    , nullif(nullif(json_query(
         websitecontents.websitecontent_metadata, 'lax $.video_metadata.youtube_id' omit quotes
-    ), '') as video_youtube_id
-    , nullif(json_query(
+    ), ''), 'null') as video_youtube_id
+    , nullif(nullif(json_query(
         websitecontents.websitecontent_metadata, 'lax $.video_metadata.video_speakers' omit quotes
-    ), '') as video_youtube_speakers
-    , nullif(json_query(
+    ), ''), 'null') as video_youtube_speakers
+    , nullif(nullif(json_query(
         websitecontents.websitecontent_metadata, 'lax $.video_metadata.video_tags' omit quotes
-    ), '') as video_youtube_tags
+    ), ''), 'null') as video_youtube_tags
     -- video_files for video resources
-    , nullif(json_query(
+    , nullif(nullif(json_query(
         websitecontents.websitecontent_metadata, 'lax $.video_files.archive_url' omit quotes
-    ), '') as video_archive_url
-    , nullif(json_query(
+    ), ''), 'null') as video_archive_url
+    , nullif(nullif(json_query(
         websitecontents.websitecontent_metadata, 'lax $.video_files.video_captions_file' omit quotes
-    ), '') as video_captions_file
-    , nullif(json_query(
+    ), ''), 'null') as video_captions_file
+    , nullif(nullif(json_query(
         websitecontents.websitecontent_metadata, 'lax $.video_files.video_thumbnail_file' omit quotes
-    ), '') as video_thumbnail_file
-    , nullif(json_query(
+    ), ''), 'null') as video_thumbnail_file
+    , nullif(nullif(json_query(
         websitecontents.websitecontent_metadata, 'lax $.video_files.video_transcript_file' omit quotes
-    ), '') as video_transcript_file
+    ), ''), 'null') as video_transcript_file
 from websites
 inner join websitecontents
     on websites.website_uuid = websitecontents.website_uuid


### PR DESCRIPTION
### What are the relevant tickets?
Related to https://github.com/mitodl/hq/issues/1555#issuecomment-2313085125.

### Description (What does it do?)
This PR updates the OCW resources report to treat the string `null` when found in metadata as a null value. This allows for identifying fields that have null values; in particular, this is useful for identifying videos that have missing captions or transcripts.

### How can this be tested?
Run the following commands; the tests should all pass.
```
dbt build --select staging.ocw  --vars 'schema_suffix: <your name>' --target dev_production
dbt build --select intermediate.ocw --vars 'schema_suffix: <your name>' --target dev_production
```

Run the following query in https://mitol.galaxy.starburst.io/query-editor to see the result of the above tables:
```
SELECT * FROM ol_data_lake_production.ol_warehouse_production_<your name>_intermediate.int__ocw__resources
```

Verify that resource fields which have the string value `null` are now showing up as `NULL` instead. For a particular example, compare running

```
select video_captions_file from ol_warehouse_production_intermediate.int__ocw__resources
where resource_uuid='9934a9cd-504b-678c-0b5b-dee566959f4d'
```

and 

```
select video_captions_file from ol_warehouse_production_<your name>_intermediate.int__ocw__resources
where resource_uuid='9934a9cd-504b-678c-0b5b-dee566959f4d'
```

The result of the first query (corresponding to the `main` branch) should be the string `null` and the result of the second query should be `NULL`.
