### PR TITLE
Remove PEx from edxorg_to_mitxonline_enrollments

### DIFF
--- a/src/ol_dbt/models/migration/edxorg_to_mitxonline_enrollments.sql
+++ b/src/ol_dbt/models/migration/edxorg_to_mitxonline_enrollments.sql
@@ -133,6 +133,9 @@ with combined_enrollments as (
     --- exclude DEDP Micromasters program courses as those are already migrated
     and (edxorg_runs.micromasters_program_id != {{ var("dedp_micromasters_program_id") }}
     or edxorg_runs.micromasters_program_id is null)
+    --- Exclude PEx runs as these are transient and don't need to be migrated. Anyone who earned a certificate
+      -- in them also earned a certificate in the corresponding non-PEx version of the course
+    and combined_enrollments.courserun_readable_id not like '%PEx%'
 )
 
 select


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
https://github.com/mitodl/hq/issues/9618#issuecomment-3770080633

### Description (What does it do?)
<!--- Describe your changes in detail -->
Based on https://github.com/mitodl/hq/issues/9618#issuecomment-3770080633, we don't need to migrate any PEx runs. This PR is to remove PEx run from edxorg_to_mitxonline_enrollments.

### Screenshots (if appropriate):
<!--- optional - delete if empty --->
- [ ] Desktop screenshots
- [ ] Mobile width screenshots

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

dbt build --select edxorg_to_mitxonline_enrollments

Verify that these PEx runs https://github.com/mitodl/hq/issues/9618#issuecomment-3770080633 are removed. Any other runs are not affected.

### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->


<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
