### PR TITLE
add edxorg_api_data_extract to workspace and fix the error occurred on op "list_edx_courses"

### DIFF
--- a/src/ol_orchestrate/resources/openedx.py
+++ b/src/ol_orchestrate/resources/openedx.py
@@ -33,7 +33,6 @@ class OpenEdxApiClient(ConfigurableResource):
         description="Token type to generate for use with authenticated requests",
     )
     token_url: str = Field(
-        default=f"{lms_url}/oauth2/access_token",
         description="URL to request token. e.g. https://lms.mitx.mit.edu/oauth2/access_token",
     )
     http_timeout: int = Field(

--- a/src/ol_orchestrate/workspace.yaml
+++ b/src/ol_orchestrate/workspace.yaml
@@ -4,6 +4,7 @@ load_from:
 - python_module: ol_orchestrate.definitions.edx.openedx_data_extract
 - python_module: ol_orchestrate.definitions.edx.retrieve_edxorg_raw_data
 - python_module: ol_orchestrate.definitions.edx.sync_program_credential_reports
+- python_module: ol_orchestrate.definitions.edx.edxorg_api_data_extract
 - python_module: ol_orchestrate.definitions.lakehouse.elt
 - python_module: ol_orchestrate.definitions.platform.notification
 - python_module: ol_orchestrate.repositories.edx_gcs_courses


### PR DESCRIPTION

### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
follow up on https://github.com/mitodl/ol-data-platform/pull/1405

### Description (What does it do?)
<!--- Describe your changes in detail -->
- Add the new pipeline definition edxorg_api_data_extract to workspace
- try to address the following error https://pipelines-qa.odl.mit.edu/runs/8aec09c5-b5fb-42df-ab4e-5b71c836dfcd?
```
dagster._core.errors.DagsterExecutionStepExecutionError: Error occurred while executing op "list_edx_courses":
The above exception was caused by the following exception:
httpx.UnsupportedProtocol: Request URL is missing an 'http://' or 'https://' protocol.
```

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->
Test on https://pipelines-qa.odl.mit.edu/
