### PR TITLE
Compress videos before uploading to S3

### DIFF
--- a/dg_projects/learning_resources/learning_resources/assets/video_shorts.py
+++ b/dg_projects/learning_resources/learning_resources/assets/video_shorts.py
@@ -265,9 +265,10 @@ def video_short_content(
             raise RuntimeError(msg)
 
         # Compress video to target size
-        target_size = float(os.environ.get("VIDEO_SHORTS_MAX_SIZE_MB", "12"))
+        target_size = float(os.environ.get("VIDEO_SHORTS_MAX_SIZE_MB", "6"))
         context.log.info("Compressing video to max %d MB: %s", target_size, video_file)
         compressed_file = compress_video(
+            context,
             input_path=video_file,
             output_path=Path(temp_dir) / "compressed" / f"{video_id}.{video_ext}",
             max_size_mb=target_size,

--- a/dg_projects/learning_resources/learning_resources/lib/google_sheets.py
+++ b/dg_projects/learning_resources/learning_resources/lib/google_sheets.py
@@ -2,7 +2,6 @@
 
 import hashlib
 import json
-import logging
 import re
 from datetime import datetime, timedelta
 from typing import Any
@@ -12,8 +11,6 @@ import pygsheets
 from dagster import OpExecutionContext
 from dateutil import parser  # type: ignore[import-untyped]
 from google.oauth2 import service_account
-
-log = logging.getLogger(__name__)
 
 
 def fetch_video_shorts_from_google_sheet(
@@ -77,7 +74,7 @@ def fetch_video_shorts_from_google_sheet(
         context.log.warning("No rows returned from Google Sheets!")
 
     # Parse rows into video metadata
-    return parse_sheet_rows(rows)
+    return parse_sheet_rows(context, rows)
 
 
 def parse_pub_date(date_value: str | float) -> datetime | None:  # noqa: PLR0911
@@ -195,11 +192,11 @@ def convert_dropbox_link_to_direct(dropbox_url: str) -> str:
     elif "dl=" not in direct_url:
         separator = "&" if "?" in direct_url else "?"
         direct_url = f"{direct_url}{separator}dl=1"
-    log.info("Converted Dropbox URL to direct link: %s", direct_url)
     return direct_url
 
 
 def parse_sheet_rows(
+    context: OpExecutionContext,
     rows: list[list[str]],
 ) -> list[dict[str, Any]]:
     """
@@ -220,7 +217,9 @@ def parse_sheet_rows(
         sorted by pub_date descending
     """
     if not rows or len(rows) < 2:  # Need at least header + 1 data row  # noqa: PLR2004
-        log.warning("Sheet has fewer than 2 rows (header + data): %d rows", len(rows))
+        context.log.warning(
+            "Sheet has fewer than 2 rows (header + data): %d rows", len(rows)
+        )
         return []
 
     # Get today's date (without time) for comparison
@@ -228,7 +227,7 @@ def parse_sheet_rows(
 
     # Parse header row
     header = [col.strip().lower() for col in rows[0]]
-    log.info("Sheet headers found: %s", header)
+    context.log.info("Sheet headers found: %s", header)
 
     # Find column indices
     try:
@@ -244,7 +243,7 @@ def parse_sheet_rows(
     skipped_rows = 0
     for row_idx, row in enumerate(rows[1:], start=2):  # Skip header, start at row 2
         if len(row) <= max(pub_date_idx, video_name_idx, dropbox_link_idx):
-            log.debug(
+            context.log.debug(
                 "Row %d: Skipped (incomplete row, only %d cells)", row_idx, len(row)
             )
             skipped_rows += 1
@@ -267,7 +266,7 @@ def parse_sheet_rows(
         # Skip rows without parseable pub_date or dropbox_link
         pub_date = parse_pub_date(pub_date_value)
         if not pub_date or not dropbox_link:
-            log.warning(
+            context.log.warning(
                 "Row %d: Skipped - pub_date_value='%s' (type=%s, parsed=%s), "
                 "dropbox_link='%s' (has_link=%s)",
                 row_idx,
@@ -282,7 +281,7 @@ def parse_sheet_rows(
 
         # Skip rows with future publication dates
         if pub_date.date() > today:
-            log.info(
+            context.log.info(
                 "Row %d: Skipped - pub_date=%s is in the future (today=%s)",
                 row_idx,
                 pub_date.date(),
@@ -296,7 +295,7 @@ def parse_sheet_rows(
         # Format date for display (convert datetime back to string)
         pub_date_str = pub_date.isoformat()
 
-        log.info(
+        context.log.info(
             "Row %d: Accepted - video='%s', file='%s', date='%s' (from %s)",
             row_idx,
             video_name[:30] if video_name else "(no name)",
@@ -319,7 +318,7 @@ def parse_sheet_rows(
     # Sort by pub_date descending (newest first)
     videos.sort(key=lambda v: v["pub_date"], reverse=True)  # type: ignore[arg-type, return-value]
 
-    log.info(
+    context.log.info(
         "Parsed %d videos with pub_date <= %s (%d rows, %d skipped)",
         len(videos),
         today,

--- a/dg_projects/learning_resources/learning_resources/lib/video_processing.py
+++ b/dg_projects/learning_resources/learning_resources/lib/video_processing.py
@@ -1,12 +1,10 @@
 """Video encoding and thumbnail generation utilities."""
 
-import logging
 import os
 from pathlib import Path
 
 import ffmpeg
-
-log = logging.getLogger(__name__)
+from dagster import OpExecutionContext
 
 
 def generate_video_thumbnail(
@@ -55,9 +53,10 @@ def generate_video_thumbnail(
 
 
 def compress_video(
+    context: OpExecutionContext,
     input_path: Path,
     output_path: Path,
-    max_size_mb: float = 12,
+    max_size_mb: float = 6,
 ) -> Path:
     """
     Compress video to a target maximum file size using two-pass H.264 encoding.
@@ -67,6 +66,7 @@ def compress_video(
     the size limit with minimal quality loss.
 
     Args:
+        context: Dagster execution context for logging
         input_path: Path to the input video file
         output_path: Path where compressed video will be saved
         max_size_mb: Maximum output file size in megabytes (default 12 MB)
@@ -80,14 +80,14 @@ def compress_video(
     file_size_mb = input_path.stat().st_size / (1024 * 1024)
 
     if file_size_mb <= max_size_mb:
-        log.info(
+        context.log.info(
             "Video already under %.1f MB (%.1f MB), skipping compression",
             max_size_mb,
             file_size_mb,
         )
         return input_path
 
-    log.info(
+    context.log.info(
         "Compressing video from %.1f MB to target %.1f MB", file_size_mb, max_size_mb
     )
 
@@ -113,7 +113,7 @@ def compress_video(
         )
         raise RuntimeError(msg)
 
-    log.info(
+    context.log.info(
         "Duration: %.1fs, target video bitrate: %d bps (%.1f Mbps)",
         duration,
         video_bitrate,
@@ -170,7 +170,7 @@ def compress_video(
         raise RuntimeError(msg)
 
     output_size_mb = output_path.stat().st_size / (1024 * 1024)
-    log.info(
+    context.log.info(
         "Compression complete: %.1f MB -> %.1f MB (%.0f%% reduction)",
         file_size_mb,
         output_size_mb,


### PR DESCRIPTION
### What are the relevant tickets?
Related to https://github.com/mitodl/hq/issues/8880

### Description (What does it do?)
- Compresses video shorts so their file size is about ~25MB max
- Generates a thumbnail at 1 second in to avoid occasional "blackout" images

### How can this be tested?
See instructions at https://github.com/mitodl/ol-data-platform/pull/1827

After pipelines have completed, check 1 or 2 video file sizes to make sure they're about ~25 MB or so maximum

```
curl -I https://rc.learn.mit.edu/media/shorts/cd8a192bc2f75f01/cd8a192bc2f75f01.mp4
```
