### PR TITLE
exclude retired users from edxorg_to_mitxonline_enrollments

### DIFF
--- a/src/ol_dbt/models/migration/edxorg_to_mitxonline_enrollments.sql
+++ b/src/ol_dbt/models/migration/edxorg_to_mitxonline_enrollments.sql
@@ -3,15 +3,10 @@ with combined_enrollments as (
 )
 
 , retired_users as (
-    select
-         distinct user_id
-    from {{ ref('stg__edxorg__bigquery__mitx_user_info_combo') }}
+    select cast(user_id as varchar) as user_id
+    from {{ ref('int__edxorg__mitx_users') }}
     where
-        courserun_platform = '{{ var("edxorg") }}'
-        and (
-            user_email like 'retired__user%'
-            or user_username like 'retired__user%'
-        )
+        user_is_active = false
 )
 
 , edxorg_grade as (
@@ -199,7 +194,7 @@ left join edx_to_mitxonline_certificate_revision
 left join edx_signatories
     on edxorg_enrollment.courserun_readable_id = edx_signatories.courserun_readable_id
 left join retired_users
-    on edxorg_enrollment.user_id = cast(retired_users.user_id as varchar)
+    on edxorg_enrollment.user_id = retired_users.user_id
 where
     edxorg_enrollment.courseruncertificate_created_on is not null
     and mitxonline_enrollment.user_email is null

--- a/src/ol_dbt/models/migration/edxorg_to_mitxonline_users.sql
+++ b/src/ol_dbt/models/migration/edxorg_to_mitxonline_users.sql
@@ -15,15 +15,10 @@ with edx_certificate as (
 )
 
 , retired_users as (
-    select
-         distinct user_id
-    from {{ ref('stg__edxorg__bigquery__mitx_user_info_combo') }}
+    select user_id
+    from {{ ref('int__edxorg__mitx_users') }}
     where
-        courserun_platform = '{{ var("edxorg") }}'
-        and (
-            user_email like 'retired__user%'
-            or user_username like 'retired__user%'
-        )
+        user_is_active = false
 )
 
 , mitx_user as (


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
https://github.com/mitodl/hq/issues/8679

### Description (What does it do?)
<!--- Describe your changes in detail -->
excludes retired users from edxorg_to_mitxonline_users and edxorg_to_mitxonline_enrollments, as some open course certificates still need to be migrated.


### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

dbt build --select edxorg_to_mitxonline_users edxorg_to_mitxonline_enrollments

### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->


<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
