### PR TITLE
Update receipt_payment_amount data type to be decimal in order mart upstream models

### DIFF
--- a/src/ol_dbt/models/intermediate/bootcamps/int__bootcamps__ecommerce_receipt.sql
+++ b/src/ol_dbt/models/intermediate/bootcamps/int__bootcamps__ecommerce_receipt.sql
@@ -9,6 +9,7 @@ select
     , receipt_updated_on
     , order_id
     , receipt_data
+    , cast(json_query(receipt_data, 'lax $.req_amount' omit quotes) as decimal(38, 2)) as receipt_payment_amount
     , json_query(receipt_data, 'lax $.req_transaction_uuid' omit quotes) as receipt_transaction_uuid
     , json_query(receipt_data, 'lax $.decision' omit quotes) as receipt_transaction_status
     , json_query(receipt_data, 'lax $.transaction_id' omit quotes) as receipt_transaction_id
@@ -18,7 +19,6 @@ select
     , json_query(receipt_data, 'lax $.req_reference_number' omit quotes) as receipt_reference_number
     , json_query(receipt_data, 'lax $.req_bill_to_address_state' omit quotes) as receipt_bill_to_address_state
     , json_query(receipt_data, 'lax $.req_bill_to_address_country' omit quotes) as receipt_bill_to_address_country
-    , json_query(receipt_data, 'lax $.req_amount' omit quotes) as receipt_payment_amount
     , json_query(receipt_data, 'lax $.req_currency' omit quotes) as receipt_payment_currency
     , json_query(receipt_data, 'lax $.req_bill_to_email' omit quotes) as receipt_payer_email
     , json_query(receipt_data, 'lax $.req_card_number' omit quotes) as receipt_payment_card_number

--- a/src/ol_dbt/models/intermediate/mitxonline/int__mitxonline__ecommerce_transaction.sql
+++ b/src/ol_dbt/models/intermediate/mitxonline/int__mitxonline__ecommerce_transaction.sql
@@ -11,6 +11,7 @@ select
     , transaction_created_on
     , transaction_readable_identifier
     , transaction_type
+    , cast(json_query(transaction_data, 'lax $.req_amount' omit quotes) as decimal(38, 2)) as transaction_payment_amount
     , json_query(transaction_data, 'lax $.req_transaction_uuid' omit quotes) as transaction_uuid
     , json_query(transaction_data, 'lax $.decision' omit quotes) as transaction_status
     , json_query(transaction_data, 'lax $.req_payment_method' omit quotes) as transaction_payment_method
@@ -20,7 +21,6 @@ select
         transaction_data, 'lax $.req_bill_to_address_country' omit quotes
     ) as transaction_bill_to_address_country
     , json_query(transaction_data, 'lax $.req_transaction_type' omit quotes) as transaction_req_type
-    , json_query(transaction_data, 'lax $.req_amount' omit quotes) as transaction_payment_amount
     , json_query(transaction_data, 'lax $.req_currency' omit quotes) as transaction_payment_currency
     , json_query(transaction_data, 'lax $.req_bill_to_email' omit quotes) as transaction_payer_email
     , json_query(transaction_data, 'lax $.req_card_number' omit quotes) as transaction_payment_card_number

--- a/src/ol_dbt/models/intermediate/mitxpro/int__mitxpro__ecommerce_receipt.sql
+++ b/src/ol_dbt/models/intermediate/mitxpro/int__mitxpro__ecommerce_receipt.sql
@@ -9,6 +9,7 @@ select
     , receipt_updated_on
     , receipt_data
     , order_id
+    , cast(json_query(receipt_data, 'lax $.req_amount' omit quotes) as decimal(38, 2)) as receipt_payment_amount
     , json_query(receipt_data, 'lax $.req_transaction_uuid' omit quotes) as receipt_transaction_uuid
     , json_query(receipt_data, 'lax $.decision' omit quotes) as receipt_transaction_status
     , json_query(receipt_data, 'lax $.transaction_id' omit quotes) as receipt_transaction_id
@@ -18,7 +19,6 @@ select
     , json_query(receipt_data, 'lax $.req_bill_to_address_state' omit quotes) as receipt_bill_to_address_state
     , json_query(receipt_data, 'lax $.req_bill_to_address_country' omit quotes) as receipt_bill_to_address_country
     , json_query(receipt_data, 'lax $.req_transaction_type' omit quotes) as receipt_transaction_type
-    , json_query(receipt_data, 'lax $.req_amount' omit quotes) as receipt_payment_amount
     , json_query(receipt_data, 'lax $.req_currency' omit quotes) as receipt_payment_currency
     , json_query(receipt_data, 'lax $.req_bill_to_email' omit quotes) as receipt_payer_email
     , json_query(receipt_data, 'lax $.req_card_number' omit quotes) as receipt_payment_card_number

--- a/src/ol_dbt/models/staging/micromasters/stg__micromasters__app__postgres__ecommerce_receipt.sql
+++ b/src/ol_dbt/models/staging/micromasters/stg__micromasters__app__postgres__ecommerce_receipt.sql
@@ -17,7 +17,7 @@ with source as (
         , json_query(data, 'lax $.req_reference_number' omit quotes) as receipt_reference_number
         , json_query(data, 'lax $.req_bill_to_address_state' omit quotes) as receipt_bill_to_address_state
         , json_query(data, 'lax $.req_bill_to_address_country' omit quotes) as receipt_bill_to_address_country
-        , json_query(data, 'lax $.req_amount' omit quotes) as receipt_payment_amount
+        , cast(json_query(data, 'lax $.req_amount' omit quotes) as decimal(38, 2)) as receipt_payment_amount
         , json_query(data, 'lax $.req_currency' omit quotes) as receipt_payment_currency
         , json_query(data, 'lax $.req_bill_to_email' omit quotes) as receipt_payer_email
         , json_query(data, 'lax $.req_card_number' omit quotes) as receipt_payment_card_number


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
https://github.com/mitodl/hq/issues/5705
Also https://docs.google.com/document/d/12k4cphQVbb9EBRxHZLEYmAqeyfMhwLxL44Lif3JFU9o/edit

### Description (What does it do?)
<!--- Describe your changes in detail -->
Updating `receipt_payment_amount` to be decimal type instead of varchar in upstream models of marts__combined__orders so that its consistent with other decimal fields. Currently, this field is pulled directly from CyberSource, superset can't format it as a number due to the data type being varchar.

The `receipt_payment_amount` field description has already indicated it's numeric so no update there.

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->
Run `dbt run --select +marts__combined__orders`

Then run `DESCRIBE "ol_data_lake_production"."ol_warehouse_production_XXXX_mart"."marts__combined__orders"` to verify `receipt_payment_amount` is decimal(38, 2)
```
receipt_payment_amount decimal(38,2)

order_tax_amount decimal(38,2)
order_tax_rate decimal(38,2)
order_total_price_paid_plus_tax decimal(38,2)
order_total_price_paid decimal(38,2)
unit_price decimal(38,2)
```
