### PR TITLE
add edxorg program courses to dbt models

### DIFF
--- a/src/ol_dbt/macros/extract_course_id.sql
+++ b/src/ol_dbt/macros/extract_course_id.sql
@@ -38,12 +38,12 @@
 
 --- course IDs come in two formats from different sources. This ensures that course IDs are consistently converted in
 --  all the downstream models.
-{% macro format_course_id(courserun_readable_id, convert_to_old_format=true) %}
+{% macro format_course_id(column_name='courserun_readable_id', convert_to_old_format=true) %}
     {% if convert_to_old_format %}
             -- format as {org}/{course number}/{run}
-           replace(replace(courserun_readable_id, 'course-v1:', ''), '+', '/')
+           replace(replace({{ column_name }}, 'course-v1:', ''), '+', '/')
      {% else %}
            -- format as course-v1:{org}+{course}+{run}
-           'course-v1:' || replace(courserun_readable_id, '/', '+')
+           'course-v1:' || replace({{ column_name }}, '/', '+')
      {% endif %}
 {% endmacro %}

--- a/src/ol_dbt/models/intermediate/edxorg/_int_edxorg__models.yml
+++ b/src/ol_dbt/models/intermediate/edxorg/_int_edxorg__models.yml
@@ -836,3 +836,37 @@ models:
       8601 string
     tests:
     - not_null
+
+- name: int__edxorg__mitx_program_courses
+  description: MITx program and its courses on edX.org
+  columns:
+  - name: program_uuid
+    description: str, UUID of the program on edX.org.
+    tests:
+    - not_null
+  - name: program_title
+    description: str, title of the program on edX.org, including the specific track
+      if applicable. e.g., Statistics and Data Science (General Track)
+  - name: program_name
+    description: str, name of the program, which does not specify which track. e.g.,
+      Statistics and Data Science
+    tests:
+    - not_null
+  - name: program_subtitle
+    description: str, subtitle of the program on edX.org
+  - name: program_type
+    description: str, type of the program. e.g., MicroMasters, XSeries
+  - name: program_status
+    description: str, status of the program. Possible values are active, retired,
+      unpublished or deleted
+  - name: course_readable_id
+    description: str, readable ID for the course in {org}/{course} format. e.g., MITx/15.415.1x
+    tests:
+    - not_null
+  - name: course_title
+    description: str, title of the course
+  - name: course_type
+    description: str, type of the course. e.g., audit, verified, professional
+  tests:
+  - dbt_expectations.expect_compound_columns_to_be_unique:
+      column_list: ["program_uuid", "course_readable_id"]

--- a/src/ol_dbt/models/intermediate/edxorg/int__edxorg__mitx_program_courses.sql
+++ b/src/ol_dbt/models/intermediate/edxorg/int__edxorg__mitx_program_courses.sql
@@ -1,0 +1,31 @@
+with programs as (
+    select * from {{ ref('stg__edxorg__s3__programs') }}
+)
+
+, program_courses as (
+    select * from {{ ref('stg__edxorg__s3__program_courses') }}
+)
+
+, micromasters_programs as (
+    select * from {{ ref('int__mitx__programs') }}
+    where is_micromasters_program = true
+)
+
+select
+    programs.program_uuid
+    , programs.program_title
+    , programs.program_type
+    , programs.program_status
+    , program_courses.course_readable_id
+    , program_courses.course_title
+    , program_courses.course_type
+    , coalesce(micromasters_programs.program_title, programs.program_title) as program_name
+from program_courses
+inner join programs
+    on program_courses.program_uuid = programs.program_uuid
+left join micromasters_programs
+    on (
+        programs.program_title like micromasters_programs.program_title || '%'
+        or programs.program_title like '%' || micromasters_programs.program_title
+    )
+where programs.program_organization = 'MITx'

--- a/src/ol_dbt/models/marts/combined/_marts__combined__models.yml
+++ b/src/ol_dbt/models/marts/combined/_marts__combined__models.yml
@@ -21,8 +21,6 @@ models:
       of Policy
   - name: program_id
     description: int, foreign key representing a single program
-    tests:
-    - not_null
   - name: course_readable_id
     description: str, Open edX ID formatted as course-v1:{org}+{course code} e.g.
       course-v1:xPRO+MLx2
@@ -31,7 +29,7 @@ models:
       code} e.g.program-v1:xPRO+MLx
   tests:
   - dbt_expectations.expect_compound_columns_to_be_unique:
-      column_list: ["platform", "program_id", "course_readable_id"]
+      column_list: ["platform", "program_title", "course_readable_id"]
 
 - name: marts__combined__users
   description: Mart model for users from different platforms

--- a/src/ol_dbt/models/marts/combined/marts__combined_coursesinprogram.sql
+++ b/src/ol_dbt/models/marts/combined/marts__combined_coursesinprogram.sql
@@ -2,6 +2,10 @@ with mitx_programs as (
     select * from {{ ref('int__mitx__program_requirements') }}
 )
 
+, edxorg_mitx_program_courses as (
+    select * from {{ ref('int__edxorg__mitx_program_courses') }}
+)
+
 , mitx__courses as (
     select * from {{ ref('int__mitx__courses') }}
 )
@@ -47,6 +51,25 @@ from mitx_programs
 inner join mitx__courses
     on mitx_programs.course_number = mitx__courses.course_number
 where mitx__courses.is_on_mitxonline = false
+
+union all
+
+select
+    '{{ var("edxorg") }}' as platform
+    , edxorg_mitx_program_courses.course_title
+    , edxorg_mitx_program_courses.program_title
+    , edxorg_mitx_program_courses.program_name
+    , null as program_id
+    , coalesce(mitx__courses.course_readable_id, edxorg_mitx_program_courses.course_readable_id) as course_readable_id
+    , null as program_readable_id
+from edxorg_mitx_program_courses
+left join mitx_programs
+    on edxorg_mitx_program_courses.program_name = mitx_programs.program_title
+left join mitx__courses
+    on
+        replace(edxorg_mitx_program_courses.course_readable_id, 'MITx/', '')
+        = replace(mitx__courses.course_readable_id, 'course-v1:MITxT+', '')
+where mitx_programs.program_title is null
 
 union all
 

--- a/src/ol_dbt/models/staging/edxorg/_edxorg_sources.yml
+++ b/src/ol_dbt/models/staging/edxorg/_edxorg_sources.yml
@@ -961,3 +961,38 @@ sources:
         block.
     - name: duration
       description: float, the length of the video, in seconds. May be 0.0.
+
+  - name: raw__edxorg__s3__programs
+    description: this table includes all the programs running on edX.org
+    columns:
+    - name: uuid
+      description: str, UUID of the program on edX.org.
+    - name: title
+      description: str, title of the program on edX.org
+    - name: subtitle
+      description: str, subtitle of the program on edX.org
+    - name: type
+      description: str, type of the program. e.g., MicroMasters, XSeries
+    - name: status
+      description: str, status of the program. Possible values are active, retired,
+        unpublished or deleted
+    - name: authoring_organizations
+      description: str, name of the organization that authored the program. e.g.,
+        MITx , HarvardX
+    - name: data_modified_timestamp
+      description: str, timestamp when the data was last modified
+
+  - name: raw__edxorg__s3__program_courses
+    description: this table includes all the program courses running on edX.org
+    columns:
+    - name: program_uuid
+      description: str, UUID of the program on edX.org.
+    - name: course_key
+      description: str, readable ID for the course in {org}+{course} format. e.g.,
+        MITx+15.415.1x
+    - name: course_title
+      description: str, title of the course
+    - name: course_description
+      description: str, short description of the course
+    - name: course_type
+      description: str, type of the course. e.g., audit, verified, professional

--- a/src/ol_dbt/models/staging/edxorg/_stg__edxorg__models.yml
+++ b/src/ol_dbt/models/staging/edxorg/_stg__edxorg__models.yml
@@ -961,3 +961,53 @@ models:
   tests:
   - dbt_expectations.expect_compound_columns_to_be_unique:
       column_list: ["courserun_readable_id", "video_block_id"]
+
+- name: stg__edxorg__s3__programs
+  description: this table includes all the programs running on edX.org
+  columns:
+  - name: program_uuid
+    description: str, UUID of the program on edX.org.
+    tests:
+    - not_null
+    - unique
+  - name: program_title
+    description: str, title of the program on edX.org
+    tests:
+    - not_null
+  - name: program_subtitle
+    description: str, subtitle of the program on edX.org
+  - name: program_type
+    description: str, type of the program. e.g., MicroMasters, XSeries
+  - name: program_status
+    description: str, status of the program. Possible values are active, retired,
+      unpublished or deleted
+    tests:
+    - not_null
+  - name: program_organization
+    description: str, name of the organization that authored the program. e.g., MITx
+      , HarvardX
+  - name: program_updated_on
+    description: str, timestamp when the data was last modified
+
+- name: stg__edxorg__s3__program_courses
+  description: this table includes all the program courses running on edX.org
+  columns:
+  - name: program_uuid
+    description: str, UUID of the program on edX.org.
+    tests:
+    - not_null
+  - name: course_readable_id
+    description: str, readable ID for the course in {org}/{course} format. e.g., MITx/15.415.1x
+    tests:
+    - not_null
+  - name: course_title
+    description: str, title of the course
+    tests:
+    - not_null
+  - name: course_description
+    description: str, short description of the course
+  - name: course_type
+    description: str, type of the course. e.g., audit, verified, professional
+  tests:
+  - dbt_expectations.expect_compound_columns_to_be_unique:
+      column_list: ["program_uuid", "course_readable_id"]

--- a/src/ol_dbt/models/staging/edxorg/stg__edxorg__s3__program_courses.sql
+++ b/src/ol_dbt/models/staging/edxorg/stg__edxorg__s3__program_courses.sql
@@ -1,0 +1,18 @@
+with source as (
+    select * from {{ source('ol_warehouse_raw_data','raw__edxorg__s3__program_courses') }}
+)
+
+{{ deduplicate_query(cte_name1='source', cte_name2='most_recent_source'
+, partition_columns = 'program_uuid, course_key') }}
+
+, cleaned as (
+    select
+        program_uuid
+        , {{ format_course_id('course_key') }} as course_readable_id
+        , course_title
+        , course_short_description as course_description
+        , course_type
+    from most_recent_source
+)
+
+select * from cleaned

--- a/src/ol_dbt/models/staging/edxorg/stg__edxorg__s3__programs.sql
+++ b/src/ol_dbt/models/staging/edxorg/stg__edxorg__s3__programs.sql
@@ -1,0 +1,19 @@
+with source as (
+    select * from {{ source('ol_warehouse_raw_data','raw__edxorg__s3__programs') }}
+)
+
+{{ deduplicate_query(cte_name1='source', cte_name2='most_recent_source' , partition_columns = 'uuid') }}
+
+, cleaned as (
+    select
+        uuid as program_uuid
+        , title as program_title
+        , subtitle as program_subtitle
+        , type as program_type
+        , status as program_status
+        , authoring_organizations as program_organization
+        , {{ cast_timestamp_to_iso8601('data_modified_timestamp') }} as program_updated_on
+    from most_recent_source
+)
+
+select * from cleaned


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
Remaining items in https://github.com/mitodl/hq/issues/6191

### Description (What does it do?)
<!--- Describe your changes in detail -->
- Creating `stg__edxorg__s3__programs`, `stg__edxorg__s3__program_courses `, `int__edxorg__mitx_program_courses` for all the edX.org programs and its courses
- Adding the missing edX.org program courses to `marts__combined_coursesinprogram`
- A few program data are populated to `program_summary_report`


### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

dbt build --select +int__edxorg__mitx_program_courses marts__combined_coursesinprogram

### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->


<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
