### PR TITLE
add program_track, program_name, program_type to combined program enrollment mart and its upstream

### DIFF
--- a/src/ol_dbt/models/intermediate/edxorg/_int_edxorg__models.yml
+++ b/src/ol_dbt/models/intermediate/edxorg/_int_edxorg__models.yml
@@ -349,10 +349,8 @@ models:
     tests:
     - not_null
   - name: program_uuid
-    description: str, the UUID of the program on edX.org. 'MIT Finance' and 'Finance'
-      are two different UUIDs, as they have different required courses. 'Statistics
-      and Data Science' is split into 'Statistics and Data Science' and 'Statistics
-      and Data Science (General track)', which are also two different program UUIDs.
+    description: str, the UUID of the program on edX.org. Each program and its separate
+      track have a different UUID.
     tests:
     - not_null
   - name: program_title
@@ -396,16 +394,24 @@ models:
     tests:
     - not_null
   - name: program_uuid
-    description: str, the UUID of the program on edX.org. 'MIT Finance' and 'Finance'
-      are two different UUIDs, as they have different required courses. 'Statistics
-      and Data Science' is split into 'Statistics and Data Science' and 'Statistics
-      and Data Science (General track)', which are also two different program UUIDs.
+    description: str,  the UUID of the program on edX.org. Each program and its separate
+      track have a different UUID.
     tests:
     - not_null
   - name: program_title
-    description: str, title of the program on edX.org.
+    description: str, title of the program on edX.org, including the specific track,
+      if applicable. e.g., Statistics and Data Science (General Track)
     tests:
     - not_null
+  - name: program_name
+    description: str, name of the program, which does not specify which track. e.g.,
+      Statistics and Data Science
+    tests:
+    - not_null
+  - name: program_track
+    description: str, name of the specific track for MicroMasters programs. For example,
+      Statistics and Data Science program has multiple tracks - General Track, Methods
+      Track, Social Sciences Track, and 'Time Series and Social Sciences Track'.
   - name: user_id
     description: int, the edX learner ID in the LMS in a user's course run enrollment
       record.

--- a/src/ol_dbt/models/intermediate/edxorg/_int_edxorg__models.yml
+++ b/src/ol_dbt/models/intermediate/edxorg/_int_edxorg__models.yml
@@ -399,8 +399,8 @@ models:
     tests:
     - not_null
   - name: program_title
-    description: str, title of the program on edX.org, including the specific track,
-      if applicable. e.g., Statistics and Data Science (General Track)
+    description: str, title of the program, including the specific track if applicable.
+      e.g., Statistics and Data Science (General Track)
     tests:
     - not_null
   - name: program_name

--- a/src/ol_dbt/models/intermediate/edxorg/int__edxorg__mitx_program_enrollments.sql
+++ b/src/ol_dbt/models/intermediate/edxorg/int__edxorg__mitx_program_enrollments.sql
@@ -27,6 +27,8 @@ select
     , program_learners_sorted.user_full_name
     , program_learners_sorted.user_has_completed_program
     , micromasters_programs.micromasters_program_id
+    , program_learners_sorted.program_track
+    , coalesce(micromasters_programs.program_title, program_learners_sorted.program_title) as program_name
 from program_learners_sorted
 left join micromasters_programs
     on (

--- a/src/ol_dbt/models/intermediate/mitxonline/_int_mitxonline__models.yml
+++ b/src/ol_dbt/models/intermediate/mitxonline/_int_mitxonline__models.yml
@@ -1238,7 +1238,7 @@ models:
     - unique
     - not_null
   - name: program_type
-    description: str, type of the program. Value is free text, it could be MicroMasters®,
+    description: str, type of the program. Value is free text, it could be MicroMasters,
       Series, etc
   - name: program_availability
     description: str, either 'anytime' or 'date'
@@ -1373,7 +1373,7 @@ models:
     tests:
     - not_null
   - name: program_type
-    description: str, type of the program. Value is free text, it could be MicroMasters®,
+    description: str, type of the program. Value is free text, it could be MicroMasters,
       Series, etc
   - name: program_is_dedp
     description: boolean, specifying if the program is DEDP from readable_id

--- a/src/ol_dbt/models/intermediate/mitxonline/_int_mitxonline__models.yml
+++ b/src/ol_dbt/models/intermediate/mitxonline/_int_mitxonline__models.yml
@@ -1220,7 +1220,7 @@ models:
   - name: program_is_live
     description: boolean, indicating whether the program is available to users
   - name: program_title
-    description: str, title of the program, including the specific track, if applicable.
+    description: str, title of the program, including the specific track if applicable.
     tests:
     - not_null
   - name: program_name

--- a/src/ol_dbt/models/intermediate/mitxonline/_int_mitxonline__models.yml
+++ b/src/ol_dbt/models/intermediate/mitxonline/_int_mitxonline__models.yml
@@ -1220,9 +1220,18 @@ models:
   - name: program_is_live
     description: boolean, indicating whether the program is available to users
   - name: program_title
-    description: str, title of the program
+    description: str, title of the program, including the specific track, if applicable.
     tests:
     - not_null
+  - name: program_name
+    description: str, name of the program, which does not specify which track. e.g.,
+      Data, Economics, and Design of Policy
+    tests:
+    - not_null
+  - name: program_track
+    description: str, name of the specific track for MicroMasters programs. For example,
+      DEDP program has two separate tracks - International Development and Public
+      Policy.
   - name: program_readable_id
     description: str, Open edX ID formatted as program-v1:{org}+{program code}
     tests:

--- a/src/ol_dbt/models/intermediate/mitxonline/int__mitxonline__programs.sql
+++ b/src/ol_dbt/models/intermediate/mitxonline/int__mitxonline__programs.sql
@@ -43,6 +43,8 @@ with programs as (
 select
     programs.program_id
     , programs.program_title
+    , programs.program_name
+    , programs.program_track
     , programs.program_is_live
     , programs.program_readable_id
     , programs.program_type

--- a/src/ol_dbt/models/marts/combined/_marts__combined__models.yml
+++ b/src/ol_dbt/models/marts/combined/_marts__combined__models.yml
@@ -435,15 +435,22 @@ models:
   - name: program_id
     description: int, id representing a single program on a particular platform
   - name: program_title
-    description: str, title of the program, including the specific track, if applicable.
+    description: str, title of the program, including the specific track if applicable.
       e.g., Statistics and Data Science (General Track)
   - name: program_name
     description: str, name of the program, which does not specify which track. e.g.,
       Statistics and Data Science
+    tests:
+    - not_null
   - name: program_track
     description: str, name of the specific track for MicroMasters programs. For example,
       Statistics and Data Science program has multiple tracks - General Track, Methods
       Track, Social Sciences Track, and 'Time Series and Social Sciences Track'.
+  - name: program_type
+    description: str,  the type of the program. Possible values are 'MicroMasters',
+      'XSeries' and 'Professional Certificate'
+    tests:
+    - not_null
   - name: program_is_live
     description: boolean, indicating whether the program is available to users on
       the MITxOnline website or MITxPro website
@@ -460,6 +467,8 @@ models:
       MITx Online based on their usernames, this will be learner's MicroMasters email.
   - name: user_username
     description: string, username on the corresponding platform
+  - name: user_full_name
+    description: string, user full name on the corresponding platform
   - name: programenrollment_is_active
     description: boolean, indicating whether the user is still enrolled in the program
   - name: programenrollment_created_on

--- a/src/ol_dbt/models/marts/combined/_marts__combined__models.yml
+++ b/src/ol_dbt/models/marts/combined/_marts__combined__models.yml
@@ -435,7 +435,15 @@ models:
   - name: program_id
     description: int, id representing a single program on a particular platform
   - name: program_title
-    description: str, title of the program
+    description: str, title of the program, including the specific track, if applicable.
+      e.g., Statistics and Data Science (General Track)
+  - name: program_name
+    description: str, name of the program, which does not specify which track. e.g.,
+      Statistics and Data Science
+  - name: program_track
+    description: str, name of the specific track for MicroMasters programs. For example,
+      Statistics and Data Science program has multiple tracks - General Track, Methods
+      Track, Social Sciences Track, and 'Time Series and Social Sciences Track'.
   - name: program_is_live
     description: boolean, indicating whether the program is available to users on
       the MITxOnline website or MITxPro website

--- a/src/ol_dbt/models/marts/combined/marts__combined_program_enrollment_detail.sql
+++ b/src/ol_dbt/models/marts/combined/marts__combined_program_enrollment_detail.sql
@@ -10,12 +10,20 @@ with mitxpro__programenrollments as (
     select * from {{ ref('int__mitxpro__program_certificates') }}
 )
 
+, mitxpro__users as (
+    select * from {{ ref('int__mitxpro__users') }}
+)
+
 , mitxonline__programenrollments as (
     select * from {{ ref('int__mitxonline__programenrollments') }}
 )
 
 , mitxonline__programs as (
     select * from {{ ref('int__mitxonline__programs') }}
+)
+
+, mitxonline__users as (
+    select * from {{ ref('int__mitxonline__users') }}
 )
 
 , mitx__programs as (
@@ -49,11 +57,13 @@ with mitxpro__programenrollments as (
         , mitxpro__programs.program_title
         , mitxpro__programs.program_title as program_name
         , null as program_track
+        , 'Professional Certificate' as program_type
         , mitxpro__programs.program_is_live
         , mitxpro__programs.program_readable_id
         , mitxpro__programenrollments.user_id
         , mitxpro__programenrollments.user_email
         , mitxpro__programenrollments.user_username
+        , mitxpro__users.user_full_name
         , mitxpro__programenrollments.programenrollment_is_active
         , mitxpro__programenrollments.programenrollment_created_on
         , mitxpro__programenrollments.programenrollment_enrollment_status
@@ -64,6 +74,8 @@ with mitxpro__programenrollments as (
     from mitxpro__programenrollments
     inner join mitxpro__programs
         on mitxpro__programenrollments.program_id = mitxpro__programs.program_id
+    left join mitxpro__users
+        on mitxpro__programenrollments.user_id = mitxpro__users.user_id
     left join mitxpro__program_certificates
         on
             mitxpro__programenrollments.program_id = mitxpro__program_certificates.program_id
@@ -77,11 +89,13 @@ with mitxpro__programenrollments as (
         , mitxonline__programs.program_title
         , mitxonline__programs.program_name
         , mitxonline__programs.program_track
+        , mitxonline__programs.program_type
         , mitxonline__programs.program_is_live
         , mitxonline__programs.program_readable_id
         , mitxonline__programenrollments.user_id
         , mitxonline__programenrollments.user_email
         , mitxonline__programenrollments.user_username
+        , mitxonline__users.user_full_name
         , mitxonline__programenrollments.programenrollment_is_active
         , mitxonline__programenrollments.programenrollment_created_on
         , mitxonline__programenrollments.programenrollment_enrollment_status
@@ -92,6 +106,8 @@ with mitxpro__programenrollments as (
     from mitxonline__programenrollments
     inner join mitxonline__programs
         on mitxonline__programenrollments.program_id = mitxonline__programs.program_id
+    left join mitxonline__users
+        on mitxonline__programenrollments.user_id = mitxonline__users.user_id
     left join mitxonline__program_certificates
         on
             mitxonline__programenrollments.user_id = mitxonline__program_certificates.user_id
@@ -105,11 +121,13 @@ with mitxpro__programenrollments as (
         , edx_program_enrollments.program_title
         , edx_program_enrollments.program_name
         , edx_program_enrollments.program_track
+        , edx_program_enrollments.program_type
         , null as program_is_live
         , null as program_readable_id
         , edx_program_enrollments.user_id
         , edxorg__users.user_email
         , edx_program_enrollments.user_username
+        , edxorg__users.user_full_name
         , null as programenrollment_is_active
         , null as programenrollment_created_on
         , null as programenrollment_enrollment_status
@@ -133,11 +151,13 @@ with mitxpro__programenrollments as (
         , micromasters__program_enrollments.program_title
         , mitxonline__programs.program_name
         , mitxonline__programs.program_track
+        , mitxonline__programs.program_type
         , mitxonline__programs.program_is_live
         , mitxonline__programs.program_readable_id
         , micromasters__program_enrollments.user_edxorg_id as user_id
         , micromasters__program_enrollments.user_email
         , micromasters__program_enrollments.user_edxorg_username as user_username
+        , micromasters__program_enrollments.user_full_name
         , null as programenrollment_is_active
         , null as programenrollment_created_on
         , null as programenrollment_enrollment_status
@@ -170,6 +190,7 @@ select
     , combined_programs.program_title
     , combined_programs.program_name
     , combined_programs.program_track
+    , combined_programs.program_type
     , combined_programs.program_is_live
     , combined_programs.program_readable_id
     , {{ generate_hash_id('cast(combined_programs.user_id as varchar) || combined_programs.platform_name') }}
@@ -177,6 +198,7 @@ select
     , combined_programs.user_id
     , combined_programs.user_email
     , combined_programs.user_username
+    , combined_programs.user_full_name
     , combined_programs.programenrollment_is_active
     , combined_programs.programenrollment_created_on
     , combined_programs.programenrollment_enrollment_status

--- a/src/ol_dbt/models/marts/combined/marts__combined_program_enrollment_detail.sql
+++ b/src/ol_dbt/models/marts/combined/marts__combined_program_enrollment_detail.sql
@@ -18,7 +18,6 @@ with mitxpro__programenrollments as (
     select * from {{ ref('int__mitxonline__programs') }}
 )
 
-
 , mitx__programs as (
     select * from {{ ref('int__mitx__programs') }}
 )
@@ -43,12 +42,13 @@ with mitxpro__programenrollments as (
     select * from {{ ref('int__micromasters__program_enrollments') }}
 )
 
-
 , combined_programs as (
     select
         mitxpro__programs.platform_name
         , mitxpro__programs.program_id
         , mitxpro__programs.program_title
+        , mitxpro__programs.program_title as program_name
+        , null as program_track
         , mitxpro__programs.program_is_live
         , mitxpro__programs.program_readable_id
         , mitxpro__programenrollments.user_id
@@ -75,6 +75,8 @@ with mitxpro__programenrollments as (
         '{{ var("mitxonline") }}' as platform_name
         , mitxonline__programs.program_id
         , mitxonline__programs.program_title
+        , mitxonline__programs.program_name
+        , mitxonline__programs.program_track
         , mitxonline__programs.program_is_live
         , mitxonline__programs.program_readable_id
         , mitxonline__programenrollments.user_id
@@ -101,6 +103,8 @@ with mitxpro__programenrollments as (
         '{{ var("edxorg") }}' as platform_name
         , edx_program_enrollments.micromasters_program_id as program_id
         , edx_program_enrollments.program_title
+        , edx_program_enrollments.program_name
+        , edx_program_enrollments.program_track
         , null as program_is_live
         , null as program_readable_id
         , edx_program_enrollments.user_id
@@ -127,6 +131,8 @@ with mitxpro__programenrollments as (
         micromasters__program_enrollments.platform_name
         , micromasters__program_enrollments.micromasters_program_id as program_id
         , micromasters__program_enrollments.program_title
+        , mitxonline__programs.program_name
+        , mitxonline__programs.program_track
         , mitxonline__programs.program_is_live
         , mitxonline__programs.program_readable_id
         , micromasters__program_enrollments.user_edxorg_id as user_id
@@ -162,6 +168,8 @@ select
     combined_programs.platform_name
     , combined_programs.program_id
     , combined_programs.program_title
+    , combined_programs.program_name
+    , combined_programs.program_track
     , combined_programs.program_is_live
     , combined_programs.program_readable_id
     , {{ generate_hash_id('cast(combined_programs.user_id as varchar) || combined_programs.platform_name') }}

--- a/src/ol_dbt/models/staging/edxorg/_stg__edxorg__models.yml
+++ b/src/ol_dbt/models/staging/edxorg/_stg__edxorg__models.yml
@@ -339,7 +339,7 @@ models:
     tests:
     - not_null
   - name: program_title
-    description: str, title of the program, including the specific track, if applicable.
+    description: str, title of the program, including the specific track if applicable.
     tests:
     - not_null
   - name: program_track

--- a/src/ol_dbt/models/staging/edxorg/_stg__edxorg__models.yml
+++ b/src/ol_dbt/models/staging/edxorg/_stg__edxorg__models.yml
@@ -334,16 +334,18 @@ models:
     - accepted_values:
         values: ['MicroMasters', 'XSeries']
   - name: program_uuid
-    description: str, the UUID of the program on edX.org. 'MIT Finance' and 'Finance'
-      are two different UUIDs, as they have different required courses. 'Statistics
-      and Data Science' is split into 'Statistics and Data Science' and 'Statistics
-      and Data Science (General track)', which are also two different program UUIDs.
+    description: str, the UUID of the program on edX.org. Each program and its separate
+      track have a different UUID.
     tests:
     - not_null
   - name: program_title
-    description: str, title of the program on edX.org
+    description: str, title of the program, including the specific track, if applicable.
     tests:
     - not_null
+  - name: program_track
+    description: str, name of the specific track for MicroMasters programs. For example,
+      Statistics and Data Science program has multiple tracks - General Track, Methods
+      Track, Social Sciences Track, and 'Time Series and Social Sciences Track'.
   - name: user_id
     description: int, the edX learner ID in the LMS in a user's course run enrollment
       record.

--- a/src/ol_dbt/models/staging/edxorg/stg__edxorg__s3__program_learner_report.sql
+++ b/src/ol_dbt/models/staging/edxorg/stg__edxorg__s3__program_learner_report.sql
@@ -53,7 +53,7 @@ with source as (
         , case
             when "program uuid" like '%941d3eaf56966c7' then 'Finance'
             when "program uuid" like '%3173ff51e11a748' then 'MIT Finance'
-            when "program uuid" like '%8c11bfd9c0d7b07' then 'Statistics and Data Science (General track)'
+            when "program uuid" like '%8c11bfd9c0d7b07' then 'Statistics and Data Science (General Track)'
             when "program uuid" like '%cd7c6461dd9b1d4' then 'Statistics and Data Science (Social Sciences Track)'
             else "program title"
         end as program_title

--- a/src/ol_dbt/models/staging/edxorg/stg__edxorg__s3__program_learner_report.sql
+++ b/src/ol_dbt/models/staging/edxorg/stg__edxorg__s3__program_learner_report.sql
@@ -53,6 +53,8 @@ with source as (
         , case
             when "program uuid" like '%941d3eaf56966c7' then 'Finance'
             when "program uuid" like '%3173ff51e11a748' then 'MIT Finance'
+            when "program uuid" like '%8c11bfd9c0d7b07' then 'Statistics and Data Science (General track)'
+            when "program uuid" like '%cd7c6461dd9b1d4' then 'Statistics and Data Science (Social Sciences Track)'
             else "program title"
         end as program_title
         , to_iso8601(date_parse("course run start date", '%Y-%m-%d %H:%i:%s Z')) as courserun_start_on
@@ -82,6 +84,7 @@ select
     cleaned.org_id
     , cleaned.program_type
     , cleaned.program_uuid
+    , cleaned.program_title
     , cleaned.user_username
     , cleaned.user_full_name
     , cleaned.courserun_readable_id
@@ -95,7 +98,6 @@ select
     , cleaned.user_roles
     , cleaned.courserungrade_letter_grade
     , cleaned.courserungrade_grade
-    , cleaned.program_title
     , cleaned.courserun_start_on
     , cleaned.courserunenrollment_created_on
     , cleaned.completed_course_on
@@ -103,6 +105,7 @@ select
     , cleaned.courserunenrollment_unenrolled_on
     , cleaned.courserunenrollment_upgraded_on
     , add_program_cert_latest.latest_program_cert_award_on as program_certificate_awarded_on
+    , regexp_extract(cleaned.program_title, '\((.*?)\)', 1) as program_track
 from cleaned
 left join add_program_cert_latest
     on

--- a/src/ol_dbt/models/staging/mitxonline/_stg_mitxonline__models.yml
+++ b/src/ol_dbt/models/staging/mitxonline/_stg_mitxonline__models.yml
@@ -820,7 +820,7 @@ models:
     tests:
     - not_null
   - name: program_type
-    description: str, type of the program. Value is free text, it could be MicroMasters®,
+    description: str, type of the program. Value is free text, it could be MicroMasters,
       Series, etc
   - name: program_availability
     description: str, either 'anytime' or 'date'

--- a/src/ol_dbt/models/staging/mitxonline/_stg_mitxonline__models.yml
+++ b/src/ol_dbt/models/staging/mitxonline/_stg_mitxonline__models.yml
@@ -816,7 +816,7 @@ models:
   - name: program_is_live
     description: boolean, indicating whether the program is available to users
   - name: program_title
-    description: str, title of the program
+    description: str, title of the program, including the specific track, if applicable.
     tests:
     - not_null
   - name: program_type
@@ -831,6 +831,15 @@ models:
       These values are currently set in the application code.
     tests:
     - not_null
+  - name: program_name
+    description: str, name of the program, which does not specify which track. e.g.,
+      Data, Economics, and Design of Policy
+    tests:
+    - not_null
+  - name: program_track
+    description: str, name of the specific track for MicroMasters programs. For example,
+      DEDP program has two separate tracks - International Development and Public
+      Policy.
   - name: program_is_dedp
     description: boolean, specifying if the program is DEDP from readable_id
     tests:

--- a/src/ol_dbt/models/staging/mitxonline/_stg_mitxonline__models.yml
+++ b/src/ol_dbt/models/staging/mitxonline/_stg_mitxonline__models.yml
@@ -816,7 +816,7 @@ models:
   - name: program_is_live
     description: boolean, indicating whether the program is available to users
   - name: program_title
-    description: str, title of the program, including the specific track, if applicable.
+    description: str, title of the program, including the specific track if applicable.
     tests:
     - not_null
   - name: program_type

--- a/src/ol_dbt/models/staging/mitxonline/stg__mitxonline__app__postgres__courses_program.sql
+++ b/src/ol_dbt/models/staging/mitxonline/stg__mitxonline__app__postgres__courses_program.sql
@@ -16,7 +16,7 @@ with source as (
         , if(program_type like 'MicroMasters%', 'MicroMasters Credential', 'Certificate of Completion')
         as program_certification_type
         , if(program_type like 'MicroMasters%', element_at(split(title, ': '), 1), title) as program_name
-        , if(program_type like 'MicroMasters%', element_at(split(title, ': '), -1), null) as program_track
+        , if(program_type like 'MicroMasters%', element_at(split(title, ': '), 2), null) as program_track
         , if(readable_id like '%DEDP%', true, false) as program_is_dedp
         ,{{ cast_timestamp_to_iso8601('created_on') }} as program_created_on
         ,{{ cast_timestamp_to_iso8601('updated_on') }} as program_updated_on

--- a/src/ol_dbt/models/staging/mitxonline/stg__mitxonline__app__postgres__courses_program.sql
+++ b/src/ol_dbt/models/staging/mitxonline/stg__mitxonline__app__postgres__courses_program.sql
@@ -10,7 +10,7 @@ with source as (
         , live as program_is_live
         , title as program_title
         , readable_id as program_readable_id
-        , program_type
+        , if(program_type like 'MicroMasters%', 'MicroMasters', program_type) as program_type
         , availability as program_availability
         , if(program_type like 'MicroMasters%', true, false) as program_is_micromasters
         , if(program_type like 'MicroMasters%', 'MicroMasters Credential', 'Certificate of Completion')

--- a/src/ol_dbt/models/staging/mitxonline/stg__mitxonline__app__postgres__courses_program.sql
+++ b/src/ol_dbt/models/staging/mitxonline/stg__mitxonline__app__postgres__courses_program.sql
@@ -15,6 +15,8 @@ with source as (
         , if(program_type like 'MicroMasters%', true, false) as program_is_micromasters
         , if(program_type like 'MicroMasters%', 'MicroMasters Credential', 'Certificate of Completion')
         as program_certification_type
+        , if(program_type like 'MicroMasters%', element_at(split(title, ': '), 1), title) as program_name
+        , if(program_type like 'MicroMasters%', element_at(split(title, ': '), -1), null) as program_track
         , if(readable_id like '%DEDP%', true, false) as program_is_dedp
         ,{{ cast_timestamp_to_iso8601('created_on') }} as program_created_on
         ,{{ cast_timestamp_to_iso8601('updated_on') }} as program_updated_on


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
https://github.com/mitodl/hq/issues/6006
specifically for `we need a creative solution to the fact that DEDP has two programs. And SDS has four, or maybe six`

### Description (What does it do?)
<!--- Describe your changes in detail -->

- Cleaning and normalizing the program title in stg__edxorg__s3__program_learner_report as it contains text like RETIRED "old version", and inconsistent capitalization.
- Adding `program_track` , `program_name`, `program_type` and `user_full_name`  to combined program enrollment mart and its upstream models
   - The existing `program_title` field contains a combination of program name and specific track, which makes it difficult to use as a filter for programs with multiple tracks.
   - The new `program_track` and `program_name` are normalized fields, which can be used for filtering programs with multiple tracks.

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->
Run 

dbt build --select +int__edxorg__mitx_program_enrollments
dbt build --select +int__mitxonline__programs
dbt build --select marts__combined_program_enrollment_detail

or
--- This will take a long time
dbt build --select +marts__combined_program_enrollment_detail

Then run this query to check these new fields
```
select distinct program_track, program_type, program_name 
from  "ol_data_lake_production"."ol_warehouse_production_XXXX_mart".marts__combined_program_enrollment_detail
```
