### PR TITLE
Remove empty string from signatory_names in edxorg_to_mitxonline_course_runs

### DIFF
--- a/src/ol_dbt/models/migration/edxorg_to_mitxonline_course_runs.sql
+++ b/src/ol_dbt/models/migration/edxorg_to_mitxonline_course_runs.sql
@@ -26,7 +26,8 @@ with mitx_courses as (
 , edx_signatories as (
     select
         courserun_readable_id
-        , array_agg(signatory_normalized_name) as signatory_names
+        , array_agg(signatory_normalized_name)
+            filter (where signatory_normalized_name <> '') as signatory_names
     from {{ ref('stg__edxorg__s3__course_certificate_signatory') }}
     group by courserun_readable_id
 )


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
https://github.com/mitodl/hq/issues/8318

### Description (What does it do?)
<!--- Describe your changes in detail -->
Removing empty string from signatory_names in edxorg_to_mitxonline_course_runs to make it easier for the edx migration script. Currently, there are some courses that contain signatory_names like `[ ,, -- ]`


### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->

Ran `dbt build --select edxorg_to_mitxonline_course_runs` to confirm

<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
