### PR TITLE
fix edxorg certificate not populated

### DIFF
--- a/src/ol_dbt/models/marts/combined/marts__combined_course_enrollment_detail.sql
+++ b/src/ol_dbt/models/marts/combined/marts__combined_course_enrollment_detail.sql
@@ -134,11 +134,23 @@ with combined_enrollments as (
         , combined_users.user_highest_education
         , combined_users.user_company
         , combined_users.user_gender
-        , if(mitxonline_certificates.courseruncertificate_is_revoked = false, true, false)
-        as courseruncertificate_is_earned
-        , mitxonline_certificates.courseruncertificate_created_on
-        , mitxonline_certificates.courseruncertificate_url
-        , mitxonline_certificates.courseruncertificate_uuid
+        , case
+            when mitxonline_certificates.courseruncertificate_is_revoked = false then true
+            when combined_enrollments.courseruncertificate_created_on is not null then true
+            else false
+        end as courseruncertificate_is_earned
+        , coalesce(
+            mitxonline_certificates.courseruncertificate_created_on
+            , combined_enrollments.courseruncertificate_created_on
+        ) as courseruncertificate_created_on
+        , coalesce(
+            mitxonline_certificates.courseruncertificate_url
+            , combined_enrollments.courseruncertificate_url
+        ) as courseruncertificate_url
+        , coalesce(
+            mitxonline_certificates.courseruncertificate_uuid
+            , combined_enrollments.courseruncertificate_uuid
+        ) as courseruncertificate_uuid
         , micromasters_completed_orders.order_id
         , micromasters_completed_orders.line_id
         , micromasters_completed_orders.order_reference_number


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
NA
Peter reported https://bi.ol.mit.edu/superset/dashboard/14/?native_filters_key=So6aqg4fecnK-vhE-C7d60CGCRPuQ0jAK8-7B36_V8ou5WsG6RcZ_Rvmm8wiuWTx

### Description (What does it do?)
<!--- Describe your changes in detail -->
This is to fix the bug where edxorg certificates are null in the marts__combined_course_enrollment_detail


### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

dbt build --select marts__combined_course_enrollment_detail

---7 certificates on production data
select courseruncertificate_uuid, courseruncertificate_created_on, courseruncertificate_is_earned
 from marts__combined_course_enrollment_detail where lower(user_email)= <EMAIL>

<EMAIL>can be found here
https://bi.ol.mit.edu/superset/dashboard/14/?native_filters_key=So6aqg4fecnK-vhE-C7d60CGCRPuQ0jAK8-7B36_V8ou5WsG6RcZ_Rvmm8wiuWTx
