### PR TITLE
Update edxorg_to_mitxonline_users

### DIFF
--- a/src/ol_dbt/models/migration/edxorg_to_mitxonline_users.sql
+++ b/src/ol_dbt/models/migration/edxorg_to_mitxonline_users.sql
@@ -5,10 +5,6 @@ with edx_certificate as (
     from {{ ref('int__edxorg__mitx_courserun_certificates') }}
 )
 
-, edx_run as (
-    select * from {{ ref('edxorg_to_mitxonline_course_runs') }}
-)
-
 , mitx_user as (
     select * from {{ ref('int__mitx__users') }}
 )


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
https://github.com/mitodl/hq/issues/9098

### Description (What does it do?)
<!--- Describe your changes in detail -->
Removes the dependency of edxorg_to_mitxonline_course_runs on edxorg_to_mitxonline_users since the edx courses have been migrated from edxorg_to_mitxonline_course_runs, preventing the join from dropping users.


### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

dbt buid --select edxorg_to_mitxonline_users

### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->


<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
