### PR TITLE
Stage MITx courses and runs ingested from API

### DIFF
--- a/src/ol_dbt/macros/apply_deduplication_query.sql
+++ b/src/ol_dbt/macros/apply_deduplication_query.sql
@@ -20,3 +20,22 @@
     )
 
 {% endmacro %}
+
+{% macro deduplicate_raw_table(order_by='_airbyte_extracted_at', partition_columns='id') %}
+    /*
+        This dedupe applied to the raw tables via Incremental Sync from Airbyte. It will deduplicate the data based on
+        the partition_columns and order by columns.
+    */
+   , source_sorted as (
+        select
+            *
+            , row_number() over ( partition by {{ partition_columns }} order by {{ order_by }} desc) as row_num
+        from source
+    )
+
+    , most_recent_source as (
+        select * from source_sorted
+        where row_num = 1
+    )
+
+{% endmacro %}

--- a/src/ol_dbt/models/staging/edxorg/_edxorg_sources.yml
+++ b/src/ol_dbt/models/staging/edxorg/_edxorg_sources.yml
@@ -996,3 +996,93 @@ sources:
       description: str, short description of the course
     - name: course_type
       description: str, type of the course. e.g., audit, verified, professional
+
+  - name: raw__edxorg__s3__mitx_courses
+    description: MITx courses on edX.org, sourced from the discovery API
+    columns:
+    - name: course_key
+      description: str, unique identifier for the course in {org}+{course number}
+        format. e.g., MITx+15.415.1x
+    - name: title
+      description: str, title of the course
+    - name: short_description
+      description: str, the short description of the course and its content
+    - name: full_description
+      description: str, the long description of the course and its content.
+    - name: level_type
+      description: str, the course’s level of difficulty. Values can be 'high_school',
+        'introductory', 'intermediate', or 'advanced'.
+    - name: course_type
+      description: str, audit, verified-audit, credit-verified-audit, or professional
+    - name: marketing_url
+      description: str, the URL for the course about page.
+    - name: image
+      description: json, course image
+    - name: subjects
+      description: json, the academic subjects that this course covers.
+    - name: prerequisites
+      description: array, array of courses a learner must complete before enrolling
+        in the current course. May be empty.
+    - name: prerequisites_raw
+      description: text, any courses a learner must complete before enrolling in the
+        current course
+    - name: modified
+      description: timestamp, the date and time the course was last modified.
+
+  - name: raw__edxorg__s3__mitx_course_runs
+    description: MITx course runs on edX.org, sourced from the discovery API
+    columns:
+    - name: run_key
+      description: str, unique identifier for the course run in {org}+{course number}+{run}
+        format.
+    - name: title
+      description: str, title of the course
+    - name: short_description
+      description: str, the short description of the course and its content
+    - name: full_description
+      description: str, the long description of the course and its content.
+    - name: level_type
+      description: str, the course’s level of difficulty. Possible values are 'high_school',
+        'introductory', 'intermediate', or 'advanced'.
+    - name: languages
+      description: str, the language for this course run.
+    - name: image
+      description: array, course image
+    - name: pacing_type
+      description: str, the pacing of the course. Possible values are 'self-paced'
+        or 'instructor-paced'.
+    - name: enrollment_type
+      description: str, audit, verified, credit, or professional.
+    - name: availability
+      description: str, the availability of the course run. Possible values are 'Upcoming',
+        'Starting Soon', 'Current' or 'Archived'
+    - name: status
+      description: str, the status of the course run. Possible values are 'published',
+        'unpublished', or 'reviewed'
+    - name: seats
+      description: array, list of the available modes for this course. The member
+        field includes type, price, currency, upgrade_deadline, credit_provider and
+        credit_hours
+    - name: staff
+      description: array, list of instructors associated with the course
+    - name: weeks_to_complete
+      description: int, the number of weeks to complete the course.
+    - name: min_effort
+      description: int, the minimum number of estimated hours of effort per week.
+    - name: max_effort
+      description: int, the maximum number of estimated hours of effort per week.
+    - name: estimated_hours
+      description: int, the estimated number of hours to complete the course.
+    - name: start_on
+      description: timestamp, the course start date.
+    - name: end_on
+      description: datetime, the course end date.
+    - name: enrollment_start
+      description: timestamp, the course enrollment start date.
+    - name: enrollment_end
+      description: timestamp, the course enrollment end date.
+    - name: announcement
+      description: timestamp, date and time when the course will be announced and
+        visible.
+    - name: modified
+      description: timestamp, the date and time the course was last modified.

--- a/src/ol_dbt/models/staging/edxorg/_stg__edxorg__models.yml
+++ b/src/ol_dbt/models/staging/edxorg/_stg__edxorg__models.yml
@@ -1011,3 +1011,109 @@ models:
   tests:
   - dbt_expectations.expect_compound_columns_to_be_unique:
       column_list: ["program_uuid", "course_readable_id"]
+
+- name: stg__edxorg__api__course
+  description: MITx courses on edX.org, sourced from the discovery API
+  columns:
+  - name: course_readable_id
+    description: str, unique identifier for the course in {org}+{course number} format.
+      e.g., MITx+15.415.1x
+    tests:
+    - unique
+    - not_null
+  - name: course_title
+    description: str, title of the course
+    tests:
+    - not_null
+  - name: course_description
+    description: str, the short description of the course and its content
+  - name: course_full_description
+    description: str, the long description of the course and its content.
+  - name: course_level
+    description: str, the course’s level of difficulty. Values can be 'high_school',
+      'introductory', 'intermediate', or 'advanced'.
+  - name: course_type
+    description: str, audit, verified-audit, credit-verified-audit, or professional
+  - name: course_marketing_url
+    description: str, the URL for the course About page.
+  - name: course_image_url
+    description: str, the URL for the course image
+  - name: course_topics
+    description: array, the academic subjects that this course covers.
+  - name: course_prerequisites_text
+    description: text, any courses a learner must complete before enrolling in the
+      current course
+  - name: course_updated_at
+    description: timestamp, the date and time the course was last modified.
+    tests:
+    - not_null
+
+- name: stg__edxorg__api__courserun
+  description: MITx course runs on edX.org, sourced from the discovery API
+  columns:
+  - name: courserun_readable_id
+    description: str, unique identifier for the course run in {org}+{course number}+{run}
+      format.
+    tests:
+    - unique
+    - not_null
+  - name: course_readable_id
+    description: str, unique identifier for the course in {org}+{course number} format.
+      e.g., MITx+15.415.1x
+    tests:
+    - not_null
+  - name: courserun_title
+    description: str, title of the course
+    tests:
+    - not_null
+  - name: courserun_short_description
+    description: str, the short description of the course and its content
+  - name: courserun_full_description
+    description: str, the long description of the course and its content.
+  - name: courserun_image_url
+    description: str, the URL for the course image
+  - name: courserun_level
+    description: str, the course’s level of difficulty. Values can be 'high_school',
+      'introductory', 'intermediate', or 'advanced'.
+  - name: courserun_marketing_url
+    description: str, the URL for the course About page.
+  - name: courserun_languages
+    description: str, the language for this course run.
+  - name: courserun_pace
+    description: str, the pacing of the course. Possible values are 'self-paced' or
+      'instructor-paced'.
+  - name: courserun_enrollment_mode
+    description: str, audit, verified, credit, or professional.
+  - name: courserun_status
+    description: str, the status of the course run. Possible values are 'published',
+      'unpublished', or 'reviewed'
+  - name: courserun_availability
+    description: str, the availability of the course run. Possible values are 'Upcoming',
+      'Starting Soon', 'Current' or 'Archived'
+  - name: courserun_enrollment_modes
+    description: array, list of the available modes for this course. The member field
+      includes type, price, currency, upgrade_deadline, credit_provider and credit_hours
+  - name: courserun_instructors
+    description: array, list of instructors associated with the course
+  - name: courserun_duration
+    description: str, the number of weeks to complete the course. e.g. '4 weeks'
+  - name: courserun_min_weekly_hours
+    description: int, the minimum number of estimated hours of effort per week.
+  - name: courserun_max_weekly_hours
+    description: int, the maximum number of estimated hours of effort per week.
+  - name: courserun_estimated_hours
+    description: int, the estimated number of hours to complete the course.
+  - name: courserun_start_on
+    description: timestamp, the course start date.
+  - name: courserun_end_on
+    description: datetime, the course end date.
+  - name: courserun_enrollment_start_on
+    description: timestamp, the course enrollment start date.
+  - name: courserun_enrollment_end_on
+    description: timestamp, the course enrollment end date.
+  - name: courserun_announce_on
+    description: timestamp, date and time when the course will be announced and visible.
+  - name: courserun_updated_at
+    description: timestamp, the date and time the course was last modified.
+    tests:
+    - not_null

--- a/src/ol_dbt/models/staging/edxorg/stg__edxorg__api__course.sql
+++ b/src/ol_dbt/models/staging/edxorg/stg__edxorg__api__course.sql
@@ -1,0 +1,28 @@
+with source as (
+    select * from {{ source('ol_warehouse_raw_data','raw__edxorg__s3__mitx_courses') }}
+)
+
+{{ deduplicate_raw_table(order_by='retrieved_at' , partition_columns = 'course_key') }}
+
+, cleaned as (
+    select
+        course_key as course_readable_id
+        , title as course_title
+        , short_description as course_description
+        , full_description as course_full_description
+        , level_type as course_level
+        , course_type
+        , marketing_url as course_marketing_url
+        , json_query(image, 'lax $.url' omit quotes) as course_image_url
+        , if(
+            subjects = '[]'
+            , null
+            , cast(json_parse(json_query(subjects, 'lax $.name' with array wrapper)) as array(varchar))  --noqa
+        ) as course_topics
+        , prerequisites_raw as course_prerequisites_text
+        , {{ cast_timestamp_to_iso8601('modified') }} as course_updated_at
+
+    from most_recent_source
+)
+
+select * from cleaned

--- a/src/ol_dbt/models/staging/edxorg/stg__edxorg__api__courserun.sql
+++ b/src/ol_dbt/models/staging/edxorg/stg__edxorg__api__courserun.sql
@@ -13,7 +13,6 @@ with source as (
         , full_description as courserun_full_description
         , level_type as courserun_level
         , marketing_url as courserun_marketing_url
-        , staff as courserun_instructors
         , languages as courserun_languages
         , min_effort as courserun_min_weekly_hours
         , max_effort as courserun_max_weekly_hours
@@ -22,6 +21,7 @@ with source as (
         , enrollment_type as courserun_enrollment_mode
         , availability as courserun_availability
         , status as courserun_status
+        , if(staff = '[]', null, staff) as courserun_instructors
         , if(seats = '[]', null, seats) as courserun_enrollment_modes
         , json_query(image, 'lax $.url' omit quotes) as courserun_image_url
         , case

--- a/src/ol_dbt/models/staging/edxorg/stg__edxorg__api__courserun.sql
+++ b/src/ol_dbt/models/staging/edxorg/stg__edxorg__api__courserun.sql
@@ -1,0 +1,41 @@
+with source as (
+    select * from {{ source('ol_warehouse_raw_data','raw__edxorg__s3__mitx_course_runs') }}
+)
+
+{{ deduplicate_raw_table(order_by='retrieved_at' , partition_columns = 'run_key') }}
+
+, cleaned as (
+    select
+        run_key as courserun_readable_id
+        , course_key as course_readable_id
+        , title as courserun_title
+        , short_description as courserun_short_description
+        , full_description as courserun_full_description
+        , level_type as courserun_level
+        , marketing_url as courserun_marketing_url
+        , staff as courserun_instructors
+        , languages as courserun_languages
+        , min_effort as courserun_min_weekly_hours
+        , max_effort as courserun_max_weekly_hours
+        , estimated_hours as courserun_estimated_hours
+        , pacing_type as courserun_pace
+        , enrollment_type as courserun_enrollment_mode
+        , availability as courserun_availability
+        , status as courserun_status
+        , if(seats = '[]', null, seats) as courserun_enrollment_modes
+        , json_query(image, 'lax $.url' omit quotes) as courserun_image_url
+        , case
+            when weeks_to_complete = 1 then cast(weeks_to_complete as varchar) || ' week'
+            when weeks_to_complete > 1 then cast(weeks_to_complete as varchar) || ' weeks'
+        end as courserun_duration
+        , {{ cast_timestamp_to_iso8601('start_on') }} as courserun_start_on
+        , {{ cast_timestamp_to_iso8601('end_on') }} as courserun_end_on
+        , {{ cast_timestamp_to_iso8601('enrollment_start') }} as courserun_enrollment_start_on
+        , {{ cast_timestamp_to_iso8601('enrollment_end') }} as courserun_enrollment_end_on
+        , {{ cast_timestamp_to_iso8601('announcement') }} as courserun_announce_on
+        , {{ cast_timestamp_to_iso8601('modified') }} as courserun_updated_at
+
+    from most_recent_source
+)
+
+select * from cleaned


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
https://github.com/mitodl/hq/issues/6337

### Description (What does it do?)
<!--- Describe your changes in detail -->
Creating `stg__edxorg__api__course` and `stg__edxorg__api__courserun`, the source tables are ingested from API

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

dbt build --select stg__edxorg__api__course stg__edxorg__api__courserun