### PR TITLE
set 1 day in the past for edx open runs

### DIFF
--- a/src/ol_dbt/models/migration/edxorg_to_mitxonline_course_runs.sql
+++ b/src/ol_dbt/models/migration/edxorg_to_mitxonline_course_runs.sql
@@ -61,10 +61,10 @@ select distinct
     , edx_courseruns.courserun_title
     , edx_courseruns.courseware_id
     , edx_courseruns.run_tag
-    , {{ from_iso8601_timestamp('edx_courseruns.courserun_enrollment_start_date') }} as enrollment_start
     , least(
-        {{ from_iso8601_timestamp('coalesce(edx_courseruns.courserun_enrollment_end_date, edx_courseruns.courserun_end_date)') }},
-        current_timestamp
+        {{ from_iso8601_timestamp('coalesce(edx_courseruns.courserun_enrollment_end_date, edx_courseruns.courserun_end_date)') }}
+         ---default to current timestamp - 1 day to avoid having courses open for enrollment on mitxonline
+        , date_add('day', -1, current_timestamp)
       ) as enrollment_end
     , {{ from_iso8601_timestamp('edx_courseruns.courserun_start_date') }} as start_date
     , {{ from_iso8601_timestamp('edx_courseruns.courserun_end_date') }} as end_date


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
followup https://github.com/mitodl/ol-data-platform/pull/2005

### Description (What does it do?)
<!--- Describe your changes in detail -->
Updates enrollment_end in edxorg_to_mitxonline_course_runs to default to current timestamp - 1 day to avoid having courses open for enrollment on mitxonline

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->
dbt build --select edxorg_to_mitxonline_course_runs

### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->


<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
