### PR TITLE
Fix MITxOnline and xPro video activity Intermediate tables to include video-related events

### DIFF
--- a/src/ol_dbt/models/intermediate/mitxonline/int__mitxonline__user_courseactivity_video.sql
+++ b/src/ol_dbt/models/intermediate/mitxonline/int__mitxonline__user_courseactivity_video.sql
@@ -24,4 +24,7 @@ select
     , json_query(useractivity_event_object, 'lax $.new_speed' omit quotes) as useractivity_video_new_speed
     , json_query(useractivity_event_object, 'lax $.old_speed' omit quotes) as useractivity_video_old_speed
 from course_activities
-where useractivity_event_type like '%\_video' escape '\' or useractivity_event_type like 'edx.video.%' --noqa
+where
+    regexp_like(useractivity_event_type, '(^[\w]+)_video') = true
+    or regexp_like(useractivity_event_type, '(^[\w]+)_transcript') = true
+    or useractivity_event_type like 'edx.video.%'

--- a/src/ol_dbt/models/intermediate/mitxpro/int__mitxpro__user_courseactivity_video.sql
+++ b/src/ol_dbt/models/intermediate/mitxpro/int__mitxpro__user_courseactivity_video.sql
@@ -24,4 +24,7 @@ select
     , json_query(useractivity_event_object, 'lax $.new_speed' omit quotes) as useractivity_video_new_speed
     , json_query(useractivity_event_object, 'lax $.old_speed' omit quotes) as useractivity_video_old_speed
 from course_activities
-where useractivity_event_type like '%\_video' escape '\' or useractivity_event_type like 'edx.video.%' --noqa
+where
+    regexp_like(useractivity_event_type, '(^[\w]+)_video') = true
+    or regexp_like(useractivity_event_type, '(^[\w]+)_transcript') = true
+    or useractivity_event_type like 'edx.video.%'


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
NA
I noticed the test failure  https://pipelines.odl.mit.edu/runs/e038c4a6-1b73-4387-a578-f113481fd010

### Description (What does it do?)
<!--- Describe your changes in detail -->
This PR addresses the issue in the int__mitxonline__user_courseactivity_video, ensuring that only [video interaction events](https://edx.readthedocs.io/projects/devdata/en/latest/internal_data_formats/tracking_logs/student_event_types.html#video-interaction-events) with useful data are included. It also aligns with the int__edxorg__mitx_user_courseactivity_video and int__mitxresidential__user_courseactivity_video for consistency.

There are a few records in int__mitxonline__user_courseactivity_video that do not contain useful data, causing the test to fail  https://pipelines.odl.mit.edu/runs/e038c4a6-1b73-4387-a578-f113481fd010 due to blank video_id


### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

Run `dbt build --select  +int__mitxonline__user_courseactivity_video  +int__mitxpro__user_courseactivity_video`, test should pass now

