### PR TITLE
Update edxorg_to_mitxonline_enrollments to remove retired users

### DIFF
--- a/src/ol_dbt/models/migration/edxorg_to_mitxonline_enrollments.sql
+++ b/src/ol_dbt/models/migration/edxorg_to_mitxonline_enrollments.sql
@@ -147,6 +147,9 @@ with combined_enrollments as (
     --- Exclude PEx runs as these are transient and don't need to be migrated. Anyone who earned a certificate
       -- in them also earned a certificate in the corresponding non-PEx version of the course
     and combined_enrollments.courserun_readable_id not like '%PEx%'
+    -- Exclude retired users
+    and combined_enrollments.user_email not like 'retired__user%'
+    and combined_enrollments.user_username not like 'retired__user%'
 )
 
 select
@@ -186,3 +189,4 @@ left join edx_signatories
 where
     edxorg_enrollment.courseruncertificate_created_on is not null
     and mitxonline_enrollment.user_email is null
+    and mitx__users.user_mitxonline_email is null


### PR DESCRIPTION

### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->

### Description (What does it do?)
<!--- Describe your changes in detail -->
Update edxorg_to_mitxonline_enrollments to remove certificates of retired edx users, as their certificates don't need to be migrated to mitxonline. Additionally, some certificates have already been migrated for users who previously had accounts in mitxonline.


### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->

dbt build --select edxorg_to_mitxonline_enrollments


<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
