### PR TITLE
add new learner demographics and certificate info reporting table

### DIFF
--- a/src/ol_dbt/models/reporting/_reporting__models.yml
+++ b/src/ol_dbt/models/reporting/_reporting__models.yml
@@ -438,7 +438,8 @@ models:
   - name: platform
     description: string, the platform name currently defaulted to MITx Online
   - name: courserun_is_current
-    description: boolean, true if the current date is between the course run start and end dates otherwise false
+    description: boolean, true if the current date is between the course run start
+      and end dates otherwise false
   - name: user_watched_video_count
     description: int, count of videos a user watched
   - name: max_coursestructure_block_index
@@ -476,11 +477,14 @@ models:
   - name: activity_date
     description: date, date that user engaged in an activity realted to the course
   - name: certificate_count
-    description: int, count of certificates granted on that particular activity date for a user and courserun
+    description: int, count of certificates granted on that particular activity date
+      for a user and courserun
   - name: enrollment_count
-    description: int, count of enrollments on that particular activity date for a user and courserun
+    description: int, count of enrollments on that particular activity date for a
+      user and courserun
   - name: unenrolled_count
-    description: int, count of unenrollments on that particular activity date for a user and courserun
+    description: int, count of unenrollments on that particular activity date for
+      a user and courserun
   - name: audit_count
     description: int, count of enrollments that have a enrollment mode status of audit
       on that particular activity date for a user and courserun
@@ -489,7 +493,8 @@ models:
       on that particular activity date for a user and courserun
   tests:
   - dbt_expectations.expect_compound_columns_to_be_unique:
-      column_list: ["courserun_readable_id", "user_email", "platform", "course_readable_id", "activity_date"]
+      column_list: ["courserun_readable_id", "user_email", "platform", "course_readable_id",
+        "activity_date"]
 
 - name: learner_demographics_and_cert_info
   description: A report that contains learner demographics and cerificate information
@@ -529,13 +534,16 @@ models:
       so this counts as same person if they use the email to register on different
       platforms
   - name: dedp_course_cert_count
-    description: int, count of the number of times the user has recieved a DEDP course credential
+    description: int, count of the number of times the user has recieved a DEDP course
+      credential
   - name: any_dedp_program_cert_ind
     description: str, indictor showing if the user has recieved any DEDP program credentials
   - name: dedp_international_program_cert_ind
-    description: str, indictor showing if the user has recieved any DEDP Inernational program credentials
+    description: str, indictor showing if the user has recieved any DEDP Inernational
+      program credentials
   - name: dedp_public_policy_program_cert_ind
-    description: str, indictor showing if the user has recieved any DEDP Public Policy program credentials
+    description: str, indictor showing if the user has recieved any DEDP Public Policy
+      program credentials
   tests:
   - dbt_expectations.expect_compound_columns_to_be_unique:
       column_list: ["user_hashed_id"]

--- a/src/ol_dbt/models/reporting/learner_demographics_and_cert_info.sql
+++ b/src/ol_dbt/models/reporting/learner_demographics_and_cert_info.sql
@@ -15,19 +15,19 @@ with combined__users as (
 )
 
 , dedp_indicators as (
-    select 
+    select
         user_hashed_id
         , 1 as Any_DEDP_Program_Indicator
-        , count(distinct case 
+        , count(distinct case
             when program_title =
             'Data, Economics, and Design of Policy: International Development'
             then user_hashed_id else null end) as DEDP_International_Program_Indicator
-        , count (distinct case 
+        , count (distinct case
             when program_title =
             'Data, Economics, and Design of Policy: Public Policy'
             then user_hashed_id else null end) as DEDP_Public_Policy_Program_Indicator
     from program_enrollment_detail
-    where program_title in 
+    where program_title in
         ('Data, Economics, and Design of Policy'
         , 'Data, Economics, and Design of Policy: International Development'
         , 'Data, Economics, and Design of Policy: Public Policy')
@@ -37,7 +37,7 @@ with combined__users as (
 )
 
 , dedp_certs as (
-    select 
+    select
         combined_course_enrollment_detail.user_hashed_id
         , count(distinct combined_course_enrollment_detail.course_readable_id) as DEDP_Course_Cert_Count
     from combined_course_enrollment_detail


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/7644

### Description (What does it do?)
add new learner demographics and certificate info reporting table

### How can this be tested?
dbt build --select Learner_Demographics_And_Cert_Info
