### PR TITLE
Update asset key for edxorg course metadata from API

### DIFF
--- a/src/ol_orchestrate/assets/edxorg_api.py
+++ b/src/ol_orchestrate/assets/edxorg_api.py
@@ -133,13 +133,13 @@ def edxorg_program_metadata(
             description="The metadata for MITx courses extracted from the edxorg's "
             "course catalog API",
             io_manager_key="s3file_io_manager",
-            key=AssetKey(("edxorg", "processed_data", "course_metadata")),
+            key=AssetKey(("edxorg", "api_data", "course_metadata")),
         ),
         "course_run_metadata": AssetOut(
             description="The metadata for MITx course runs extracted from the edxorg's "
             "course catalog API",
             io_manager_key="s3file_io_manager",
-            key=AssetKey(("edxorg", "processed_data", "course_run_metadata")),
+            key=AssetKey(("edxorg", "api_data", "course_run_metadata")),
         ),
     },
 )


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
https://github.com/mitodl/hq/issues/6337

### Description (What does it do?)
<!--- Describe your changes in detail -->
Updating the Asset Key for the new course_metadata and course_run_metadata assets to be written to a new path "edxorg/api_data/course_metadata" instead of "edxorg/processed_data/course_metadata" so that they don't conflict with the existing `course_metadata` asset generated in [openedx_course_archives.py](https://github.com/mitodl/ol-data-platform/blob/main/src/ol_orchestrate/assets/openedx_course_archives.py#L49)

I noticed it on QA https://pipelines-qa.odl.mit.edu/assets/edxorg/processed_data?view=folder


### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->
Can be tested on QA
