### PR TITLE
Replace apt-key with gpg

### DIFF
--- a/dockerfiles/orchestrate/Dockerfile.global
+++ b/dockerfiles/orchestrate/Dockerfile.global
@@ -10,8 +10,8 @@ RUN apt update && \
     apt autoremove -y && \
     rm -rf /var/lib/apt/lists/*
 # Install packages needed to talk to edxapp mongodb
-RUN wget -qO - https://www.mongodb.org/static/pgp/server-7.0.asc | apt-key add - && \
-    echo "deb http://repo.mongodb.org/apt/debian bookworm/mongodb-org/7.0 main" > /etc/apt/sources.list.d/mongodb-org-7.0.list && \
+RUN wget -qO - https://www.mongodb.org/static/pgp/server-7.0.asc | gpg --dearmor -o /usr/share/keyrings/mongodb-server-7.0.gpg && \
+    echo "deb [signed-by=/usr/share/keyrings/mongodb-server-7.0.gpg] http://repo.mongodb.org/apt/debian bookworm/mongodb-org/7.0 main" > /etc/apt/sources.list.d/mongodb-org-7.0.list && \
     apt update && \
     apt install -y mongodb-org-tools && \
     apt clean && \


### PR DESCRIPTION
### Description (What does it do?)
<!--- Describe your changes in detail -->
Replaces apt-key add - with gpg --dearmor -o /usr/share/keyrings/mongodb-server-7.0.gpg to store the key in the modern location
