### PR TITLE
fix the divide by zero error in the learner engagement report

### DIFF
--- a/src/ol_dbt/models/reporting/learner_engagement_report.sql
+++ b/src/ol_dbt/models/reporting/learner_engagement_report.sql
@@ -166,9 +166,8 @@ with video_pre_query as (
         , courserun_readable_id
         , openedx_user_id
         , avg(
-            case when max_grade = '0' then
-                0 else (cast(grade as decimal(30, 10))
-            / cast(max_grade as decimal(30, 10))) end
+            cast(grade as decimal(30, 10))
+            / nullif(cast(max_grade as decimal(30, 10)), 0)
         )
         as avg_percent_grade
     from ol_warehouse_production_dimensional.tfact_problem_events


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/5226

### Description (What does it do?)
<!--- Describe your changes in detail -->
For the avg_percent_grade calculated metric on learner_engagement_report fixes the divide by zero error message that has been showing up in superset sometimes.

### How can this be tested?
dbt build --select learner_engagement_report
