### PR TITLE
add deduplication to xpro cms coursepage

### DIFF
--- a/src/ol_dbt/models/staging/mitxpro/stg__mitxpro__app__postgres__cms_coursepage.sql
+++ b/src/ol_dbt/models/staging/mitxpro/stg__mitxpro__app__postgres__cms_coursepage.sql
@@ -2,8 +2,32 @@ with coursepage as (
     select * from {{ source('ol_warehouse_raw_data','raw__xpro__app__postgres__cms_coursepage') }}
 )
 
+, coursepage_sorted as (
+    select
+        *
+        , row_number() over (partition by course_id order by _airbyte_extracted_at desc) as row_num
+    from coursepage
+)
+
+, most_recent_coursepage as (
+    select * from coursepage_sorted
+    where row_num = 1
+)
+
 , externalcoursepage as (
     select * from {{ source('ol_warehouse_raw_data','raw__xpro__app__postgres__cms_externalcoursepage') }}
+)
+
+, externalcoursepage_sorted as (
+    select
+        *
+        , row_number() over (partition by course_id order by _airbyte_extracted_at desc) as row_num
+    from externalcoursepage
+)
+
+, most_recent_externalcoursepage as (
+    select * from externalcoursepage_sorted
+    where row_num = 1
 )
 
 select
@@ -17,23 +41,23 @@ select
     , catalog_details as cms_coursepage_catalog_details
     , external_marketing_url as cms_coursepage_external_marketing_url
     , 'cms_coursepage' as cms_coursepage_model
-from coursepage
+from most_recent_coursepage
 union all
 select
-    externalcoursepage.page_ptr_id as wagtail_page_id
-    , externalcoursepage.description as cms_coursepage_description
-    , externalcoursepage.course_id
-    , externalcoursepage.duration as cms_coursepage_duration
-    , externalcoursepage.format as cms_coursepage_format
-    , externalcoursepage.subhead as cms_coursepage_subhead
-    , externalcoursepage.time_commitment as cms_coursepage_time_commitment
-    , externalcoursepage.catalog_details as cms_coursepage_catalog_details
-    , externalcoursepage.external_marketing_url as cms_coursepage_external_marketing_url
+    most_recent_externalcoursepage.page_ptr_id as wagtail_page_id
+    , most_recent_externalcoursepage.description as cms_coursepage_description
+    , most_recent_externalcoursepage.course_id
+    , most_recent_externalcoursepage.duration as cms_coursepage_duration
+    , most_recent_externalcoursepage.format as cms_coursepage_format
+    , most_recent_externalcoursepage.subhead as cms_coursepage_subhead
+    , most_recent_externalcoursepage.time_commitment as cms_coursepage_time_commitment
+    , most_recent_externalcoursepage.catalog_details as cms_coursepage_catalog_details
+    , most_recent_externalcoursepage.external_marketing_url as cms_coursepage_external_marketing_url
     , 'cms_externalcoursepage' as cms_coursepage_model
 
-from externalcoursepage
+from most_recent_externalcoursepage
 -- There are currently courses that has both a course page and an external course page but
 -- adding a dedup in case any are added in the future and to match cms_programpage
 left join coursepage
-    on externalcoursepage.course_id = coursepage.course_id
+    on most_recent_externalcoursepage.course_id = coursepage.course_id
 where coursepage.course_id is null


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
NA


### Description (What does it do?)
<!--- Describe your changes in detail -->
Adding the deduplication to stg__mitxpro__app__postgres__cms_coursepage to resolve a few cascading dbt test failures in notifications-data-platform, e.g. https://pipelines.odl.mit.edu/runs/704c0f30-ca9b-46fa-8cbc-918d1501dc27 due to a xpro course's cms page was removed and replaced with a new one, but the old record was not removed from data platform and propagated to downstream


### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

dbt build --select +int__mitxpro__courses
