### PR TITLE
Sort signatory_names in edxorg_to_mitxonline_course_runs

### DIFF
--- a/src/ol_dbt/models/migration/edxorg_to_mitxonline_course_runs.sql
+++ b/src/ol_dbt/models/migration/edxorg_to_mitxonline_course_runs.sql
@@ -26,7 +26,7 @@ with mitx_courses as (
 , edx_signatories as (
     select
         courserun_readable_id
-        , array_agg(signatory_normalized_name)
+        , array_agg(signatory_normalized_name order by signatory_normalized_name)
             filter (where signatory_normalized_name <> '') as signatory_names
     from {{ ref('stg__edxorg__s3__course_certificate_signatory') }}
     group by courserun_readable_id


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
Related to https://github.com/mitodl/hq/issues/9301

### Description (What does it do?)
<!--- Describe your changes in detail -->
Updates signatory_names in edxorg_to_mitxonline_course_runs  so the list is sorted alphabetically. The current unordered list makes it difficult to dedupe.


### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

dbt build --select edxorg_to_mitxonline_course_runs

