### PR TITLE
Incorporate Residential course structure to staging, intermediate and mart

### DIFF
--- a/src/ol_dbt/models/intermediate/combined/_combined_models.yml
+++ b/src/ol_dbt/models/intermediate/combined/_combined_models.yml
@@ -257,10 +257,11 @@ models:
 
 - name: int__combined__course_structure
   description: this table contains the latest course structure of the courses from
-    MITx Online ,xPro and edX.org.
+    MITx Online ,xPro, edX.org and Residential MITx.
   columns:
   - name: platform
-    description: str, MITx Online, xPro, edX.org
+    description: str, open edx platform, e.g., MITx Online, edX.org, xPro, Residential
+      MITx.
     tests:
     - not_null
     - accepted_values:
@@ -311,6 +312,9 @@ models:
     description: str, block id of chapter within which this child block belongs to.
       Null for the 'course' block as it's the top block that doesn't belong to any
       chapter.
+    tests:
+    - dbt_expectations.expect_column_values_to_not_be_null:
+        row_condition: "coursestructure_block_category != 'course'"
   - name: coursestructure_chapter_title
     description: str, title of chapter within which this child block belongs to.
   tests:
@@ -319,8 +323,13 @@ models:
 
 - name: int__combined__course_videos
   description: this table contains video structure and metadata for MITx Online, xPro
-    and edX.org courses.
+    , edX.org and Residential MITx courses.
   columns:
+  - name: platform
+    description: open edx platform, e.g., MITx Online, edX.org, xPro, Residential
+      MITx.
+    tests:
+    - not_null
   - name: courserun_readable_id
     description: str, the open edX course ID formatted as course-v1:{org}+{course
       code}+{run_tag} for MITxOnline and xPro courses, {org}/{course}/{run_tag} for
@@ -357,6 +366,8 @@ models:
     - not_null
   - name: chapter_id
     description: str, block id of chapter within which this video belongs to.
+    tests:
+    - not_null
   - name: chapter_title
     description: str, title of chapter this video belongs to.
   - name: video_duration

--- a/src/ol_dbt/models/intermediate/combined/int__combined__course_structure.sql
+++ b/src/ol_dbt/models/intermediate/combined/int__combined__course_structure.sql
@@ -10,6 +10,9 @@ with mitxonline_course_structure as (
     select * from {{ ref('int__mitxpro__course_structure') }}
 )
 
+, residential_course_structure as (
+    select * from {{ ref('int__mitxresidential__course_structure') }}
+)
 
 , combined as (
     select
@@ -62,6 +65,24 @@ with mitxonline_course_structure as (
         , coursestructure_chapter_id
         , coursestructure_chapter_title
     from xpro_course_structure
+    where coursestructure_is_latest = true
+
+    union all
+
+    select
+        '{{ var("residential") }}' as platform
+        , courserun_readable_id
+        , courserun_title
+        , coursestructure_block_index
+        , coursestructure_block_id
+        , coursestructure_parent_block_id
+        , coursestructure_block_category
+        , coursestructure_block_title
+        , coursestructure_block_metadata
+        , coursestructure_retrieved_at
+        , coursestructure_chapter_id
+        , coursestructure_chapter_title
+    from residential_course_structure
     where coursestructure_is_latest = true
 )
 

--- a/src/ol_dbt/models/intermediate/combined/int__combined__course_videos.sql
+++ b/src/ol_dbt/models/intermediate/combined/int__combined__course_videos.sql
@@ -7,75 +7,52 @@ with video_structure as (
     where coursestructure_block_category = 'video'
 )
 
-, mitxonline_videos as (
-    select * from {{ ref('int__mitxonline__courserun_videos') }}
-)
+--- no edxorg course videos until we parse the data from course xml
+, combined_videos as (
 
-, xpro_videos as (
-    select * from {{ ref('int__mitxpro__courserun_videos') }}
-)
-
-, combined as (
     select
         '{{ var("mitxonline") }}' as platform
-        , video_structure.courserun_readable_id
-        , video_structure.video_id
-        , mitxonline_videos.video_edx_uuid as video_edx_id
-        , video_structure.coursestructure_block_id as video_block_id
-        , video_structure.coursestructure_parent_block_id as video_parent_block_id
-        , video_structure.coursestructure_block_metadata as video_metadata
-        , video_structure.coursestructure_block_title as video_title
-        , video_structure.coursestructure_block_index as video_index
-        , video_structure.coursestructure_chapter_title as chapter_title
-        , video_structure.coursestructure_chapter_id as chapter_id
-        , mitxonline_videos.video_duration
-    from video_structure
-    left join mitxonline_videos
-        on
-            video_structure.courserun_readable_id = mitxonline_videos.courserun_readable_id
-            and video_structure.video_edx_uuid = mitxonline_videos.video_edx_uuid
-    where video_structure.platform = '{{ var("mitxonline") }}'
-
-    union all
-
-    select
-        '{{ var("edxorg") }}' as platform
         , courserun_readable_id
-        , video_id
-        , video_edx_uuid as video_edx_id
-        , coursestructure_block_id as video_block_id
-        , coursestructure_parent_block_id as video_parent_block_id
-        , coursestructure_block_metadata as video_metadata
-        , coursestructure_block_title as video_title
-        , coursestructure_block_index as video_index
-        , coursestructure_chapter_title as chapter_title
-        , coursestructure_chapter_id as chapter_id
-        --- null until we parse it from course xml for edxorg
-        , null as video_duration
-    from video_structure
-    where video_structure.platform = '{{ var("edxorg") }}'
+        , video_edx_uuid
+        , video_duration
+    from {{ ref('int__mitxonline__courserun_videos') }}
 
     union all
 
     select
         '{{ var("mitxpro") }}' as platform
-        , video_structure.courserun_readable_id
-        , video_structure.video_id
-        , xpro_videos.video_edx_uuid as video_edx_id
-        , video_structure.coursestructure_block_id as video_block_id
-        , video_structure.coursestructure_parent_block_id as video_parent_block_id
-        , video_structure.coursestructure_block_metadata as video_metadata
-        , video_structure.coursestructure_block_title as video_title
-        , video_structure.coursestructure_block_index as video_index
-        , video_structure.coursestructure_chapter_title as chapter_title
-        , video_structure.coursestructure_chapter_id as chapter_id
-        , xpro_videos.video_duration
-    from video_structure
-    left join xpro_videos
-        on
-            video_structure.courserun_readable_id = xpro_videos.courserun_readable_id
-            and video_structure.video_edx_uuid = xpro_videos.video_edx_uuid
-    where video_structure.platform = '{{ var("mitxpro") }}'
+        , courserun_readable_id
+        , video_edx_uuid
+        , video_duration
+    from {{ ref('int__mitxpro__courserun_videos') }}
+
+    union all
+
+    select
+        '{{ var("residential") }}' as platform
+        , courserun_readable_id
+        , video_edx_uuid
+        , video_duration
+    from {{ ref('int__mitxresidential__courserun_videos') }}
+
 )
 
-select * from combined
+select
+    video_structure.platform
+    , video_structure.courserun_readable_id
+    , video_structure.video_id
+    , combined_videos.video_edx_uuid as video_edx_id
+    , video_structure.coursestructure_block_id as video_block_id
+    , video_structure.coursestructure_parent_block_id as video_parent_block_id
+    , video_structure.coursestructure_block_metadata as video_metadata
+    , video_structure.coursestructure_block_title as video_title
+    , video_structure.coursestructure_block_index as video_index
+    , video_structure.coursestructure_chapter_title as chapter_title
+    , video_structure.coursestructure_chapter_id as chapter_id
+    , combined_videos.video_duration
+from video_structure
+left join combined_videos
+    on
+        video_structure.courserun_readable_id = combined_videos.courserun_readable_id
+        and video_structure.platform = combined_videos.platform
+        and video_structure.video_edx_uuid = combined_videos.video_edx_uuid

--- a/src/ol_dbt/models/intermediate/mitxresidential/_int_mitxresidential__models.yml
+++ b/src/ol_dbt/models/intermediate/mitxresidential/_int_mitxresidential__models.yml
@@ -588,3 +588,74 @@ models:
   tests:
   - dbt_expectations.expect_compound_columns_to_be_unique:
       column_list: ["courserun_readable_id", "video_edx_uuid"]
+
+- name: int__mitxresidential__course_structure
+  description: This table contains the historical changes made to the course structure.
+    It also includes a coursestructure_chapter_id that identifies the chapter to which
+    each subsection belongs.
+  columns:
+  - name: courserun_readable_id
+    description: str, Open edX Course ID formatted as course-v1:{org}+{course code}+{run_tag}
+    tests:
+    - not_null
+  - name: coursestructure_content_hash
+    description: str, sha256 hashed string of the course content.
+    tests:
+    - not_null
+  - name: coursestructure_block_content_hash
+    description: str, sha256 hashed string of the block content in a course
+    tests:
+    - not_null
+  - name: coursestructure_block_id
+    description: str, Unique ID for a distinct piece of content in a course, formatted
+      as block-v1:{org}+{course}+{run}type@{block type}+block@{hash code}
+    tests:
+    - not_null
+  - name: coursestructure_parent_block_id
+    description: str, parent block ID, same format as block_id
+  - name: coursestructure_block_index
+    description: int, sequence number giving order in which this block content appears
+      within the course
+    tests:
+    - not_null
+  - name: coursestructure_block_category
+    description: str, category/type of the block, it identifies core structural elements
+      of a course. Value includes but not limited to course, chapter, sequential,
+      vertical, discussion, html, problem, video, etc.
+    tests:
+    - not_null
+  - name: coursestructure_block_title
+    description: str, title of the block extracted from the metadata of the block.
+      This field comes from name field for the section, subsection, or unit on the
+      Studio 'Course Outline' page.
+  - name: coursestructure_block_metadata
+    description: str, json string of the metadata field for the block. It provides
+      additional information about this block, different block type may have different
+      member fields inside metadata.
+    tests:
+    - not_null
+  - name: courserun_title
+    description: str, title of the course extracted from the metadata of 'course'
+      block
+  - name: courserun_start_on
+    description: timestamp, indicating when the course run starts extracted from the
+      metadata of 'course' block
+  - name: coursestructure_retrieved_at
+    description: timestamp, indicating when this course structure was initially retrieved
+      from REST API.
+    tests:
+    - not_null
+  - name: coursestructure_chapter_id
+    description: str, block id of chapter within which this child block belongs to.
+      Null for the 'course' block as it's the top block that doesn't belong to any
+      chapter.
+    tests:
+    - dbt_expectations.expect_column_values_to_not_be_null:
+        row_condition: "coursestructure_block_category != 'course'"
+  - name: coursestructure_chapter_title
+    description: str, title of chapter within which this child block belongs to.
+  - name: coursestructure_is_latest
+    description: boolean, indicating if the course content is the latest version
+  tests:
+  - dbt_expectations.expect_table_row_count_to_equal_other_table:
+      compare_model: ref('stg__mitxresidential__openedx__api__course_structure')

--- a/src/ol_dbt/models/intermediate/mitxresidential/int__mitxresidential__course_structure.sql
+++ b/src/ol_dbt/models/intermediate/mitxresidential/int__mitxresidential__course_structure.sql
@@ -1,0 +1,66 @@
+with course_structure as (
+    select * from {{ ref('stg__mitxresidential__openedx__api__course_structure') }}
+    order by courserun_readable_id, coursestructure_retrieved_at, coursestructure_block_index
+
+)
+
+, latest_course_structure_date as (
+    select
+        courserun_readable_id
+        , max(coursestructure_retrieved_at) as max_retrieved_date
+    from course_structure
+    group by courserun_readable_id
+)
+
+, chapters as (
+    select * from course_structure
+    where coursestructure_block_category = 'chapter'
+)
+
+, course_structure_with_chapters as (
+    select
+        course_structure.*
+        , chapters.coursestructure_block_id as coursestructure_chapter_id
+        , chapters.coursestructure_block_title as coursestructure_chapter_title
+        , row_number() over (
+            partition by
+                course_structure.courserun_readable_id
+                , course_structure.coursestructure_block_index
+                , course_structure.coursestructure_retrieved_at
+            order by chapters.coursestructure_block_index desc
+        ) as row_num
+    from course_structure
+    inner join chapters
+        on
+            course_structure.courserun_readable_id = chapters.courserun_readable_id
+            and course_structure.coursestructure_retrieved_at = chapters.coursestructure_retrieved_at
+            and course_structure.coursestructure_block_index >= chapters.coursestructure_block_index
+)
+
+select
+    course_structure.courserun_readable_id
+    , course_structure.courserun_title
+    , course_structure.coursestructure_block_index
+    , course_structure.coursestructure_block_id
+    , course_structure.coursestructure_parent_block_id
+    , course_structure.coursestructure_block_category
+    , course_structure.coursestructure_block_title
+    , course_structure.coursestructure_content_hash
+    , course_structure.coursestructure_block_content_hash
+    , course_structure.coursestructure_block_metadata
+    , course_structure.courserun_start_on
+    , course_structure.coursestructure_retrieved_at
+    , course_structure_with_chapters.coursestructure_chapter_id
+    , course_structure_with_chapters.coursestructure_chapter_title
+    , if(latest_course_structure_date.max_retrieved_date is not null, true, false) as coursestructure_is_latest
+from course_structure
+left join latest_course_structure_date
+    on
+        course_structure.courserun_readable_id = latest_course_structure_date.courserun_readable_id
+        and course_structure.coursestructure_retrieved_at = latest_course_structure_date.max_retrieved_date
+left join course_structure_with_chapters
+    on
+        course_structure.courserun_readable_id = course_structure_with_chapters.courserun_readable_id
+        and course_structure.coursestructure_block_id = course_structure_with_chapters.coursestructure_block_id
+        and course_structure.coursestructure_retrieved_at = course_structure_with_chapters.coursestructure_retrieved_at
+        and course_structure_with_chapters.row_num = 1

--- a/src/ol_dbt/models/staging/edxorg/_stg__edxorg__models.yml
+++ b/src/ol_dbt/models/staging/edxorg/_stg__edxorg__models.yml
@@ -595,7 +595,11 @@ models:
       column_list: ["user_id", "courserun_readable_id"]
 
 - name: stg__edxorg__s3__course_structure
-  description: edx.org course contents
+  description: This table captures the historical changes made to the edX.org course
+    structure by comparing the new course block to the course block from the previous
+    day. If no changes are detected, no new rows are added to the table. If there
+    are any changes to the course structure, all blocks, including the updated or
+    new ones, are added to the table.
   columns:
   - name: courserun_readable_id
     description: str, course ID formatted as {org}/{course code}/{run_tag}

--- a/src/ol_dbt/models/staging/mitxonline/_stg_mitxonline__models.yml
+++ b/src/ol_dbt/models/staging/mitxonline/_stg_mitxonline__models.yml
@@ -1273,8 +1273,11 @@ models:
         "useractivity_event_type", "useractivity_event_object", "useractivity_timestamp"]
 
 - name: stg__mitxonline__openedx__api__course_structure
-  description: this table contains historical changes to open edX's course content
-    data.
+  description: This table captures the historical changes made to the MITx Online
+    course structure by comparing the new course block to the course block from the
+    previous day. If no changes are detected, no new rows are added to the table.
+    If there are any changes to the course structure, all blocks, including the updated
+    or new ones, are added to the table.
   columns:
   - name: courserun_readable_id
     description: str, Open edX Course ID formatted as course-v1:{org}+{course code}+{run_tag}

--- a/src/ol_dbt/models/staging/mitxpro/_stg_mitxpro__models.yml
+++ b/src/ol_dbt/models/staging/mitxpro/_stg_mitxpro__models.yml
@@ -1843,7 +1843,11 @@ models:
     - not_null
 
 - name: stg__mitxpro__openedx__api__course_structure
-  description: This table contains historical changes to xPro's course content
+  description: This table captures the historical changes made to the xPro course
+    structure by comparing the new course block to the course block from the previous
+    day. If no changes are detected, no new rows are added to the table. If there
+    are any changes to the course structure, all blocks, including the updated or
+    new ones, are added to the table.
   columns:
   - name: courserun_readable_id
     description: str, Open edX Course ID formatted as course-v1:xPRO+{course code}+{run_tag}

--- a/src/ol_dbt/models/staging/mitxresidential/_mitxresidential__sources.yml
+++ b/src/ol_dbt/models/staging/mitxresidential/_mitxresidential__sources.yml
@@ -1031,3 +1031,41 @@ sources:
       description: int, foreign key in edxval_video
     - name: is_hidden
       description: boolean, indicating if the video is hidden for the course.
+
+  - name: raw__mitx__openedx__api__course_blocks
+    columns:
+    - name: block_id
+      description: str, Unique ID for a distinct piece of content in a course, formatted
+        as block-v1:{org}+{course}+{run}type@{block type}+block@{hash code}
+    - name: block_index
+      description: int, sequence number giving order in which this block content appears
+        within the course
+    - name: block_parent
+      description: str, parent block ID, same format as block_id field
+    - name: block_type
+      description: str, category/type of the block, it identifies core structural
+        elements of a course. Value includes but not limited to course, chapter, sequential,
+        vertical, discussion, html, problem, video, etc.
+    - name: block_title
+      description: str, title of the block extracted from the metadata field of the
+        block. This field comes from name field for the section, subsection, or unit
+        on the Studio 'Course Outline' page
+    - name: block_details
+      description: str, json string of the block. It contains the attribute fields
+        like category, children and metadata. Different block type may have different
+        member fields inside metadata.
+    - name: course_id
+      description: str, Open edX Course ID formatted as course-v1:{org}+{course code}+{run_tag}
+    - name: course_title
+      description: str, title of the course extracted from the metadata field of 'course'
+        block
+    - name: course_content_hash
+      description: str, sha256 hashed string of the course content.
+    - name: block_content_hash
+      description: str, sha256 hashed string of the block content in a course
+    - name: course_start
+      description: timestamp, time indicating when the course starts, extracted from
+        metadata of the 'course' block
+    - name: retrieved_at
+      description: timestamp, time indicating when this block was initially retrieved
+        from REST API.

--- a/src/ol_dbt/models/staging/mitxresidential/_stg_mitxresidential__models.yml
+++ b/src/ol_dbt/models/staging/mitxresidential/_stg_mitxresidential__models.yml
@@ -421,3 +421,66 @@ models:
   tests:
   - dbt_expectations.expect_compound_columns_to_be_unique:
       column_list: ["courserun_readable_id", "video_id"]
+
+- name: stg__mitxresidential__openedx__api__course_structure
+  description: This table captures the historical changes made to the Residential
+    MITx course structure by comparing the new course block to the course block from
+    the previous day. If no changes are detected, no new rows are added to the table.
+    If there are any changes to the course structure, all blocks, including the updated
+    or new ones, are added to the table.
+  columns:
+  - name: courserun_readable_id
+    description: str, Open edX Course ID formatted as course-v1:xPRO+{course code}+{run_tag}
+    tests:
+    - not_null
+  - name: coursestructure_content_hash
+    description: str, sha256 hashed string of the course content.
+    tests:
+    - not_null
+  - name: coursestructure_block_content_hash
+    description: str, sha256 hashed string of the block content in a course
+    tests:
+    - not_null
+  - name: coursestructure_block_id
+    description: str, Unique ID for a distinct piece of content in a course, formatted
+      as block-v1:xPRO+{course}+{run}type@{block type}+block@{hash code}
+    tests:
+    - not_null
+  - name: coursestructure_parent_block_id
+    description: str, parent block ID, same format as block_id
+  - name: coursestructure_block_index
+    description: int, sequence number giving order in which this block content appears
+      within the course
+    tests:
+    - not_null
+  - name: coursestructure_block_category
+    description: str, category/type of the block, it identifies core structural elements
+      of a course. Value includes but not limited to course, chapter, sequential,
+      vertical, discussion, html, problem, video, etc.
+    tests:
+    - not_null
+  - name: coursestructure_block_title
+    description: str, title of the block extracted from the metadata of the block.
+      This field comes from name field for the section, subsection, or unit on the
+      Studio 'Course Outline' page.
+  - name: coursestructure_block_metadata
+    description: str, json string of the metadata field for the block. It provides
+      additional information about this block, different block type may have different
+      member fields inside metadata.
+    tests:
+    - not_null
+  - name: courserun_title
+    description: str, title of the course extracted from the metadata of 'course'
+      block
+  - name: courserun_start_on
+    description: timestamp, indicating when the course run starts extracted from the
+      metadata of 'course' block
+  - name: coursestructure_retrieved_at
+    description: timestamp, indicating when this course structure was initially retrieved
+      from REST API.
+    tests:
+    - not_null
+  tests:
+  - dbt_expectations.expect_compound_columns_to_be_unique:
+      column_list: ["courserun_readable_id", "coursestructure_block_id", "coursestructure_content_hash",
+        "coursestructure_retrieved_at"]

--- a/src/ol_dbt/models/staging/mitxresidential/stg__mitxresidential__openedx__api__course_structure.sql
+++ b/src/ol_dbt/models/staging/mitxresidential/stg__mitxresidential__openedx__api__course_structure.sql
@@ -1,5 +1,5 @@
 with course_block_source as (
-    select * from {{ source('ol_warehouse_raw_data','raw__xpro__openedx__api__course_blocks') }}
+    select * from {{ source('ol_warehouse_raw_data','raw__mitx__openedx__api__course_blocks') }}
 )
 
 , course_block as (


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
Close https://github.com/mitodl/hq/issues/5052

### Description (What does it do?)
<!--- Describe your changes in detail -->
 - Creating `stg__mitxresidential__openedx__api__course_structure` and `int__mitxresidential__course_structure` 
 - Adding Residential data and additional tests to int__combined__course_structure and int__combined__course_videos


marts__combined_video_engagements should now have chapter_title and chapter_id populated for most courses (_not_ all) from Residential


### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

Run `dbt build --select +int__combined__course_videos`

### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->


<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
