### PR TITLE
add product readable id to all coupons mart

### DIFF
--- a/src/ol_dbt/models/marts/mitxpro/_marts__mitxpro__models.yml
+++ b/src/ol_dbt/models/marts/mitxpro/_marts__mitxpro__models.yml
@@ -127,10 +127,12 @@ models:
     description: int, count of coupons used by coupon payment name
   - name: product_readable_id
     description: string, the product identifier either referring to courserun_readable_id,
-      programrun_readable_id, or program_readable_id. Might be null for unredeemed coupons.
+      programrun_readable_id, or program_readable_id. Might be null for unredeemed
+      coupons.
   - name: redeemed
     description: boolean, set to true if the coupon has at least one redeemed order
       otherwise it's false.
   tests:
   - dbt_expectations.expect_compound_columns_to_be_unique:
-      column_list: ["b2bcoupon_id", "coupon_id", "couponpaymentversion_id", "b2border_contract_number", "product_readable_id"]
+      column_list: ["b2bcoupon_id", "coupon_id", "couponpaymentversion_id", "b2border_contract_number",
+        "product_readable_id"]

--- a/src/ol_dbt/models/marts/mitxpro/marts__mitxpro_all_coupons.sql
+++ b/src/ol_dbt/models/marts/mitxpro/marts__mitxpro_all_coupons.sql
@@ -70,7 +70,7 @@ with allcoupons as (
 )
 
 , pull_product_regular as (
-    select 
+    select
         allorders.coupon_id
         , ecommerce_couponpaymentversion.couponpaymentversion_id
         , coalesce(
@@ -84,12 +84,12 @@ with allcoupons as (
     left join mitxpro__programruns
         on ecommerce_line.programrun_id = mitxpro__programruns.programrun_id
     left join ecommerce_couponpaymentversion
-        on 
-            allorders.couponpaymentversion_payment_transaction 
+        on
+            allorders.couponpaymentversion_payment_transaction
             = ecommerce_couponpaymentversion.couponpaymentversion_payment_transaction
-    where 
+    where
         allorders.order_id is not null
-        and allorders.coupon_id is not null 
+        and allorders.coupon_id is not null
     group by
         allorders.coupon_id
         , ecommerce_couponpaymentversion.couponpaymentversion_id
@@ -101,7 +101,7 @@ with allcoupons as (
 )
 
 , pull_product_b2b as (
-    select 
+    select
         allorders.b2bcoupon_id
         , allorders.b2border_contract_number
         , coalesce(
@@ -114,10 +114,10 @@ with allcoupons as (
         on allorders.line_id = ecommerce_line.line_id
     left join mitxpro__programruns
         on ecommerce_line.programrun_id = mitxpro__programruns.programrun_id
-    where 
+    where
         allorders.order_id is not null
         and allorders.b2bcoupon_id is not null
-    group by 
+    group by
         allorders.b2bcoupon_id
         , allorders.b2border_contract_number
         , coalesce(
@@ -177,7 +177,7 @@ left join ecommerce_company
 left join coupons_used_by_name
     on ecommerce_couponpaymentversion.couponpayment_name = coupons_used_by_name.couponpayment_name
 left join pull_product_regular
-    on 
+    on
         allcoupons.coupon_id = pull_product_regular.coupon_id
         and ecommerce_couponpaymentversion.couponpaymentversion_id = pull_product_regular.couponpaymentversion_id
 left join pull_product_b2b


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/6997

### Description (What does it do?)
adds the product readable id field to all coupons mart table

### How can this be tested?
dbt build --select marts__mitxpro_all_coupons