### PR TITLE
add engagement totals mart table marts__combined_total_course_engagements

### DIFF
--- a/src/ol_dbt/models/marts/combined/_marts__combined__models.yml
+++ b/src/ol_dbt/models/marts/combined/_marts__combined__models.yml
@@ -678,8 +678,8 @@ models:
       is in the past and courserun_end_on is in the future.
 
 - name: marts__combined_total_course_engagements
-  description: Total courserun engagement statistics from MITx Online, xPro,
-    edX.org, Residential MITx.
+  description: Total courserun engagement statistics from MITx Online, xPro, edX.org,
+    Residential MITx.
   columns:
   - name: platform
     description: str, open edx platform, e.g., MITx Online, edX.org, xPro, Residential

--- a/src/ol_dbt/models/marts/combined/marts__combined_total_course_engagements.sql
+++ b/src/ol_dbt/models/marts/combined/marts__combined_total_course_engagements.sql
@@ -1,5 +1,5 @@
 with combined_engagements as (
-    select 
+    select
         platform
         , courserun_readable_id
         , count(
@@ -24,13 +24,13 @@ with combined_engagements as (
             end
         ) as total_courserun_problems
     from {{ ref('int__combined__course_structure') }}
-    group by 
+    group by
         platform
         , courserun_readable_id
 )
 
 , combined_runs as (
-    select * 
+    select *
     from {{ ref('int__combined__course_runs') }}
     where courserun_readable_id is not null
 )


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/6176

### Description (What does it do?)
adds a new table with engagement metadata totals per courserun for reporting

### How can this be tested?
dbt build --select marts__combined_total_course_engagements

