### PR TITLE
add io_manager_key to edxorg_program_metadata

### DIFF
--- a/src/ol_orchestrate/assets/edxorg_api.py
+++ b/src/ol_orchestrate/assets/edxorg_api.py
@@ -23,11 +23,13 @@ from ol_orchestrate.resources.openedx import OpenEdxApiClientFactory
     outs={
         "program_metadata": AssetOut(
             description="The metadata for programs extracted from edxorg program API",
+            io_manager_key="s3file_io_manager",
             key=AssetKey(("edxorg", "processed_data", "program_metadata")),
         ),
         "program_course_metadata": AssetOut(
             description="The metadata of all the associated program courses extracted "
             "from edxorg program API",
+            io_manager_key="s3file_io_manager",
             key=AssetKey(("edxorg", "processed_data", "program_course_metadata")),
         ),
     },


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
https://github.com/mitodl/hq/issues/6191

### Description (What does it do?)
<!--- Describe your changes in detail -->

The assets ran successfully on QA https://pipelines-qa.odl.mit.edu/runs/6e92c8dd-63fa-4b24-a909-c3872152b703. But the output file on S3 s3://dagster-data-qa/assets/edxorg/processed_data/program_course_metadata is not the expected json file and content . 

This PR is to add the missing `io_manager_key` to edxorg_program_metadata

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

This can be ran on QA


### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->


<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
