### PR TITLE
fix typo in staging tutorbotoutput

### DIFF
--- a/src/ol_dbt/models/staging/learn-ai/_stg_learn_ai__models.yml
+++ b/src/ol_dbt/models/staging/learn-ai/_stg_learn_ai__models.yml
@@ -114,10 +114,10 @@ models:
   - dbt_expectations.expect_compound_columns_to_be_unique:
       column_list: ["checkpoint_namespace", "chatsession_thread_id", "checkpoint_id"]
 
-- name: stg__learn_ai__app__postgres__chatbots_turorbotoutput
+- name: stg__learn_ai__app__postgres__chatbots_tutorbotoutput
   description: TutorBot chat history
   columns:
-  - name: turorbotoutput_id
+  - name: tutorbotoutput_id
     description: int, primary key in ai_chatbots_tutorbotoutput
     tests:
     - not_null
@@ -126,5 +126,5 @@ models:
     description: str, unique identifier for the chat thread.
     tests:
     - not_null
-  - name: turorbot_chat_json
+  - name: tutorbot_chat_json
     description: json string, the chat history and internal state of the TutorBot.

--- a/src/ol_dbt/models/staging/learn-ai/stg__learn_ai__app__postgres__chatbots_tutorbotoutput.sql
+++ b/src/ol_dbt/models/staging/learn-ai/stg__learn_ai__app__postgres__chatbots_tutorbotoutput.sql
@@ -5,9 +5,9 @@ with source as (
 {{ deduplicate_raw_table(order_by='_airbyte_extracted_at' , partition_columns = 'id') }}
 , cleaned as (
     select
-        id as turorbotoutput_id
+        id as tutorbotoutput_id
         , thread_id as chatsession_thread_id
-        , chat_json as turorbot_chat_json
+        , chat_json as tutorbot_chat_json
     from most_recent_source
 )
 


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
https://github.com/mitodl/ol-data-platform/pull/1609

### Description (What does it do?)
<!--- Describe your changes in detail -->
fix the typo in stg__learn_ai__app__postgres__chatbots_tutorbotoutput

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->
dbt build --select staging.learn_ai
