### PR TITLE
refactor: Move courseware change detection into a sensor

### DIFF
--- a/src/ol_orchestrate/assets/openedx.py
+++ b/src/ol_orchestrate/assets/openedx.py
@@ -15,7 +15,6 @@ from dagster import (
     AssetIn,
     AssetKey,
     AssetOut,
-    AutomationCondition,
     DataVersion,
     Output,
     asset,
@@ -34,7 +33,6 @@ from ol_orchestrate.lib.openedx import (
 
 
 @asset(
-    automation_condition=AutomationCondition.on_cron(cron_schedule="0 */6 * * *"),
     description=("An instance of courseware running in an Open edX environment."),
     group_name="openedx",
     key=AssetKey(["openedx", "courseware"]),

--- a/src/ol_orchestrate/definitions/edx/openedx_data_extract.py
+++ b/src/ol_orchestrate/definitions/edx/openedx_data_extract.py
@@ -24,7 +24,7 @@ from ol_orchestrate.lib.dagster_helpers import default_io_manager
 from ol_orchestrate.partitions.openedx import OPENEDX_COURSE_RUN_PARTITIONS
 from ol_orchestrate.resources.openedx import OpenEdxApiClientFactory
 from ol_orchestrate.resources.secrets.vault import Vault
-from ol_orchestrate.sensors.openedx import course_run_sensor
+from ol_orchestrate.sensors.openedx import course_run_sensor, course_version_sensor
 
 if DAGSTER_ENV == "dev":
     vault = Vault(vault_addr=VAULT_ADDRESS, vault_auth_type="github")
@@ -87,6 +87,7 @@ for deployment_name in OPENEDX_DEPLOYMENTS:
             assets=deployment_assets,
             sensors=[
                 course_run_sensor,
+                course_version_sensor,
                 AutomationConditionSensorDefinition(
                     f"{deployment_name}_openedx_automation_sensor",
                     minimum_interval_seconds=3600,

--- a/src/ol_orchestrate/sensors/openedx.py
+++ b/src/ol_orchestrate/sensors/openedx.py
@@ -1,21 +1,37 @@
+import json
+from datetime import UTC, datetime, timedelta
+
+import httpx
 from dagster import (
+    AssetKey,
+    AssetMaterialization,
+    DataVersion,
     SensorEvaluationContext,
     SensorResult,
     sensor,
 )
+from dagster._core.definitions.data_version import DATA_VERSION_TAG
+from pydantic import BaseModel
 
 from ol_orchestrate.lib.dagster_helpers import contains_invalid_partition_strings
+from ol_orchestrate.lib.magic_numbers import HTTP_NOT_FOUND
 from ol_orchestrate.partitions.openedx import (
     OPENEDX_COURSE_RUN_PARTITIONS,
 )
 from ol_orchestrate.resources.openedx import OpenEdxApiClientFactory
 
 
+class CourseCursor(BaseModel):
+    published_version: str
+    published_at: datetime | None = None
+    course_start: datetime | None = None
+    course_end: datetime | None = None
+
+
 @sensor(
     name="openedx_courseware_sensor",
     minimum_interval_seconds=60 * 60,
-    description="Query a running Open edX system for courseware definitions "
-    "and version changes.",
+    description="Query a running Open edX system for a list of course runs.",
 )
 def course_run_sensor(
     context: SensorEvaluationContext,
@@ -45,3 +61,91 @@ def course_run_sensor(
             )
         ],
     )
+
+
+@sensor(
+    name="openedx_course_version_sensor",
+    description=(
+        "Monitor course runs in a running Open edX system for updates to their "
+        "published versions."
+    ),
+    minimum_interval_seconds=60 * 60,
+)
+def course_version_sensor(
+    context: SensorEvaluationContext, openedx: OpenEdxApiClientFactory
+):
+    course_run_ids = OPENEDX_COURSE_RUN_PARTITIONS[
+        openedx.deployment
+    ].get_partition_keys(dynamic_partitions_store=context.instance)
+    # There is a dictionary consisting of course_run_ids as the keys, and the values are
+    # instances of the CourseCursor pydantic class. This sensor calls the
+    # openedx.client.get_course_outline method for a given course_run_id to detect the
+    # current published_version and other metadata to populate an instance of the
+    # CourseCursor object. For any course runs that have course_end datetime that is
+    # more than 3 months in the past, don't bother fetching their versions. For any
+    # course_run_ids that don't have keys in the context cursor, create an entry in the
+    # cursor dictionary with the results of the call to the get_course_outline method.
+
+    cursor = json.loads(context.cursor or "{}")
+    asset_events = []
+    for course_run_id in course_run_ids:
+        course_cursor = CourseCursor(
+            **cursor.get(
+                course_run_id,
+                CourseCursor(
+                    published_version="", course_end=datetime(9999, 12, 31, tzinfo=UTC)
+                ).model_dump(),
+            ),
+        )
+        if (
+            not course_cursor
+            or not course_cursor.course_end
+            or course_cursor.course_end > datetime.now(tz=UTC) - timedelta(days=90)
+        ):
+            try:
+                response = openedx.client.get_course_outline(course_run_id)
+            except httpx.HTTPStatusError as e:
+                if e.response.status_code == HTTP_NOT_FOUND:
+                    context.log.exception(
+                        "Course outline not found for key %s", course_run_id
+                    )
+                    continue
+                else:
+                    raise
+            if response["published_version"] == course_cursor.published_version:
+                continue
+            else:
+                course_update = CourseCursor(
+                    published_version=response["published_version"],
+                    published_at=datetime.fromisoformat(response["published_at"]),
+                    course_start=datetime.fromisoformat(response["course_start"]),
+                    course_end=datetime.fromisoformat(response["course_end"])
+                    if response["course_end"]
+                    else None,
+                )
+                asset_events.append(
+                    AssetMaterialization(
+                        asset_key=AssetKey(
+                            (openedx.deployment, "openedx", "courseware")
+                        ),
+                        partition=course_run_id,
+                        metadata={
+                            "source": f"{openedx.deployment} openedx",
+                            "materialization_time": datetime.fromisoformat(
+                                response["at_time"]
+                            ).isoformat(),
+                        },
+                        tags={
+                            DATA_VERSION_TAG: DataVersion(
+                                course_update.published_version
+                            ).value
+                        },
+                    )
+                )
+                cursor[course_run_id] = course_update.model_dump_json()
+
+        else:
+            continue
+    context.update_cursor(json.dumps(cursor))
+
+    return SensorResult(asset_events=asset_events)


### PR DESCRIPTION
### What are the relevant tickets?
N/A

### Description (What does it do?)
<!--- Describe your changes in detail -->
Relying on a periodic asset materialization to detect new versions of courses was a naive approach which led to way too many tasks being executed and didn't properly reduce materializations where there were no changes. This moves that logic into a sensor that uses a cursor for change detection.

### Screenshots (if appropriate):
<!--- optional - delete if empty --->
- [ ] Desktop screenshots
- [ ] Mobile width screenshots

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->
`export DAGSTER_SENSOR_GRPC_TIMEOUT_SECONDS=300` and then run the dagster dev server targeting the openedx code location and trigger the course-run and course-version sensors to verify that the sensor triggers materialization of assets that have changed.

### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->


<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
