### PR TITLE
add activity metrics to org reporting table

### DIFF
--- a/src/ol_dbt/models/reporting/_reporting__models.yml
+++ b/src/ol_dbt/models/reporting/_reporting__models.yml
@@ -362,7 +362,8 @@ models:
   - name: chatbot_used_count
     description: int, a count of 1 if the user engaged with a chatbot otherwise 0
   - name: certificate_count
-    description: int, a count of 1 if the user earned a certificate that day otherwise 0
+    description: int, a count of 1 if the user earned a certificate that day otherwise
+      0
   - name: videos_watched
     description: int, a count of 1 if the user watched a video otherwise 0
   - name: problems_count

--- a/src/ol_dbt/models/reporting/organization_administration_report.sql
+++ b/src/ol_dbt/models/reporting/organization_administration_report.sql
@@ -60,7 +60,7 @@ with enrollment_detail as (
 )
 
 , chatbot_data as (
-    select 
+    select
         user.email as user_email
         , cast(chatbot_events.event_timestamp as date) as activity_date
         , chatbot_events.courserun_readable_id
@@ -69,14 +69,14 @@ with enrollment_detail as (
     inner join user
         on chatbot_events.user_fk = user.user_pk
     where chatbot_events.event_type = 'ol_openedx_chat.drawer.submit'
-    group by 
+    group by
         user.email
         , cast(chatbot_events.event_timestamp as date)
         , chatbot_events.courserun_readable_id
 )
 
 , video_data as (
-    select 
+    select
         user.email as user_email
         , cast(video_events.event_timestamp as date) as activity_date
         , video_events.courserun_readable_id
@@ -92,7 +92,7 @@ with enrollment_detail as (
 )
 
 , problem_data as (
-    select 
+    select
         user.email as user_email
         , cast(problem_events.event_timestamp as date) as activity_date
         , problem_events.courserun_readable_id
@@ -107,7 +107,7 @@ with enrollment_detail as (
 )
 
 , navigation_data as (
-    select 
+    select
         user.email as user_email
         , cast(navigation_events.event_timestamp as date) as activity_date
         , navigation_events.courserun_readable_id
@@ -122,7 +122,7 @@ with enrollment_detail as (
 )
 
 , discussion_data as (
-    select 
+    select
         user.email as user_email
         , cast(discussion_events.event_timestamp as date) as activity_date
         , discussion_events.courserun_readable_id
@@ -137,7 +137,7 @@ with enrollment_detail as (
 )
 
 , combined_data as (
-    select 
+    select
         distinct user_email
         , activity_date
         , courserun_readable_id
@@ -151,7 +151,7 @@ with enrollment_detail as (
 
     union
 
-    select 
+    select
         distinct user_email
         , certificate_created_date as activity_date
         , courserun_readable_id
@@ -166,7 +166,7 @@ with enrollment_detail as (
 
     union
 
-    select 
+    select
         distinct user_email
         , activity_date
         , courserun_readable_id
@@ -180,7 +180,7 @@ with enrollment_detail as (
 
     union
 
-    select 
+    select
         distinct user_email
         , activity_date
         , courserun_readable_id
@@ -194,7 +194,7 @@ with enrollment_detail as (
 
     union
 
-    select 
+    select
         distinct user_email
         , activity_date
         , courserun_readable_id
@@ -208,7 +208,7 @@ with enrollment_detail as (
 
     union
 
-    select 
+    select
         distinct user_email
         , activity_date
         , courserun_readable_id
@@ -222,7 +222,7 @@ with enrollment_detail as (
 )
 
 , activity_day_data as (
-    select 
+    select
         user_email
         , activity_date
         , courserun_readable_id
@@ -251,17 +251,17 @@ select
     , activity_day_data.certificate_count
     , activity_day_data.videos_watched
     , activity_day_data.problems_count
-    , case when activity_day_data.navigation_count > 0 
-        or activity_day_data.discussion_count > 0 
+    , case when activity_day_data.navigation_count > 0
+        or activity_day_data.discussion_count > 0
         or activity_day_data.videos_watched > 0
-        or activity_day_data.problems_count > 0 
-        or activity_day_data.chatbot_used_count > 0 
-        or activity_day_data.certificate_count > 0 
+        or activity_day_data.problems_count > 0
+        or activity_day_data.chatbot_used_count > 0
+        or activity_day_data.certificate_count > 0
         then 1 else 0 end as active_count
 from enroll_data
 left join org_field
     on enroll_data.courserun_readable_id = org_field.courserun_readable_id
 left join activity_day_data
-    on 
+    on
         enroll_data.user_email = activity_day_data.user_email
         and enroll_data.courserun_readable_id = activity_day_data.courserun_readable_id


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/8886

### Description (What does it do?)
adds active_count, problems_count, videos_watched, and enrolled_count to the organization_administration_report table and modifies the way chatbot_used_count is calculated 

### How can this be tested?
 dbt build --select organization_administration_report
