### PR TITLE
dedup mitxonline staging models due to deleted records from source

### DIFF
--- a/src/ol_dbt/models/staging/mitxonline/_stg_mitxonline__models.yml
+++ b/src/ol_dbt/models/staging/mitxonline/_stg_mitxonline__models.yml
@@ -69,7 +69,7 @@ models:
       column_list: ["courserun_id", "user_id"]
   - dbt_utils.recency:
       datepart: day
-      field: from_iso8601_timestamp(courserunenrollment_created_on)
+      field: from_iso8601_timestamp_nanos(courserunenrollment_created_on)
       interval: 2
       config:
         severity: error

--- a/src/ol_dbt/models/staging/mitxonline/stg__mitxonline__app__postgres__ecommerce_basket.sql
+++ b/src/ol_dbt/models/staging/mitxonline/stg__mitxonline__app__postgres__ecommerce_basket.sql
@@ -4,6 +4,8 @@ with source as (
 
 )
 
+{{ deduplicate_raw_table(order_by='id' , partition_columns = 'user_id') }}
+
 , renamed as (
 
     select
@@ -12,7 +14,7 @@ with source as (
         ,{{ cast_timestamp_to_iso8601('created_on') }} as basket_created_on
         ,{{ cast_timestamp_to_iso8601('updated_on') }} as basket_updated_on
 
-    from source
+    from most_recent_source
 
 )
 

--- a/src/ol_dbt/models/staging/mitxonline/stg__mitxonline__app__postgres__flexiblepricing_currencyexchangerate.sql
+++ b/src/ol_dbt/models/staging/mitxonline/stg__mitxonline__app__postgres__flexiblepricing_currencyexchangerate.sql
@@ -5,6 +5,8 @@ with source as (
 
 )
 
+{{ deduplicate_raw_table(order_by='id' , partition_columns = 'currency_code') }}
+
 , renamed as (
 
     select
@@ -15,7 +17,7 @@ with source as (
         ,{{ cast_timestamp_to_iso8601('created_on') }} as currencyexchangerate_created_on
         ,{{ cast_timestamp_to_iso8601('updated_on') }} as currencyexchangerate_updated_on
 
-    from source
+    from most_recent_source
 
 )
 


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
https://github.com/mitodl/hq/issues/6787

### Description (What does it do?)
<!--- Describe your changes in detail -->
Addressing the failures in https://pipelines.odl.mit.edu/runs/7f4cfdb2-8f4f-4c43-816f-1e7124c08e58 due to the duplication introduced by the new Airbyte connector.
- dedup stg__mitxonline__app__postgres__ecommerce_basket by user_id to be consistent with the model design in the mitxonline application 
- dedup stg__mitxonline__app__postgres__flexiblepricing_currencyexchangerate by most recent id, as this source model is updated based on the latest rates by deleting the existing rates in the mitxonline application 

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

dbt build --select int__mitxonline__ecommerce_basket int__mitxonline__flexiblepricing_currencyexchangerate int__mitxonline__courserunenrollments

