### PR TITLE
Extract course policy and certificate signatories from edxorg course XML

### DIFF
--- a/src/ol_orchestrate/lib/openedx.py
+++ b/src/ol_orchestrate/lib/openedx.py
@@ -126,7 +126,7 @@ def process_policy_json(
         archive_root = tf.next()
         if archive_root is None:
             msg = "Unable to retrieve the archive root of the course XML."
-            raise Exception(msg)  # noqa: TRY002
+            raise ValueError(msg)
         tar_info_course = tf.getmember(f"{archive_root.name}/course.xml")
         course_xml_file = Path(
             NamedTemporaryFile(delete=False, suffix="_course.xml").name
@@ -172,7 +172,6 @@ def process_policy_json(
                                 signatory_row["course_id"] = course_id
                                 signatory_row["certificate_id"] = cert_id
                                 signatory_rows.append(signatory_row)
-                        break  # Only process the first element
 
     return course_policy_rows, signatory_rows
 

--- a/src/ol_orchestrate/lib/openedx.py
+++ b/src/ol_orchestrate/lib/openedx.py
@@ -128,8 +128,12 @@ def process_policy_json(
             msg = "Unable to retrieve the archive root of the course XML."
             raise Exception(msg)  # noqa: TRY002
         tar_info_course = tf.getmember(f"{archive_root.name}/course.xml")
-        xml_file = tf.extractfile(tar_info_course)
-        course_id, course_number, run_tag, org = parse_course_id(str(xml_file))
+        course_xml_file = Path(
+            NamedTemporaryFile(delete=False, suffix="_course.xml").name
+        )
+        course_xml_file.write_bytes(tf.extractfile(tar_info_course).read())  # type: ignore[union-attr]
+        course_id, course_number, run_tag, org = parse_course_id(str(course_xml_file))
+        course_xml_file.unlink()
         for member in tf.getmembers():
             if not member.isdir() and member.path.startswith(
                 f"{archive_root.name}/policies/{run_tag}/"


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
https://github.com/mitodl/hq/issues/8435

### Description (What does it do?)
<!--- Describe your changes in detail -->
Adding two JSON exports - `course_policy` and `course_certificate_signatory` as part of the `extract_edxorg_courserun_metadata` asset 

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->
docker compose up

had to modify [dummy_edxorg_course_xml](https://github.com/mitodl/ol-data-platform/blob/main/src/ol_orchestrate/assets/openedx_course_archives.py#L35) to download [MITx-4.605x-3T2024|prod](https://pipelines.odl.mit.edu/assets/edxorg/raw_data/course_xml?view=partitions&partition=MITx-4.605x-3T2024%7Cprod) from s3 to local

then materialize the `course_policy` and `course_certificate_signatory` assets

edxorg/processed_data/course_policy

<img width="1713" height="491" alt="image" src="https://github.com/user-attachments/assets/cff42f96-9af9-4fc5-8ed3-2833e2cc41c3" />



edxorg/processed_data/course_certificate_signatory
<img width="1521" height="539" alt="image" src="https://github.com/user-attachments/assets/96b06d36-027e-4484-b7c0-3c7b5e5a4008" />


Then verify these two json files are valid