### PR TITLE
Update salesforce models

### DIFF
--- a/src/ol_dbt/.dbtignore
+++ b/src/ol_dbt/.dbtignore
@@ -1,10 +1,1 @@
 # .dbtignore
-
-# ignore individual files
-int__salesforce__opportunitylineitem.sql
-int__salesforce__opportunity.sql
-stg__salesforce__opportunitylineitem.sql
-stg__salesforce__opportunity.sql
-_salesforce__sources.yml
-_stg_salesforce__models.yml
-_int_salesforce__models.yml

--- a/src/ol_dbt/models/intermediate/mitxpro/_int_mitxpro__models.yml
+++ b/src/ol_dbt/models/intermediate/mitxpro/_int_mitxpro__models.yml
@@ -321,11 +321,12 @@ models:
     description: string, readable product type
     tests:
     - not_null
-#  - name: salesforce_opportunity_id
-#    description: string, ID of Salesforce Opportunity
+  - name: salesforce_opportunity_id
+    description: string, ID of Salesforce Opportunity
   tests:
   - dbt_expectations.expect_table_row_count_to_equal_other_table:
       compare_model: ref('stg__mitxpro__app__postgres__b2becommerce_b2border')
+
 - name: int__mitxpro__b2becommerce_b2bcoupon
   description: B2B coupons are coupons that allow us to give a discount to companies
     buying bulk seats for their employees

--- a/src/ol_dbt/models/intermediate/mitxpro/int__mitxpro__b2becommerce_b2border.sql
+++ b/src/ol_dbt/models/intermediate/mitxpro/int__mitxpro__b2becommerce_b2border.sql
@@ -13,9 +13,14 @@ with b2borders as (
     from {{ ref('int__mitxpro__ecommerce_product') }}
 )
 
-/*  salesforce_opportunity = int__salesforce__opportunity
+, salesforce_opportunity as (
+    select * from {{ ref('int__salesforce__opportunity') }}
+)
 
-, couponpaymentversion = int__mitxpro__ecommerce_couponpaymentversion
+, couponpaymentversion as (
+    select *
+    from {{ ref('int__mitxpro__ecommerce_couponpaymentversion') }}
+)
 
 , salesforce_b2border as (
     select
@@ -26,7 +31,7 @@ with b2borders as (
         on b2borders.couponpaymentversion_id = couponpaymentversion.couponpaymentversion_id
     inner join salesforce_opportunity
         on b2borders.b2border_contract_number like '%' || salesforce_opportunity.opportunity_id
-)*/
+)
 
 
 select
@@ -49,8 +54,8 @@ select
     , products.courserun_id
     , products.program_id
     , products.product_type
-/*    , salesforce_b2border.opportunity_id as salesforce_opportunity_id*/
+    , salesforce_b2border.opportunity_id as salesforce_opportunity_id
 from b2borders
 inner join productversions on b2borders.productversion_id = productversions.productversion_id
 inner join products on productversions.product_id = products.product_id
-/*left join salesforce_b2border on b2borders.b2border_id = salesforce_b2border.b2border_id*/
+left join salesforce_b2border on b2borders.b2border_id = salesforce_b2border.b2border_id

--- a/src/ol_dbt/models/staging/salesforce/_salesforce__sources.yml
+++ b/src/ol_dbt/models/staging/salesforce/_salesforce__sources.yml
@@ -7,7 +7,7 @@ sources:
   database: '{{ target.database }}'
   schema: '{{ target.schema.replace(var("schema_suffix", ""), "").rstrip("_") }}_raw'
   tables:
-  - name: raw__thirdparty__salesforce__Opportunity
+  - name: raw__thirdparty__salesforce___destination_v2__Opportunity
     description: Salesforce opportunity, which is a sale or pending deal
     columns:
     - name: id
@@ -179,7 +179,7 @@ sources:
         by Airbyte connector. This field should be used internally to deduplicate
         records.
 
-  - name: raw__thirdparty__salesforce__OpportunityLineItem
+  - name: raw__thirdparty__salesforce___destination_v2__OpportunityLineItem
     description: Salesforce opportunity product line items
     columns:
     - name: id

--- a/src/ol_dbt/models/staging/salesforce/stg__salesforce__opportunity.sql
+++ b/src/ol_dbt/models/staging/salesforce/stg__salesforce__opportunity.sql
@@ -1,29 +1,12 @@
---- source table contains duplicated rows per primary key. This means there could be multiple copies of the same record,
---- thus deduplicate records here using _airbyte_emitted_at
-
 with source as (
 
     select *
-    from {{ source('ol_warehouse_raw_data', 'raw__thirdparty__salesforce__Opportunity') }}
+    from {{ source('ol_warehouse_raw_data', 'raw__thirdparty__salesforce___destination_v2__Opportunity') }}
     where isdeleted = false
 
 )
 
-, source_sorted as (
-    select
-        *
-        , row_number() over (
-            partition by id
-            order by _airbyte_emitted_at desc
-        ) as row_num
-    from source
-)
-
-, most_recent_source as (
-    select *
-    from source_sorted
-    where row_num = 1
-)
+{{ deduplicate_raw_table(order_by='systemmodstamp', partition_columns = 'id') }}
 
 , renamed as (
 

--- a/src/ol_dbt/models/staging/salesforce/stg__salesforce__opportunitylineitem.sql
+++ b/src/ol_dbt/models/staging/salesforce/stg__salesforce__opportunitylineitem.sql
@@ -1,29 +1,13 @@
---- source table contains duplicated rows per primary key. This means there could be multiple copies of the same record,
---- thus deduplicate records here using _airbyte_emitted_at
-
 with source as (
 
     select *
-    from {{ source('ol_warehouse_raw_data', 'raw__thirdparty__salesforce__OpportunityLineItem') }}
+    from {{ source('ol_warehouse_raw_data', 'raw__thirdparty__salesforce___destination_v2__OpportunityLineItem') }}
     where isdeleted = false
 
 )
 
-, source_sorted as (
-    select
-        *
-        , row_number() over (
-            partition by id
-            order by _airbyte_emitted_at desc
-        ) as row_num
-    from source
-)
+{{ deduplicate_raw_table(order_by='systemmodstamp', partition_columns = 'id') }}
 
-, most_recent_source as (
-    select *
-    from source_sorted
-    where row_num = 1
-)
 
 , renamed as (
 


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
https://github.com/mitodl/hq/issues/6787

### Description (What does it do?)
<!--- Describe your changes in detail -->
The new Airbyte connection "OL Salesforce → S3 Data Lake" is created with a new prefix table name. This PR is to update the raw table names and fix any dbt build error for the deprecated airbyte meta fields in Salesforce staging models and re-enable the disabled staging/intermediate models

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

dbt build --select +int__salesforce__opportunity +int__salesforce__opportunitylineitem int__mitxpro__b2becommerce_b2border

You can either ignore the warning dbt_expectations_expect_table_row_count_to_equal_other_table_int__mitxpro__b2becommerce_b2border since this command doesn't refresh stg__mitxpro__app__postgres__b2becommerce_b2border, or refresh +int__mitxpro__b2becommerce_b2border so the count matches
