### PR TITLE
change discount format for combined orders mart

### DIFF
--- a/src/ol_dbt/models/marts/combined/marts__combined__orders.sql
+++ b/src/ol_dbt/models/marts/combined/marts__combined__orders.sql
@@ -230,11 +230,11 @@ with bootcamps__ecommerce_order as (
         , null as order_tax_amount
         , order_total_price_paid as order_total_price_paid_plus_tax
         , order_total_price_paid
-        , case 
+        , case
             when discount_amount_text like '%Fixed%'
                 then cast(
                     product_price - cast(
-                        substring(discount_amount_text, 14) 
+                        substring(discount_amount_text, 14)
                         as decimal(38, 2)
                     ) as varchar
                 )
@@ -380,11 +380,11 @@ with bootcamps__ecommerce_order as (
         , null as order_tax_amount
         , order_total_price_paid as order_total_price_paid_plus_tax
         , order_total_price_paid
-        , case 
+        , case
             when coupon_discount_amount_text like '%Fixed%'
                 then cast(
                     line_price - cast(
-                        substring(coupon_discount_amount_text, 14) 
+                        substring(coupon_discount_amount_text, 14)
                         as decimal(38, 2)
                     ) as varchar
                 )


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/2425

But also feedback from the finance team
https://docs.google.com/document/d/12k4cphQVbb9EBRxHZLEYmAqeyfMhwLxL44Lif3JFU9o/edit?tab=t.0

### Description (What does it do?)
Remove “Fixed Price:” from the discount and calculate discount against the unit_price

### How can this be tested?
dbt build --select marts__combined__orders 
