### PR TITLE
add mitxonline video engagement with video counts reporting table

### DIFF
--- a/src/ol_dbt/models/reporting/_reporting__models.yml
+++ b/src/ol_dbt/models/reporting/_reporting__models.yml
@@ -431,7 +431,8 @@ models:
   - name: platform
     description: string, the platform name currently defaulted to MITx Online
   - name: courserun_is_current
-    description: boolean, true if the current date is between the course run start and end dates otherwise false
+    description: boolean, true if the current date is between the course run start
+      and end dates otherwise false
   - name: course_readable_id
     description: string, unique string to identify a course on the corresponding platform.
   - name: user_watched_video_count

--- a/src/ol_dbt/models/reporting/mitxonline_video_engagements_w_video_counts.sql
+++ b/src/ol_dbt/models/reporting/mitxonline_video_engagements_w_video_counts.sql
@@ -19,16 +19,16 @@ with mitxonline_video_engagements as (
         , courserun_readable_id
 )
 
-select 
+select
     mitxonline_video_engagements.user_email
     , mitxonline_video_engagements.section_title
     , mitxonline_video_engagements.courserun_readable_id
     , subq_video_engagements.total_video_count
     , 'MITx Online' as platform
     , case
-        when 
+        when
                 cast(substring(mitxonline_video_engagements.courserun_start_on, 1, 10) as date) <= current_date
-            and 
+            and
                 (mitxonline_video_engagements.courserun_end_on is null
                 or cast(substring(mitxonline_video_engagements.courserun_end_on, 1, 10) as date) >= current_date)
         then true
@@ -39,8 +39,8 @@ select
     , max(mitxonline_video_engagements.coursestructure_block_index) as max_coursestructure_block_index
 from mitxonline_video_engagements
 join subq_video_engagements
-    on 
-        mitxonline_video_engagements.section_title = subq_video_engagements.section_title 
+    on
+        mitxonline_video_engagements.section_title = subq_video_engagements.section_title
         and mitxonline_video_engagements.courserun_readable_id = subq_video_engagements.courserun_readable_id
 left join mitx__courses
     on mitxonline_video_engagements.course_number = mitx__courses.course_number
@@ -52,12 +52,11 @@ group by
     , subq_video_engagements.total_video_count
     , 'MITx Online'
     , case
-        when 
+        when
                 cast(substring(mitxonline_video_engagements.courserun_start_on, 1, 10) as date) <= current_date
-            and 
+            and
                 (mitxonline_video_engagements.courserun_end_on is null
                 or cast(substring(mitxonline_video_engagements.courserun_end_on, 1, 10) as date) >= current_date)
         then true
         else false end
     , mitx__courses.course_readable_id
-


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/7644

### Description (What does it do?)
<!--- Describe your changes in detail -->
adds the new mitxonline video engagement with video counts reporting table to replace the [virtual superset dataset](https://bi.ol.mit.edu/explore/?datasource_type=table&datasource_id=43)

### How can this be tested?
dbt build --select mitxonline_video_engagements_w_video_counts