### PR TITLE
Remove not_null check in int__learn_ai__tutorbot

### DIFF
--- a/src/ol_dbt/models/intermediate/learn-ai/_learn_ai__models.yml.yml
+++ b/src/ol_dbt/models/intermediate/learn-ai/_learn_ai__models.yml.yml
@@ -23,12 +23,9 @@ models:
     description: str, the initial question of the chat session.
   - name: edx_module_id
     description: str, edX module ID for the chat session
-    tests:
-    - not_null
   - name: courserun_readable_id
-    description: str, the edX course ID for the chat session
-    tests:
-    - not_null
+    description: str, the course ID for the chat session. May be blank for Canvas
+      courses
   - name: user_id
     description: int, user ID in learn AI application. Null if the user is not logged
       in.


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
NA 
https://pipelines.odl.mit.edu/runs/f55abe8a-e3f9-402f-b936-74039c48feb8

```
296 of 324 FAIL 100 not_null_int__learn_ai__tutorbot_courserun_readable_id ..... [[31mFAIL 100[0m in 0.66s]

[31mFailure in test not_null_int__learn_ai__tutorbot_courserun_readable_id (models/intermediate/learn-ai/_learn_ai__models.yml.yml)[0m

  Got 100 results, configured to fail if >10
```

### Description (What does it do?)
<!--- Describe your changes in detail -->
Removing the `not_null` check and updating dbt doc on courserun_readable_id for Canvas courses

Once https://github.com/mitodl/hq/issues/8233 is fixed in learn ai, I will add the check back.


### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

dbt test --select int__learn_ai__tutorbot

### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->


<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
