### PR TITLE
Added platform_fk and user_fk columns where missing

### DIFF
--- a/src/ol_dbt/models/dimensional/_dim__models.yml
+++ b/src/ol_dbt/models/dimensional/_dim__models.yml
@@ -6,6 +6,11 @@ models:
   description: Aggregate fact table summarizing video engagement by video, learner,
     and a courserun.
   columns:
+  - name: platform_fk
+    description: string, foreign key to dim_platform
+  - name: user_fk
+    description: string, foreign key to dim_user, referencing the user who triggered
+      the event
   - name: platform
     description: string, name of the platform
   - name: video_id
@@ -305,6 +310,11 @@ models:
 - name: tfact_course_navigation_events
   description: Transactional fact table for learner navigation events in a course
   columns:
+  - name: platform_fk
+    description: string, foreign key to dim_platform
+  - name: user_fk
+    description: string, foreign key to dim_user, referencing the user who triggered
+      the event
   - name: openedx_user_id
     description: int, user ID on the corresponding open edX platform
     tests:
@@ -359,6 +369,11 @@ models:
 - name: tfact_video_events
   description: Transactional fact table for learner video events in a course
   columns:
+  - name: platform_fk
+    description: string, foreign key to dim_platform
+  - name: user_fk
+    description: string, foreign key to dim_user, referencing the user who triggered
+      the event
   - name: openedx_user_id
     description: int, user ID on the corresponding open edX platform
     tests:
@@ -546,6 +561,11 @@ models:
   description: Aggregate fact table summarizing course page engagement by learner
     within a course.
   columns:
+  - name: platform_fk
+    description: string, foreign key to dim_platform
+  - name: user_fk
+    description: string, foreign key to dim_user, referencing the user who triggered
+      the event
   - name: platform
     description: string, foreign key to dim_platform
     tests:
@@ -582,6 +602,11 @@ models:
   description: Aggregate fact table summarizing problem engagement by learners within
     a course.
   columns:
+  - name: platform_fk
+    description: string, foreign key to dim_platform
+  - name: user_fk
+    description: string, foreign key to dim_user, referencing the user who triggered
+      the event
   - name: platform
     description: string, foreign key to dim_platform, referencing the platform where
       the video event occurred

--- a/src/ol_dbt/models/dimensional/afact_course_page_engagement.sql
+++ b/src/ol_dbt/models/dimensional/afact_course_page_engagement.sql
@@ -17,6 +17,8 @@ with vertical_structure as (
         , openedx_user_id
         , courserun_readable_id
         , block_fk
+        , arbitrary(platform_fk) as platform_fk
+        , arbitrary(user_fk) as user_fk
         , count(*) as num_of_views
         , max(event_timestamp) as last_view_timestamp
     from {{ ref('tfact_course_navigation_events') }}
@@ -26,7 +28,9 @@ with vertical_structure as (
 
 , combined as (
     select
-        page_navigation_events.platform
+        page_navigation_events.platform_fk
+        , page_navigation_events.user_fk
+        , page_navigation_events.platform
         , page_navigation_events.openedx_user_id
         , page_navigation_events.courserun_readable_id
         , page_navigation_events.block_fk
@@ -40,7 +44,9 @@ with vertical_structure as (
 )
 
 select
-    platform
+    platform_fk
+    , user_fk
+    , platform
     , openedx_user_id
     , courserun_readable_id
     , block_fk

--- a/src/ol_dbt/models/dimensional/afact_problem_engagement.sql
+++ b/src/ol_dbt/models/dimensional/afact_problem_engagement.sql
@@ -12,7 +12,9 @@ with problem_structure as (
 
 , pre_problem_attempt_aggregated as (
     select
-        platform
+        platform_fk
+        , user_fk
+        , platform
         , openedx_user_id
         , problem_block_fk
         , courserun_readable_id
@@ -36,6 +38,8 @@ with problem_structure as (
         , openedx_user_id
         , problem_block_fk
         , courserun_readable_id
+        , arbitrary(platform_fk) as platform_fk
+        , arbitrary(user_fk) as user_fk
         , max(attempt) as num_of_attempts
         , max(event_timestamp) as last_attempt_timestamp
         , count(case when success = 'correct' then 1 end) as num_of_correct_attempts
@@ -46,7 +50,9 @@ with problem_structure as (
 
 , combined as (
     select
-        problem_attempt_aggregated.platform
+        problem_attempt_aggregated.platform_fk
+        , problem_attempt_aggregated.user_fk
+        , problem_attempt_aggregated.platform
         , problem_attempt_aggregated.openedx_user_id
         , problem_attempt_aggregated.courserun_readable_id
         , problem_attempt_aggregated.problem_block_fk
@@ -61,7 +67,9 @@ with problem_structure as (
 )
 
 select
-    platform
+    platform_fk
+    , user_fk
+    , platform
     , openedx_user_id
     , courserun_readable_id
     , problem_block_fk

--- a/src/ol_dbt/models/dimensional/afact_video_engagement.sql
+++ b/src/ol_dbt/models/dimensional/afact_video_engagement.sql
@@ -15,6 +15,8 @@ with course_content as (
         openedx_user_id
         , courserun_readable_id
         , video_block_fk
+        , arbitrary(platform_fk) as platform_fk
+        , arbitrary(user_fk) as user_fk
         , max(case when video_position = 'null' then '0' end) as end_time
         , min(case when event_type = 'play_video' then (case when video_position = 'null' then '0' end) end)
         as start_time
@@ -45,6 +47,8 @@ select
     , f.content_block_pk as subsection_content_fk
     , g.block_title as section_title
     , g.content_block_pk as section_content_fk
+    , arbitrary(tfact_video_events.platform_fk) as platform_fk
+    , arbitrary(tfact_video_events.user_fk) as user_fk
     , (
         cast(start_and_end_times.end_time as decimal(30, 10))
         - cast(start_and_end_times.start_time as decimal(30, 10))


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/ol-data-platform/issues/1533

### Description (What does it do?)
A number of the tfact and fact tables are missing the user_fk and platform_fk foreign keys to join back to dim_user and dim_platform.
- user_fk and platform_fk have been included in the correct tfact and afact models (course, video, and problem fact tables).
- Column definitions were added for the respective tables in _dim__models.yml
- Used the "arbitrary" function instead of adding the new columns to the group by

**Affected tables:**
tfact_course_navigation_events
tfact_video_events
afact_course_page_engagement
afact_problem_engagement
afact_video_engagement

### How can this be tested?
```
dbt build --select tfact_course_navigation_events
dbt build --select tfact_video_events
dbt build --select afact_course_page_engagement
dbt build --select afact_problem_engagement
dbt build --select afact_video_engagement
```