### PR TITLE
fix program_readable_id to orders 

### DIFF
--- a/src/ol_dbt/models/marts/combined/marts__combined__orders.sql
+++ b/src/ol_dbt/models/marts/combined/marts__combined__orders.sql
@@ -64,6 +64,7 @@ with bootcamps__ecommerce_order as (
         , mitxonline__ecommerce_order.line_id
         , mitxonline__ecommerce_order.courserun_id
         , mitxonline__ecommerce_order.courserun_readable_id
+        , mitxonline__ecommerce_order.program_readable_id
         , mitxonline__ecommerce_order.product_id
         , mitxonline__ecommerce_order.product_type
         , mitxonline__ecommerce_order.product_price
@@ -242,7 +243,7 @@ with bootcamps__ecommerce_order as (
         , courserun_id
         , courserun_readable_id
         , product_id
-        , courserun_readable_id as product_readable_id
+        , coalesce(courserun_readable_id, program_readable_id) as product_readable_id
         , product_type
         , product_price as unit_price
         , user_email


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
https://github.com/mitodl/hq/issues/10804

### Description (What does it do?)
<!--- Describe your changes in detail -->
Fix program_readable_id in marts__combined__orders, as it currently only uses the course readable ID

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->
I ran `dbt build --select marts__combined__orders`
