### PR TITLE
Add where clause to is_incremental in tfact-studentmodule-problems 

### DIFF
--- a/src/ol_dbt/macros/transform_studentmodule_data.sql
+++ b/src/ol_dbt/macros/transform_studentmodule_data.sql
@@ -1,4 +1,4 @@
-{% macro generate_studentmodule_problem_events(studentmodule_table, studentmodulehistory_table, user_id_field) %}
+{% macro generate_studentmodule_problem_events(studentmodule_table, studentmodulehistory_table, user_id_field, platform='mitxonline') %}
   with studentmodule as (
     select
       studentmodule_id
@@ -17,6 +17,7 @@
     {% if is_incremental %}
       and from_iso8601_timestamp_nanos(studentmodule_created_on) > (
           select max(event_timestamp) from {{ this }}
+          where platform = '{{ platform }}'
       )
     {% endif %}
 
@@ -35,6 +36,7 @@
     {% if is_incremental %}
       where from_iso8601_timestamp_nanos(to_iso8601(studentmodule_created_on)) > (
           select max(event_timestamp) from {{ this }}
+            where platform = '{{ platform }}'
       )
     {% endif %}
 

--- a/src/ol_dbt/models/dimensional/tfact_studentmodule_problems.sql
+++ b/src/ol_dbt/models/dimensional/tfact_studentmodule_problems.sql
@@ -8,7 +8,8 @@ with mitxonline_studentmodule_problems as (
     {{ generate_studentmodule_problem_events(
         ref('stg__mitxonline__openedx__mysql__courseware_studentmodule'),
         ref('stg__mitxonline__openedx__courseware_studentmodulehistoryextended'),
-        'openedx_user_id'
+        'openedx_user_id',
+        'mitxonline'
     ) }}
 )
 
@@ -16,7 +17,8 @@ with mitxonline_studentmodule_problems as (
     {{ generate_studentmodule_problem_events(
         ref('stg__mitxpro__openedx__mysql__courseware_studentmodule'),
         ref('stg__mitxpro__openedx__courseware_studentmodulehistoryextended'),
-        'openedx_user_id'
+        'openedx_user_id',
+        'mitxpro'
     ) }}
 )
 
@@ -24,7 +26,8 @@ with mitxonline_studentmodule_problems as (
     {{ generate_studentmodule_problem_events(
         ref('stg__mitxresidential__openedx__courseware_studentmodule'),
         ref('stg__mitxresidential__openedx__courseware_studentmodulehistoryextended'),
-        'user_id'
+        'user_id',
+        'residential'
     ) }}
 )
 


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
Followup https://github.com/mitodl/ol-data-platform/pull/1750

### Description (What does it do?)
<!--- Describe your changes in detail -->
tfact_studentmodule_problems has been successfully built. I realized that these studentmodule tables (from mitxonline, mitxpro, residential) referenced in this model might have different refresh schedules. This PR is to add a where clause to `is_incremental` macro to account for these different refresh schedules, ensuring the new data from these open edx platforms are processed


### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

dbt build --select tfact_studentmodule_problems`
