### PR TITLE
alter staging table logic for program certificates as a partial fix to missing program certificate dates

### DIFF
--- a/src/ol_dbt/models/staging/edxorg/stg__edxorg__s3__program_learner_report.sql
+++ b/src/ol_dbt/models/staging/edxorg/stg__edxorg__s3__program_learner_report.sql
@@ -26,10 +26,11 @@ with source as (
     select
         cast("user id" as integer) as user_id
         , "program uuid" as program_uuid
+        , "course run key" as courserun_readable_id
         , min(program_certificate_awarded_at) as earliest_program_cert_award_on
         , max("completed program") as ever_completed_program
     from source_sorted
-    group by 1, 2
+    group by 1, 2, 3
 )
 
 , dedup_source as (
@@ -117,3 +118,4 @@ left join aggregated_program_certificate
     on
         cleaned.user_id = aggregated_program_certificate.user_id
         and cleaned.program_uuid = aggregated_program_certificate.program_uuid
+        and cleaned.courserun_readable_id = aggregated_program_certificate.courserun_readable_id


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/7581

### Description (What does it do?)
<!--- Describe your changes in detail -->
In order to partially fix the issue of missing program certificate dates this adds course run readable id in the de-duplication logic for the program certificate staging table. 

### How can this be tested?
dbt build --select stg__edxorg__s3__program_learner_report.
