### PR TITLE
Update user_email and exclude retired users in edxorg_to_mitxonline_users 

### DIFF
--- a/src/ol_dbt/models/migration/edxorg_to_mitxonline_users.sql
+++ b/src/ol_dbt/models/migration/edxorg_to_mitxonline_users.sql
@@ -3,6 +3,7 @@ with edx_certificate as (
         *
         ,  {{ format_course_id('courserun_readable_id', false) }} as courseware_id
     from {{ ref('int__edxorg__mitx_courserun_certificates') }}
+    where user_email not like 'retired__user%' and user_username not like 'retired__user%'
 )
 
 , mitx_user as (
@@ -35,4 +36,3 @@ where
     edx_certificate_user.row_number = 1
     and mitx_user1.user_mitxonline_username is null
     and mitx_user2.user_mitxonline_email is null
-    and edx_certificate_user.user_email not like 'retired__user%'


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
https://github.com/mitodl/hq/issues/9098

### Description (What does it do?)
<!--- Describe your changes in detail -->
Updating user_email in edxorg_to_mitxonline_users to be lowercase, to avoid ongoing confusion about case matching.
Excluding retired users in edxorg_to_mitxonline_users, since these users don't have valid email address to migrate

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->
dbt build --select edxorg_to_mitxonline_users

