### PR TITLE
create studentmodulehistoryextended under external/irx models

### DIFF
--- a/src/ol_dbt/models/external/irx/mitx/_irx_mitx__models.yml
+++ b/src/ol_dbt/models/external/irx/mitx/_irx_mitx__models.yml
@@ -209,3 +209,32 @@ models:
     description: int, display_tag_filter_strategy
   - name: consecutive_days_visit_count
     description: int, consecutive_days_visit_count
+
+- name: irx__mitx__openedx__mysql__courseware_studentmodulehistoryextended
+  description: history of studentmodule in Residential MITx open edx platform
+  config:
+    grants:
+      select: ['mit_irx']
+  columns:
+  - name: user_id
+    description: int, reference user id in auth_user
+  - name: course_id
+    description: str, Open edX Course ID in the format course-v1:{org}+{course code}+{run_tag}
+  - name: module_id
+    description: str, block ID for a distinct piece of content in a course, referencing
+      course_structure
+  - name: module_type
+    description: str, category/type of the block, referencing course_structure.
+  - name: state_data
+    description: str, JSON text indicating the learner's state for the corresponding
+      module such as course, chapter, problemset, sequential, videosequence, etc.
+  - name: grade
+    description: str, floating point value indicating the total unweighted grade for
+      this problem that the learner has scored. e.g. how many responses they got right
+      within the problem.
+  - name: max_grade
+    description: str, floating point value indicating the total possible unweighted
+      grade for this problem, or basically the number of responses that are in this
+      problem.
+  - name: created
+    description: timestamp, datetime when this row was created

--- a/src/ol_dbt/models/external/irx/mitx/irx__mitx__openedx__mysql__courseware_studentmodulehistoryextended.sql
+++ b/src/ol_dbt/models/external/irx/mitx/irx__mitx__openedx__mysql__courseware_studentmodulehistoryextended.sql
@@ -1,0 +1,19 @@
+with studentmodulehistoryextended as (
+    select * from {{ ref('stg__mitxresidential__openedx__courseware_studentmodulehistoryextended') }}
+)
+
+, studentmodule as (
+    select * from {{ ref('stg__mitxresidential__openedx__courseware_studentmodule') }}
+)
+
+select
+    studentmodule.courserun_readable_id as course_id
+    , studentmodule.user_id
+    , studentmodule.coursestructure_block_id as module_id
+    , studentmodule.coursestructure_block_category as module_type
+    , studentmodulehistoryextended.studentmodule_state_data as state_data
+    , studentmodulehistoryextended.studentmodule_problem_grade as grade
+    , studentmodulehistoryextended.studentmodule_problem_max_grade as max_grade
+    , studentmodulehistoryextended.studentmodule_created_on as created
+from studentmodulehistoryextended
+inner join studentmodule on studentmodulehistoryextended.studentmodule_id = studentmodule.studentmodule_id


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
https://github.com/mitodl/hq/issues/6049
https://github.com/mitodl/hq/issues/6661

### Description (What does it do?)
<!--- Describe your changes in detail -->
Creating `irx__mitx__openedx__mysql__courseware_studentmodulehistoryextended` under external/irx models. These models are specifically designed for data delivery to IRx

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

dbt build --select irx__mitx__openedx__mysql__courseware_studentmodulehistoryextended
