### PR TITLE
Update cast_date_to_iso8601 to handle date and string

### DIFF
--- a/src/ol_dbt/macros/cast_date_to_iso8601.sql
+++ b/src/ol_dbt/macros/cast_date_to_iso8601.sql
@@ -1,3 +1,9 @@
 {% macro cast_date_to_iso8601(column_name) %}
-    to_iso8601(from_iso8601_date({{ column_name }}))
+  case
+   -- If the column is already a date, convert to ISO 8601
+    when try_cast({{ column_name }} AS date) is not null
+       then to_iso8601(try_cast({{ column_name }} AS date))
+    -- otherwise, convert to ISO 8601 from a string
+    else to_iso8601(from_iso8601_date(try_cast({{ column_name }} AS varchar)))
+end
 {% endmacro %}

--- a/src/ol_dbt/macros/cast_date_to_iso8601.sql
+++ b/src/ol_dbt/macros/cast_date_to_iso8601.sql
@@ -1,9 +1,8 @@
 {% macro cast_date_to_iso8601(column_name) %}
   case
-   -- If the column is already a date, convert to ISO 8601
-    when try_cast({{ column_name }} AS date) is not null
+    when try_cast({{ column_name }} AS date) is not null -- Use try_cast to check if the column is already a date
        then to_iso8601(try_cast({{ column_name }} AS date))
-    -- otherwise, convert to ISO 8601 from a string
-    else to_iso8601(from_iso8601_date(try_cast({{ column_name }} AS varchar)))
+
+    else to_iso8601(from_iso8601_date(try_cast({{ column_name }} AS varchar))) -- Convert to ISO 8601 from a string
 end
 {% endmacro %}


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
https://github.com/mitodl/hq/issues/6787


### Description (What does it do?)
<!--- Describe your changes in detail -->

Updating cast_date_to_iso8601 to handle both date and string fields.

I've updated [MicroMasters Production App DB → S3 Data Lake](https://airbyte.odl.mit.edu/workspaces/3f0ccc59-baa3-4567-92e5-c61fb737467b/connections/537bca54-8723-49f9-b26b-8c089a823ca4) to use the new destination connector.  The only minor issue is with date conversion, as seen in the error in https://pipelines.odl.mit.edu/runs/933e89c8-86c1-4fea-b281-c21fecbecaeb. This PR addresses the issue by updating the cast_date_to_iso8601 function to handle both date and string fields

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

No error running this. The only warning is ` Warning in test dbt_expectations_expect_table_row_count_to_equal_other_table__`, which you can ignore or update the intermediate table to ensure the count matches.

dbt build --select staging.micromasters --target dev_production

