### PR TITLE
fix: update model tests for int__mitxonline__ecommerce_order and deduplicate in enrollment_detail_report

### DIFF
--- a/src/ol_dbt/models/intermediate/mitxonline/_int_mitxonline__models.yml
+++ b/src/ol_dbt/models/intermediate/mitxonline/_int_mitxonline__models.yml
@@ -507,7 +507,6 @@ models:
       orders have exactly one line
     tests:
     - not_null
-    - unique
   - name: order_state
     description: string, order state. Options are "pending", "fulfilled", "canceled"
       "declined", "errored", "refunded", "review", "partially_refunded"
@@ -560,7 +559,7 @@ models:
     - not_null
     - accepted_values:
         arguments:
-          values: ['course run', 'program run']
+          values: ['course run', 'program']
   - name: product_id
     description: int, sequential ID for ecommerce product
     tests:
@@ -610,10 +609,7 @@ models:
     description: str, address state from most recent cybersource payment
   - name: payment_bill_to_address_country
     description: str, address country from most recent cybersource payment
-  tests:
-  - dbt_expectations.expect_table_row_count_to_equal_other_table:
-      arguments:
-        compare_model: ref('stg__mitxonline__app__postgres__ecommerce_order')
+
 - name: int__mitxonline__ecommerce_product
   description: Intermediate model of MITx Online Products.
   columns:

--- a/src/ol_dbt/models/intermediate/mitxonline/_int_mitxonline__models.yml
+++ b/src/ol_dbt/models/intermediate/mitxonline/_int_mitxonline__models.yml
@@ -496,15 +496,12 @@ models:
       arguments:
         compare_model: ref('stg__mitxonline__app__postgres__ecommerce_transaction')
 - name: int__mitxonline__ecommerce_order
-  description: Since mitxonline orders always have exactly one line, we can combine
-    the ecommerce_line and ecommnerce_order tables into one intermediate table. This
-    may change at some point in the future (xpro orders have multiple lines). If it
-    does, the unique test on order_id in this model will fail and we will know to
-    change this query and the queries that depend on it
+  description: MITx Online ecommerce order table at the grain of an order line. An
+    order line is a single product within an order.
   columns:
   - name: order_id
-    description: int, primary key representing a single MITx Online order.  Currently
-      orders have exactly one line
+    description: int, the primary key representing an order. An order can have multiple
+      lines
     tests:
     - not_null
   - name: order_state

--- a/src/ol_dbt/models/reporting/enrollment_detail_report.sql
+++ b/src/ol_dbt/models/reporting/enrollment_detail_report.sql
@@ -84,7 +84,9 @@ select
     ) as receipt_url
 from enrollments
 left join orders
-    on enrollments.order_id = orders.order_id and enrollments.platform = orders.platform
+    on enrollments.order_id = orders.order_id
+    and enrollments.line_id = orders.line_id
+    and enrollments.platform = orders.platform
 left join course_passed_counts
     on enrollments.user_email = course_passed_counts.user_email
 left join programs


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
NA 
Failed test in https://pipelines.odl.mit.edu/assets/intermediate/int__mitxonline__ecommerce_order

### Description (What does it do?)
<!--- Describe your changes in detail -->

* Removed the `unique` test from the `order_id` column in the `orders` model to support multiple lines in an order
* Changed the accepted values for the `product_type` column from `['course run', 'program run']` to `['course run', 'program']` to align with current product types.
* Removed the `dbt_expectations.expect_table_row_count_to_equal_other_table` test, which is no longer accurate 

* Updated the join condition between `enrollments` and `orders` in `enrollment_detail_report.sql` to include both `order_id` and `line_id`, ensuring a more precise match between enrollment records and their corresponding order lines.


### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

--- test should now pass
dbt build --select int__mitxonline__ecommerce_order

dbt build --select enrollment_detail_report

### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->


<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
