### PR TITLE
Update emeritus staging model due to switching to new airbyte connector

### DIFF
--- a/src/ol_dbt/models/staging/mitxpro/stg__emeritus__api__bigquery__user_enrollments.sql
+++ b/src/ol_dbt/models/staging/mitxpro/stg__emeritus__api__bigquery__user_enrollments.sql
@@ -2,8 +2,10 @@ with source as (
     select * from {{ source('ol_warehouse_raw_data','raw__emeritus__bigquery__api_enrollments') }}
 )
 
-{{ deduplicate_query(cte_name1='source', cte_name2='most_recent_source'
-, partition_columns = 'batch_id, email, first_name, last_name') }}
+{{ deduplicate_raw_table(
+  order_by='opportunity_last_modified_date'
+  , partition_columns='batch_id, email, first_name, last_name'
+) }}
 
 , cleaned as (
     select


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
https://github.com/mitodl/hq/issues/6787

### Description (What does it do?)
<!--- Describe your changes in detail -->
Updating `stg__emeritus__api__bigquery__user_enrollments` due to the deprecation of `_airbyte_emitted_at` in the new Destinations V2


### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

No error running `dbt build --select stg__emeritus__api__bigquery__user_enrollments`
