### PR TITLE
fix learner engagement reporting to adjust for different course run id formats in the fact tables

### DIFF
--- a/src/ol_dbt/models/reporting/learner_engagement_report.sql
+++ b/src/ol_dbt/models/reporting/learner_engagement_report.sql
@@ -29,7 +29,7 @@ with video_pre_query as (
         , a.courserun_readable_id
         , d.block_title as section_title
         , c.block_title as subsection_title
-        , coalesce(h.course_title, h2.course_title) as course_title
+        , h2.course_title
         , coalesce(u.email, ou.email) as email
         , sum(a.post_created) as posts_created
         , sum(a.post_replied) as posts_replied
@@ -38,8 +38,6 @@ with video_pre_query as (
         on a.platform = 'mitxonline' and a.openedx_user_id = u.mitxonline_openedx_user_id
     left join ol_warehouse_production_dimensional.dim_user as ou
         on a.platform = 'edxorg' and a.openedx_user_id = ou.edxorg_openedx_user_id
-    left join ol_warehouse_production_intermediate.int__combined__course_runs as h
-        on replace(replace(a.courserun_readable_id, 'course-v1:', ''), '+', '/') = h.courserun_readable_id
     left join ol_warehouse_production_intermediate.int__combined__course_runs as h2
         on a.courserun_readable_id = h2.courserun_readable_id
     left join ol_warehouse_production_dimensional.dim_course_content as c
@@ -55,7 +53,7 @@ with video_pre_query as (
         , a.courserun_readable_id
         , d.block_title
         , c.block_title
-        , coalesce(h.course_title, h2.course_title)
+        , h2.course_title
         , coalesce(u.email, ou.email)
 )
 
@@ -65,7 +63,7 @@ with video_pre_query as (
         , a.courserun_readable_id
         , d.block_title as section_title
         , c.block_title as subsection_title
-        , coalesce(h.course_title, h2.course_title) as course_title
+        , h2.course_title
         , coalesce(u.email, ou.email) as email
         , sum(a.num_of_views) as num_of_page_views
     from ol_warehouse_production_dimensional.afact_course_page_engagement as a
@@ -89,8 +87,6 @@ with video_pre_query as (
         on
             a.platform = 'edxorg'
             and a.openedx_user_id = ou.edxorg_openedx_user_id
-    left join ol_warehouse_production_intermediate.int__combined__course_runs as h
-        on replace(replace(a.courserun_readable_id, 'course-v1:', ''), '+', '/') = h.courserun_readable_id
     left join ol_warehouse_production_intermediate.int__combined__course_runs as h2
         on a.courserun_readable_id = h2.courserun_readable_id
     group by
@@ -98,7 +94,7 @@ with video_pre_query as (
         , a.courserun_readable_id
         , d.block_title
         , c.block_title
-        , coalesce(h.course_title, h2.course_title)
+        , h2.course_title
         , coalesce(u.email, ou.email)
 )
 
@@ -108,7 +104,7 @@ with video_pre_query as (
         , a.courserun_readable_id
         , cc_section.block_title as section_title
         , cc_subsection.block_title as subsection_title
-        , coalesce(h.course_title, h2.course_title) as course_title
+        , h2.course_title
         , coalesce(b.email, ob.email) as email
         , sum(
             cast(case when a.end_time = 'null' then '0' else a.end_time end as decimal(30, 10))
@@ -129,8 +125,6 @@ with video_pre_query as (
         on
             a.platform = 'edxorg'
             and a.openedx_user_id = ob.edxorg_openedx_user_id
-    left join ol_warehouse_production_intermediate.int__combined__course_runs as h
-        on replace(replace(a.courserun_readable_id, 'course-v1:', ''), '+', '/') = h.courserun_readable_id
     left join ol_warehouse_production_intermediate.int__combined__course_runs as h2
         on a.courserun_readable_id = h2.courserun_readable_id
     left join ol_warehouse_production_dimensional.dim_course_content as v
@@ -152,7 +146,7 @@ with video_pre_query as (
         , a.courserun_readable_id
         , cc_section.block_title
         , cc_subsection.block_title
-        , coalesce(h.course_title, h2.course_title)
+        , h2.course_title
         , coalesce(b.email, ob.email)
 )
 
@@ -190,7 +184,7 @@ with video_pre_query as (
         , a.courserun_readable_id
         , sec.block_title as section_title
         , d.block_title as subsection_title
-        , coalesce(h.course_title, h2.course_title) as course_title
+        , h2.course_title
         , coalesce(u.email, ou.email) as email
         , avg(g.avg_percent_grade) as avg_percent_grade
         , count(distinct case when cast(a.num_of_attempts as int) > 0 then a.problem_block_fk end) as problems_attempted
@@ -212,8 +206,6 @@ with video_pre_query as (
         on
             a.platform = 'edxorg'
             and a.openedx_user_id = ou.edxorg_openedx_user_id
-    left join ol_warehouse_production_intermediate.int__combined__course_runs as h
-        on replace(replace(a.courserun_readable_id, 'course-v1:', ''), '+', '/') = h.courserun_readable_id
     left join ol_warehouse_production_intermediate.int__combined__course_runs as h2
         on a.courserun_readable_id = h2.courserun_readable_id
     inner join ol_warehouse_production_dimensional.dim_course_content as d
@@ -234,7 +226,7 @@ with video_pre_query as (
         , a.courserun_readable_id
         , sec.block_title
         , d.block_title
-        , coalesce(h.course_title, h2.course_title)
+        , h2.course_title
         , coalesce(u.email, ou.email)
 )
 


### PR DESCRIPTION
### What are the relevant tickets?
related to adding data for holistic assessment project work https://github.com/mitodl/hq/issues/7388

### Description (What does it do?)
We [modified](https://github.com/mitodl/ol-data-platform/pull/1571) the format of the course run id's in the tfacts and that flows through into the afacts as well. As a result joins for this reporting table(which is sourced from the fact tables) needed to be adjusted as well.  The course run id's are used in the "on" clauses for some of the joins for this reporting table. This PR adjusts the joins so that the missing course runs show up. 

This PR modifies the learner_engagement_report in order to pull missing course runs including course-v1:UAI_HHC+UAI.1+2T2025_HHC.

### How can this be tested?
dbt build --select learner_engagement_report