### PR TITLE
Update dbt_automation_sensor to exclude staging adding group name to dbt assets

### DIFF
--- a/src/ol_orchestrate/assets/lakehouse/dbt.py
+++ b/src/ol_orchestrate/assets/lakehouse/dbt.py
@@ -34,6 +34,9 @@ class DbtAutomationTranslator(DagsterDbtTranslator):
     ) -> Optional[AutomationCondition]:
         return upstream_or_code_changes()
 
+    def get_group_name(self, dbt_resource_props: Mapping[str, Any]) -> Optional[str]:
+        return dbt_resource_props.get("config", {}).get("schema", None)
+
 
 @dbt_assets(
     manifest=dbt_project.manifest_path,

--- a/src/ol_orchestrate/definitions/lakehouse/elt.py
+++ b/src/ol_orchestrate/definitions/lakehouse/elt.py
@@ -81,7 +81,6 @@ airbyte_assets = load_assets_from_airbyte_instance(
     ),
 )
 
-
 # This section creates a separate job and schedule for each Airbyte connection that will
 # materialize the tables for that connection and any associated dbt staging models for
 # those tables. The eager auto materialize policy will then take effect for any
@@ -113,7 +112,6 @@ for count, group_name in enumerate(group_names, start=1):
     )
     airbyte_asset_jobs.append(job)
 
-
 elt = Definitions(
     assets=[*with_source_code_references([full_dbt_project]), airbyte_assets],
     resources={"dbt": dbt_cli},
@@ -121,7 +119,9 @@ elt = Definitions(
         AutomationConditionSensorDefinition(
             "dbt_automation_sensor",
             minimum_interval_seconds=3600,
-            target=[full_dbt_project],
+            # exclude staging as they are already handled by "sync_and_stage_" job
+            target=AssetSelection.assets(full_dbt_project)
+            - AssetSelection.groups("staging"),
         )
     ],
     jobs=airbyte_asset_jobs,


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
https://github.com/mitodl/hq/issues/6920

### Description (What does it do?)
<!--- Describe your changes in detail -->
Update `dbt_automation_sensor` to exclude dbt staging assets since they are already handled by the corresponding `sync_and_stage_*` job
Adding the appropriate group name to dbt assets, as they are currently named as 'default' in ol_orchestrate.definitions.lakehouse.elt


### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->
export GITHUB_TOKEN=
docker compose up

Go to the dagster assets UI and notice that all the dbt models have appropriate group names now instead of default

<img width="926" alt="image" src="https://github.com/user-attachments/assets/268ca261-a447-4f53-a4af-dea292bc6923" />

Go to `dbt_automation_sensor` automation UI, the target should now exclude staging

![image](https://github.com/user-attachments/assets/11271964-de8e-4a5d-9fff-c94d9332778e)
