### PR TITLE
Update any_deps_updated automation policy to use data version

### DIFF
--- a/src/ol_orchestrate/lib/automation_policies.py
+++ b/src/ol_orchestrate/lib/automation_policies.py
@@ -3,7 +3,9 @@ from dagster import AutomationCondition
 
 def upstream_or_code_changes() -> AutomationCondition:
     no_upstream_dependencies_in_process = ~AutomationCondition.any_deps_in_progress()
-    has_upstream_changes = AutomationCondition.any_deps_updated()
+    has_upstream_changes = AutomationCondition.any_deps_updated().replace(
+        "newly_updated", AutomationCondition.data_version_changed()
+    )
     has_code_changes = AutomationCondition.code_version_changed()
     newly_missing = AutomationCondition.newly_missing()
     all_upstream_dependencies_present = ~AutomationCondition.any_deps_missing()


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
NA

### Description (What does it do?)
<!--- Describe your changes in detail -->
Updating the `any_deps_updated` condition in our `upstream_or_code_change` automation policy to respect the data version, overwriting the default behavior as outlined in https://docs.dagster.io/guides/automate/declarative-automation/customizing-automation-conditions/customizing-eager-condition#respecting-data-versioning

Currently, `any_deps_updated` evaluates `true` whenever an upstream asset is updated, regardless of whether the data version has changed. We want to modify this behavior so that `any_deps_updated` should only be true if the upstream asset's data version has changed.

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

- docker compose up
- From UI `assets/canvas`,  pick one course
- Materialize the `course_content` and `course_metadata` asset for that course
- After materialization, check the evaluation result at `locations/ol_orchestrate.definitions.canvas_course_export/sensors/default_automation_condition_sensor`
- Verify:
  - It does NOT pickup the "canvas / course_content_metadata" materialization if there is no data version change.
  -  It DOES pickup the "canvas/course_content_metadata" materialization if there is a data version change.


### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->


<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
