### PR TITLE
Tweak to address new ruff A005 error

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -195,6 +195,9 @@ convention = "pep257"
 [tool.ruff.lint.flake8-quotes]
 inline-quotes = "double"
 
+[tool.ruff.lint.flake8-builtins]
+builtins-allowed-modules = ["secrets", "platform"]
+
 [tool.ruff.lint.per-file-ignores]
 "tests/**" = ["S101"]
 "test_*.py" = ["S101"]


### PR DESCRIPTION
### Description (What does it do?)
<!--- Describe your changes in detail -->
This [PR](https://github.com/mitodl/ol-data-platform/pull/1471) with an updated version of ruff is throwing the following [error](https://results.pre-commit.ci/run/github/259444786/1739230687.WGbq80jASbSWBaDWS25FFQ). This PR adds an exception as I doubt we'll be renaming either module.

