### PR TITLE
add is_live and free courses to combined product mart

### DIFF
--- a/src/ol_dbt/models/marts/combined/_marts__combined__models.yml
+++ b/src/ol_dbt/models/marts/combined/_marts__combined__models.yml
@@ -511,9 +511,9 @@ models:
     tests:
     - not_null
   - name: is_live
-    description: boolean, indicating whether the course/program is set as live on
-      MITx Online or xPro. Courses/Programs set as is_live=false are not listed on
-      the catalog page.
+    description: boolean, indicating whether the course/program page is set as live
+      on MITx Online or xPro. Courses/Programs set as is_live=false are not listed
+      on the catalog page.
     tests:
     - not_null
 

--- a/src/ol_dbt/models/marts/combined/_marts__combined__models.yml
+++ b/src/ol_dbt/models/marts/combined/_marts__combined__models.yml
@@ -510,6 +510,12 @@ models:
     description: str, 'MITx' or 'xPro'
     tests:
     - not_null
+  - name: is_live
+    description: boolean, indicating whether the course/program is set as live on
+      MITx Online or xPro. Courses/Programs set as is_live=false are not listed on
+      the catalog page.
+    tests:
+    - not_null
 
 - name: marts__combined_video_engagements
   description: Learners video engagements - play, pause, seek, or stop video actions

--- a/src/ol_dbt/models/marts/combined/_marts__combined__models.yml
+++ b/src/ol_dbt/models/marts/combined/_marts__combined__models.yml
@@ -460,8 +460,8 @@ models:
   - name: product_description
     description: str, product description
   - name: list_price
-    description: numeric, the latest list price for the product. May be Null for MITx
-      Online program.
+    description: str, the latest list price for the product or 'Free' for some MITx
+      Online courses. Null for MITx Online programs.
   - name: product_is_active
     description: boolean, indicating whether the product is visible at the checkout
       page on MITx Online or xPro

--- a/src/ol_dbt/models/marts/combined/_marts__combined__models.yml
+++ b/src/ol_dbt/models/marts/combined/_marts__combined__models.yml
@@ -460,8 +460,8 @@ models:
   - name: product_description
     description: str, product description
   - name: list_price
-    description: str, the latest list price for the product or 'Free' for some MITx
-      Online courses. Null for MITx Online programs.
+    description: numeric, the latest list price for the product. Null for MITx Online
+      programs and some MITx Online courses that have no normalized price.
   - name: product_is_active
     description: boolean, indicating whether the product is visible at the checkout
       page on MITx Online or xPro

--- a/src/ol_dbt/models/marts/combined/marts__combined__products.sql
+++ b/src/ol_dbt/models/marts/combined/marts__combined__products.sql
@@ -37,9 +37,11 @@ with mitxonline_product as (
 , mitxonline_product_view as (
     select
         mitxonline_product.product_id
-        , mitxonline_product.product_type
-        , mitxonline_product.courserun_readable_id as product_readable_id
-        , mitxonline_product.product_price as list_price
+        , coalesce(mitxonline_product.product_type, 'course run') as product_type
+        , coalesce(
+            mitxonline_product.courserun_readable_id, mitxonline_course_runs.courserun_readable_id
+        ) as product_readable_id
+        , coalesce(cast(mitxonline_product.product_price as varchar), mitxonline_courses.course_price) as list_price
         , mitxonline_product.product_description
         , mitxonline_product.product_is_active
         , mitxonline_product.product_created_on
@@ -61,13 +63,12 @@ with mitxonline_product as (
             , true
             , false
         ) as is_live
-    from mitxonline_product
-    left join mitxonline_course_runs
-        on mitxonline_product.courserun_id = mitxonline_course_runs.courserun_id
-    left join mitxonline_courses
+    from mitxonline_course_runs
+    inner join mitxonline_courses
         on mitxonline_course_runs.course_id = mitxonline_courses.course_id
-    left join mitxonline_programs
-        on mitxonline_product.program_readable_id = mitxonline_programs.program_readable_id
+    left join mitxonline_product
+        on mitxonline_course_runs.courserun_id = mitxonline_product.courserun_id
+
 
     union all
 
@@ -105,7 +106,7 @@ with mitxonline_product as (
 , mitxpro_product_view as (
     select
         mitxpro_product.product_id
-        , mitxpro_product.product_list_price as list_price
+        , cast(mitxpro_product.product_list_price as varchar) as list_price
         , mitxpro_product.product_description
         , mitxpro_product.product_is_private
         , mitxpro_product.product_is_active

--- a/src/ol_dbt/models/marts/combined/marts__combined__products.sql
+++ b/src/ol_dbt/models/marts/combined/marts__combined__products.sql
@@ -41,7 +41,7 @@ with mitxonline_product as (
         , coalesce(
             mitxonline_product.courserun_readable_id, mitxonline_course_runs.courserun_readable_id
         ) as product_readable_id
-        , coalesce(cast(mitxonline_product.product_price as varchar), mitxonline_courses.course_price) as list_price
+        , mitxonline_product.product_price as list_price
         , mitxonline_product.product_description
         , mitxonline_product.product_is_active
         , mitxonline_product.product_created_on
@@ -106,7 +106,7 @@ with mitxonline_product as (
 , mitxpro_product_view as (
     select
         mitxpro_product.product_id
-        , cast(mitxpro_product.product_list_price as varchar) as list_price
+        , mitxpro_product.product_list_price as list_price
         , mitxpro_product.product_description
         , mitxpro_product.product_is_private
         , mitxpro_product.product_is_active

--- a/src/ol_dbt/models/marts/combined/marts__combined__products.sql
+++ b/src/ol_dbt/models/marts/combined/marts__combined__products.sql
@@ -56,6 +56,11 @@ with mitxonline_product as (
         , mitxonline_courses.course_instructors as instructors
         , if(mitxonline_course_runs.courserun_is_self_paced = true, 'Self-paced', 'Instructor-paced')
         as pace
+        , if(
+            mitxonline_courses.course_page_is_live = true and mitxonline_courses.course_is_live = true
+            , true
+            , false
+        ) as is_live
     from mitxonline_product
     left join mitxonline_course_runs
         on mitxonline_product.courserun_id = mitxonline_course_runs.courserun_id
@@ -86,6 +91,11 @@ with mitxonline_product as (
         , mitxonline_programs.program_topics as topics
         , mitxonline_programs.program_instructors as instructors
         , null as pace
+        , if(
+            mitxonline_programs.program_is_live = true and mitxonline_programs.program_page_is_live = true
+            , true
+            , false
+        ) as is_live
     from mitxonline_programs
     left join mitxonline_product
         on mitxonline_programs.program_readable_id = mitxonline_product.program_readable_id
@@ -119,6 +129,13 @@ with mitxonline_product as (
         , coalesce(mitxpro_course_runs.courserun_title, mitxpro_program_runs.program_title) as product_name
         , coalesce(mitxpro_course_runs.courserun_start_on, mitxpro_program_runs.programrun_start_on) as start_on
         , coalesce(mitxpro_course_runs.courserun_end_on, mitxpro_program_runs.programrun_end_on) as end_on
+        , case
+            when mitxpro_courses.course_is_live = true and mitxpro_courses.cms_coursepage_is_live = true
+                then true
+            when mitxpro_programs.program_is_live = true and mitxpro_programs.cms_programpage_is_live = true
+                then true
+            else false
+        end as is_live
     from mitxpro_product
     left join mitxpro_course_runs
         on mitxpro_product.courserun_id = mitxpro_course_runs.courserun_id
@@ -157,6 +174,7 @@ select
     , topics
     , instructors
     , 'MITx' as offered_by
+    , is_live
 from mitxonline_product_view
 
 union all
@@ -187,4 +205,5 @@ select
     , topics
     , instructors
     , 'xPro' as offered_by
+    , is_live
 from mitxpro_product_view


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
https://github.com/mitodl/hq/issues/3992

### Description (What does it do?)
<!--- Describe your changes in detail -->
Adding `is_live` and 'free' courses to marts__combined__products so that it can be used as part of the `Open for enrollment` filter in https://bi.ol.mit.edu/superset/dashboard/25/
   - The calculated field `Open for enrollment` should return 72 results, which should match with https://mitxonline.mit.edu/api/v2/courses/?courserun_is_enrollable=true&live=true&page__live=true
   - `is_live` = true is same as `live=true&page__live=true` filter used on MITx Online api.
   - free course e.g. https://mitxonline.mit.edu/courses/course-v1:MITxT+8.EFTx/ is included now

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->
dbt build --select marts__combined__products  

Then verify this query returns 72 rows
select * from ol_data_lake_production.ol_warehouse_production_YOURNAME_mart.marts__combined__products
where platform='MITx Online'
and from_iso8601_timestamp(enrollment_start_on) <= current_date
and (enrollment_end_on is null or from_iso8601_timestamp(enrollment_end_on) > current_date)
and **is_live = true**
