### PR TITLE
add verified enrollment filter to cheating report

### DIFF
--- a/src/ol_dbt/models/reporting/cheating_detection_report.sql
+++ b/src/ol_dbt/models/reporting/cheating_detection_report.sql
@@ -23,7 +23,7 @@ with problem_events as (
 )
 
 , problems_joined as (
-    select 
+    select
         problem_events.platform
         , problem_events.openedx_user_id
         , problem_events.courserun_readable_id
@@ -35,35 +35,35 @@ with problem_events as (
         , overall_grade.courserungrade_grade
         , unit.block_title as unit_name
         , chapter.block_title as chapter_name
-        , lag(problem_events.event_timestamp, 1) 
+        , lag(problem_events.event_timestamp, 1)
             over (
-                partition by 
+                partition by
                     problem_events.platform
                     , problem_events.openedx_user_id
                     , problem_events.courserun_readable_id
                 order by problem_events.event_timestamp
-            ) as prev_event_timestamp 
+            ) as prev_event_timestamp
     from problem_events
     inner join overall_grade
-        on 
+        on
             cast(problem_events.openedx_user_id as varchar) = overall_grade.user_id
             and problem_events.courserun_readable_id = overall_grade.courserun_readable_id
     left join course_content as cc
-        on 
+        on
             problem_events.problem_block_fk = cc.block_id
             and cc.is_latest = true
     left join course_content as unit
-        on 
+        on
             cc.parent_block_id = unit.block_id
             and unit.is_latest = true
     left join course_content as chapter
-        on 
+        on
             cc.chapter_block_id = chapter.block_id
             and chapter.is_latest = true
     where overall_grade.verified_cnt > 0
 )
 
-select 
+select
     platform
     , openedx_user_id
     , courserun_readable_id
@@ -74,14 +74,14 @@ select
     , max(attempt) as attempts_on_problem
     , array_agg(grade) as grades
     , min(
-        case 
+        case
             when date_diff('second', event_timestamp, prev_event_timestamp) < 600
                 then cast(event_timestamp - prev_event_timestamp as varchar)
         end
     ) as time_spent_on_problem
     , max(courserungrade_grade) as courserungrade_grade
 from problems_joined
-group by 
+group by
     platform
     , openedx_user_id
     , courserun_readable_id


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/8067

### Description (What does it do?)
adds a new filter to the cheating detection report to only include verified enrollment

### How can this be tested?
dbt build --select cheating_detection_report 