### PR TITLE
Fix duplicates in organization_administration_report by removing courserun_title from GROUP BY

### DIFF
--- a/src/ol_dbt/models/reporting/organization_administration_report.sql
+++ b/src/ol_dbt/models/reporting/organization_administration_report.sql
@@ -61,12 +61,11 @@ with enrollment_detail as (
 , enroll_data as (
     select
         courserun_readable_id
-        , courserun_title
+        , max(courserun_title) as courserun_title
         , user_email
     from enrollment_detail
     group by
         courserun_readable_id
-        , courserun_title
         , user_email
 )
 


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
NA
```
of 1885 FAIL 29 dbt_expectations_expect_compound_columns_to_be_unique_organization_administration_report_courserun_readable_id__organization_key__user_email__activity_date  [[31mFAIL 29[0m in 2.73s]

[31mFailure in test dbt_expectations_expect_compound_columns_to_be_unique_organization_administration_report_courserun_readable_id__organization_key__user_email__activity_date (models/reporting/_reporting__models.yml)[0m

  Got 29 results, configured to fail if >10
```
This has been failed for a few days https://pipelines.odl.mit.edu/assets/reporting/organization_administration_report?view=checks

### Description (What does it do?)
<!--- Describe your changes in detail -->
Fixes duplicate rows in `organization_administration_report` caused by multiple courserun_title variations for the same courserun_readable_id. e.g. VJx/VJx/3T2014 from Residential and edX


### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->
The build should run clean now

dbt build --select organization_administration_report

### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->


<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
