### PR TITLE
Fix dbt test errors related to course_number for UAI courses

### DIFF
--- a/src/ol_dbt/models/intermediate/combined/int__combined__course_runs.sql
+++ b/src/ol_dbt/models/intermediate/combined/int__combined__course_runs.sql
@@ -70,7 +70,7 @@ with mitx_courses as (
             else false
         end as courserun_is_current
     from mitxonline_runs
-    left join mitx_courses on mitxonline_runs.course_number = mitx_courses.course_number
+    left join mitx_courses on mitxonline_runs.course_id = mitx_courses.mitxonline_course_id
     where mitxonline_runs.courserun_platform = '{{ var("mitxonline") }}'
 
     union all

--- a/src/ol_dbt/models/intermediate/mitx/_int_mitx__models.yml
+++ b/src/ol_dbt/models/intermediate/mitx/_int_mitx__models.yml
@@ -34,10 +34,7 @@ models:
   columns:
   - name: course_number
     description: str, unique string for the course. It can contain letters, numbers,
-      or periods. e.g. 6.002.1x
-    tests:
-    - unique
-    - not_null
+      or periods. e.g. 6.002.1x. May not be unique for UAI course.
   - name: course_readable_id
     description: str, Open edX ID for the course formatted as course-v1:{org}+{course
       code} for MITx Online and {org}/{course} for edX.org

--- a/src/ol_dbt/models/intermediate/mitxonline/_int_mitxonline__models.yml
+++ b/src/ol_dbt/models/intermediate/mitxonline/_int_mitxonline__models.yml
@@ -907,9 +907,8 @@ models:
     - not_null
   - name: course_number
     description: str, unique string for the course. It can contain letters, numbers,
-      or periods. e.g. 18.03.1x
+      or periods. e.g. 18.03.1x. May not be unique for UAI course.
     tests:
-    - unique
     - not_null
   - name: course_description
     description: text, the description shown on the home page and product page.

--- a/src/ol_dbt/models/staging/mitxonline/_stg_mitxonline__models.yml
+++ b/src/ol_dbt/models/staging/mitxonline/_stg_mitxonline__models.yml
@@ -797,9 +797,9 @@ models:
     - unique
     - not_null
   - name: course_number
-    description: str, unique string for the course e.g. 14.009x
+    description: str, unique string for the course e.g. 14.009x. May not be unique
+      for UAI course.
     tests:
-    - unique
     - not_null
   - name: course_created_on
     description: timestamp, specifying when a course was initially created

--- a/src/ol_dbt/models/staging/mitxpro/_stg_mitxpro__models.yml
+++ b/src/ol_dbt/models/staging/mitxpro/_stg_mitxpro__models.yml
@@ -1551,11 +1551,11 @@ models:
     description: str, a short description indicating how long the course takes to
       complete (e.g. '4 weeks')
   - name: cms_coursepage_format
-    description: str, format of the course (Online, Other)
+    description: str, format of the course (Online, Other, Hybrid)
     tests:
     - not_null
     - accepted_values:
-        values: ['Online', 'Other']
+        values: ['Online', 'Other', 'Hybrid']
   - name: cms_coursepage_subhead
     description: str, short subheading to appear below the title on the course page
     tests:


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
N/A

### Description (What does it do?)
<!--- Describe your changes in detail -->
There are a few dbt test errors like https://pipelines.odl.mit.edu/runs/124511d4-c301-4e18-81c7-48be2187392d due to course_number is not unique for UAI courses. e.g. course-v1:UAI_SOURCE+UAI.2 and course-v1:UAI_HHC+UAI.2

This PR is to fix the join on `int__combined__course_runs` to use course_readable_id instead of course_numbe, also remove the unique check on course_number since its not unique anymore.

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

No error running

dbt build --select +int__combined__course_runs
dbt build --select marts__combined_course_enrollment_detail
