### PR TITLE
fix: suppresses the foreign key tests in tfact_order

### DIFF
--- a/src/ol_dbt/models/dimensional/_fact_tables.yml
+++ b/src/ol_dbt/models/dimensional/_fact_tables.yml
@@ -125,6 +125,8 @@ models:
         to: ref('dim_user')
         field: user_pk
         where: "user_fk is not null"
+        config:
+          severity: warn
   - name: platform_fk
     description: Foreign key to dim_platform
     tests:
@@ -140,6 +142,8 @@ models:
         to: ref('dim_product')
         field: product_pk
         where: "product_fk is not null"
+        config:
+          severity: warn
   - name: platform
     description: Platform identifier string
     tests:


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
https://pipelines.odl.mit.edu/runs/6bc53342-ec5f-4177-a72d-3c725734f5cf

```
510 of 919 FAIL 12 relationships_tfact_order_user_fk__user_pk__ref_dim_user_ ... [[31mFAIL 12[0m in 5.89s]

[31mFailure in test relationships_tfact_order_user_fk__user_pk__ref_dim_user_ (models/dimensional/_fact_tables.yml)[0m

  Got 12 results, configured to fail if >10
```

### Description (What does it do?)
<!--- Describe your changes in detail -->
suppresses the foreign key tests `user_fk` and product_fk in the new dimensional model `tfact_order`, as they are currently blocking the materialization of other important models 

e.g., superset_enrollment_detail_report hasn't been updated since yesterday https://pipelines.odl.mit.edu/assets/superset/dataset/enrollment_detail_report?view=events 


### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->
dbt test --select tfact_order


### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->


<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
