### PR TITLE
MetadataValue.path() method expects a string

### DIFF
--- a/src/ol_orchestrate/io_managers/filepath.py
+++ b/src/ol_orchestrate/io_managers/filepath.py
@@ -52,7 +52,7 @@ class FileObjectIOManager(ConfigurableIOManager):
             obj[1], **self.configure_path_fs(output_path.protocol).storage_options
         )
         output_path.write_bytes(obj[0].read_bytes())
-        context.add_output_metadata({"path": MetadataValue.path(output_path)})
+        context.add_output_metadata({"path": MetadataValue.path(str(output_path))})
         obj[0].unlink()
 
     def configure_path_fs(


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
https://pipelines-qa.odl.mit.edu/runs/d52a5b64-96a3-401c-8c79-b4031f5b6bbd
https://pipelines-qa.odl.mit.edu/runs/6ff8c0a6-7e28-42d5-a2de-6fcceb87a8b7

### Description (What does it do?)
<!--- Describe your changes in detail -->
Addressing `dagster_shared.check.functions.ParameterCheckError: Param "path" is not one of ['PathLike', 'str']. ` error.
It appears that it's related to the recent change in https://github.com/fsspec/universal_pathlib/compare/v0.2.1...v0.3.1
This PR is to cast the UPath to string before passing to `MetadataValue.path`

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->
docker compose up --build

I ran one canvas course export and it worked

### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->


<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
