### PR TITLE
Create a dagster pipeline for UAI partner data export

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ dependencies = [
     "polars ~= 1.19",
     "pyarrow ~=19.0.0",
     "pydantic ~= 2.10.0",
+    "pyiceberg>=0.9.0",
     "pymysql ~= 1.1",
     "s3fs (>=2025.2.0,<2026.0.0)",
     "universal-pathlib ~= 0.2.2",

--- a/src/ol_orchestrate/assets/uai_partner.py
+++ b/src/ol_orchestrate/assets/uai_partner.py
@@ -1,0 +1,101 @@
+import hashlib
+from datetime import UTC, datetime
+from pathlib import Path
+
+import boto3
+import polars as pl
+from dagster import (
+    AssetExecutionContext,
+    AssetKey,
+    ExpectationResult,
+    MetadataValue,
+    Output,
+    asset,
+)
+from dagster_dbt.asset_utils import get_asset_key_for_model
+
+from ol_orchestrate.assets.lakehouse.dbt import full_dbt_project
+from ol_orchestrate.partitions.openedx import UAI_PARTNER_PARTITIONS
+
+# Sample partner course ids
+partner_course_mapping = [
+    {"partner_id": "partner1", "course_run_id": "course-v1:TestX+Test101+3T2022"},
+    {"partner_id": "partner2", "course_run_id": "course-v1:DEMO+MLx1DEMO+DEMO"},
+]
+
+
+@asset(
+    description="It contains the learner enrollment data for a specific partner",
+    group_name="universal_ai",
+    io_manager_key="s3file_io_manager",
+    key=AssetKey(["universal_ai", "learner_enrollment"]),
+    deps=[
+        get_asset_key_for_model(
+            [full_dbt_project], "marts__combined_course_enrollment_detail"
+        )
+    ],
+    partitions_def=UAI_PARTNER_PARTITIONS,
+)
+def learner_enrollment_data(context: AssetExecutionContext):
+    partner_id = context.partition_key
+
+    partner_course_runs = [
+        entry["course_run_id"]
+        for entry in partner_course_mapping
+        if entry["partner_id"] == partner_id
+    ]
+
+    glue = boto3.client("glue")
+    response = glue.get_table(
+        DatabaseName="ol_warehouse_production_mart",
+        Name="marts__combined_course_enrollment_detail",
+    )
+    table_metadata = response["Table"]
+    storage_descriptor = table_metadata["StorageDescriptor"]
+    iceberg_table_location = storage_descriptor.get("Location", None)
+    metadata_location = table_metadata["Parameters"]["metadata_location"]
+
+    if iceberg_table_location:
+        df = pl.scan_iceberg(metadata_location).collect()
+        partner_data_df = df.filter(
+            pl.col("courserun_readable_id").is_in(partner_course_runs)
+        )
+        num_rows = len(partner_data_df)
+        context.log.info("%d rows for %s's enrollment data", num_rows, partner_id)
+
+        # Export the filtered data to a CSV file
+        enrollment_data_file = Path(f"{partner_id}_enrollment_data.csv")
+        partner_data_df.write_csv(enrollment_data_file)
+
+        context.log.info(
+            "Exported %s's enrollment data to %s", partner_id, enrollment_data_file
+        )
+
+        enrollment_data_version = hashlib.sha256(
+            partner_data_df.write_csv().encode("utf-8")
+        ).hexdigest()
+
+        enrollment_data_object_key = (
+            f"/universal_ai/{partner_id}/enrollment_data_{datetime.now(tz=UTC).strftime('%Y-%m-%d')}_"
+            f"{enrollment_data_version}.csv"
+        )
+
+        yield ExpectationResult(
+            success=not partner_data_df.is_empty(),
+            label="learner_enrollment_data_not_empty",
+            metadata={
+                "number_of_enrollments": MetadataValue.text(
+                    text=str(partner_data_df.height)
+                )
+            },
+        )
+        yield Output(
+            (enrollment_data_file, enrollment_data_object_key),
+            metadata={
+                "partner_id": partner_id,
+                "object_key": enrollment_data_object_key,
+                "rows": num_rows,
+                "file_size_in_bytes": enrollment_data_file.stat().st_size,
+                "materialization_time": datetime.now(tz=UTC).isoformat(),
+            },
+        )

--- a/src/ol_orchestrate/definitions/uai_partner/export_learner_data.py
+++ b/src/ol_orchestrate/definitions/uai_partner/export_learner_data.py
@@ -1,0 +1,24 @@
+from dagster import (
+    Definitions,
+)
+
+from ol_orchestrate.assets.uai_partner import learner_enrollment_data
+from ol_orchestrate.io_managers.filepath import S3FileObjectIOManager
+from ol_orchestrate.lib.constants import DAGSTER_ENV, VAULT_ADDRESS
+from ol_orchestrate.lib.dagster_helpers import default_io_manager
+from ol_orchestrate.lib.utils import authenticate_vault, s3_uploads_bucket
+from ol_orchestrate.sensors.openedx import uai_partner_sensor
+
+vault = authenticate_vault(DAGSTER_ENV, VAULT_ADDRESS)
+
+partner_data_export = Definitions(
+    assets=[learner_enrollment_data],
+    sensors=[uai_partner_sensor],
+    resources={
+        "io_manager": default_io_manager(DAGSTER_ENV),
+        "s3file_io_manager": S3FileObjectIOManager(
+            bucket=s3_uploads_bucket(DAGSTER_ENV)["bucket"],
+            path_prefix=s3_uploads_bucket(DAGSTER_ENV)["prefix"],
+        ),
+    },
+)

--- a/src/ol_orchestrate/partitions/openedx.py
+++ b/src/ol_orchestrate/partitions/openedx.py
@@ -10,3 +10,5 @@ OPENEDX_COURSE_RUN_PARTITIONS = {
     deployment: DynamicPartitionsDefinition(name=f"{deployment}_openedx_course_run")
     for deployment in OPENEDX_DEPLOYMENTS
 }
+
+UAI_PARTNER_PARTITIONS = DynamicPartitionsDefinition(name="uai_partners")

--- a/src/ol_orchestrate/sensors/openedx.py
+++ b/src/ol_orchestrate/sensors/openedx.py
@@ -4,6 +4,7 @@ from datetime import UTC, datetime, timedelta
 import httpx
 from dagster import (
     AssetKey,
+    DefaultSensorStatus,
     RunRequest,
     SensorEvaluationContext,
     SensorResult,
@@ -15,6 +16,7 @@ from ol_orchestrate.lib.dagster_helpers import contains_invalid_partition_string
 from ol_orchestrate.lib.magic_numbers import HTTP_NOT_FOUND
 from ol_orchestrate.partitions.openedx import (
     OPENEDX_COURSE_RUN_PARTITIONS,
+    UAI_PARTNER_PARTITIONS,
 )
 from ol_orchestrate.resources.openedx import OpenEdxApiClientFactory
 
@@ -130,3 +132,19 @@ def course_version_sensor(
 
     context.update_cursor(json.dumps(cursor))
     return SensorResult(run_requests=run_requests)
+
+
+@sensor(
+    name="uai_partner_sensor",
+    description="Query a list of Universal AI partners",
+    default_status=DefaultSensorStatus.STOPPED,
+    minimum_interval_seconds=60 * 60 * 24,  # daily
+)
+def uai_partner_sensor():
+    # Simulate fetching the partners from a table or API
+    partners = ["partner1", "partner2"]
+    return SensorResult(
+        dynamic_partitions_requests=[
+            UAI_PARTNER_PARTITIONS.build_add_request(partition_keys=partners)
+        ],
+    )

--- a/src/ol_orchestrate/workspace.yaml
+++ b/src/ol_orchestrate/workspace.yaml
@@ -5,6 +5,7 @@ load_from:
 - python_module: ol_orchestrate.definitions.edx.retrieve_edxorg_raw_data
 - python_module: ol_orchestrate.definitions.edx.sync_program_credential_reports
 - python_module: ol_orchestrate.definitions.learning_resource.extract_api_data
+- python_module: ol_orchestrate.definitions.uai_partner.export_learner_data
 - python_module: ol_orchestrate.definitions.lakehouse.elt
 - python_module: ol_orchestrate.definitions.platform.notification
 - python_module: ol_orchestrate.repositories.edx_gcs_courses

--- a/uv.lock
+++ b/uv.lock
@@ -1437,6 +1437,30 @@ wheels = [
 ]
 
 [[package]]
+name = "mmh3"
+version = "5.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/47/1b/1fc6888c74cbd8abad1292dde2ddfcf8fc059e114c97dd6bf16d12f36293/mmh3-5.1.0.tar.gz", hash = "sha256:136e1e670500f177f49ec106a4ebf0adf20d18d96990cc36ea492c651d2b406c", size = 33728 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/47/e5f452bdf16028bfd2edb4e2e35d0441e4a4740f30e68ccd4cfd2fb2c57e/mmh3-5.1.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:45712987367cb9235026e3cbf4334670522a97751abfd00b5bc8bfa022c3311d", size = 56152 },
+    { url = "https://files.pythonhosted.org/packages/60/38/2132d537dc7a7fdd8d2e98df90186c7fcdbd3f14f95502a24ba443c92245/mmh3-5.1.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:b1020735eb35086ab24affbea59bb9082f7f6a0ad517cb89f0fc14f16cea4dae", size = 40564 },
+    { url = "https://files.pythonhosted.org/packages/c0/2a/c52cf000581bfb8d94794f58865658e7accf2fa2e90789269d4ae9560b16/mmh3-5.1.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:babf2a78ce5513d120c358722a2e3aa7762d6071cd10cede026f8b32452be322", size = 40104 },
+    { url = "https://files.pythonhosted.org/packages/83/33/30d163ce538c54fc98258db5621447e3ab208d133cece5d2577cf913e708/mmh3-5.1.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d4f47f58cd5cbef968c84a7c1ddc192fef0a36b48b0b8a3cb67354531aa33b00", size = 102634 },
+    { url = "https://files.pythonhosted.org/packages/94/5c/5a18acb6ecc6852be2d215c3d811aa61d7e425ab6596be940877355d7f3e/mmh3-5.1.0-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:2044a601c113c981f2c1e14fa33adc9b826c9017034fe193e9eb49a6882dbb06", size = 108888 },
+    { url = "https://files.pythonhosted.org/packages/1f/f6/11c556324c64a92aa12f28e221a727b6e082e426dc502e81f77056f6fc98/mmh3-5.1.0-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:c94d999c9f2eb2da44d7c2826d3fbffdbbbbcde8488d353fee7c848ecc42b968", size = 106968 },
+    { url = "https://files.pythonhosted.org/packages/5d/61/ca0c196a685aba7808a5c00246f17b988a9c4f55c594ee0a02c273e404f3/mmh3-5.1.0-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:a015dcb24fa0c7a78f88e9419ac74f5001c1ed6a92e70fd1803f74afb26a4c83", size = 93771 },
+    { url = "https://files.pythonhosted.org/packages/b4/55/0927c33528710085ee77b808d85bbbafdb91a1db7c8eaa89cac16d6c513e/mmh3-5.1.0-cp312-cp312-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:457da019c491a2d20e2022c7d4ce723675e4c081d9efc3b4d8b9f28a5ea789bd", size = 101726 },
+    { url = "https://files.pythonhosted.org/packages/49/39/a92c60329fa470f41c18614a93c6cd88821412a12ee78c71c3f77e1cfc2d/mmh3-5.1.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:71408579a570193a4ac9c77344d68ddefa440b00468a0b566dcc2ba282a9c559", size = 98523 },
+    { url = "https://files.pythonhosted.org/packages/81/90/26adb15345af8d9cf433ae1b6adcf12e0a4cad1e692de4fa9f8e8536c5ae/mmh3-5.1.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:8b3a04bc214a6e16c81f02f855e285c6df274a2084787eeafaa45f2fbdef1b63", size = 96628 },
+    { url = "https://files.pythonhosted.org/packages/8a/4d/340d1e340df972a13fd4ec84c787367f425371720a1044220869c82364e9/mmh3-5.1.0-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:832dae26a35514f6d3c1e267fa48e8de3c7b978afdafa0529c808ad72e13ada3", size = 105190 },
+    { url = "https://files.pythonhosted.org/packages/d3/7c/65047d1cccd3782d809936db446430fc7758bda9def5b0979887e08302a2/mmh3-5.1.0-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:bf658a61fc92ef8a48945ebb1076ef4ad74269e353fffcb642dfa0890b13673b", size = 98439 },
+    { url = "https://files.pythonhosted.org/packages/72/d2/3c259d43097c30f062050f7e861075099404e8886b5d4dd3cebf180d6e02/mmh3-5.1.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:3313577453582b03383731b66447cdcdd28a68f78df28f10d275d7d19010c1df", size = 97780 },
+    { url = "https://files.pythonhosted.org/packages/29/29/831ea8d4abe96cdb3e28b79eab49cac7f04f9c6b6e36bfc686197ddba09d/mmh3-5.1.0-cp312-cp312-win32.whl", hash = "sha256:1d6508504c531ab86c4424b5a5ff07c1132d063863339cf92f6657ff7a580f76", size = 40835 },
+    { url = "https://files.pythonhosted.org/packages/12/dd/7cbc30153b73f08eeac43804c1dbc770538a01979b4094edbe1a4b8eb551/mmh3-5.1.0-cp312-cp312-win_amd64.whl", hash = "sha256:aa75981fcdf3f21759d94f2c81b6a6e04a49dfbcdad88b152ba49b8e20544776", size = 41509 },
+    { url = "https://files.pythonhosted.org/packages/80/9d/627375bab4c90dd066093fc2c9a26b86f87e26d980dbf71667b44cbee3eb/mmh3-5.1.0-cp312-cp312-win_arm64.whl", hash = "sha256:a4c1a76808dfea47f7407a0b07aaff9087447ef6280716fd0783409b3088bb3c", size = 38888 },
+]
+
+[[package]]
 name = "more-itertools"
 version = "10.6.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1603,6 +1627,7 @@ dependencies = [
     { name = "polars" },
     { name = "pyarrow" },
     { name = "pydantic" },
+    { name = "pyiceberg" },
     { name = "pymysql" },
     { name = "pypika" },
     { name = "s3fs" },
@@ -1642,6 +1667,7 @@ requires-dist = [
     { name = "polars", specifier = "~=1.19" },
     { name = "pyarrow", specifier = "~=19.0.0" },
     { name = "pydantic", specifier = "~=2.10.0" },
+    { name = "pyiceberg", specifier = ">=0.9.0" },
     { name = "pymysql", specifier = "~=1.1" },
     { name = "pypika", specifier = "~=0.48.9" },
     { name = "s3fs", specifier = ">=2025.2.0,<2026.0.0" },
@@ -1956,6 +1982,32 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/7c/2d/c3338d48ea6cc0feb8446d8e6937e1408088a72a39937982cc6111d17f84/pygments-2.19.1.tar.gz", hash = "sha256:61c16d2a8576dc0649d9f39e089b5f02bcd27fba10d8fb4dcc28173f7a45151f", size = 4968581 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/8a/0b/9fcc47d19c48b59121088dd6da2488a49d5f72dacf8262e2790a1d2c7d15/pygments-2.19.1-py3-none-any.whl", hash = "sha256:9ea1544ad55cecf4b8242fab6dd35a93bbce657034b0611ee383099054ab6d8c", size = 1225293 },
+]
+
+[[package]]
+name = "pyiceberg"
+version = "0.9.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cachetools" },
+    { name = "click" },
+    { name = "fsspec" },
+    { name = "mmh3" },
+    { name = "pydantic" },
+    { name = "pyparsing" },
+    { name = "requests" },
+    { name = "rich" },
+    { name = "sortedcontainers" },
+    { name = "strictyaml" },
+    { name = "tenacity" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/55/35/1c67977f26eea825104d18fc3f0e01b14e15de41fe9c0d06e5bb501c4be8/pyiceberg-0.9.0.tar.gz", hash = "sha256:70d255903dda31ed1f7753d41fec0c031aae36ef95e8a824cdae7df593439d8b", size = 611994 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d0/af/5dc5f2aaa65e3508c7eab7a1fafb8d481af9574e8dd1c37a07c57ec5717c/pyiceberg-0.9.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:6b868726045ccc013a723130aaa7cf2f2ddeae359930b0c54de8bc29f7103326", size = 604132 },
+    { url = "https://files.pythonhosted.org/packages/8c/24/64706626f6e538bdbb412d7efc5afc767c5523480e5fb107bb4b1b75ffcc/pyiceberg-0.9.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:785b5ee8d00b1f38c8643f9c1ca22f2dd034cf9610804972fddfc6ac97ced002", size = 595703 },
+    { url = "https://files.pythonhosted.org/packages/a7/06/e8d4d667a7e1e9fa8c16ef926a2089672959d5fa3be8dd4dacb6cefe26f8/pyiceberg-0.9.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d6630cac07feb5894c2311be5ca62ffa3432803878fb112ae47c1d3edbd08609", size = 1275772 },
+    { url = "https://files.pythonhosted.org/packages/e1/31/b5609e727ea6137b27bb8e0559cbab33a9fac4d56dc1e5799c492a962116/pyiceberg-0.9.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:ac640aa29f57b2cb282f9a25427b73373d6fb54e82a589e8cc616f90e6f5e5b7", size = 1267452 },
+    { url = "https://files.pythonhosted.org/packages/fa/73/211fd2460b894c1b3413e832069168d07f273abdaf2834170ea0035b53f9/pyiceberg-0.9.0-cp312-cp312-win_amd64.whl", hash = "sha256:c13328f6b5bd5210e845e6a69977b38f2d0272ed431d27c825c587b6d7999b5e", size = 593838 },
 ]
 
 [[package]]
@@ -2317,6 +2369,15 @@ wheels = [
 ]
 
 [[package]]
+name = "sortedcontainers"
+version = "2.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e8/c4/ba2f8066cceb6f23394729afe52f3bf7adec04bf9ed2c820b39e19299111/sortedcontainers-2.4.0.tar.gz", hash = "sha256:25caa5a06cc30b6b83d11423433f65d1f9d76c4c6a0c90e3379eaa43b9bfdb88", size = 30594 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/32/46/9cb0e58b2deb7f82b84065f37f3bffeb12413f947f9388e4cac22c4621ce/sortedcontainers-2.4.0-py2.py3-none-any.whl", hash = "sha256:a163dcaede0f1c021485e957a39245190e74249897e2ae4b2aa38595db237ee0", size = 29575 },
+]
+
+[[package]]
 name = "sqlalchemy"
 version = "2.0.39"
 source = { registry = "https://pypi.org/simple" }
@@ -2414,6 +2475,18 @@ wheels = [
 ]
 
 [[package]]
+name = "strictyaml"
+version = "1.7.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "python-dateutil" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b3/08/efd28d49162ce89c2ad61a88bd80e11fb77bc9f6c145402589112d38f8af/strictyaml-1.7.3.tar.gz", hash = "sha256:22f854a5fcab42b5ddba8030a0e4be51ca89af0267961c8d6cfa86395586c407", size = 115206 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/96/7c/a81ef5ef10978dd073a854e0fa93b5d8021d0594b639cc8f6453c3c78a1d/strictyaml-1.7.3-py3-none-any.whl", hash = "sha256:fb5c8a4edb43bebb765959e420f9b3978d7f1af88c80606c03fb420888f5d1c7", size = 123917 },
+]
+
+[[package]]
 name = "structlog"
 version = "25.2.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2438,6 +2511,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/1a/df/4f2cd7eaa6d41a7994d46527349569d46e34d9cdd07590b5c5b0dcf53de3/tblib-3.0.0.tar.gz", hash = "sha256:93622790a0a29e04f0346458face1e144dc4d32f493714c6c3dff82a4adb77e6", size = 30616 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/9b/87/ce70db7cae60e67851eb94e1a2127d4abb573d3866d2efd302ceb0d4d2a5/tblib-3.0.0-py3-none-any.whl", hash = "sha256:80a6c77e59b55e83911e1e607c649836a69c103963c5f28a46cbeef44acf8129", size = 12478 },
+]
+
+[[package]]
+name = "tenacity"
+version = "9.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/cd/94/91fccdb4b8110642462e653d5dcb27e7b674742ad68efd146367da7bdb10/tenacity-9.0.0.tar.gz", hash = "sha256:807f37ca97d62aa361264d497b0e31e92b8027044942bfa756160d908320d73b", size = 47421 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b6/cb/b86984bed139586d01532a587464b5805f12e397594f19f931c4c2fbfa61/tenacity-9.0.0-py3-none-any.whl", hash = "sha256:93de0c98785b27fcf659856aa9f54bfbd399e29969b0621bc7f762bd441b4539", size = 28169 },
 ]
 
 [[package]]


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
https://github.com/mitodl/hq/issues/6906

### Description (What does it do?)
<!--- Describe your changes in detail -->
Creating a Dagster definition to export enrollment data for each partner to a CSV file, ensuring that each partner only receives their own enrollment data.
   - It uses the `marts__combined_course_enrollment_detail` table for the export
  -  sample data used: course-v1:TestX+Test101+3T2022 for partner1, course-v1:DEMO+MLx1DEMO+DEMO for partner2

The export is in our S3 bucket in this PR. A separate PR will be created to automate the creation of S3 buckets and move the partner data there.

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

export GITHUB_TOKEN=
docker compose up

Go to http://127.0.0.1:3000/assets/universal_ai/learner_enrollment?view=partitions
Materialize `partner1` and `partner2`

![image](https://github.com/user-attachments/assets/97326bdc-9bc0-4d58-816a-eb79ec7fa5bf)


The exports are in s3://ol-devops-sandbox/pipeline-storage/universal_ai/partner1/
