### PR TITLE
Stage edxorg course video and add to intermediate combined video

### DIFF
--- a/src/ol_dbt/models/staging/edxorg/_edxorg_sources.yml
+++ b/src/ol_dbt/models/staging/edxorg/_edxorg_sources.yml
@@ -945,3 +945,19 @@ sources:
     - name: modified
       description: timestamp, datetime when this row was last updated. A change in
         this field implies that there was a state change.
+
+  - name: raw__edxorg__s3__course_structure__course_video
+    description: edX.org course video metadata
+    columns:
+    - name: courserun_id
+      description: str, edX Course ID formatted as course-v1:{org}+{course code}+{run_tag}
+    - name: video_block_id
+      description: str, hash code or module name for the video. This value is the
+        last part of video block ID string, e.g., block-v1:{org}+{course}+{run}type@{block
+        type}+block@{module name or hash code}.
+    - name: edx_video_id
+      description: str, video ID on the edX platform. This value is the same as the
+        edx_video_id field in the coursestructure_block_metadata JSON for the video
+        block.
+    - name: duration
+      description: float, the length of the video, in seconds. May be 0.0.

--- a/src/ol_dbt/models/staging/edxorg/_stg__edxorg__models.yml
+++ b/src/ol_dbt/models/staging/edxorg/_stg__edxorg__models.yml
@@ -936,6 +936,11 @@ models:
     description: str, edX Course ID formatted as course-v1:{org}+{course code}+{run_tag}
     tests:
     - not_null
+  - name: courserun_old_readable_id
+    description: str, edX Course ID formatted as {org}/{course number}/{run}, which
+      is used for joining because it matches the format in other edX.org tables.
+    tests:
+    - not_null
   - name: video_block_id
     description: str, hash code or module name for the video. This value is the last
       part of video block ID string, e.g., block-v1:{org}+{course}+{run}type@{block

--- a/src/ol_dbt/models/staging/edxorg/_stg__edxorg__models.yml
+++ b/src/ol_dbt/models/staging/edxorg/_stg__edxorg__models.yml
@@ -928,3 +928,28 @@ models:
   tests:
   - dbt_expectations.expect_compound_columns_to_be_unique:
       column_list: ["user_id", "courserun_readable_id", "coursestructure_block_id"]
+
+- name: stg__edxorg__s3__course_video
+  description: edX.org course video metadata
+  columns:
+  - name: courserun_readable_id
+    description: str, edX Course ID formatted as course-v1:{org}+{course code}+{run_tag}
+    tests:
+    - not_null
+  - name: video_block_id
+    description: str, hash code or module name for the video. This value is the last
+      part of video block ID string, e.g., block-v1:{org}+{course}+{run}type@{block
+      type}+block@{module name or hash code}.
+    tests:
+    - not_null
+  - name: video_edx_id
+    description: str, video ID on the edX platform. This value is the same as the
+      edx_video_id field in the coursestructure_block_metadata JSON for the video
+      block.
+  - name: video_duration
+    description: float, the length of the video, in seconds. May be 0.0.
+    tests:
+    - not_null
+  tests:
+  - dbt_expectations.expect_compound_columns_to_be_unique:
+      column_list: ["courserun_readable_id", "video_block_id"]

--- a/src/ol_dbt/models/staging/edxorg/stg__edxorg__s3__course_video.sql
+++ b/src/ol_dbt/models/staging/edxorg/stg__edxorg__s3__course_video.sql
@@ -12,6 +12,7 @@ with source as (
         , video_block_id
         , edx_video_id as video_edx_id
         , cast(duration as decimal(38, 4)) as video_duration
+        , replace(replace(course_id, 'course-v1:', ''), '+', '/') as courserun_old_readable_id
     from most_recent_source
 )
 

--- a/src/ol_dbt/models/staging/edxorg/stg__edxorg__s3__course_video.sql
+++ b/src/ol_dbt/models/staging/edxorg/stg__edxorg__s3__course_video.sql
@@ -1,0 +1,18 @@
+with source as (
+    select * from {{ source('ol_warehouse_raw_data', 'raw__edxorg__s3__course_structure__course_video') }}
+)
+
+{{ deduplicate_query(cte_name1='source', cte_name2='most_recent_source'
+, partition_columns = 'course_id, video_block_id') }}
+
+, cleaned as (
+
+    select
+        course_id as courserun_readable_id
+        , video_block_id
+        , edx_video_id as video_edx_id
+        , duration as video_duration
+    from most_recent_source
+)
+
+select * from cleaned

--- a/src/ol_dbt/models/staging/edxorg/stg__edxorg__s3__course_video.sql
+++ b/src/ol_dbt/models/staging/edxorg/stg__edxorg__s3__course_video.sql
@@ -11,7 +11,7 @@ with source as (
         course_id as courserun_readable_id
         , video_block_id
         , edx_video_id as video_edx_id
-        , duration as video_duration
+        , cast(duration as decimal(38, 4)) as video_duration
     from most_recent_source
 )
 


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
https://github.com/mitodl/hq/issues/6048

### Description (What does it do?)
<!--- Describe your changes in detail -->
creating `stg__edxorg__s3__course_video`
adding to `int__combined__course_videos`


### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

Run 

dbt build --select stg__edxorg__s3__course_video
dbt build --select int__combined__course_videos

Then check the following query to see if the video_duration is populated now

select * from "ol_data_lake_production"."ol_warehouse_production_XXXXX_intermediate".int__combined__course_videos
where platform  ='edX.org' and video_duration is not null


VS 

On production, video_duration is not populated
 
select * from "ol_data_lake_production"."ol_warehouse_production_intermediate".int__combined__course_videos
where platform  ='edX.org' and video_duration is not null
