### PR TITLE
Add xPro, Residential, and edXorg users to dim_user

### DIFF
--- a/src/ol_dbt/models/dimensional/_dim__models.yml
+++ b/src/ol_dbt/models/dimensional/_dim__models.yml
@@ -240,6 +240,20 @@ models:
     description: string, user id on MITxOnline application
   - name: user_mitxonline_username
     description: string, username on MITxOnline
+  - name: mitxpro_openedx_user_id
+    description: int, openedx user id for MITx Pro
+  - name: mitxpro_application_user_id
+    description: string, user id on MITx Pro application
+  - name: user_mitxpro_username
+    description: string, username on MITx Pro
+  - name: residential_openedx_user_id
+    description: int, openedx user id for MITx Residential
+  - name: user_residential_username
+    description: string, username on MITx Residential
+  - name: edxorg_openedx_user_id
+    description: int, openedx user id for edX.org
+  - name: user_edxorg_username
+    description: string, username on edX.org
   - name: email
     description: string, user email on the corresponding platform including xpro,
       bootcamps, edX.org, MITx Online, and Residential MITx.

--- a/src/ol_dbt/models/dimensional/_dim__models.yml
+++ b/src/ol_dbt/models/dimensional/_dim__models.yml
@@ -226,8 +226,7 @@ models:
 - name: dim_user
   description: Eventually a dimensional model for users from different platforms.
     It will contain one record for a user that's potentially a part of different platforms
-    where we are able to see they are the same person. It currently only contains
-    mitxonline data though.
+    where we are able to see they are the same person.
   columns:
   - name: user_pk
     description: string, primary key for this user dim table

--- a/src/ol_dbt/models/dimensional/_dim__models.yml
+++ b/src/ol_dbt/models/dimensional/_dim__models.yml
@@ -276,11 +276,22 @@ models:
     description: str, user's job title
   - name: industry
     description: str, user's job industry
-  - name: user_is_active
-    description: boolean, indicating if user's account is active on the corresponding
-      platform including xpro, bootcamps, edX.org, MITx Online, and Residential MITx.
-  - name: user_joined_on
-    description: str, when the user joined on
+  - name: user_is_active_on_mitxonline
+    description: boolean, indicating if user's account is active on MITx Online.
+  - name: user_is_active_on_edxorg
+    description: boolean, indicating if user's account is active on edX.org.
+  - name: user_is_active_on_mitxpro
+    description: boolean, indicating if user's account is active on MITx Pro.
+  - name: user_is_active_on_residential
+    description: boolean, indicating if user's account is active on Residential MITx.
+  - name: user_joined_on_mitxonline
+    description: str, when the user joined on MITx Online.
+  - name: user_joined_on_edxorg
+    description: str, when the user joined on edX.org.
+  - name: user_joined_on_mitxpro
+    description: str, when the user joined on MITx Pro.
+  - name: user_joined_on_residential
+    description: str, when the user joined on Residential MITx.
 
 - name: tfact_course_navigation_events
   description: Transactional fact table for learner navigation events in a course

--- a/src/ol_dbt/models/dimensional/dim_user.sql
+++ b/src/ol_dbt/models/dimensional/dim_user.sql
@@ -1,12 +1,13 @@
 -- MITx users from MITx Online and edX with dedup
 -- For users exist on both MITx Online and edX.org
-with mitxonline_user_view as (
+with mitx_users as (
     select
         user_mitxonline_id as mitxonline_application_user_id
         , user_mitxonline_username
         , user_edxorg_id as edxorg_openedx_user_id
         , user_edxorg_username
-        , user_mitxonline_email as email
+        , user_mitxonline_email
+        , user_edxorg_email
         , user_full_name as full_name
         , user_address_country as address_country
         , user_highest_education as highest_education
@@ -136,55 +137,58 @@ with mitxonline_user_view as (
 
 , combined_users as (
     select
-        {{ dbt_utils.generate_surrogate_key(['mitxonline_user_view.user_email']) }} as user_pk
-        , mitxonline_openedx_users.openedx_user_id as mitxonline_openedx_user_id
-        , mitxonline_user_view.mitxonline_application_user_id
-        , mitxonline_user_view.user_mitxonline_username
-        , cast(null as bigint) as mitxpro_openedx_user_id
-        , cast(null as bigint) as mitxpro_application_user_id
-        , cast(null as varchar) as user_mitxpro_username
-        , cast(null as bigint) as residential_openedx_user_id
-        , cast(null as varchar) as user_residential_username
-        , mitxonline_user_view.edxorg_openedx_user_id
-        , mitxonline_user_view.user_edxorg_username
-        , mitxonline_user_view.user_email as email
-        , mitxonline_user_view.full_name
-        , mitxonline_user_view.address_country
-        , mitxonline_user_view.highest_education
-        , mitxonline_user_view.gender
-        , mitxonline_user_view.birth_year
-        , mitxonline_user_view.company
-        , mitxonline_user_view.job_title
-        , mitxonline_user_view.industry
-        , mitxonline_user_view.user_is_active_on_mitxonline
-        , mitxonline_user_view.user_joined_on_mitxonline
-        , mitxonline_user_view.user_is_active_on_edxorg
-        , mitxonline_user_view.user_joined_on_edxorg
-        , cast(null as boolean) as user_is_active_on_mitxpro
-        , cast(null as varchar) as user_joined_on_mitxpro
-        , cast(null as boolean) as user_is_active_on_residential
-        , cast(null as varchar) as user_joined_on_residential
-    from mitxonline_user_view
-    left join mitxonline_openedx_users
-        on (
-            mitxonline_user_view.user_mitxonline_username = mitxonline_openedx_users.user_username
-            or mitxonline_user_view.user_email = mitxonline_openedx_users.user_email
-        )
+        {{ dbt_utils.generate_surrogate_key(['mitx_users.user_email']) }} as user_pk
+        , coalesce(
+            openedx_users_username.openedx_user_id, openedx_users_email.openedx_user_id
+        ) as mitxonline_openedx_user_id
+        , mitx_users.mitxonline_application_user_id
+        , mitx_users.user_mitxonline_username
+        , null as mitxpro_openedx_user_id
+        , null as mitxpro_application_user_id
+        , null as user_mitxpro_username
+        , null as residential_openedx_user_id
+        , null as user_residential_username
+        , mitx_users.edxorg_openedx_user_id
+        , mitx_users.user_edxorg_username
+        , mitx_users.user_email as email
+        , mitx_users.full_name
+        , mitx_users.address_country
+        , mitx_users.highest_education
+        , mitx_users.gender
+        , mitx_users.birth_year
+        , mitx_users.company
+        , mitx_users.job_title
+        , mitx_users.industry
+        , mitx_users.user_is_active_on_mitxonline
+        , mitx_users.user_joined_on_mitxonline
+        , mitx_users.user_is_active_on_edxorg
+        , mitx_users.user_joined_on_edxorg
+        , null as user_is_active_on_mitxpro
+        , null as user_joined_on_mitxpro
+        , null as user_is_active_on_residential
+        , null as user_joined_on_residential
+    from mitx_users
+    left join mitxonline_openedx_users as openedx_users_username
+        on mitx_users.user_mitxonline_username = openedx_users_username.user_username
+    left join mitxonline_openedx_users as openedx_users_email
+        on mitx_users.user_email = openedx_users_email.user_email
 
     union all
 
     select
         {{ dbt_utils.generate_surrogate_key(['mitxpro_user_view.user_email']) }} as user_pk
-        , cast(null as bigint) as mitxonline_openedx_user_id
-        , cast(null as bigint) as mitxonline_application_user_id
-        , cast(null as varchar) as user_mitxonline_username
-        , mitxpro_openedx_users.openedx_user_id as mitxpro_openedx_user_id
+        , null as mitxonline_openedx_user_id
+        , null as mitxonline_application_user_id
+        , null as user_mitxonline_username
+        , coalesce(
+            openedx_users_username.openedx_user_id, openedx_users_email.openedx_user_id
+        ) as mitxpro_openedx_user_id
         , mitxpro_user_view.user_id as mitxpro_application_user_id
         , mitxpro_user_view.user_username as user_mitxpro_username
-        , cast(null as bigint) as residential_openedx_user_id
-        , cast(null as varchar) as user_residential_username
-        , cast(null as bigint) as edxorg_openedx_user_id
-        , cast(null as varchar) as user_edxorg_username
+        , null as residential_openedx_user_id
+        , null as user_residential_username
+        , null as edxorg_openedx_user_id
+        , null as user_edxorg_username
         , mitxpro_user_view.user_email as email
         , mitxpro_user_view.user_full_name as full_name
         , mitxpro_user_view.user_address_country as address_country
@@ -194,50 +198,49 @@ with mitxonline_user_view as (
         , mitxpro_user_view.user_company as company
         , mitxpro_user_view.user_job_title as job_title
         , mitxpro_user_view.user_industry as industry
-        , cast(null as boolean) as user_is_active_on_mitxonline
-        , cast(null as varchar) as user_joined_on_mitxonline
-        , cast(null as boolean) as user_is_active_on_edxorg
-        , cast(null as varchar) as user_joined_on_edxorg
+        , null as user_is_active_on_mitxonline
+        , null as user_joined_on_mitxonline
+        , null as user_is_active_on_edxorg
+        , null as user_joined_on_edxorg
         , mitxpro_user_view.user_is_active as user_is_active_on_mitxpro
         , mitxpro_user_view.user_joined_on as user_joined_on_mitxpro
-        , cast(null as boolean) as user_is_active_on_residential
-        , cast(null as varchar) as user_joined_on_residential
+        , null as user_is_active_on_residential
+        , null as user_joined_on_residential
     from mitxpro_user_view
-    left join mitxpro_openedx_users
-        on (
-            mitxpro_user_view.user_username = mitxpro_openedx_users.user_username
-            or mitxpro_user_view.user_email = mitxpro_openedx_users.user_email
-        )
+    left join mitxpro_openedx_users as openedx_users_username
+        on mitxpro_user_view.user_username = openedx_users_username.user_username
+    left join mitxpro_openedx_users as openedx_users_email
+        on mitxpro_user_view.user_email = openedx_users_email.user_email
 
     union all
 
     select
         {{ dbt_utils.generate_surrogate_key(['mitxresidential_user_view.user_email']) }} as user_pk
-        , cast(null as bigint) as mitxonline_openedx_user_id
-        , cast(null as bigint) as mitxonline_application_user_id
-        , cast(null as varchar) as user_mitxonline_username
-        , cast(null as bigint) as mitxpro_openedx_user_id
-        , cast(null as bigint) as mitxpro_application_user_id
-        , cast(null as varchar) as user_mitxpro_username
+        , null as mitxonline_openedx_user_id
+        , null as mitxonline_application_user_id
+        , null as user_mitxonline_username
+        , null as mitxpro_openedx_user_id
+        , null as mitxpro_application_user_id
+        , null as user_mitxpro_username
         , mitxresidential_user_view.user_id as residential_openedx_user_id
         , mitxresidential_user_view.user_username as user_residential_username
-        , cast(null as bigint) as edxorg_openedx_user_id
-        , cast(null as varchar) as user_edxorg_username
+        , null as edxorg_openedx_user_id
+        , null as user_edxorg_username
         , mitxresidential_user_view.user_email as email
         , mitxresidential_user_view.user_full_name as full_name
         , mitxresidential_user_view.user_address_country as address_country
         , mitxresidential_user_view.user_highest_education as highest_education
         , mitxresidential_user_view.user_gender as gender
         , mitxresidential_user_view.user_birth_year as birth_year
-        , cast(null as varchar) as company
-        , cast(null as varchar) as job_title
-        , cast(null as varchar) as industry
-        , cast(null as boolean) as user_is_active_on_mitxonline
-        , cast(null as varchar) as user_joined_on_mitxonline
-        , cast(null as boolean) as user_is_active_on_edxorg
-        , cast(null as varchar) as user_joined_on_edxorg
-        , cast(null as boolean) as user_is_active_on_mitxpro
-        , cast(null as varchar) as user_joined_on_mitxpro
+        , null as company
+        , null as job_title
+        , null as industry
+        , null as user_is_active_on_mitxonline
+        , null as user_joined_on_mitxonline
+        , null as user_is_active_on_edxorg
+        , null as user_joined_on_edxorg
+        , null as user_is_active_on_mitxpro
+        , null as user_joined_on_mitxpro
         , mitxresidential_user_view.user_is_active as user_is_active_on_residential
         , mitxresidential_user_view.user_joined_on as user_joined_on_residential
     from mitxresidential_user_view
@@ -260,16 +263,12 @@ with mitxonline_user_view as (
 )
 
 , base_info as (
-    select
-        user_pk
-        , email
-        , full_name
-        , address_country
+    select *
     from ranked_users
     where row_num = 1
 )
 
-, id_agg as (
+, agg_view as (
     select
         user_pk
         , max(mitxonline_openedx_user_id) as mitxonline_openedx_user_id
@@ -282,12 +281,6 @@ with mitxonline_user_view as (
         , max(user_residential_username) as user_residential_username
         , max(edxorg_openedx_user_id) as edxorg_openedx_user_id
         , max(user_edxorg_username) as user_edxorg_username
-        , max(highest_education) as highest_education
-        , max(gender) as gender
-        , max(birth_year) as birth_year
-        , max(company) as company
-        , max(job_title) as job_title
-        , max(industry) as industry
         , max(user_is_active_on_mitxonline) as user_is_active_on_mitxonline
         , max(user_joined_on_mitxonline) as user_joined_on_mitxonline
         , max(user_is_active_on_edxorg) as user_is_active_on_edxorg
@@ -315,12 +308,12 @@ select
     , base.email
     , base.full_name
     , base.address_country
-    , agg.highest_education
-    , agg.gender
-    , agg.birth_year
-    , agg.company
-    , agg.job_title
-    , agg.industry
+    , base.highest_education
+    , base.gender
+    , base.birth_year
+    , base.company
+    , base.job_title
+    , base.industry
     , agg.user_is_active_on_mitxonline
     , agg.user_joined_on_mitxonline
     , agg.user_is_active_on_edxorg
@@ -330,4 +323,4 @@ select
     , agg.user_is_active_on_residential
     , agg.user_joined_on_residential
 from base_info as base
-inner join id_agg as agg on base.user_pk = agg.user_pk
+inner join agg_view as agg on base.user_pk = agg.user_pk

--- a/src/ol_dbt/models/dimensional/dim_user.sql
+++ b/src/ol_dbt/models/dimensional/dim_user.sql
@@ -1,32 +1,30 @@
--- MITx Online Users
-with mitxonline_users as (
+-- MITx users from MITx Online and edX with dedup
+-- For users exist on both MITx Online and edX.org
+with mitxonline_user_view as (
     select
-        user_id
-        , user_username
-        , user_email
-        , user_full_name
-        , user_is_active
-        , user_joined_on
-    from {{ ref('stg__mitxonline__app__postgres__users_user') }}
-)
-
-, mitxonline_legaladdress as (
-    select
-        user_id
-        , user_address_country
-    from {{ ref('stg__mitxonline__app__postgres__users_legaladdress') }}
-)
-
-, mitxonline_profile as (
-    select
-        user_id
-        , user_highest_education
-        , user_gender
-        , user_birth_year
-        , user_company
-        , user_job_title
-        , user_industry
-    from {{ ref('stg__mitxonline__app__postgres__users_userprofile') }}
+        user_mitxonline_id as mitxonline_application_user_id
+        , user_mitxonline_username
+        , user_edxorg_id as edxorg_openedx_user_id
+        , user_edxorg_username
+        , user_mitxonline_email as email
+        , user_full_name as full_name
+        , user_address_country as address_country
+        , user_highest_education as highest_education
+        , user_gender as gender
+        , user_birth_year as birth_year
+        , user_company as company
+        , user_job_title as job_title
+        , user_industry as industry
+        , user_is_active_on_mitxonline
+        , user_is_active_on_edxorg
+        , user_joined_on_mitxonline
+        , user_joined_on_edxorg
+        , case
+            when user_is_active_on_mitxonline and user_joined_on_mitxonline > user_joined_on_edxorg
+                then user_mitxonline_email
+            else coalesce(user_edxorg_email, user_mitxonline_email, user_micromasters_email)
+        end as user_email
+    from {{ ref('int__mitx__users') }}
 )
 
 , mitxonline_openedx_users as (
@@ -35,27 +33,6 @@ with mitxonline_users as (
         , user_username
         , user_email
     from {{ ref('stg__mitxonline__openedx__mysql__auth_user') }}
-)
-
-, mitxonline_user_view as (
-    select
-        mitxonline_users.user_username
-        , mitxonline_users.user_email
-        , mitxonline_users.user_full_name
-        , mitxonline_legaladdress.user_address_country
-        , mitxonline_profile.user_highest_education
-        , mitxonline_profile.user_gender
-        , mitxonline_profile.user_birth_year
-        , mitxonline_profile.user_company
-        , mitxonline_profile.user_job_title
-        , mitxonline_profile.user_industry
-        , mitxonline_users.user_is_active
-        , 'mitxonline' as platform
-        , mitxonline_users.user_id
-        , mitxonline_users.user_joined_on
-    from mitxonline_users
-    left join mitxonline_legaladdress on mitxonline_users.user_id = mitxonline_legaladdress.user_id
-    left join mitxonline_profile on mitxonline_users.user_id = mitxonline_profile.user_id
 )
 
 -- MITx Pro Users
@@ -109,9 +86,9 @@ with mitxonline_users as (
         , mitxpro_profile.user_company
         , mitxpro_profile.user_job_title
         , mitxpro_profile.user_industry
-        , mitxpro_users.user_is_active
         , 'mitxpro' as platform
         , mitxpro_users.user_id
+        , mitxpro_users.user_is_active
         , mitxpro_users.user_joined_on
     from mitxpro_users
     left join mitxpro_legaladdress on mitxpro_users.user_id = mitxpro_legaladdress.user_id
@@ -149,134 +126,48 @@ with mitxonline_users as (
         , mitxresidential_profile.user_highest_education
         , mitxresidential_profile.user_gender
         , mitxresidential_profile.user_birth_year
-        , mitxresidential_openedx_users.user_is_active
         , 'residential' as platform
         , mitxresidential_openedx_users.user_id
+        , mitxresidential_openedx_users.user_is_active
         , mitxresidential_openedx_users.user_joined_on
     from mitxresidential_openedx_users
     left join mitxresidential_profile on mitxresidential_openedx_users.user_id = mitxresidential_profile.user_id
-)
-
--- edXorg Users
---- this table contains multiple records per user, use a window function to pick one per user_id
-, edxorg_bigquery_user_info as (
-    select
-        user_full_name
-        , user_username
-        , user_email
-        , user_country
-        , user_highest_education
-        , user_gender
-        , user_birth_year
-        , courserunenrollment_is_active
-        , courserun_platform
-        , user_id
-        , user_joined_on
-        , row_number() over (
-            partition by user_id
-            order by user_joined_on desc
-        ) as row_num
-    from {{ ref('stg__edxorg__bigquery__mitx_user_info_combo') }}
-    where courserun_platform = '{{ var("edxorg") }}'
-)
-
-, most_recent_edxorg_bigquery_user_info as (
-    select
-        user_full_name
-        , user_username
-        , user_email
-        , user_country
-        , user_highest_education
-        , user_gender
-        , user_birth_year
-        , courserunenrollment_is_active
-        , courserun_platform
-        , user_id
-        , user_joined_on
-    from edxorg_bigquery_user_info
-    where row_num = 1
-)
-
-, edxorg_bigquery_person_course as (
-    select
-        user_username
-        , user_profile_country
-        , user_highest_education
-        , user_gender
-        , user_birth_year
-        , courserunenrollment_is_active
-        , courserun_platform
-        , user_id
-        , row_number() over (
-            partition by user_id
-            order by courseactivitiy_last_event_timestamp desc
-        ) as row_num
-    from {{ ref('stg__edxorg__bigquery__mitx_person_course') }}
-    where courserun_platform = '{{ var("edxorg") }}'
-)
-
-, most_recent_edxorg_bigquery_person_course as (
-    select
-        user_username
-        , user_profile_country
-        , user_highest_education
-        , user_gender
-        , user_birth_year
-        , courserunenrollment_is_active
-        , courserun_platform
-        , user_id
-    from edxorg_bigquery_person_course
-    where row_num = 1
-)
-
-, edxorg_user_view as (
-    select
-        user_info.user_full_name
-        , user_info.user_email
-        , user_info.user_joined_on
-        , coalesce(user_info.user_username, person_course.user_username) as user_username
-        , coalesce(user_info.user_country, person_course.user_profile_country) as user_address_country
-        , coalesce(user_info.user_highest_education, person_course.user_highest_education) as user_highest_education
-        , coalesce(user_info.user_gender, person_course.user_gender) as user_gender
-        , coalesce(user_info.user_birth_year, person_course.user_birth_year) as user_birth_year
-        , coalesce(
-            coalesce(user_info.courserunenrollment_is_active = 1, false)
-            , person_course.courserunenrollment_is_active
-        ) as user_is_active
-        , coalesce(user_info.courserun_platform, person_course.courserun_platform) as platform
-        , coalesce(user_info.user_id, person_course.user_id) as user_id
-    from most_recent_edxorg_bigquery_user_info as user_info
-    left join most_recent_edxorg_bigquery_person_course as person_course on user_info.user_id = person_course.user_id
 )
 
 , combined_users as (
     select
         {{ dbt_utils.generate_surrogate_key(['mitxonline_user_view.user_email']) }} as user_pk
         , mitxonline_openedx_users.openedx_user_id as mitxonline_openedx_user_id
-        , mitxonline_user_view.user_id as mitxonline_application_user_id
-        , mitxonline_user_view.user_username as user_mitxonline_username
+        , mitxonline_user_view.mitxonline_application_user_id
+        , mitxonline_user_view.user_mitxonline_username
         , cast(null as bigint) as mitxpro_openedx_user_id
         , cast(null as bigint) as mitxpro_application_user_id
         , cast(null as varchar) as user_mitxpro_username
         , cast(null as bigint) as residential_openedx_user_id
         , cast(null as varchar) as user_residential_username
-        , cast(null as bigint) as edxorg_openedx_user_id
-        , cast(null as varchar) as user_edxorg_username
+        , mitxonline_user_view.edxorg_openedx_user_id
+        , mitxonline_user_view.user_edxorg_username
         , mitxonline_user_view.user_email as email
-        , mitxonline_user_view.user_full_name as full_name
-        , mitxonline_user_view.user_address_country as address_country
-        , mitxonline_user_view.user_highest_education as highest_education
-        , mitxonline_user_view.user_gender as gender
-        , mitxonline_user_view.user_birth_year as birth_year
-        , mitxonline_user_view.user_company as company
-        , mitxonline_user_view.user_job_title as job_title
-        , mitxonline_user_view.user_industry as industry
-        , mitxonline_user_view.user_is_active
-        , mitxonline_user_view.user_joined_on
+        , mitxonline_user_view.full_name
+        , mitxonline_user_view.address_country
+        , mitxonline_user_view.highest_education
+        , mitxonline_user_view.gender
+        , mitxonline_user_view.birth_year
+        , mitxonline_user_view.company
+        , mitxonline_user_view.job_title
+        , mitxonline_user_view.industry
+        , mitxonline_user_view.user_is_active_on_mitxonline
+        , mitxonline_user_view.user_joined_on_mitxonline
+        , mitxonline_user_view.user_is_active_on_edxorg
+        , mitxonline_user_view.user_joined_on_edxorg
+        , cast(null as boolean) as user_is_active_on_mitxpro
+        , cast(null as varchar) as user_joined_on_mitxpro
+        , cast(null as boolean) as user_is_active_on_residential
+        , cast(null as varchar) as user_joined_on_residential
     from mitxonline_user_view
     left join mitxonline_openedx_users
         on (
-            mitxonline_user_view.user_username = mitxonline_openedx_users.user_username
+            mitxonline_user_view.user_mitxonline_username = mitxonline_openedx_users.user_username
             or mitxonline_user_view.user_email = mitxonline_openedx_users.user_email
         )
 
@@ -303,8 +194,14 @@ with mitxonline_users as (
         , mitxpro_user_view.user_company as company
         , mitxpro_user_view.user_job_title as job_title
         , mitxpro_user_view.user_industry as industry
-        , mitxpro_user_view.user_is_active
-        , mitxpro_user_view.user_joined_on
+        , cast(null as boolean) as user_is_active_on_mitxonline
+        , cast(null as varchar) as user_joined_on_mitxonline
+        , cast(null as boolean) as user_is_active_on_edxorg
+        , cast(null as varchar) as user_joined_on_edxorg
+        , mitxpro_user_view.user_is_active as user_is_active_on_mitxpro
+        , mitxpro_user_view.user_joined_on as user_joined_on_mitxpro
+        , cast(null as boolean) as user_is_active_on_residential
+        , cast(null as varchar) as user_joined_on_residential
     from mitxpro_user_view
     left join mitxpro_openedx_users
         on (
@@ -335,69 +232,102 @@ with mitxonline_users as (
         , cast(null as varchar) as company
         , cast(null as varchar) as job_title
         , cast(null as varchar) as industry
-        , mitxresidential_user_view.user_is_active
-        , mitxresidential_user_view.user_joined_on
+        , cast(null as boolean) as user_is_active_on_mitxonline
+        , cast(null as varchar) as user_joined_on_mitxonline
+        , cast(null as boolean) as user_is_active_on_edxorg
+        , cast(null as varchar) as user_joined_on_edxorg
+        , cast(null as boolean) as user_is_active_on_mitxpro
+        , cast(null as varchar) as user_joined_on_mitxpro
+        , mitxresidential_user_view.user_is_active as user_is_active_on_residential
+        , mitxresidential_user_view.user_joined_on as user_joined_on_residential
     from mitxresidential_user_view
-
-    union all
-
-    select
-        {{ dbt_utils.generate_surrogate_key(['edxorg_user_view.user_email']) }} as user_pk
-        , cast(null as bigint) as mitxonline_openedx_user_id
-        , cast(null as bigint) as mitxonline_application_user_id
-        , cast(null as varchar) as user_mitxonline_username
-        , cast(null as bigint) as mitxpro_openedx_user_id
-        , cast(null as bigint) as mitxpro_application_user_id
-        , cast(null as varchar) as user_mitxpro_username
-        , cast(null as bigint) as residential_openedx_user_id
-        , cast(null as varchar) as user_residential_username
-        , edxorg_user_view.user_id as edxorg_openedx_user_id
-        , edxorg_user_view.user_username as user_edxorg_username
-        , edxorg_user_view.user_email as email
-        , edxorg_user_view.user_full_name as full_name
-        , edxorg_user_view.user_address_country as address_country
-        , edxorg_user_view.user_highest_education as highest_education
-        , edxorg_user_view.user_gender as gender
-        , edxorg_user_view.user_birth_year as birth_year
-        , cast(null as varchar) as company
-        , cast(null as varchar) as job_title
-        , cast(null as varchar) as industry
-        , edxorg_user_view.user_is_active
-        , edxorg_user_view.user_joined_on
-    from edxorg_user_view
 )
 
 , ranked_users as (
     select
-        user_pk
-        , mitxonline_openedx_user_id
-        , mitxonline_application_user_id
-        , user_mitxonline_username
-        , mitxpro_openedx_user_id
-        , mitxpro_application_user_id
-        , user_mitxpro_username
-        , residential_openedx_user_id
-        , user_residential_username
-        , edxorg_openedx_user_id
-        , user_edxorg_username
-        , email
-        , full_name
-        , address_country
-        , highest_education
-        , gender
-        , birth_year
-        , company
-        , job_title
-        , industry
-        , user_is_active
-        , user_joined_on
+        *
         , row_number() over (
             partition by user_pk
-            order by user_joined_on desc
+            order by
+                greatest(
+                    user_joined_on_mitxonline
+                    , user_joined_on_edxorg
+                    , user_joined_on_mitxpro
+                    , user_joined_on_residential
+                ) desc
         ) as row_num
     from combined_users
 )
 
-select *
-from ranked_users
-where row_num = 1
+, base_info as (
+    select
+        user_pk
+        , email
+        , full_name
+        , address_country
+    from ranked_users
+    where row_num = 1
+)
+
+, id_agg as (
+    select
+        user_pk
+        , max(mitxonline_openedx_user_id) as mitxonline_openedx_user_id
+        , max(mitxonline_application_user_id) as mitxonline_application_user_id
+        , max(user_mitxonline_username) as user_mitxonline_username
+        , max(mitxpro_openedx_user_id) as mitxpro_openedx_user_id
+        , max(mitxpro_application_user_id) as mitxpro_application_user_id
+        , max(user_mitxpro_username) as user_mitxpro_username
+        , max(residential_openedx_user_id) as residential_openedx_user_id
+        , max(user_residential_username) as user_residential_username
+        , max(edxorg_openedx_user_id) as edxorg_openedx_user_id
+        , max(user_edxorg_username) as user_edxorg_username
+        , max(highest_education) as highest_education
+        , max(gender) as gender
+        , max(birth_year) as birth_year
+        , max(company) as company
+        , max(job_title) as job_title
+        , max(industry) as industry
+        , max(user_is_active_on_mitxonline) as user_is_active_on_mitxonline
+        , max(user_joined_on_mitxonline) as user_joined_on_mitxonline
+        , max(user_is_active_on_edxorg) as user_is_active_on_edxorg
+        , max(user_joined_on_edxorg) as user_joined_on_edxorg
+        , max(user_is_active_on_mitxpro) as user_is_active_on_mitxpro
+        , max(user_joined_on_mitxpro) as user_joined_on_mitxpro
+        , max(user_is_active_on_residential) as user_is_active_on_residential
+        , max(user_joined_on_residential) as user_joined_on_residential
+    from combined_users
+    group by user_pk
+)
+
+select
+    base.user_pk
+    , agg.mitxonline_openedx_user_id
+    , agg.mitxonline_application_user_id
+    , agg.user_mitxonline_username
+    , agg.mitxpro_openedx_user_id
+    , agg.mitxpro_application_user_id
+    , agg.user_mitxpro_username
+    , agg.residential_openedx_user_id
+    , agg.user_residential_username
+    , agg.edxorg_openedx_user_id
+    , agg.user_edxorg_username
+    , base.email
+    , base.full_name
+    , base.address_country
+    , agg.highest_education
+    , agg.gender
+    , agg.birth_year
+    , agg.company
+    , agg.job_title
+    , agg.industry
+    , agg.user_is_active_on_mitxonline
+    , agg.user_joined_on_mitxonline
+    , agg.user_is_active_on_edxorg
+    , agg.user_joined_on_edxorg
+    , agg.user_is_active_on_mitxpro
+    , agg.user_joined_on_mitxpro
+    , agg.user_is_active_on_residential
+    , agg.user_joined_on_residential
+from base_info as base
+inner join id_agg as agg on base.user_pk = agg.user_pk

--- a/src/ol_dbt/models/dimensional/dim_user.sql
+++ b/src/ol_dbt/models/dimensional/dim_user.sql
@@ -171,7 +171,7 @@ with mitx_users as (
     left join mitxonline_openedx_users as openedx_users_username
         on mitx_users.user_mitxonline_username = openedx_users_username.user_username
     left join mitxonline_openedx_users as openedx_users_email
-        on mitx_users.user_email = openedx_users_email.user_email
+        on mitx_users.user_mitxonline_email = openedx_users_email.user_email
 
     union all
 

--- a/src/ol_dbt/models/dimensional/dim_user.sql
+++ b/src/ol_dbt/models/dimensional/dim_user.sql
@@ -1,20 +1,40 @@
+-- MITx Online Users
 with mitxonline_users as (
-    select *
+    select
+        user_id
+        , user_username
+        , user_email
+        , user_full_name
+        , user_is_active
+        , user_joined_on
     from {{ ref('stg__mitxonline__app__postgres__users_user') }}
 )
 
 , mitxonline_legaladdress as (
-    select *
+    select
+        user_id
+        , user_address_country
     from {{ ref('stg__mitxonline__app__postgres__users_legaladdress') }}
 )
 
 , mitxonline_profile as (
-    select *
+    select
+        user_id
+        , user_highest_education
+        , user_gender
+        , user_birth_year
+        , user_company
+        , user_job_title
+        , user_industry
     from {{ ref('stg__mitxonline__app__postgres__users_userprofile') }}
 )
 
-, openedx_users as (
-    select * from {{ ref('stg__mitxonline__openedx__mysql__auth_user') }}
+, mitxonline_openedx_users as (
+    select
+        openedx_user_id
+        , user_username
+        , user_email
+    from {{ ref('stg__mitxonline__openedx__mysql__auth_user') }}
 )
 
 , mitxonline_user_view as (
@@ -38,25 +58,317 @@ with mitxonline_users as (
     left join mitxonline_profile on mitxonline_users.user_id = mitxonline_profile.user_id
 )
 
-select
-    {{ dbt_utils.generate_surrogate_key(['mitxonline_user_view.user_email']) }} as user_pk
-    , openedx_users.openedx_user_id as mitxonline_openedx_user_id
-    , mitxonline_user_view.user_id as mitxonline_application_user_id
-    , mitxonline_user_view.user_username as user_mitxonline_username
-    , mitxonline_user_view.user_email as email
-    , mitxonline_user_view.user_full_name as full_name
-    , mitxonline_user_view.user_address_country as address_country
-    , mitxonline_user_view.user_highest_education as highest_education
-    , mitxonline_user_view.user_gender as gender
-    , mitxonline_user_view.user_birth_year as birth_year
-    , mitxonline_user_view.user_company as company
-    , mitxonline_user_view.user_job_title as job_title
-    , mitxonline_user_view.user_industry as industry
-    , mitxonline_user_view.user_is_active
-    , mitxonline_user_view.user_joined_on
-from mitxonline_user_view
-left join openedx_users
-    on (
-        mitxonline_user_view.user_username = openedx_users.user_username
-        or mitxonline_user_view.user_email = openedx_users.user_email
-    )
+-- MITx Pro Users
+, mitxpro_users as (
+    select
+        user_id
+        , user_username
+        , user_email
+        , user_full_name
+        , user_is_active
+        , user_joined_on
+    from {{ ref('stg__mitxpro__app__postgres__users_user') }}
+)
+
+, mitxpro_legaladdress as (
+    select
+        user_id
+        , user_address_country
+    from {{ ref('stg__mitxpro__app__postgres__users_legaladdress') }}
+)
+
+, mitxpro_profile as (
+    select
+        user_id
+        , user_highest_education
+        , user_gender
+        , user_birth_year
+        , user_company
+        , user_job_title
+        , user_industry
+    from {{ ref('stg__mitxpro__app__postgres__users_profile') }}
+)
+
+, mitxpro_openedx_users as (
+    select
+        openedx_user_id
+        , user_username
+        , user_email
+    from {{ ref('stg__mitxpro__openedx__mysql__auth_user') }}
+)
+
+, mitxpro_user_view as (
+    select
+        mitxpro_users.user_username
+        , mitxpro_users.user_email
+        , mitxpro_users.user_full_name
+        , mitxpro_legaladdress.user_address_country
+        , mitxpro_profile.user_highest_education
+        , mitxpro_profile.user_gender
+        , mitxpro_profile.user_birth_year
+        , mitxpro_profile.user_company
+        , mitxpro_profile.user_job_title
+        , mitxpro_profile.user_industry
+        , mitxpro_users.user_is_active
+        , 'mitxpro' as platform
+        , mitxpro_users.user_id
+        , mitxpro_users.user_joined_on
+    from mitxpro_users
+    left join mitxpro_legaladdress on mitxpro_users.user_id = mitxpro_legaladdress.user_id
+    left join mitxpro_profile on mitxpro_users.user_id = mitxpro_profile.user_id
+)
+
+-- Residential Users
+, mitxresidential_openedx_users as (
+    select
+        user_username
+        , user_email
+        , user_full_name
+        , user_is_active
+        , user_id
+        , user_joined_on
+    from {{ ref('stg__mitxresidential__openedx__auth_user') }}
+)
+
+, mitxresidential_profile as (
+    select
+        user_address_country
+        , user_highest_education
+        , user_gender
+        , user_birth_year
+        , user_id
+    from {{ ref('stg__mitxresidential__openedx__auth_userprofile') }}
+)
+
+, mitxresidential_user_view as (
+    select
+        mitxresidential_openedx_users.user_username
+        , mitxresidential_openedx_users.user_email
+        , mitxresidential_openedx_users.user_full_name
+        , mitxresidential_profile.user_address_country
+        , mitxresidential_profile.user_highest_education
+        , mitxresidential_profile.user_gender
+        , mitxresidential_profile.user_birth_year
+        , mitxresidential_openedx_users.user_is_active
+        , 'residential' as platform
+        , mitxresidential_openedx_users.user_id
+        , mitxresidential_openedx_users.user_joined_on
+    from mitxresidential_openedx_users
+    left join mitxresidential_profile on mitxresidential_openedx_users.user_id = mitxresidential_profile.user_id
+)
+
+-- edXorg Users
+, edxorg_bigquery_user_info as (
+    select
+        user_full_name
+        , user_username
+        , user_email
+        , user_country
+        , user_highest_education
+        , user_gender
+        , user_birth_year
+        , courserunenrollment_is_active
+        , courserun_platform
+        , user_id
+        , user_joined_on
+    from {{ ref('stg__edxorg__bigquery__mitx_user_info_combo') }}
+)
+
+, edxorg_bigquery_person_course as (
+    select
+        user_username
+        , user_profile_country
+        , user_highest_education
+        , user_gender
+        , user_birth_year
+        , courserunenrollment_is_active
+        , courserun_platform
+        , user_id
+    from {{ ref('stg__edxorg__bigquery__mitx_person_course') }}
+)
+
+, edxorg_bigquery_s3_user as (
+    select
+        user_id
+        , user_username
+        , user_email
+        , user_is_active
+        , user_joined_on
+    from {{ ref('stg__edxorg__s3__user') }}
+)
+
+, edxorg_user_view as (
+    select
+        user_info.user_full_name
+        , coalesce(user_info.user_username, person_course.user_username, s3_user.user_username) as user_username
+        , coalesce(user_info.user_email, s3_user.user_email) as user_email
+        , coalesce(user_info.user_country, person_course.user_profile_country) as user_address_country
+        , coalesce(user_info.user_highest_education, person_course.user_highest_education) as user_highest_education
+        , coalesce(user_info.user_gender, person_course.user_gender) as user_gender
+        , coalesce(user_info.user_birth_year, person_course.user_birth_year) as user_birth_year
+        , coalesce(
+            coalesce(user_info.courserunenrollment_is_active = 1, false)
+            , person_course.courserunenrollment_is_active
+            , s3_user.user_is_active
+        ) as user_is_active
+        , coalesce(user_info.courserun_platform, person_course.courserun_platform) as platform
+        , coalesce(user_info.user_id, person_course.user_id, s3_user.user_id) as user_id
+        , coalesce(user_info.user_joined_on, s3_user.user_joined_on) as user_joined_on
+    from edxorg_bigquery_user_info as user_info
+    left join edxorg_bigquery_person_course as person_course on user_info.user_id = person_course.user_id
+    left join edxorg_bigquery_s3_user as s3_user on user_info.user_email = s3_user.user_email
+)
+
+, combined_users as (
+    select
+        {{ dbt_utils.generate_surrogate_key(['mitxonline_user_view.user_email']) }} as user_pk
+        , mitxonline_openedx_users.openedx_user_id as mitxonline_openedx_user_id
+        , mitxonline_user_view.user_id as mitxonline_application_user_id
+        , mitxonline_user_view.user_username as user_mitxonline_username
+        , cast(null as bigint) as mitxpro_openedx_user_id
+        , cast(null as bigint) as mitxpro_application_user_id
+        , cast(null as varchar) as user_mitxpro_username
+        , cast(null as bigint) as residential_openedx_user_id
+        , cast(null as varchar) as user_residential_username
+        , cast(null as bigint) as edxorg_openedx_user_id
+        , cast(null as varchar) as user_edxorg_username
+        , mitxonline_user_view.user_email as email
+        , mitxonline_user_view.user_full_name as full_name
+        , mitxonline_user_view.user_address_country as address_country
+        , mitxonline_user_view.user_highest_education as highest_education
+        , mitxonline_user_view.user_gender as gender
+        , mitxonline_user_view.user_birth_year as birth_year
+        , mitxonline_user_view.user_company as company
+        , mitxonline_user_view.user_job_title as job_title
+        , mitxonline_user_view.user_industry as industry
+        , mitxonline_user_view.user_is_active
+        , mitxonline_user_view.user_joined_on
+    from mitxonline_user_view
+    left join mitxonline_openedx_users
+        on (
+            mitxonline_user_view.user_username = mitxonline_openedx_users.user_username
+            or mitxonline_user_view.user_email = mitxonline_openedx_users.user_email
+        )
+
+    union all
+
+    select
+        {{ dbt_utils.generate_surrogate_key(['mitxpro_user_view.user_email']) }} as user_pk
+        , cast(null as bigint) as mitxonline_openedx_user_id
+        , cast(null as bigint) as mitxonline_application_user_id
+        , cast(null as varchar) as user_mitxonline_username
+        , mitxpro_openedx_users.openedx_user_id as mitxpro_openedx_user_id
+        , mitxpro_user_view.user_id as mitxpro_application_user_id
+        , mitxpro_user_view.user_username as user_mitxpro_username
+        , cast(null as bigint) as residential_openedx_user_id
+        , cast(null as varchar) as user_residential_username
+        , cast(null as bigint) as edxorg_openedx_user_id
+        , cast(null as varchar) as user_edxorg_username
+        , mitxpro_user_view.user_email as email
+        , mitxpro_user_view.user_full_name as full_name
+        , mitxpro_user_view.user_address_country as address_country
+        , mitxpro_user_view.user_highest_education as highest_education
+        , mitxpro_user_view.user_gender as gender
+        , mitxpro_user_view.user_birth_year as birth_year
+        , mitxpro_user_view.user_company as company
+        , mitxpro_user_view.user_job_title as job_title
+        , mitxpro_user_view.user_industry as industry
+        , mitxpro_user_view.user_is_active
+        , mitxpro_user_view.user_joined_on
+    from mitxpro_user_view
+    left join mitxpro_openedx_users
+        on (
+            mitxpro_user_view.user_username = mitxpro_openedx_users.user_username
+            or mitxpro_user_view.user_email = mitxpro_openedx_users.user_email
+        )
+
+    union all
+
+    select
+        {{ dbt_utils.generate_surrogate_key(['mitxresidential_user_view.user_email']) }} as user_pk
+        , cast(null as bigint) as mitxonline_openedx_user_id
+        , cast(null as bigint) as mitxonline_application_user_id
+        , cast(null as varchar) as user_mitxonline_username
+        , cast(null as bigint) as mitxpro_openedx_user_id
+        , cast(null as bigint) as mitxpro_application_user_id
+        , cast(null as varchar) as user_mitxpro_username
+        , mitxresidential_user_view.user_id as residential_openedx_user_id
+        , mitxresidential_user_view.user_username as user_residential_username
+        , cast(null as bigint) as edxorg_openedx_user_id
+        , cast(null as varchar) as user_edxorg_username
+        , mitxresidential_user_view.user_email as email
+        , mitxresidential_user_view.user_full_name as full_name
+        , mitxresidential_user_view.user_address_country as address_country
+        , mitxresidential_user_view.user_highest_education as highest_education
+        , mitxresidential_user_view.user_gender as gender
+        , mitxresidential_user_view.user_birth_year as birth_year
+        , cast(null as varchar) as company
+        , cast(null as varchar) as job_title
+        , cast(null as varchar) as industry
+        , mitxresidential_user_view.user_is_active
+        , mitxresidential_user_view.user_joined_on
+    from mitxresidential_user_view
+
+    union all
+
+    select
+        {{ dbt_utils.generate_surrogate_key(['edxorg_user_view.user_email']) }} as user_pk
+        , cast(null as bigint) as mitxonline_openedx_user_id
+        , cast(null as bigint) as mitxonline_application_user_id
+        , cast(null as varchar) as user_mitxonline_username
+        , cast(null as bigint) as mitxpro_openedx_user_id
+        , cast(null as bigint) as mitxpro_application_user_id
+        , cast(null as varchar) as user_mitxpro_username
+        , cast(null as bigint) as residential_openedx_user_id
+        , cast(null as varchar) as user_residential_username
+        , edxorg_user_view.user_id as edxorg_openedx_user_id
+        , edxorg_user_view.user_username as user_edxorg_username
+        , edxorg_user_view.user_email as email
+        , edxorg_user_view.user_full_name as full_name
+        , edxorg_user_view.user_address_country as address_country
+        , edxorg_user_view.user_highest_education as highest_education
+        , edxorg_user_view.user_gender as gender
+        , edxorg_user_view.user_birth_year as birth_year
+        , cast(null as varchar) as company
+        , cast(null as varchar) as job_title
+        , cast(null as varchar) as industry
+        , edxorg_user_view.user_is_active
+        , edxorg_user_view.user_joined_on
+    from edxorg_user_view
+)
+
+, ranked_users as (
+    select
+        user_pk
+        , max(mitxonline_openedx_user_id) as mitxonline_openedx_user_id
+        , max(mitxonline_application_user_id) as mitxonline_application_user_id
+        , max(user_mitxonline_username) as user_mitxonline_username
+        , max(mitxpro_openedx_user_id) as mitxpro_openedx_user_id
+        , max(mitxpro_application_user_id) as mitxpro_application_user_id
+        , max(user_mitxpro_username) as user_mitxpro_username
+        , max(residential_openedx_user_id) as residential_openedx_user_id
+        , max(user_residential_username) as user_residential_username
+        , max(edxorg_openedx_user_id) as edxorg_openedx_user_id
+        , max(user_edxorg_username) as user_edxorg_username
+        , max(email) as email
+        , max(full_name) as full_name
+        , max(address_country) as address_country
+        , max(highest_education) as highest_education
+        , max(gender) as gender
+        , max(birth_year) as birth_year
+        , max(company) as company
+        , max(job_title) as job_title
+        , max(industry) as industry
+        , max(user_is_active) as user_is_active
+        , max(user_joined_on) as user_joined_on
+        , row_number() over (
+            partition by user_pk
+            order by max(user_joined_on) desc
+        ) as row_num
+    from combined_users
+    group by user_pk
+)
+
+select *
+from ranked_users
+where row_num = 1


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/ol-data-platform/issues/1533

### Description (What does it do?)
Adding logic to populate MITxPro, Residental MITx, and edX.org users in the dim_user model.

### How can this be tested?
```
dbt build --select dim_user
```