### PR TITLE
Optimize performance of stg__mitxresidential__openedx__courseware_studentmodulehistoryextended

### DIFF
--- a/src/ol_dbt/models/staging/mitxresidential/stg__mitxresidential__openedx__courseware_studentmodulehistoryextended.sql
+++ b/src/ol_dbt/models/staging/mitxresidential/stg__mitxresidential__openedx__courseware_studentmodulehistoryextended.sql
@@ -7,13 +7,6 @@
 }}
 
 with source as (
-    select * from
-    {{
-      source('ol_warehouse_raw_data'
-      ,'raw__mitx__openedx__mysql__courseware_studentmodulehistory')
-    }}
-
-    union all
 
     select * from
     {{
@@ -24,6 +17,18 @@ with source as (
     {% if is_incremental() %}
         where created >= (select max(this.studentmodule_created_on) from {{ this }} as this)
     {% endif %}
+
+
+    {% if not is_incremental() %}
+
+        union all
+         --- ONLY run on full-refresh / first build to backfill data from the old raw table
+        select * from
+        {{
+          source('ol_warehouse_raw_data', 'raw__mitx__openedx__mysql__courseware_studentmodulehistory')
+        }}
+    {% endif %}
+
 )
 
 --- this is needed for the initial dbt run to deduplicate the data from raw table


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
NA
https://pipelines.odl.mit.edu/runs/cabaa31d-b671-4b0d-836e-785bc639822f

### Description (What does it do?)
<!--- Describe your changes in detail -->
Improves the performance of `stg__mitxresidential__openedx__courseware_studentmodulehistoryextended`, which was causing repeated dbt errors and long runtimes (+20 mins).

https://pipelines.odl.mit.edu/assets/staging/stg__mitxresidential__openedx__courseware_studentmodulehistoryextended?view=events

`raw__mitx__openedx__mysql__courseware_studentmodulehistory` only contains historical data before 2018, However, due to the way the UNION ALL and incremental logic were structured when this table was added, dbt was reprocessing this entire table on every incremental run.

This change ensures the historical table is only needed on the initial run, so this model behave as a true incremental model.


### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->
It should now takes 2 mins instead of 20 mins

dbt build --select stg__mitxresidential__openedx__courseware_studentmodulehistoryextended

### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->


<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
