### PR TITLE
Fix mitxonline program product and order models

### DIFF
--- a/src/ol_dbt/models/intermediate/mitxonline/_int_mitxonline__models.yml
+++ b/src/ol_dbt/models/intermediate/mitxonline/_int_mitxonline__models.yml
@@ -542,8 +542,8 @@ models:
     - not_null
   - name: courserun_id
     description: int, primary key representing a single MITx Online course run
-  - name: programrun_id
-    description: int, primary key representing a single MITx Online program run
+  - name: program_id
+    description: int, primary key representing a single MITx Online program
   - name: courserun_readable_id
     description: str, Open edX Course ID formatted as course-v1:{org}+{course code}+{run_tag}
   - name: program_readable_id

--- a/src/ol_dbt/models/intermediate/mitxonline/int__mitxonline__ecommerce_order.sql
+++ b/src/ol_dbt/models/intermediate/mitxonline/int__mitxonline__ecommerce_order.sql
@@ -77,7 +77,7 @@ select
     , intermediate_products_view.product_type
     , intermediate_products_view.product_id
     , intermediate_products_view.courserun_id
-    , intermediate_products_view.programrun_id
+    , intermediate_products_view.program_id
     , intermediate_products_view.courserun_readable_id
     , intermediate_products_view.program_readable_id
     , discounts.discount_source

--- a/src/ol_dbt/models/intermediate/mitxonline/int__mitxonline__ecommerce_product.sql
+++ b/src/ol_dbt/models/intermediate/mitxonline/int__mitxonline__ecommerce_product.sql
@@ -41,7 +41,6 @@ with products as (
 select
     product_subquery.*
     , courseruns.course_id
-    , programs.program_id
     , courseruns.courserun_readable_id
     , programs.program_readable_id
 from product_subquery


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
NA 

### Description (What does it do?)
<!--- Describe your changes in detail -->
Fixes bugs in `int__mitxonline__ecommerce_order` and `int__mitxonline__ecommerce_product` for program product and orders. 

On MITx online product model, there are `courserun` and `program` types, so there is no `programrun`. This is an old bug that existed because we did not have a program product until yesterday, when James created one (`product_id = 1404`) on production.

<img width="442" height="166" alt="image" src="https://github.com/user-attachments/assets/9ad0a1c1-20d6-4563-83ab-999f92757149" />

There are no downstream usage for programrun_id from these two models

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

dbt build --select +int__mitxonline__ecommerce_order

Check program fields are now populated
```
select * from "ol_data_lake_production"."ol_warehouse_production_X_intermediate".int__mitxonline__ecommerce_product
where product_id=1404

select * from "ol_data_lake_production"."ol_warehouse_production_X_intermediate".int__mitxonline__ecommerce_order
where order_id=402054
```

### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->


<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
