### PR TITLE
Openedx course xml export

### DIFF
--- a/src/ol_orchestrate/definitions/edx/openedx_data_extract.py
+++ b/src/ol_orchestrate/definitions/edx/openedx_data_extract.py
@@ -8,6 +8,7 @@ from dagster_aws.s3 import S3Resource
 from ol_orchestrate.assets.openedx import (
     course_structure,
     course_xml,
+    extract_courserun_details,
     openedx_live_courseware,
 )
 from ol_orchestrate.io_managers.filepath import (
@@ -75,6 +76,12 @@ for deployment_name in OPENEDX_DEPLOYMENTS:
                 ),
                 late_bind_partition_to_asset(
                     add_prefix_to_asset_keys(course_xml, deployment_name),
+                    OPENEDX_COURSE_RUN_PARTITIONS[deployment_name],
+                ),
+                late_bind_partition_to_asset(
+                    add_prefix_to_asset_keys(
+                        extract_courserun_details, deployment_name
+                    ),
                     OPENEDX_COURSE_RUN_PARTITIONS[deployment_name],
                 ),
             ],

--- a/src/ol_orchestrate/definitions/edx/openedx_data_extract.py
+++ b/src/ol_orchestrate/definitions/edx/openedx_data_extract.py
@@ -3,8 +3,13 @@ from typing import Any, Literal
 from dagster import (
     create_repository_using_definitions_args,
 )
+from dagster_aws.s3 import S3Resource
 
-from ol_orchestrate.assets.openedx import course_structure, openedx_live_courseware
+from ol_orchestrate.assets.openedx import (
+    course_structure,
+    course_xml,
+    openedx_live_courseware,
+)
 from ol_orchestrate.io_managers.filepath import (
     S3FileObjectIOManager,
 )
@@ -57,6 +62,7 @@ for deployment_name in OPENEDX_DEPLOYMENTS:
                 "openedx": OpenEdxApiClientFactory(
                     deployment=deployment_name, vault=vault
                 ),
+                "s3": S3Resource(),
             },
             assets=[
                 late_bind_partition_to_asset(
@@ -65,6 +71,10 @@ for deployment_name in OPENEDX_DEPLOYMENTS:
                 ),
                 late_bind_partition_to_asset(
                     add_prefix_to_asset_keys(course_structure, deployment_name),
+                    OPENEDX_COURSE_RUN_PARTITIONS[deployment_name],
+                ),
+                late_bind_partition_to_asset(
+                    add_prefix_to_asset_keys(course_xml, deployment_name),
                     OPENEDX_COURSE_RUN_PARTITIONS[deployment_name],
                 ),
             ],

--- a/src/ol_orchestrate/lib/openedx.py
+++ b/src/ol_orchestrate/lib/openedx.py
@@ -3,6 +3,7 @@ import json
 import tarfile
 from datetime import UTC, datetime
 from pathlib import Path
+from tempfile import NamedTemporaryFile
 from typing import IO, Any, Optional
 from xml.etree.ElementTree import ElementTree
 
@@ -97,7 +98,9 @@ def process_video_xml(archive_path: Path) -> list[dict[str, str]]:
             msg = "Unable to retrieve the archive root of the course XML."
             raise ValueError(msg)
         tar_info_course = tf.getmember(f"{archive_root.name}/course.xml")
-        course_xml_file = Path("course.xml")
+        course_xml_file = Path(
+            NamedTemporaryFile(delete=False, suffix="_course.xml").name
+        )
         course_xml_file.write_bytes(tf.extractfile(tar_info_course).read())  # type: ignore[union-attr]
         course_id, course_number, run_tag, org = parse_course_id(str(course_xml_file))
         course_xml_file.unlink()
@@ -175,12 +178,16 @@ def process_course_xml(archive_path: Path) -> dict[str, Any]:
             msg = "Unable to retrieve the archive root of the course XML."
             raise ValueError(msg)
         tar_info_course = tf.getmember(f"{archive_root.name}/course.xml")
-        course_xml_file = Path("course.xml")
+        course_xml_file = Path(
+            NamedTemporaryFile(delete=False, suffix="_course.xml").name
+        )
         course_xml_file.write_bytes(tf.extractfile(tar_info_course).read())  # type: ignore[union-attr]
         course_id, course_number, run_tag, org = parse_course_id(str(course_xml_file))
         # use the run_tag to find the course metadata file
         tar_info_metadata = tf.getmember(f"{archive_root.name}/course/{run_tag}.xml")
-        course_metadata_file = Path("course_metadata.xml")
+        course_metadata_file = Path(
+            NamedTemporaryFile(delete=False, suffix="_metadata.xml").name
+        )
         course_metadata_file.write_bytes(tf.extractfile(tar_info_metadata).read())  # type: ignore[union-attr]
         course_metadata = parse_course_xml(str(course_metadata_file))
         # add courserun data from the parse_course_id output


### PR DESCRIPTION
### What are the relevant tickets?
N/A

### Description (What does it do?)
<!--- Describe your changes in detail -->
Implements an asset-oriented method for course XML export from Open edX instances so that it can be used for downstream processing.

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->
Run the code location:
```
export GITHUB_TOKEN=<token with read:org scope>
dagster dev -f src/ol_orchestrate/definitions/edx/openedx_data_extract.py
```
Then go to the local running Dagster instance, visit the "Deployments" tab and turn on the sensors for one of the target deployments. Once it generates the list of partitions, manually trigger a materialization for one of the partitions in the `openedx/courseware` asset. That will then kick off a materialization of the downstream assets, including the course XML

### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->
Our current means of exporting course XML is on a naive daily trigger. This updates the logic to only export the course data when there is a change in the running course. This also simplifies the work of consuming and processing the course XML data to derive other details, such as video duration data.
