### PR TITLE
fix: correct column names in learner engagement reporting models

### DIFF
--- a/src/ol_dbt/models/reporting/_reporting__models.yml
+++ b/src/ol_dbt/models/reporting/_reporting__models.yml
@@ -786,10 +786,10 @@ models:
     description: int, count of the total number of problems
   - name: number_of_total_attempts
     description: int, number of attempts on a problem
-  - name: percent_problems_correct
+  - name: percentage_problems_correct
     description: decimal, percentage of problems the user got correct out of the total
       number of problems
-  - name: percent_problems_attempted
+  - name: percentage_problems_attempted
     description: decimal, percentage of problems the user attempted out of the total
       number of problems
   tests:

--- a/src/ol_dbt/models/reporting/engagement_problem_completion_raw.sql
+++ b/src/ol_dbt/models/reporting/engagement_problem_completion_raw.sql
@@ -55,10 +55,10 @@ select
     , sum(f_problem_engagement.num_of_attempts) as number_of_total_attempts
     , cast(count(distinct (case when cast(f_problem_engagement.num_of_correct_attempts as int)> 0
         then f_problem_engagement.problem_block_fk else null end)) as decimal(30,10))
-        /cast(max(problems_in_block.problem_numb) as decimal(30,10)) as percent_problems_correct
+        /cast(max(problems_in_block.problem_numb) as decimal(30,10)) as percentage_problems_correct
     , cast(count(distinct (case when cast(f_problem_engagement.num_of_attempts as int)> 0
         then f_problem_engagement.problem_block_fk else null end)) as decimal(30,10))
-        /cast(max(problems_in_block.problem_numb) as decimal(30,10)) as percent_problems_attempted
+        /cast(max(problems_in_block.problem_numb) as decimal(30,10)) as percentage_problems_attempted
 from f_problem_engagement
 left join problems_in_block
     on f_problem_engagement.chapter_block_fk = problems_in_block.chapter_block_id

--- a/src/ol_dbt/models/reporting/learner_engagement_report.sql
+++ b/src/ol_dbt/models/reporting/learner_engagement_report.sql
@@ -236,7 +236,7 @@ with video_pre_query as (
                 then a.problem_block_fk
         end) as decimal(30, 10))
         / cast(max(c.problem_numb) as decimal(30, 10)
-        ) as percetage_problems_attempted
+        ) as percentage_problems_attempted
     from ol_warehouse_production_dimensional.afact_problem_engagement as a
     inner join ol_warehouse_production_dimensional.dim_problem as problem
         on a.problem_block_fk = problem.problem_block_pk
@@ -320,7 +320,7 @@ with video_pre_query as (
         , page_and_video.video_duration
         , problems_table.problems_attempted
         , problems_table.number_of_problems
-        , problems_table.percetage_problems_attempted
+        , problems_table.percentage_problems_attempted
         , problems_table.num_of_problems_correct
         , problems_table.avg_percent_grade
         , problems_table.max_possible_grade
@@ -354,7 +354,7 @@ select
     , page_video_problems.video_duration
     , page_video_problems.problems_attempted
     , page_video_problems.number_of_problems
-    , page_video_problems.percetage_problems_attempted
+    , page_video_problems.percentage_problems_attempted
     , page_video_problems.num_of_problems_correct
     , page_video_problems.avg_percent_grade
     , page_video_problems.max_possible_grade


### PR DESCRIPTION
## Summary

Fixes column naming issues in learner engagement reporting models that are causing Superset dashboard errors.

### Changes

- **`learner_engagement_report.sql`**: Fix typo `percetage_problems_attempted` → `percentage_problems_attempted` (missing 'n')
- **`engagement_problem_completion_raw.sql`**: Rename `percent_problems_correct` → `percentage_problems_correct` and `percent_problems_attempted` → `percentage_problems_attempted` for consistency with the rest of the reporting layer
- **`_reporting__models.yml`**: Update column documentation to match renamed columns

### Context

The 'Learner Engagement' Superset dashboard has three broken charts:
- **Problem Engagement by CourseRun** – invalid column `percetage_problems_attempted`
- **Problem Engagement by Section** – missing columns `section_title`, `percetage_problems_attempted`, `percentage_problems_correct`
- **Page Engagement by Section** – missing column `section_title`

This PR fixes the dbt model column names. A follow-up PR will update the Superset dataset and chart assets to point to the correct reporting models using these corrected column names.