### PR TITLE
Update discount field in staging discount models

### DIFF
--- a/src/ol_dbt/models/marts/combined/_marts__combined__models.yml
+++ b/src/ol_dbt/models/marts/combined/_marts__combined__models.yml
@@ -149,8 +149,8 @@ models:
     description: string, unique string to identify a course run on the corresponding
       platform.
   - name: discount
-    description: str, discount applied for the order in readable format, e.g., $100
-      off, 30% off.
+    description: str, discount applied for the order in readable format, e.g., $100,
+      30%.
   - name: order_created_on
     description: timestamp, specifying when the order was initially created. If this
       is a b2b order it will be the timestamp that order was created otherwise it

--- a/src/ol_dbt/models/marts/combined/_marts__combined__models.yml
+++ b/src/ol_dbt/models/marts/combined/_marts__combined__models.yml
@@ -149,8 +149,9 @@ models:
     description: string, unique string to identify a course run on the corresponding
       platform.
   - name: discount
-    description: str, discount applied for the order in readable format, e.g., $100,
-      30%.
+    description: str, discount applied to the order in a readable format. The value
+      is always an amount taken off the list price of the order, e.g., "$100" means
+      $100 was taken off the price. "30%" means the price was reduced by 30%.
   - name: order_created_on
     description: timestamp, specifying when the order was initially created. If this
       is a b2b order it will be the timestamp that order was created otherwise it

--- a/src/ol_dbt/models/staging/micromasters/stg__micromasters__app__postgres__ecommerce_coupon.sql
+++ b/src/ol_dbt/models/staging/micromasters/stg__micromasters__app__postgres__ecommerce_coupon.sql
@@ -18,7 +18,7 @@ with source as (
         , invoice_id as couponinvoice_id
         , case
             when amount_type = 'fixed-discount'
-                then concat('$', format('%.2f', amount), ' off')
+                then concat('$', format('%.2f', amount))
             when amount_type = 'fixed-price'
                 then concat('Fixed Price: ', format('%.2f', amount))
             when amount_type = 'percent-discount'

--- a/src/ol_dbt/models/staging/micromasters/stg__micromasters__app__postgres__ecommerce_coupon.sql
+++ b/src/ol_dbt/models/staging/micromasters/stg__micromasters__app__postgres__ecommerce_coupon.sql
@@ -18,11 +18,11 @@ with source as (
         , invoice_id as couponinvoice_id
         , case
             when amount_type = 'fixed-discount'
-                then concat(format('%.2f', amount), ' off')
+                then concat('$', format('%.2f', amount), ' off')
             when amount_type = 'fixed-price'
                 then concat('Fixed Price: ', format('%.2f', amount))
             when amount_type = 'percent-discount'
-                then concat(format('%.2f', amount * 100), '% off')
+                then concat(format('%.2f', amount * 100), '%')
         end as coupon_discount_amount_text
         ,{{ cast_timestamp_to_iso8601('created_on') }} as coupon_created_on
         ,{{ cast_timestamp_to_iso8601('updated_on') }} as coupon_updated_on

--- a/src/ol_dbt/models/staging/mitxonline/stg__mitxonline__app__postgres__ecommerce_discount.sql
+++ b/src/ol_dbt/models/staging/mitxonline/stg__mitxonline__app__postgres__ecommerce_discount.sql
@@ -16,9 +16,9 @@ with source as (
         , payment_type as discount_source
         , case
             when discount_type = 'percent-off'
-                then concat(format('%.2f', amount), '% off')
+                then concat(format('%.2f', amount), '%')
             when discount_type = 'dollars-off'
-                then concat('$', format('%.2f', amount), ' off')
+                then concat('$', format('%.2f', amount))
             when discount_type = 'fixed-price'
                 then concat('Fixed Price: ', format('%.2f', amount))
         end as discount_amount_text

--- a/src/ol_dbt/models/staging/mitxpro/stg__mitxpro__app__postgres__ecommerce_couponpaymentversion.sql
+++ b/src/ol_dbt/models/staging/mitxpro/stg__mitxpro__app__postgres__ecommerce_couponpaymentversion.sql
@@ -22,9 +22,9 @@ with source as (
         , max_redemptions as couponpaymentversion_max_redemptions
         , case
             when discount_type = 'dollars-off'
-                then concat('$', format('%.2f', amount), ' off')
+                then concat('$', format('%.2f', amount))
             when discount_type = 'percent-off'
-                then concat(format('%.2f', amount * 100), '% off')
+                then concat(format('%.2f', amount * 100), '%')
         end as couponpaymentversion_discount_amount_text
         ,{{ cast_timestamp_to_iso8601('expiration_date') }} as couponpaymentversion_expires_on
         ,{{ cast_timestamp_to_iso8601('activation_date') }} as couponpaymentversion_activated_on


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
Item 2 from https://github.com/mitodl/hq/issues/5705 needs dbt code change as discount fields are formatted in staging.

### Description (What does it do?)
<!--- Describe your changes in detail -->
Removing the text “off” from the ‘discount’ field and keeping $” or “%” signs


### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->
dbt run --select +marts__combined__orders

then verify the field
select discount from ol_data_lake_production.ol_warehouse_production_mart.marts__combined__orders
where discount is not null
