### PR TITLE
fix unique test failure in int__mitxonline__proctored_exam_grades

### DIFF
--- a/src/ol_dbt/models/intermediate/mitxonline/int__mitxonline__proctored_exam_grades.sql
+++ b/src/ol_dbt/models/intermediate/mitxonline/int__mitxonline__proctored_exam_grades.sql
@@ -2,7 +2,7 @@ with exam_unit_grades as (
     select * from {{ ref('int__mitxonline__courserun_subsection_grades') }}
     where
         lower(coursestructure_block_title) = 'proctored exam'
-        and subsectiongrade_total_graded_score > 0
+        and subsectiongrade_total_earned_graded_score > 0
 )
 
 , exam_courserun_grades as (


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
https://pipelines.odl.mit.edu/runs/aa5e3d63-4a2c-4116-ac5e-94c860eccb1f

### Description (What does it do?)
<!--- Describe your changes in detail -->
Fixes the unique test failure in int__mitxonline__proctored_exam_grades
```
[31mFailure in test dbt_expectations_expect_compound_columns_to_be_unique_int__mitxonline__proctored_exam_grades_user_username__courserun_readable_id (models/intermediate/mitxonline/_int_mitxonline__models.yml)[0m

  Got 14 results, configured to fail if >10
```

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

Run `dbt build --select int__mitxonline__proctored_exam_grades` and test should be passed now

### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->


<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
