### PR TITLE
Add global alumni data to intermediate and marts

### DIFF
--- a/src/ol_dbt/dbt_project.yml
+++ b/src/ol_dbt/dbt_project.yml
@@ -29,8 +29,8 @@ vars:
   schema_suffix: dev
 
   open_learning:
-    platforms: ['Bootcamps', 'xPro', 'xPRO Emeritus', 'MITx Online', 'MicroMasters',
-      'edX.org', 'Residential MITx']
+    platforms: ['Bootcamps', 'xPro', 'xPRO Emeritus', 'xPRO Global Alumni', 'MITx
+        Online', 'MicroMasters', 'edX.org', 'Residential MITx']
     bootcamps: 'Bootcamps'
     edxorg: 'edX.org'
     mitxpro: 'xPro'
@@ -38,6 +38,7 @@ vars:
     mitxonline: 'MITx Online'
     residential: 'Residential MITx'
     emeritus: 'xPRO Emeritus'
+    global_alumni: 'xPRO Global Alumni'
     dedp_micromasters_program_id: 2
     dedp_mitxonline_international_development_program_id: 1
     dedp_mitxonline_public_policy_program_id: 2

--- a/src/ol_dbt/models/intermediate/combined/_combined_models.yml
+++ b/src/ol_dbt/models/intermediate/combined/_combined_models.yml
@@ -78,7 +78,8 @@ models:
     description: timestamp, specifying when an enrollment was initially created on
       the corresponding platform
     tests:
-    - not_null
+    - dbt_expectations.expect_column_values_to_not_be_null:
+        row_condition: "platform != 'xPRO Global Alumni'"
   - name: courserunenrollment_enrollment_mode
     description: string, enrollment mode for user on the corresponding platform
   - name: courserunenrollment_enrollment_status

--- a/src/ol_dbt/models/intermediate/combined/_combined_models.yml
+++ b/src/ol_dbt/models/intermediate/combined/_combined_models.yml
@@ -216,8 +216,6 @@ models:
     description: string, application where the data is from
     tests:
     - not_null
-    - accepted_values:
-        values: '{{ var("platforms") }}'
   - name: courserun_readable_id
     description: str, unique string to identify a course run on the corresponding
       platform. Maybe null for Bootcamps runs.

--- a/src/ol_dbt/models/intermediate/combined/int__combined__course_runs.sql
+++ b/src/ol_dbt/models/intermediate/combined/int__combined__course_runs.sql
@@ -129,7 +129,7 @@ with mitx_courses as (
     select
         case
             when mitxpro_runs.platform_id = 2 then '{{ var("mitxpro") }}'
-            else 'xPRO' || mitxpro_runs.platform_name
+            else 'xPRO ' || mitxpro_runs.platform_name
         end as platform
         , mitxpro_courses.course_title
         , mitxpro_courses.course_readable_id

--- a/src/ol_dbt/models/intermediate/combined/int__combined__course_runs.sql
+++ b/src/ol_dbt/models/intermediate/combined/int__combined__course_runs.sql
@@ -130,7 +130,7 @@ with mitx_courses as (
         case
             when mitxpro_runs.platform_id = 2 then '{{ var("mitxpro") }}'
             else 'xPRO' || mitxpro_runs.platform_name
-        end as platform_name
+        end as platform
         , mitxpro_courses.course_title
         , mitxpro_courses.course_readable_id
         , mitxpro_runs.courserun_title

--- a/src/ol_dbt/models/intermediate/combined/int__combined__course_runs.sql
+++ b/src/ol_dbt/models/intermediate/combined/int__combined__course_runs.sql
@@ -31,21 +31,35 @@ with mitx_courses as (
 )
 
 , emeritus_runs as (
-    select distinct
-        courserun_external_readable_id
-        , courserun_title
-        , courserun_start_on
-        , courserun_end_on
-    from {{ ref('stg__emeritus__api__bigquery__user_enrollments') }}
+    select * from (
+        select
+            courserun_external_readable_id
+            , courserun_title
+            , courserun_start_on
+            , courserun_end_on
+            , row_number() over (
+                partition by courserun_external_readable_id
+                order by courserun_start_on desc, courserun_end_on desc, enrollment_created_on desc
+            ) as row_num
+        from {{ ref('stg__emeritus__api__bigquery__user_enrollments') }}
+    )
+    where row_num = 1
 )
 
 , global_alumni_runs as (
-    select distinct
-        courserun_external_readable_id
-        , courserun_title
-        , courserun_start_on
-        , courserun_end_on
-    from {{ ref('stg__global_alumni__api__bigquery__user_enrollments') }}
+    select * from (
+        select
+            courserun_external_readable_id
+            , courserun_title
+            , courserun_start_on
+            , courserun_end_on
+            , row_number() over (
+                partition by courserun_external_readable_id
+                order by courserun_start_on desc, courserun_end_on desc, user_gdpr_consent_date desc
+            ) as row_num
+        from {{ ref('stg__global_alumni__api__bigquery__user_enrollments') }}
+    )
+    where row_num = 1
 )
 
 , residential_runs as (

--- a/src/ol_dbt/models/intermediate/combined/int__combined__courserun_enrollments.sql
+++ b/src/ol_dbt/models/intermediate/combined/int__combined__courserun_enrollments.sql
@@ -10,6 +10,10 @@ with mitx_enrollments as (
     select * from {{ ref('stg__emeritus__api__bigquery__user_enrollments') }}
 )
 
+, global_alumni_enrollments as (
+    select * from {{ ref('stg__global_alumni__api__bigquery__user_enrollments') }}
+)
+
 , bootcamps_enrollments as (
     select * from {{ ref('int__bootcamps__courserunenrollments') }}
 )
@@ -146,6 +150,32 @@ with mitx_enrollments as (
     left join mitxpro_courseruns
         on
             emeritus_enrollments.courserun_external_readable_id = mitxpro_courseruns.courserun_external_readable_id
+
+    union all
+
+    select
+        '{{ var("global_alumni") }}' as platform
+        , null as courserunenrollment_id
+        , global_alumni_enrollments.is_enrolled as courserunenrollment_is_active
+        , null as courserunenrollment_created_on
+        , null as courserunenrollment_enrollment_mode
+        , global_alumni_enrollments.enrollment_status as courserunenrollment_enrollment_status
+        , null as courserunenrollment_is_edx_enrolled
+        , null as courserun_upgrade_deadline
+        , global_alumni_enrollments.user_id
+        , mitxpro_courseruns.courserun_id
+        , coalesce(mitxpro_courseruns.courserun_title, global_alumni_enrollments.courserun_title) as courserun_title
+        , coalesce(mitxpro_courseruns.courserun_readable_id, global_alumni_enrollments.courserun_external_readable_id)
+        as courserun_readable_id
+        , null as user_username
+        , global_alumni_enrollments.user_email
+        , global_alumni_enrollments.user_full_name
+        , null as courserungrade_grade
+        , null as courserungrade_is_passing
+    from global_alumni_enrollments
+    left join mitxpro_courseruns
+        on
+            global_alumni_enrollments.courserun_external_readable_id = mitxpro_courseruns.courserun_external_readable_id
 
     union all
 

--- a/src/ol_dbt/models/intermediate/combined/int__combined__users.sql
+++ b/src/ol_dbt/models/intermediate/combined/int__combined__users.sql
@@ -54,7 +54,7 @@ with mitxonline_users as (
         , user_job_title
         , user_industry
         , row_number() over (
-            partition by coalesce(user_id, user_email)
+            partition by user_email
             order by coalesce(user_gdpr_consent_date, courserun_start_on) desc
         ) as row_num
     from {{ ref('stg__global_alumni__api__bigquery__user_enrollments') }}

--- a/src/ol_dbt/models/intermediate/combined/int__combined__users.sql
+++ b/src/ol_dbt/models/intermediate/combined/int__combined__users.sql
@@ -38,7 +38,7 @@ with mitxonline_users as (
         , user_industry
         , row_number() over (
             partition by coalesce(user_id, user_email, user_full_name)
-            order by coalesce(user_gdpr_consent_date, enrollment_created_on) desc
+            order by user_gdpr_consent_date desc, enrollment_created_on desc
         ) as row_num
     from {{ ref('stg__emeritus__api__bigquery__user_enrollments') }}
 )
@@ -55,7 +55,7 @@ with mitxonline_users as (
         , user_industry
         , row_number() over (
             partition by user_email
-            order by coalesce(user_gdpr_consent_date, courserun_start_on) desc
+            order by user_gdpr_consent_date desc, courserun_start_on desc
         ) as row_num
     from {{ ref('stg__global_alumni__api__bigquery__user_enrollments') }}
 )

--- a/src/ol_dbt/models/intermediate/combined/int__combined__users.sql
+++ b/src/ol_dbt/models/intermediate/combined/int__combined__users.sql
@@ -55,7 +55,7 @@ with mitxonline_users as (
         , user_industry
         , row_number() over (
             partition by coalesce(user_id, user_email)
-            order by user_gdpr_consent_date desc
+            order by coalesce(user_gdpr_consent_date, courserun_start_on) desc
         ) as row_num
     from {{ ref('stg__global_alumni__api__bigquery__user_enrollments') }}
 )

--- a/src/ol_dbt/models/intermediate/combined/int__combined__users.sql
+++ b/src/ol_dbt/models/intermediate/combined/int__combined__users.sql
@@ -43,6 +43,23 @@ with mitxonline_users as (
     from {{ ref('stg__emeritus__api__bigquery__user_enrollments') }}
 )
 
+, global_alumni_users as (
+    select
+        user_id
+        , user_email
+        , user_full_name
+        , user_address_country
+        , user_gender
+        , user_company
+        , user_job_title
+        , user_industry
+        , row_number() over (
+            partition by coalesce(user_id, user_email)
+            order by user_gdpr_consent_date desc
+        ) as row_num
+    from {{ ref('stg__global_alumni__api__bigquery__user_enrollments') }}
+)
+
 , combined_users as (
     select
         '{{ var("mitxonline") }}' as platform
@@ -101,6 +118,27 @@ with mitxonline_users as (
         , null as user_last_login
         , null as user_is_active
     from emeritus_users
+    where row_num = 1
+
+    union all
+
+    select
+        '{{ var("global_alumni") }}' as platform
+        , user_id
+        , null as user_username
+        , user_email
+        , user_full_name
+        , user_address_country
+        , null as user_highest_education
+        , user_gender
+        , null as user_birth_year
+        , user_company
+        , user_job_title
+        , user_industry
+        , null as user_joined_on
+        , null as user_last_login
+        , null as user_is_active
+    from global_alumni_users
     where row_num = 1
 
     union all

--- a/src/ol_dbt/models/intermediate/mitxpro/_int_mitxpro__models.yml
+++ b/src/ol_dbt/models/intermediate/mitxpro/_int_mitxpro__models.yml
@@ -1358,8 +1358,16 @@ models:
     - unique
     - not_null
   - name: courserun_external_readable_id
-    description: str, course run readable ID on the external platforms such as xPRO
-      Emeritus.
+    description: str, course run readable ID on the external platforms such as Emeritus,
+      Global Alumni, etc.
+  - name: platform_id
+    description: int, foreign key to int__mitxpro__platforms
+    tests:
+    - not_null
+  - name: platform_name
+    description: str, name of the platform for xPro courses
+    tests:
+    - not_null
   - name: courserun_url
     description: str, url location for the course run on MITxPro website
   - name: courserun_start_on

--- a/src/ol_dbt/models/intermediate/mitxpro/int__mitxpro__course_runs.sql
+++ b/src/ol_dbt/models/intermediate/mitxpro/int__mitxpro__course_runs.sql
@@ -4,18 +4,32 @@ with course_runs as (
     select * from {{ ref('stg__mitxpro__app__postgres__courses_courserun') }}
 )
 
+, courses as (
+    select * from {{ ref('stg__mitxpro__app__postgres__courses_course') }}
+)
+
+, platforms as (
+    select * from {{ ref('stg__mitxpro__app__postgres__courses_platform') }}
+)
+
 select
-    courserun_id
-    , course_id
-    , courserun_title
-    , courserun_readable_id
-    , courserun_edx_readable_id
-    , courserun_external_readable_id
-    , courserun_tag
-    , courserun_url
-    , courserun_start_on
-    , courserun_end_on
-    , courserun_enrollment_start_on
-    , courserun_enrollment_end_on
-    , courserun_is_live
+    course_runs.courserun_id
+    , course_runs.course_id
+    , course_runs.courserun_title
+    , course_runs.courserun_readable_id
+    , course_runs.courserun_edx_readable_id
+    , course_runs.courserun_external_readable_id
+    , course_runs.courserun_tag
+    , course_runs.courserun_url
+    , course_runs.courserun_start_on
+    , course_runs.courserun_end_on
+    , course_runs.courserun_enrollment_start_on
+    , course_runs.courserun_enrollment_end_on
+    , course_runs.courserun_is_live
+    , platforms.platform_name
+    , platforms.platform_id
 from course_runs
+inner join courses
+    on course_runs.course_id = courses.course_id
+left join platforms
+    on courses.platform_id = platforms.platform_id

--- a/src/ol_dbt/models/marts/combined/_marts__combined__models.yml
+++ b/src/ol_dbt/models/marts/combined/_marts__combined__models.yml
@@ -128,7 +128,7 @@ models:
   - dbt_expectations.expect_compound_columns_to_be_unique:
       column_list: ["user_mitxonline_username", "user_edxorg_username", "user_mitxpro_username",
         "user_bootcamps_username", "platforms"]
-      row_condition: "platforms != 'xPRO Emeritus'"
+      row_condition: "platforms not in ('xPRO Emeritus', 'xPRO Global Alumni')"
 
 - name: marts__combined__orders
   description: ecommerce regular b2c orders
@@ -349,7 +349,8 @@ models:
   - name: courserunenrollment_created_on
     description: timestamp, specifying when the enrollment was initially
     tests:
-    - not_null
+    - dbt_expectations.expect_column_values_to_not_be_null:
+        row_condition: "platform != 'xPRO Global Alumni'"
   - name: courserunenrollment_enrollment_mode
     description: string, enrollment mode for user on the corresponding platform
   - name: courserunenrollment_enrollment_status
@@ -406,20 +407,20 @@ models:
     description: str, gender on the platform user enrolled
   - name: user_id
     description: int, user ID on the corresponding platform. May be null for some
-      xPRO Emeritus learners.
+      xPRO Emeritus and Global Alumni learners.
     tests:
     - dbt_expectations.expect_column_values_to_not_be_null:
-        row_condition: "platform != 'xPRO Emeritus'"
+        row_condition: "platform not in ('xPRO Emeritus', 'xPRO Global Alumni')'"
   - name: user_hashed_id
     description: str, foreign key to combined_users to identify the user
     tests:
     - not_null
   - name: user_username
     description: string, username to identify a user on the corresponding platform.
-      Null for all the xPRO Emeritus.
+      Null for xPRO Emeritus and Global Alumni learners.
     tests:
     - dbt_expectations.expect_column_values_to_not_be_null:
-        row_condition: "platform != 'xPRO Emeritus'"
+        row_condition: "platform not in ('xPRO Emeritus', 'xPRO Global Alumni')"
   tests:
   - dbt_expectations.expect_compound_columns_to_be_unique:
       column_list: ["user_hashed_id", "courserun_readable_id"]
@@ -430,6 +431,9 @@ models:
   - dbt_expectations.expect_compound_columns_to_be_unique:
       column_list: ["courserunenrollment_id", "combined_orders_hash_id"]
       row_condition: "platform ='xPro'"
+  - dbt_expectations.expect_compound_columns_to_be_unique:
+      column_list: ["user_email", "courserun_readable_id"]
+      row_condition: "platform ='xPRO Global Alumni'"
   - dbt_expectations.expect_compound_columns_to_be_unique:
       column_list: ["courserunenrollment_id", "order_reference_number"]
       row_condition: "platform='Bootcamps'"

--- a/src/ol_dbt/models/marts/combined/_marts__combined__models.yml
+++ b/src/ol_dbt/models/marts/combined/_marts__combined__models.yml
@@ -410,7 +410,7 @@ models:
       xPRO Emeritus and Global Alumni learners.
     tests:
     - dbt_expectations.expect_column_values_to_not_be_null:
-        row_condition: "platform not in ('xPRO Emeritus', 'xPRO Global Alumni')'"
+        row_condition: "platform not in ('xPRO Emeritus', 'xPRO Global Alumni')"
   - name: user_hashed_id
     description: str, foreign key to combined_users to identify the user
     tests:

--- a/src/ol_dbt/models/marts/combined/marts__combined__users.sql
+++ b/src/ol_dbt/models/marts/combined/marts__combined__users.sql
@@ -209,6 +209,34 @@ with mitx__users as (
         , user_industry
     from non_mitx_users
     where platform = '{{ var("emeritus") }}'
+
+    union all
+
+    select
+        user_hashed_id
+        , null as user_mitxonline_id
+        , null as user_edxorg_id
+        , null as user_mitxpro_id
+        , null as user_bootcamps_id
+        , null as user_mitxonline_username
+        , null as user_edxorg_username
+        , null as user_mitxpro_username
+        , null as user_bootcamps_username
+        , user_email
+        , user_joined_on
+        , user_last_login
+        , user_is_active
+        , '{{ var("global_alumni") }}' as platforms
+        , user_full_name
+        , user_address_country
+        , user_highest_education
+        , user_gender
+        , user_birth_year
+        , user_company
+        , user_job_title
+        , user_industry
+    from non_mitx_users
+    where platform = '{{ var("global_alumni") }}'
 )
 
 select

--- a/src/ol_dbt/models/marts/combined/marts__combined__users.sql
+++ b/src/ol_dbt/models/marts/combined/marts__combined__users.sql
@@ -198,7 +198,7 @@ with mitx__users as (
         , user_joined_on
         , user_last_login
         , user_is_active
-        , '{{ var("emeritus") }}' as platforms
+        , platform as platforms
         , user_full_name
         , user_address_country
         , user_highest_education
@@ -208,35 +208,8 @@ with mitx__users as (
         , user_job_title
         , user_industry
     from non_mitx_users
-    where platform = '{{ var("emeritus") }}'
+    where platform in ('{{ var("emeritus") }}', '{{ var("global_alumni") }}')
 
-    union all
-
-    select
-        user_hashed_id
-        , null as user_mitxonline_id
-        , null as user_edxorg_id
-        , null as user_mitxpro_id
-        , null as user_bootcamps_id
-        , null as user_mitxonline_username
-        , null as user_edxorg_username
-        , null as user_mitxpro_username
-        , null as user_bootcamps_username
-        , user_email
-        , user_joined_on
-        , user_last_login
-        , user_is_active
-        , '{{ var("global_alumni") }}' as platforms
-        , user_full_name
-        , user_address_country
-        , user_highest_education
-        , user_gender
-        , user_birth_year
-        , user_company
-        , user_job_title
-        , user_industry
-    from non_mitx_users
-    where platform = '{{ var("global_alumni") }}'
 )
 
 select

--- a/src/ol_dbt/models/marts/combined/marts__combined_course_enrollment_detail.sql
+++ b/src/ol_dbt/models/marts/combined/marts__combined_course_enrollment_detail.sql
@@ -284,10 +284,7 @@ with combined_enrollments as (
     from combined_enrollments
     left join combined_users
         on
-            (
-                combined_enrollments.user_email = combined_users.user_email
-                or combined_enrollments.user_full_name = combined_users.user_full_name
-            )
+            combined_enrollments.user_email = combined_users.user_email
             and combined_enrollments.platform = combined_users.platform
     left join combined_courseruns
         on combined_enrollments.courserun_readable_id = combined_courseruns.courserun_readable_id

--- a/src/ol_dbt/models/marts/combined/marts__combined_course_enrollment_detail.sql
+++ b/src/ol_dbt/models/marts/combined/marts__combined_course_enrollment_detail.sql
@@ -284,7 +284,8 @@ with combined_enrollments as (
     from combined_enrollments
     left join combined_users
         on
-            combined_enrollments.user_email = combined_users.user_email
+            combined_enrollments.user_id = combined_users.user_id
+            and combined_enrollments.user_email = combined_users.user_email
             and combined_enrollments.platform = combined_users.platform
     left join combined_courseruns
         on combined_enrollments.courserun_readable_id = combined_courseruns.courserun_readable_id

--- a/src/ol_dbt/models/marts/combined/marts__combined_course_enrollment_detail.sql
+++ b/src/ol_dbt/models/marts/combined/marts__combined_course_enrollment_detail.sql
@@ -246,7 +246,7 @@ with combined_enrollments as (
     union all
 
     select
-        '{{ var("emeritus") }}' as platform
+        combined_enrollments.platform
         , combined_enrollments.courserunenrollment_id
         , combined_enrollments.courserunenrollment_is_active
         , combined_enrollments.courserunenrollment_created_on
@@ -291,7 +291,7 @@ with combined_enrollments as (
             and combined_enrollments.platform = combined_users.platform
     left join combined_courseruns
         on combined_enrollments.courserun_readable_id = combined_courseruns.courserun_readable_id
-    where combined_enrollments.platform = '{{ var("emeritus") }}'
+    where combined_enrollments.platform in ('{{ var("emeritus") }}', '{{ var("global_alumni") }}')
 
     union all
 

--- a/src/ol_dbt/seeds/platforms.csv
+++ b/src/ol_dbt/seeds/platforms.csv
@@ -2,6 +2,8 @@ id,platform_name,platform_description,platform_domain
 mitxonline,MITx Online,Online courses from MIT faculty and instructors,mitxonline.mit.edu
 edxorg,edX.org,MIT Online courses on edX.org,www.edx.org
 mitxpro,MIT xPRO,MIT Professional development courses and programs that build skills and augment careers,xpro.mit.edu
+emeritus,xPRO Emeritus,xPro course offered on Emeritus platform,emeritus.org
+global_alumni,xPRO Global Alumni,xPro course offered on Global Alumni platform,globalalumni.org
 residential,MITx Residential,MITx Residential,lms.mitx.mit.edu
 bootcamps,MIT Bootcamps,MIT Bootcamps,bootcamp.odl.mit.edu
 ocw,OCW,MIT Open Course Ware,ocw.mit.edu


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
https://github.com/mitodl/hq/issues/7019

### Description (What does it do?)
<!--- Describe your changes in detail -->
Adds global alumni data to intermediate and marts. It addresses some duplicates in emeritus enrollment data as well.

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->
Run
`dbt build --select int__mitxpro__course_runs int__combined__users int__combined__course_runs int__combined__courserun_enrollments marts__combined__users marts__combined_course_enrollment_detail` tests should all pass
