### PR TITLE
add mart combined orders table to finance permissions

### DIFF
--- a/src/ol_dbt/models/marts/combined/_marts__combined__models.yml
+++ b/src/ol_dbt/models/marts/combined/_marts__combined__models.yml
@@ -112,6 +112,9 @@ models:
 
 - name: marts__combined__orders
   description: ecommerce regular b2c orders
+  config:
+    grants:
+      select: ['finance']
   columns:
   - name: combined_orders_hash_id
     description: int, primary key for this table. At the grain of order id, line id,

--- a/src/ol_dbt/models/marts/mitxonline/_marts__mitxonline__models.yml
+++ b/src/ol_dbt/models/marts/mitxonline/_marts__mitxonline__models.yml
@@ -90,9 +90,6 @@ models:
 
 - name: marts__mitxonline_course_enrollments
   description: learners MITx Online course enrollments and demographics
-  config:
-    grants:
-      select: ['finance']
   columns:
   - name: course_number
     description: str, unique string for the course. It can contain letters, numbers,


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/5548 bryan requested mart orders in addition to demographics as well for Phoebe and finance

### Description (What does it do?)
adds combined orders mart to finance permissions per the request of Bryan yesterday

### How can this be tested?
dbt build --select marts__combined__orders and review yaml

