### PR TITLE
create edxorg_to_mitxonline_course_runs for migration

### DIFF
--- a/src/ol_dbt/macros/transform_code_to_readable_values.sql
+++ b/src/ol_dbt/macros/transform_code_to_readable_values.sql
@@ -97,3 +97,48 @@
         else {{ column_name }}
     end
 {% endmacro %}
+
+
+--- https://github.com/mitodl/mit-learn/blob/main/learning_resources/constants.py#L189-L227
+{% macro transform_edx_department_number(column_name='department_number') %}
+   case
+       when {{ column_name }} = '1' then 'Civil and Environmental Engineering'
+       when {{ column_name }} = '2' then 'Mechanical Engineering'
+       when {{ column_name }} = '3' then 'Materials Science and Engineering'
+       when {{ column_name }} = '4' then 'Architecture'
+       when {{ column_name }} = '5' then 'Chemistry'
+       when {{ column_name }} = '6' then 'Electrical Engineering and Computer Science'
+       when {{ column_name }} = '7' then 'Biology'
+       when {{ column_name }} = '8' then 'Physics'
+       when {{ column_name }} = '9' then 'Brain and Cognitive Sciences'
+       when {{ column_name }} = '10' then 'Chemical Engineering'
+       when {{ column_name }} = '11' then 'Urban Studies and Planning'
+       when {{ column_name }} = '12' then 'Earth, Atmospheric, and Planetary Sciences'
+       when {{ column_name }} = '14' then 'Economics'
+       when {{ column_name }} = '15' then 'Management'
+       when {{ column_name }} = '16' then 'Aeronautics and Astronautics'
+       when {{ column_name }} = '17' then 'Political Science'
+       when {{ column_name }} = '18' then 'Mathematics'
+       when {{ column_name }} = '20' then 'Biological Engineering'
+       when {{ column_name }} = '21A' then 'Anthropology'
+       when {{ column_name }} = '21G' then 'Global Languages'
+       when {{ column_name }} = '21H' then 'History'
+       when {{ column_name }} = '21L' then 'Literature'
+       when {{ column_name }} = '21M' then 'Music and Theater Arts'
+       when {{ column_name }} = '22' then 'Nuclear Science and Engineering'
+       when {{ column_name }} = '24' then 'Linguistics and Philosophy'
+       when {{ column_name }} = 'CC' then 'Concourse'
+       when {{ column_name }} = 'CMS-W' then 'Comparative Media Studies/Writing'
+       when {{ column_name }} = 'EC' then 'Edgerton Center'
+       when {{ column_name }} = 'ES' then 'Experimental Study Group'
+       when {{ column_name }} = 'ESD' then 'Engineering Systems Division'
+       when {{ column_name }} = 'HST' then 'Medical Engineering and Science'
+       when {{ column_name }} = 'IDS' then 'Data, Systems, and Society'
+       when {{ column_name }} = 'MAS' then 'Media Arts and Sciences'
+       when {{ column_name }} = 'PE' then 'Athletics, Physical Education and Recreation'
+       when {{ column_name }} = 'SP' then 'Special Programs'
+       when {{ column_name }} = 'STS' then 'Science, Technology, and Society'
+       when {{ column_name }} = 'WGS' then 'Women''s and Gender Studies'
+       else {{ column_name }}
+   end
+{% endmacro %}

--- a/src/ol_dbt/models/intermediate/edxorg/_int_edxorg__models.yml
+++ b/src/ol_dbt/models/intermediate/edxorg/_int_edxorg__models.yml
@@ -21,6 +21,10 @@ models:
     description: str, Open edX ID for the course formatted as {org}/{course}
     tests:
     - not_null
+  - name: coursedepartment_name
+    description: str, course department name
+  - name: coursedeptartment_number
+    description: int, course department number
   - name: courserun_semester
     description: str, The semester during which the course was launched e.g Fall 2020
   - name: courserun_enrollment_start_date

--- a/src/ol_dbt/models/intermediate/edxorg/int__edxorg__mitx_courseruns.sql
+++ b/src/ol_dbt/models/intermediate/edxorg/int__edxorg__mitx_courseruns.sql
@@ -51,6 +51,8 @@ with runs_from_bigquery as (
     select
         runs_from_bigquery.course_number
         , runs_from_bigquery.courserun_semester
+        , runs_from_bigquery.coursedeptartment_name
+        , runs_from_bigquery.coursedeptartment_number
         , runs_from_api.courserun_enrollment_end_on as courserun_enrollment_end_date
         , runs_from_api.courserun_short_description as courserun_description
         , runs_from_api.course_topics
@@ -102,6 +104,8 @@ select
     runs.courserun_readable_id
     , runs.course_number
     , runs.course_readable_id
+    , runs.coursedeptartment_name
+    , runs.coursedeptartment_number
     , runs.courserun_title
     , runs.courserun_semester
     , runs.courserun_url

--- a/src/ol_dbt/models/migration/_migration__models.yml
+++ b/src/ol_dbt/models/migration/_migration__models.yml
@@ -1,0 +1,43 @@
+---
+version: 2
+
+models:
+- name: edxorg_to_mitxonline_course_runs
+  description: Course runs not yet migrated to MITx Online from edx.org
+  columns:
+  - name: mitxonline_course_id
+    description: int, foreign key to courses table in the mitxonline database
+  - name: course_readable_id
+    description: str, edX course readable id formatted as {org}+{course code}
+    tests:
+    - not_null
+  - name: course_title
+    description: str, title of the course
+    tests:
+    - not_null
+  - name: courserun_title
+    description: str, the title of the course run
+    tests:
+    - not_null
+  - name: courseware_id
+    description: str, the edx course run readable id formatted as course-v1:{org}+{course
+      code}+{run tag}
+    tests:
+    - not_null
+  - name: enrollment_start
+    description: timestamp, the course enrollment start date.
+  - name: enrollment_end
+    description: timestamp, the course enrollment end date.
+  - name: start_date
+    description: timestamp, The date on which the course starts
+  - name: end_date
+    description: timestamp, The date on which the course ends
+  - name: is_self_paced
+    description: boolean, indicate whether or not the course is self paced
+  - name: is_published
+    description: boolean, indicating whether the course run is published and open
+      for enrollment
+  - name: run_tag
+    description: str, the edX course run tag. e.g. 2T2024
+  - name: department_name
+    description: str, the department offering the course

--- a/src/ol_dbt/models/migration/edxorg_to_mitxonline_course_runs.sql
+++ b/src/ol_dbt/models/migration/edxorg_to_mitxonline_course_runs.sql
@@ -1,0 +1,36 @@
+with mitx_courses as (
+    select * from {{ ref('int__mitx__courses') }}
+)
+
+, edx_courseruns as (
+    select
+        *
+        , element_at(split(edx_courseruns.course_number, '.'), 1) as extracted_department_number
+    from {{ ref('int__edxorg__mitx_courseruns') }}
+)
+
+, edxorg_enrollments as (
+    select * from {{ ref('int__edxorg__mitx_courserun_enrollments') }}
+)
+
+select
+    mitx_courses.mitxonline_course_id
+    , mitx_courses.course_readable_id
+    , mitx_courses.course_title
+    , edx_courseruns.courserun_is_self_paced as is_self_paced
+    , edx_courseruns.courserun_is_published as is_published
+    , {{ format_course_id('edx_courseruns.courserun_readable_id', false) }} as courseware_id
+    , element_at(split(mitx_courses.course_readable_id, '/'), 3) as run_tag
+    , from_iso8601_timestamp(edx_courseruns.courserun_enrollment_start_date) as enrollment_start
+    , from_iso8601_timestamp(edx_courseruns.courserun_enrollment_end_date) as enrollment_end
+    , from_iso8601_timestamp(edx_courseruns.courserun_start_date) as start_date
+    , from_iso8601_timestamp(edx_courseruns.courserun_end_date) as end_date
+    , coalesce(
+        edx_courseruns.coursedeptartment_name
+        , {{ transform_ocw_department_number('edx_courseruns.extracted_department_number') }}
+    ) as department_number
+from mitx_courses
+inner join edx_courseruns
+    on mitx_courses.course_number = edx_courseruns.course_number
+inner join edxorg_enrollments
+    on edx_courseruns.courserun_readable_id = edxorg_enrollments.courserun_readable_id

--- a/src/ol_dbt/models/staging/edxorg/_stg__edxorg__models.yml
+++ b/src/ol_dbt/models/staging/edxorg/_stg__edxorg__models.yml
@@ -42,6 +42,10 @@ models:
     description: str, Open edX ID for the course formatted as {org}/{course}
     tests:
     - not_null
+  - name: coursedepartment_name
+    description: str, course department name
+  - name: coursedeptartment_number
+    description: int, course department number
 
 - name: stg__edxorg__bigquery__mitx_person_course
   description: It contains user activities from edX.org, MITxOnline/xPro open edx

--- a/src/ol_dbt/models/staging/edxorg/stg__edxorg__bigquery__mitx_courserun.sql
+++ b/src/ol_dbt/models/staging/edxorg/stg__edxorg__bigquery__mitx_courserun.sql
@@ -20,6 +20,8 @@ with source as (
         , registration_open as courserun_enrollment_start_date
         , course_launch as courserun_start_date
         , course_wrap as courserun_end_date
+        , deptartment as coursedeptartment_name
+        , dept_number as coursedeptartment_number
         , case course_id
             when 'MITx/14.74x/3T2015' then '14.740x'
             when 'MITx/ESD.SCM1x/3T2014' then 'CTL.SC1x'


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
https://github.com/mitodl/hq/issues/8318

### Description (What does it do?)
<!--- Describe your changes in detail -->
Creating edxorg_to_mitxonline_course_runs to be used in mitxonline 
Adding coursedeptartment_name and coursedeptartment_number to int__edxorg__mitx_courseruns (sourced from BigQuery)
Adding a department mapping to handle cases where the BigQuery source is blank


### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->


<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
