### PR TITLE
Fix the unique test in engagement_problem_completion_summary

### DIFF
--- a/src/ol_dbt/models/reporting/_reporting__models.yml
+++ b/src/ol_dbt/models/reporting/_reporting__models.yml
@@ -757,8 +757,8 @@ models:
       number of problems
   tests:
   - dbt_expectations.expect_compound_columns_to_be_unique:
-      column_list: ["user_email", "course_title", "courserun_readable_id", "subsection_block_index",
-        "chapter_block_fk"]
+      column_list: ["user_email", "course_title", "courserun_readable_id", "subsection_title",
+        "subsection_block_index", "chapter_block_fk"]
 
 - name: engagement_problem_completion_raw
   description: A report that contains learner engagement info with problem data


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
NA
https://pipelines.odl.mit.edu/runs/fabccb2f-3399-4759-95ae-6b39466a980c
```
of 1849 FAIL 183 dbt_expectations_expect_compound_columns_to_be_unique_engagement_problem_completion_summary_user_email__course_title__courserun_readable_id__subsection_block_index__chapter_block_fk  [[31mFAIL 183[0m in 1.72s]

[31mFailure in test dbt_expectations_expect_compound_columns_to_be_unique_engagement_problem_completion_summary_user_email__course_title__courserun_readable_id__subsection_block_index__chapter_block_fk (models/reporting/_reporting__models.yml)[0m

  Got 183 results, configured to fail if >10
```

### Description (What does it do?)
<!--- Describe your changes in detail -->
Fixes the dbt_expectations.expect_compound_columns_to_be_unique test in engagement_problem_completion_summary to match with the GROUP BY columns in the sql file


### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->
dbt test --select engagement_problem_completion_summary

### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->


<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
