### PR TITLE
add logging and pass extra_params to edxorg program API

### DIFF
--- a/src/ol_orchestrate/assets/edxorg_api.py
+++ b/src/ol_orchestrate/assets/edxorg_api.py
@@ -43,10 +43,10 @@ def edxorg_program_metadata(
     total_extracted_count = 0
     for i, data in enumerate(program_data_generator):
         if i == 0:
-            count, result_batch = data # First iteration gives total count and results
+            count, result_batch = data  # First iteration gives total count and results
             context.log.info("Total programs to extract: %d programs", count)
         else:
-            result_batch = data # Subsequent iterations give only results
+            result_batch = data  # Subsequent iterations give only results
 
         batch_count = len(result_batch)
         total_extracted_count += batch_count

--- a/src/ol_orchestrate/assets/edxorg_api.py
+++ b/src/ol_orchestrate/assets/edxorg_api.py
@@ -40,14 +40,20 @@ def edxorg_program_metadata(
     edxorg_programs = []
     edxorg_program_courses = []
     data_retrieval_timestamp = datetime.now(tz=UTC).isoformat()
-    total_count = 0
-    for result_batch in program_data_generator:
+    total_extracted_count = 0
+    for i, data in enumerate(program_data_generator):
+        if i == 0:
+            count, result_batch = data # First iteration gives total count and results
+            context.log.info("Total programs to extract: %d programs", count)
+        else:
+            result_batch = data # Subsequent iterations give only results
+
         batch_count = len(result_batch)
-        total_count += batch_count
+        total_extracted_count += batch_count
         context.log.info(
             "Extracted a batch of %d programs. Total so far: %d programs.",
             batch_count,
-            total_count,
+            total_extracted_count,
         )
         for program in result_batch:
             program_uuid = program["uuid"]

--- a/src/ol_orchestrate/assets/edxorg_api.py
+++ b/src/ol_orchestrate/assets/edxorg_api.py
@@ -40,7 +40,15 @@ def edxorg_program_metadata(
     edxorg_programs = []
     edxorg_program_courses = []
     data_retrieval_timestamp = datetime.now(tz=UTC).isoformat()
+    total_count = 0
     for result_batch in program_data_generator:
+        batch_count = len(result_batch)
+        total_count += batch_count
+        context.log.info(
+            "Extracted a batch of %d programs. Total so far: %d programs.",
+            batch_count,
+            total_count,
+        )
         for program in result_batch:
             program_uuid = program["uuid"]
             org = (
@@ -71,8 +79,10 @@ def edxorg_program_metadata(
                     }
                 )
 
-    context.log.info("Extracted %d programs....", len(edxorg_programs))
-    context.log.info("Extracted %d program courses....", len(edxorg_program_courses))
+    context.log.info("Total extracted %d programs....", len(edxorg_programs))
+    context.log.info(
+        "Total extracted %d program courses....", len(edxorg_program_courses)
+    )
 
     program_data_version = hashlib.sha256(
         json.dumps(edxorg_programs).encode("utf-8")

--- a/src/ol_orchestrate/resources/openedx.py
+++ b/src/ol_orchestrate/resources/openedx.py
@@ -200,7 +200,9 @@ class OpenEdxApiClient(ConfigurableResource):
         count = response_data["count"]
         yield count, results
         while next_page:
-            response_data = self._fetch_with_auth(request_url, extra_params=parse_qs(next_page))
+            response_data = self._fetch_with_auth(
+                request_url, extra_params=parse_qs(next_page)
+            )
             next_page = response_data["next"]
             yield response_data["results"]
 

--- a/src/ol_orchestrate/resources/openedx.py
+++ b/src/ol_orchestrate/resources/openedx.py
@@ -197,9 +197,10 @@ class OpenEdxApiClient(ConfigurableResource):
         response_data = self._fetch_with_auth(request_url)
         results = response_data["results"]
         next_page = response_data["next"]
-        yield results
+        count = response_data["count"]
+        yield count, results
         while next_page:
-            response_data = self._fetch_with_auth(next_page)
+            response_data = self._fetch_with_auth(request_url, extra_params=parse_qs(next_page))
             next_page = response_data["next"]
             yield response_data["results"]
 


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
https://github.com/mitodl/hq/issues/6191

### Description (What does it do?)
<!--- Describe your changes in detail -->
Adding some logging to help debug `edxorg_api_data_extract` on QA
Updating the `get_edxorg_programs` to pass extra_params explicitly, instead of relying on full URL

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->
 dagster dev -d src/ol_orchestrate/ -f src/ol_orchestrate/definitions/edx/edxorg_api_data_extract.py

go to http://127.0.0.1:3000/assets/edxorg/processed_data to manually trigger the materialization.

you should be able to see the logging

```
Total programs to extract: 1171 programs

Extracted a batch of 20 programs. Total so far: 20 programs.
-----
Extracted a batch of 11 programs. Total so far: 1171 programs.
Total extracted 1171 programs....
Total extracted 3067 program courses....
```

<img width="1321" alt="image" src="https://github.com/user-attachments/assets/47428a64-c36d-4f8f-af05-b1d0aa935834" />
