### PR TITLE
Add learn ai thread_id and checkpoint_pk to tfact_chatbot_events

### DIFF
--- a/src/ol_dbt/models/dimensional/_dim__models.yml
+++ b/src/ol_dbt/models/dimensional/_dim__models.yml
@@ -859,3 +859,7 @@ models:
       the event occurred
     tests:
     - not_null
+  - name: learn_ai_thread_id
+    description: string, unique identifier for the chat thread in the Learn AI database.
+  - name: learn_ai_checkpoint_pk
+    description: int, foreign key to chatbots_djangocheckpoint in Learn AI database


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->

related to https://github.com/mitodl/hq/issues/9015#issuecomment-3581509568

### Description (What does it do?)
<!--- Describe your changes in detail -->
Adds `learn_ai_thread_id` and `learn_ai_checkpoint_pk ` to tfact_chatbot_events, which would help us associate and align data between Learn AI and the open edX tracking logs. These two fields will be populated going forward.

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

dbt build --select tfact_chatbot_events

