### PR TITLE
populate user_global_id in dim_user

### DIFF
--- a/src/ol_dbt/models/dimensional/dim_user.sql
+++ b/src/ol_dbt/models/dimensional/dim_user.sql
@@ -532,7 +532,7 @@ with mitx_users as (
 
 select
     base.user_pk
-    , base.user_global_id
+    , agg.user_global_id
     , agg.mitlearn_user_id
     , agg.mitxonline_openedx_user_id
     , agg.mitxonline_application_user_id


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->

### Description (What does it do?)
<!--- Describe your changes in detail -->
- Follow up my PR https://github.com/mitodl/ol-data-platform/pull/1633. The user_global_id wasn't populated for some Learn users, this is to fix it

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->
I ran `dbt build --select dim_user ` and verified that most learn users now have global_user_id except 20 users
```
select * from "ol_data_lake_production"."ol_warehouse_production_dimensional".dim_user
where mitlearn_user_id is not null and user_global_id is null
```
### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->


<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
