### PR TITLE
Use the new raw__edxorg__s3__course_blocks in staging model

### DIFF
--- a/src/ol_dbt/models/staging/edxorg/_edxorg_sources.yml
+++ b/src/ol_dbt/models/staging/edxorg/_edxorg_sources.yml
@@ -643,7 +643,7 @@ sources:
       description: str, time when the course grade was was last updated for this user
         for this course run
 
-  - name: raw__edxorg__s3__course_structure__course_blocks
+  - name: raw__edxorg__s3__course_blocks
     columns:
     - name: block_id
       description: str, Unique ID for a distinct piece of content in a course, formatted

--- a/src/ol_dbt/models/staging/edxorg/stg__edxorg__s3__course_structure.sql
+++ b/src/ol_dbt/models/staging/edxorg/stg__edxorg__s3__course_structure.sql
@@ -1,5 +1,5 @@
 with course_block_source as (
-    select * from {{ source('ol_warehouse_raw_data','raw__edxorg__s3__course_structure__course_blocks') }}
+    select * from {{ source('ol_warehouse_raw_data','raw__edxorg__s3__course_blocks') }}
 )
 
 , course_block as (


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
NA

### Description (What does it do?)
<!--- Describe your changes in detail -->
Updating stg__edxorg__s3__course_structure to use the new raw__edxorg__s3__course_blocks, as previously one was wiped out


### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->
I've ran `dbt build --select stg__edxorg__s3__course_structure int__edxorg__mitx_course_structure

### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->


<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
