### PR TITLE
feat: Canvas course export and S3 upload

### DIFF
--- a/src/ol_orchestrate/assets/canvas.py
+++ b/src/ol_orchestrate/assets/canvas.py
@@ -1,0 +1,91 @@
+import hashlib
+import time
+from pathlib import Path
+
+import requests
+from dagster import (
+    AssetExecutionContext,
+    AssetKey,
+    AssetOut,
+    DataVersion,
+    Output,
+    multi_asset,
+)
+
+# Define a list of course IDs to export.
+course_ids = [7023]
+
+
+@multi_asset(
+    outs={
+        f"course_{course_id}": AssetOut(
+            key=AssetKey(["canvas", f"course_{course_id}"]),
+            io_manager_key="s3file_io_manager",
+        )
+        for course_id in course_ids
+    },
+    group_name="canvas",
+    required_resource_keys={"canvas_api"},
+)
+def export_courses(context: AssetExecutionContext):
+    for course_id in course_ids:
+        course = context.resources.canvas_api.client.get_course(course_id)
+
+        export_course_response = (
+            context.resources.canvas_api.client.export_course_content(course_id)
+        )
+        context.log.info(
+            "Initiated export of course ID %s: %s", course_id, export_course_response
+        )
+        export_id = export_course_response["id"]
+
+        # Poll until the export is ready
+        while True:
+            export_status = (
+                context.resources.canvas_api.client.check_course_export_status(
+                    course_id, export_id
+                )
+            )
+            if export_status["workflow_state"] == "exported":
+                attachment = export_status.get("attachment", {})
+                download_url = attachment.get("url")
+                context.log.info(
+                    "Export started for course ID %s at %s", course_id, download_url
+                )
+                break
+            elif export_status["workflow_state"] in ["failed", "error"]:
+                message = f"Export failed for course {course_id}"
+                context.log.error(message)
+                raise Exception(message)  # noqa: TRY002
+            else:
+                context.log.info(
+                    "Waiting for course export (state: %s)",
+                    export_status["workflow_state"],
+                )
+                time.sleep(30)
+
+        course_export_path = Path(f"{course_id}_course_export.imscc")
+        response = requests.get(download_url, timeout=20)
+        response.raise_for_status()
+
+        course_export_path.write_bytes(response.content)
+
+        with course_export_path.open("rb") as f:
+            data_version = hashlib.file_digest(f, "sha256").hexdigest()
+
+        target_path = f"canvas/course_export/{course_id}/{data_version}.imscc"
+
+        context.log.info("Downloading %s file to %s", download_url, target_path)
+
+        yield Output(
+            value=(course_export_path, target_path),
+            output_name=f"course_{course_id}",
+            data_version=DataVersion(data_version),
+            metadata={
+                "course_id": course_id,
+                "course_name": course["name"],
+                "course_code": course["course_code"],
+                "course_readable_id": course["sis_course_id"],
+                "object_key": target_path,
+            },
+        )

--- a/src/ol_orchestrate/assets/canvas.py
+++ b/src/ol_orchestrate/assets/canvas.py
@@ -1,98 +1,94 @@
 import hashlib
 import time
+from datetime import UTC, datetime
 from pathlib import Path
 
-import requests
 from dagster import (
     AssetExecutionContext,
     AssetKey,
-    AssetOut,
     DataVersion,
     Output,
-    multi_asset,
+    StaticPartitionsDefinition,
+    asset,
 )
 
-# Define a list of course IDs to export.
-course_ids = [7023]
+# predefined course IDs to export
+course_partitions = StaticPartitionsDefinition(["7023"])
 
 
-@multi_asset(
-    outs={
-        f"course_{course_id}": AssetOut(
-            key=AssetKey(["canvas", f"course_{course_id}"]),
-            io_manager_key="s3file_io_manager",
-        )
-        for course_id in course_ids
-    },
+@asset(
+    key=AssetKey(["canvas", "course_export"]),
     group_name="canvas",
     required_resource_keys={"canvas_api"},
+    io_manager_key="s3file_io_manager",
+    partitions_def=course_partitions,
 )
 def export_courses(context: AssetExecutionContext):
+    course_id = int(context.partition_key)
+    export_date = datetime.now(tz=UTC).strftime("%Y%m%d")
     # only export common cartridge for now
     export_type = "common_cartridge"
-
     extension = "imscc" if export_type == "common_cartridge" else export_type
 
-    for course_id in course_ids:
-        course = context.resources.canvas_api.client.get_course(course_id)
+    course = context.resources.canvas_api.client.get_course(course_id)
+    export_course_response = context.resources.canvas_api.client.export_course_content(
+        course_id, export_type
+    )
+    context.log.info(
+        "Initiated export of course ID %s: %s", course_id, export_course_response
+    )
+    export_id = export_course_response["id"]
 
-        export_course_response = (
-            context.resources.canvas_api.client.export_course_content(
-                course_id, export_type
+    # Poll until the export is ready
+    max_retries = 20  # 10 minutes with 30 seconds interval
+    retry_count = 0
+    while retry_count < max_retries:
+        export_status = context.resources.canvas_api.client.check_course_export_status(
+            course_id, export_id
+        )
+        if export_status["workflow_state"] == "exported":
+            attachment = export_status.get("attachment", {})
+            download_url = attachment.get("url")
+            context.log.info(
+                "Export started for course ID %s at %s", course_id, download_url
             )
-        )
-        context.log.info(
-            "Initiated export of course ID %s: %s", course_id, export_course_response
-        )
-        export_id = export_course_response["id"]
-
-        # Poll until the export is ready
-        while True:
-            export_status = (
-                context.resources.canvas_api.client.check_course_export_status(
-                    course_id, export_id
-                )
+            break
+        elif export_status["workflow_state"] in ["failed", "error"]:
+            message = f"Export failed for course {course_id}"
+            context.log.error(message)
+            raise Exception(message)  # noqa: TRY002
+        else:
+            context.log.info(
+                "Waiting for course export (state: %s)",
+                export_status["workflow_state"],
             )
-            if export_status["workflow_state"] == "exported":
-                attachment = export_status.get("attachment", {})
-                download_url = attachment.get("url")
-                context.log.info(
-                    "Export started for course ID %s at %s", course_id, download_url
-                )
-                break
-            elif export_status["workflow_state"] in ["failed", "error"]:
-                message = f"Export failed for course {course_id}"
-                context.log.error(message)
-                raise Exception(message)  # noqa: TRY002
-            else:
-                context.log.info(
-                    "Waiting for course export (state: %s)",
-                    export_status["workflow_state"],
-                )
-                time.sleep(30)
+            retry_count += 1
+            time.sleep(30)
+    else:
+        message = f"Course export timed out for {course_id}"
+        context.log.error(message)
+        raise Exception(message)  # noqa: TRY002
 
-        course_export_path = Path(f"{course_id}_course_export.{extension}")
-        response = requests.get(download_url, timeout=20)
-        response.raise_for_status()
+    course_export_path = Path(f"{course_id}_course_export.{extension}")
+    context.resources.canvas_api.client.download_course_export(
+        download_url, course_export_path
+    )
 
-        course_export_path.write_bytes(response.content)
+    with course_export_path.open("rb") as f:
+        data_version = hashlib.file_digest(f, "sha256").hexdigest()
 
-        with course_export_path.open("rb") as f:
-            data_version = hashlib.file_digest(f, "sha256").hexdigest()
+    target_path = f"canvas/{export_date}/course_{course_id}/{data_version}.{extension}"
 
-        target_path = f"canvas/course_export/{course_id}/{data_version}.{extension}"
+    context.log.info("Downloading %s file to %s", download_url, target_path)
 
-        context.log.info("Downloading %s file to %s", download_url, target_path)
-
-        yield Output(
-            value=(course_export_path, target_path),
-            output_name=f"course_{course_id}",
-            data_version=DataVersion(data_version),
-            metadata={
-                "course_id": course_id,
-                "course_name": course["name"],
-                "course_code": course["course_code"],
-                "course_readable_id": course["sis_course_id"],
-                "object_key": target_path,
-            },
-        )
+    yield Output(
+        value=(course_export_path, target_path),
+        data_version=DataVersion(data_version),
+        metadata={
+            "course_id": course_id,
+            "course_name": course["name"],
+            "course_code": course["course_code"],
+            "course_readable_id": course["sis_course_id"],
+            "object_key": target_path,
+        },
+    )

--- a/src/ol_orchestrate/definitions/canvas_course_export.py
+++ b/src/ol_orchestrate/definitions/canvas_course_export.py
@@ -6,9 +6,11 @@ from dagster import (
 from dagster_aws.s3 import S3Resource
 
 from ol_orchestrate.assets.canvas import export_courses
-from ol_orchestrate.io_managers.filepath import S3FileObjectIOManager
 from ol_orchestrate.lib.constants import DAGSTER_ENV, VAULT_ADDRESS
-from ol_orchestrate.lib.dagster_helpers import default_io_manager
+from ol_orchestrate.lib.dagster_helpers import (
+    default_file_object_io_manager,
+    default_io_manager,
+)
 from ol_orchestrate.lib.utils import authenticate_vault, s3_uploads_bucket
 from ol_orchestrate.resources.canvas_api import CanvasApiClientFactory
 
@@ -24,7 +26,8 @@ canvas_course_export_schedule = ScheduleDefinition(
 canvas_course_export = Definitions(
     resources={
         "io_manager": default_io_manager(DAGSTER_ENV),
-        "s3file_io_manager": S3FileObjectIOManager(
+        "s3file_io_manager": default_file_object_io_manager(
+            dagster_env=DAGSTER_ENV,
             bucket=s3_uploads_bucket(DAGSTER_ENV)["bucket"],
             path_prefix=s3_uploads_bucket(DAGSTER_ENV)["prefix"],
         ),

--- a/src/ol_orchestrate/definitions/canvas_course_export.py
+++ b/src/ol_orchestrate/definitions/canvas_course_export.py
@@ -1,0 +1,37 @@
+from dagster import (
+    AssetSelection,
+    Definitions,
+    ScheduleDefinition,
+)
+from dagster_aws.s3 import S3Resource
+
+from ol_orchestrate.assets.canvas import export_courses
+from ol_orchestrate.io_managers.filepath import S3FileObjectIOManager
+from ol_orchestrate.lib.constants import DAGSTER_ENV, VAULT_ADDRESS
+from ol_orchestrate.lib.dagster_helpers import default_io_manager
+from ol_orchestrate.lib.utils import authenticate_vault, s3_uploads_bucket
+from ol_orchestrate.resources.canvas_api import CanvasApiClientFactory
+
+vault = authenticate_vault(DAGSTER_ENV, VAULT_ADDRESS)
+
+canvas_course_export_schedule = ScheduleDefinition(
+    name="canvas_course_export_schedule",
+    target=AssetSelection.assets(export_courses),
+    cron_schedule="@daily",
+    execution_timezone="Etc/UTC",
+)
+
+canvas_course_export = Definitions(
+    resources={
+        "io_manager": default_io_manager(DAGSTER_ENV),
+        "s3file_io_manager": S3FileObjectIOManager(
+            bucket=s3_uploads_bucket(DAGSTER_ENV)["bucket"],
+            path_prefix=s3_uploads_bucket(DAGSTER_ENV)["prefix"],
+        ),
+        "vault": vault,
+        "s3": S3Resource(),
+        "canvas_api": CanvasApiClientFactory(vault=vault),
+    },
+    assets=[export_courses],
+    schedules=[canvas_course_export_schedule],
+)

--- a/src/ol_orchestrate/lib/constants.py
+++ b/src/ol_orchestrate/lib/constants.py
@@ -11,3 +11,13 @@ else:
     VAULT_ADDRESS = os.getenv("VAULT_ADDR", f"https://vault-{DAGSTER_ENV}.odl.mit.edu")
 
 OPENEDX_DEPLOYMENTS = ["mitx", "mitxonline", "xpro"]
+
+EXPORT_TYPE_COMMON_CARTRIDGE = "common_cartridge"
+EXPORT_TYPE_ZIP = "zip"
+EXPORT_TYPE_QTI = "qti"
+
+EXPORT_TYPE_EXTENSIONS = {
+    EXPORT_TYPE_COMMON_CARTRIDGE: "imscc",
+    EXPORT_TYPE_ZIP: EXPORT_TYPE_ZIP,  # Extension matches the type
+    EXPORT_TYPE_QTI: EXPORT_TYPE_QTI,  # Extension matches the type
+}

--- a/src/ol_orchestrate/lib/utils.py
+++ b/src/ol_orchestrate/lib/utils.py
@@ -1,3 +1,6 @@
+import hashlib
+import zipfile
+from pathlib import Path
 from typing import Any, Literal
 
 from ol_orchestrate.resources.secrets.vault import Vault
@@ -47,3 +50,30 @@ def s3_uploads_bucket(
         },
     }
     return bucket_map[dagster_env]
+
+
+def compute_zip_content_hash(zip_path: Path, skip_filename: str) -> str:
+    """Compute a SHA-256 hash of the contents of a ZIP file, skipping specified file
+    that has volatile data (e.g., timestamps).
+
+    Args:
+        zip_path (Path): Path to the ZIP file.
+        skip_filename (str): file name to exclude from hashing (e.g., imsmanifest.xml).
+
+    Returns:
+        str: Hex digest of the SHA-256 hash.
+    """
+    hasher = hashlib.new("sha256")
+
+    with zipfile.ZipFile(zip_path, "r") as zip_file:
+        for item in zip_file.infolist():
+            hasher.update(item.filename.encode("utf-8"))
+            if not item.is_dir() and item.filename != skip_filename:
+                with zip_file.open(item.filename) as file_content:
+                    while True:
+                        chunk = file_content.read(4096)
+                        if not chunk:
+                            break
+                        hasher.update(chunk)
+
+    return hasher.hexdigest()

--- a/src/ol_orchestrate/resources/canvas_api.py
+++ b/src/ol_orchestrate/resources/canvas_api.py
@@ -1,5 +1,6 @@
 from collections.abc import Generator
 from contextlib import contextmanager
+from pathlib import Path
 from typing import Optional, Self
 
 import httpx
@@ -88,6 +89,24 @@ class CanvasApiClient(ConfigurableResource):
         )
         response.raise_for_status()
         return response.json()
+
+    def download_course_export(self, url: str, output_path: Path) -> None:
+        """Download a file from a URL to a local path, following redirects and streaming
+        to disk.
+
+        :param url: The URL to download the file from.
+        :type url: str
+        :param output_path: The local path where the file will be saved.
+        :type output_path: Path
+        """
+        with self.http_client.stream(
+            "GET", url, follow_redirects=True, timeout=60
+        ) as response:
+            response.raise_for_status()
+            with output_path.open("wb") as f:
+                for chunk in response.iter_bytes():
+                    if chunk:
+                        f.write(chunk)
 
 
 class CanvasApiClientFactory(ConfigurableResource):

--- a/src/ol_orchestrate/resources/canvas_api.py
+++ b/src/ol_orchestrate/resources/canvas_api.py
@@ -90,7 +90,7 @@ class CanvasApiClient(ConfigurableResource):
         response.raise_for_status()
         return response.json()
 
-    def download_course_export(self, url: str, output_path: Path) -> None:
+    def download_course_export(self, url: str, output_path: Path) -> Path:
         """Download a file from a URL to a local path, following redirects and streaming
         to disk.
 
@@ -107,6 +107,7 @@ class CanvasApiClient(ConfigurableResource):
                 for chunk in response.iter_bytes():
                     if chunk:
                         f.write(chunk)
+        return output_path
 
 
 class CanvasApiClientFactory(ConfigurableResource):

--- a/src/ol_orchestrate/resources/canvas_api.py
+++ b/src/ol_orchestrate/resources/canvas_api.py
@@ -44,11 +44,17 @@ class CanvasApiClient(ConfigurableResource):
         response.raise_for_status()
         return response.json()
 
-    def export_course_content(self, course_id: int) -> dict[str, str]:
+    def export_course_content(
+        self, course_id: int, export_type: str = "common_cartridge"
+    ) -> dict[str, str]:
         """Trigger export of canvas courses via an API request.
 
-        param course_id: The unique identifier of the course to be exported.
-        type course_id: str
+        :param course_id: The unique identifier of the course to be exported.
+        :type course_id: int
+
+        :param export_type: either "common_cartridge", "zip" or "qti"
+        :type export_type: str
+
 
         returns: A dictionary containing information about the export, including
         the export ID.
@@ -56,7 +62,7 @@ class CanvasApiClient(ConfigurableResource):
         request_url = f"{self.base_url}/api/v1/courses/{course_id}/content_exports"
         response = self.http_client.post(
             request_url,
-            json={"export_type": "common_cartridge"},
+            json={"export_type": export_type},
             headers={"Authorization": f"{self.token_type} {self.access_token}"},
         )
         response.raise_for_status()
@@ -68,7 +74,7 @@ class CanvasApiClient(ConfigurableResource):
         """Trigger export of canvas courses via an API request.
 
         param course_id: The unique identifier of the course to be exported.
-        type course_id: str
+        type course_id: int
 
         returns: A dictionary containing information about the export, including
         the export ID.

--- a/src/ol_orchestrate/resources/canvas_api.py
+++ b/src/ol_orchestrate/resources/canvas_api.py
@@ -1,0 +1,110 @@
+from collections.abc import Generator
+from contextlib import contextmanager
+from typing import Optional, Self
+
+import httpx
+from dagster import ConfigurableResource, InitResourceContext, ResourceDependency
+from pydantic import Field, PrivateAttr
+
+from ol_orchestrate.resources.secrets.vault import Vault
+
+
+class CanvasApiClient(ConfigurableResource):
+    token_type: str = Field(
+        default="Bearer",
+        description="Token type to generate for use with authenticated requests",
+    )
+    access_token: str = Field(
+        description="Access token for the Canvas API",
+    )
+    base_url: str = Field(
+        description="Base URL of the canvas API. e.g. https://canvas.mit.edu",
+    )
+    http_timeout: int = Field(
+        default=60,
+        description=(
+            "Time (in seconds) to allow for requests to complete before timing out."
+        ),
+    )
+    _http_client: Optional[httpx.Client] = PrivateAttr(default=None)
+
+    @property
+    def http_client(self) -> httpx.Client:
+        if not self._http_client:
+            timeout = httpx.Timeout(self.http_timeout, connect=10)
+            self._http_client = httpx.Client(timeout=timeout)
+        return self._http_client
+
+    def get_course(self, course_id: int):
+        request_url = f"{self.base_url}/api/v1/courses/{course_id}"
+        response = self.http_client.get(
+            request_url,
+            headers={"Authorization": f"{self.token_type} {self.access_token}"},
+        )
+        response.raise_for_status()
+        return response.json()
+
+    def export_course_content(self, course_id: int) -> dict[str, str]:
+        """Trigger export of canvas courses via an API request.
+
+        param course_id: The unique identifier of the course to be exported.
+        type course_id: str
+
+        returns: A dictionary containing information about the export, including
+        the export ID.
+        """
+        request_url = f"{self.base_url}/api/v1/courses/{course_id}/content_exports"
+        response = self.http_client.post(
+            request_url,
+            json={"export_type": "common_cartridge"},
+            headers={"Authorization": f"{self.token_type} {self.access_token}"},
+        )
+        response.raise_for_status()
+        return response.json()
+
+    def check_course_export_status(
+        self, course_id: int, export_id: int
+    ) -> dict[str, str]:
+        """Trigger export of canvas courses via an API request.
+
+        param course_id: The unique identifier of the course to be exported.
+        type course_id: str
+
+        returns: A dictionary containing information about the export, including
+        the export ID.
+        """
+        request_url = (
+            f"{self.base_url}/api/v1/courses/{course_id}/content_exports/{export_id}"
+        )
+        response = self.http_client.get(
+            request_url,
+            headers={"Authorization": f"{self.token_type} {self.access_token}"},
+        )
+        response.raise_for_status()
+        return response.json()
+
+
+class CanvasApiClientFactory(ConfigurableResource):
+    _client: Optional[CanvasApiClient] = PrivateAttr(default=None)
+    vault: ResourceDependency[Vault]
+
+    def _initialize_client(self) -> CanvasApiClient:
+        client_secrets = self.vault.client.secrets.kv.v1.read_secret(
+            mount_point="secret-data",
+            path="pipelines/canvas",
+        )["data"]
+
+        return CanvasApiClient(
+            base_url=client_secrets["base_url"],
+            access_token=client_secrets["access_token"],
+        )
+
+    @property
+    def client(self) -> CanvasApiClient:
+        if not self._client:
+            self._client = self._initialize_client()
+        return self._client
+
+    @contextmanager
+    def yield_for_execution(self, context: InitResourceContext) -> Generator[Self]:  # noqa: ARG002
+        yield self

--- a/src/ol_orchestrate/workspace.yaml
+++ b/src/ol_orchestrate/workspace.yaml
@@ -5,6 +5,7 @@ load_from:
 - python_module: ol_orchestrate.definitions.edx.retrieve_edxorg_raw_data
 - python_module: ol_orchestrate.definitions.edx.sync_program_credential_reports
 - python_module: ol_orchestrate.definitions.learning_resource.extract_api_data
+- python_module: ol_orchestrate.definitions.canvas_course_export
 - python_module: ol_orchestrate.definitions.lakehouse.elt
 - python_module: ol_orchestrate.definitions.platform.notification
 - python_module: ol_orchestrate.repositories.edx_gcs_courses


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
https://github.com/mitodl/hq/issues/7459

### Description (What does it do?)
<!--- Describe your changes in detail -->

Implementing a Dagster pipeline to export canvas course content and upload to our designed bucket in S3
- s3://ol-devops-sandbox/ for local testing
- s3://ol-data-lake-landing-zone-production/ for production

For now, we only need to export the course content for https://canvas.mit.edu/courses/7023. We will add more later once Peter give us a list of courses.

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->
```
export AWS_ACCESS_KEY_ID=
export AWS_SECRET_ACCESS_KEY=
export GITHUB_TOKEN=
dagster dev -d src/ol_orchestrate/ -f src/ol_orchestrate/definitions/canvas_course_export.py
```
Navigate to http://127.0.0.1:3000/assets/canvas?view=folder and click on "Materialize"
Course ID 7023 should be uploaded to `s3://ol-devops-sandbox/pipeline-storage/canvas/course_export/`
