### PR TITLE
add username to afact events

### DIFF
--- a/src/ol_dbt/models/dimensional/_dim__models.yml
+++ b/src/ol_dbt/models/dimensional/_dim__models.yml
@@ -17,6 +17,8 @@ models:
     description: string, id for the video
   - name: openedx_user_id
     description: int, user ID on the corresponding open edX platform
+  - name: user_username
+    description: str, username of the open edX user who caused the event to be emitted.
   - name: courserun_readable_id
     description: string, foreign key to dim_course_content, referencing the edX course
       run ID
@@ -637,6 +639,10 @@ models:
     description: integer, user ID on the corresponding open edX platform
     tests:
     - not_null
+  - name: user_username
+    description: str, username of the open edX user who caused the event to be emitted.
+    tests:
+    - not_null
   - name: block_fk
     description: string, foreign key referencing the vertical or page block ID in
       the dim_course_content table, formatted as block-v1:{org}+{course}+{run}type@vertical-block@{hash
@@ -679,6 +685,8 @@ models:
     description: integer, user ID on the corresponding open edX platform
     tests:
     - not_null
+  - name: user_username
+    description: str, username of the open edX user who caused the event to be emitted.
   - name: problem_block_fk
     description: string, foreign key referencing the problem block ID in the dim_course_content
       table, formatted as block-v1:{org}+{course}+{run}type@problem@{hash code}.
@@ -721,6 +729,10 @@ models:
     description: string, foreign key to dim_user
   - name: openedx_user_id
     description: int, user ID on the corresponding open edX platform
+    tests:
+    - not_null
+  - name: user_username
+    description: str, username of the open edX user who caused the event to be emitted.
     tests:
     - not_null
   - name: courserun_readable_id

--- a/src/ol_dbt/models/dimensional/afact_course_page_engagement.sql
+++ b/src/ol_dbt/models/dimensional/afact_course_page_engagement.sql
@@ -17,6 +17,7 @@ with vertical_structure as (
         , openedx_user_id
         , courserun_readable_id
         , block_fk
+        , arbitrary(user_username) as user_username
         , arbitrary(platform_fk) as platform_fk
         , arbitrary(user_fk) as user_fk
         , count(*) as num_of_views
@@ -32,6 +33,7 @@ with vertical_structure as (
         , page_navigation_events.user_fk
         , page_navigation_events.platform
         , page_navigation_events.openedx_user_id
+        , page_navigation_events.user_username
         , page_navigation_events.courserun_readable_id
         , page_navigation_events.block_fk
         , page_navigation_events.num_of_views
@@ -48,6 +50,7 @@ select
     , user_fk
     , platform
     , openedx_user_id
+    , user_username
     , courserun_readable_id
     , block_fk
     , num_of_views

--- a/src/ol_dbt/models/dimensional/afact_discussion_engagement.sql
+++ b/src/ol_dbt/models/dimensional/afact_discussion_engagement.sql
@@ -17,6 +17,7 @@ with discussion_events as (
         , discussion_events.openedx_user_id
         , discussion_events.commentable_id
         , discussion_events.post_id
+        , arbitrary(discussion_events.user_username) as user_username
         , arbitrary(discussion_events.platform) as platform
         , arbitrary(discussion_events.user_fk) as user_fk
         , arbitrary(discussion_events.post_title) as post_title
@@ -40,6 +41,7 @@ select
     aggregated.platform_fk
     , aggregated.courserun_readable_id
     , aggregated.openedx_user_id
+    , aggregated.user_username
     , aggregated.commentable_id
     , aggregated.post_id
     , aggregated.platform

--- a/src/ol_dbt/models/dimensional/afact_problem_engagement.sql
+++ b/src/ol_dbt/models/dimensional/afact_problem_engagement.sql
@@ -16,6 +16,7 @@ with problem_structure as (
         , user_fk
         , platform
         , openedx_user_id
+        , user_username
         , problem_block_fk
         , courserun_readable_id
         , cast(attempt as int) as attempt
@@ -38,6 +39,7 @@ with problem_structure as (
         , openedx_user_id
         , problem_block_fk
         , courserun_readable_id
+        , arbitrary(user_username) as user_username
         , arbitrary(platform_fk) as platform_fk
         , arbitrary(user_fk) as user_fk
         , max(attempt) as num_of_attempts
@@ -54,6 +56,7 @@ with problem_structure as (
         , problem_attempt_aggregated.user_fk
         , problem_attempt_aggregated.platform
         , problem_attempt_aggregated.openedx_user_id
+        , problem_attempt_aggregated.user_username
         , problem_attempt_aggregated.courserun_readable_id
         , problem_attempt_aggregated.problem_block_fk
         , problem_attempt_aggregated.num_of_attempts
@@ -71,6 +74,7 @@ select
     , user_fk
     , platform
     , openedx_user_id
+    , user_username
     , courserun_readable_id
     , problem_block_fk
     , num_of_attempts

--- a/src/ol_dbt/models/dimensional/afact_video_engagement.sql
+++ b/src/ol_dbt/models/dimensional/afact_video_engagement.sql
@@ -15,6 +15,7 @@ with course_content as (
         openedx_user_id
         , courserun_readable_id
         , video_block_fk
+        , arbitrary(user_username) as user_username
         , arbitrary(platform_fk) as platform_fk
         , arbitrary(user_fk) as user_fk
         , max(case when video_position = 'null' then '0' end) as end_time
@@ -47,6 +48,7 @@ select
     , f.content_block_pk as subsection_content_fk
     , g.block_title as section_title
     , g.content_block_pk as section_content_fk
+    , arbitrary(tfact_video_events.user_username) as user_username
     , arbitrary(tfact_video_events.platform_fk) as platform_fk
     , arbitrary(tfact_video_events.user_fk) as user_fk
     , (


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
followup comments on https://github.com/mitodl/ol-data-platform/pull/1596

### Description (What does it do?)
<!--- Describe your changes in detail -->
adding user_username to afact tables for cases where openedx_user_id alone isn't sufficient to link to dim_user

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

dbt build --select afact_video_engagement afact_problem_engagement afact_discussion_engagement afact_course_page_engagement 

### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->


<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
