### PR TITLE
Add course/program metadata to combined product mart

### DIFF
--- a/src/ol_dbt/models/intermediate/mitxonline/_int_mitxonline__models.yml
+++ b/src/ol_dbt/models/intermediate/mitxonline/_int_mitxonline__models.yml
@@ -928,6 +928,14 @@ models:
     description: text, details about this course.
   - name: course_what_you_learn
     description: text, what you will learn from this course.
+  - name: course_certification_type
+    description: str, either 'MicroMasters Credential' or 'Certificate of Completion'.
+    tests:
+    - not_null
+  - name: course_topics
+    description: str, list of topic names for a course.
+  - name: course_instructors
+    description: str, list of instructor names for a course.
   - name: course_page_slug
     description: str, used for constructing the program page’s URL.
   - name: course_page_url_path

--- a/src/ol_dbt/models/intermediate/mitxonline/_int_mitxonline__models.yml
+++ b/src/ol_dbt/models/intermediate/mitxonline/_int_mitxonline__models.yml
@@ -1247,6 +1247,10 @@ models:
     description: boolean, specifying if the program is MITx MicroMasters® Program
     tests:
     - not_null
+  - name: program_topics
+    description: str, list of topic names for all courses in the program
+  - name: program_instructors
+    description: str, list of instructor names for the program
   - name: program_description
     description: text, the description shown on the home page and product page.
   - name: program_price
@@ -2070,7 +2074,7 @@ models:
 - name: int__mitxonline__course_instructors
   columns:
   - name: course_id
-    description: int, primary key in the courses_course table
+    description: int, foreign key to the courses_course table
     tests:
     - not_null
   - name: instructor_name
@@ -2107,3 +2111,23 @@ models:
   tests:
   - dbt_expectations.expect_compound_columns_to_be_unique:
       column_list: ["course_id", "coursetopic_id"]
+
+- name: int__mitxonline__program_instructors
+  columns:
+  - name: program_id
+    description: int, foreign key to the courses_program table
+    tests:
+    - not_null
+  - name: instructor_name
+    description: str, the name of the instructor.
+    tests:
+    - not_null
+  - name: instructor_title
+    description: str, the instructor's title (academic or otherwise).
+  - name: instructor_bio_short
+    description: str, a short biography of the instructor. May be blank.
+  - name: instructor_bio_long
+    description: str, a longer biography of the instructor.
+  tests:
+  - dbt_expectations.expect_compound_columns_to_be_unique:
+      column_list: ["program_id", "instructor_name"]

--- a/src/ol_dbt/models/intermediate/mitxonline/int__mitxonline__courses.sql
+++ b/src/ol_dbt/models/intermediate/mitxonline/int__mitxonline__courses.sql
@@ -36,6 +36,22 @@ with courses as (
     where row_num = 1
 )
 
+, course_topics as (
+    select
+        course_id
+        , array_join(array_agg(coursetopic_name), ', ') as course_topics
+    from {{ ref('int__mitxonline__course_to_topics') }}
+    group by course_id
+)
+
+, course_instructors as (
+    select
+        course_id
+        , array_join(array_agg(instructor_name), ', ') as course_instructors
+    from {{ ref('int__mitxonline__course_instructors') }}
+    group by course_id
+)
+
 select
     courses.course_id
     , courses.course_title
@@ -49,13 +65,19 @@ select
     , course_pages.course_prerequisites
     , course_pages.course_about
     , course_pages.course_what_you_learn
-    , course_certification_type.program_certification_type as course_certification_type
+    , course_topics.course_topics
+    , course_instructors.course_instructors
     , wagtail_page.wagtail_page_slug as course_page_slug
     , wagtail_page.wagtail_page_url_path as course_page_url_path
     , wagtail_page.wagtail_page_is_live as course_page_is_live
     , wagtail_page.wagtail_page_first_published_on as course_page_first_published_on
     , wagtail_page.wagtail_page_last_published_on as course_page_last_published_on
+    , coalesce(
+        course_certification_type.program_certification_type, 'Certificate of Completion'
+    ) as course_certification_type
 from courses
 left join course_pages on courses.course_id = course_pages.course_id
 left join wagtail_page on course_pages.wagtail_page_id = wagtail_page.wagtail_page_id
 left join course_certification_type on courses.course_id = course_certification_type.course_id
+left join course_topics on courses.course_id = course_topics.course_id
+left join course_instructors on courses.course_id = course_instructors.course_id

--- a/src/ol_dbt/models/intermediate/mitxonline/int__mitxonline__program_instructors.sql
+++ b/src/ol_dbt/models/intermediate/mitxonline/int__mitxonline__program_instructors.sql
@@ -1,0 +1,21 @@
+with instructors as (
+    select * from {{ ref('stg__mitxonline__app__postgres__cms_instructorpage') }}
+)
+
+, instructor_pagelinks as (
+    select * from {{ ref('stg__mitxonline__app__postgres__cms_instructorpagelink') }}
+)
+
+, program_pages as (
+    select * from {{ ref('stg__mitxonline__app__postgres__cms_programpage') }}
+)
+
+select
+    program_pages.program_id
+    , instructors.instructor_name
+    , instructors.instructor_title
+    , instructors.instructor_bio_short
+    , instructors.instructor_bio_long
+from program_pages
+inner join instructor_pagelinks on program_pages.wagtail_page_id = instructor_pagelinks.wagtail_page_id
+inner join instructors on instructor_pagelinks.instructor_wagtail_page_id = instructors.wagtail_page_id

--- a/src/ol_dbt/models/intermediate/mitxonline/int__mitxonline__programs.sql
+++ b/src/ol_dbt/models/intermediate/mitxonline/int__mitxonline__programs.sql
@@ -8,8 +8,36 @@ with programs as (
     select * from {{ ref('stg__mitxonline__app__postgres__cms_programpage') }}
 )
 
+, program_requirements as (
+    select
+        program_id
+        , course_id
+    from {{ ref('int__mitxonline__program_requirements') }}
+)
+
 , wagtail_page as (
     select * from {{ ref('stg__mitxonline__app__postgres__cms_wagtail_page') }}
+)
+
+, course_topics as (
+    select * from {{ ref('int__mitxonline__course_to_topics') }}
+)
+
+, program_topics as (
+    select
+        program_requirements.program_id
+        , array_join(array_distinct(array_agg(course_topics.coursetopic_name)), ', ') as program_topics
+    from course_topics
+    inner join program_requirements on course_topics.course_id = program_requirements.course_id
+    group by program_requirements.program_id
+)
+
+, program_instructors as (
+    select
+        program_id
+        , array_join(array_agg(instructor_name), ', ') as program_instructors
+    from {{ ref('int__mitxonline__program_instructors') }}
+    group by program_id
 )
 
 select
@@ -29,6 +57,8 @@ select
     , program_pages.program_prerequisites
     , program_pages.program_about
     , program_pages.program_what_you_learn
+    , program_topics.program_topics
+    , program_instructors.program_instructors
     , wagtail_page.wagtail_page_slug as program_page_slug
     , wagtail_page.wagtail_page_url_path as program_page_url_path
     , wagtail_page.wagtail_page_is_live as program_page_is_live
@@ -37,3 +67,5 @@ select
 from programs
 left join program_pages on programs.program_id = program_pages.program_id
 left join wagtail_page on program_pages.wagtail_page_id = wagtail_page.wagtail_page_id
+left join program_topics on programs.program_id = program_topics.program_id
+left join program_instructors on programs.program_id = program_instructors.program_id

--- a/src/ol_dbt/models/intermediate/mitxpro/_int_mitxpro__models.yml
+++ b/src/ol_dbt/models/intermediate/mitxpro/_int_mitxpro__models.yml
@@ -965,6 +965,7 @@ models:
   tests:
   - dbt_expectations.expect_table_row_count_to_equal_other_table:
       compare_model: ref('stg__mitxpro__app__postgres__ecommerce_productversion')
+
 - name: int__mitxpro__ecommerce_product
   description: Intermediate model of xPro Products.
   columns:

--- a/src/ol_dbt/models/intermediate/mitxpro/_int_mitxpro__models.yml
+++ b/src/ol_dbt/models/intermediate/mitxpro/_int_mitxpro__models.yml
@@ -1199,6 +1199,13 @@ models:
     description: str, short subheading to appear below the title on the program page
   - name: cms_programpage_time_commitment
     description: str, short description indicating about the time commitments
+  - name: cms_certificate_ceus
+    description: str, number of continuing education units or credits offered. e.g.
+      4.5
+  - name: program_topics
+    description: str, list of topic names for all courses in the program
+  - name: program_instructors
+    description: str, list of instructor names for the program
   - name: cms_programpage_catalog_details
     description: str, the description shown on the catalog page for this product
   - name: cms_programpage_slug
@@ -1583,16 +1590,10 @@ models:
     description: int, foreign key to courses_program representing a single program
     tests:
     - not_null
-    - relationships:
-        to: ref('int__mitxpro__programs')
-        field: program_id
   - name: user_id
     description: str, foreign key to users_user representing a single user
     tests:
     - not_null
-    - relationships:
-        to: ref('int__mitxpro__users')
-        field: user_id
   - name: programcertificate_is_revoked
     description: boolean, indicating whether the certificate is revoked and invalid
   - name: programcertificate_created_on

--- a/src/ol_dbt/models/intermediate/mitxpro/_int_mitxpro__models.yml
+++ b/src/ol_dbt/models/intermediate/mitxpro/_int_mitxpro__models.yml
@@ -1294,6 +1294,9 @@ models:
     description: str, short description indicating about the time commitments
   - name: cms_coursepage_catalog_details
     description: str, the description shown on the catalog page for this product
+  - name: cms_certificate_ceus
+    description: str, number of continuing education units or credits offered. e.g.
+      4.5
   - name: cms_coursepage_slug
     description: str, used for constructing the course page’s URL.
   - name: cms_coursepage_url_path

--- a/src/ol_dbt/models/intermediate/mitxpro/_int_mitxpro__models.yml
+++ b/src/ol_dbt/models/intermediate/mitxpro/_int_mitxpro__models.yml
@@ -1297,6 +1297,10 @@ models:
   - name: cms_certificate_ceus
     description: str, number of continuing education units or credits offered. e.g.
       4.5
+  - name: course_topics
+    description: str, list of topic names for a course.
+  - name: course_instructors
+    description: str, list of instructor names for a course.
   - name: cms_coursepage_slug
     description: str, used for constructing the course page’s URL.
   - name: cms_coursepage_url_path
@@ -1452,9 +1456,6 @@ models:
       run
     tests:
     - not_null
-    - relationships:
-        to: ref('int__mitxpro__course_runs')
-        field: courserun_id
   - name: courserun_title
     description: str, title of the course run
     tests:
@@ -1469,9 +1470,6 @@ models:
     description: int, foreign key to courses_course representing a single course
     tests:
     - not_null
-    - relationships:
-        to: ref('int__mitxpro__courses')
-        field: course_id
   - name: courserungrade_grade
     description: float, user's grade for the course (range between 0.0 to 1.0)
     tests:
@@ -1523,23 +1521,14 @@ models:
       run
     tests:
     - not_null
-    - relationships:
-        to: ref('int__mitxpro__course_runs')
-        field: courserun_id
   - name: course_id
     description: int, foreign key to courses_course representing a single course
     tests:
     - not_null
-    - relationships:
-        to: ref('int__mitxpro__courses')
-        field: course_id
   - name: user_id
     description: str, foreign key to users_user representing a single user
     tests:
     - not_null
-    - relationships:
-        to: ref('int__mitxpro__users')
-        field: user_id
   - name: courseruncertificate_url
     description: str, the full URL to the certificate on MIT xPro if it's not revoked
     tests:
@@ -1840,6 +1829,13 @@ models:
     description: int, primary key in courses_coursetopic
     tests:
     - not_null
+  - name: coursetopic_name
+    description: str, name of a course topic
+    tests:
+    - not_null
+  - name: coursetopic_parent_coursetopic_id
+    description: int, id for the parent coursetopic for subtopics. For example 'Technology'
+      is the parent topic for 'Technology:Data Science'
   tests:
   - dbt_expectations.expect_compound_columns_to_be_unique:
       column_list: ["course_id", "coursetopic_id"]

--- a/src/ol_dbt/models/intermediate/mitxpro/int__mitxpro__courses.sql
+++ b/src/ol_dbt/models/intermediate/mitxpro/int__mitxpro__courses.sql
@@ -16,6 +16,19 @@ with courses as (
     select * from {{ ref('stg__mitxpro__app__postgres__courses_platform') }}
 )
 
+, certificate_page as (
+    select * from {{ ref('stg__mitxpro__app__postgres__cms_certificatepage') }}
+)
+
+, certificate_page_path as (
+    select
+        certificate_page.wagtail_page_id
+        , wagtail_page.wagtail_page_path
+    from certificate_page
+    inner join wagtail_page
+        on certificate_page.wagtail_page_id = wagtail_page.wagtail_page_id
+)
+
 select
     courses.course_id
     , courses.program_id
@@ -31,6 +44,7 @@ select
     , cms_courses.cms_coursepage_duration
     , cms_courses.cms_coursepage_format
     , cms_courses.cms_coursepage_time_commitment
+    , certificate_page.cms_certificate_ceus
     , wagtail_page.wagtail_page_slug as cms_coursepage_slug
     , wagtail_page.wagtail_page_url_path as cms_coursepage_url_path
     , wagtail_page.wagtail_page_is_live as cms_coursepage_is_live
@@ -43,3 +57,5 @@ left join wagtail_page
     on cms_courses.wagtail_page_id = wagtail_page.wagtail_page_id
 left join platform
     on courses.platform_id = platform.platform_id
+left join certificate_page_path
+    on wagtail_page.wagtail_page_path like certificate_page_path.wagtail_page_path || '%'

--- a/src/ol_dbt/models/intermediate/mitxpro/int__mitxpro__courses.sql
+++ b/src/ol_dbt/models/intermediate/mitxpro/int__mitxpro__courses.sql
@@ -23,10 +23,27 @@ with courses as (
 , certificate_page_path as (
     select
         certificate_page.wagtail_page_id
+        , certificate_page.cms_certificate_ceus
         , wagtail_page.wagtail_page_path
     from certificate_page
     inner join wagtail_page
         on certificate_page.wagtail_page_id = wagtail_page.wagtail_page_id
+)
+
+, course_topics as (
+    select
+        course_id
+        , array_join(array_agg(coursetopic_name), ', ') as course_topics
+    from {{ ref('int__mitxpro__courses_to_topics') }}
+    group by course_id
+)
+
+, course_instructors as (
+    select
+        course_id
+        , array_join(array_agg(cms_facultymemberspage_facultymember_name), ', ') as course_instructors
+    from {{ ref('int__mitxpro__coursesfaculty') }}
+    group by course_id
 )
 
 select
@@ -44,7 +61,9 @@ select
     , cms_courses.cms_coursepage_duration
     , cms_courses.cms_coursepage_format
     , cms_courses.cms_coursepage_time_commitment
-    , certificate_page.cms_certificate_ceus
+    , certificate_page_path.cms_certificate_ceus
+    , course_topics.course_topics
+    , course_instructors.course_instructors
     , wagtail_page.wagtail_page_slug as cms_coursepage_slug
     , wagtail_page.wagtail_page_url_path as cms_coursepage_url_path
     , wagtail_page.wagtail_page_is_live as cms_coursepage_is_live
@@ -59,3 +78,5 @@ left join platform
     on courses.platform_id = platform.platform_id
 left join certificate_page_path
     on wagtail_page.wagtail_page_path like certificate_page_path.wagtail_page_path || '%'
+left join course_topics on courses.course_id = course_topics.course_id
+left join course_instructors on courses.course_id = course_instructors.course_id

--- a/src/ol_dbt/models/intermediate/mitxpro/int__mitxpro__courses_to_topics.sql
+++ b/src/ol_dbt/models/intermediate/mitxpro/int__mitxpro__courses_to_topics.sql
@@ -3,6 +3,10 @@ with coursepagetopic as (
     from {{ ref('stg__mitxpro__app__postgres__cms_coursepage_topics') }}
 )
 
+, course_topics as (
+    select * from {{ ref('stg__mitxpro__app__postgres__courses_coursetopic') }}
+)
+
 , coursepages as (
     select *
     from {{ ref('stg__mitxpro__app__postgres__cms_coursepage') }}
@@ -11,6 +15,10 @@ with coursepagetopic as (
 select
     coursepages.course_id
     , coursepagetopic.coursetopic_id
+    , course_topics.coursetopic_parent_coursetopic_id
+    , course_topics.coursetopic_name
 from coursepagetopic
 inner join coursepages
     on coursepagetopic.wagtail_page_id = coursepages.wagtail_page_id
+inner join course_topics
+    on coursepagetopic.coursetopic_id = course_topics.coursetopic_id

--- a/src/ol_dbt/models/intermediate/mitxpro/int__mitxpro__ecommerce_product.sql
+++ b/src/ol_dbt/models/intermediate/mitxpro/int__mitxpro__ecommerce_product.sql
@@ -24,7 +24,7 @@ with products as (
             select
                 *
                 , row_number() over (partition by product_id order by productversion_updated_on desc) as row_num
-            from {{ ref('stg__mitxpro__app__postgres__ecommerce_productversion') }}
+            from {{ ref('int__mitxpro__ecommerce_productversion') }}
         ) as product
     where row_num = 1
 )

--- a/src/ol_dbt/models/intermediate/mitxpro/int__mitxpro__programs.sql
+++ b/src/ol_dbt/models/intermediate/mitxpro/int__mitxpro__programs.sql
@@ -16,6 +16,45 @@ with programs as (
     select * from {{ ref('stg__mitxpro__app__postgres__courses_platform') }}
 )
 
+, course_program as (
+    select * from {{ ref('int__mitxpro__coursesinprogram') }}
+)
+
+, course_topics as (
+    select * from {{ ref('int__mitxpro__courses_to_topics') }}
+)
+
+, certificate_page as (
+    select * from {{ ref('stg__mitxpro__app__postgres__cms_certificatepage') }}
+)
+
+, certificate_page_path as (
+    select
+        certificate_page.wagtail_page_id
+        , certificate_page.cms_certificate_ceus
+        , wagtail_page.wagtail_page_path
+    from certificate_page
+    inner join wagtail_page
+        on certificate_page.wagtail_page_id = wagtail_page.wagtail_page_id
+)
+
+, program_topics as (
+    select
+        course_program.program_id
+        , array_join(array_agg(course_topics.coursetopic_name), ', ') as program_topics
+    from course_topics
+    inner join course_program on course_topics.course_id = course_program.course_id
+    group by course_program.program_id
+)
+
+, program_instructors as (
+    select
+        program_id
+        , array_join(array_agg(cms_facultymemberspage_facultymember_name), ', ') as program_instructors
+    from {{ ref('int__mitxpro__programsfaculty') }}
+    group by program_id
+)
+
 select
     programs.program_id
     , programs.program_title
@@ -29,6 +68,9 @@ select
     , cms_programs.cms_programpage_duration
     , cms_programs.cms_programpage_format
     , cms_programs.cms_programpage_time_commitment
+    , certificate_page_path.cms_certificate_ceus
+    , program_topics.program_topics
+    , program_instructors.program_instructors
     , wagtail_page.wagtail_page_slug as cms_programpage_slug
     , wagtail_page.wagtail_page_url_path as cms_programpage_url_path
     , wagtail_page.wagtail_page_is_live as cms_programpage_is_live
@@ -41,3 +83,7 @@ left join wagtail_page
     on cms_programs.wagtail_page_id = wagtail_page.wagtail_page_id
 left join platform
     on programs.platform_id = platform.platform_id
+left join certificate_page_path
+    on wagtail_page.wagtail_page_path like certificate_page_path.wagtail_page_path || '%'
+left join program_topics on programs.program_id = program_topics.program_id
+left join program_instructors on programs.program_id = program_instructors.program_id

--- a/src/ol_dbt/models/marts/combined/_marts__combined__models.yml
+++ b/src/ol_dbt/models/marts/combined/_marts__combined__models.yml
@@ -454,6 +454,33 @@ models:
   - name: courserun_upgrade_deadline
     description: timestamp, date and time beyond which the learner can not enroll
       in paid course mode. Only populated for MITx Online courses.
+  - name: duration
+    description: str, a short description indicating how long the course or program
+      takes to complete (e.g. '4 weeks')
+  - name: time_commitment
+    description: str, short description indicating about the time commitments
+  - name: certification_type
+    description: str, either 'MicroMasters Credential' or 'Certificate of Completion'
+      for MITx Online courses. 'Professional Certificate' for xPro courses.
+    tests:
+    - not_null
+  - name: delivery
+    description: str, 'Online' or 'Other' for xPro. 'Online' for MITx Online.
+    tests:
+    - not_null
+  - name: continuing_education_credits
+    description: str, number of continuing education units or credits offered. e.g.
+      4.5. NULL for MITx Online courses.
+  - name: pace
+    description: str, 'Self-paced' or 'Instructor-paced' for MITx Online courses.
+  - name: topics
+    description: str, list of topic names for a course.
+  - name: instructors
+    description: str, list of instructor names for a course.
+  - name: offered_by
+    description: str, 'MITx' or 'xPro'
+    tests:
+    - not_null
 
 - name: marts__combined_video_engagements
   description: Learners video engagements - play, pause, seek, or stop video actions

--- a/src/ol_dbt/models/marts/combined/_marts__combined__models.yml
+++ b/src/ol_dbt/models/marts/combined/_marts__combined__models.yml
@@ -455,7 +455,8 @@ models:
     description: str, a short description indicating how long the course or program
       takes to complete (e.g. '4 weeks')
   - name: time_commitment
-    description: str, short description indicating about the time commitments
+    description: str, short description indicating about the time commitments (e.g.
+      '5-7 hours per week')
   - name: certification_type
     description: str, either 'MicroMasters Credential' or 'Certificate of Completion'
       for MITx Online courses. 'Professional Certificate' for xPro courses.

--- a/src/ol_dbt/models/marts/combined/_marts__combined__models.yml
+++ b/src/ol_dbt/models/marts/combined/_marts__combined__models.yml
@@ -427,14 +427,11 @@ models:
   - name: product_description
     description: str, product description
   - name: list_price
-    description: numeric, the latest list price for the product.
-    tests:
-    - not_null
+    description: numeric, the latest list price for the product. May be Null for MITx
+      Online program.
   - name: product_is_active
     description: boolean, indicating whether the product is visible at the checkout
       page on MITx Online or xPro
-    tests:
-    - not_null
   - name: product_is_private
     description: boolean, indicating whether the product is public or private. Public
       products are listed in the product drop-down on the bulk purchase form for xPro.
@@ -451,7 +448,7 @@ models:
     description: timestamp, date and time when the course or program enrollment starts
   - name: enrollment_end
     description: timestamp, date and time when the course or program enrollment ends
-  - name: courserun_upgrade_deadline
+  - name: upgrade_deadline
     description: timestamp, date and time beyond which the learner can not enroll
       in paid course mode. Only populated for MITx Online courses.
   - name: duration

--- a/src/ol_dbt/models/marts/combined/_marts__combined__models.yml
+++ b/src/ol_dbt/models/marts/combined/_marts__combined__models.yml
@@ -463,8 +463,6 @@ models:
     - not_null
   - name: delivery
     description: str, 'Online' or 'Other' for xPro. 'Online' for MITx Online.
-    tests:
-    - not_null
   - name: continuing_education_credits
     description: str, number of continuing education units or credits offered. e.g.
       4.5. NULL for MITx Online courses.

--- a/src/ol_dbt/models/marts/combined/marts__combined__products.sql
+++ b/src/ol_dbt/models/marts/combined/marts__combined__products.sql
@@ -48,6 +48,8 @@ with mitxonline_product as (
         , mitxonline_courses.course_length as duration
         , mitxonline_courses.course_effort as time_commitment
         , mitxonline_courses.course_certification_type as certification_type
+        , mitxonline_courses.course_topics as topics
+        , mitxonline_courses.course_instructors as instructors
         , if(mitxonline_course_runs.courserun_is_self_paced = true, 'Self-paced', 'Instructor-paced')
         as pace
     from mitxonline_product
@@ -55,8 +57,6 @@ with mitxonline_product as (
         on mitxonline_product.courserun_id = mitxonline_course_runs.courserun_id
     left join mitxonline_courses
         on mitxonline_course_runs.course_id = mitxonline_courses.course_id
-    left join program_requirements
-        on mitxonline_courses.course_id = program_requirements.course_id
 )
 
 , mitxpro_product_view as (
@@ -73,6 +73,8 @@ with mitxonline_product as (
         , mitxpro_courses.cms_coursepage_time_commitment as time_commitment
         , mitxpro_courses.cms_coursepage_format as delivery
         , mitxpro_courses.cms_certificate_ceus as continuing_education_credits
+        , mitxpro_courses.course_topics as topics
+        , mitxpro_courses.course_instructors as instructors
         , if(mitxpro_product.product_type = 'program', 'program run', mitxpro_product.product_type) as product_type
         , coalesce(mitxpro_courses.platform_name, mitxpro_programs.platform_name) as product_platform
         , coalesce(
@@ -116,6 +118,8 @@ select
     , certification_type
     , 'Online' as delivery
     , null as continuing_education_credits
+    , topics
+    , instructors
     , 'MITx' as offered_by
 from mitxonline_product_view
 
@@ -144,5 +148,7 @@ select
     , 'Professional Certificate' as certification_type
     , delivery
     , continuing_education_credits
+    , topics
+    , instructors
     , 'xPro' as offered_by
 from mitxpro_product_view

--- a/src/ol_dbt/models/staging/mitxpro/_stg_mitxpro__models.yml
+++ b/src/ol_dbt/models/staging/mitxpro/_stg_mitxpro__models.yml
@@ -1235,16 +1235,10 @@ models:
       run
     tests:
     - not_null
-    - relationships:
-        to: ref('stg__mitxpro__app__postgres__courses_courserun')
-        field: courserun_id
   - name: user_id
     description: str, foreign key to users_user representing a single user
     tests:
     - not_null
-    - relationships:
-        to: ref('stg__mitxpro__app__postgres__users_user')
-        field: user_id
   - name: courserungrade_grade
     description: float, user's grade for the course (range between 0.0 to 1.0)
     tests:
@@ -1283,16 +1277,10 @@ models:
       run
     tests:
     - not_null
-    - relationships:
-        to: ref('stg__mitxpro__app__postgres__courses_courserun')
-        field: courserun_id
   - name: user_id
     description: str, foreign key to users_user representing a single user
     tests:
     - not_null
-    - relationships:
-        to: ref('stg__mitxpro__app__postgres__users_user')
-        field: user_id
   - name: courseruncertificate_url
     description: str, the full URL to the certificate on xPro if it's not revoked
     tests:
@@ -1326,9 +1314,6 @@ models:
     description: int, foreign key to courses_program representing a single program
     tests:
     - not_null
-    - relationships:
-        to: ref('stg__mitxpro__app__postgres__courses_program')
-        field: program_id
   - name: user_id
     description: str, foreign key to users_user representing a single user
     tests:


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
Close https://github.com/mitodl/hq/issues/5229

### Description (What does it do?)
<!--- Describe your changes in detail -->
Adding some course or program metadata to int__mitxonline/mitxpro__courses and combined product mart
 pace
 duration
 time_commitment
 certification_type
 delivery
 continuing_education_credits
 topics
 instructors
offered_by

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->
dbt build --select +marts__combined__products
