### PR TITLE
fix org chart date formats

### DIFF
--- a/src/ol_superset/assets/charts/Organization_Administration_Certificates_f1674827-3018-4ff5-bafc-8d4e0fbea7a6.yaml
+++ b/src/ol_superset/assets/charts/Organization_Administration_Certificates_f1674827-3018-4ff5-bafc-8d4e0fbea7a6.yaml
@@ -75,7 +75,7 @@ params:
     label: activity_date
     sqlExpression: date_format(activity_date, '%c-%Y')
   x_axis_sort_asc: true
-  x_axis_time_format: smart_date
+  x_axis_time_format: '%Y-%m'
   x_axis_title_margin: 15
   y_axis_bounds:
   - null

--- a/src/ol_superset/assets/charts/Organization_Administration_Chatbot_Use_a8eba8e2-dff3-4975-8b54-9f6f4dd39478.yaml
+++ b/src/ol_superset/assets/charts/Organization_Administration_Chatbot_Use_a8eba8e2-dff3-4975-8b54-9f6f4dd39478.yaml
@@ -90,7 +90,7 @@ params:
   show_legend: true
   legendType: scroll
   legendOrientation: top
-  x_axis_time_format: smart_date
+  x_axis_time_format: '%Y-%m'
   xAxisLabelInterval: auto
   y_axis_format: SMART_NUMBER
   y_axis_bounds:

--- a/src/ol_superset/assets/charts/Organization_Administration_Enrollment_Count_cumulative_01f7089f-1355-4a0f-8a51-277c79f26e2b.yaml
+++ b/src/ol_superset/assets/charts/Organization_Administration_Enrollment_Count_cumulative_01f7089f-1355-4a0f-8a51-277c79f26e2b.yaml
@@ -76,7 +76,7 @@ params:
     label: activity_date
     sqlExpression: date_format(activity_date, '%c-%Y')
   x_axis_sort_asc: true
-  x_axis_time_format: smart_date
+  x_axis_time_format: '%Y-%m'
   x_axis_title_margin: 15
   y_axis_bounds:
   - null

--- a/src/ol_superset/assets/charts/Organization_Administration_Problems_Tried_fe95c76a-352c-41a4-8e41-9252b68421ea.yaml
+++ b/src/ol_superset/assets/charts/Organization_Administration_Problems_Tried_fe95c76a-352c-41a4-8e41-9252b68421ea.yaml
@@ -73,7 +73,7 @@ params:
     expressionType: SQL
     label: activity_date
     sqlExpression: date_format(activity_date, '%c-%Y')
-  x_axis_time_format: smart_date
+  x_axis_time_format: '%Y-%m'
   x_axis_title_margin: 15
   y_axis_bounds:
   - null

--- a/src/ol_superset/assets/charts/Organization_Administration_Unique_Active_Learners_33b8ff2e-ddd7-4fa6-a438-d422da92fb27.yaml
+++ b/src/ol_superset/assets/charts/Organization_Administration_Unique_Active_Learners_33b8ff2e-ddd7-4fa6-a438-d422da92fb27.yaml
@@ -89,7 +89,7 @@ params:
     expressionType: SQL
     label: activity_date
     sqlExpression: date_format(activity_date, '%c-%Y')
-  x_axis_time_format: smart_date
+  x_axis_time_format: '%Y-%m'
   x_axis_title_margin: 15
   y_axis_bounds:
   - null

--- a/src/ol_superset/assets/charts/Organization_Administration_Videos_Watched_5d97d317-30ee-46df-882b-0451efe2ac1d.yaml
+++ b/src/ol_superset/assets/charts/Organization_Administration_Videos_Watched_5d97d317-30ee-46df-882b-0451efe2ac1d.yaml
@@ -73,7 +73,7 @@ params:
     expressionType: SQL
     label: activity_date
     sqlExpression: date_format(activity_date, '%c-%Y')
-  x_axis_time_format: smart_date
+  x_axis_time_format: '%Y-%m'
   x_axis_title_margin: 15
   y_axis_bounds:
   - null


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/10436

### Description (What does it do?)
All the charts on the Org dashboard https://bi.ol.mit.edu/superset/dashboard/p/M4e54gnqRbp/ need to be changed to "2026-1", "2026-2"  instead of months like "January".

### How can this be tested?
Review the code and check that the changes look good in QA
