### PR TITLE
 fix: include missing edxorg enrollments where courserun not yet migrated to MITx Online

### DIFF
--- a/src/ol_dbt/models/migration/edxorg_to_mitxonline_enrollments.sql
+++ b/src/ol_dbt/models/migration/edxorg_to_mitxonline_enrollments.sql
@@ -196,6 +196,10 @@ left join mitx__users
        on edxorg_enrollment.user_id = cast(mitx__users.user_edxorg_id as varchar)
 left join mitx__users as mitx_users_by_email
        on lower(edxorg_enrollment.user_email) = lower(mitx_users_by_email.user_mitxonline_email)
+left join mitxonline_enrollment as mitxonline_enrollment_by_userid
+    on coalesce(mitx_users_by_email.user_mitxonline_id, mitx__users.user_mitxonline_id)
+        = mitxonline_enrollment_by_userid.user_id
+    and edxorg_enrollment.courserun_readable_id = mitxonline_enrollment_by_userid.courserun_readable_id
 left join edx_to_mitxonline_certificate_revision
     on edxorg_enrollment.courserun_readable_id = edx_to_mitxonline_certificate_revision.courserun_readable_id
 left join edx_signatories
@@ -205,5 +209,5 @@ left join retired_users
 where
     edxorg_enrollment.courseruncertificate_created_on is not null
     and mitxonline_enrollment.user_email is null
-    and mitx__users.user_mitxonline_email is null
+    and mitxonline_enrollment_by_userid.user_id is null
     and retired_users.user_id is null


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->

### Description (What does it do?)
<!--- Describe your changes in detail -->
Updates edxorg_to_mitxonline_enrollments where some enrollment records were being excluded from the migration table
 -  The WHERE clause and mitx__users.user_mitxonline_email is null was meant to guard against already-migrated enrollments, but it dropped records where a user was identifiable in MITx Online (via both email and edxorg user_id) but the courserun itself hadn't been migrated yet.


### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->
dbt build --select edxorg_to_mitxonline_enrollments

### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->


<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
