### PR TITLE
fix number correct metric on problem afact table

### DIFF
--- a/src/ol_dbt/models/dimensional/afact_problem_engagement.sql
+++ b/src/ol_dbt/models/dimensional/afact_problem_engagement.sql
@@ -19,12 +19,12 @@ with problem_structure as (
         , cast(attempt as int) as attempt
         , event_timestamp
         , success
-        , row_number() 
-            over 
+        , row_number()
+            over
             (
-                partition by platform, openedx_user_id, courserun_readable_id, problem_block_fk, attempt 
+                partition by platform, openedx_user_id, courserun_readable_id, problem_block_fk, attempt
                 order by event_timestamp desc
-            ) 
+            )
         as rn
     from {{ ref('tfact_problem_events') }}
     where event_type = 'problem_check'


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/ol-data-platform/issues/1515

### Description (What does it do?)
Fixes the number of correct attempts metric on the afact_problem_engagement table


### How can this be tested?
```
dbt build --select afact_problem_engagement
```