### PR TITLE
Update dbt AutomationCondition to skip the in-progress run

### DIFF
--- a/dg_projects/lakehouse/lakehouse/assets/lakehouse/dbt.py
+++ b/dg_projects/lakehouse/lakehouse/assets/lakehouse/dbt.py
@@ -31,7 +31,7 @@ class DbtAutomationTranslator(DagsterDbtTranslator):
         self,
         dbt_resource_props: Mapping[str, Any],  # noqa: ARG002
     ) -> AutomationCondition | None:
-        return upstream_or_code_changes() & ~AutomationCondition.in_progress()
+        return upstream_or_code_changes()
 
     def get_group_name(self, dbt_resource_props: Mapping[str, Any]) -> str | None:
         """

--- a/packages/ol-orchestrate-lib/src/ol_orchestrate/lib/automation_policies.py
+++ b/packages/ol-orchestrate-lib/src/ol_orchestrate/lib/automation_policies.py
@@ -2,6 +2,7 @@ from dagster import AutomationCondition
 
 
 def upstream_or_code_changes() -> AutomationCondition:
+    not_in_progress = ~AutomationCondition.in_progress()
     no_upstream_dependencies_in_process = ~AutomationCondition.any_deps_in_progress()
     has_upstream_changes = AutomationCondition.any_deps_updated().replace(
         "newly_updated", AutomationCondition.data_version_changed()
@@ -10,7 +11,8 @@ def upstream_or_code_changes() -> AutomationCondition:
     newly_missing = AutomationCondition.newly_missing()
     all_upstream_dependencies_present = ~AutomationCondition.any_deps_missing()
     return (
-        no_upstream_dependencies_in_process
+        not_in_progress
+        & no_upstream_dependencies_in_process
         & (has_upstream_changes | has_code_changes | newly_missing)
         & all_upstream_dependencies_present
     )


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
NA
https://mitodl.slack.com/archives/C08GCS95HB5/p1761757549248479?thread_ts=1761755096.084779&cid=C08GCS95HB5

### Description (What does it do?)
<!--- Describe your changes in detail -->
Currently, our dbt_automation_sensor evaluate the dbt assets that are still in-process, which leads to dbt build errors due to conflicts (e.g. https://pipelines.odl.mit.edu/runs/36084d85-8d7f-4e40-bc6f-65fadc18a0d6 and https://pipelines.odl.mit.edu/runs/925b7d5b-6e5f-4a8c-9c7e-ee8176e44ac8). 

This PR updates our upstream_or_code_changes automation condition to skip in-process runs based on https://github.com/dagster-io/dagster/discussions/19214#discussioncomment-10290657, avoiding dbt assets being triggered by multiple runs.

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

cd dg_projects
docker compose up --build
Toggle `locations/lakehouse/sensors/dbt_automation_sensor` on
Pick a random dbt model to materialize, e.g. `assets/dimensional/dim_platform`
Check if the downstream models are evaluated: locations/lakehouse/sensors/dbt_automation_sensor

More through tests can be done in QA
