### PR TITLE
minor change to afact video engagement table

### DIFF
--- a/src/ol_dbt/models/dimensional/afact_video_engagement.sql
+++ b/src/ol_dbt/models/dimensional/afact_video_engagement.sql
@@ -22,8 +22,7 @@ with course_content as (
         , f.block_title as section_title
         , f.content_block_pk as section_content_fk
         , replace(json_query(a.useractivity_event_object, 'lax $.id'), '"', '') as video_id
-        , coalesce(cast(json_query(a.useractivity_event_object, 'lax $.currentTime') as decimal(30, 10)), 0
-        ) as currenttime
+        , try_cast(json_query(a.useractivity_event_object, 'lax $.currentTime') as decimal(30, 10)) as currenttime
     from video_events as a
     left join course_content as b
         on


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/ol-data-platform/issues/1515

### Description (What does it do?)
in some rare cases the time watched wasn't calculating correctly this is to fix that
- afact_video_engagement


### How can this be tested?
```
dbt build --select afact_video_engagement
```