### PR TITLE
fix dbt test on int__mitxonline__user_courseactivities

### DIFF
--- a/src/ol_dbt/models/intermediate/mitxonline/_int_mitxonline__models.yml
+++ b/src/ol_dbt/models/intermediate/mitxonline/_int_mitxonline__models.yml
@@ -1809,7 +1809,7 @@ models:
     - not_null
   - name: openedx_user_id
     description: int, either reference openedx_user_id in open edX users table, or
-      from tracking logs if no reference found.
+      pulled from tracking logs if no reference found.
     tests:
     - not_null
   - name: courserun_readable_id
@@ -1845,7 +1845,7 @@ models:
       course
   tests:
   - dbt_expectations.expect_compound_columns_to_be_unique:
-      column_list: ["user_username", "courserun_readable_id"]
+      column_list: ["user_username", "openedx_user_id", "courserun_readable_id"]
 
 - name: int__mitxonline__user_courseactivities_daily
   description: MITx Online daily aggregate learner activities within a course


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
NA

### Description (What does it do?)
<!--- Describe your changes in detail -->
Fixing the unique constraint on int__mitxonline__user_courseactivities in https://pipelines.odl.mit.edu/runs/13ec2ea2-5692-4ccd-b50b-a6fa8f232485. These 141 records have openedx_user_id value that don't match with the corresponding user_username, mostly due to staff impersonating other users, so update the unique constraint to count for that.

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

dbt test --select int__mitxonline__user_courseactivities

