### PR TITLE
add hw ind, time flags, and avg grade to cheating report table

### DIFF
--- a/src/ol_dbt/models/reporting/_reporting__models.yml
+++ b/src/ol_dbt/models/reporting/_reporting__models.yml
@@ -304,14 +304,18 @@ models:
   - name: user_avg_exam_grade
     description: number, avg of grades the learner got for all exam problems
   - name: user_hw_median_solving_time
-    description: string, the estimated median amount of time the learner spent on all homework problems.
+    description: string, the estimated median amount of time the learner spent on
+      all homework problems.
   - name: user_exam_median_solving_time
-    description: string, the estimated median amount of time the learner spent on all exam problems.
+    description: string, the estimated median amount of time the learner spent on
+      all exam problems.
   - name: user_hw_attempts_on_problem
-    description: int, total learner attempts generated when parsing answer submissions on homework problems
+    description: int, total learner attempts generated when parsing answer submissions
+      on homework problems
   - name: user_exam_time_flags
-    description: int, total times a learner gets a performance time flag when their exam problem solving time was
-      below the 10th percentile of time taken by all students to solve an exam problem
+    description: int, total times a learner gets a performance time flag when their
+      exam problem solving time was below the 10th percentile of time taken by all
+      students to solve an exam problem
 
 - name: chatbot_usage_report
   description: AI chatbot interactions from Learn AI application including TutorBot,

--- a/src/ol_dbt/models/reporting/cheating_detection_report.sql
+++ b/src/ol_dbt/models/reporting/cheating_detection_report.sql
@@ -144,7 +144,7 @@ with problem_events as (
         or upper(chapter_name) like '%EXAM %'
         or upper(unit_name) like '%EXAM %', true
         )
-        , coalesce((unit_metadata like '%"format":"Homework"%' 
+        , coalesce((unit_metadata like '%"format":"Homework"%'
         or problem_metadata like '%"format":"Homework"%'
         or sequential_metadata like '%"format":"Homework"%'), true
         )
@@ -157,7 +157,7 @@ with problem_events as (
         , problem_block_fk
         , approx_percentile(time_spent_on_problem, 0.1) as time_spent_percentile_10
     from final
-    group by 
+    group by
         platform
         , courserun_readable_id
         , problem_block_fk
@@ -176,7 +176,7 @@ with problem_events as (
         , ten_percent_time.time_spent_percentile_10
     from final
     left join ten_percent_time
-        on 
+        on
             final.problem_block_fk = ten_percent_time.problem_block_fk
             and final.platform = ten_percent_time.platform
             and final.courserun_readable_id = ten_percent_time.courserun_readable_id
@@ -195,7 +195,7 @@ with problem_events as (
             as user_hw_attempts_on_problem
     from add_time
     where hw_indicator = true
-    group by 
+    group by
         platform
         , courserun_readable_id
         , openedx_user_id
@@ -214,7 +214,7 @@ with problem_events as (
             then 1 else 0 end) as user_exam_time_flags
     from add_time
     where exam_indicator = true
-    group by 
+    group by
         platform
         , courserun_readable_id
         , openedx_user_id
@@ -245,12 +245,12 @@ select
     , exam_grouping.user_exam_time_flags
 from final
 left join hw_grouping
-    on 
+    on
         final.platform = hw_grouping.platform
         and final.openedx_user_id = hw_grouping.openedx_user_id
         and final.courserun_readable_id = hw_grouping.courserun_readable_id
 left join exam_grouping
-    on 
+    on
         final.platform = exam_grouping.platform
         and final.openedx_user_id = exam_grouping.openedx_user_id
         and final.courserun_readable_id = exam_grouping.courserun_readable_id


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/8646

### Description (What does it do?)
add hw ind, time flags, and avg grade fields to cheating report table(cheating_detection_report)

### How can this be tested?
dbt build --select cheating_detection_report 
