### PR TITLE
Increasing timeout to call check_course_export_status

### DIFF
--- a/src/ol_orchestrate/assets/openedx.py
+++ b/src/ol_orchestrate/assets/openedx.py
@@ -150,7 +150,7 @@ def course_xml(context: AssetExecutionContext, courseware):  # noqa: ARG001
     failed_exports: set[str] = set()
     tasks = exported_courses["upload_task_ids"]
     while len(successful_exports.union(failed_exports)) < len(tasks):
-        time.sleep(timedelta(seconds=5).seconds)
+        time.sleep(timedelta(seconds=60).seconds)
         for course_id, task_id in tasks.items():
             task_status = context.resources.openedx.client.check_course_export_status(
                 course_id,

--- a/src/ol_orchestrate/assets/openedx.py
+++ b/src/ol_orchestrate/assets/openedx.py
@@ -150,7 +150,7 @@ def course_xml(context: AssetExecutionContext, courseware):  # noqa: ARG001
     failed_exports: set[str] = set()
     tasks = exported_courses["upload_task_ids"]
     while len(successful_exports.union(failed_exports)) < len(tasks):
-        time.sleep(timedelta(seconds=60).seconds)
+        time.sleep(timedelta(seconds=20).seconds)
         for course_id, task_id in tasks.items():
             task_status = context.resources.openedx.client.check_course_export_status(
                 course_id,

--- a/src/ol_orchestrate/ops/open_edx.py
+++ b/src/ol_orchestrate/ops/open_edx.py
@@ -632,7 +632,7 @@ def export_edx_courses(
     # Possible status values found here:
     # https://github.com/openedx/django-user-tasks/blob/master/user_tasks/models.py
     while len(successful_exports.union(failed_exports)) < len(tasks):
-        time.sleep(timedelta(seconds=5).seconds)
+        time.sleep(timedelta(seconds=60).seconds)
         for course_id, task_id in tasks.items():
             task_status = context.resources.openedx.check_course_export_status(
                 course_id,

--- a/src/ol_orchestrate/resources/openedx.py
+++ b/src/ol_orchestrate/resources/openedx.py
@@ -164,13 +164,10 @@ class OpenEdxApiClient(ConfigurableResource):
     def check_course_export_status(
         self, course_id: str, task_id: str
     ) -> dict[str, str]:
-        response = self._http_client.get(
-            f"{self.studio_url}/api/courses/v0/export/{course_id}/?task_id={task_id}",
-            headers={"Authorization": f"JWT {self._fetch_access_token()}"},
-            timeout=60,
+        request_url = (
+            f"{self.studio_url}/api/courses/v0/export/{course_id}/?task_id={task_id}"
         )
-        response.raise_for_status()
-        return response.json()
+        return self._fetch_with_auth(request_url)
 
     def get_course_structure_document(self, course_id: str):
         """Retrieve the course structure for an active course as JSON.


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/6413

After looking at error logs on the openedx Dagster pipelines, we found that these two:
mitxonline_edx_course_pipeline and xpro_edx_course_pipeline were hitting 500 errors.
This was due to a race condition when the pipeline tries to check on the course export job status too quickly and the resulting behavior is observed.

### Description (What does it do?)
- Increased the timeout between calls of the check_course_export_status method from 5 to 60 seconds.
- Updated the check_course_export_status code to use the _fetch_with_auth method.

### How can this be tested?
