### PR TITLE
add 5 columns to combined users mart in order to move a redash report with these columns to superset

### DIFF
--- a/src/ol_dbt/models/marts/combined/_marts__combined__models.yml
+++ b/src/ol_dbt/models/marts/combined/_marts__combined__models.yml
@@ -110,7 +110,8 @@ models:
   - name: last_course_start_datetime
     description: string, year and term from the users latest course enrollment
   - name: number_of_courserun_certificates
-    description: int, number of course run enrollment certificates associated with the user
+    description: int, number of course run enrollment certificates associated with
+      the user
   - name: total_amount_paid_orders
     description: int, sum of total orders paid associated with the user
   - name: latest_income_usd

--- a/src/ol_dbt/models/marts/combined/marts__combined__users.sql
+++ b/src/ol_dbt/models/marts/combined/marts__combined__users.sql
@@ -33,31 +33,31 @@ with mitx__users as (
 )
 
 , program_stats as (
-    select 
+    select
         user_email
         , count(distinct programcertificate_uuid) as cert_count
-        , sum(case 
-            when 
+        , sum(case
+            when
                 program_title in (
                     'Data, Economics, and Design of Policy'
                     , 'Data, Economics, and Design of Policy: International Development'
                     , 'Data, Economics, and Design of Policy: Public Policy'
-                ) 
-                and 
+                )
+                and
                 programcertificate_uuid is not null
-                then 1 
+                then 1
             else 0
         end) as dedp_program_cred_count
     from combined_programs
-    group by user_email 
+    group by user_email
 )
 
 , orders_stats as (
-    select 
+    select
         user_email
         , sum(order_total_price_paid) as total_amount_paid_orders
     from orders
-    group by user_email 
+    group by user_email
 )
 
 , course_stats as (
@@ -67,7 +67,7 @@ with mitx__users as (
         , count(
             distinct
             case
-                when combined_enrollments.courserungrade_is_passing = true 
+                when combined_enrollments.courserungrade_is_passing = true
                     then combined_enrollments.course_title
             end
         ) as num_of_course_passed


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/5610

### Description (What does it do?)
Currently in Redash we report on the first time a user was enrolled in a course, the last time a user was enrolled in a course, the number of certificates awarded to a user, the total amount a user has paid, the user's income, and  whether they are a program credential holder. In order to continue to report on these values we should add the columns to our marts so that we can surface them more easily in superset.

adds the following columns to the combined users mart:
first_course_start_datetime, last_course_start_datetime, number_of_courserun_certificates, total_amount_paid_orders, latest_income_usd, program_cred_ind


### How can this be tested?
dbt build --select marts__combined__users

