### PR TITLE
Extract edxorg course xml for video metadata

### DIFF
--- a/src/ol_orchestrate/assets/openedx_course_archives.py
+++ b/src/ol_orchestrate/assets/openedx_course_archives.py
@@ -9,7 +9,6 @@ from dagster import (
     AssetIn,
     AssetKey,
     AssetOut,
-    AutoMaterializePolicy,
     DataVersion,
     Output,
     asset,
@@ -39,7 +38,6 @@ def dummy_edxorg_course_xml(): ...
 @multi_asset(
     partitions_def=course_and_source_partitions,
     group_name="edxorg",
-    io_manager_key="s3file_io_manager",
     ins={"course_archive": AssetIn(key=AssetKey(("edxorg", "raw_data", "course_xml")))},
     outs={
         "course_metadata": AssetOut(
@@ -60,9 +58,6 @@ def dummy_edxorg_course_xml(): ...
             key=AssetKey(("edxorg", "processed_data", "course_video")),
         ),
     },
-    auto_materialize_policy=AutoMaterializePolicy.eager(
-        max_materializations_per_minute=None
-    ),
 )
 def extract_edxorg_courserun_metadata(
     context: AssetExecutionContext, course_archive: UPath

--- a/src/ol_orchestrate/assets/openedx_course_archives.py
+++ b/src/ol_orchestrate/assets/openedx_course_archives.py
@@ -1,15 +1,19 @@
 import hashlib
 import json
 from pathlib import Path
+from tempfile import NamedTemporaryFile
 
+import jsonlines
 from dagster import (
     AssetExecutionContext,
     AssetIn,
     AssetKey,
+    AssetOut,
     AutoMaterializePolicy,
     DataVersion,
     Output,
     asset,
+    multi_asset,
 )
 from dagster._core.definitions.multi_dimensional_partitions import (
     MULTIPARTITION_KEY_DELIMITER,
@@ -17,7 +21,11 @@ from dagster._core.definitions.multi_dimensional_partitions import (
 from upath import UPath
 
 from ol_orchestrate.assets.edxorg_archive import course_and_source_partitions
-from ol_orchestrate.lib.openedx import process_course_xml
+from ol_orchestrate.lib.automation_policies import upstream_or_code_changes
+from ol_orchestrate.lib.openedx import (
+    process_course_xml,
+    process_video_xml,
+)
 
 
 @asset(
@@ -28,12 +36,30 @@ from ol_orchestrate.lib.openedx import process_course_xml
 def dummy_edxorg_course_xml(): ...
 
 
-@asset(
-    key=AssetKey(("edxorg", "processed_data", "course_metadata")),
+@multi_asset(
     partitions_def=course_and_source_partitions,
     group_name="edxorg",
     io_manager_key="s3file_io_manager",
     ins={"course_archive": AssetIn(key=AssetKey(("edxorg", "raw_data", "course_xml")))},
+    outs={
+        "course_metadata": AssetOut(
+            automation_condition=upstream_or_code_changes(),
+            description=(
+                "Metadata about the course run that is extracted form the XML export."
+            ),
+            io_manager_key="s3file_io_manager",
+            key=AssetKey(("edxorg", "processed_data", "course_metadata")),
+        ),
+        "course_video": AssetOut(
+            automation_condition=upstream_or_code_changes(),
+            description=(
+                "Details about the video elements in the courses that are extracted "
+                "from the XML export."
+            ),
+            io_manager_key="s3file_io_manager",
+            key=AssetKey(("edxorg", "processed_data", "course_video")),
+        ),
+    },
     auto_materialize_policy=AutoMaterializePolicy.eager(
         max_materializations_per_minute=None
     ),
@@ -42,14 +68,18 @@ def extract_edxorg_courserun_metadata(
     context: AssetExecutionContext, course_archive: UPath
 ):
     # Download the remote file to the current working directory
-    course_xml = Path("course.xml.tar.gz")
-    course_archive.fs.get_file(course_archive, course_xml)
-    course_metadata = process_course_xml(course_xml)
-    course_metadata_file = Path("course_metadata.json")
+    course_xml_path = Path(NamedTemporaryFile(delete=False, suffix=".xml.tar.gz").name)
+    course_archive.fs.get_file(course_archive, course_xml_path)
+    data_version = hashlib.file_digest(course_xml_path.open("rb"), "sha256").hexdigest()
+
+    # Process the course metadata
+    course_metadata = process_course_xml(course_xml_path)
+    course_metadata_file = Path(
+        NamedTemporaryFile(delete=False, suffix="_metadata.json").name
+    )
     course_metadata_file.write_text(json.dumps(course_metadata))
-    data_version = hashlib.file_digest(
-        course_metadata_file.open("rb"), "sha256"
-    ).hexdigest()
+
+    # Multipartition Key Logic
     partition_parts = context.partition_key.split(MULTIPARTITION_KEY_DELIMITER)
     partition_dict = {}
     for partition_part in partition_parts:
@@ -57,13 +87,30 @@ def extract_edxorg_courserun_metadata(
             partition_dict["source_system"] = partition_part
         else:
             partition_dict["course_id"] = partition_part
-    course_metadata_object_key = f"edxorg/processed_data/course_metadata/{partition_dict['source_system']}/{partition_dict['course_id']}/{data_version}.json"  # noqa: E501
+    course_metadata_object_key = f"{'/'.join(context.asset_key_for_output('course_metadata').path)}/{partition_dict['source_system']}/{partition_dict['course_id']}/{data_version}.json"  # noqa: E501
     yield Output(
         (course_metadata_file, course_metadata_object_key),
         data_version=DataVersion(data_version),
         metadata={
-            "course_id": course_metadata["course_id"],
+            "course_id": partition_dict["course_id"],
             "object_key": course_metadata_object_key,
         },
     )
-    course_xml.unlink()
+
+    # Process the course video details
+    video_details = process_video_xml(course_xml_path)
+    course_video_file = Path(
+        NamedTemporaryFile(delete=False, suffix="_video.jsonl").name
+    )
+    jsonlines.open(course_video_file, "w").write_all(video_details)
+    course_video_object_key = f"{'/'.join(context.asset_key_for_output('course_video').path)}/{partition_dict['source_system']}/{partition_dict['course_id']}/{data_version}.json"  # noqa: E501
+    yield Output(
+        (course_video_file, course_video_object_key),
+        output_name="course_video",
+        data_version=DataVersion(data_version),
+        metadata={
+            "course_id": partition_dict["course_id"],
+            "object_key": course_video_object_key,
+        },
+    )
+    course_xml_path.unlink()


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/5540

### Description (What does it do?)
We need to extract video metadata (e.g. duration) for edXorg courses from the course XML.
We can do this the same way as we are getting the video metadata for openedx.

The changes in this PR were made to the openedx_course_archives pipeline:
Refactored the edxorg course metadata extraction pipeline to be be a multi_asset.
Extended the pipeline to process the course video metadata.
Abstracted some of the logic similar to the way it is done in the openedx pipeline.

### How can this be tested?
Try running the pipeline locally.
```
export GITHUB_TOKEN=<your_token>
dagster dev -f src/ol_orchestrate/definitions/edx/openedx_data_extract.py
```

### Checklist:
- [ ] Get pipeline running locally
- [ ] Configure the necessary stream(s) in Airbyte QA
- [ ] Verify that we have edxorg course video metadata in our data lake