### PR TITLE
fix: add course export get status timeout to avoid infinite blocking

### DIFF
--- a/src/ol_orchestrate/assets/openedx.py
+++ b/src/ol_orchestrate/assets/openedx.py
@@ -179,8 +179,8 @@ def course_xml(context: AssetExecutionContext, courseware):  # noqa: ARG001
                 datetime.now(tz=UTC) - start_time
                 > COURSE_EXPORT_GET_TASKS_STATUS_TIMEOUT
             ):
-                context.log.warning("Timeout reached before all tasks completed.")
-                raise TimeoutError(f"Course export timed out for {course_key}")
+                err_msg = f"Course export timed out for {course_key}"
+                raise TimeoutError(err_msg)
             time.sleep(timedelta(seconds=20).seconds)
             for course_id, task_id in tasks.items():
                 task_status = (
@@ -198,7 +198,9 @@ def course_xml(context: AssetExecutionContext, courseware):  # noqa: ARG001
                 elif details:
                     context.log.info(
                         "Details of export task for course %s (task %s): %s",
-                        course_id, task_id, details,
+                        course_id,
+                        task_id,
+                        details,
                     )
         if failed_exports:
             errmsg = f"Unable to export the course XML for {course_key}"

--- a/src/ol_orchestrate/assets/openedx.py
+++ b/src/ol_orchestrate/assets/openedx.py
@@ -175,7 +175,10 @@ def course_xml(context: AssetExecutionContext, courseware):  # noqa: ARG001
         tasks = exported_courses["upload_task_ids"]
         start_time = datetime.now(tz=UTC)
         while len(successful_exports.union(failed_exports)) < len(tasks):
-            if datetime.now(tz=UTC) - start_time > COURSE_EXPORT_GET_TASKS_STATUS_TIMEOUT:
+            if (
+                datetime.now(tz=UTC) - start_time
+                > COURSE_EXPORT_GET_TASKS_STATUS_TIMEOUT
+            ):
                 context.log.warning("Timeout reached before all tasks completed.")
                 break
             time.sleep(timedelta(seconds=20).seconds)


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/8223

### Description (What does it do?)
This PR introduces a timeout in the polling loop that calls the course export plugin’s GET API to fetch task status. The timeout ensures the loop does not block indefinitely in cases where a task takes too long to complete.

I wasn’t able to do a proper smoke test for these changes. Could the reviewer please handle the smoke testing as part of the review?

### Screenshots (if appropriate):
<!--- optional - delete if empty --->
- [ ] Desktop screenshots
- [ ] Mobile width screenshots

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->


<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
