### PR TITLE
add chatbot data to org reporting table

### DIFF
--- a/src/ol_dbt/models/reporting/_reporting__models.yml
+++ b/src/ol_dbt/models/reporting/_reporting__models.yml
@@ -361,6 +361,8 @@ models:
   - name: activity_date
     description: date, date the user engaged in an activity
   - name: chatbot_used_count
-    description: int, a count of 1 if the user used a chatbot during the course run otherwise 0
+    description: int, a count of 1 if the user used a chatbot during the course run
+      otherwise 0
   - name: certificate_count
-    description: int, a count of 1 if the user earned a certificate that day otherwise 0
+    description: int, a count of 1 if the user earned a certificate that day otherwise
+      0

--- a/src/ol_dbt/models/reporting/organization_administration_report.sql
+++ b/src/ol_dbt/models/reporting/organization_administration_report.sql
@@ -41,7 +41,7 @@ with enrollment_detail as (
 )
 
 , chatbot_data as (
-    select 
+    select
         distinct user.email as user_email
         , cast(chatbot_events.event_timestamp as date) as activity_date
         , chatbot_events.courserun_readable_id
@@ -53,7 +53,7 @@ with enrollment_detail as (
 
     union
 
-    select 
+    select
         distinct user_email
         , certificate_created_date as activity_date
         , courserun_readable_id
@@ -65,7 +65,7 @@ with enrollment_detail as (
 )
 
 , activity_day_data as (
-    select 
+    select
         user_email
         , activity_date
         , courserun_readable_id
@@ -92,6 +92,6 @@ from enroll_data
 left join org_field
     on enroll_data.courserun_readable_id = org_field.courserun_readable_id
 left join activity_day_data
-    on 
+    on
         enroll_data.user_email = activity_day_data.user_email
         and enroll_data.courserun_readable_id = activity_day_data.courserun_readable_id


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/8928

### Description (What does it do?)
adds chatbot usage counts to org reporting table (organization_administration_report)

### How can this be tested?
dbt build --select organization_administration_report
