### PR TITLE
Generate course file urls for canvas course export

### DIFF
--- a/src/ol_orchestrate/assets/canvas.py
+++ b/src/ol_orchestrate/assets/canvas.py
@@ -77,9 +77,9 @@ canvas_course_ids = StaticPartitionsDefinition(
             io_manager_key="s3file_io_manager",
             key=AssetKey(["canvas", "course_content"]),
         ),
-        "course_file_ids": AssetOut(
+        "course_files": AssetOut(
             io_manager_key="s3file_io_manager",
-            key=AssetKey(["canvas", "course_file_ids"]),
+            key=AssetKey(["canvas", "course_files"]),
         ),
     },
 )
@@ -166,8 +166,8 @@ def export_course_content(context: AssetExecutionContext):
         "Total extracted %d files from course %s", len(files_detail), course_id
     )
 
-    json_file = Path(f"file_ids_{data_version}.json")
-    json_file_path = f"{'/'.join(context.asset_key_for_output('course_content').path)}/{course_id}/file_ids_{data_version}.json"  # noqa: E501
+    json_file = Path(f"course_files_{data_version}.json")
+    json_file_path = f"{'/'.join(context.asset_key_for_output('course_content').path)}/{course_id}/course_files_{data_version}.json"  # noqa: E501
 
     with Path.open(json_file, "w") as file:
         json.dump(files_detail, file, indent=2)
@@ -187,7 +187,7 @@ def export_course_content(context: AssetExecutionContext):
 
     yield Output(
         (json_file, json_file_path),
-        output_name="course_file_ids",
+        output_name="course_files",
         data_version=DataVersion(data_version),
         metadata={
             "course_id": course_id,


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
https://github.com/mitodl/hq/issues/8124

### Description (What does it do?)
<!--- Describe your changes in detail -->
Generate course file urls and dump to a json file in course content folder as part of canvas course export

For example `canvas/course_content/14566/{data_version}.metadata.json`
```
{
 "course_files": [
  {
    "file_id": 5466336,
    "file_name": "15_095_HW1_2024_Problems.pdf",
    "file_path": "course files/ai/tutor/15.095 - Homework 1/15_095_HW1_2024_Problems.pdf",
    "url": "https://canvas.mit.edu/courses/14566/files/5466336/"
  },
  {
    "file_id": 5466338,
    "file_name": "15_095_HW1_2024_Solutions-1.pdf",
    "file_path": "course files/ai/tutor/15.095 - Homework 1/15_095_HW1_2024_Solutions-1.pdf",
    "url": "https://canvas.mit.edu/courses/14566/files/5466338/"
  },
  ],
  "course_id": ,
  "course_name": xx,
  "course_code": ,
  "course_readable_id": xx,
  "course_created_at": xxx
}
```

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->
docker compose up
ttp://0.0.0.0:3000/locations/ol_orchestrate.definitions.canvas_course_export/jobs/canvas_course_export_job - Materialize all
