### PR TITLE
fix: update unique column list in marts__combined__models.yml

### DIFF
--- a/src/ol_dbt/models/marts/combined/_marts__combined__models.yml
+++ b/src/ol_dbt/models/marts/combined/_marts__combined__models.yml
@@ -31,7 +31,7 @@ models:
       code} e.g.program-v1:xPRO+MLx
   tests:
   - dbt_expectations.expect_compound_columns_to_be_unique:
-      column_list: ["platform", "program_title", "course_readable_id"]
+      column_list: ["platform", "program_title", "program_readable_id", "course_readable_id"]
 
 - name: marts__combined__users
   description: Mart model for users from different platforms


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
NA
https://pipelines.odl.mit.edu/runs/7622b70a-10af-442e-83d0-62dc2a4827d3
```
Failure in test dbt_expectations_expect_compound_columns_to_be_unique_marts__combined_coursesinprogram_platform__program_title__course_readable_id (models/marts/combined/_marts__combined__models.yml)[0m
```

### Description (What does it do?)
<!--- Describe your changes in detail -->
Updates the unique column list for `marts__combined_coursesinprogram`. 

There are currently two programs named `Fundamentals of Deep Learning` on MITx Online, both associated with the required course `course-v1:UAI_SOURCE+UAI.6`. But their program_readable_id is different. This change updates the uniqueness test to account for the different program_readable_id.


### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->
The test should now pass.

dbt test --select marts__combined_coursesinprogram

### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->


<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
