### PR TITLE
Give Finance Team Access to All Marts Tables

### DIFF
--- a/src/ol_dbt/dbt_project.yml
+++ b/src/ol_dbt/dbt_project.yml
@@ -85,7 +85,7 @@ models:
       +materialized: table
       +schema: mart
       +grants:
-        select: ['read_only_production', 'business_intelligence', 'reverse_etl']
+        select: ['read_only_production', 'business_intelligence', 'reverse_etl', 'finance']
     external:
       +materialized: table
       +schema: external

--- a/src/ol_dbt/models/marts/combined/_marts__combined__models.yml
+++ b/src/ol_dbt/models/marts/combined/_marts__combined__models.yml
@@ -31,9 +31,6 @@ models:
 
 - name: marts__combined__users
   description: Mart model for users from different platforms
-  config:
-    grants:
-      select: ['finance']
   columns:
   - name: user_hashed_id
     description: str, primary key for the combined_users table.
@@ -131,9 +128,6 @@ models:
 
 - name: marts__combined__orders
   description: ecommerce regular b2c orders
-  config:
-    grants:
-      select: ['finance']
   columns:
   - name: combined_orders_hash_id
     description: int, primary key for this table. At the grain of order id, line id,
@@ -280,9 +274,6 @@ models:
 - name: marts__combined_course_enrollment_detail
   description: course enrollment detail with certificates, orders and coupons from
     OL platforms. No order data for edX.org course purchase.
-  config:
-    grants:
-      select: ['finance']
   columns:
   - name: platform
     description: string, application where the data is from

--- a/src/ol_dbt/models/marts/mitxpro/_marts__mitxpro__models.yml
+++ b/src/ol_dbt/models/marts/mitxpro/_marts__mitxpro__models.yml
@@ -4,9 +4,6 @@ version: 2
 models:
 - name: marts__mitxpro_ecommerce_productlist
   description: Xpro product line table with denormalized data
-  config:
-    grants:
-      select: ['finance']
   columns:
   - name: product_platform
     description: string, defaulted to xPro


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/ol-data-platform/issues/1384

### Description (What does it do?)
Added finance to the list of roles that will get global select privileges to all of the tables in the marts schema.
Removed 4 instances of granular access that was given to finance to access specific tables.

### How can this be tested?
dbt build --select marts --vars 'schema_suffix: qhoque' --target dev_production --full-refresh

<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] Run dbt build command to generate marts tables
- [ ] Check various marts tables in Starburst to confirm that the finance role was given access
