### PR TITLE
Addressing duckdb CatalogException

### DIFF
--- a/src/ol_orchestrate/assets/edxorg_archive.py
+++ b/src/ol_orchestrate/assets/edxorg_archive.py
@@ -533,7 +533,7 @@ def normalize_edxorg_tracking_log(
             """  # noqa: S608
         )
         col_names = conn.execute(
-            """SELECT column_name FROM temp.information_schema.columns
+            """SELECT column_name FROM information_schema.columns
             WHERE table_name = 'tracking_logs'
             """
         ).fetchall()


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/ol-data-platform/issues/1460
[Dagster Asset Job Failure for edxorg__raw_data__tracking_logs](https://mitodl.slack.com/archives/C08GCS95HB5/p1743606935727869)

### Description (What does it do?)
The Dagster pipeline [failure traceback](https://pipelines.odl.mit.edu/runs/4a6549f8-63f5-4f13-9687-fe8d09a4581d) indicates that we may be referencing the information_schema incorrectly:
`duckdb.duckdb.CatalogException: Catalog Error: Table with name columns does not exist!
Did you mean "information_schema.columns"?

LINE 1: SELECT column_name FROM temp.information_schema.columns`

It would be good measure to connect to one of our QA Dagster instances when that pipeline is running so we can see the actual schema and table names being used by duckdb.

### How can this be tested?
Get the Dagster pipelines running locally:
```
export GITHUB_TOKEN=<your_github_token>
docker compose up
```
Some additional troubleshooting is required to get the tracking log pipeline code location running locally. All other code locations are loading successfully except for retrieve_edxorg_raw_data.
`Exception: gRPC server exited with return code -4 while starting up with the command:...`
