### PR TITLE
Fix course_content asset path issue

### DIFF
--- a/src/ol_orchestrate/assets/canvas.py
+++ b/src/ol_orchestrate/assets/canvas.py
@@ -135,7 +135,7 @@ def export_course_content(context: AssetExecutionContext):
         downloaded_path, skip_filename="imsmanifest.xml"
     )
 
-    target_path = f"canvas/course_content/{course_id}/{data_version}.{extension}"
+    target_path = f"{'/'.join(context.asset_key_for_output('course_content').path)}/{course_id}/{data_version}.{extension}"  # noqa: E501
 
     context.log.info("Downloading %s file to %s", download_url, target_path)
 


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
follow up https://github.com/mitodl/ol-data-platform/pull/1711

### Description (What does it do?)
<!--- Describe your changes in detail -->
fixing https://pipelines-qa.odl.mit.edu/runs/de96cb24-1f40-4bf6-a09e-a5b0710b8d47. Updating to use the asset’s defined key from context.asset_key_for_output() to dynamically build the output instead of hardcoded path


### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->
Ran `docker compose up` 

### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->


<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
