### PR TITLE
add last virtual to physical table Data_Detail_Nav

### DIFF
--- a/src/ol_dbt/models/reporting/Data_Detail_Nav.sql
+++ b/src/ol_dbt/models/reporting/Data_Detail_Nav.sql
@@ -18,7 +18,7 @@ select
 from  navigation_events
 inner join combined__course_runs
     on navigation_events.courserun_readable_id = combined__course_runs.courserun_readable_id
-group by 
+group by
     navigation_events.platform
     , combined__course_runs.course_title
     , navigation_events.courserun_readable_id

--- a/src/ol_dbt/models/reporting/_reporting__models.yml
+++ b/src/ol_dbt/models/reporting/_reporting__models.yml
@@ -1196,12 +1196,12 @@ models:
   - name: event_type
     description: string, type of the navigation event
   - name: starting_position
-    description: string, when the navigation event starts. 
+    description: string, when the navigation event starts.
   - name: ending_position
     description: string, when the navigation event ends.
   - name: event_timestamp
     description: timestamp, date and time when the navigation event was recorded.
   tests:
   - dbt_expectations.expect_compound_columns_to_be_unique:
-      column_list: ["platform", "course_title", "courserun_readable_id", "user_username"
-        , "event_type", "starting_position", "ending_position", "event_timestamp"]
+      column_list: ["platform", "course_title", "courserun_readable_id", "user_username",
+        "event_type", "starting_position", "ending_position", "event_timestamp"]


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/9520

### Description (What does it do?)
adds last virtual to physical table Data_Detail_Nav

### How can this be tested?
dbt build --select Data_Detail_Nav --vars 'schema_suffix: {putsuffixhere}' --target dev_production