### PR TITLE
feat: dagster pipeline to ingest edx.org course via API

### DIFF
--- a/src/ol_orchestrate/assets/edxorg_api.py
+++ b/src/ol_orchestrate/assets/edxorg_api.py
@@ -237,6 +237,7 @@ def edxorg_mitx_course_metadata(
                         "max_effort": course_run["max_effort"],
                         "estimated_hours": course_run["estimated_hours"],
                         "modified": course_run["modified"],
+                        "retrieved_at": data_retrieval_timestamp,
                     }
                 )
 

--- a/src/ol_orchestrate/definitions/edx/edxorg_api_data_extract.py
+++ b/src/ol_orchestrate/definitions/edx/edxorg_api_data_extract.py
@@ -7,7 +7,10 @@ from dagster import (
 )
 from dagster_aws.s3 import S3Resource
 
-from ol_orchestrate.assets.edxorg_api import edxorg_program_metadata
+from ol_orchestrate.assets.edxorg_api import (
+    edxorg_mitx_course_metadata,
+    edxorg_program_metadata,
+)
 from ol_orchestrate.io_managers.filepath import S3FileObjectIOManager
 from ol_orchestrate.lib.constants import DAGSTER_ENV, VAULT_ADDRESS
 from ol_orchestrate.lib.dagster_helpers import default_io_manager
@@ -40,12 +43,12 @@ def s3_uploads_bucket(
 
 edxorg_api_daily_schedule = ScheduleDefinition(
     name="edxorg_api_schedule",
-    target=AssetSelection.assets(edxorg_program_metadata),
+    target=AssetSelection.assets(edxorg_program_metadata, edxorg_mitx_course_metadata),
     cron_schedule="@daily",
     execution_timezone="Etc/UTC",
 )
 
-edxorg_program_metadata_extract = Definitions(
+edxorg_api_data = Definitions(
     resources={
         "io_manager": default_io_manager(DAGSTER_ENV),
         "s3file_io_manager": S3FileObjectIOManager(
@@ -56,6 +59,6 @@ edxorg_program_metadata_extract = Definitions(
         "s3": S3Resource(),
         "edxorg_api": OpenEdxApiClientFactory(deployment="edxorg", vault=vault),
     },
-    assets=[edxorg_program_metadata],
+    assets=[edxorg_program_metadata, edxorg_mitx_course_metadata],
     schedules=[edxorg_api_daily_schedule],
 )

--- a/src/ol_orchestrate/resources/openedx.py
+++ b/src/ol_orchestrate/resources/openedx.py
@@ -213,7 +213,7 @@ class OpenEdxApiClient(ConfigurableResource):
 
         Yield: A generator for walking the paginated list of courses
         """
-        course_catalog_url = "https://api.edx.org/catalog/v1/catalogs/10/courses"
+        course_catalog_url = "https://discovery.edx.org/api/v1/catalogs/10/courses/"
         response_data = self._fetch_with_auth(course_catalog_url)
         results = response_data["results"]
         next_page = response_data["next"]

--- a/src/ol_orchestrate/resources/openedx.py
+++ b/src/ol_orchestrate/resources/openedx.py
@@ -206,6 +206,26 @@ class OpenEdxApiClient(ConfigurableResource):
             next_page = response_data["next"]
             yield response_data["results"]
 
+    def get_edxorg_mitx_courses(self):
+        """
+        Retrieve a list of all the active courses in MITx catalog by walking through the
+        paginated results
+
+        Yield: A generator for walking the paginated list of courses
+        """
+        course_catalog_url = "https://discovery.edx.org/api/v1/catalogs/10/courses/"
+        response_data = self._fetch_with_auth(course_catalog_url)
+        results = response_data["results"]
+        next_page = response_data["next"]
+        count = response_data["count"]
+        yield count, results
+        while next_page:
+            response_data = self._fetch_with_auth(
+                course_catalog_url, extra_params=parse_qs(next_page)
+            )
+            next_page = response_data["next"]
+            yield response_data["results"]
+
 
 class OpenEdxApiClientFactory(ConfigurableResource):
     deployment: str = Field(

--- a/src/ol_orchestrate/resources/openedx.py
+++ b/src/ol_orchestrate/resources/openedx.py
@@ -213,7 +213,7 @@ class OpenEdxApiClient(ConfigurableResource):
 
         Yield: A generator for walking the paginated list of courses
         """
-        course_catalog_url = "https://discovery.edx.org/api/v1/catalogs/10/courses/"
+        course_catalog_url = "https://api.edx.org/catalog/v1/catalogs/10/courses"
         response_data = self._fetch_with_auth(course_catalog_url)
         results = response_data["results"]
         next_page = response_data["next"]


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
https://github.com/mitodl/hq/issues/6337

### Description (What does it do?)
<!--- Describe your changes in detail -->
adding a new dagster asset edxorg_mitx_course_metadata to ingest the MITx course data from the edx.org course catalog API. This will be part of the existing automation [edxorg_api_schedule](https://pipelines.odl.mit.edu/locations/ol_orchestrate.definitions.edx.edxorg_api_data_extract/schedules/edxorg_api_schedule) 


### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

This can't tested with the new API credential in https://vault-qa.odl.mit.edu/ui/vault/secrets/secret-data/show/pipelines/edx/edxorg/edx-oauth-client (blocked by https://github.com/mitodl/hq/issues/6638)

Once the credential issue is solved, it should be 
dagster dev -d src/ol_orchestrate/ -f src/ol_orchestrate/definitions/edx/edxorg_api_data_extract.py


You should see the logs like:
```
Total MITx courses to extract: 448 courses
Extracted a batch of 20 MITx courses. Total so far: 20 courses.
-----

Total extracted 448 MITx courses....
Total extracted 1437 MITx course runs....
```

