### PR TITLE
add order type and redeemed email fields to enrollment detail reporting table

### DIFF
--- a/src/ol_dbt/models/reporting/_reporting__models.yml
+++ b/src/ol_dbt/models/reporting/_reporting__models.yml
@@ -250,8 +250,8 @@ models:
       and may be null for others.
   - name: redeemed_email
     description: string, email address associated with the redeemed order/seat. For
-      some platforms this may differ from the purchaser email, while for others
-      (for example MITx Online) it may be the same as user_email.
+      some platforms this may differ from the purchaser email, while for others (for
+      example MITx Online) it may be the same as user_email.
   - name: receipt_url
     description: string, URL to the receipt for the order on the MITx Online application
 

--- a/src/ol_dbt/models/reporting/_reporting__models.yml
+++ b/src/ol_dbt/models/reporting/_reporting__models.yml
@@ -245,6 +245,10 @@ models:
     description: numeric, price for the order line item before discount
   - name: program_name
     description: string, name of the program the course belongs to
+  - name: order_type
+    description: string, type of the order
+  - name: redeemed_email
+    description: string, email address of the person who placed the B2B order
   - name: receipt_url
     description: string, URL to the receipt for the order on the MITx Online application
 

--- a/src/ol_dbt/models/reporting/_reporting__models.yml
+++ b/src/ol_dbt/models/reporting/_reporting__models.yml
@@ -246,9 +246,12 @@ models:
   - name: program_name
     description: string, name of the program the course belongs to
   - name: order_type
-    description: string, type of the order
+    description: string, type of the order. Only populated for some platforms/orders
+      and may be null for others.
   - name: redeemed_email
-    description: string, email address of the person who placed the B2B order
+    description: string, email address associated with the redeemed order/seat. For
+      some platforms this may differ from the purchaser email, while for others
+      (for example MITx Online) it may be the same as user_email.
   - name: receipt_url
     description: string, URL to the receipt for the order on the MITx Online application
 

--- a/src/ol_dbt/models/reporting/enrollment_detail_report.sql
+++ b/src/ol_dbt/models/reporting/enrollment_detail_report.sql
@@ -94,6 +94,8 @@ select
     , orders.receipt_payment_timestamp
     , orders.unit_price
     , programs.program_name
+    , orders.order_type
+    , orders.redeemed_email
     , if(
         enrollments.platform = '{{ var("mitxonline") }}'
         , concat('https://mitxonline.mit.edu/orders/receipt/', cast(orders.order_id as varchar))


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/10344

### Description (What does it do?)
add order type and redeemed email fields to enrollment detail reporting table

### How can this be tested?
dbt build --select enrollment_detail_report
