### PR TITLE
Add certificate_page_revision_id to edxorg_to_mitxonline_enrollments

### DIFF
--- a/src/ol_dbt/models/migration/_migration__models.yml
+++ b/src/ol_dbt/models/migration/_migration__models.yml
@@ -63,7 +63,7 @@ models:
   - name: courserun_id
     description: int, foreign key representing a single course run on the corresponding
       platform.
-  - name: course_readable_id
+  - name: courserun_readable_id
     description: str, Open edX readable ID
   - name: courserunenrollment_enrollment_mode
     description: string, enrollment mode for user on the corresponding platform
@@ -81,7 +81,7 @@ models:
   - name: certificate_page_revision_id
     description: int, certificate page revision id on mitxonline
   - name: signatory_names
-    description: string, the names of the signatories for the course certificate
+    description: array of strings, the names of the signatories for the course certificate
 
 - name: edxorg_to_mitxonline_users
   description: edX.org certificate learners who not yet have account on MITx Online

--- a/src/ol_dbt/models/migration/edxorg_to_mitxonline_enrollments.sql
+++ b/src/ol_dbt/models/migration/edxorg_to_mitxonline_enrollments.sql
@@ -26,11 +26,11 @@ with combined_enrollments as (
        , certificate_page.wagtail_page_id as certificate_page_id
    from mitxonline__course_runs
     join course_pages
-        on mitxonline__course_runs.course_id = mitxonline__course_runs.course_id
+        on mitxonline__course_runs.course_id = course_pages.course_id
     join wagtail_page
        on course_pages.wagtail_page_id = wagtail_page.wagtail_page_id
    join wagtail_page as certificate_page
-       on certificate_page.wagtail_page_path like certificate_page.wagtail_page_path || '%'
+       on certificate_page.wagtail_page_path like wagtail_page.wagtail_page_path || '%'
         and certificate_page.wagtail_page_path <> wagtail_page.wagtail_page_path
 
 )


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
https://github.com/mitodl/hq/issues/8679

### Description (What does it do?)
<!--- Describe your changes in detail -->
- Adds `certificate_page_revision_id` to edxorg_to_mitxonline_enrollments so that it can be used to create certificate record on mitxonline. 
    - The blank records will be populated after I run the remaining runs in https://github.com/mitodl/hq/issues/8318 and https://github.com/mitodl/hq/issues/9301

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->
dbt build --select edxorg_to_mitxonline_enrollments

### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->


<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
