### PR TITLE
Update marts_combined_course_enrollment_detail to use user_id

### DIFF
--- a/src/ol_dbt/models/marts/combined/marts__combined_course_enrollment_detail.sql
+++ b/src/ol_dbt/models/marts/combined/marts__combined_course_enrollment_detail.sql
@@ -126,11 +126,11 @@ with combined_enrollments as (
     from combined_enrollments
     left join combined_users
         on
-            combined_enrollments.user_username = combined_users.user_username
+            combined_enrollments.user_id = combined_users.user_id
             and combined_enrollments.platform = combined_users.platform
     left join mitxonline_completed_orders
         on
-            combined_enrollments.user_username = mitxonline_completed_orders.user_username
+            combined_enrollments.user_id = cast(mitxonline_completed_orders.user_id as varchar)
             and combined_enrollments.courserun_id = mitxonline_completed_orders.courserun_id
             and mitxonline_completed_orders.row_num = 1
     left join combined_courseruns


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
NA

```
of 962 FAIL 13 dbt_expectations_expect_compound_columns_to_be_unique_marts__combined_course_enrollment_detail_courserunenrollment_id__platform_MITx_Online_  [[31mFAIL 13[0m in 4.07s]

[31mFailure in test dbt_expectations_expect_compound_columns_to_be_unique_marts__combined_course_enrollment_detail_courserunenrollment_id__platform_MITx_Online_ (models/marts/combined/_marts__combined__models.yml)[0m

  Got 13 results, configured to fail if >10
```

### Description (What does it do?)
<!--- Describe your changes in detail -->
Updating marts_combined_course_enrollment_detail to use user_id instead of username for MITxOnline to resolve a few duplicates 


### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->
Run `dbt build --select marts_combined_course_enrollment_detail` successful with no duplicates
