### PR TITLE
Fix a few duplicates in mitxonline engagement mart

### DIFF
--- a/src/ol_dbt/models/marts/mitxonline/marts__mitxonline_course_engagements_daily.sql
+++ b/src/ol_dbt/models/marts/mitxonline/marts__mitxonline_course_engagements_daily.sql
@@ -4,6 +4,7 @@ with course_activities_daily as (
 
 , users as (
     select * from {{ ref('int__mitxonline__users') }}
+    where openedx_user_id is not null
 )
 
 , video as (

--- a/src/ol_dbt/models/marts/mitxonline/marts__mitxonline_discussions.sql
+++ b/src/ol_dbt/models/marts/mitxonline/marts__mitxonline_discussions.sql
@@ -29,4 +29,6 @@ select
     , course_runs.courserun_end_on
 from discussions
 inner join course_runs on discussions.courserun_readable_id = course_runs.courserun_readable_id
-left join users on discussions.user_username = users.user_username
+left join users on
+    discussions.user_username = users.user_username
+    and discussions.openedx_user_id = users.openedx_user_id

--- a/src/ol_dbt/models/marts/mitxonline/marts__mitxonline_problem_submissions.sql
+++ b/src/ol_dbt/models/marts/mitxonline/marts__mitxonline_problem_submissions.sql
@@ -36,4 +36,7 @@ select
     , if(problem_response.most_recent_num = 1, true, false) as is_most_recent_attempt
 from problem_response
 inner join course_runs on problem_response.courserun_readable_id = course_runs.courserun_readable_id
-left join users on problem_response.user_username = users.user_username
+left join users
+    on
+        problem_response.user_username = users.user_username
+        and problem_response.openedx_user_id = users.openedx_user_id

--- a/src/ol_dbt/models/marts/mitxonline/marts__mitxonline_problem_summary.sql
+++ b/src/ol_dbt/models/marts/mitxonline/marts__mitxonline_problem_summary.sql
@@ -37,6 +37,7 @@ with showanswers as (
 
 , users as (
     select * from {{ ref('int__mitxonline__users') }}
+    where openedx_user_id is not null
 )
 
 , combined as (

--- a/src/ol_dbt/models/marts/mitxonline/marts__mitxonline_video_engagements.sql
+++ b/src/ol_dbt/models/marts/mitxonline/marts__mitxonline_video_engagements.sql
@@ -54,5 +54,8 @@ left join mitxonline_videos
     on
         video_structure.courserun_readable_id = mitxonline_videos.courserun_readable_id
         and video_structure.video_edx_uuid = mitxonline_videos.video_edx_uuid
-left join users on video.user_username = users.user_username
+left join users
+    on
+        video.user_username = users.user_username
+        and video.openedx_user_id = users.openedx_user_id
 where video.useractivity_event_type in ('play_video', 'seek_video', 'complete_video', 'pause_video', 'stop_video')


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
NA
https://pipelines.odl.mit.edu/runs/b876bd4b-b977-4fc3-afd1-eb3c0a67d636

### Description (What does it do?)
<!--- Describe your changes in detail -->
There are a few duplicates in mitxonline engagement marts due to a user has two accounts - one linked to an openedx account, the other one not). This PR is to ensure we use the account that has the linked openedx username in these engagement marts to avoid the duplicates.

The duplicates in marts__combined_course_engagements will be addressed in a later PR

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->
Run ` dbt build --select marts.mitxonline` to confirm

