### PR TITLE
remove openedx_user_id not null check in marts__mitxonline_course_cer…

### DIFF
--- a/src/ol_dbt/models/marts/mitxonline/_marts__mitxonline__models.yml
+++ b/src/ol_dbt/models/marts/mitxonline/_marts__mitxonline__models.yml
@@ -42,8 +42,6 @@ models:
     - not_null
   - name: openedx_user_id
     description: int, foreign key to open edX users.
-    tests:
-    - not_null
 
 - name: marts__mitxonline_user_profiles
   description: MITx Online user profiles


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
NA
https://pipelines.odl.mit.edu/runs/f88345c9-6fdb-4ea6-92d2-43aa0daa2710
```
[31mFailure in test not_null_marts__mitxonline_course_certificates_openedx_user_id (models/marts/mitxonline/_marts__mitxonline__models.yml)[0m

  Got 1473 results, configured to fail if >10
```

### Description (What does it do?)
<!--- Describe your changes in detail -->
Remove the not_null test on openedx_user_id in marts__mitxonline_course_certificates, since the legacy edx certificates were migrated to mitxonline recently and they don't yet have openedx ID in learn


### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->
dbt build --select marts__mitxonline_course_certificates

