### PR TITLE
add new total course engagement mart

### DIFF
--- a/src/ol_dbt/models/reporting/_reporting__models.yml
+++ b/src/ol_dbt/models/reporting/_reporting__models.yml
@@ -52,7 +52,8 @@ models:
       in both the General and Social Sciences tracks, it would be counted as one program
       certificate.
 - name: report_mitxonline_course_engagements
-  description: MITx Online learners course video, problem, and discussion engagement metrics
+  description: MITx Online learners course video, problem, and discussion engagement
+    metrics
   columns:
   - name: courserun_readable_id
     description: string, unique ID representing a single MITx Online course run

--- a/src/ol_dbt/models/reporting/report_mitxonline_course_engagements.sql
+++ b/src/ol_dbt/models/reporting/report_mitxonline_course_engagements.sql
@@ -103,24 +103,24 @@ select
     , problems_in_courserun.count_problems_in_courserun
     , discussions_paticipated_in_count_tbl.discussions_paticipated_in
     , discussions_in_courserun.discussions_total
-    , case 
+    , case
         when videos_in_courserun.count_videos_in_courserun <> 0
-            then 
-                videos_played_count_tbl.count_videos_played 
+            then
+                videos_played_count_tbl.count_videos_played
                 / videos_in_courserun.count_videos_in_courserun
     end
     as pct_videos_played
-    , case 
+    , case
         when problems_in_courserun.count_problems_in_courserun <> 0
-            then 
-                problems_submitted_count_tbl.count_problems_submitted 
+            then
+                problems_submitted_count_tbl.count_problems_submitted
                 / problems_in_courserun.count_problems_in_courserun
     end
     as pct_problems_submitted
-    , case 
+    , case
         when discussions_in_courserun.discussions_total <> 0
-            then 
-                discussions_paticipated_in_count_tbl.discussions_paticipated_in 
+            then
+                discussions_paticipated_in_count_tbl.discussions_paticipated_in
                 / discussions_in_courserun.discussions_total
     end
     as pct_discussions_in
@@ -132,13 +132,13 @@ left join videos_played_count_tbl
 left join videos_in_courserun
     on courserunenrollments.courserun_readable_id = videos_in_courserun.courserun_readable_id
 left join problems_submitted_count_tbl
-    on 
+    on
         courserunenrollments.courserun_readable_id = problems_submitted_count_tbl.courserun_readable_id
         and courserunenrollments.user_username = problems_submitted_count_tbl.user_username
 left join problems_in_courserun
     on courserunenrollments.courserun_readable_id = problems_in_courserun.courserun_readable_id
 left join discussions_paticipated_in_count_tbl
-    on 
+    on
         courserunenrollments.courserun_readable_id = discussions_paticipated_in_count_tbl.courserun_readable_id
         and courserunenrollments.user_username = discussions_paticipated_in_count_tbl.user_username
 left join discussions_in_courserun


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/6176
Will be opening up seperate tickets for additional platforms

### Description (What does it do?)
<!--- Describe your changes in detail -->
add new engagement mart (mart_total_course_engagements) which gives counts of video, problem, and discussion engagement as well as percentages 

### How can this be tested?
dbt build --select mart_total_course_engagements
