### PR TITLE
update the sourcing for enrollment upgrade on timestamp in the marts

### DIFF
--- a/src/ol_dbt/models/marts/combined/marts__combined_course_enrollment_detail.sql
+++ b/src/ol_dbt/models/marts/combined/marts__combined_course_enrollment_detail.sql
@@ -55,7 +55,7 @@ with combined_enrollments as (
 )
 
 , mitxpro_receipts as (
-    select 
+    select
         order_id
         , max(receipt_payment_timestamp) as payment_timestamp
     from {{ ref('int__mitxpro__ecommerce_receipt') }}
@@ -69,7 +69,7 @@ with combined_enrollments as (
 )
 
 , bootcamps_receipts as (
-    select 
+    select
         order_id
         , max(receipt_payment_timestamp) as receipt_payment_timestamp
     from {{ ref('int__bootcamps__ecommerce_receipt') }}


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
https://github.com/mitodl/hq/issues/7175

### Description (What does it do?)
<!--- Describe your changes in detail -->
Update the sourcing for enrollment upgrade on timestamp(courserunenrollment_upgraded_on) in the marts__combined_course_enrollment_detail  mart table. The field should be populated with when the learner actually upgraded and paid instead of when the order was first created when available.

### How can this be tested?
dbt build --select marts__combined_course_enrollment_detail