### PR TITLE
Fix unknown data type issues in edxorg course_policy and course_certificate_signatory json files

### DIFF
--- a/src/ol_orchestrate/lib/openedx.py
+++ b/src/ol_orchestrate/lib/openedx.py
@@ -144,20 +144,20 @@ def process_policy_json(
 
                 policy_data = json.load(json_data)
 
-                for course_id, course_info in policy_data.items():
-                    if course_id.startswith("course/"):
+                for policy_key, course_info in policy_data.items():
+                    if policy_key.startswith("course/"):
                         course_policy_row = {
                             "course_id": course_id,
-                            "advanced_modules": course_info.get("advanced_modules"),
+                            "advanced_modules": course_info.get("advanced_modules", []),
                             "discussions_settings": course_info.get(
-                                "discussions_settings"
+                                "discussions_settings", {}
                             ),
                             "display_coursenumber": course_info.get(
-                                "display_coursenumber"
+                                "display_coursenumber", ""
                             ),
                             "self_paced": course_info.get("self_paced"),
-                            "tabs": course_info.get("tabs"),
-                            "tags": course_info.get("tags"),
+                            "tabs": course_info.get("tabs", []),
+                            "tags": course_info.get("tags", []),
                         }
                         course_policy_rows.append(course_policy_row)
 


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
followup https://github.com/mitodl/ol-data-platform/pull/1678

### Description (What does it do?)
<!--- Describe your changes in detail -->
Fixing a few unknown data type issues in course_policy file, which Airbyte can't sync. And also course_id is wrong in course_policy and course_certificate_signatory files

<img width="535" height="398" alt="image" src="https://github.com/user-attachments/assets/dafcd59f-31c6-4087-bdc2-5284a11a73fe" />


### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->
Same test as https://github.com/mitodl/ol-data-platform/pull/1678
Verify the "course_id" value is correct (e.g. "course-v1:MITx+4.605x+3T2024") in course_policy and  course_certificate_signatory JSON file, and "tags",  "tabs", "discussions_settings", "advanced_modules" fields have default value in the course_policy JSON file
