### PR TITLE
Fix program learner report error

### DIFF
--- a/src/ol_dbt/models/staging/edxorg/_stg__edxorg__models.yml
+++ b/src/ol_dbt/models/staging/edxorg/_stg__edxorg__models.yml
@@ -416,7 +416,8 @@ models:
       was generated for that verified learner.
   - name: program_certificate_awarded_on
     description: timestamp, the date in ISO-8601 format that the learner has passed
-      each of the courses in the program and was awarded a program certificate.
+      each of the courses in the program and was awarded a program certificate. This
+      is the first date that the learner was awarded a program certificate.
   - name: courserun_start_on
     description: timestamp, the start date of the course run in ISO-8601 string.
     tests:

--- a/src/ol_dbt/models/staging/edxorg/stg__edxorg__s3__program_learner_report.sql
+++ b/src/ol_dbt/models/staging/edxorg/stg__edxorg__s3__program_learner_report.sql
@@ -22,11 +22,11 @@ with source as (
     from source
 )
 
-, add_program_cert_latest as (
+, aggregated_program_certificate as (
     select
         cast("user id" as integer) as user_id
         , "program uuid" as program_uuid
-        , max(program_certificate_awarded_dt) as latest_program_cert_award_on
+        , min(program_certificate_awarded_dt) as earliest_program_cert_award_on
         , max("completed program") as ever_completed_program
     from source_sorted
     group by 1, 2
@@ -98,7 +98,7 @@ select
     , cleaned.courserunenrollment_enrollment_mode
     , cleaned.user_id
     , cleaned.user_has_completed_course
-    , cast(add_program_cert_latest.ever_completed_program as boolean) as user_has_completed_program
+    , cast(aggregated_program_certificate.ever_completed_program as boolean) as user_has_completed_program
     , cleaned.courserunenrollment_is_active
     , cleaned.user_has_purchased_as_bundle
     , cleaned.user_roles
@@ -110,10 +110,10 @@ select
     , cleaned.courseactivity_last_activity_date
     , cleaned.courserunenrollment_unenrolled_on
     , cleaned.courserunenrollment_upgraded_on
-    , add_program_cert_latest.latest_program_cert_award_on as program_certificate_awarded_on
+    , aggregated_program_certificate.earliest_program_cert_award_on as program_certificate_awarded_on
     , regexp_extract(cleaned.program_title, '\((.*?)\)', 1) as program_track
 from cleaned
-left join add_program_cert_latest
+left join aggregated_program_certificate
     on
-        cleaned.user_id = add_program_cert_latest.user_id
-        and cleaned.program_uuid = add_program_cert_latest.program_uuid
+        cleaned.user_id = aggregated_program_certificate.user_id
+        and cleaned.program_uuid = aggregated_program_certificate.program_uuid

--- a/src/ol_dbt/models/staging/edxorg/stg__edxorg__s3__program_learner_report.sql
+++ b/src/ol_dbt/models/staging/edxorg/stg__edxorg__s3__program_learner_report.sql
@@ -81,7 +81,7 @@ with source as (
             when "date first upgraded to verified" = 'null' then null
             else to_iso8601(date_parse("date first upgraded to verified", '%Y-%m-%d %H:%i:%s Z'))
         end as courserunenrollment_upgraded_on
-        , program_certificate_awarded_dt as program_certificate_awarded_on
+        , program_certificate_awarded_at as program_certificate_awarded_on
     from dedup_source
 
 )

--- a/src/ol_dbt/models/staging/edxorg/stg__edxorg__s3__program_learner_report.sql
+++ b/src/ol_dbt/models/staging/edxorg/stg__edxorg__s3__program_learner_report.sql
@@ -14,7 +14,7 @@ with source as (
                     , to_iso8601(date_parse("date program certificate awarded", '%Y-%m-%d %H:%i:%s Z'))
                 )
 
-        end as program_certificate_awarded_dt
+        end as program_certificate_awarded_at
         , row_number() over (
             partition by "user id", "course run key", "program uuid"
             order by _airbyte_emitted_at desc, _ab_source_file_last_modified desc
@@ -26,7 +26,7 @@ with source as (
     select
         cast("user id" as integer) as user_id
         , "program uuid" as program_uuid
-        , min(program_certificate_awarded_dt) as earliest_program_cert_award_on
+        , min(program_certificate_awarded_at) as earliest_program_cert_award_on
         , max("completed program") as ever_completed_program
     from source_sorted
     group by 1, 2

--- a/src/ol_dbt/models/staging/edxorg/stg__edxorg__s3__program_learner_report.sql
+++ b/src/ol_dbt/models/staging/edxorg/stg__edxorg__s3__program_learner_report.sql
@@ -7,7 +7,13 @@ with source as (
         *
         , case
             when "date program certificate awarded" = 'null' then null
-            else to_iso8601(date_parse("date program certificate awarded", '%Y-%m-%dT%H:%i:%sZ'))
+            else
+            -- Try parsing once and handle both formats
+                coalesce(
+                    try(to_iso8601(date_parse("date program certificate awarded", '%Y-%m-%dT%H:%i:%sZ')))
+                    , to_iso8601(date_parse("date program certificate awarded", '%Y-%m-%d %H:%i:%s Z'))
+                )
+
         end as program_certificate_awarded_dt
         , row_number() over (
             partition by "user id", "course run key", "program uuid"


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
NA
https://pipelines.odl.mit.edu/runs/4f26f858-f9f1-4405-9deb-9caa359533a3

### Description (What does it do?)
<!--- Describe your changes in detail -->
- fixing the following database error on "date program certificate awarded" in stg__edxorg__s3__program_learner_report
```
  Database Error in model stg__edxorg__s3__program_learner_report (models/staging/edxorg/stg__edxorg__s3__program_learner_report.sql)
  TrinoUserError(type=USER_ERROR, name=INVALID_FUNCTION_ARGUMENT, message="Invalid format: "2024-11-07 00:00:00 Z" is malformed at " 00:00:00 Z"", query_id=20241220_064556_42933_7jh9z)
```
- Updating `program_certificate_awarded_on` to be the first date if there are multiple "date program certificate awarded" for the learner on the same program

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->
dbt build --select stg__edxorg__s3__program_learner_report

This will take almost two hours. https://github.com/mitodl/hq/issues/6342 will address the performance issue
