### PR TITLE
Fix AttributeError on openedx extract_courserun_details ops

### DIFF
--- a/dg_projects/edxorg/edxorg/assets/openedx_course_archives.py
+++ b/dg_projects/edxorg/edxorg/assets/openedx_course_archives.py
@@ -84,7 +84,7 @@ def extract_edxorg_courserun_metadata(
         course_archive,
         course_xml_path,
     )
-    course_archive.fs.get_file(str(course_archive), course_xml_path)
+    course_archive.fs.get_file(str(course_archive), str(course_xml_path))
     data_version = hashlib.file_digest(course_xml_path.open("rb"), "sha256").hexdigest()
 
     # Process the course metadata

--- a/dg_projects/openedx/openedx/assets/openedx.py
+++ b/dg_projects/openedx/openedx/assets/openedx.py
@@ -260,7 +260,7 @@ def extract_courserun_details(context: AssetExecutionContext, course_xml: UPath)
     context.log.info(
         "Attempting to download course XML from %s to %s", course_xml, course_xml_path
     )
-    course_xml.fs.get_file(str(course_xml), course_xml_path)
+    course_xml.fs.get_file(str(course_xml), str(course_xml_path))
     data_version = hashlib.file_digest(course_xml_path.open("rb"), "sha256").hexdigest()
 
     # Process the course metadata


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
NA

### Description (What does it do?)
<!--- Describe your changes in detail -->
Fixes `AttributeError: 'S3Path' object has no attribute 'rstrip'` error on extract_courserun_details execution. See https://pipelines.odl.mit.edu/runs/b/mzfurshc?tab=runs. It's probably due to the fsspec upgrade in https://github.com/mitodl/ol-data-platform/pull/1893


### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->
docker compose up --build
Materialize `assets/mitxonline/openedx/processed_data/course_metadata` and it's upstream asset `course_xml`, and there should be no error



<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
