### PR TITLE
Update dagster generated asset group name

### DIFF
--- a/dg_projects/student_risk_probability/student_risk_probability/assets/risk_probability.py
+++ b/dg_projects/student_risk_probability/student_risk_probability/assets/risk_probability.py
@@ -18,7 +18,7 @@ from student_risk_probability.lib.helper import (
 
 @asset(
     code_version="student_risk_probability_v1",
-    group_name="student_risk_probability",
+    group_name="reporting",
     deps=[AssetKey(["reporting", "cheating_detection_report"])],
     automation_condition=upstream_or_code_changes(),
     io_manager_key="io_manager",


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
NA 

### Description (What does it do?)
<!--- Describe your changes in detail -->
tries to fix the automation of https://pipelines.odl.mit.edu/assets/reporting/student_risk_probability_report?view=automation, as it either evaluates `reporting/student_risk_probability` as missing or any_deps_missing



### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->
docker compose up

In dagster UI, it should now shows  the dagster-generated asset `student_risk_probability` under reporting group 

<img width="991" height="664" alt="image" src="https://github.com/user-attachments/assets/3e33cc99-5f6d-4a15-9c10-c3814fbea03d" />
### Additional Context
<!--- optional - delete if empty --->

<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->


<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
