### PR TITLE
fix: update Superset datasets and charts for Learner Engagement dashboard

### DIFF
--- a/src/ol_superset/assets/charts/Problem_Engagement_by_Courserun_1e30a45b-d97d-4f44-ac2c-1d9de9e05bc1.yaml
+++ b/src/ol_superset/assets/charts/Problem_Engagement_by_Courserun_1e30a45b-d97d-4f44-ac2c-1d9de9e05bc1.yaml
@@ -26,7 +26,7 @@ params:
     hasCustomLabel: true
     label: Avg_%_problems_attempted
     optionName: metric_v0x9x3vkxs_lyd8fkz8ah
-    sqlExpression: AVG(percetage_problems_attempted)
+    sqlExpression: AVG(percentage_problems_attempted)
   order_by_cols: []
   order_desc: true
   percent_metrics: []
@@ -43,17 +43,17 @@ params:
 query_context: '{"datasource": {"id": 87, "type": "table"}, "force": false, "queries":
   [{"filters": [], "extras": {"having": "", "where": ""}, "applied_time_extras": {},
   "columns": ["courserun_readable_id"], "metrics": [{"expressionType": "SQL", "sqlExpression":
-  "AVG(percetage_problems_attempted)", "column": null, "aggregate": null, "datasourceWarning":
+  "AVG(percentage_problems_attempted)", "column": null, "aggregate": null, "datasourceWarning":
   false, "hasCustomLabel": true, "label": "Avg_%_problems_attempted", "optionName":
   "metric_v0x9x3vkxs_lyd8fkz8ah"}], "orderby": [[{"expressionType": "SQL", "sqlExpression":
-  "AVG(percetage_problems_attempted)", "column": null, "aggregate": null, "datasourceWarning":
+  "AVG(percentage_problems_attempted)", "column": null, "aggregate": null, "datasourceWarning":
   false, "hasCustomLabel": true, "label": "Avg_%_problems_attempted", "optionName":
   "metric_v0x9x3vkxs_lyd8fkz8ah"}, false]], "annotation_layers": [], "row_limit":
   1000, "series_limit": 0, "order_desc": true, "url_params": {}, "custom_params":
   {}, "custom_form_data": {}, "post_processing": [], "time_offsets": []}], "form_data":
   {"datasource": "87__table", "viz_type": "table", "slice_id": 90, "query_mode": "aggregate",
   "groupby": ["courserun_readable_id"], "time_grain_sqla": "P1D", "temporal_columns_lookup":
-  {}, "metrics": [{"expressionType": "SQL", "sqlExpression": "AVG(percetage_problems_attempted)",
+  {}, "metrics": [{"expressionType": "SQL", "sqlExpression": "AVG(percentage_problems_attempted)",
   "column": null, "aggregate": null, "datasourceWarning": false, "hasCustomLabel":
   true, "label": "Avg_%_problems_attempted", "optionName": "metric_v0x9x3vkxs_lyd8fkz8ah"}],
   "all_columns": [], "percent_metrics": [], "adhoc_filters": [], "order_by_cols":

--- a/src/ol_superset/assets/charts/Problem_Engagement_by_Section_ec8dc53c-60d0-4bd1-9913-4388b41ca53d.yaml
+++ b/src/ol_superset/assets/charts/Problem_Engagement_by_Section_ec8dc53c-60d0-4bd1-9913-4388b41ca53d.yaml
@@ -28,7 +28,7 @@ params:
       advanced_data_type: null
       certification_details: null
       certified_by: null
-      column_name: percetage_problems_attempted
+      column_name: percentage_problems_attempted
       description: null
       expression: null
       filterable: true
@@ -119,7 +119,7 @@ params:
 query_context: '{"datasource": {"id": 87, "type": "table"}, "force": false, "queries":
   [{"filters": [], "extras": {"having": "", "where": ""}, "applied_time_extras": {},
   "columns": ["section_title"], "metrics": [{"aggregate": "AVG", "column": {"advanced_data_type":
-  null, "certification_details": null, "certified_by": null, "column_name": "percetage_problems_attempted",
+  null, "certification_details": null, "certified_by": null, "column_name": "percentage_problems_attempted",
   "description": null, "expression": null, "filterable": true, "groupby": true, "id":
   1080, "is_certified": false, "is_dttm": false, "python_date_format": null, "type":
   "DECIMAL(38, 10)", "type_generic": 0, "verbose_name": null, "warning_markdown":
@@ -154,7 +154,7 @@ query_context: '{"datasource": {"id": 87, "type": "table"}, "force": false, "que
   [], "time_offsets": []}], "form_data": {"datasource": "87__table", "viz_type": "table",
   "slice_id": 87, "query_mode": "aggregate", "groupby": ["section_title"], "temporal_columns_lookup":
   {}, "metrics": [{"aggregate": "AVG", "column": {"advanced_data_type": null, "certification_details":
-  null, "certified_by": null, "column_name": "percetage_problems_attempted", "description":
+  null, "certified_by": null, "column_name": "percentage_problems_attempted", "description":
   null, "expression": null, "filterable": true, "groupby": true, "id": 1080, "is_certified":
   false, "is_dttm": false, "python_date_format": null, "type": "DECIMAL(38, 10)",
   "type_generic": 0, "verbose_name": null, "warning_markdown": null}, "datasourceWarning":

--- a/src/ol_superset/assets/datasets/Trino/afact_course_page_engagement_68c544d7-726d-495a-bf87-81255b2e8604.yaml
+++ b/src/ol_superset/assets/datasets/Trino/afact_course_page_engagement_68c544d7-726d-495a-bf87-81255b2e8604.yaml
@@ -1,11 +1,11 @@
-table_name: afact_course_page_engagement
-main_dttm_col: last_view_timestamp
+table_name: page_engagement_views_report
+main_dttm_col: null
 description: Auto refreshed at 2026-02-05T13:50:59.338969+00:00
 default_endpoint: null
 offset: 0
 cache_timeout: null
 catalog: ol_data_lake_production
-schema: ol_warehouse_production_dimensional
+schema: ol_warehouse_production_reporting
 sql: null
 params: null
 template_params: null
@@ -27,19 +27,7 @@ metrics:
   extra: null
   warning_text: null
 columns:
-- column_name: last_view_timestamp
-  verbose_name: null
-  is_dttm: true
-  is_active: true
-  type: TIMESTAMP(6) WITH TIME ZONE
-  advanced_data_type: null
-  groupby: true
-  filterable: true
-  expression: ''
-  description: null
-  python_date_format: null
-  extra: null
-- column_name: courserun_readable_id
+- column_name: user_email
   verbose_name: null
   is_dttm: false
   is_active: true
@@ -51,67 +39,7 @@ columns:
   description: null
   python_date_format: null
   extra: null
-- column_name: chapter_block_fk
-  verbose_name: null
-  is_dttm: false
-  is_active: true
-  type: VARCHAR
-  advanced_data_type: null
-  groupby: true
-  filterable: true
-  expression: ''
-  description: null
-  python_date_format: null
-  extra: null
-- column_name: sequential_block_fk
-  verbose_name: null
-  is_dttm: false
-  is_active: true
-  type: VARCHAR
-  advanced_data_type: null
-  groupby: true
-  filterable: true
-  expression: ''
-  description: null
-  python_date_format: null
-  extra: null
-- column_name: user_username
-  verbose_name: null
-  is_dttm: false
-  is_active: true
-  type: VARCHAR
-  advanced_data_type: null
-  groupby: true
-  filterable: true
-  expression: ''
-  description: null
-  python_date_format: null
-  extra: null
-- column_name: platform_fk
-  verbose_name: null
-  is_dttm: false
-  is_active: true
-  type: VARCHAR
-  advanced_data_type: null
-  groupby: true
-  filterable: true
-  expression: ''
-  description: null
-  python_date_format: null
-  extra: null
-- column_name: block_fk
-  verbose_name: null
-  is_dttm: false
-  is_active: true
-  type: VARCHAR
-  advanced_data_type: null
-  groupby: true
-  filterable: true
-  expression: ''
-  description: null
-  python_date_format: null
-  extra: null
-- column_name: user_fk
+- column_name: full_name
   verbose_name: null
   is_dttm: false
   is_active: true
@@ -135,6 +63,18 @@ columns:
   description: null
   python_date_format: null
   extra: null
+- column_name: courserun_readable_id
+  verbose_name: null
+  is_dttm: false
+  is_active: true
+  type: VARCHAR
+  advanced_data_type: null
+  groupby: true
+  filterable: true
+  expression: ''
+  description: null
+  python_date_format: null
+  extra: null
 - column_name: num_of_views
   verbose_name: null
   is_dttm: false
@@ -147,11 +87,71 @@ columns:
   description: null
   python_date_format: null
   extra: null
-- column_name: openedx_user_id
+- column_name: unit_title
   verbose_name: null
   is_dttm: false
   is_active: true
-  type: INTEGER
+  type: VARCHAR
+  advanced_data_type: null
+  groupby: true
+  filterable: true
+  expression: ''
+  description: null
+  python_date_format: null
+  extra: null
+- column_name: subsection_title
+  verbose_name: null
+  is_dttm: false
+  is_active: true
+  type: VARCHAR
+  advanced_data_type: null
+  groupby: true
+  filterable: true
+  expression: ''
+  description: null
+  python_date_format: null
+  extra: null
+- column_name: subsection_block_index
+  verbose_name: null
+  is_dttm: false
+  is_active: true
+  type: BIGINT
+  advanced_data_type: null
+  groupby: true
+  filterable: true
+  expression: ''
+  description: null
+  python_date_format: null
+  extra: null
+- column_name: section_title
+  verbose_name: null
+  is_dttm: false
+  is_active: true
+  type: VARCHAR
+  advanced_data_type: null
+  groupby: true
+  filterable: true
+  expression: ''
+  description: null
+  python_date_format: null
+  extra: null
+- column_name: section_block_index
+  verbose_name: null
+  is_dttm: false
+  is_active: true
+  type: BIGINT
+  advanced_data_type: null
+  groupby: true
+  filterable: true
+  expression: ''
+  description: null
+  python_date_format: null
+  extra: null
+- column_name: course_title
+  verbose_name: null
+  is_dttm: false
+  is_active: true
+  type: VARCHAR
   advanced_data_type: null
   groupby: true
   filterable: true

--- a/src/ol_superset/assets/datasets/Trino/afact_problem_engagement_37bb25c7-421f-432a-bc42-5cc10a129746.yaml
+++ b/src/ol_superset/assets/datasets/Trino/afact_problem_engagement_37bb25c7-421f-432a-bc42-5cc10a129746.yaml
@@ -1,11 +1,11 @@
-table_name: afact_problem_engagement
-main_dttm_col: last_attempt_timestamp
-description: Auto refreshed at 2026-03-07T19:49:43.606824+00:00
+table_name: engagement_problem_completion_raw
+main_dttm_col: null
+description: Auto refreshed at 2026-03-06T20:32:30.586193+00:00
 default_endpoint: null
 offset: 0
 cache_timeout: null
 catalog: ol_data_lake_production
-schema: ol_warehouse_production_dimensional
+schema: ol_warehouse_production_reporting
 sql: null
 params: null
 template_params: null
@@ -27,11 +27,35 @@ metrics:
   extra: null
   warning_text: null
 columns:
-- column_name: last_attempt_timestamp
+- column_name: platform
   verbose_name: null
-  is_dttm: true
+  is_dttm: false
   is_active: true
-  type: TIMESTAMP(6) WITH TIME ZONE
+  type: VARCHAR
+  advanced_data_type: null
+  groupby: true
+  filterable: true
+  expression: ''
+  description: null
+  python_date_format: null
+  extra: null
+- column_name: user_email
+  verbose_name: null
+  is_dttm: false
+  is_active: true
+  type: VARCHAR
+  advanced_data_type: null
+  groupby: true
+  filterable: true
+  expression: ''
+  description: null
+  python_date_format: null
+  extra: null
+- column_name: course_title
+  verbose_name: null
+  is_dttm: false
+  is_active: true
+  type: VARCHAR
   advanced_data_type: null
   groupby: true
   filterable: true
@@ -51,7 +75,7 @@ columns:
   description: null
   python_date_format: null
   extra: null
-- column_name: chapter_block_fk
+- column_name: section_title
   verbose_name: null
   is_dttm: false
   is_active: true
@@ -63,79 +87,7 @@ columns:
   description: null
   python_date_format: null
   extra: null
-- column_name: sequential_block_fk
-  verbose_name: null
-  is_dttm: false
-  is_active: true
-  type: VARCHAR
-  advanced_data_type: null
-  groupby: true
-  filterable: true
-  expression: ''
-  description: null
-  python_date_format: null
-  extra: null
-- column_name: problem_block_fk
-  verbose_name: null
-  is_dttm: false
-  is_active: true
-  type: VARCHAR
-  advanced_data_type: null
-  groupby: true
-  filterable: true
-  expression: ''
-  description: null
-  python_date_format: null
-  extra: null
-- column_name: user_username
-  verbose_name: null
-  is_dttm: false
-  is_active: true
-  type: VARCHAR
-  advanced_data_type: null
-  groupby: true
-  filterable: true
-  expression: ''
-  description: null
-  python_date_format: null
-  extra: null
-- column_name: platform_fk
-  verbose_name: null
-  is_dttm: false
-  is_active: true
-  type: VARCHAR
-  advanced_data_type: null
-  groupby: true
-  filterable: true
-  expression: ''
-  description: null
-  python_date_format: null
-  extra: null
-- column_name: user_fk
-  verbose_name: null
-  is_dttm: false
-  is_active: true
-  type: VARCHAR
-  advanced_data_type: null
-  groupby: true
-  filterable: true
-  expression: ''
-  description: null
-  python_date_format: null
-  extra: null
-- column_name: platform
-  verbose_name: null
-  is_dttm: false
-  is_active: true
-  type: VARCHAR
-  advanced_data_type: null
-  groupby: true
-  filterable: true
-  expression: ''
-  description: null
-  python_date_format: null
-  extra: null
-- column_name: num_of_correct_attempts
+- column_name: section_block_index
   verbose_name: null
   is_dttm: false
   is_active: true
@@ -147,7 +99,7 @@ columns:
   description: null
   python_date_format: null
   extra: null
-- column_name: openedx_user_id
+- column_name: problems_correct
   verbose_name: null
   is_dttm: false
   is_active: true
@@ -159,11 +111,59 @@ columns:
   description: null
   python_date_format: null
   extra: null
-- column_name: num_of_attempts
+- column_name: problems_attempted
   verbose_name: null
   is_dttm: false
   is_active: true
-  type: INTEGER
+  type: BIGINT
+  advanced_data_type: null
+  groupby: true
+  filterable: true
+  expression: ''
+  description: null
+  python_date_format: null
+  extra: null
+- column_name: number_of_problems
+  verbose_name: null
+  is_dttm: false
+  is_active: true
+  type: BIGINT
+  advanced_data_type: null
+  groupby: true
+  filterable: true
+  expression: ''
+  description: null
+  python_date_format: null
+  extra: null
+- column_name: number_of_total_attempts
+  verbose_name: null
+  is_dttm: false
+  is_active: true
+  type: BIGINT
+  advanced_data_type: null
+  groupby: true
+  filterable: true
+  expression: ''
+  description: null
+  python_date_format: null
+  extra: null
+- column_name: percentage_problems_correct
+  verbose_name: null
+  is_dttm: false
+  is_active: true
+  type: DECIMAL(38, 10)
+  advanced_data_type: null
+  groupby: true
+  filterable: true
+  expression: ''
+  description: null
+  python_date_format: null
+  extra: null
+- column_name: percentage_problems_attempted
+  verbose_name: null
+  is_dttm: false
+  is_active: true
+  type: DECIMAL(38, 10)
   advanced_data_type: null
   groupby: true
   filterable: true

--- a/src/ol_superset/assets/datasets/Trino/learner_engagement_report_4752cd11-a13e-4a8e-be31-4d9227b07ca2.yaml
+++ b/src/ol_superset/assets/datasets/Trino/learner_engagement_report_4752cd11-a13e-4a8e-be31-4d9227b07ca2.yaml
@@ -27,7 +27,7 @@ metrics:
   extra: {}
   warning_text: null
 columns:
-- column_name: percetage_problems_attempted
+- column_name: percentage_problems_attempted
   verbose_name: null
   is_dttm: false
   is_active: true


### PR DESCRIPTION
## Summary

Fixes three broken charts in the 'Learner Engagement' Superset dashboard by pointing datasets at the correct reporting-layer models and correcting column name typos.

> ⚠️ **Merge after #1993** — the dbt column renames in that PR must be deployed before these Superset asset changes take effect.

---

### Problem Engagement by CourseRun / Problem Engagement by Section

Both charts (dataset uuid `37bb25c7`) used the raw `afact_problem_engagement` dimensional fact table, which does not expose `section_title`, `section_block_index`, or problem completion percentage columns.

**Fix**: Point the dataset at `ol_warehouse_production_reporting.engagement_problem_completion_raw`, which was designed to support exactly these charts. Column list updated accordingly.

Also fixes the typo `percetage_problems_attempted` → `percentage_problems_attempted` in both chart `params` and `query_context` to match the corrected dbt column name from PR #1993.

### Page Engagement by Section

Chart (dataset uuid `68c544d7`) used the raw `afact_course_page_engagement` dimensional fact table, which does not expose `section_title` or `section_block_index`.

**Fix**: Point the dataset at `ol_warehouse_production_reporting.page_engagement_views_report`, which provides the full content hierarchy with section/subsection/unit titles and block indices.

### learner_engagement_report dataset

Fixes the typo `percetage_problems_attempted` → `percentage_problems_attempted` in the column definition to match the corrected dbt column name from PR #1993.

---

### Files changed
| File | Change |
|------|--------|
| `afact_problem_engagement_37bb25c7.yaml` | Point to `engagement_problem_completion_raw` reporting model |
| `afact_course_page_engagement_68c544d7.yaml` | Point to `page_engagement_views_report` reporting model |
| `Problem_Engagement_by_Courserun_*.yaml` | Fix `percetage_` typo in metric SQL |
| `Problem_Engagement_by_Section_*.yaml` | Fix `percetage_` typo in column reference |
| `learner_engagement_report_*.yaml` | Fix `percetage_` typo in column definition |