### PR TITLE
Fix: populate edx courserun grade in dbt models

### DIFF
--- a/src/ol_dbt/models/intermediate/edxorg/_int_edxorg__models.yml
+++ b/src/ol_dbt/models/intermediate/edxorg/_int_edxorg__models.yml
@@ -301,6 +301,8 @@ models:
   - name: courserungrade_is_passing
     description: boolean, indicating that the user completed the course with a passing
       grade
+    tests:
+    - not_null
   - name: courserun_title
     description: str, The title of the course run
   - name: course_number

--- a/src/ol_dbt/models/intermediate/edxorg/int__edxorg__mitx_courserun_grades.sql
+++ b/src/ol_dbt/models/intermediate/edxorg/int__edxorg__mitx_courserun_grades.sql
@@ -48,7 +48,10 @@ with grades as (
             user_info_combo.courseruncertificate_grade
         ) as courserungrade_user_grade
         , grades.courserungrade_passing_grade
-        , grades.courserungrade_is_passing
+        , coalesce(
+            grades.courserungrade_is_passing
+           , nullif(user_info_combo.courseruncertificate_verify_uuid, '') is not null
+        ) as  courserungrade_is_passing
     from grades
     full outer join user_info_combo on
         grades.user_id = user_info_combo.user_id

--- a/src/ol_dbt/models/intermediate/mitx/_int_mitx__models.yml
+++ b/src/ol_dbt/models/intermediate/mitx/_int_mitx__models.yml
@@ -471,6 +471,8 @@ models:
   - name: courserungrade_is_passing
     description: boolean, indicating whether the user has passed the passing score
       set for this course on edX.org or MITxOnline
+    tests:
+    - not_null
   tests:
   - dbt_expectations.expect_compound_columns_to_be_unique:
       column_list: ["user_mitxonline_username", "user_edxorg_username", "courserun_readable_id"]

--- a/src/ol_dbt/models/migration/edxorg_to_mitxonline_enrollments.sql
+++ b/src/ol_dbt/models/migration/edxorg_to_mitxonline_enrollments.sql
@@ -5,7 +5,7 @@ with combined_enrollments as (
 , edxorg_grade as (
     select
           {{ format_course_id('courseruncertificate_courserun_readable_id', false) }} as courserun_readable_id
-         , user_id
+         , cast(user_id as varchar) as user_id
          , courseruncertificate_grade
     from {{ ref('stg__edxorg__bigquery__mitx_user_info_combo') }}
     where
@@ -167,7 +167,7 @@ select
     , edx_signatories.signatory_names
 from edxorg_enrollment
 left join edxorg_grade
-    on edxorg_enrollment.user_id = cast(edxorg_grade.user_id as varchar)
+    on edxorg_enrollment.user_id = edxorg_grade.user_id
     and edxorg_enrollment.courserun_readable_id = edxorg_grade.courserun_readable_id
 left join mitxonline_enrollment
     on


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
Discovered as part of https://github.com/mitodl/hq/issues/8679

### Description (What does it do?)
<!--- Describe your changes in detail -->
- fixes the missing grades in `int__edxorg__mitx_courserun_grades`, which caused some certificate earners to show null grades. e.g. https://bi.ol.mit.edu/superset/dashboard/p/knMZKQQqOB1/
- populates the missing grades in `edxorg_to_mitxonline_enrollments`

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

test should pass

dbt build --select int__edxorg__mitx_courserun_grades edxorg_to_mitxonline_enrollments

### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->


<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
