### PR TITLE
Update the email join to be case-insensitive in edxorg_to_mitxonline_enrollments

### DIFF
--- a/src/ol_dbt/models/migration/edxorg_to_mitxonline_enrollments.sql
+++ b/src/ol_dbt/models/migration/edxorg_to_mitxonline_enrollments.sql
@@ -140,7 +140,7 @@ with combined_enrollments as (
 
 select
     edxorg_enrollment.user_id as user_edxorg_id
-    , coalesce(mitx__users.user_mitxonline_id, mitx_users_by_email.user_mitxonline_id) as user_mitxonline_id
+    , coalesce(mitx_users_by_email.user_mitxonline_id, mitx__users.user_mitxonline_id) as user_mitxonline_id
     , edxorg_enrollment.user_email
     , mitxonline__course_runs.courserun_id
     , edxorg_enrollment.courserun_readable_id
@@ -154,7 +154,7 @@ select
 from edxorg_enrollment
 left join mitxonline_enrollment
     on
-        edxorg_enrollment.user_email = mitxonline_enrollment.user_email
+        lower(edxorg_enrollment.user_email) = lower(mitxonline_enrollment.user_email)
        and edxorg_enrollment.courserun_readable_id = mitxonline_enrollment.courserun_readable_id
 left join mitxonline__course_runs
     on edxorg_enrollment.courserun_readable_id = mitxonline__course_runs.courserun_readable_id


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
https://github.com/mitodl/hq/issues/8679

### Description (What does it do?)
<!--- Describe your changes in detail -->
Updates the email join to be case-insensitive in edxorg_to_mitxonline_enrollments, as some of emails we migrated were converted to lowercase, prioritize email-based user matching.

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->
dbt build --select edxorg_to_mitxonline_enrollments

