### PR TITLE
Format edxorg course_id to ensure data flow into combined engagement marts 

### DIFF
--- a/src/ol_dbt/macros/extract_course_id.sql
+++ b/src/ol_dbt/macros/extract_course_id.sql
@@ -35,3 +35,15 @@
              )
       end
 {% endmacro %}
+
+--- course IDs come in two formats from different sources. This ensures that course IDs are consistently converted in
+--  all the downstream models.
+{% macro format_course_id(courserun_readable_id, convert_to_old_format=true) %}
+    {% if convert_to_old_format %}
+            -- format as {org}/{course number}/{run}
+           replace(replace(courserun_readable_id, 'course-v1:', ''), '+', '/')
+     {% else %}
+           -- format as course-v1:{org}+{course}+{run}
+           'course-v1:' || replace(courserun_readable_id, '/', '+')
+     {% endif %}
+{% endmacro %}

--- a/src/ol_dbt/models/intermediate/edxorg/_int_edxorg__models.yml
+++ b/src/ol_dbt/models/intermediate/edxorg/_int_edxorg__models.yml
@@ -562,8 +562,7 @@ models:
     tests:
     - not_null
   - name: courserun_readable_id
-    description: str, open edX Course ID formatted as course-v1:{org}+{course}+{run}
-      for course runs since Fall 2014, {org}/{course number}/{run} for older runs
+    description: str, open edX Course ID formatted as {org}/{course number}/{run}
     tests:
     - not_null
   - name: useractivity_event_source
@@ -642,8 +641,7 @@ models:
     tests:
     - not_null
   - name: courserun_readable_id
-    description: str, open edX Course ID formatted as course-v1:{org}+{course}+{run}
-      for course runs since Fall 2014, {org}/{course number}/{run} for older runs
+    description: str, open edX Course ID formatted as {org}/{course number}/{run}
     tests:
     - not_null
   - name: useractivity_event_source
@@ -709,8 +707,7 @@ models:
     tests:
     - not_null
   - name: courserun_readable_id
-    description: str, open edX Course ID formatted as course-v1:{org}+{course}+{run}
-      for course runs since Fall 2014, {org}/{course number}/{run} for older runs
+    description: str, open edX Course ID formatted as {org}/{course number}/{run}
     tests:
     - not_null
   - name: courseactivity_num_events
@@ -789,3 +786,47 @@ models:
   tests:
   - dbt_expectations.expect_table_row_count_to_equal_other_table:
       compare_model: ref('stg__edxorg__s3__course_structure')
+
+- name: int__edxorg__mitx_user_activity
+  description: edx.org non-aggregated users activities for a course
+  columns:
+  - name: user_username
+    description: str, username of a learner on edX.org
+    tests:
+    - not_null
+  - name: user_id
+    description: int, learner's user ID on edX.org. Extracted from context field.
+    tests:
+    - not_null
+  - name: courserun_readable_id
+    description: str, open edX Course ID formatted as {org}/{course number}/{run}.
+  - name: useractivity_path
+    description: str, URL that generated this event. Extracted from context field
+  - name: useractivity_context_object
+    description: object, it includes member fields that provide contextual information.
+      Common fields apply to all events are course_id, org_id, path, user_id. Other
+      member fields for applicable events are course_user_tags, module.
+  - name: useractivity_event_source
+    description: str, specifies the source of the interaction that triggered the event.
+      The values are - browser, mobile, server, task
+    tests:
+    - not_null
+  - name: useractivity_event_type
+    description: str, type of event triggered. Values depend on event_source.
+    tests:
+    - not_null
+  - name: useractivity_event_object
+    description: object,it includes member fields that identify specifics of each
+      triggered event. Different member fields are supplied for different events.
+    tests:
+    - not_null
+  - name: useractivity_event_name
+    description: str, type of event triggered. When this field is present for an event,
+      it supersedes the event_type field.
+  - name: useractivity_page_url
+    description: str, url of the page the user was visiting when the event was emitted.
+  - name: useractivity_timestamp
+    description: timestamp, time at which the event was emitted, formatted as ISO
+      8601 string
+    tests:
+    - not_null

--- a/src/ol_dbt/models/intermediate/edxorg/int__edxorg__mitx_user_activity.sql
+++ b/src/ol_dbt/models/intermediate/edxorg/int__edxorg__mitx_user_activity.sql
@@ -1,0 +1,16 @@
+{{ config(materialized='view') }}
+
+select
+    user_username
+    , user_id
+    , useractivity_path
+    , useractivity_context_object
+    , useractivity_event_source
+    , useractivity_event_type
+    , useractivity_event_object
+    , useractivity_event_name
+    , useractivity_page_url
+    , useractivity_timestamp
+    , {{ format_course_id('courserun_readable_id') }} as courserun_readable_id
+from {{ ref('stg__edxorg__s3__tracking_logs__user_activity') }}
+where courserun_readable_id is not null

--- a/src/ol_dbt/models/intermediate/edxorg/int__edxorg__mitx_user_courseactivities.sql
+++ b/src/ol_dbt/models/intermediate/edxorg/int__edxorg__mitx_user_courseactivities.sql
@@ -1,6 +1,5 @@
 with course_activities as (
-    select * from {{ ref('stg__edxorg__s3__tracking_logs__user_activity') }}
-    where courserun_readable_id is not null
+    select * from {{ ref('int__edxorg__mitx_user_activity') }}
 )
 
 , course_activities_video as (

--- a/src/ol_dbt/models/intermediate/edxorg/int__edxorg__mitx_user_courseactivities_daily.sql
+++ b/src/ol_dbt/models/intermediate/edxorg/int__edxorg__mitx_user_courseactivities_daily.sql
@@ -1,6 +1,5 @@
 with course_activities as (
-    select * from {{ ref('stg__edxorg__s3__tracking_logs__user_activity') }}
-    where courserun_readable_id is not null
+    select * from {{ ref('int__edxorg__mitx_user_activity') }}
 )
 
 , daily_activities_stats as (

--- a/src/ol_dbt/models/intermediate/edxorg/int__edxorg__mitx_user_courseactivity_discussion.sql
+++ b/src/ol_dbt/models/intermediate/edxorg/int__edxorg__mitx_user_courseactivity_discussion.sql
@@ -1,8 +1,7 @@
 {{ config(materialized='view') }}
 
 with course_activities as (
-    select * from {{ ref('stg__edxorg__s3__tracking_logs__user_activity') }}
-    where courserun_readable_id is not null
+    select * from {{ ref('int__edxorg__mitx_user_activity') }}
 )
 
 select

--- a/src/ol_dbt/models/intermediate/edxorg/int__edxorg__mitx_user_courseactivity_problemcheck.sql
+++ b/src/ol_dbt/models/intermediate/edxorg/int__edxorg__mitx_user_courseactivity_problemcheck.sql
@@ -1,8 +1,7 @@
 {{ config(materialized='view') }}
 
 with course_activities as (
-    select * from {{ ref('stg__edxorg__s3__tracking_logs__user_activity') }}
-    where courserun_readable_id is not null
+    select * from {{ ref('int__edxorg__mitx_user_activity') }}
 )
 
 select

--- a/src/ol_dbt/models/intermediate/edxorg/int__edxorg__mitx_user_courseactivity_problemsubmitted.sql
+++ b/src/ol_dbt/models/intermediate/edxorg/int__edxorg__mitx_user_courseactivity_problemsubmitted.sql
@@ -1,8 +1,7 @@
 {{ config(materialized='view') }}
 
 with course_activities as (
-    select * from {{ ref('stg__edxorg__s3__tracking_logs__user_activity') }}
-    where courserun_readable_id is not null
+    select * from {{ ref('int__edxorg__mitx_user_activity') }}
 )
 
 select

--- a/src/ol_dbt/models/intermediate/edxorg/int__edxorg__mitx_user_courseactivity_video.sql
+++ b/src/ol_dbt/models/intermediate/edxorg/int__edxorg__mitx_user_courseactivity_video.sql
@@ -1,8 +1,7 @@
 {{ config(materialized='view') }}
 
 with course_activities as (
-    select * from {{ ref('stg__edxorg__s3__tracking_logs__user_activity') }}
-    where courserun_readable_id is not null
+    select * from {{ ref('int__edxorg__mitx_user_activity') }}
 )
 
 select


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
https://github.com/mitodl/hq/issues/5052

### Description (What does it do?)
<!--- Describe your changes in detail -->
Not all the edx.org courses flow into `marts__combined_course_engagements` and `marts__combined_video_engagements`, due to course ID in two different formats from various sources, e.g. , course structure and tracking log. The edxorg course IDs are formatted as {org}/{course}/{run_tag} in other marts.

This PR converts the course ID sourced from the tracking log into {org}/{course}/{run_tag} format so that they are consistent and can be joined with the course ID from other sources. All edx.org data should now flow into  `marts__combined_course_engagements` and `marts__combined_video_engagements` 

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->
Run these commands
dbt build --select intermediate.edxorg
dbt build --select marts__combined_course_engagements
dbt build --select marts__combined_video_engagements

Then verify all the course IDs are in the marts
```
select distinct courserun_readable_id from "ol_data_lake_production"."ol_warehouse_production_<YOURSCHEMA>_mart".marts__combined_course_engagements
where platform ='edX.org'

select distinct courserun_readable_id from "ol_data_lake_production"."ol_warehouse_production_<YOURSCHEMA>_mart".marts__combined_video_engagements
where platform ='edX.org'
```

