### PR TITLE
fix bug in fetch_with_auth

### DIFF
--- a/src/ol_orchestrate/resources/oauth.py
+++ b/src/ol_orchestrate/resources/oauth.py
@@ -89,6 +89,8 @@ class OAuthApiClient(ConfigurableResource):
         else:
             request_params = {}
 
+        request_params.update(**(extra_params or {}))
+
         response = self._http_client.get(
             request_url,
             headers={"Authorization": f"JWT {self._fetch_access_token()}"},


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
NA

### Description (What does it do?)
<!--- Describe your changes in detail -->
I accidentally removed `request_params.update(**(extra_params or {}))` in [this PR](https://github.com/mitodl/ol-data-platform/pull/1487/files#diff-5e6a741ebf4c26b8cb90f1fd826ea7a9e9b12fadc4444aa82f8eac81e9cd7569L101) yesterday, which caused 500 error when materilizing openedx__raw_data__course_xml for `course-v1:MITx+15.871r_8+2025_Spring`  https://pipelines.odl.mit.edu/runs/4cd13b46-83b3-44ac-859e-50b8aae6c41f


### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->
This can be tested on QA