### PR TITLE
fix(ol-dbt-cli): eliminate false positives in broken_ref_columns and upstream_refs

### DIFF
--- a/src/ol_dbt_cli/ol_dbt_cli/lib/manifest.py
+++ b/src/ol_dbt_cli/ol_dbt_cli/lib/manifest.py
@@ -142,7 +142,9 @@ def load_manifest(manifest_path: Path) -> ManifestRegistry:
     for uid, node_data in all_nodes.items():
         model = _parse_node(node_data)
         registry.nodes[uid] = model
-        if model.is_model:
+        if model.is_model or model.resource_type == "seed":
+            # Seeds are ref()-able just like models and carry column metadata when
+            # a schema.yml is present, so index them for upstream resolution.
             registry.by_name[model.name] = model
         elif model.resource_type == "source":
             # Index by "source_name.table_name" matching the sql_parser placeholder format

--- a/src/ol_dbt_cli/ol_dbt_cli/lib/sql_parser.py
+++ b/src/ol_dbt_cli/ol_dbt_cli/lib/sql_parser.py
@@ -879,6 +879,16 @@ def get_columns_read_from_ref(
                         pass  # table.* — not an added alias
                     elif isinstance(expr, exp.Star):
                         pass  # bare * — not an added alias
+                    elif isinstance(expr, exp.Column):
+                        # Unaliased qualified column from a non-passthrough table — the
+                        # column was adopted from a JOIN target, not inherited from the
+                        # upstream ref.  Downstream refs to this column name must not be
+                        # attributed back to the original upstream.
+                        tbl = expr.args.get("table")
+                        if tbl is not None:
+                            qualifier = tbl.name.lower() if hasattr(tbl, "name") else str(tbl).lower()
+                            if qualifier not in passthrough_aliases:
+                                added.add(expr.name.lower())
                     else:
                         if hasattr(expr, "alias") and expr.alias:
                             added.add(expr.alias.lower())
@@ -899,8 +909,8 @@ def get_columns_read_from_ref(
     cols_read: set[str] = set()
 
     # Pass 1: qualified column refs — ``passthrough_alias.col_name``
-    # Skip columns that were explicitly added (computed) by the passthrough CTE itself,
-    # since those are not from the original upstream.
+    # Skip columns that were added by ANY passthrough CTE in the chain (not just the
+    # immediate CTE), since a column added two hops up is still not from the upstream.
     for col_node in parsed_sql.find_all(exp.Column):
         table = col_node.args.get("table")
         if table is None:
@@ -908,8 +918,12 @@ def get_columns_read_from_ref(
         table_name = table.name.lower() if hasattr(table, "name") else str(table).lower()
         if table_name in passthrough_aliases:
             col_name = col_node.name.lower()
-            cte_added = passthrough_added_cols.get(table_name, set())
-            if col_name and col_name != "*" and col_name not in jinja_placeholders and col_name not in cte_added:
+            if (
+                col_name
+                and col_name != "*"
+                and col_name not in jinja_placeholders
+                and col_name not in passthrough_computed
+            ):
                 cols_read.add(col_name)
 
     # Pass 2: unqualified column refs in SELECT/WHERE of passthrough-only sources.
@@ -930,7 +944,12 @@ def get_columns_read_from_ref(
             continue
         joins = select_node.args.get("joins") or []
         if any(
-            (jt := j.find(exp.Table)) is not None and jt.alias_or_name.lower() not in passthrough_aliases for j in joins
+            # Non-passthrough regular table join — column attribution is ambiguous.
+            ((jt := j.find(exp.Table)) is not None and jt.alias_or_name.lower() not in passthrough_aliases)
+            # UNNEST lateral join — produces new column names that are not from the upstream
+            # ref and that j.find(exp.Table) would miss (UNNEST is not an exp.Table node).
+            or j.find(exp.Unnest) is not None
+            for j in joins
         ):
             continue
         clauses: list[exp.Expression] = list(select_node.expressions)

--- a/src/ol_dbt_cli/tests/test_impact.py
+++ b/src/ol_dbt_cli/tests/test_impact.py
@@ -210,6 +210,181 @@ class TestGetColumnsReadFromRef:
         # user_email is read from the upstream even though it's aliased in output
         assert "user_email" in cols_read
 
+    def test_unnest_lateral_alias_not_attributed_to_upstream(self, tmp_path: Path) -> None:
+        """UNNEST lateral join column aliases must not be attributed to the upstream ref.
+
+        Pattern: ``cross join unnest(...) as t(col)`` produces ``col`` as an unqualified
+        name in the SELECT, but it comes from UNNEST, not from the upstream ref.
+        False positive: was incorrectly flagging ``col`` as missing from upstream.
+        """
+        from ol_dbt_cli.lib.sql_parser import get_columns_read_from_ref, parse_model_sql
+
+        sql = """
+        with websitecontent as (
+            select * from ref_stg_websites
+        )
+        select
+            websitecontent.course_uuid,
+            department_number,
+            upper(department_number) as department_name
+        from websitecontent
+        cross join unnest(cast(json_parse(department_numbers_json) as array(varchar)))
+            as t(department_number)
+        """
+        sql_file = tmp_path / "downstream.sql"
+        sql_file.write_text(sql)
+
+        parsed = parse_model_sql("downstream", sql)
+        parsed.refs = ["stg_websites"]
+        parsed.ref_placeholder_map = {"ref_stg_websites": "stg_websites"}
+        parsed.source_path = sql_file
+
+        result = get_columns_read_from_ref(parsed, "stg_websites")
+        # course_uuid is a real upstream column (qualified via passthrough alias)
+        assert result is not None
+        assert "course_uuid" in result
+        # department_number comes from UNNEST — not from the upstream ref
+        assert "department_number" not in result
+        assert "department_name" not in result
+
+    def test_unnest_lateral_alias_in_cte_not_attributed_to_upstream(self, tmp_path: Path) -> None:
+        """UNNEST-produced columns inside a passthrough CTE SELECT must not be attributed.
+
+        Pattern: a CTE selects an unqualified UNNEST column alongside qualified upstream
+        columns.  The UNNEST column is not from the upstream ref.
+        """
+        from ol_dbt_cli.lib.sql_parser import get_columns_read_from_ref, parse_model_sql
+
+        sql = """
+        with source as (
+            select * from ref_stg_cms
+        ),
+        unnested as (
+            select
+                source.page_id,
+                member_json
+            from source
+            cross join unnest(source.members_array) as t(member_json)
+        )
+        select
+            unnested.page_id,
+            json_query(unnested.member_json, 'lax $.name') as member_name
+        from unnested
+        """
+        sql_file = tmp_path / "downstream.sql"
+        sql_file.write_text(sql)
+
+        parsed = parse_model_sql("downstream", sql)
+        parsed.refs = ["stg_cms"]
+        parsed.ref_placeholder_map = {"ref_stg_cms": "stg_cms"}
+        parsed.source_path = sql_file
+
+        result = get_columns_read_from_ref(parsed, "stg_cms")
+        # page_id is a real upstream column
+        assert result is not None
+        assert "page_id" in result
+        # member_json is a UNNEST alias — not from the upstream
+        assert "member_json" not in result
+
+    def test_join_table_columns_not_attributed_to_upstream(self, tmp_path: Path) -> None:
+        """Unaliased qualified columns from JOIN tables must not be attributed to upstream.
+
+        Pattern: ``select src.*, other.col from src join other`` — ``col`` is from
+        ``other``, not from ``src``.  The passthrough CTE detection must capture it
+        in ``added`` so downstream refs to it are not flagged.
+        """
+        from ol_dbt_cli.lib.sql_parser import get_columns_read_from_ref, parse_model_sql
+
+        sql = """
+        with courseruns as (
+            select * from ref_stg_courserun
+        ),
+        courses as (
+            select * from ref_stg_course
+        ),
+        enriched as (
+            select
+                courseruns.*,
+                courses.course_title,
+                courses.course_org
+            from courseruns
+            inner join courses on courseruns.course_id = courses.course_id
+        )
+        select
+            enriched.courserun_id,
+            enriched.course_title,
+            enriched.course_org,
+            enriched.enrollment_count
+        from enriched
+        """
+        sql_file = tmp_path / "downstream.sql"
+        sql_file.write_text(sql)
+
+        parsed = parse_model_sql("downstream", sql)
+        parsed.refs = ["stg_courserun", "stg_course"]
+        parsed.ref_placeholder_map = {
+            "ref_stg_courserun": "stg_courserun",
+            "ref_stg_course": "stg_course",
+        }
+        parsed.source_path = sql_file
+
+        result = get_columns_read_from_ref(parsed, "stg_courserun")
+        assert result is not None
+        # courserun_id and enrollment_count come from stg_courserun
+        assert "courserun_id" in result
+        assert "enrollment_count" in result
+        # course_title and course_org come from stg_course, not stg_courserun
+        assert "course_title" not in result
+        assert "course_org" not in result
+
+    def test_passthrough_chain_computed_column_not_attributed_to_upstream(self, tmp_path: Path) -> None:
+        """Passthrough chain: a computed column must not be attributed to the upstream.
+
+        A column added in an early passthrough CTE (via a Jinja macro) must not be
+        attributed to the upstream ref even when accessed via a later passthrough CTE in
+        the chain.  CTE B passes through CTE A with ``select *``; downstream reading
+        ``cte_b.computed_col`` should not trigger a missing-column error.
+        """
+        from ol_dbt_cli.lib.sql_parser import get_columns_read_from_ref, parse_model_sql
+
+        sql = """
+        with base as (
+            select
+                *,
+                __macro__ as hashed_id
+            from ref_stg_learners
+        ),
+        deduplicated as (
+            select
+                *,
+                row_number() over (partition by user_id order by created_on desc) as row_num
+            from base
+        )
+        select
+            deduplicated.user_id,
+            deduplicated.user_email,
+            deduplicated.hashed_id
+        from deduplicated
+        where deduplicated.row_num = 1
+        """
+        sql_file = tmp_path / "downstream.sql"
+        sql_file.write_text(sql)
+
+        parsed = parse_model_sql("downstream", sql)
+        parsed.refs = ["stg_learners"]
+        parsed.ref_placeholder_map = {"ref_stg_learners": "stg_learners"}
+        parsed.source_path = sql_file
+
+        result = get_columns_read_from_ref(parsed, "stg_learners")
+        assert result is not None
+        # user_id and user_email are real upstream columns
+        assert "user_id" in result
+        assert "user_email" in result
+        # hashed_id was added by the base CTE via macro — not from upstream
+        assert "hashed_id" not in result
+        # row_num was added by the deduplicated CTE — not from upstream
+        assert "row_num" not in result
+
 
 class TestOutputColumnPassthrough:
     """Tests for output-column passthrough detection in downstream impact functions."""

--- a/src/ol_dbt_cli/tests/test_validate.py
+++ b/src/ol_dbt_cli/tests/test_validate.py
@@ -576,3 +576,107 @@ class TestBrokenRefColumns:
             report=report_obj,
         )
         assert not report_obj.issues
+
+
+class TestUpstreamRefsSeedResolution:
+    """Seeds are ref()-able nodes — manifest should resolve them without warnings."""
+
+    def test_seed_ref_resolves_via_manifest_no_warning(self, tmp_path: Path) -> None:
+        """A ref() pointing to a seed that has columns in the manifest must not warn."""
+        from ol_dbt_cli.commands.validate import _check_upstream_refs
+        from ol_dbt_cli.lib.manifest import ManifestColumn, ManifestModel, ManifestRegistry
+        from ol_dbt_cli.lib.sql_parser import ParsedModel
+        from ol_dbt_cli.lib.yaml_registry import YamlRegistry
+
+        # Build a manifest that includes a seed with column definitions.
+        registry = ManifestRegistry()
+        seed = ManifestModel(
+            unique_id="seed.pkg.platforms",
+            name="platforms",
+            resource_type="seed",
+            original_file_path="seeds/platforms.csv",
+            schema="public",
+            database="",
+            columns={
+                "id": ManifestColumn(name="id"),
+                "name": ManifestColumn(name="name"),
+            },
+        )
+        registry.nodes[seed.unique_id] = seed
+        registry.by_name[seed.name] = seed
+
+        # Downstream model refs the seed.
+        downstream = ParsedModel(
+            name="dim_platform",
+            refs=["platforms"],
+            ref_placeholder_map={"ref_platforms": "platforms"},
+        )
+        report_obj = ValidationReport()
+        _check_upstream_refs(
+            "dim_platform",
+            downstream,
+            YamlRegistry(),
+            manifest=registry,
+            sql_models_by_name={},
+            report=report_obj,
+        )
+        # Seed columns are known → no warning
+        assert not report_obj.issues
+
+    def test_seed_not_in_manifest_by_name_produces_warning(self, tmp_path: Path) -> None:
+        """When a seed is missing from manifest.by_name (old behaviour), warn about it.
+
+        This test documents the *fixed* behaviour: seeds ARE indexed in by_name, so
+        the warning should NOT fire when columns are present.  Compare with a manifest
+        that genuinely has no entry for the seed — that should still warn.
+        """
+        from ol_dbt_cli.commands.validate import _check_upstream_refs
+        from ol_dbt_cli.lib.manifest import ManifestRegistry
+        from ol_dbt_cli.lib.sql_parser import ParsedModel
+        from ol_dbt_cli.lib.yaml_registry import YamlRegistry
+
+        # Empty manifest — seed is not resolvable anywhere.
+        empty_registry = ManifestRegistry()
+
+        downstream = ParsedModel(
+            name="dim_platform",
+            refs=["platforms"],
+            ref_placeholder_map={"ref_platforms": "platforms"},
+        )
+        report_obj = ValidationReport()
+        _check_upstream_refs(
+            "dim_platform",
+            downstream,
+            YamlRegistry(),
+            manifest=empty_registry,
+            sql_models_by_name={},
+            report=report_obj,
+        )
+        # No columns anywhere → should produce a warning
+        assert any("platforms" in issue.message for issue in report_obj.issues)
+
+    def test_resolve_upstream_columns_finds_seed_in_manifest(self) -> None:
+        """_resolve_upstream_columns returns column set for a seed indexed in by_name."""
+        from ol_dbt_cli.commands.validate import _resolve_upstream_columns
+        from ol_dbt_cli.lib.manifest import ManifestColumn, ManifestModel, ManifestRegistry
+        from ol_dbt_cli.lib.yaml_registry import YamlRegistry
+
+        registry = ManifestRegistry()
+        seed = ManifestModel(
+            unique_id="seed.pkg.user_course_roles",
+            name="user_course_roles",
+            resource_type="seed",
+            original_file_path="seeds/user_course_roles.csv",
+            schema="public",
+            database="",
+            columns={
+                "user_id": ManifestColumn(name="user_id"),
+                "course_id": ManifestColumn(name="course_id"),
+                "role": ManifestColumn(name="role"),
+            },
+        )
+        registry.nodes[seed.unique_id] = seed
+        registry.by_name[seed.name] = seed
+
+        cols = _resolve_upstream_columns("user_course_roles", YamlRegistry(), registry, {})
+        assert cols == {"user_id", "course_id", "role"}


### PR DESCRIPTION
### What are the relevant tickets?
N/A — identified during systematic `ol-dbt validate` run across all categories.

### Description (What does it do?)

Fixes four root causes of false positive validation errors in the `ol-dbt` CLI:

**1. Seeds not indexed in `manifest.by_name`** (`upstream_refs` false positives)

Seeds (`resource_type='seed'`) were stored in `registry.nodes` but never added to `registry.by_name`, so `manifest.get_model()` could not find them. The `upstream_refs` check would warn that column lists were unknown for `ref('platforms')`, `ref('user_course_roles')`, and `ref('legacy_edx_certificate_revision_mapping')` — all of which have column definitions in schema YAMLs.

Fix: index seeds in `by_name` alongside models in `load_manifest()`.

**2. UNNEST lateral join columns attributed to upstream ref** (`broken_ref_columns` false positives)

`cross join unnest(...) as t(col)` creates an unqualified column `col`. Pass 2 of `get_columns_read_from_ref()` skips attribution when a non-passthrough regular JOIN is present, but `j.find(exp.Table)` returns `None` for an UNNEST node so the guard never triggered, wrongly attributing UNNEST aliases to the upstream ref.

Fix: extend the join guard to also fire when `j.find(exp.Unnest) is not None`.

Affected models: `int__mitxpro__coursesinprogram`, `int__mitxpro__coursesfaculty`, `int__mitxpro__programsfaculty`, `int__ocw__course_departments`, `int__ocw__course_instructors`.

**3. Unaliased qualified columns from JOIN tables attributed to upstream** (`broken_ref_columns` false positives)

Pattern: `select upstream.*, other.col1 from upstream join other`. The passthrough CTE detection collected `exp.Alias` nodes but skipped unaliased qualified columns (`exp.Column` with a table qualifier). So `other.col1` was never added to `passthrough_added_cols`, and downstream reads of `col1` were incorrectly attributed to the upstream.

Fix: in the passthrough CTE added-column collection loop, also capture unaliased qualified columns whose qualifier is NOT in `passthrough_aliases`.

Affected models: `int__edxorg__mitx_courseruns`, `edxorg_to_mitxonline_users`.

**4. Passthrough chain does not propagate added columns across hops** (`broken_ref_columns` false positives)

Pattern: CTE A (passthrough + adds `hash_col`), CTE B (`select * from CTE A`). Pass 1 checked `cte_added = passthrough_added_cols.get(table_name)` for the *immediate* CTE alias, so accessing `B.hash_col` looked up B's added set which didn't include `hash_col` (only A's set did).

Fix: replace per-CTE `cte_added` lookup with `passthrough_computed` (the union of all added cols across all passthrough CTEs) for Pass 1 exclusion.

Affected model: `int__edxorg__mitx_program_certificates`.

### How can this be tested?

1. Generate compiled SQL: `cd src/ol_dbt && dbt compile --target dev_local`
2. Run the affected checks from the `src/ol_dbt_cli` directory:
   ```
   uv run ol-dbt validate --only broken_ref_columns
   uv run ol-dbt validate --only upstream_refs
   ```
   Before this fix: 8 false positive errors in `broken_ref_columns` and 3 false positive warnings in `upstream_refs`.
   After this fix: 0 errors and 0 warnings from these false positive patterns.

3. Run the unit tests:
   ```
   cd src/ol_dbt_cli && uv run pytest tests/ -v
   ```
   7 new tests cover all four false positive patterns.

### Additional Context

These false positives were identified during a systematic validation pass (PRs #2020 and #2021 fixed the genuine issues in `yaml_sql_sync`, `docs_coverage`, and `select_star`). This PR makes the CLI accurate enough to use in CI without generating noise.