### PR TITLE
update cast_timestamp_to_iso8601 to work with timestamp and string

### DIFF
--- a/src/ol_dbt/macros/cast_timestamp_to_iso8601.sql
+++ b/src/ol_dbt/macros/cast_timestamp_to_iso8601.sql
@@ -1,3 +1,9 @@
 {% macro cast_timestamp_to_iso8601(column_name) %}
-    to_iso8601(from_iso8601_timestamp({{ column_name }}))
+  case
+       -- If the column is already a timestamp, convert to ISO 8601
+        when try_cast({{ column_name }} AS timestamp) is not null
+           then to_iso8601(try_cast({{ column_name }} AS timestamp))
+        -- otherwise, convert to ISO 8601 from a string
+        else to_iso8601(from_iso8601_timestamp(try_cast({{ column_name }} AS varchar)))
+   end
 {% endmacro %}


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
Part of https://github.com/mitodl/hq/issues/6733

### Description (What does it do?)
<!--- Describe your changes in detail -->
 Updating cast_timestamp_to_iso8601 to work with both timestamp and string fields. 

 This change is needed to transition [xPro application database sync on production](https://airbyte.odl.mit.edu/workspaces/3f0ccc59-baa3-4567-92e5-c61fb737467b/connections/47e45503-fc2f-430d-8766-a31ab790e49a/status) to the new Iceberg destination connector in order to resolve the performance issue. Tobias setup on [Airbyte QA](https://airbyte-qa.odl.mit.edu/workspaces/7f17cc8d-2d97-454c-b840-e6711ba67cca/connections/5b794c1a-0edc-4da9-8c49-ea5e58d129c7/status), but we need to ensure that the xPro staging models are running without errors. The only error we saw is related to timestamp conversion, which this PR is trying to address


### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

I ran it `dbt run --select staging.mitxpro --vars 'schema_suffix: rlougee' --target dev_qa`, there are 3 errors on raw__emeritus__bigquery__api_enrollments, raw__xpro__openedx__api__course_blocks and raw__xpro__openedx__tracking_logs  but they are unrelated to the new connector. 

I  ran `dbt build --select stg__emeritus__api__bigquery__user_enrollments --vars 'schema_suffix: rlougee' --target dev_production` to ensure the existing raw table synced by the old connector still works
