### PR TITLE
Update edxorg_to_mitxonline_course_runs to handle open runs 

### DIFF
--- a/src/ol_dbt/models/migration/edxorg_to_mitxonline_course_runs.sql
+++ b/src/ol_dbt/models/migration/edxorg_to_mitxonline_course_runs.sql
@@ -63,7 +63,7 @@ select distinct
     , edx_courseruns.run_tag
     , {{ from_iso8601_timestamp('edx_courseruns.courserun_enrollment_start_date') }} as enrollment_start
     , least(
-        from_iso8601_timestamp(coalesce(edx_courseruns.courserun_enrollment_end_date, edx_courseruns.courserun_end_date)),
+        {{ from_iso8601_timestamp('coalesce(edx_courseruns.courserun_enrollment_end_date, edx_courseruns.courserun_end_date)') }},
         current_timestamp
       ) as enrollment_end
     , {{ from_iso8601_timestamp('edx_courseruns.courserun_start_date') }} as start_date


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
https://github.com/mitodl/hq/issues/10336

### Description (What does it do?)
<!--- Describe your changes in detail -->
Updates `edxorg_to_mitxonline_course_runs` to handle open runs, and sets the enrollment end date to be in the past so they are not open for enrollment on mitxonline.

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

dbt build --select edxorg_to_mitxonline_course_runs
