### PR TITLE
Populate signatory_names in edxorg_to_mitxonline_enrollments

### DIFF
--- a/src/ol_dbt/models/migration/edxorg_to_mitxonline_enrollments.sql
+++ b/src/ol_dbt/models/migration/edxorg_to_mitxonline_enrollments.sql
@@ -147,7 +147,7 @@ select
     , edxorg_enrollment.courserunenrollment_created_on
     , edxorg_enrollment.courseruncertificate_created_on
     , edx_to_mitxonline_certificate_revision.wagtailcore_revision_id as certificate_page_revision_id
-    , edx_to_mitxonline_certificate_revision.signatory_names
+    , edx_signatories.signatory_names
 from edxorg_enrollment
 left join mitxonline_enrollment
     on
@@ -159,6 +159,8 @@ left join mitx__users
     on edxorg_enrollment.user_id = cast(mitx__users.user_edxorg_id as varchar)
 left join edx_to_mitxonline_certificate_revision
     on edxorg_enrollment.courserun_readable_id = edx_to_mitxonline_certificate_revision.courserun_readable_id
+left join edx_signatories
+    on edxorg_enrollment.courserun_readable_id = edx_signatories.courserun_readable_id
 where
     edxorg_enrollment.courseruncertificate_created_on is not null
     and mitxonline_enrollment.user_email is null


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
https://github.com/mitodl/hq/issues/8679

### Description (What does it do?)
<!--- Describe your changes in detail -->
Populates signatory_names in edxorg_to_mitxonline_enrollments, so that its easier to verify whether the signatories are included  the edx course export


### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

dbt build --select edxorg_to_mitxonline_enrollments
