### PR TITLE
replace the deprecated courseware_url_path

### DIFF
--- a/src/ol_dbt/models/staging/mitxonline/_mitxonline__sources.yml
+++ b/src/ol_dbt/models/staging/mitxonline/_mitxonline__sources.yml
@@ -446,8 +446,9 @@ sources:
         course
     - name: courseware_id
       description: str, Open edX Course ID formatted as course-v1:{org}+{course code}+{run_tag}
-    - name: courseware_url_path
-      description: str, url location for the course run in MITx Online
+    - name: has_courseware_url
+      description: boolean, whether this course run should expose a courseware URL.Set
+        to False for test/placeholder runs
     - name: is_self_paced
       description: boolean, indicating whether users can take this course at their
         own pace and earn certificate at any time

--- a/src/ol_dbt/models/staging/mitxonline/stg__mitxonline__app__postgres__courses_courserun.sql
+++ b/src/ol_dbt/models/staging/mitxonline/stg__mitxonline__app__postgres__courses_courserun.sql
@@ -11,7 +11,10 @@ with source as (
         , live as courserun_is_live
         , title as courserun_title
         , courseware_id as courserun_readable_id
-        , courseware_url_path as courserun_url
+        , if(has_courseware_url=true
+           , concat('{{ var("mitxonline_openedx_url") }}', '/learn/course/', courseware_id,'/home')
+            , null
+        ) as courserun_url
         , run_tag as courserun_tag
         , is_self_paced as courserun_is_self_paced
         , b2b_contract_id


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
Related to https://github.com/mitodl/mitxonline/pull/3254
```
Dagster  [8:51 AM]
Dagster Production Run FailureJob Name: sync_and_stage_mitx_online_production_app_db__s3_data_lake
Run ID: 331c0e43Step: full_dbt_project
DBT Error:f 345 ERROR creating sql table model ol_warehouse_production_staging.stg__mitxonline__app__postgres__courses_courserun  [[31mERROR[0m in 0.76s]

[31mFailure in model stg__mitxonline__app__postgres__courses_courserun (models/staging/mitxonline/stg__mitxonline__app__postgres__courses_courserun.sql)[0m

  Database Error in model stg__mitxonline__app__postgres__courses_courserun (models/staging/mitxonline/stg__mitxonline__app__postgres__courses_courserun.sql)
  TrinoUserError(type=USER_ERROR, name=COLUMN_NOT_FOUND, message="line 23:11: Column 'courseware_url_path' cannot be resolved",
```

### Description (What does it do?)
<!--- Describe your changes in detail -->
The change needs to be applied in staging model for the deprecation in https://github.com/mitodl/mitxonline/pull/3254

### Screenshots (if appropriate):
<!--- optional - delete if empty --->
- [ ] Desktop screenshots
- [ ] Mobile width screenshots

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

dbt build --select stg__mitxonline__app__postgres__courses_courserun

Check the courserun_url in stg__mitxonline__app__postgres__courses_courserun