### PR TITLE
feat: add tax information to fact order and related models

### DIFF
--- a/src/ol_dbt/models/dimensional/_dim__models.yml
+++ b/src/ol_dbt/models/dimensional/_dim__models.yml
@@ -1009,7 +1009,7 @@ models:
     code.
   columns:
   - name: tax_rate_pk
-    description: string, surrogate primary key generated from tax_rate_country_code
+    description: string, surrogate primary key generated from country_code
     tests:
     - not_null
     - unique

--- a/src/ol_dbt/models/dimensional/_dim__models.yml
+++ b/src/ol_dbt/models/dimensional/_dim__models.yml
@@ -1002,3 +1002,32 @@ models:
   - name: updated_on
     description: string, ISO-8601 timestamp indicating when the discount record was
       last updated
+
+- name: dim_tax_rate
+  description: Dimension table of tax rates by country. Each row represents the tax
+    rate for a single country, identified by a surrogate key derived from the country
+    code.
+  columns:
+  - name: tax_rate_pk
+    description: string, surrogate primary key generated from tax_rate_country_code
+    tests:
+    - not_null
+    - unique
+  - name: country_code
+    description: string, ISO 3166-1 alpha-2 country code this tax rate applies to.
+      Unique per country
+    tests:
+    - not_null
+    - unique
+  - name: tax_rate
+    description: numeric, the tax rate as a percentage (e.g. 15 means 15%)
+    tests:
+    - not_null
+  - name: tax_rate_name
+    description: string, name of the tax assessed (e.g. GST)
+    tests:
+    - not_null
+  - name: is_active
+    description: boolean, indicates whether this tax rate is currently active
+    tests:
+    - not_null

--- a/src/ol_dbt/models/dimensional/_fact_tables.yml
+++ b/src/ol_dbt/models/dimensional/_fact_tables.yml
@@ -167,6 +167,18 @@ models:
       Total amount paid for the entire order. Repeated across all lines of the same
       order —
       NOT additive across lines. Use line_price for revenue aggregations.
+  - name: order_total_price_paid_plus_tax
+    description: >
+      Total amount paid for the entire order plus tax. Repeated across all lines of
+      the
+      same order — NOT additive across lines.
+  - name: order_tax_amount
+    description: Total tax amount for the order
+  - name: order_tax_rate
+    description: Tax rate applied to the order.
+  - name: tax_rate_fk
+    description: Foreign key to dim_tax_rate (null if tax rate cannot be determined
+      or order is not taxable)
   - name: order_reference_number
     description: Order reference/confirmation number
   - name: order_updated_on

--- a/src/ol_dbt/models/dimensional/_fact_tables.yml
+++ b/src/ol_dbt/models/dimensional/_fact_tables.yml
@@ -179,6 +179,11 @@ models:
   - name: tax_rate_fk
     description: Foreign key to dim_tax_rate (null if tax rate cannot be determined
       or order is not taxable)
+    tests:
+    - relationships:
+        to: ref('dim_tax_rate')
+        field: tax_rate_pk
+        where: "tax_rate_fk is not null"
   - name: order_reference_number
     description: Order reference/confirmation number
   - name: order_updated_on

--- a/src/ol_dbt/models/dimensional/dim_tax_rate.sql
+++ b/src/ol_dbt/models/dimensional/dim_tax_rate.sql
@@ -1,0 +1,16 @@
+{{ config(
+    materialized='table'
+) }}
+
+with xpro_tax_rates as (
+    select * from {{ ref('stg__mitxpro__app__postgres__ecommerce_taxrate') }}
+)
+
+--- Grain: one row per unique tax rate.
+select
+    {{ dbt_utils.generate_surrogate_key(['taxrate_country_code']) }} as tax_rate_pk
+    , taxrate_country_code as country_code
+    , taxrate_tax_rate as tax_rate
+    , taxrate_tax_rate_name as tax_rate_name
+    , taxrate_is_active as is_active
+from xpro_tax_rates

--- a/src/ol_dbt/models/dimensional/dim_tax_rate.sql
+++ b/src/ol_dbt/models/dimensional/dim_tax_rate.sql
@@ -6,7 +6,6 @@ with xpro_tax_rates as (
     select * from {{ ref('stg__mitxpro__app__postgres__ecommerce_taxrate') }}
 )
 
---- Grain: one row per unique tax rate.
 select
     {{ dbt_utils.generate_surrogate_key(['taxrate_country_code']) }} as tax_rate_pk
     , taxrate_country_code as country_code

--- a/src/ol_dbt/models/dimensional/tfact_order.sql
+++ b/src/ol_dbt/models/dimensional/tfact_order.sql
@@ -19,6 +19,11 @@ with mitxonline_orders as (
         , product_price as line_price
         , order_state
         , order_total_price_paid
+          --- placeholder for tax information on MITx Online orders, which is not currently implemented.
+        , order_total_price_paid as order_total_price_paid_plus_tax
+        , null as order_tax_amount
+        , null as order_tax_rate
+        , null as order_tax_country_code
         , order_reference_number
         , order_created_on
         , order_updated_on
@@ -45,6 +50,10 @@ with mitxonline_orders as (
         , lines.product_price as line_price
         , orders.order_state
         , orders.order_total_price_paid
+        , orders.order_total_price_paid_plus_tax
+        , orders.order_tax_amount
+        , orders.order_tax_rate
+        , orders.order_tax_country_code
         , cast(null as varchar) as order_reference_number
         , orders.order_created_on
         , orders.order_updated_on
@@ -71,6 +80,10 @@ with mitxonline_orders as (
         , line_price
         , order_state
         , order_total_price_paid
+        , order_total_price_paid as order_total_price_paid_plus_tax
+        , null as order_tax_amount
+        , null as order_tax_rate
+        , null as order_tax_country_code
         , cast(null as varchar) as order_reference_number
         , order_created_on
         , order_created_on as order_updated_on  -- micromasters has no updated_on
@@ -120,6 +133,11 @@ with mitxonline_orders as (
     from {{ ref('dim_discount') }}
 )
 
+, dim_tax_rate as (
+    select tax_rate_pk, country_code
+    from {{ ref('dim_tax_rate') }}
+)
+
 , orders_with_fks as (
     select
         combined_orders.*
@@ -138,6 +156,7 @@ with mitxonline_orders as (
         , dim_discount_type.discount_type_pk as discount_type_fk
         , dim_product.product_pk as product_fk
         , dim_discount.discount_pk as discount_fk
+        , dim_tax_rate.tax_rate_pk as tax_rate_fk
         , {{ iso8601_to_date_key('order_created_on') }} as order_date_key
         , {{ iso8601_to_date_key('order_updated_on') }} as order_updated_date_key
     from combined_orders
@@ -160,6 +179,8 @@ with mitxonline_orders as (
     left join dim_discount
         on combined_orders.discount_id = dim_discount.source_discount_id
         and combined_orders.platform = dim_discount.platform_code
+    left join dim_tax_rate
+        on combined_orders.order_tax_country_code = dim_tax_rate.country_code
 )
 
 {% if is_incremental() %}
@@ -193,6 +214,10 @@ with mitxonline_orders as (
         , order_state
         , line_price
         , order_total_price_paid
+        , tax_rate_fk
+        , order_total_price_paid_plus_tax
+        , order_tax_amount
+        , order_tax_rate
         , order_reference_number
         , order_updated_on
     from orders_with_fks as owf

--- a/src/ol_dbt/models/staging/mitxpro/_mitxpro__sources.yml
+++ b/src/ol_dbt/models/staging/mitxpro/_mitxpro__sources.yml
@@ -2343,3 +2343,25 @@ sources:
     - name: course_key
       description: string, unique string to identify a course run on the corresponding
         platform.
+
+  - name: raw__xpro__app__postgres__ecommerce_taxrate
+    description: MITx Pro ecommerce tax rates by country, used to calculate tax on
+      course orders in the MITx Pro app
+    columns:
+    - name: id
+      description: int, primary key in ecommerce_taxrate
+    - name: country_code
+      description: string, ISO 3166-1 alpha-2 country code this tax rate applies to.
+        Unique per country
+    - name: tax_rate
+      description: numeric, the tax rate as a percentage (e.g. 15 means 15%)
+    - name: tax_rate_name
+      description: string, name of the tax assessed (e.g. GST)
+    - name: active
+      description: boolean, whether this tax rate is currently active and used to
+        calculate tax on new course orders
+    - name: created_on
+      description: timestamp, specifying when the tax rate record was initially created
+    - name: updated_on
+      description: timestamp, specifying when the tax rate record was most recently
+        updated

--- a/src/ol_dbt/models/staging/mitxpro/_stg_mitxpro__models.yml
+++ b/src/ol_dbt/models/staging/mitxpro/_stg_mitxpro__models.yml
@@ -861,6 +861,42 @@ models:
     tests:
     - not_null
 
+- name: stg__mitxpro__app__postgres__ecommerce_taxrate
+  description: Staging model for MITx Pro ecommerce tax rates by country, used to
+    calculate tax on course orders
+  columns:
+  - name: taxrate_id
+    description: int, primary key representing a tax rate record
+    tests:
+    - not_null
+    - unique
+  - name: taxrate_country_code
+    description: string, ISO 3166-1 alpha-2 country code this tax rate applies to.
+      Unique per country
+    tests:
+    - not_null
+    - unique
+  - name: taxrate_tax_rate
+    description: numeric, the tax rate as a percentage (e.g. 15 means 15%)
+    tests:
+    - not_null
+  - name: taxrate_tax_rate_name
+    description: string, name of the tax assessed (e.g. GST)
+  - name: taxrate_is_active
+    description: boolean, whether this tax rate is currently active and used to calculate
+      tax on new course orders
+    tests:
+    - not_null
+  - name: taxrate_created_on
+    description: timestamp, specifying when the tax rate record was initially created
+    tests:
+    - not_null
+  - name: taxrate_updated_on
+    description: timestamp, specifying when the tax rate record was most recently
+      updated
+    tests:
+    - not_null
+
 - name: stg__mitxpro__app__postgres__ecommerce_order
   columns:
   - name: order_id

--- a/src/ol_dbt/models/staging/mitxpro/stg__mitxpro__app__postgres__ecommerce_taxrate.sql
+++ b/src/ol_dbt/models/staging/mitxpro/stg__mitxpro__app__postgres__ecommerce_taxrate.sql
@@ -9,7 +9,7 @@ with source as (
     select
         id as taxrate_id
         , country_code as taxrate_country_code
-        , tax_rate as taxrate_tax_rate
+        , cast(tax_rate as decimal(38, 2)) as taxrate_tax_rate
         , tax_rate_name as taxrate_tax_rate_name
         , active as taxrate_is_active
         ,{{ cast_timestamp_to_iso8601('created_on') }} as taxrate_created_on

--- a/src/ol_dbt/models/staging/mitxpro/stg__mitxpro__app__postgres__ecommerce_taxrate.sql
+++ b/src/ol_dbt/models/staging/mitxpro/stg__mitxpro__app__postgres__ecommerce_taxrate.sql
@@ -1,0 +1,21 @@
+with source as (
+
+    select * from {{ source('ol_warehouse_raw_data', 'raw__xpro__app__postgres__ecommerce_taxrate') }}
+
+)
+
+, renamed as (
+
+    select
+        id as taxrate_id
+        , country_code as taxrate_country_code
+        , tax_rate as taxrate_tax_rate
+        , tax_rate_name as taxrate_tax_rate_name
+        , active as taxrate_is_active
+        ,{{ cast_timestamp_to_iso8601('created_on') }} as taxrate_created_on
+        ,{{ cast_timestamp_to_iso8601('updated_on') }} as taxrate_updated_on
+    from source
+
+)
+
+select * from renamed


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
https://github.com/mitodl/ol-data-platform/issues/1982

### Description (What does it do?)
<!--- Describe your changes in detail -->
- Creates a  `stg__mitxpro__app__postgres__ecommerce_taxrate`
- Creates a new dimensional model `dim_tax_rate`
- Adds tax_rate_fk, order_tax_amount, order_tax_rate and order_total_price_paid_plus_tax to tfact_order

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

dbt build --select +dim_tax_rate
dbt build --select tfact_order --full-refresh

### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->


<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
