### PR TITLE
Add external resource link status codes to resource report

### DIFF
--- a/src/ol_dbt/models/intermediate/ocw/_int_ocw__models.yml
+++ b/src/ol_dbt/models/intermediate/ocw/_int_ocw__models.yml
@@ -192,12 +192,16 @@ models:
     - not_null
   - name: external_resource_backup_url
     description: str, backup URL of the external resource
+  - name: external_resource_backup_url_status_code
+    description: int, status code of the external resource backup URL
   - name: external_resource_is_broken
     description: boolean, whether the external resource link is broken
   - name: external_resource_license_warning
     description: boolean, whether the external resource has a license warning
   - name: external_resource_url
     description: URL of the external resource
+  - name: external_resource_url_status_code
+    description: int, status code of the external resource URL
   - name: image_alt_text
     description: str, alt text of the image resource
   - name: image_caption

--- a/src/ol_dbt/models/intermediate/ocw/int__ocw__resources.sql
+++ b/src/ol_dbt/models/intermediate/ocw/int__ocw__resources.sql
@@ -44,12 +44,12 @@ select
             json_query(websitecontents.websitecontent_metadata, 'lax $.has_external_license_warning' omit quotes), ''
         ) as boolean
     ) as external_resource_license_warning
-    , nullif(
+    , nullif(nullif(
         json_query(websitecontents.websitecontent_metadata, 'lax $.url_status_code' omit quotes), ''
-    ) as external_resource_url_status_code
-    , nullif(
+    ), 'null') as external_resource_url_status_code
+    , nullif(nullif(
         json_query(websitecontents.websitecontent_metadata, 'lax $.backup_url_status_code' omit quotes), ''
-    ) as external_resource_backup_url_status_code
+    ), 'null') as external_resource_backup_url_status_code
     , coalesce(sitemetadata.sitemetadata_primary_course_number, websites.primary_course_number) as course_number
     , coalesce(sitemetadata.sitemetadata_course_term, websites.metadata_course_term) as course_term
     , coalesce(sitemetadata.sitemetadata_course_title, websites.metadata_course_title) as course_title


### PR DESCRIPTION
### What are the relevant tickets?
Related to https://github.com/mitodl/hq/issues/4023 and https://github.com/mitodl/hq/issues/5515.

### Description (What does it do?)

This PR adds the status code for external resource links (both primary and backup) to the resources report.

### How can this be tested?

Run the following commands; the tests should all pass
```
dbt build --select staging.ocw  --vars 'schema_suffix: <your name>' --target dev_production
dbt build --select intermediate.ocw --vars 'schema_suffix: <your name>' --target dev_production
```

Run the following query in https://mitol.galaxy.starburst.io/query-editor to see the result of the above tables:
```
SELECT * FROM ol_data_lake_production.ol_warehouse_production_<your name>_intermediate.int__ocw__resources
```

Then, verify that status codes for external resources are properly pulled in, using a query like

```
select course_name, resource_uuid, studio_url, external_resource_url, external_resource_backup_url, external_resource_url_status_code, external_resource_backup_url_status_code from ol_data_lake_production.ol_warehouse_production_<your name>_intermediate.int__ocw__resources
where external_resource_is_broken = true
```