### PR TITLE
add sequential_name to cheating report

### DIFF
--- a/src/ol_dbt/models/reporting/_reporting__models.yml
+++ b/src/ol_dbt/models/reporting/_reporting__models.yml
@@ -282,8 +282,8 @@ models:
   - name: attempts_on_problem
     description: int, max attempt number generated when parsing answer submissions
   - name: max_learner_grade
-    description: number, max of how many responses the learner got right
-      within the problem.
+    description: number, max of how many responses the learner got right within the
+      problem.
   - name: grades
     description: number, current values indicating the total unweighted grades for
       this problem that the learner has scored. e.g. how many responses they got right

--- a/src/ol_dbt/models/reporting/cheating_detection_report.sql
+++ b/src/ol_dbt/models/reporting/cheating_detection_report.sql
@@ -63,7 +63,7 @@ with problem_events as (
             cc.chapter_block_id = chapter.block_id
             and chapter.is_latest = true
     left join course_content as sequential
-        on 
+        on
             cc.sequential_block_id = sequential.block_id
             and sequential.is_latest = true
     where overall_grade.verified_cnt > 0


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/8391

### Description (What does it do?)
Adds sequential name to the cheating reporting dataset- One thing that is required for the cheating analysis is to match data in the table to a real course. To help do this the project team needs the sequential name as a column to run the exam logic against. The sequential name would pick up more specifics that chapter name(which is currently part of the dashboard) may miss, especially for courses that use things like Week 1 for a chapter.

Change the exam indicator logic to exclude the word "practice".

And add a field showing the max learner score so it can be used to calculate the max % grade in the dashboard.

### How can this be tested?
dbt build --select cheating_detection_report
