### PR TITLE
Add combined_video_engagements_counts_report

### DIFF
--- a/src/ol_dbt/models/reporting/_reporting__models.yml
+++ b/src/ol_dbt/models/reporting/_reporting__models.yml
@@ -777,9 +777,8 @@ models:
   - name: user_email
     description: string, user email address. May be null for some xPRO Emeritus learners.
   - name: chapter_title
-    description: string, title of the chapter/section within the course
-    tests:
-    - not_null
+    description: string, title of the chapter/section within the course. May be null
+      for Residential MITx data.
   - name: courserun_readable_id
     description: string, unique identifier for the course run formatted as course-v1:{org}+{course
       code}+{run_tag}

--- a/src/ol_dbt/models/reporting/combined_video_engagements_counts_report.sql
+++ b/src/ol_dbt/models/reporting/combined_video_engagements_counts_report.sql
@@ -24,7 +24,7 @@ select
     , count(distinct combined_video_engagements.video_title) as user_watched_video_count
     , max(combined_video_engagements.video_index) as max_video_index
 from combined_video_engagements
-join video_counts_by_chapter
+inner join video_counts_by_chapter
     on combined_video_engagements.chapter_title = video_counts_by_chapter.chapter_title
     and combined_video_engagements.courserun_readable_id = video_counts_by_chapter.courserun_readable_id
 where combined_video_engagements.video_event_type = 'play_video'


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/7644

### Description (What does it do?)
This PR converts the Superset virtual dataset `marts__combined_video_engagements_w_video_counts` into a physical dbt reporting model to improve query performance in Superset.

The new `combined_video_engagements_counts_report` model extends the existing `marts__combined_video_engagements` mart by adding calculated fields that were previously computed in the virtual dataset:
- `total_video_count` - Total number of distinct videos in each chapter for the course run (calculated via subquery)
- `courserun_is_current` - Boolean indicating if the course run is currently active (checks if current date falls between courserun start and end dates)
- `user_watched_video_count` - Number of distinct videos the user has watched (play_video events) in each chapter
- `max_video_index` - Maximum video sequence index the user has reached in each chapter

The model filters for `play_video` events only and aggregates by user, chapter, course run, and platform.

### How can this be tested?
**Build and test the model:**
```bash
dbt build --select combined_video_engagements_counts_report --vars 'schema_suffix: <your_username>' --target dev_production
```