### PR TITLE
Add dim_contract and normalize bridge_organization_courserun

### DIFF
--- a/src/ol_dbt/models/dimensional/_dim_contract.yml
+++ b/src/ol_dbt/models/dimensional/_dim_contract.yml
@@ -1,0 +1,48 @@
+---
+version: 2
+
+models:
+- name: dim_contract
+  description: >
+    MITx Online B2B contracts dimension. Each contract defines the terms under which
+    an organization gains access to one or more course runs. Grain: one row per contract.
+  columns:
+  - name: contract_pk
+    description: Surrogate primary key derived from b2b_contract_id.
+    tests:
+    - unique
+    - not_null
+  - name: contract_id
+    description: Source system contract ID (bigint).
+    tests:
+    - unique
+    - not_null
+  - name: organization_fk
+    description: Foreign key to dim_organization.organization_pk.
+    tests:
+    - not_null
+    - relationships:
+        to: ref('dim_organization')
+        field: organization_pk
+  - name: b2b_contract_name
+    description: Human-readable name of the contract.
+    tests:
+    - not_null
+  - name: b2b_contract_is_active
+    description: Whether the contract is marked active. Date rules still apply.
+  - name: b2b_contract_description
+    description: Long-form description of the contract terms.
+  - name: b2b_contract_start_date
+    description: Start date of the contract.
+  - name: b2b_contract_end_date
+    description: End date of the contract (null if open-ended).
+  - name: b2b_contract_max_learners
+    description: Maximum number of seats allowed under this contract. Zero or null
+      means unlimited.
+  - name: b2b_contract_integration_type
+    description: Integration type for the contract (e.g. SSO, Non-SSO).
+  - name: b2b_contract_enrollment_fixed_price
+    description: Fixed price per enrollment under this contract. Zero or null for
+      no fixed price.
+  - name: b2b_contract_membership_type
+    description: Membership management method for the contract (e.g. SSO, Non-SSO).

--- a/src/ol_dbt/models/dimensional/_dim_contract.yml
+++ b/src/ol_dbt/models/dimensional/_dim_contract.yml
@@ -20,7 +20,6 @@ models:
   - name: organization_fk
     description: Foreign key to dim_organization.organization_pk.
     tests:
-    - not_null
     - relationships:
         to: ref('dim_organization')
         field: organization_pk

--- a/src/ol_dbt/models/dimensional/_dim_organization.yml
+++ b/src/ol_dbt/models/dimensional/_dim_organization.yml
@@ -41,9 +41,9 @@ models:
 
 - name: bridge_organization_courserun
   description: >
-    Many-to-many bridge between B2B organizations and course runs.
+    Bridge between B2B organizations and course runs via contracts.
     Currently covers MITx Online organizations linked via B2B contracts.
-    Grain: one row per (organization, course_run, contract).
+    Grain: one row per (organization, contract, course_run).
   columns:
   - name: organization_fk
     description: Foreign key to dim_organization.organization_pk.
@@ -52,6 +52,13 @@ models:
     - relationships:
         to: ref('dim_organization')
         field: organization_pk
+  - name: contract_fk
+    description: Foreign key to dim_contract.contract_pk.
+    tests:
+    - not_null
+    - relationships:
+        to: ref('dim_contract')
+        field: contract_pk
   - name: courserun_fk
     description: Foreign key to dim_course_run.courserun_pk.
     tests:
@@ -59,12 +66,3 @@ models:
     - relationships:
         to: ref('dim_course_run')
         field: courserun_pk
-  - name: b2b_contract_name
-    description: Human-readable name of the B2B contract linking this organization
-      to the course run.
-  - name: b2b_contract_is_active
-    description: Whether the B2B contract is currently active.
-  - name: b2b_contract_start_date
-    description: Start date of the B2B contract.
-  - name: b2b_contract_end_date
-    description: End date of the B2B contract (null if open-ended).

--- a/src/ol_dbt/models/dimensional/_dim_organization.yml
+++ b/src/ol_dbt/models/dimensional/_dim_organization.yml
@@ -44,6 +44,12 @@ models:
     Bridge between B2B organizations and course runs via contracts.
     Currently covers MITx Online organizations linked via B2B contracts.
     Grain: one row per (organization, contract, course_run).
+  tests:
+  - dbt_utils.unique_combination_of_columns:
+      combination_of_columns:
+      - organization_fk
+      - contract_fk
+      - courserun_fk
   columns:
   - name: organization_fk
     description: Foreign key to dim_organization.organization_pk.

--- a/src/ol_dbt/models/dimensional/bridge_organization_courserun.sql
+++ b/src/ol_dbt/models/dimensional/bridge_organization_courserun.sql
@@ -2,25 +2,20 @@
     materialized='table'
 ) }}
 
--- Maps MITx Online B2B organizations to course runs via B2B contracts.
--- Grain: one row per (organization, course_run, contract).
+-- Maps MITx Online B2B organizations to course runs via contracts.
+-- Grain: one row per (organization, contract, course_run).
 -- Note: xPro B2B purchases are tracked via orders (see int__mitxpro__b2becommerce_b2border).
-with b2b_mappings as (
+with contracts_to_courseruns as (
     select
-        courserun_readable_id
-        , organization_key
-        , organization_name
-        , b2b_contract_name
-        , b2b_contract_is_active
-        , b2b_contract_start_date
-        , b2b_contract_end_date
-    from {{ ref('int__mitxonline__b2b_contract_to_courseruns') }}
+        b2b_contract_id as contract_id
+        , courserun_readable_id
+    from {{ ref('stg__mitxonline__app__postgres__courses_courserun') }}
+    where b2b_contract_id is not null
 )
 
-, dim_organization as (
-    select organization_pk, organization_key, platform
-    from {{ ref('dim_organization') }}
-    where platform = 'mitxonline'
+, dim_contract as (
+    select contract_pk, contract_id, organization_fk
+    from {{ ref('dim_contract') }}
 )
 
 , dim_course_run as (
@@ -31,16 +26,9 @@ with b2b_mappings as (
 )
 
 select
-    org.organization_pk as organization_fk
+    dc.organization_fk
+    , dc.contract_pk as contract_fk
     , cr.courserun_pk as courserun_fk
-    , b2b_mappings.b2b_contract_name
-    , b2b_mappings.b2b_contract_is_active
-    , b2b_mappings.b2b_contract_start_date
-    , b2b_mappings.b2b_contract_end_date
-from b2b_mappings
-left join dim_organization as org
-    on b2b_mappings.organization_key = org.organization_key
-left join dim_course_run as cr
-    on b2b_mappings.courserun_readable_id = cr.courserun_readable_id
-where org.organization_pk is not null
-    and cr.courserun_pk is not null
+from contracts_to_courseruns as ctc
+inner join dim_contract as dc on ctc.contract_id = dc.contract_id
+inner join dim_course_run as cr on ctc.courserun_readable_id = cr.courserun_readable_id

--- a/src/ol_dbt/models/dimensional/dim_contract.sql
+++ b/src/ol_dbt/models/dimensional/dim_contract.sql
@@ -1,0 +1,32 @@
+{{ config(
+    materialized='table'
+) }}
+
+-- MITx Online B2B contracts dimension.
+-- Grain: one row per contract.
+with contracts as (
+    select * from {{ ref('stg__mitxonline__app__postgres__b2b_contractpage') }}
+)
+
+, dim_organization as (
+    select organization_pk, organization_id
+    from {{ ref('dim_organization') }}
+    where platform = 'mitxonline'
+)
+
+select
+    {{ dbt_utils.generate_surrogate_key(['b2b_contract_id']) }} as contract_pk
+    , b2b_contract_id as contract_id
+    , b2b_contract_name
+    , b2b_contract_is_active
+    , b2b_contract_description
+    , b2b_contract_start_date
+    , b2b_contract_end_date
+    , b2b_contract_max_learners
+    , b2b_contract_integration_type
+    , b2b_contract_enrollment_fixed_price
+    , b2b_contract_membership_type
+    , org.organization_pk as organization_fk
+from contracts
+left join dim_organization as org
+    on cast(contracts.organization_id as varchar) = org.organization_id


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
https://github.com/mitodl/ol-data-platform/issues/2127

### Description (What does it do?)
<!--- Describe your changes in detail -->

-  New dim_contract — one row per MITx Online B2B contract with all contract terms (name, is_active, start/end dates, max_learners, integration_type, etc.)
   -  Each contract belongs to one organization via organization_fk → dim_organization, reflecting the one-org-to-many-contracts relationship.


-   Updated bridge_organization_courserun — replaced 4 denormalized contract fields with a single contract_fk → dim_contract. Bridge now outputs three clean FKs: organization_fk, contract_fk, courserun_fk.


### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

dbt build -select dim_contract bridge_organization_courserun


### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->


<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
