### PR TITLE
Include all attributes from file and folder api in canvas metadata file

### DIFF
--- a/src/ol_orchestrate/assets/canvas.py
+++ b/src/ol_orchestrate/assets/canvas.py
@@ -88,14 +88,14 @@ def _extract_course_files(context, course_id):
             folder_detail = context.resources.canvas_api.client.get_course_folders(
                 course_id, folder_id
             )
-            folder_path = folder_detail["full_name"]
             files_detail.append(
                 {
-                    "file_id": file["id"],
-                    "display_name": file["display_name"],
-                    "file_name": file["filename"],
-                    "file_path": folder_path + "/" + file["display_name"],
+                    **{k if k != "url" else "download_url": v for k, v in file.items()},
+                    "file_path": folder_detail["full_name"]
+                    + "/"
+                    + file["display_name"],
                     "url": f"https://canvas.mit.edu/courses/{course_id}/files/{file['id']}/",
+                    "folder": folder_detail,
                 }
             )
     return files_detail

--- a/src/ol_orchestrate/assets/canvas.py
+++ b/src/ol_orchestrate/assets/canvas.py
@@ -91,9 +91,7 @@ def _extract_course_files(context, course_id):
             files_detail.append(
                 {
                     **{k if k != "url" else "download_url": v for k, v in file.items()},
-                    "file_path": folder_detail["full_name"]
-                    + "/"
-                    + file["display_name"],
+                    "file_path": f"{folder_detail['full_name']}/{file['display_name']}",
                     "url": f"https://canvas.mit.edu/courses/{course_id}/files/{file['id']}/",
                     "folder": folder_detail,
                 }


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->

https://github.com/mitodl/hq/issues/8518

### Description (What does it do?)
<!--- Describe your changes in detail -->
Including all attributes from file and folder APIs in the `course_files` of .metadata.json file, but keep the existing `file_path` and `url` since Learn uses them.


### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->
docker compose up
Materialize any existing canvas course ID from UI /assets/canvas/course_metadata
