### PR TITLE
add program_readable_id to micromasters program certificate intermediate and mart

### DIFF
--- a/src/ol_dbt/macros/generate_program_readable_id.sql
+++ b/src/ol_dbt/macros/generate_program_readable_id.sql
@@ -1,0 +1,19 @@
+{% macro generate_micromasters_program_readable_id(micromasters_program_id, program_title) %}
+ -- Generate readable IDs for MicroMasters programs that runs on the edx platform
+    --- This is needed for programs that have not migrated to MITx Online yet
+    case
+        when {{ micromasters_program_id }} = 4
+             --- Statistics and Data Science has multiple tracks, we need to extract the track name and add it to
+             --- the readable id
+             then 'program-v1:MITx+SDS+' || replace(regexp_extract({{ program_title }}, '\((.*?)\)', 1),' ', '-')
+        when {{ micromasters_program_id }} = 5
+             --- Finance (active) and MIT Finance (retired) has the same readable ID
+             then 'program-v1:MITx+FIN'
+        else
+              'program-v1:MITx+' || upper(array_join(
+                  transform(split({{ program_title }}, ' '), -- noqa: PRS
+                    x -> substring(x, 1, 1)
+                  ), ''
+                ))
+    end
+{% endmacro %}

--- a/src/ol_dbt/models/intermediate/micromasters/_int_micromasters__models.yml
+++ b/src/ol_dbt/models/intermediate/micromasters/_int_micromasters__models.yml
@@ -269,9 +269,14 @@ models:
       MicroMasters
   - name: program_is_dedp
     description: boolean, specifying if the program is DEDP
+  - name: program_readable_id
+    description: str, readable ID formatted as program-v1:{org}+{program code}, e.g.,
+      program-v1:MITx+DEDP
+    tests:
+    - not_null
   tests:
   - dbt_expectations.expect_compound_columns_to_be_unique:
-      column_list: ["user_email", "micromasters_program_id", "mitxonline_program_id"]
+      column_list: ["user_email", "program_readable_id"]
 
 - name: int__micromasters__course_certificates
   description: course certificates earned for MicroMasters programs. This include

--- a/src/ol_dbt/models/intermediate/micromasters/int__micromasters__program_certificates.sql
+++ b/src/ol_dbt/models/intermediate/micromasters/int__micromasters__program_certificates.sql
@@ -17,6 +17,11 @@ with program_certificates_dedp_from_micromasters as (
     select * from {{ ref('int__mitx__users') }}
 )
 
+, mitxonline_programs as (
+    select * from {{ ref('int__mitxonline__programs') }}
+)
+
+
 -- Some micromasters learners from previous semesters don't have mitxonline logins. The mitxonline
 -- database does not include the certificates for those users. However, for future semesters,
 -- the mitxonline  database will be the source for dedp program certificates and the table in
@@ -128,5 +133,12 @@ select
     , report.user_street_address
     , report.user_address_state_or_territory
     , report.program_is_dedp
+    , if(
+        mitxonline_programs.program_id is not null
+        , mitxonline_programs.program_readable_id
+        , {{ generate_micromasters_program_readable_id('report.micromasters_program_id','report.program_title') }}
+    ) as program_readable_id
 from report
+left join mitxonline_programs
+    on report.mitxonline_program_id = mitxonline_programs.program_id
 order by report.program_completion_timestamp desc

--- a/src/ol_dbt/models/marts/micromasters/_marts_micromasters__models.yml
+++ b/src/ol_dbt/models/marts/micromasters/_marts_micromasters__models.yml
@@ -270,3 +270,8 @@ models:
     description: int, id of the program in the mitxonline database
   - name: user_mitxonline_username
     description: str, The username of the learner on the mitxonline platform
+  - name: program_readable_id
+    description: str, readable ID formatted as program-v1:{org}+{program code}, e.g.,
+      program-v1:MITx+DEDP
+    tests:
+    - not_null


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
Close out https://github.com/mitodl/hq/issues/3852

### Description (What does it do?)
<!--- Describe your changes in detail -->
- adding `program_readable_id` to int__micromasters__program_certificates and marts__micromasters_program_certificates 
    - For the micromasters programs that run on edx, program_readable_id is created internally. I've created a macro for this since it will be used in other models later.
    - For the micromasters programs that run on MITx online, program_readable_id is pulled from the application database

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

Run
`dbt build --select int__micromasters__program_certificates marts__micromasters_program_certificates`, tests should all pass
