### PR TITLE
Format edxorg courserun_readable_id in tfact 

### DIFF
--- a/src/ol_dbt/models/dimensional/tfact_course_navigation_events.sql
+++ b/src/ol_dbt/models/dimensional/tfact_course_navigation_events.sql
@@ -88,7 +88,7 @@ with mitxonline_navigation_events as (
     select
         user_username
         , user_id
-        , courserun_readable_id
+        , {{ format_course_id('courserun_readable_id') }} as courserun_readable_id
         , useractivity_event_type as event_type
         , useractivity_event_object as event_json
         , json_query(useractivity_event_object, 'lax $.old' omit quotes) as starting_tab

--- a/src/ol_dbt/models/dimensional/tfact_discussion_events.sql
+++ b/src/ol_dbt/models/dimensional/tfact_discussion_events.sql
@@ -72,7 +72,7 @@ with mitxonline_discussion_events as (
     select
         user_username
         , user_id as openedx_user_id
-        , courserun_readable_id
+        , {{ format_course_id('courserun_readable_id') }} as courserun_readable_id
         , useractivity_event_type as event_type
         , useractivity_event_object as event_json
         , json_query(useractivity_event_object, 'lax $.id' omit quotes) as post_id

--- a/src/ol_dbt/models/dimensional/tfact_problem_events.sql
+++ b/src/ol_dbt/models/dimensional/tfact_problem_events.sql
@@ -75,7 +75,7 @@ with mitxonline_problem_events as (
     select
         user_username
         , user_id
-        , courserun_readable_id
+        , {{ format_course_id('courserun_readable_id') }} as courserun_readable_id
         , useractivity_event_type as event_type
         , useractivity_event_object as event_json
         , json_query(useractivity_context_object, 'lax $.module.display_name' omit quotes) as problem_name

--- a/src/ol_dbt/models/dimensional/tfact_video_events.sql
+++ b/src/ol_dbt/models/dimensional/tfact_video_events.sql
@@ -84,7 +84,7 @@ with mitxonline_video_events as (
     select
         user_username
         , user_id
-        , courserun_readable_id
+        , {{ format_course_id('courserun_readable_id') }} as courserun_readable_id
         , useractivity_event_type as event_type
         , useractivity_event_object as event_json
         , json_query(useractivity_event_object, 'lax $.id' omit quotes) as video_id


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
na
followup https://github.com/mitodl/ol-data-platform/pull/1569

### Description (What does it do?)
<!--- Describe your changes in detail -->
Format edxorg courserun_readable_id in tfact_ models to match the format in `dim_` tables. This ensures consistency with the  courserun_readable_id in mart tables and allows for proper joins


### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->
dbt build --select tfact_course_navigation_events tfact_discussion_events tfact_problem_events tfact_video_events 
dbt build --select learner_engagement_report
