### PR TITLE
Update to dim_user and tfact_chatbot_events

### DIFF
--- a/src/ol_dbt/models/dimensional/_dim__models.yml
+++ b/src/ol_dbt/models/dimensional/_dim__models.yml
@@ -250,10 +250,12 @@ models:
     description: string, a unique identifier for the user across all platforms
     tests:
     - unique
-  - name: mitlearner_user_id
+  - name: mitlearn_user_id
     description: int, a unique identifier for the user on the MIT Learn
+  - name: mitlearn_openedx_user_id
+    description: string, user id on the MIT Learn open edX platform
   - name: mitxonline_openedx_user_id
-    description: string, openedx user id
+    description: string, openedx user id. This is deprecated in favor of mitlearn_openedx_user_id.
   - name: mitxonline_application_user_id
     description: string, user id on MITxOnline application
   - name: user_mitxonline_username
@@ -810,6 +812,10 @@ models:
   - name: org_id
     description: string, the name of the organization that created the course. e.g.
       MITxT, MITx, UAI_MIT, etc.
+    tests:
+    - not_null
+  - name: user_fk
+    description: string, foreign key to dim_user
     tests:
     - not_null
   - name: openedx_user_id

--- a/src/ol_dbt/models/dimensional/dim_user.sql
+++ b/src/ol_dbt/models/dimensional/dim_user.sql
@@ -255,6 +255,7 @@ with mitx_users as (
 , users_with_global_id as (
     select
         learn_user_view.mitlearn_user_id
+        , mitx_users_view.mitlearn_openedx_user_id
         , mitx_users_view.mitxonline_openedx_user_id
         , mitx_users_view.mitxonline_application_user_id
         , mitx_users_view.user_mitxonline_username
@@ -293,6 +294,7 @@ with mitx_users as (
         {{ dbt_utils.generate_surrogate_key(['email']) }} as user_pk
         , user_global_id
         , mitlearn_user_id
+        , mitlearn_openedx_user_id
         , mitxonline_openedx_user_id
         , mitxonline_application_user_id
         , user_mitxonline_username
@@ -332,6 +334,7 @@ with mitx_users as (
         {{ dbt_utils.generate_surrogate_key(['mitxpro_user_view.user_email']) }} as user_pk
         , null as user_global_id
         , null as mitlearn_user_id
+        , null as mitlearn_openedx_user_id
         , null as mitxonline_openedx_user_id
         , null as mitxonline_application_user_id
         , null as user_mitxonline_username
@@ -377,6 +380,7 @@ with mitx_users as (
         {{ dbt_utils.generate_surrogate_key(['user_email']) }} as user_pk
         , null as user_global_id
         , null as mitlearn_user_id
+        , null as mitlearn_openedx_user_id
         , null as mitxonline_openedx_user_id
         , null as mitxonline_application_user_id
         , null as user_mitxonline_username
@@ -417,6 +421,7 @@ with mitx_users as (
         {{ dbt_utils.generate_surrogate_key(['user_email']) }} as user_pk
         , null as user_global_id
         , null as mitlearn_user_id
+        , null as mitlearn_openedx_user_id
         , null as mitxonline_openedx_user_id
         , null as mitxonline_application_user_id
         , null as user_mitxonline_username
@@ -457,6 +462,7 @@ with mitx_users as (
         {{ dbt_utils.generate_surrogate_key(['mitxresidential_user_view.user_email']) }} as user_pk
         , null as user_global_id
         , null as mitlearn_user_id
+        , null as mitlearn_openedx_user_id
         , null as mitxonline_openedx_user_id
         , null as mitxonline_application_user_id
         , null as user_mitxonline_username
@@ -520,6 +526,7 @@ with mitx_users as (
         user_pk
         , max(user_global_id) as user_global_id
         , max(mitlearn_user_id) as mitlearn_user_id
+        , max(mitlearn_openedx_user_id) as mitlearn_openedx_user_id
         , max(mitxonline_openedx_user_id) as mitxonline_openedx_user_id
         , max(mitxonline_application_user_id) as mitxonline_application_user_id
         , max(user_mitxonline_username) as user_mitxonline_username
@@ -550,6 +557,7 @@ select
     base.user_pk
     , agg.user_global_id
     , agg.mitlearn_user_id
+    , agg.mitlearn_openedx_user_id
     , agg.mitxonline_openedx_user_id
     , agg.mitxonline_application_user_id
     , agg.user_mitxonline_username


### PR DESCRIPTION
### Description (What does it do?)
<!--- Describe your changes in detail -->
Followup to https://github.com/mitodl/ol-data-platform/pull/1738

- Adding the remaining users from Learn open edX platform, and a new `mitlearn_openedx_user_id` column to `dim_user`, as `mitlearn_openedx_user_id` will be our primary field to join with the open edX data going forward.

- Adding a `user_fk` and updating courserun_readable_id  to `tfact_chatbot_events`
   - e.g. 34642-15.095_FA25 is the canvas course ID format


### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->
dbt run +dim_user
dbt build dim_user tfact_chatbot_events
