### PR TITLE
feat: add courserun_created_on to course_staff_report and upstream

### DIFF
--- a/src/ol_dbt/models/intermediate/combined/_combined_models.yml
+++ b/src/ol_dbt/models/intermediate/combined/_combined_models.yml
@@ -277,6 +277,9 @@ models:
     - not_null
   - name: course_title
     description: string, title of the course
+  - name: courserun_created_on
+    description: timestamp, when the course run was created on the corresponding platform.
+      Populated for MITx Online, xPro, and Residential MITx.
 
 - name: int__combined__course_structure
   description: this table contains the latest course structure of the courses from

--- a/src/ol_dbt/models/intermediate/combined/int__combined__course_runs.sql
+++ b/src/ol_dbt/models/intermediate/combined/int__combined__course_runs.sql
@@ -84,6 +84,7 @@ with mitx_courses as (
         , mitxonline_runs.courserun_upgrade_deadline
         , mitxonline_runs.courserun_is_live
         , mitxonline_runs.course_number
+        , mitxonline_runs.courserun_created_on
     from mitxonline_runs
     left join mitx_courses on mitxonline_runs.course_id = mitx_courses.mitxonline_course_id
     where mitxonline_runs.courserun_platform = '{{ var("mitxonline") }}'
@@ -102,6 +103,7 @@ with mitx_courses as (
         , micromasters_runs.courserun_upgrade_deadline
         , null as courserun_is_live
         , edxorg_runs.course_number
+        , null as courserun_created_on
     from edxorg_runs
     left join mitx_courses on edxorg_runs.course_number = mitx_courses.course_number
     left join micromasters_runs on edxorg_runs.courserun_readable_id = micromasters_runs.courserun_edxorg_readable_id
@@ -126,6 +128,7 @@ with mitx_courses as (
             when cardinality(split(mitxpro_runs.courserun_readable_id, '+')) >= 2
                 then split(mitxpro_runs.courserun_readable_id, '+')[2]
         end as course_number
+        , mitxpro_runs.courserun_created_on
     from mitxpro_runs
     left join mitxpro_courses on mitxpro_runs.course_id = mitxpro_courses.course_id
 
@@ -143,6 +146,7 @@ with mitx_courses as (
         , null as courserun_upgrade_deadline
         , null as courserun_is_live
         , emeritus_runs.course_number
+        , null as courserun_created_on
     from emeritus_runs
     left join mitxpro_runs
         on emeritus_runs.courserun_external_readable_id = mitxpro_runs.courserun_external_readable_id
@@ -162,6 +166,7 @@ with mitx_courses as (
         , null as courserun_upgrade_deadline
         , null as courserun_is_live
         , global_alumni_runs.course_number
+        , null as courserun_created_on
     from global_alumni_runs
     left join mitxpro_runs
         on global_alumni_runs.courserun_external_readable_id = mitxpro_runs.courserun_external_readable_id
@@ -184,6 +189,7 @@ with mitx_courses as (
             when cardinality(split(bootcamps_runs.courserun_readable_id, '+')) >= 2
                 then split(bootcamps_runs.courserun_readable_id, '+')[2]
         end as course_number
+        , null as courserun_created_on
     from bootcamps_runs
     left join bootcamps_courses on bootcamps_runs.course_id = bootcamps_courses.course_id
 
@@ -204,6 +210,7 @@ with mitx_courses as (
             when cardinality(split(courserun_readable_id, '+')) >= 2
                 then split(courserun_readable_id, '+')[2]
         end as course_number
+        , courserun_created_on
     from residential_runs
 )
 
@@ -216,6 +223,7 @@ select
     , courserun_url
     , courserun_start_on
     , courserun_end_on
+    , courserun_created_on
     , courserun_upgrade_deadline
     , courserun_is_live
     , course_number

--- a/src/ol_dbt/models/intermediate/mitxonline/_int_mitxonline__models.yml
+++ b/src/ol_dbt/models/intermediate/mitxonline/_int_mitxonline__models.yml
@@ -1087,6 +1087,8 @@ models:
   - name: courserun_is_live
     description: boolean, indicating whether the course run is available to users
       on MITx Online website
+  - name: courserun_created_on
+    description: timestamp, when the course run was created on mitxonline
 
 - name: int__mitxonline__courserun_grades
   description: Intermediate model for MITxOnline course run grades

--- a/src/ol_dbt/models/intermediate/mitxonline/int__mitxonline__course_runs.sql
+++ b/src/ol_dbt/models/intermediate/mitxonline/int__mitxonline__course_runs.sql
@@ -20,6 +20,7 @@ select
     , runs.courserun_url
     , runs.courserun_start_on
     , runs.courserun_end_on
+    , runs.courserun_created_on
     , runs.courserun_enrollment_start_on
     , runs.courserun_enrollment_end_on
     , runs.courserun_upgrade_deadline

--- a/src/ol_dbt/models/intermediate/mitxpro/_int_mitxpro__models.yml
+++ b/src/ol_dbt/models/intermediate/mitxpro/_int_mitxpro__models.yml
@@ -1411,6 +1411,8 @@ models:
     description: timestamp, specifying when enrollment starts
   - name: courserun_enrollment_end_on
     description: timestamp, specifying when enrollment ends
+  - name: courserun_created_on
+    description: timestamp, when the course run was created on mitxpro
 
 - name: int__mitxpro__users
   description: Intermediate model of users in MIT xPro.

--- a/src/ol_dbt/models/intermediate/mitxpro/int__mitxpro__course_runs.sql
+++ b/src/ol_dbt/models/intermediate/mitxpro/int__mitxpro__course_runs.sql
@@ -26,6 +26,7 @@ select
     , course_runs.courserun_enrollment_start_on
     , course_runs.courserun_enrollment_end_on
     , course_runs.courserun_is_live
+    , course_runs.courserun_created_on
     , platforms.platform_name
     , platforms.platform_id
 from course_runs

--- a/src/ol_dbt/models/reporting/_reporting__models.yml
+++ b/src/ol_dbt/models/reporting/_reporting__models.yml
@@ -1180,6 +1180,9 @@ models:
     description: timestamp, date and time when the course run starts. May be null.
   - name: courserun_end_on
     description: timestamp, date and time when the course run ends. May be null.
+  - name: courserun_created_on
+    description: timestamp, when the course run was created on the corresponding platform.
+      Populated for MITx Online, xPro, and Residential MITx.
   - name: courserun_is_current
     description: boolean, indicating if the course run is currently running. True
       if courserun_start_on is in the past and blank courserun_end_on, or courserun_start_on

--- a/src/ol_dbt/models/reporting/course_staff_report.sql
+++ b/src/ol_dbt/models/reporting/course_staff_report.sql
@@ -31,6 +31,7 @@ select
     , combined_course_runs.courserun_start_on
     , combined_course_runs.courserun_end_on
     , combined_course_runs.courserun_is_current
+    , combined_course_runs.courserun_created_on
     , combined_course_roles.course_roles
     , course_activities.last_course_activity_date
 from combined_course_roles


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
https://github.com/mitodl/hq/issues/10410#issuecomment-4169820848

### Description (What does it do?)
<!--- Describe your changes in detail -->
adds `courserun_created_on` to course_staff_report and upstream models


### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->
Run `dbt build --select int__mitxonline__course_runs int__mitxpro__course_runs int__combined__course_runs course_staff_report`

