### PR TITLE
Add certificate url to combined program enrollment mart

### DIFF
--- a/src/ol_dbt/models/intermediate/mitxonline/_int_mitxonline__models.yml
+++ b/src/ol_dbt/models/intermediate/mitxonline/_int_mitxonline__models.yml
@@ -1388,6 +1388,10 @@ models:
     description: str, user full name on MITx Online
     tests:
     - not_null
+  - name: programcertificate_url
+    description: str, URL to the program certificate on mitxonline.mit.edu
+    tests:
+    - unique
   tests:
   - dbt_expectations.expect_table_row_count_to_equal_other_table:
       compare_model: ref('stg__mitxonline__app__postgres__courses_programcertificate')

--- a/src/ol_dbt/models/intermediate/mitxonline/_int_mitxonline__models.yml
+++ b/src/ol_dbt/models/intermediate/mitxonline/_int_mitxonline__models.yml
@@ -1389,7 +1389,8 @@ models:
     tests:
     - not_null
   - name: programcertificate_url
-    description: str, URL to the program certificate on mitxonline.mit.edu
+    description: str, URL to the program certificate on mitxonline.mit.edu. Null for
+      certificates that have been revoked.
     tests:
     - unique
   tests:

--- a/src/ol_dbt/models/intermediate/mitxonline/int__mitxonline__program_certificates.sql
+++ b/src/ol_dbt/models/intermediate/mitxonline/int__mitxonline__program_certificates.sql
@@ -30,6 +30,11 @@ with certificates as (
         , users.user_edxorg_username
         , users.user_full_name
         , users.user_email
+        , if(
+            certificates.programcertificate_is_revoked = false
+            , concat('https://xpro.mit.edu/certificate/program/', certificates.programcertificate_uuid)
+            , null
+        ) as programcertificate_url
     from certificates
     inner join programs on certificates.program_id = programs.program_id
     inner join users on certificates.user_id = users.user_id

--- a/src/ol_dbt/models/intermediate/mitxonline/int__mitxonline__program_certificates.sql
+++ b/src/ol_dbt/models/intermediate/mitxonline/int__mitxonline__program_certificates.sql
@@ -32,7 +32,7 @@ with certificates as (
         , users.user_email
         , if(
             certificates.programcertificate_is_revoked = false
-            , concat('https://xpro.mit.edu/certificate/program/', certificates.programcertificate_uuid)
+            , concat('https://mitxonline.mit.edu/certificate/program/', certificates.programcertificate_uuid)
             , null
         ) as programcertificate_url
     from certificates

--- a/src/ol_dbt/models/intermediate/mitxpro/_int_mitxpro__models.yml
+++ b/src/ol_dbt/models/intermediate/mitxpro/_int_mitxpro__models.yml
@@ -1582,7 +1582,8 @@ models:
     - unique
     - not_null
   - name: programcertificate_uuid
-    description: str, unique identifier for the program certificate
+    description: str, unique identifier for the program certificate. Null for certificates
+      that have been revoked.
     tests:
     - unique
     - not_null

--- a/src/ol_dbt/models/intermediate/mitxpro/_int_mitxpro__models.yml
+++ b/src/ol_dbt/models/intermediate/mitxpro/_int_mitxpro__models.yml
@@ -1616,6 +1616,10 @@ models:
     description: str, email
     tests:
     - not_null
+  - name: programcertificate_url
+    description: str, URL to the program certificate on xpro.mit.edu
+    tests:
+    - unique
   tests:
   - dbt_expectations.expect_table_row_count_to_equal_other_table:
       compare_model: ref('stg__mitxpro__app__postgres__courses_programcertificate')

--- a/src/ol_dbt/models/intermediate/mitxpro/int__mitxpro__program_certificates.sql
+++ b/src/ol_dbt/models/intermediate/mitxpro/int__mitxpro__program_certificates.sql
@@ -25,6 +25,11 @@ with certificates as (
         , certificates.user_id
         , users.user_username
         , users.user_email
+        , if(
+            certificates.programcertificate_is_revoked = false
+            , concat('https://xpro.mit.edu/certificate/program/', certificates.programcertificate_uuid)
+            , null
+        ) as programcertificate_url
     from certificates
     inner join programs on certificates.program_id = programs.program_id
     inner join users on certificates.user_id = users.user_id

--- a/src/ol_dbt/models/marts/combined/_marts__combined__models.yml
+++ b/src/ol_dbt/models/marts/combined/_marts__combined__models.yml
@@ -463,6 +463,10 @@ models:
     description: boolean, indicating whether the certificate is revoked and invalid
   - name: programcertificate_uuid
     description: str, unique identifier for the program certificate
+  - name: programcertificate_url
+    description: str, URL to the program certificate for users who earned the certificate
+      on either mitxonline.mit.edu or xpro.mit.edu. Null for certificate earned on
+      edX.org.
   tests:
   - dbt_expectations.expect_compound_columns_to_be_unique:
       column_list: ["program_title", "user_username", "platform_name", "programenrollment_created_on"]

--- a/src/ol_dbt/models/marts/combined/_marts__combined__models.yml
+++ b/src/ol_dbt/models/marts/combined/_marts__combined__models.yml
@@ -466,7 +466,7 @@ models:
   - name: programcertificate_url
     description: str, URL to the program certificate for users who earned the certificate
       on either mitxonline.mit.edu or xpro.mit.edu. Null for certificate earned on
-      edX.org.
+      edX.org or certificates that have been revoked.
   tests:
   - dbt_expectations.expect_compound_columns_to_be_unique:
       column_list: ["program_title", "user_username", "platform_name", "programenrollment_created_on"]

--- a/src/ol_dbt/models/marts/combined/marts__combined_program_enrollment_detail.sql
+++ b/src/ol_dbt/models/marts/combined/marts__combined_program_enrollment_detail.sql
@@ -169,9 +169,14 @@ with mitxpro__programenrollments as (
             and micromasters__program_enrollments.user_email = micromasters__certs.user_email
     left join mitxonline__program_certificates
         on
-            micromasters__program_enrollments.micromasters_program_id
-            = mitxonline__program_certificates.micromasters_program_id
-            and micromasters__program_enrollments.user_id = mitxonline__program_certificates.user_id
+            micromasters__program_enrollments.mitxonline_program_id
+            = mitxonline__program_certificates.program_id
+            and (
+                micromasters__program_enrollments.user_mitxonline_username
+                = mitxonline__program_certificates.user_username
+                or micromasters__program_enrollments.user_email
+                = mitxonline__program_certificates.user_email
+            )
     left join combined_programs
         on
             micromasters__program_enrollments.user_email = combined_programs.user_email


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
https://github.com/mitodl/hq/issues/5907

### Description (What does it do?)
<!--- Describe your changes in detail -->
Adding `programcertificate_url` to marts__combined_program_enrollment_detail and its upstream int__mitxonline__program_certificates and int__mitxpro__program_certificates to simplify the query in the mart.

There are bugs in the marts__combined_program_enrollment_detail, which will be addressed in https://github.com/mitodl/hq/issues/5914 later.

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->
dbt build --select int__mitxonline__program_certificates
dbt build --select int__mitxpro__program_certificates
dbt build --select marts__combined_program_enrollment_detail

And verify `programcertificate_url` is valid
