### PR TITLE
add program completion days field to program enrollment mart

### DIFF
--- a/src/ol_dbt/models/marts/combined/_marts__combined__models.yml
+++ b/src/ol_dbt/models/marts/combined/_marts__combined__models.yml
@@ -504,11 +504,11 @@ models:
       on either mitxonline.mit.edu or xpro.mit.edu. Null for certificate earned on
       edX.org or certificates that have been revoked.
   - name: unique_courses_taken_in_program
-    description: int, count of unique course readable ids the learner enrolled
-      in within that program
+    description: int, count of unique course readable ids the learner enrolled in
+      within that program
   - name: capstone_indicator
-    description: str, if the learner has taken a course with the word capstone in the title 
-      then it will be Y otherwise the value will be N
+    description: str, if the learner has taken a course with the word capstone in
+      the title then it will be Y otherwise the value will be N
   - name: program_completion_days
     description: int, number of days between the first course start date and the program
       completion certificate date

--- a/src/ol_dbt/models/marts/combined/marts__combined_program_enrollment_detail.sql
+++ b/src/ol_dbt/models/marts/combined/marts__combined_program_enrollment_detail.sql
@@ -297,12 +297,12 @@ with mitxpro__programenrollments as (
     left join courses_in_programs
         on combined_programs.program_readable_id = courses_in_programs.program_readable_id
     left join combined_enrollments
-        on 
+        on
             cast(combined_programs.user_id as varchar) = combined_enrollments.user_id
             and courses_in_programs.course_readable_id = combined_enrollments.course_readable_id
     left join combined_courseruns
         on combined_enrollments.courserun_readable_id = combined_courseruns.courserun_readable_id
-    group by 
+    group by
         combined_programs.platform_name
         , combined_programs.program_id
         , combined_programs.program_title


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/7321

### Description (What does it do?)
adds the program_completion_days, unique_courses_taken_in_program,  capstone_indicator  fields to the marts__combined_program_enrollment_detail table

### How can this be tested?
dbt build --select marts__combined_program_enrollment_detail
