### PR TITLE
Update file_path in Canvas course metadata file to use display_name

### DIFF
--- a/src/ol_orchestrate/assets/canvas.py
+++ b/src/ol_orchestrate/assets/canvas.py
@@ -158,8 +158,9 @@ def export_course_content(context: AssetExecutionContext):
             files_detail.append(
                 {
                     "file_id": file["id"],
+                    "display_name": file["display_name"],
                     "file_name": file["filename"],
-                    "file_path": folder_path + "/" + file["filename"],
+                    "file_path": folder_path + "/" + file["display_name"],
                     "url": f"https://canvas.mit.edu/courses/{course_id}/files/{file['id']}/",
                 }
             )


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
NA
https://mitodl.slack.com/archives/C03K5HYGPT9/p1756400657802489

### Description (What does it do?)
<!--- Describe your changes in detail -->
Updating the `file_path` in the canvas course metadata file `{data_version}.metadata.json` to use display_name instead of filename, so that it matches the files in web resource folders

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->
 docker compose up
 Go to UI http://127.0.0.1:3000/assets/canvas/course_metadata to pick a course ID to Materialize.

The `{data_version}.metadata.json` now shows:
```
    {
      "file_id": 5532705,
      "display_name": "15_095_syllabus_Fall_2025.pdf",
      "file_name": "15_095_syllabus_Fall_2025+%281%29.pdf",
      "file_path": "course files/15_095_syllabus_Fall_2025.pdf",
      "url": "https://canvas.mit.edu/courses/34642/files/5532705/"
    }
```

