### PR TITLE
Populate micromasters program_readable_id in combined program enrollment mart

### DIFF
--- a/src/ol_dbt/macros/generate_program_readable_id.sql
+++ b/src/ol_dbt/macros/generate_program_readable_id.sql
@@ -9,7 +9,7 @@
         when {{ micromasters_program_id }} = 5
              --- Finance (active) and MIT Finance (retired) has the same readable ID
              then 'program-v1:MITx+FIN'
-        else
+         when {{ micromasters_program_id }} is not null then
               'program-v1:MITx+' || upper(array_join(
                   transform(split({{ program_title }}, ' '), -- noqa: PRS
                     x -> substring(x, 1, 1)

--- a/src/ol_dbt/models/marts/combined/marts__combined_program_enrollment_detail.sql
+++ b/src/ol_dbt/models/marts/combined/marts__combined_program_enrollment_detail.sql
@@ -127,7 +127,10 @@ with mitxpro__programenrollments as (
         , edx_program_enrollments.program_track
         , edx_program_enrollments.program_type
         , null as program_is_live
-        , null as program_readable_id
+        , {{ generate_micromasters_program_readable_id(
+              'edx_program_enrollments.micromasters_program_id'
+              ,'edx_program_enrollments.program_title')
+         }} as program_readable_id
         , edx_program_enrollments.user_id
         , edxorg__users.user_email
         , edx_program_enrollments.user_username


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
follow up https://github.com/mitodl/ol-data-platform/pull/1452

### Description (What does it do?)
<!--- Describe your changes in detail -->
Populating the program_readable_id in marts__combined_program_enrollment_detail for the "MicroMasters" program. This is similar to how it was done in the previous linked PR. All other programs are not affected by this PR.


### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

dbt build --select marts__combined_program_enrollment_detail

