### PR TITLE
Create intermediate zendesk ticket and relevant staging models

### DIFF
--- a/src/ol_dbt/models/intermediate/zendesk/_zendesk_models.yml
+++ b/src/ol_dbt/models/intermediate/zendesk/_zendesk_models.yml
@@ -1,0 +1,105 @@
+---
+version: 2
+
+models:
+- name: int__zendesk__ticket
+  description: Intermediate model for Zendesk tickets
+  columns:
+  - name: ticket_id
+    description: int, primary key for the ticket
+    tests:
+    - not_null
+    - unique
+  - name: ticket_api_url
+    description: str, the API url of the ticket
+  - name: ticket_tags
+    description: array, the array of tags applied to this ticket.
+  - name: ticket_type
+    description: str, the type of this ticket. Possible values are "problem", "incident",
+      "question", or "task".
+  - name: ticket_status
+    description: str, the state of the ticket. Possible values are "new", "open",
+      "pending", "hold", "solved", or "closed".
+  - name: ticket_description
+    description: str, first comment on the ticket
+  - name: ticket_priority
+    description: str, the urgency with which the ticket should be addressed. Possible
+      values are "urgent", "high", "normal", or "low".
+  - name: ticket_subject
+    description: str, the subject/title of the ticket
+    tests:
+    - not_null
+  - name: ticket_source_channel
+    description: str, the channel through which the ticket was created. e.g. "web",
+      "email"
+    tests:
+    - not_null
+  - name: ticket_source_email
+    description: str, source email address of the ticket
+  - name: ticket_source_rel
+    description: str, the relationship of the source channel to the ticket. e.g. "follow_up"
+  - name: ticket_source_ticket_id
+    description: str, the ID of the source ticket, if this ticket is a follow-up to
+      another ticket.
+  - name: brand_name
+    description: str, the name of the brand associated with the ticket
+  - name: group_name
+    description: str, the name of the group associated with the ticket
+  - name: ticket_is_public
+    description: bool, whether this ticket is publicly visible
+  - name: ticket_recipient_email
+    description: str, the original recipient e-mail address of the ticket.
+  - name: ticket_requester
+    description: str, the name of the requester of the ticket.
+    tests:
+    - not_null
+  - name: ticket_submitter
+    description: str, the name of the submitter of the ticket.
+    tests:
+    - not_null
+  - name: ticket_assignee
+    description: str, the name of the assignee of the ticket.
+  - name: ticket_email_cc_user_ids
+    description: array, array of IDs agent or end users email CC to the ticket.
+  - name: ticket_follower_user_ids
+    description: array, the IDs of users currently following this ticket
+  - name: ticket_collaborator_user_ids
+    description: array, The IDs of users currently CC'ed on the ticket
+  - name: ticket_form_id
+    description: int, the ID of the ticket form to render for the ticket
+  - name: organization_id
+    description: int, foreign key to the organization associated with the ticket
+  - name: ticket_has_incidents
+    description: bool, true if a ticket is a problem type and has one or more incidents
+      linked to it. Otherwise, the value is false.
+  - name: ticket_satisfaction_rating_object
+    description: object, the satisfaction rating of the ticket, if it exists, or the
+      state of satisfaction
+  - name: ticket_satisfaction_rating_score
+    description: str, the satisfaction rating score of the ticket. e.g. "good", "bad",
+      "offered".
+  - name: ticket_satisfaction_rating_comment
+    description: str, the satisfaction rating comment of the ticket
+  - name: ticket_satisfaction_rating_reason
+    description: str, the satisfaction rating reason
+  - name: ticket_is_from_messaging_channel
+    description: bool, true if the ticket's via type is a messaging channel.
+  - name: ticket_custom_fields
+    description: array, custom fields for the ticket. e.g. {"id":360028099972,"value":"course_information"}
+      indicates this ticket is related to course information.
+  - name: ticket_due_at
+    description: timestamp, if this is a ticket of type "task" it has a due date.
+  - name: ticket_unix_timestamp
+    description: int, a unix timestamp that represents the most accurate reading of
+      when this record was last updated. It is updated for all ticket updates, including
+      system updates.
+    tests:
+    - not_null
+  - name: ticket_created_at
+    description: timestamp, the time when the ticket was created
+    tests:
+    - not_null
+  - name: ticket_updated_at
+    description: timestamp, the time when the ticket was last updated
+    tests:
+    - not_null

--- a/src/ol_dbt/models/intermediate/zendesk/int__zendesk__ticket.sql
+++ b/src/ol_dbt/models/intermediate/zendesk/int__zendesk__ticket.sql
@@ -1,0 +1,101 @@
+with ticket as (  -- noqa: PRS
+   select * from {{ ref('stg__zendesk__ticket') }}
+)
+
+, user as (
+    select * from {{ ref('stg__zendesk__user') }}
+)
+
+, organization as (
+    select * from {{ ref('stg__zendesk__organization') }}
+)
+
+, brand as (
+    select * from {{ ref('stg__zendesk__brand') }}
+)
+
+, field as (
+    select * from {{ ref('stg__zendesk__ticket_field') }}
+)
+
+, groups as (
+    select * from {{ ref('stg__zendesk__group') }}
+)
+
+, named_custom_fields as (
+    SELECT
+      ticket.ticket_id
+      , json_format(
+         cast(
+          array_agg(
+            json_parse(
+              json_object(
+                'name' : field.field_title,
+                'value' : value
+              )
+            )
+          ) as json
+        )
+      ) as custom_fields
+    from ticket
+    cross join unnest(ticket.ticket_custom_fields) AS t(json_str)
+    cross join unnest(
+      array[
+        cast(json_parse(json_str) AS row(id bigint, value varchar))
+      ]
+    ) as u(id, value)
+    join field on id = field.field_id
+    where value is not null
+    group by ticket.ticket_id
+)
+
+
+select
+    ticket.ticket_id
+    , ticket.ticket_api_url
+    , ticket.ticket_type
+    , ticket.ticket_tags
+    , ticket.ticket_subject
+    , ticket.ticket_description
+    , ticket.ticket_priority
+    , ticket.ticket_status
+    , ticket.ticket_source_channel
+    , ticket.ticket_source_email
+    , ticket.ticket_source_rel
+    , requester.user_name as ticket_requester
+    , assignee.user_name as ticket_assignee
+    , submitter.user_name as ticket_submitter
+    , ticket.ticket_recipient_email
+    , ticket.ticket_email_cc_user_ids
+    , ticket.ticket_follower_user_ids
+    , ticket.ticket_collaborator_user_ids
+    , brand.brand_name
+    , groups.group_name
+    , ticket.organization_id
+    , organization.organization_name
+    , named_custom_fields.custom_fields
+    , ticket.ticket_due_at
+    , ticket.ticket_has_incidents
+    , ticket.ticket_is_public
+    , ticket.ticket_satisfaction_rating_score
+    , ticket.ticket_satisfaction_rating_comment
+    , ticket.ticket_satisfaction_rating_reason
+    , ticket.ticket_satisfaction_rating_object
+    , ticket.ticket_unix_timestamp
+    , ticket.ticket_created_at
+    , ticket.ticket_updated_at
+from ticket
+left join organization
+    on ticket.organization_id = organization.organization_id
+left join brand
+    on ticket.brand_id = brand.brand_id
+left join groups
+    on ticket.group_id = groups.group_id
+left join user as submitter
+    on ticket.ticket_submitter_user_id = submitter.user_id
+left join user as requester
+    on ticket.ticket_requester_user_id = requester.user_id
+left join user as assignee
+    on ticket.ticket_assignee_user_id = assignee.user_id
+left join named_custom_fields
+    on ticket.ticket_id = named_custom_fields.ticket_id

--- a/src/ol_dbt/models/staging/zendesk/_stg_zendesk_models.yml
+++ b/src/ol_dbt/models/staging/zendesk/_stg_zendesk_models.yml
@@ -351,3 +351,61 @@ models:
     description: timestamp, the time the user was last updated
     tests:
     - not_null
+
+- name: stg__zendesk__group
+  description: Groups in Zendesk system
+  columns:
+  - name: group_id
+    description: int, primary key for the group
+    tests:
+    - not_null
+    - unique
+  - name: group_api_url
+    description: str, the API url of the group
+  - name: group_name
+    description: str, the name of the group. e.g. "Admin", "Finance"
+    tests:
+    - not_null
+  - name: group_description
+    description: str, the description of the group
+  - name: group_is_default
+    description: bool, if the group is the default one for the account
+  - name: group_is_deleted
+    description: bool, if the group has been deleted
+  - name: group_is_public
+    description: bool, if the group is public or private
+  - name: group_created_at
+    description: timestamp, the time the group was created
+    tests:
+    - not_null
+  - name: group_updated_at
+    description: timestamp, the time of the last update of the group
+    tests:
+    - not_null
+
+- name: stg__zendesk__ticket_field
+  description: Custom fields for Zendesk tickets
+  columns:
+  - name: field_id
+    description: int, primary key for the ticket field
+    tests:
+    - not_null
+    - unique
+  - name: field_api_url
+    description: str, the API url of the ticket field
+  - name: field_title
+    description: str, the title of the ticket field. e.g. MIT xPRO Course or Program
+    tests:
+    - not_null
+  - name: field_is_active
+    description: bool, if the field is active or not
+  - name: field_description
+    description: str, the description of the ticket field
+  - name: field_created_at
+    description: timestamp, the time the field was created
+    tests:
+    - not_null
+  - name: field_updated_at
+    description: timestamp, the time of the last update of the field
+    tests:
+    - not_null

--- a/src/ol_dbt/models/staging/zendesk/_zendesk__sources.yml
+++ b/src/ol_dbt/models/staging/zendesk/_zendesk__sources.yml
@@ -294,3 +294,41 @@ sources:
       description: str, the time the user was created
     - name: updated_at
       description: str, the time the user was last updated
+
+  - name: raw__thirdparty__zendesk_support__groups
+    description: Groups in Zendesk system
+    columns:
+    - name: id
+      description: int, primary key for the group
+    - name: url
+      description: str, the API url of the group
+    - name: name
+      description: str, the name of the group. e.g. "Admin", "Finance"
+    - name: description
+      description: str, the description of the group
+    - name: default
+      description: bool, if the group is the default one for the account
+    - name: deleted
+      description: bool, if the group has been deleted
+    - name: is_public
+      description: bool, if the group is public or private
+    - name: created_at
+      description: str, the time the group was created
+    - name: updated_at
+      description: str, the time of the last update of the group
+
+  - name: raw__thirdparty__zendesk_support__ticket_fields
+    description: Custom fields for Zendesk tickets
+    columns:
+    - name: id
+      description: int, primary key for the ticket field
+    - name: url
+      description: str, the API url of the ticket field
+    - name: title
+      description: str, the title of the ticket field. e.g. MIT xPRO Course or Program
+    - name: description
+      description: str, the description of the ticket field
+    - name: created_at
+      description: str, the time the field was created
+    - name: updated_at
+      description: str, the time of the last update of the field

--- a/src/ol_dbt/models/staging/zendesk/stg__zendesk__group.sql
+++ b/src/ol_dbt/models/staging/zendesk/stg__zendesk__group.sql
@@ -1,0 +1,20 @@
+with source as (
+    select * from {{ source('ol_warehouse_raw_data','raw__thirdparty__zendesk_support__groups') }}
+)
+
+{{ deduplicate_raw_table(order_by='_airbyte_extracted_at' , partition_columns = 'id') }}
+, cleaned as (
+    select
+        id as group_id
+        , url as group_api_url
+        , name as group_name
+        , description as group_description
+        , default as group_is_default
+        , deleted as group_is_deleted
+        , is_public as group_is_public
+        , {{ cast_timestamp_to_iso8601('created_at') }} as group_created_at
+        , {{ cast_timestamp_to_iso8601('updated_at') }} as group_updated_at
+    from most_recent_source
+)
+
+select * from cleaned

--- a/src/ol_dbt/models/staging/zendesk/stg__zendesk__ticket_field.sql
+++ b/src/ol_dbt/models/staging/zendesk/stg__zendesk__ticket_field.sql
@@ -1,0 +1,18 @@
+with source as (
+    select * from {{ source('ol_warehouse_raw_data','raw__thirdparty__zendesk_support__ticket_fields') }}
+)
+
+{{ deduplicate_raw_table(order_by='_airbyte_extracted_at' , partition_columns = 'id') }}
+, cleaned as (
+    select
+        id as field_id
+        , url as field_api_url
+        , description as field_description
+        , title as field_title
+        , active as field_is_active
+        , {{ cast_timestamp_to_iso8601('created_at') }} as field_created_at
+        , {{ cast_timestamp_to_iso8601('updated_at') }} as field_updated_at
+    from most_recent_source
+)
+
+select * from cleaned


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
followup to https://github.com/mitodl/hq/issues/7938

### Description (What does it do?)
<!--- Describe your changes in detail -->
Adding a couple of staging models stg__zendesk__group and stg__zendesk__ticket_field for custom fields
Adding intermediate model `int__zendesk__ticket` with the relevant fields without foreign key reference


### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

dbt build --select +int__zendesk__ticket

### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->


<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
