### PR TITLE
Populate user_full_name and deduplicate edxorg_to_mitxonline_users

### DIFF
--- a/src/ol_dbt/models/migration/edxorg_to_mitxonline_users.sql
+++ b/src/ol_dbt/models/migration/edxorg_to_mitxonline_users.sql
@@ -37,7 +37,7 @@ with edx_certificate as (
         , edx_certificate_user.user_full_name
         , edx_certificate_user.user_gender
         , edx_certificate_user.user_birth_year
-        , edx_certificate_user.user_address_country
+        , edx_certificate_user.user_address_country as user_country
     from edx_certificate_user
     left join mitx_user as mitx_user1 on edx_certificate_user.user_mitxonline_username = mitx_user1.user_mitxonline_username
     left join mitx_user as mitx_user2 on lower(edx_certificate_user.user_email) = lower(mitx_user2.user_mitxonline_email)
@@ -48,9 +48,12 @@ with edx_certificate as (
 )
 
 , entitlement_users as (
-    select
+    select distinct
         lower(program_entitlements.user_email) as user_email
         , coalesce(mitx_user.user_full_name, program_entitlements.user_full_name, '') as user_full_name
+        , mitx_user.user_gender
+        , mitx_user.user_birth_year
+        , mitx_user.user_address_country as user_country
     from program_entitlements
     left join mitx_user
          on program_entitlements.user_edxorg_id = mitx_user.user_edxorg_id
@@ -64,9 +67,9 @@ with edx_certificate as (
 select
     coalesce(cert_users.user_email, entitlement_users.user_email) as user_email
     , coalesce(cert_users.user_full_name, entitlement_users.user_full_name) as user_full_name
-    , cert_users.user_gender
-    , cert_users.user_birth_year
-    , cert_users.user_address_country
+    , coalesce(cert_users.user_gender, entitlement_users.user_gender) as user_gender
+    , coalesce(cert_users.user_birth_year, entitlement_users.user_birth_year) as user_birth_year
+    , coalesce(cert_users.user_country, entitlement_users.user_country) as user_country
 from cert_users
 full outer join entitlement_users
     on cert_users.user_email = entitlement_users.user_email

--- a/src/ol_dbt/models/staging/edxorg/_stg__edxorg__models.yml
+++ b/src/ol_dbt/models/staging/edxorg/_stg__edxorg__models.yml
@@ -475,6 +475,10 @@ models:
   - name: user_username
     data_type: varchar
     description: username of the learner on edX.org
+  - name: user_full_name
+    data_type: varchar
+    description: full name of the learner who purchased the program bundle, derived
+      from first name and last name fields
   - name: user_email
     data_type: varchar
     description: email address of the learner who purchased the program bundle

--- a/src/ol_dbt/models/staging/edxorg/stg__edxorg__program_entitlement.sql
+++ b/src/ol_dbt/models/staging/edxorg/stg__edxorg__program_entitlement.sql
@@ -12,7 +12,15 @@ with source as (
         , email as user_email
         , username as user_username
         , cast("user id" as integer) as user_id
-        , nullif(concat_ws(' ', "first name", "last name"), '') as user_full_name
+        , nullif(
+              trim(
+                 concat_ws(' ',
+                    nullif(trim("first name"), ''),
+                    nullif(trim("last name"), '')
+                  )
+              ),
+              ''
+        ) as user_full_name
         , cast(entitlements as integer) as number_of_entitlements
         , cast("redeemed entitlements" as integer) as number_of_redeemed_entitlements
         , cast(date_parse("purchase date", '%m/%d/%Y') as date) as purchase_date


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
https://github.com/mitodl/hq/issues/10382

### Description (What does it do?)
<!--- Describe your changes in detail -->
populates user_full_name from edx entitlement data source and deduplicate users in edxorg_to_mitxonline_users


### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->
dbt build --select stg__edxorg__program_entitlement edxorg_to_mitxonline_users

### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->


<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
