### PR TITLE
fix blank openedx_user_id

### DIFF
--- a/src/ol_dbt/models/intermediate/mitxonline/int__mitxonline__users.sql
+++ b/src/ol_dbt/models/intermediate/mitxonline/int__mitxonline__users.sql
@@ -77,4 +77,4 @@ left join micromasters_profile on users.user_username = micromasters_profile.use
 left join micromasters_users
     on micromasters_profile.user_profile_id = micromasters_users.user_profile_id
 left join openedx_users
-    on users.user_email = openedx_users.user_email
+    on lower(users.user_email) = lower(openedx_users.user_email)

--- a/src/ol_dbt/models/marts/mitxonline/marts__mitxonline_course_certificates.sql
+++ b/src/ol_dbt/models/marts/mitxonline/marts__mitxonline_course_certificates.sql
@@ -19,7 +19,4 @@ select
     , users.openedx_user_id
 from course_certificates
 left join users
-    on (
-        course_certificates.user_mitxonline_username = users.user_username
-        or course_certificates.user_email = users.user_email
-    )
+    on course_certificates.user_email = users.user_email


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
NA

### Description (What does it do?)
<!--- Describe your changes in detail -->
Populating the 39 blank openedx_user_id in marts__mitxonline_course_certificates https://pipelines.odl.mit.edu/runs/7fd1bab2-38e5-4cd2-8228-fa8c4ca5d9f9. These were caused by mismatched email addresses between mitxonline and openedx due to case sensitivity.


### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

I ran `dbt build --select int__mitxonline__users marts__mitxonline_course_certificates` to confirm the issue is resolved
