### PR TITLE
Populate blank enrollment_end date in edxorg_to_mitxonline_course_runs

### DIFF
--- a/src/ol_dbt/models/migration/_migration__models.yml
+++ b/src/ol_dbt/models/migration/_migration__models.yml
@@ -27,7 +27,8 @@ models:
   - name: enrollment_start
     description: timestamp, the course enrollment start date.
   - name: enrollment_end
-    description: timestamp, the course enrollment end date.
+    description: timestamp, either the course enrollment end date or the course end
+      date if no enrollment end date is specified
   - name: start_date
     description: timestamp, The date on which the course starts
   - name: end_date

--- a/src/ol_dbt/models/migration/edxorg_to_mitxonline_course_runs.sql
+++ b/src/ol_dbt/models/migration/edxorg_to_mitxonline_course_runs.sql
@@ -62,7 +62,9 @@ select distinct
     , edx_courseruns.courseware_id
     , edx_courseruns.run_tag
     , from_iso8601_timestamp(edx_courseruns.courserun_enrollment_start_date) as enrollment_start
-    , from_iso8601_timestamp(edx_courseruns.courserun_enrollment_end_date) as enrollment_end
+    , from_iso8601_timestamp(
+       coalesce(edx_courseruns.courserun_enrollment_end_date, edx_courseruns.courserun_end_date)
+    ) as enrollment_end
     , from_iso8601_timestamp(edx_courseruns.courserun_start_date) as start_date
     , from_iso8601_timestamp(edx_courseruns.courserun_end_date) as end_date
     , coalesce(


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
Part of https://github.com/mitodl/hq/issues/8318

### Description (What does it do?)
<!--- Describe your changes in detail -->
Populates the blank `enrollment_end` date with the `end_date` in `edxorg_to_mitxonline_course_runs`, because the blank enrollment_end makes the old course enrollable on mitxonline, which is not expected.

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

dbt build --select edxorg_to_mitxonline_course_runs
