### PR TITLE
add join format fixes for learner engagement dashboard

### DIFF
--- a/src/ol_dbt/models/reporting/learner_engagement_report.sql
+++ b/src/ol_dbt/models/reporting/learner_engagement_report.sql
@@ -140,13 +140,13 @@ with video_pre_query as (
             c.content_block_fk = v.content_block_pk
             and replace(replace(a.courserun_readable_id, 'course-v1:', ''), '+', '/') = v.courserun_readable_id
     inner join ol_warehouse_production_dimensional.dim_course_content as cc_subsection
-        on 
+        on
             v.parent_block_id = cc_subsection.block_id
             and replace(replace(a.courserun_readable_id, 'course-v1:', ''), '+', '/')
             = cc_subsection.courserun_readable_id
             and cc_subsection.is_latest = true
     inner join ol_warehouse_production_dimensional.dim_course_content as cc_section
-        on 
+        on
             cc_subsection.parent_block_id = cc_section.block_id
             and replace(replace(a.courserun_readable_id, 'course-v1:', ''), '+', '/') = cc_section.courserun_readable_id
             and cc_section.is_latest = true


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/7388

### Description (What does it do?)
course run readable id's in different formats complicate joins this should fix the formatting when joining for the learner engagement report/dashboard

### How can this be tested?
dbt build --select learner_engagement_report
