### PR TITLE
Add a dagster asset to notify Learn when canvas course export files are updated

### DIFF
--- a/src/ol_orchestrate/resources/api_client.py
+++ b/src/ol_orchestrate/resources/api_client.py
@@ -1,0 +1,44 @@
+from typing import Any, Optional
+
+import httpx
+from dagster import ConfigurableResource
+from pydantic import Field, PrivateAttr
+
+
+class BaseApiClient(ConfigurableResource):
+    base_url: str = Field(description="Base URL of the API.")
+    token_type: str = Field(
+        default="Bearer",
+        description="Token type to generate for use with authenticated requests",
+    )
+    http_timeout: int = Field(
+        default=60,
+        description="seconds to allow for requests to complete before timing out",
+    )
+    _http_client: Optional[httpx.Client] = PrivateAttr(default=None)
+
+    @property
+    def http_client(self) -> httpx.Client:
+        if not self._http_client:
+            timeout = httpx.Timeout(self.http_timeout, connect=10)
+            self._http_client = httpx.Client(timeout=timeout)
+        return self._http_client
+
+    def get_request(
+        self, endpoint: str, headers: Optional[dict[str, str]] = None
+    ) -> httpx.Response:
+        url = f"{self.base_url}/{endpoint}"
+        response = self.http_client.get(url, headers=headers)
+        response.raise_for_status()
+        return response
+
+    def post_request(
+        self,
+        endpoint: str,
+        data: dict[str, Any],
+        headers: Optional[dict[str, str]] = None,
+    ) -> httpx.Response:
+        url = f"{self.base_url}/{endpoint}"
+        response = self.http_client.post(url, json=data, headers=headers)
+        response.raise_for_status()
+        return response

--- a/src/ol_orchestrate/resources/api_client_factory.py
+++ b/src/ol_orchestrate/resources/api_client_factory.py
@@ -1,0 +1,55 @@
+from collections.abc import Generator
+from contextlib import contextmanager
+from typing import ClassVar, Optional, Self
+
+from dagster import ConfigurableResource, InitResourceContext, ResourceDependency
+from pydantic import Field, PrivateAttr
+
+from ol_orchestrate.resources.api_client import BaseApiClient
+from ol_orchestrate.resources.canvas_api import CanvasApiClient
+from ol_orchestrate.resources.learn_api import MITLearnApiClient
+from ol_orchestrate.resources.secrets.vault import Vault
+
+
+class ApiClientFactory(ConfigurableResource):
+    deployment: str = Field(
+        description="The deployment name this resource is used in. e.g. canvas"
+    )
+
+    vault: ResourceDependency[Vault]
+
+    client_class: str = Field(
+        description="Type of client to instantiate. e.g. 'CanvasApiClient'"
+    )
+    config_path: str = Field(
+        description="Vault secret path where API credentials are stored. "
+        "e.g. 'pipelines/canvas'"
+    )
+    mount_point: str = Field(
+        description="Vault mount point for secrets. e.g. 'secret-data'"
+    )
+    _client: Optional[BaseApiClient] = PrivateAttr(default=None)
+
+    supported_client_class: ClassVar[dict[str, type[BaseApiClient]]] = {
+        "CanvasApiClient": CanvasApiClient,
+        "MITLearnApiClient": MITLearnApiClient,
+    }
+
+    def _initialize_client(self) -> BaseApiClient:
+        client_class = self.supported_client_class[self.client_class]
+        client_secrets = self.vault.client.secrets.kv.v1.read_secret(
+            mount_point=self.mount_point,
+            path=self.config_path,
+        )["data"]
+
+        return client_class(**client_secrets)
+
+    @property
+    def client(self) -> BaseApiClient:
+        if not self._client:
+            self._client = self._initialize_client()
+        return self._client
+
+    @contextmanager
+    def yield_for_execution(self, context: InitResourceContext) -> Generator[Self]:  # noqa: ARG002
+        yield self

--- a/src/ol_orchestrate/resources/canvas_api.py
+++ b/src/ol_orchestrate/resources/canvas_api.py
@@ -1,40 +1,14 @@
-from collections.abc import Generator
-from contextlib import contextmanager
 from pathlib import Path
-from typing import Optional, Self
 
-import httpx
-from dagster import ConfigurableResource, InitResourceContext, ResourceDependency
-from pydantic import Field, PrivateAttr
+from pydantic import Field
 
-from ol_orchestrate.resources.secrets.vault import Vault
+from ol_orchestrate.resources.api_client import BaseApiClient
 
 
-class CanvasApiClient(ConfigurableResource):
-    token_type: str = Field(
-        default="Bearer",
-        description="Token type to generate for use with authenticated requests",
-    )
+class CanvasApiClient(BaseApiClient):
     access_token: str = Field(
         description="Access token for the Canvas API",
     )
-    base_url: str = Field(
-        description="Base URL of the canvas API. e.g. https://canvas.mit.edu",
-    )
-    http_timeout: int = Field(
-        default=60,
-        description=(
-            "Time (in seconds) to allow for requests to complete before timing out."
-        ),
-    )
-    _http_client: Optional[httpx.Client] = PrivateAttr(default=None)
-
-    @property
-    def http_client(self) -> httpx.Client:
-        if not self._http_client:
-            timeout = httpx.Timeout(self.http_timeout, connect=10)
-            self._http_client = httpx.Client(timeout=timeout)
-        return self._http_client
 
     def get_course(self, course_id: int):
         request_url = f"{self.base_url}/api/v1/courses/{course_id}"
@@ -108,29 +82,3 @@ class CanvasApiClient(ConfigurableResource):
                     if chunk:
                         f.write(chunk)
         return output_path
-
-
-class CanvasApiClientFactory(ConfigurableResource):
-    _client: Optional[CanvasApiClient] = PrivateAttr(default=None)
-    vault: ResourceDependency[Vault]
-
-    def _initialize_client(self) -> CanvasApiClient:
-        client_secrets = self.vault.client.secrets.kv.v1.read_secret(
-            mount_point="secret-data",
-            path="pipelines/canvas",
-        )["data"]
-
-        return CanvasApiClient(
-            base_url=client_secrets["base_url"],
-            access_token=client_secrets["access_token"],
-        )
-
-    @property
-    def client(self) -> CanvasApiClient:
-        if not self._client:
-            self._client = self._initialize_client()
-        return self._client
-
-    @contextmanager
-    def yield_for_execution(self, context: InitResourceContext) -> Generator[Self]:  # noqa: ARG002
-        yield self

--- a/src/ol_orchestrate/resources/learn_api.py
+++ b/src/ol_orchestrate/resources/learn_api.py
@@ -1,0 +1,30 @@
+import hashlib
+import hmac
+import json
+from typing import Any
+
+from pydantic import Field
+
+from ol_orchestrate.resources.api_client import BaseApiClient
+
+
+class MITLearnApiClient(BaseApiClient):
+    secret: str = Field(
+        description="secret key for HMAC signing of requests",
+    )
+
+    def notify_course_export(self, data: dict[str, Any]) -> dict[str, Any]:
+        payload_bytes = json.dumps(data).encode()
+        signature = hmac.new(
+            self.secret.encode(), payload_bytes, hashlib.sha256
+        ).hexdigest()
+
+        headers = {"X-Signature": signature, "Content-Type": "application/json"}
+
+        response = self.http_client.post(
+            f"{self.base_url}/webhooks/content_files",
+            content=payload_bytes,
+            headers=headers,
+        )
+        response.raise_for_status()
+        return response.json()


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
close out https://github.com/mitodl/hq/issues/7459

### Description (What does it do?)
<!--- Describe your changes in detail -->
Adding `BaseApiClient` and `ApiClientFactory` for reusable httpx api client
Add `create course_export_metadata` asset to send POST request with the following data to Learn when canvas course export files are updated

e.g.
data = {
'course_id': 7023, 
'course_name': 'xxxxxx, 
'course_code': 'xxxx', 
'course_readable_id': 'xxxx', 
'content_url': 'canvas/course_7023/xxxx.imscc', 
'source': 'canvas'
}

headers={
'X-Signature': computed_signature
}

to `http://{LEARN API BASE URL}/webhooks/content_files/'`
 

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

docker compose up


### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->

This depends on https://github.com/mitodl/hq/issues/7552


<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
