### PR TITLE
Populate courserun_readable_id for video bot

### DIFF
--- a/src/ol_dbt/models/intermediate/learn-ai/int__learn_ai__chatbot.sql
+++ b/src/ol_dbt/models/intermediate/learn-ai/int__learn_ai__chatbot.sql
@@ -36,7 +36,6 @@ with chatsession as (
                 replace(chatsession.chatsession_object_id, 'asset-v1:', ''), 1
                 , strpos(replace(chatsession.chatsession_object_id, 'asset-v1:', ''), '+type@asset+block@') - 1
             )
-            and chatsession.chatsession_created_on < video.retrieved_at
 )
 
 select


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
https://github.com/mitodl/hq/issues/8442

### Description (What does it do?)
<!--- Describe your changes in detail -->
Populating courserun_readable_id for VideoGPTBot. Currently, there are some VideoGPTBot records don't have  courserun_readable_id populated in int__learn_ai__chatbot. This PR is to fix that.

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

dbt build --select int__learn_ai__chatbot

courserun_readable_id should be populated now except one case `asset-v1:MITxT+3.012Sx+3T2024+type@asset+block@df9493c5-4765-4b0c-a7bb-7ea732fea90e-en.srt`
```
select * from "ol_data_lake_production"."ol_warehouse_production_rlougee_intermediate".int__learn_ai__chatbot
where chatsession_agent='VideoGPTBot'
```

### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->


<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
