### PR TITLE
Format edxorg courserun_readable_id to populate marts__combined__products

### DIFF
--- a/src/ol_dbt/models/intermediate/edxorg/_int_edxorg__models.yml
+++ b/src/ol_dbt/models/intermediate/edxorg/_int_edxorg__models.yml
@@ -897,7 +897,7 @@ models:
   description: MITx course available modes and prices on edX.org
   columns:
   - name: courserun_readable_id
-    description: str, unique identifier for the course run in {org}+{course number}+{run}
+    description: str, unique identifier for the course run in {org}/{course number}/{run}
       format.
     tests:
     - not_null
@@ -921,5 +921,3 @@ models:
   - name: credit_hours
     description: str, the number of credit hours that learners who pass the course
       earn.
-runs:
-  courserun_time_commitment:

--- a/src/ol_dbt/models/intermediate/edxorg/int__edxorg__mitx_product.sql
+++ b/src/ol_dbt/models/intermediate/edxorg/int__edxorg__mitx_product.sql
@@ -3,7 +3,7 @@ with courseruns as (
 )
 
 select
-    courseruns.courserun_readable_id
+    {{ format_course_id('courseruns.courserun_readable_id') }} as courserun_readable_id
     , cast(json_extract_scalar(t.seat, '$.price') as decimal(38, 2)) as price
     , json_extract_scalar(t.seat, '$.type') as courserun_mode
     , json_extract_scalar(t.seat, '$.currency') as currency

--- a/src/ol_dbt/models/marts/combined/_marts__combined__models.yml
+++ b/src/ol_dbt/models/marts/combined/_marts__combined__models.yml
@@ -518,6 +518,7 @@ models:
   - name: product_readable_id
     description: str, unique open edX Course ID formatted as course-v1:{org}+{course
       code}+{run_tag} or program run ID formatted as program-v1:{org}+{program code}+{run_tag}
+      for MITx Online and xPro. For edX.org, the course ID is formatted as {org}/{course}/{run_tag}.
     tests:
     - not_null
     - unique
@@ -553,7 +554,7 @@ models:
     description: timestamp, date and time when the course or program enrollment ends
   - name: upgrade_deadline
     description: timestamp, date and time beyond which the learner can not enroll
-      in paid course mode. Only populated for MITx Online courses.
+      in paid course mode. Only populated for MITx courses.
   - name: duration
     description: str, a short description indicating how long the course or program
       takes to complete (e.g. '4 weeks')
@@ -562,16 +563,16 @@ models:
       '5-7 hours per week')
   - name: certification_type
     description: str, either 'MicroMasters Credential' or 'Certificate of Completion'
-      for MITx Online courses. 'Professional Certificate' for xPro courses.
+      for MITx courses. 'Professional Certificate' for xPro courses.
     tests:
     - not_null
   - name: delivery
-    description: str, 'Online' or 'Other' for xPro. 'Online' for MITx Online.
+    description: str, 'Online' or 'Other' for xPro. 'Online' for MITx.
   - name: continuing_education_credits
     description: str, number of continuing education units or credits offered. e.g.
-      4.5. NULL for MITx Online courses.
+      4.5. NULL for MITx courses.
   - name: pace
-    description: str, 'Self-paced' or 'Instructor-paced' for MITx Online courses.
+    description: str, 'Self-paced' or 'Instructor-paced'
   - name: topics
     description: str, list of topic names for a course.
   - name: instructors


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
https://github.com/mitodl/hq/issues/6337


### Description (What does it do?)
<!--- Describe your changes in detail -->

I noticed that only some old edxorg products are populated in https://bi.ol.mit.edu/superset/dashboard/25/ due to the course IDs in different formats between the source tables. This PR is to fix that by updating courserun_readable_id format so that old and new edxorg courses are propagated to marts__combined__products


### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

dbt build --select int__edxorg__mitx_product marts__combined__products

-- around 1178 now
select count(*) from  "ol_data_lake_production"."ol_warehouse_production_X_mart"."marts__combined__products"
where platform ='edX.org'
