### PR TITLE
Add learn users to dim user

### DIFF
--- a/src/ol_dbt/models/dimensional/_dim__models.yml
+++ b/src/ol_dbt/models/dimensional/_dim__models.yml
@@ -246,6 +246,12 @@ models:
     tests:
     - not_null
     - unique
+  - name: user_global_id
+    description: string, a unique identifier for the user across all platforms
+    tests:
+    - unique
+  - name: mitlearner_user_id
+    description: int, a unique identifier for the user on the MIT Learn
   - name: mitxonline_openedx_user_id
     description: string, openedx user id
   - name: mitxonline_application_user_id
@@ -292,6 +298,10 @@ models:
     description: str, user's job title
   - name: industry
     description: str, user's job industry
+  - name: user_is_active_on_mitlearn
+    description: boolean, indicating if user's account is active on MIT Learn.
+  - name: user_joined_on_mitlearn
+    description: str, date and time when the user joined on MIT Learn.
   - name: user_is_active_on_mitxonline
     description: boolean, indicating if user's account is active on MITx Online.
   - name: user_is_active_on_edxorg

--- a/src/ol_dbt/models/dimensional/_dim__models.yml
+++ b/src/ol_dbt/models/dimensional/_dim__models.yml
@@ -298,6 +298,17 @@ models:
     description: str, user's job title
   - name: industry
     description: str, user's job industry
+  - name: delivery_preference
+    description: array, a list of course format that MIT Learn users prefer to take
+      courses in. e.g. 'online', 'in-person', 'hybrid', 'offline'.
+  - name: goals
+    description: array, learning goals or objectives set by MIT Learn users
+  - name: certificate_desired
+    description: boolean, indicating whether the MIT Learn user wants to receive certificates
+      upon course completion
+  - name: completed_onboarding
+    description: boolean, indicating whether the user has completed the platform onboarding
+      process on MIT Learn
   - name: user_is_active_on_mitlearn
     description: boolean, indicating if user's account is active on MIT Learn.
   - name: user_joined_on_mitlearn

--- a/src/ol_dbt/models/dimensional/dim_user.sql
+++ b/src/ol_dbt/models/dimensional/dim_user.sql
@@ -555,6 +555,10 @@ select
     , base.company
     , base.job_title
     , base.industry
+    , learn_profile.user_goals as goals
+    , learn_profile.user_delivery_preference as delivery_preference
+    , learn_profile.user_completed_onboarding as completed_onboarding
+    , learn_profile.user_certificate_desired as certificate_desired
     , agg.user_is_active_on_mitlearn
     , agg.user_joined_on_mitlearn
     , agg.user_is_active_on_mitxonline
@@ -567,3 +571,4 @@ select
     , agg.user_joined_on_residential
 from base_info as base
 inner join agg_view as agg on base.user_pk = agg.user_pk
+left join learn_profile on base.mitlearn_user_id = learn_profile.user_id

--- a/src/ol_dbt/models/dimensional/dim_user.sql
+++ b/src/ol_dbt/models/dimensional/dim_user.sql
@@ -238,14 +238,12 @@ with mitx_users as (
 
 , users_with_global_id as (
     select
-        mitx_users_view.user_global_id
-        , learn_user_view.mitlearn_user_id
+        learn_user_view.mitlearn_user_id
         , mitx_users_view.mitxonline_openedx_user_id
         , mitx_users_view.mitxonline_application_user_id
         , mitx_users_view.user_mitxonline_username
         , mitx_users_view.edxorg_openedx_user_id
         , mitx_users_view.user_edxorg_username
-        , mitx_users_view.full_name
         , mitx_users_view.address_country
         , mitx_users_view.gender
         , mitx_users_view.birth_year
@@ -258,6 +256,8 @@ with mitx_users as (
         , mitx_users_view.user_joined_on_mitxonline
         , mitx_users_view.user_is_active_on_edxorg
         , mitx_users_view.user_joined_on_edxorg
+        , coalesce(learn_user_view.full_name, mitx_users_view.full_name) as full_name
+        , coalesce(learn_user_view.user_global_id, mitx_users_view.user_global_id) as user_global_id
         , coalesce(learn_user_view.highest_education, mitx_users_view.highest_education) as highest_education
         , coalesce(
             case

--- a/src/ol_dbt/models/dimensional/dim_user.sql
+++ b/src/ol_dbt/models/dimensional/dim_user.sql
@@ -4,6 +4,7 @@ with mitx_users as (
     select
         user_mitxonline_id as mitxonline_application_user_id
         , user_mitxonline_username
+        , user_global_id
         , user_edxorg_id as edxorg_openedx_user_id
         , user_edxorg_username
         , user_mitxonline_email
@@ -175,23 +176,16 @@ with mitx_users as (
     left join mitxresidential_profile on mitxresidential_openedx_users.user_id = mitxresidential_profile.user_id
 )
 
-, combined_users as (
+, mitx_users_view as (
     select
-        {{ dbt_utils.generate_surrogate_key(['mitx_users.user_email']) }} as user_pk
+        mitx_users.user_global_id
         , coalesce(
             openedx_users_username.openedx_user_id, openedx_users_email.openedx_user_id
         ) as mitxonline_openedx_user_id
         , mitx_users.mitxonline_application_user_id
         , mitx_users.user_mitxonline_username
-        , null as mitxpro_openedx_user_id
-        , null as mitxpro_application_user_id
-        , null as user_mitxpro_username
-        , null as residential_openedx_user_id
-        , null as user_residential_username
         , mitx_users.edxorg_openedx_user_id
         , mitx_users.user_edxorg_username
-        , null as emeritus_user_id
-        , null as global_alumni_user_id
         , mitx_users.user_email as email
         , mitx_users.full_name
         , mitx_users.address_country
@@ -205,20 +199,123 @@ with mitx_users as (
         , mitx_users.user_joined_on_mitxonline
         , mitx_users.user_is_active_on_edxorg
         , mitx_users.user_joined_on_edxorg
-        , null as user_is_active_on_mitxpro
-        , null as user_joined_on_mitxpro
-        , null as user_is_active_on_residential
-        , null as user_joined_on_residential
     from mitx_users
     left join mitxonline_openedx_users as openedx_users_username
         on mitx_users.user_mitxonline_username = openedx_users_username.user_username
     left join mitxonline_openedx_users as openedx_users_email
         on mitx_users.user_mitxonline_email = openedx_users_email.user_email
+)
+
+, learn_user as (
+    select * from (
+        select
+            *
+            , row_number() over (
+                partition by user_email
+                order by user_created_on desc
+            ) as row_num
+        from {{ ref('stg__mitlearn__app__postgres__users_user') }}
+    )
+    where row_num = 1
+)
+
+, learn_profile as (
+    select * from {{ ref('stg__mitlearn__app__postgres__profiles_profile') }}
+)
+
+, learn_user_view as(
+    select
+        learn_user.user_global_id
+        , learn_user.user_id as mitlearn_user_id
+        , learn_user.user_email as email
+        , concat(learn_user.user_first_name, ' ', learn_user.user_last_name) as full_name
+        , learn_profile.user_current_education as highest_education
+        , learn_user.user_is_active as user_is_active_on_mitlearn
+        , learn_user.user_joined_on as user_joined_on_mitlearn
+    from learn_user
+    left join learn_profile on learn_user.user_id = learn_profile.user_id
+)
+
+, users_with_global_id as (
+    select
+        mitx_users_view.user_global_id
+        , learn_user_view.mitlearn_user_id
+        , mitx_users_view.mitxonline_openedx_user_id
+        , mitx_users_view.mitxonline_application_user_id
+        , mitx_users_view.user_mitxonline_username
+        , mitx_users_view.edxorg_openedx_user_id
+        , mitx_users_view.user_edxorg_username
+        , mitx_users_view.full_name
+        , mitx_users_view.address_country
+        , mitx_users_view.gender
+        , mitx_users_view.birth_year
+        , mitx_users_view.company
+        , mitx_users_view.job_title
+        , mitx_users_view.industry
+        , learn_user_view.user_is_active_on_mitlearn
+        , learn_user_view.user_joined_on_mitlearn
+        , mitx_users_view.user_is_active_on_mitxonline
+        , mitx_users_view.user_joined_on_mitxonline
+        , mitx_users_view.user_is_active_on_edxorg
+        , mitx_users_view.user_joined_on_edxorg
+        , coalesce(learn_user_view.highest_education, mitx_users_view.highest_education) as highest_education
+        , coalesce(
+            case
+                when mitx_users_view.user_is_active_on_mitxonline
+                    and mitx_users_view.user_joined_on_mitxonline > learn_user_view.user_joined_on_mitlearn
+                then mitx_users_view.email
+            end,
+            learn_user_view.email,
+            mitx_users_view.email
+        ) as email
+    from mitx_users_view
+             full outer join learn_user_view on mitx_users_view.user_global_id = learn_user_view.user_global_id
+)
+
+, combined_users as (
+    select
+        {{ dbt_utils.generate_surrogate_key(['email']) }} as user_pk
+        , user_global_id
+        , mitlearn_user_id
+        , mitxonline_openedx_user_id
+        , mitxonline_application_user_id
+        , user_mitxonline_username
+        , null as mitxpro_openedx_user_id
+        , null as mitxpro_application_user_id
+        , null as user_mitxpro_username
+        , null as residential_openedx_user_id
+        , null as user_residential_username
+        , edxorg_openedx_user_id
+        , user_edxorg_username
+        , null as emeritus_user_id
+        , null as global_alumni_user_id
+        , email
+        , full_name
+        , address_country
+        , highest_education
+        , gender
+        , birth_year
+        , company
+        , job_title
+        , industry
+        , user_is_active_on_mitlearn
+        , user_joined_on_mitlearn
+        , user_is_active_on_mitxonline
+        , user_joined_on_mitxonline
+        , user_is_active_on_edxorg
+        , user_joined_on_edxorg
+        , null as user_is_active_on_mitxpro
+        , null as user_joined_on_mitxpro
+        , null as user_is_active_on_residential
+        , null as user_joined_on_residential
+    from users_with_global_id
 
     union all
 
     select
         {{ dbt_utils.generate_surrogate_key(['mitxpro_user_view.user_email']) }} as user_pk
+        , null as user_global_id
+        , null as mitlearn_user_id
         , null as mitxonline_openedx_user_id
         , null as mitxonline_application_user_id
         , null as user_mitxonline_username
@@ -242,6 +339,8 @@ with mitx_users as (
         , mitxpro_user_view.user_company as company
         , mitxpro_user_view.user_job_title as job_title
         , mitxpro_user_view.user_industry as industry
+        , null as user_is_active_on_mitlearn
+        , null as user_joined_on_mitlearn
         , null as user_is_active_on_mitxonline
         , null as user_joined_on_mitxonline
         , null as user_is_active_on_edxorg
@@ -260,6 +359,8 @@ with mitx_users as (
 
     select
         {{ dbt_utils.generate_surrogate_key(['user_email']) }} as user_pk
+        , null as user_global_id
+        , null as mitlearn_user_id
         , null as mitxonline_openedx_user_id
         , null as mitxonline_application_user_id
         , null as user_mitxonline_username
@@ -281,6 +382,8 @@ with mitx_users as (
         , user_company as company
         , user_job_title as job_title
         , user_industry as industry
+        , null as user_is_active_on_mitlearn
+        , null as user_joined_on_mitlearn
         , null as user_is_active_on_mitxonline
         , null as user_joined_on_mitxonline
         , null as user_is_active_on_edxorg
@@ -296,6 +399,8 @@ with mitx_users as (
 
     select
         {{ dbt_utils.generate_surrogate_key(['user_email']) }} as user_pk
+        , null as user_global_id
+        , null as mitlearn_user_id
         , null as mitxonline_openedx_user_id
         , null as mitxonline_application_user_id
         , null as user_mitxonline_username
@@ -317,6 +422,8 @@ with mitx_users as (
         , user_company as company
         , user_job_title as job_title
         , user_industry as industry
+        , null as user_is_active_on_mitlearn
+        , null as user_joined_on_mitlearn
         , null as user_is_active_on_mitxonline
         , null as user_joined_on_mitxonline
         , null as user_is_active_on_edxorg
@@ -332,6 +439,8 @@ with mitx_users as (
 
     select
         {{ dbt_utils.generate_surrogate_key(['mitxresidential_user_view.user_email']) }} as user_pk
+        , null as user_global_id
+        , null as mitlearn_user_id
         , null as mitxonline_openedx_user_id
         , null as mitxonline_application_user_id
         , null as user_mitxonline_username
@@ -353,6 +462,8 @@ with mitx_users as (
         , null as company
         , null as job_title
         , null as industry
+        , null as user_is_active_on_mitlearn
+        , null as user_joined_on_mitlearn
         , null as user_is_active_on_mitxonline
         , null as user_joined_on_mitxonline
         , null as user_is_active_on_edxorg
@@ -362,6 +473,7 @@ with mitx_users as (
         , mitxresidential_user_view.user_is_active as user_is_active_on_residential
         , mitxresidential_user_view.user_joined_on as user_joined_on_residential
     from mitxresidential_user_view
+
 )
 
 , ranked_users as (
@@ -371,7 +483,8 @@ with mitx_users as (
             partition by user_pk
             order by
                 greatest(
-                    user_joined_on_mitxonline
+                    user_joined_on_mitlearn
+                    , user_joined_on_mitxonline
                     , user_joined_on_edxorg
                     , user_joined_on_mitxpro
                     , user_joined_on_residential
@@ -389,6 +502,8 @@ with mitx_users as (
 , agg_view as (
     select
         user_pk
+        , max(user_global_id) as user_global_id
+        , max(mitlearn_user_id) as mitlearn_user_id
         , max(mitxonline_openedx_user_id) as mitxonline_openedx_user_id
         , max(mitxonline_application_user_id) as mitxonline_application_user_id
         , max(user_mitxonline_username) as user_mitxonline_username
@@ -401,6 +516,8 @@ with mitx_users as (
         , max(emeritus_user_id) as emeritus_user_id
         , max(global_alumni_user_id) as global_alumni_user_id
         , max(user_edxorg_username) as user_edxorg_username
+        , max(user_is_active_on_mitlearn) as user_is_active_on_mitlearn
+        , max(user_joined_on_mitlearn) as user_joined_on_mitlearn
         , max(user_is_active_on_mitxonline) as user_is_active_on_mitxonline
         , max(user_joined_on_mitxonline) as user_joined_on_mitxonline
         , max(user_is_active_on_edxorg) as user_is_active_on_edxorg
@@ -415,6 +532,8 @@ with mitx_users as (
 
 select
     base.user_pk
+    , base.user_global_id
+    , agg.mitlearn_user_id
     , agg.mitxonline_openedx_user_id
     , agg.mitxonline_application_user_id
     , agg.user_mitxonline_username
@@ -436,6 +555,8 @@ select
     , base.company
     , base.job_title
     , base.industry
+    , agg.user_is_active_on_mitlearn
+    , agg.user_joined_on_mitlearn
     , agg.user_is_active_on_mitxonline
     , agg.user_joined_on_mitxonline
     , agg.user_is_active_on_edxorg

--- a/src/ol_dbt/models/intermediate/mitx/_int_mitx__models.yml
+++ b/src/ol_dbt/models/intermediate/mitx/_int_mitx__models.yml
@@ -119,6 +119,11 @@ models:
     description: str, primary key for this table to identify the user
     tests:
     - unique
+  - name: user_global_id
+    description: str, str, The SSO ID (usually a Keycloak UUID) for the user across
+      all platforms.
+    tests:
+    - unique
   - name: is_mitxonline_user
     description: boolean, indicating if this user has an account on MITx Online
   - name: is_edxorg_user

--- a/src/ol_dbt/models/intermediate/mitx/int__mitx__users.sql
+++ b/src/ol_dbt/models/intermediate/mitx/int__mitx__users.sql
@@ -131,6 +131,7 @@ with mitxonline_users as (
 select
     is_mitxonline_user
     , is_edxorg_user
+    , user_global_id
     , user_mitxonline_id
     , user_edxorg_id
     , user_micromasters_id
@@ -172,6 +173,7 @@ union distinct
 select
     if(micromasters_users.user_mitxonline_username is not null, true, false) as is_mitxonline_user
     , if(micromasters_users.user_edxorg_username is not null, true, false) as is_edxorg_user
+    , null as user_global_id
     , null as user_mitxonline_id
     , null as user_edxorg_id
     , micromasters_users.user_id as user_micromasters_id

--- a/src/ol_dbt/models/intermediate/mitx/int__mitx__users.sql
+++ b/src/ol_dbt/models/intermediate/mitx/int__mitx__users.sql
@@ -16,6 +16,7 @@ with mitxonline_users as (
 , mitxonline_users_view as (
     select
         mitxonline_users.user_id as user_mitxonline_id
+        , mitxonline_users.user_global_id
         , mitxonline_users.user_username as user_mitxonline_username
         , mitxonline_users.user_edxorg_username
         , mitxonline_users.user_email as user_mitxonline_email
@@ -86,6 +87,7 @@ with mitxonline_users as (
     select
         mitxonline_users_view.user_mitxonline_id
         , edxorg_users_view.user_edxorg_id
+        , mitxonline_users_view.user_global_id
         , mitxonline_users_view.user_mitxonline_username
         , edxorg_users_view.user_edxorg_username
         , mitxonline_users_view.user_mitxonline_email

--- a/src/ol_dbt/models/intermediate/mitxonline/_int_mitxonline__models.yml
+++ b/src/ol_dbt/models/intermediate/mitxonline/_int_mitxonline__models.yml
@@ -1163,9 +1163,6 @@ models:
     description: str, foreign key to users_user representing a single user
     tests:
     - not_null
-    - relationships:
-        to: ref('int__mitxonline__users')
-        field: user_id
   - name: courseruncertificate_is_revoked
     description: boolean, indicating whether the certificate is revoked and invalid
   - name: courseruncertificate_created_on
@@ -1351,9 +1348,6 @@ models:
     description: str, foreign key to users_user representing a single user
     tests:
     - not_null
-    - relationships:
-        to: ref('int__mitxonline__users')
-        field: user_id
   - name: programcertificate_is_revoked
     description: boolean, indicating whether the certificate is revoked and invalid
   - name: programcertificate_created_on

--- a/src/ol_dbt/models/intermediate/mitxonline/_int_mitxonline__models.yml
+++ b/src/ol_dbt/models/intermediate/mitxonline/_int_mitxonline__models.yml
@@ -1102,9 +1102,6 @@ models:
     description: str, foreign key to users_user representing a single user
     tests:
     - not_null
-    - relationships:
-        to: ref('int__mitxonline__users')
-        field: user_id
   - name: user_username
     description: string, username
     tests:
@@ -1413,6 +1410,11 @@ models:
     tests:
     - unique
     - not_null
+  - name: user_global_id
+    description: str, str, The SSO ID (usually a Keycloak UUID) for the user across
+      all platforms.
+    tests:
+    - unique
   - name: openedx_user_id
     description: int, foreign key to open edX users. Not all app users have openedx_user_id
       due to username or email mismatch between app and open edX. Also, there may

--- a/src/ol_dbt/models/intermediate/mitxonline/int__mitxonline__users.sql
+++ b/src/ol_dbt/models/intermediate/mitxonline/int__mitxonline__users.sql
@@ -42,6 +42,7 @@ with users as (
 
 select
     users.user_id
+    , users.user_global_id
     , openedx_users.openedx_user_id
     , users.user_username
     , users.user_full_name

--- a/src/ol_dbt/models/intermediate/mitxonline/int__mitxonline__users.sql
+++ b/src/ol_dbt/models/intermediate/mitxonline/int__mitxonline__users.sql
@@ -77,7 +77,4 @@ left join micromasters_profile on users.user_username = micromasters_profile.use
 left join micromasters_users
     on micromasters_profile.user_profile_id = micromasters_users.user_profile_id
 left join openedx_users
-    on (
-        users.user_username = openedx_users.user_username
-        or users.user_email = openedx_users.user_email
-    )
+    on users.user_email = openedx_users.user_email

--- a/src/ol_dbt/models/staging/learn/_stg_learn_models.yml
+++ b/src/ol_dbt/models/staging/learn/_stg_learn_models.yml
@@ -77,9 +77,6 @@ models:
     tests:
     - unique
     - not_null
-    - relationships:
-        to: ref('stg__mitlearn__app__postgres__users_user')
-        field: user_id
   - name: user_name
     description: str, display name for the user
   - name: user_bio

--- a/src/ol_dbt/models/staging/learn/stg__mitlearn__app__postgres__users_user.sql
+++ b/src/ol_dbt/models/staging/learn/stg__mitlearn__app__postgres__users_user.sql
@@ -17,7 +17,7 @@ with source as (
         , scim_id as user_scim_id
         , scim_username as user_scim_username
         , scim_external_id as user_scim_external_id
-        , global_id as user_global_id
+        , coalesce(nullif(global_id, ''), scim_external_id) as user_global_id
         , {{ cast_timestamp_to_iso8601('created_on') }} as user_created_on
         , {{ cast_timestamp_to_iso8601('updated_on') }} as user_updated_on
         , {{ cast_timestamp_to_iso8601('date_joined') }} as user_joined_on

--- a/src/ol_dbt/models/staging/mitxonline/_stg_mitxonline__models.yml
+++ b/src/ol_dbt/models/staging/mitxonline/_stg_mitxonline__models.yml
@@ -657,6 +657,22 @@ models:
     tests:
     - unique
     - not_null
+  - name: user_global_id
+    description: str, The SSO ID (usually a Keycloak UUID) for the user across all
+      platforms.
+    tests:
+    - unique
+  - name: user_scim_id
+    description: str, The unique identifier for the SCIM resource
+    tests:
+    - unique
+  - name: user_scim_username
+    description: str, The username for the SCIM resource
+    tests:
+    - unique
+  - name: user_scim_external_id
+    description: str, a string identifier for the SCIM resource as defined by the
+      provisioning client
   - name: user_username
     description: str, name chosen by user
     tests:
@@ -718,9 +734,6 @@ models:
     tests:
     - unique
     - not_null
-    - relationships:
-        to: ref('stg__mitxonline__app__postgres__users_user')
-        field: user_id
   - name: user_birth_year
     description: int, user birth year
   - name: user_company
@@ -1078,16 +1091,10 @@ models:
       run
     tests:
     - not_null
-    - relationships:
-        to: ref('stg__mitxonline__app__postgres__courses_courserun')
-        field: courserun_id
   - name: user_id
     description: str, foreign key to users_user representing a single user
     tests:
     - not_null
-    - relationships:
-        to: ref('stg__mitxonline__app__postgres__users_user')
-        field: user_id
   - name: certificate_page_revision_id
     description: int, foreign key to wagtailcore_pagerevision (could be blank)
   - name: courseruncertificate_created_on
@@ -1124,9 +1131,6 @@ models:
     description: str, foreign key to users_user representing a single user
     tests:
     - not_null
-    - relationships:
-        to: ref('stg__mitxonline__app__postgres__users_user')
-        field: user_id
   - name: certificate_page_revision_id
     description: int, foreign key to wagtailcore_pagerevision (could be blank)
   - name: programcertificate_created_on
@@ -1158,9 +1162,6 @@ models:
     description: str, foreign key to users_user representing a single user
     tests:
     - not_null
-    - relationships:
-        to: ref('stg__mitxonline__app__postgres__users_user')
-        field: user_id
   - name: courserungrade_grade
     description: float, user's grade for the course (range between 0.0 to 1.0)
     tests:

--- a/src/ol_dbt/models/staging/mitxonline/stg__mitxonline__app__postgres__users_user.sql
+++ b/src/ol_dbt/models/staging/mitxonline/stg__mitxonline__app__postgres__users_user.sql
@@ -11,6 +11,10 @@ with source as (
         , username as user_username
         , email as user_email
         , is_active as user_is_active
+        , nullif(global_id, '') as user_global_id
+        , nullif(scim_id, '') as user_scim_id
+        , nullif(scim_username, '') as user_scim_username
+        , nullif(scim_external_id, '') as user_scim_external_id
         , replace(replace(replace(name, ' ', '<>'), '><', ''), '<>', ' ') as user_full_name
         ,{{ cast_timestamp_to_iso8601('created_on') }} as user_joined_on
         ,{{ cast_timestamp_to_iso8601('last_login') }} as user_last_login


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
https://github.com/mitodl/hq/issues/7993#issuecomment-3156261847

### Description (What does it do?)
<!--- Describe your changes in detail -->

- Populating the missing `user_global_id` in stg__mitlearn__app__postgres__users_user with their scim_external_id , as these are supposed to be populated per Nathan
- Adding `user_global_id` to stg__mitxonline__app__postgres__users_user,int__mitxonline__users and int__mitx__users
- Adding Learn users and their profile data to dim_user  (It doesn't include topic_interests yet so I will have another PR to add that)

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

dbt build --select staging.learn stg__mitxonline__app__postgres__users_user int__mitxonline__users int__mitx__users dim_user

You might some warnings about table count mismatch but they can be ignored unless you want to run all the related models
