### PR TITLE
Restore student_risk_probability_report table definition

### DIFF
--- a/src/ol_dbt/models/reporting/_reporting__models.yml
+++ b/src/ol_dbt/models/reporting/_reporting__models.yml
@@ -324,6 +324,29 @@ models:
   - dbt_expectations.expect_compound_columns_to_be_unique:
       column_list: ["platform", "openedx_user_id", "courserun_readable_id", "problem_block_fk"]
 
+- name: student_risk_probability_report
+  description: A report that contains student risk probability scores and course grade
+  columns:
+  - name: platform
+    description: str, name of the platform
+  - name: courserun_readable_id
+    description: str, open edX course ID formatted as course-v1:{org}+{course code}+{run_tag}
+      for MITxOnline and xPro courses, {org}/{course}/{run_tag} for edX.org courses
+  - name: openedx_user_id
+    description: int, user ID on the corresponding open edX platform
+  - name: email
+    description: str, user email
+  - name: risk_probability
+    description: float, probability scores between 0 and 1 representing the model-estimated
+      probability that a student exhibits suspicious behavior. Higher values indicate
+      a higher likelihood of suspicious behavior, while values closer to 0 indicate
+      normal behavior.
+  - name: created_timestamp
+    description: timestamp, date and time when probability was calculated
+  tests:
+  - dbt_expectations.expect_compound_columns_to_be_unique:
+      column_list: ["courserun_readable_id", "openedx_user_id", "platform"]
+
 - name: chatbot_usage_report
   description: AI chatbot interactions from Learn AI application including TutorBot,
     ResourceRecommendationBot, SyllabusBot and VideoGPTBot. No personal information


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
NA

### Description (What does it do?)
<!--- Describe your changes in detail -->
Restores the student_risk_probability_report table definition that was accidentally removed in this PR https://github.com/mitodl/ol-data-platform/pull/1861


### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

