### PR TITLE
Populate mitxonline_user_id in edxorg_to_mitxonline_enrollments

### DIFF
--- a/src/ol_dbt/models/migration/edxorg_to_mitxonline_enrollments.sql
+++ b/src/ol_dbt/models/migration/edxorg_to_mitxonline_enrollments.sql
@@ -140,7 +140,7 @@ with combined_enrollments as (
 
 select
     edxorg_enrollment.user_id as user_edxorg_id
-    , mitx__users.user_mitxonline_id
+    , coalesce(mitx__users.user_mitxonline_id, mitx_users_by_email.user_mitxonline_id) as user_mitxonline_id
     , edxorg_enrollment.user_email
     , mitxonline__course_runs.courserun_id
     , edxorg_enrollment.courserun_readable_id
@@ -159,7 +159,9 @@ left join mitxonline_enrollment
 left join mitxonline__course_runs
     on edxorg_enrollment.courserun_readable_id = mitxonline__course_runs.courserun_readable_id
 left join mitx__users
-    on edxorg_enrollment.user_id = cast(mitx__users.user_edxorg_id as varchar)
+       on edxorg_enrollment.user_id = cast(mitx__users.user_edxorg_id as varchar)
+left join mitx__users as mitx_users_by_email
+       on lower(edxorg_enrollment.user_email) = lower(mitx_users_by_email.user_mitxonline_email)
 left join edx_to_mitxonline_certificate_revision
     on edxorg_enrollment.courserun_readable_id = edx_to_mitxonline_certificate_revision.courserun_readable_id
 left join edx_signatories


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
https://github.com/mitodl/hq/issues/8679

### Description (What does it do?)
<!--- Describe your changes in detail -->
Populates mitxonline_user_id in edxorg_to_mitxonline_enrollments.

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

dbt build --select edxorg_to_mitxonline_enrollments

-- there are only retired users certificate records left we won't migrate
select * from edxorg_to_mitxonline_enrollments where mitxonline_user_id is null 
