### PR TITLE
add partitioning to organization_administration_report

### DIFF
--- a/src/ol_dbt/models/reporting/organization_administration_report.sql
+++ b/src/ol_dbt/models/reporting/organization_administration_report.sql
@@ -1,3 +1,12 @@
+{{ config (
+    materialized='table',
+    properties= {
+      "format": "'PARQUET'",
+      "partitioning": "ARRAY['organization_key']",
+    }
+)
+}}
+
 with enrollment_detail as (
     select * from {{ ref('marts__combined_course_enrollment_detail') }}
 )


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
https://github.com/mitodl/hq/issues/6906

### Description (What does it do?)
<!--- Describe your changes in detail -->
Apply Iceberg partitioning to the `organization_administration_report` model to reduce scanned data and improve query performance for https://github.com/mitodl/ol-data-platform/pull/1512.


### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->
dbt build --select organization_administration_report

Run EXPLAIN ANALYZE to show how much data it scanned for a query

```
EXPLAIN ANALYZE
SELECT * from ol_warehouse_production_rlougee_reporting."organization_administration_report"
where organization_key='MITx'

vs

EXPLAIN ANALYZE
SELECT * from ol_warehouse_production_reporting."organization_administration_report"
where organization_key='MITx'
```

### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->


<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
