### PR TITLE
Adjust the Canvas course export timeout to count for large files

### DIFF
--- a/src/ol_orchestrate/assets/canvas.py
+++ b/src/ol_orchestrate/assets/canvas.py
@@ -59,6 +59,7 @@ canvas_course_ids = StaticPartitionsDefinition(
         "28845",
         "28847",
         "28849",
+        "34545",
     ]
 )
 


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
NA

### Description (What does it do?)
<!--- Describe your changes in detail -->
Increase the Canvas course export timeout to 70 minutes to count for large files. Currently, exporting 3 of sloan courses  https://pipelines.odl.mit.edu/runs/4be8ee6b-c51e-4493-8b33-f4ca59337d5d failed because the successful export response takes up to 50 minutes- way beyond the current 10-minute polling timeout. Since some courses take over 1 min to download, so I set sleep interval to 120 seconds and retry up to 35 times. These values can be adjusted.

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->
can test on QA
