### PR TITLE
Include assignment and page metadata to canvas course export

### DIFF
--- a/src/ol_orchestrate/assets/canvas.py
+++ b/src/ol_orchestrate/assets/canvas.py
@@ -111,7 +111,6 @@ def _extract_course_assignments(context, course_id):
             "id": assignment["id"],
             "name": assignment["name"],
             "html_url": assignment["html_url"],
-            "url": assignment["url"],
             "visible_to_everyone": assignment["visible_to_everyone"],
             "published": assignment["published"],
         }

--- a/src/ol_orchestrate/assets/canvas.py
+++ b/src/ol_orchestrate/assets/canvas.py
@@ -76,6 +76,50 @@ canvas_course_ids = StaticPartitionsDefinition(
 )
 
 
+def _extract_course_files(context, course_id):
+    """Extract course file information."""
+    course_file_generator = context.resources.canvas_api.client.get_course_files(
+        course_id
+    )
+    files_detail = []
+    for course_file in course_file_generator:
+        for file in course_file:
+            folder_id = file["folder_id"]
+            folder_detail = context.resources.canvas_api.client.get_course_folders(
+                course_id, folder_id
+            )
+            folder_path = folder_detail["full_name"]
+            files_detail.append(
+                {
+                    "file_id": file["id"],
+                    "display_name": file["display_name"],
+                    "file_name": file["filename"],
+                    "file_path": folder_path + "/" + file["display_name"],
+                    "url": f"https://canvas.mit.edu/courses/{course_id}/files/{file['id']}/",
+                }
+            )
+    return files_detail
+
+
+def _extract_course_assignments(context, course_id):
+    """Extract course assignment information."""
+    assignment_generator = context.resources.canvas_api.client.get_course_assignments(
+        course_id
+    )
+    return [
+        {
+            "id": assignment["id"],
+            "name": assignment["name"],
+            "html_url": assignment["html_url"],
+            "url": assignment["url"],
+            "visible_to_everyone": assignment["visible_to_everyone"],
+            "published": assignment["published"],
+        }
+        for batch in assignment_generator
+        for assignment in batch
+    ]
+
+
 @multi_asset(
     group_name="canvas",
     required_resource_keys={"canvas_api"},
@@ -150,41 +194,34 @@ def export_course_content(context: AssetExecutionContext):
     context.log.info("Downloading %s file to %s", download_url, target_path)
 
     # Course file ID extraction
-    course_file_generator = context.resources.canvas_api.client.get_course_files(
-        course_id
-    )
-    files_detail = []
-    for course_file in course_file_generator:
-        for file in course_file:
-            folder_id = file["folder_id"]
-            folder_detail = context.resources.canvas_api.client.get_course_folders(
-                course_id, folder_id
-            )
-            folder_path = folder_detail["full_name"]
-            files_detail.append(
-                {
-                    "file_id": file["id"],
-                    "display_name": file["display_name"],
-                    "file_name": file["filename"],
-                    "file_path": folder_path + "/" + file["display_name"],
-                    "url": f"https://canvas.mit.edu/courses/{course_id}/files/{file['id']}/",
-                }
-            )
-
+    files_detail = _extract_course_files(context, course_id)
     context.log.info(
         "Total extracted %d files from course %s", len(files_detail), course_id
     )
+
+    # Course Assignments
+    assignments = _extract_course_assignments(context, course_id)
+    context.log.info(
+        "Total extracted %d assignments from course %s", len(assignments), course_id
+    )
+
+    # course pages
+    page_generator = context.resources.canvas_api.client.get_course_pages(course_id)
+    pages = [item for batch in page_generator for item in batch]
+    context.log.info("Total extracted %d pages from course %s", len(pages), course_id)
 
     json_file = Path(f"{data_version}.metadata.json")
     json_file_path = f"{'/'.join(context.asset_key_for_output('course_content').path)}/{course_id}/{data_version}.metadata.json"  # noqa: E501
 
     course_metadata = {
-        "course_files": files_detail,
         "course_id": course_id,
         "course_name": course["name"],
         "course_code": course["course_code"],
         "course_readable_id": course["sis_course_id"],
         "course_created_at": course["created_at"],
+        "course_files": files_detail,
+        "assignments": assignments,
+        "pages": pages,
     }
     with Path.open(json_file, "w") as file:
         json.dump(course_metadata, file, indent=2)

--- a/src/ol_orchestrate/resources/canvas_api.py
+++ b/src/ol_orchestrate/resources/canvas_api.py
@@ -158,7 +158,7 @@ class CanvasApiClient(BaseApiClient):
 
     def get_course_pages(
         self, course_id: int, per_page: int = 100
-    ) -> Generator[list[dict[str, str]], None, None]:
+    ) -> Generator[list[dict[str, Any]], None, None]:
         """Get a list of Pages in a course including pagination.
 
         :param course_id: The unique identifier of the course

--- a/src/ol_orchestrate/resources/canvas_api.py
+++ b/src/ol_orchestrate/resources/canvas_api.py
@@ -1,5 +1,6 @@
 from collections.abc import Generator
 from pathlib import Path
+from typing import Any
 
 from pydantic import Field
 
@@ -84,9 +85,39 @@ class CanvasApiClient(BaseApiClient):
                         f.write(chunk)
         return output_path
 
+    def get_all_items(
+        self, course_id: int, endpoint: str, per_page: int = 100
+    ) -> Generator[list[dict[str, Any]], None, None]:
+        """
+        Fetch all paginated results from a Canvas course endpoint.
+
+        Example endpoints:
+          - 'files'
+          - 'pages'
+          - 'assignments'
+        """
+        page = 1
+        while True:
+            request_url = (
+                f"{self.base_url}/api/v1/courses/{course_id}/{endpoint}"
+                f"?page={page}&per_page={per_page}"
+            )
+            response = self.http_client.get(
+                request_url,
+                headers={"Authorization": f"{self.token_type} {self.access_token}"},
+            )
+            response.raise_for_status()
+            items = response.json()
+
+            if not items:
+                break
+
+            yield items
+            page += 1
+
     def get_course_files(
         self, course_id: int, per_page: int = 100
-    ) -> Generator[list[dict[str, str]], None, None]:
+    ) -> Generator[list[dict[str, Any]], None, None]:
         """Get a list of files in a course including pagination.
 
         :param course_id: The unique identifier of the course
@@ -94,23 +125,7 @@ class CanvasApiClient(BaseApiClient):
         :param per_page: Number of items per page
         :type per_page: int
         """
-        page = 1
-
-        while True:
-            request_url = f"{self.base_url}/api/v1/courses/{course_id}/files?page={page}&per_page={per_page}"  # noqa: E501
-            response = self.http_client.get(
-                request_url,
-                headers={"Authorization": f"{self.token_type} {self.access_token}"},
-            )
-            response.raise_for_status()
-            page_files = response.json()
-
-            # If no files returned, we've reached the end
-            if not page_files:
-                break
-
-            yield page_files
-            page += 1
+        yield from self.get_all_items(course_id, "files", per_page=per_page)
 
     def get_course_folders(self, course_id: int, folder_id: int) -> dict[str, str]:
         """Get details of a specific folder in a course.
@@ -128,3 +143,27 @@ class CanvasApiClient(BaseApiClient):
         )
         response.raise_for_status()
         return response.json()
+
+    def get_course_assignments(
+        self, course_id: int, per_page: int = 100
+    ) -> Generator[list[dict[str, Any]], None, None]:
+        """Get a list of Assignments in a course including pagination.
+
+        :param course_id: The unique identifier of the course
+        :type course_id: int
+        :param per_page: Number of items per page
+        :type per_page: int
+        """
+        yield from self.get_all_items(course_id, "assignments", per_page=per_page)
+
+    def get_course_pages(
+        self, course_id: int, per_page: int = 100
+    ) -> Generator[list[dict[str, str]], None, None]:
+        """Get a list of Pages in a course including pagination.
+
+        :param course_id: The unique identifier of the course
+        :type course_id: int
+        :param per_page: Number of items per page
+        :type per_page: int
+        """
+        yield from self.get_all_items(course_id, "pages", per_page=per_page)


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
https://github.com/mitodl/hq/issues/8490

### Description (What does it do?)
<!--- Describe your changes in detail -->
Adding assignment and page metadata including url to the canvas course export `.metadata.json`file

```
"assignments": [
    {
      "id": 424877,
      "name": "HW0",
      "html_url": "https://canvas.mit.edu/courses/xxxx/assignments/424877",
      "visible_to_everyone": true,
      "published": true
    },
    {
      "id": 427218,
      "name": "HW1",
      "html_url": "https://canvas.mit.edu/courses/xxx/assignments/427218",
      "visible_to_everyone": true,
      "published": true
    }
  ],
  "pages": [
    {
      "title": "Panopto Lecture Videos",
      "html_url": "https://canvas.mit.edu/courses/xxx/pages/panopto-lecture-videos",
      ----
    }
  ]
}
```
### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->
docker compose up
Materialize any existing canvas course ID from UI /assets/canvas/course_metadata

