### PR TITLE
Optimize tfact_studentmodule_problems

### DIFF
--- a/src/ol_dbt/macros/transform_studentmodule_data.sql
+++ b/src/ol_dbt/macros/transform_studentmodule_data.sql
@@ -11,9 +11,15 @@
       , cast(studentmodule_problem_max_grade as varchar) as max_grade
       , from_iso8601_timestamp_nanos(studentmodule_created_on) as studentmodule_created_on
       , from_iso8601_timestamp_nanos(studentmodule_updated_on) as studentmodule_updated_on
-      , cast(json_query(studentmodule_state_data, 'lax $.attempts' omit quotes) as int) as attempt
+      , json_query(studentmodule_state_data, 'lax $.attempts' omit quotes) as attempt
     from {{ studentmodule_table }}
     where coursestructure_block_category = 'problem'
+    {% if is_incremental %}
+      and from_iso8601_timestamp_nanos(studentmodule_created_on) > (
+          select max(event_timestamp) from {{ this }}
+      )
+    {% endif %}
+
   )
 
   , studentmodulehistoryextended as (
@@ -24,8 +30,14 @@
       , cast(studentmodule_problem_grade as varchar) as grade
       , cast(studentmodule_problem_max_grade as varchar) as max_grade
       , from_iso8601_timestamp_nanos(to_iso8601(studentmodule_created_on)) as studentmodule_created_on
-      , cast(json_query(studentmodule_state_data, 'lax $.attempts' omit quotes) as int) as attempt
+      , json_query(studentmodule_state_data, 'lax $.attempts' omit quotes) as attempt
     from {{ studentmodulehistory_table }}
+    {% if is_incremental %}
+      where from_iso8601_timestamp_nanos(to_iso8601(studentmodule_created_on)) > (
+          select max(event_timestamp) from {{ this }}
+      )
+    {% endif %}
+
   )
 
     -- Pull out arrays from the state data
@@ -41,7 +53,7 @@
       , coalesce(smhe.grade, sm.grade) as grade
       , coalesce(smhe.max_grade, sm.max_grade) as max_grade
       , coalesce(smhe.studentmodule_created_on, sm.studentmodule_updated_on) as event_timestamp
-      , cast(smhe.attempt as varchar) as attempt
+      , smhe.attempt as attempt
       , if(
             coalesce(smhe.grade, sm.grade) is not null
             and coalesce(smhe.max_grade, sm.max_grade) is not null

--- a/src/ol_dbt/models/dimensional/tfact_studentmodule_problems.sql
+++ b/src/ol_dbt/models/dimensional/tfact_studentmodule_problems.sql
@@ -1,3 +1,9 @@
+{{ config(
+    materialized='incremental',
+    unique_key=['platform', 'openedx_user_id', 'courserun_readable_id', 'problem_block_id', 'attempt'],
+    incremental_strategy='delete+insert'
+) }}
+
 with mitxonline_studentmodule_problems as (
     {{ generate_studentmodule_problem_events(
         ref('stg__mitxonline__openedx__mysql__courseware_studentmodule'),
@@ -137,3 +143,6 @@ select
     , max_grade
     , success
 from deduped_combined
+{% if is_incremental() %}
+  where event_timestamp >= (select max(event_timestamp) from {{ this }})
+{% endif %}


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
https://github.com/mitodl/hq/issues/9031

### Description (What does it do?)
<!--- Describe your changes in detail -->
Currently, tfact_studentmodule_problems is impossible to build using 281 GB memory https://mitol.galaxy.starburst.io/query-insights/20251027_195402_48929_hk94y/advanced. It is using two largest tables from open edx in 3 different sources. This PR is to 
 - Convert it to use incremental strategy so we avoid processing the same old data in each build.
 - Remove the redundant cast in `generate_studentmodule_problem_events` macro

There are further improvements in generate_studentmodule_problem_events, but switching to the incremental approach should improve build time

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

If this is first time building this table, you'll need to copy the data from the production table tfact_studentmodule_problems . Otherwise, it would be a full refresh, which won't work. The production table already has data up to 2025-10-20, so this should be sufficient. 

dbt build --select tfact_studentmodule_problems

### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->

Related to https://github.com/mitodl/hq/issues/7195

