### PR TITLE
Refactor course_staff_report to use dimensional models

### DIFF
--- a/src/ol_dbt/models/dimensional/_bridge_tables.yml
+++ b/src/ol_dbt/models/dimensional/_bridge_tables.yml
@@ -33,6 +33,11 @@ models:
       for rows where courserun_fk is null.
     tests:
     - not_null
+  - name: platform_code
+    description: Platform identifier code (e.g. mitxonline, edxorg, mitxpro, residential)
+      for the course run.
+    tests:
+    - not_null
   - name: courseaccess_role
     description: The role assigned to the user for this course run (e.g. instructor,
       staff, beta_tester, finance_admin, sales_admin).

--- a/src/ol_dbt/models/dimensional/_bridge_tables.yml
+++ b/src/ol_dbt/models/dimensional/_bridge_tables.yml
@@ -2,6 +2,43 @@
 version: 2
 
 models:
+- name: bridge_user_courserun_role
+  description: >
+    User to course run roles bridge across all platforms. Links users to course runs
+    via their course access roles (e.g. instructor, staff, beta_tester).
+    Grain: one row per (user, course_run, role).
+  tests:
+  - dbt_utils.unique_combination_of_columns:
+      combination_of_columns:
+      - user_fk
+      - courserun_readable_id
+      - courseaccess_role
+  columns:
+  - name: user_fk
+    description: Foreign key to dim_user.user_pk.
+    tests:
+    - not_null
+    - relationships:
+        to: ref('dim_user')
+        field: user_pk
+  - name: courserun_fk
+    description: Foreign key to dim_course_run.courserun_pk. Null when the course
+      run does not exist in dim_course_run.
+    tests:
+    - relationships:
+        to: ref('dim_course_run')
+        field: courserun_pk
+  - name: courserun_readable_id
+    description: Human-readable course run identifier from the source system. Preserved
+      for rows where courserun_fk is null.
+    tests:
+    - not_null
+  - name: courseaccess_role
+    description: The role assigned to the user for this course run (e.g. instructor,
+      staff, beta_tester, finance_admin, sales_admin).
+    tests:
+    - not_null
+
 - name: bridge_program_course
   description: >
     Many-to-many bridge table connecting programs to their required courses.

--- a/src/ol_dbt/models/dimensional/_bridge_tables.yml
+++ b/src/ol_dbt/models/dimensional/_bridge_tables.yml
@@ -5,7 +5,7 @@ models:
 - name: bridge_user_courserun_role
   description: >
     User to course run roles bridge across all platforms. Links users to course runs
-    via their course access roles (e.g. instructor, staff, beta_tester).
+    via their course access roles (e.g. instructor, staff, beta_testers).
     Grain: one row per (user, course_run, role).
   tests:
   - dbt_utils.unique_combination_of_columns:
@@ -40,7 +40,7 @@ models:
     - not_null
   - name: courseaccess_role
     description: The role assigned to the user for this course run (e.g. instructor,
-      staff, beta_tester, finance_admin, sales_admin).
+      staff, beta_testers, finance_admin, sales_admin).
     tests:
     - not_null
 

--- a/src/ol_dbt/models/dimensional/_dim_course_run.yml
+++ b/src/ol_dbt/models/dimensional/_dim_course_run.yml
@@ -73,6 +73,10 @@ models:
     description: Foreign key to dim_date for enrollment period end
   - name: courserun_is_live
     description: Boolean indicating if course run is live
+  - name: courserun_created_on
+    description: >
+      Timestamp when the course run was created in the source system. Populated for
+      mitxonline, mitxpro, and residential platforms. Null for edxorg.
   - name: effective_date
     description: >
       Timestamp (UTC) when this SCD Type 2 version became effective. Always set for

--- a/src/ol_dbt/models/dimensional/bridge_user_courserun_role.sql
+++ b/src/ol_dbt/models/dimensional/bridge_user_courserun_role.sql
@@ -30,6 +30,7 @@ select
     -- Some course runs have no courserun_pk (due to missing course run metadata in source), so retaining readable_id allows
      -- those course runs to still be identifiable in downstream reporting tables
     , ucr.courserun_readable_id
+    , ucr.platform_code
     , ucr.courseaccess_role
 from user_course_roles as ucr
 inner join dim_user as du on lower(ucr.user_email) = lower(du.email)

--- a/src/ol_dbt/models/dimensional/bridge_user_courserun_role.sql
+++ b/src/ol_dbt/models/dimensional/bridge_user_courserun_role.sql
@@ -1,0 +1,39 @@
+{{ config(
+    materialized='table'
+) }}
+
+-- User to course run roles bridge across all platforms.
+-- Grain: one row per (user, course_run, role).
+with user_course_roles as (
+    select
+        user_email
+        , courserun_readable_id
+        , platform_code
+        , courseaccess_role
+    from {{ ref('int__combined__user_course_roles') }}
+)
+
+, dim_user as (
+    select user_pk, email
+    from {{ ref('dim_user') }}
+)
+
+, dim_course_run as (
+    select courserun_pk, courserun_readable_id, platform
+    from {{ ref('dim_course_run') }}
+    where is_current = true
+)
+
+select
+    du.user_pk as user_fk
+    , cr.courserun_pk as courserun_fk
+    -- Some course runs have no courserun_pk (due to missing course run metadata in source), so retaining readable_id allows
+     -- those course runs to still be identifiable in downstream reporting tables
+    , ucr.courserun_readable_id
+    , ucr.courseaccess_role
+from user_course_roles as ucr
+inner join dim_user as du on lower(ucr.user_email) = lower(du.email)
+left join dim_course_run as cr
+    on
+        ucr.courserun_readable_id = cr.courserun_readable_id
+        and ucr.platform_code = cr.platform

--- a/src/ol_dbt/models/dimensional/dim_course_run.sql
+++ b/src/ol_dbt/models/dimensional/dim_course_run.sql
@@ -18,6 +18,9 @@ with mitxonline_courseruns as (
         , courserun_is_live
         , 'mitxonline' as platform
     from {{ ref('int__mitxonline__course_runs') }}
+    --- Filter to just course runs on MITx Online platform since int__mitxonline__course_runs includes
+    -- the migrated edX runs as well, these migrated runs are captured in the edxorg_courseruns CTE below
+    where courserun_platform = '{{ var("mitxonline") }}'
 )
 
 , mitxpro_courseruns as (

--- a/src/ol_dbt/models/dimensional/dim_course_run.sql
+++ b/src/ol_dbt/models/dimensional/dim_course_run.sql
@@ -16,11 +16,9 @@ with mitxonline_courseruns as (
         , courserun_enrollment_start_on as enrollment_start
         , courserun_enrollment_end_on as enrollment_end
         , courserun_is_live
+        , courserun_created_on
         , 'mitxonline' as platform
     from {{ ref('int__mitxonline__course_runs') }}
-    --- Filter to just course runs on MITx Online platform since int__mitxonline__course_runs includes
-    -- the migrated edX runs as well, these migrated runs are captured in the edxorg_courseruns CTE below
-    where courserun_platform = '{{ var("mitxonline") }}'
 )
 
 , mitxpro_courseruns as (
@@ -34,6 +32,7 @@ with mitxonline_courseruns as (
         , courserun_enrollment_start_on as enrollment_start
         , courserun_enrollment_end_on as enrollment_end
         , courserun_is_live
+        , courserun_created_on
         , 'mitxpro' as platform
     from {{ ref('int__mitxpro__course_runs') }}
 )
@@ -49,6 +48,7 @@ with mitxonline_courseruns as (
         , courserun_enrollment_start_date as enrollment_start
         , courserun_enrollment_end_date as enrollment_end
         , courserun_is_published as courserun_is_live
+        , cast(null as varchar) as courserun_created_on
         , 'edxorg' as platform
     from {{ ref('int__edxorg__mitx_courseruns') }}
 )
@@ -64,6 +64,7 @@ with mitxonline_courseruns as (
         , courserun_enrollment_start_on as enrollment_start
         , courserun_enrollment_end_on as enrollment_end
         , cast(null as boolean) as courserun_is_live
+        , courserun_created_on
         , 'residential' as platform
     from {{ ref('int__mitxresidential__courseruns') }}
 )
@@ -156,6 +157,7 @@ with mitxonline_courseruns as (
         , enrollment_start
         , enrollment_end
         , courserun_is_live
+        , courserun_created_on
         , current_timestamp as effective_date
         , cast(null as timestamp) as end_date
         , true as is_current
@@ -199,6 +201,7 @@ with mitxonline_courseruns as (
         , existing.enrollment_start
         , existing.enrollment_end
         , existing.courserun_is_live
+        , existing.courserun_created_on
         , existing.effective_date
         , current_timestamp as end_date
         , false as is_current

--- a/src/ol_dbt/models/dimensional/dim_user.sql
+++ b/src/ol_dbt/models/dimensional/dim_user.sql
@@ -192,7 +192,9 @@ with mitx_users as (
         , mitlearn_openedx_users.openedx_user_id as mitxonline_openedx_user_id
         , mitx_users.mitxonline_application_user_id
         , coalesce(
-            mitxonline_app_openedxuser_mapping.openedxuser_username, mitx_users.user_mitxonline_username
+            mitxonline_app_openedxuser_mapping.openedxuser_username
+            , mitx_users.user_mitxonline_username
+            , mitlearn_openedx_users.user_username
         ) as user_mitxonline_username
         , mitx_users.edxorg_openedx_user_id
         , mitx_users.user_edxorg_username

--- a/src/ol_dbt/models/intermediate/combined/_combined_models.yml
+++ b/src/ol_dbt/models/intermediate/combined/_combined_models.yml
@@ -202,6 +202,11 @@ models:
     description: str, the open edX platform where the data is from
     tests:
     - not_null
+  - name: platform_code
+    description: str, the platform identifier code (e.g. mitxonline, edxorg, mitxpro,
+      residential) used to join with dimensional models like dim_course_run
+    tests:
+    - not_null
   - name: courserun_readable_id
     description: str, the open edX Course ID formatted as course-v1:{org}+{course
       number}+{run_tag} for MITx Online, xPro and Residential MITx. For edx.org platform,

--- a/src/ol_dbt/models/intermediate/combined/int__combined__user_course_roles.sql
+++ b/src/ol_dbt/models/intermediate/combined/int__combined__user_course_roles.sql
@@ -53,6 +53,7 @@ with mitxonline_courseroles as (
 , combined_courseroles as (
     select
         '{{ var("mitxonline") }}' as platform
+        , 'mitxonline' as platform_code
         , mitxonline_openedx_users.user_username
         , mitxonline_openedx_users.user_email
         , mitxonline_app_users.user_full_name
@@ -72,6 +73,7 @@ with mitxonline_courseroles as (
 
     select
         '{{ var("edxorg") }}' as platform
+        , 'edxorg' as platform_code
         , edxorg_users.user_username
         , edxorg_users.user_email
         , edxorg_profiles.user_full_name
@@ -89,6 +91,7 @@ with mitxonline_courseroles as (
 
     select
         '{{ var("mitxpro") }}' as platform
+        , 'mitxpro' as platform_code
         , mitxpro_openedx_users.user_username
         , mitxpro_openedx_users.user_email
         , mitxpro_app_users.user_full_name
@@ -108,6 +111,7 @@ with mitxonline_courseroles as (
 
     select
         '{{ var("residential") }}' as platform
+        , 'residential' as platform_code
         , residential_openedx_users.user_username
         , residential_openedx_users.user_email
         , residential_openedx_users.user_full_name
@@ -140,6 +144,7 @@ with mitxonline_courseroles as (
 
 select
     platform
+    , platform_code
     , combined_courseroles.user_username
     , combined_courseroles.user_email
     , combined_courseroles.user_full_name
@@ -153,6 +158,12 @@ union all
 
 select
     user_course_role_seed_file.platform
+    , case user_course_role_seed_file.platform
+        when '{{ var("mitxonline") }}' then 'mitxonline'
+        when '{{ var("edxorg") }}' then 'edxorg'
+        when '{{ var("mitxpro") }}' then 'mitxpro'
+        when '{{ var("residential") }}' then 'residential'
+    end as platform_code
     , seed_file_users.user_username
     , seed_file_users.user_email
     , seed_file_users.user_full_name

--- a/src/ol_dbt/models/reporting/_reporting__models.yml
+++ b/src/ol_dbt/models/reporting/_reporting__models.yml
@@ -1178,8 +1178,8 @@ models:
     platforms and their last course activity date
   columns:
   - name: platform
-    description: string, name of the platform (e.g. MITx Online, xPro, edX.org, Residential
-      MITx)
+    description: string, platform code identifying the source platform (e.g. mitxonline,
+      mitxpro, edxorg, residential)
     tests:
     - not_null
   - name: user_username

--- a/src/ol_dbt/models/reporting/_reporting__models.yml
+++ b/src/ol_dbt/models/reporting/_reporting__models.yml
@@ -1183,11 +1183,11 @@ models:
     tests:
     - not_null
   - name: user_username
-    description: string, username of the course staff member on the platform
-    tests:
-    - not_null
+    description: string, username of the course staff member on the platform.
   - name: user_email
     description: string, email address of the course staff member
+    tests:
+    - not_null
   - name: courserun_readable_id
     description: string, unique identifier for the course run formatted as course-v1:{org}+{course
       code}+{run_tag}
@@ -1213,7 +1213,7 @@ models:
   tests:
   - dbt_expectations.expect_compound_columns_to_be_unique:
       arguments:
-        column_list: ["platform", "user_username", "courserun_readable_id"]
+        column_list: ["platform", "user_email", "courserun_readable_id"]
 
 - name: data_detail_nav
   description: Report of navigatation events

--- a/src/ol_dbt/models/reporting/course_staff_report.sql
+++ b/src/ol_dbt/models/reporting/course_staff_report.sql
@@ -10,13 +10,7 @@ with user_roles as (
 
 , combined_course_roles as (
     select
-        case ucr.platform_code
-            when 'mitxonline' then '{{ var("mitxonline") }}'
-            when 'edxorg' then '{{ var("edxorg") }}'
-            when 'mitxpro' then '{{ var("mitxpro") }}'
-            when 'residential' then '{{ var("residential") }}'
-        end as platform
-        , ucr.platform_code
+        ucr.platform_code as platform
         , case ucr.platform_code
             when 'mitxonline' then du.user_mitxonline_username
             when 'edxorg' then du.user_edxorg_username
@@ -66,9 +60,8 @@ select
     , course_activities.last_course_activity_date
 from combined_course_roles
 left join combined_course_runs
-    on combined_course_runs.platform = combined_course_roles.platform_code
+    on combined_course_runs.platform = combined_course_roles.platform
     and combined_course_runs.courserun_readable_id = combined_course_roles.courserun_readable_id
 left join course_activities
-    on course_activities.platform = combined_course_roles.platform
-    and course_activities.user_username = combined_course_roles.user_username
+    on course_activities.user_username = combined_course_roles.user_username
     and course_activities.courserun_readable_id = combined_course_roles.courserun_readable_id

--- a/src/ol_dbt/models/reporting/course_staff_report.sql
+++ b/src/ol_dbt/models/reporting/course_staff_report.sql
@@ -1,16 +1,46 @@
-with combined_course_roles as (
+with user_roles as (
     select
-        platform
-        , user_username
-        , user_email
+        user_fk
+        , platform_code
         , courserun_readable_id
-        ,  {{ array_join('array_agg(courseaccess_role order by courseaccess_role)', ", ") }} as course_roles
-    from {{ ref('int__combined__user_course_roles') }}
-    group by platform, user_username, user_email, courserun_readable_id
+        , {{ array_join('array_agg(courseaccess_role order by courseaccess_role)', ", ") }} as course_roles
+    from {{ ref('bridge_user_courserun_role') }}
+    group by user_fk, platform_code, courserun_readable_id
+)
+
+, combined_course_roles as (
+    select
+        case ucr.platform_code
+            when 'mitxonline' then '{{ var("mitxonline") }}'
+            when 'edxorg' then '{{ var("edxorg") }}'
+            when 'mitxpro' then '{{ var("mitxpro") }}'
+            when 'residential' then '{{ var("residential") }}'
+        end as platform
+        , ucr.platform_code
+        , case ucr.platform_code
+            when 'mitxonline' then du.user_mitxonline_username
+            when 'edxorg' then du.user_edxorg_username
+            when 'mitxpro' then du.user_mitxpro_username
+            when 'residential' then du.user_residential_username
+        end as user_username
+        , du.email as user_email
+        , ucr.courserun_readable_id
+        , ucr.course_roles
+    from user_roles as ucr
+    inner join {{ ref('dim_user') }} as du on ucr.user_fk = du.user_pk
 )
 
 , combined_course_runs as (
-    select * from {{ ref('int__combined__course_runs') }}
+    select
+        platform
+        , courserun_readable_id
+        , courserun_start_on
+        , courserun_end_on
+        , {{ is_courserun_current('courserun_start_on', 'courserun_end_on') }} as courserun_is_current
+        -- courserun_created_on is not available in dim_course_run
+        , null as courserun_created_on
+    from {{ ref('dim_course_run') }}
+    where is_current = true
 )
 
 , course_activities as (
@@ -36,7 +66,7 @@ select
     , course_activities.last_course_activity_date
 from combined_course_roles
 left join combined_course_runs
-    on combined_course_runs.platform = combined_course_roles.platform
+    on combined_course_runs.platform = combined_course_roles.platform_code
     and combined_course_runs.courserun_readable_id = combined_course_roles.courserun_readable_id
 left join course_activities
     on course_activities.platform = combined_course_roles.platform

--- a/src/ol_dbt/models/reporting/course_staff_report.sql
+++ b/src/ol_dbt/models/reporting/course_staff_report.sql
@@ -39,11 +39,11 @@ with user_roles as (
 , course_activities as (
     select
         platform
-        , user_username
+        , user_email
         , courserun_readable_id
         , max(courseactivity_date) as last_course_activity_date
     from {{ ref('marts__combined_course_engagements') }}
-    group by platform, user_username, courserun_readable_id
+    group by platform, user_email, courserun_readable_id
 )
 
 select
@@ -62,5 +62,5 @@ left join combined_course_runs
     on combined_course_runs.platform = combined_course_roles.platform
     and combined_course_runs.courserun_readable_id = combined_course_roles.courserun_readable_id
 left join course_activities
-    on course_activities.user_username = combined_course_roles.user_username
+    on course_activities.user_email = combined_course_roles.user_email
     and course_activities.courserun_readable_id = combined_course_roles.courserun_readable_id

--- a/src/ol_dbt/models/reporting/course_staff_report.sql
+++ b/src/ol_dbt/models/reporting/course_staff_report.sql
@@ -31,8 +31,7 @@ with user_roles as (
         , courserun_start_on
         , courserun_end_on
         , {{ is_courserun_current('courserun_start_on', 'courserun_end_on') }} as courserun_is_current
-        -- courserun_created_on is not available in dim_course_run
-        , null as courserun_created_on
+        , courserun_created_on
     from {{ ref('dim_course_run') }}
     where is_current = true
 )


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
https://github.com/mitodl/ol-data-platform/issues/2101

### Description (What does it do?)
<!--- Describe your changes in detail -->

-   int__combined__user_course_roles.sql
     Added platform_code column ('mitxonline', 'edxorg', 'mitxpro', 'residential') to all 4 platform. 
    Enables standardized joins with dimensional models.

-   bridge_user_courserun_role.sql (new file)
    New bridge table sourcing from int__combined__user_course_roles

 - dim_course_run.sql
    Added courserun_created_on to all platform CTEs (null cast for edxorg which lacks the field).

- course_staff_report.sql
  Refactored to use bridge_user_courserun_role + dim_user + dim_course_run instead of reading int__combined__user_course_roles directly. 
  Updated the unique test to use (platform, user_email, courserun_readable_id) because a couple of MIT staff in edX.org courses don't have a user_username due to upstream source data issues, causing the previous username-based uniqueness test to fail


### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

dbt run --select +dim_user +dim_course_run +int__combined__user_course_roles 
dbt run --select dim_course_run --full-refresh
--- test should pass for these two models
dbt build --select bridge_user_courserun_role course_staff_report

The count of course_staff_report in your schema match with production

```
---23080
select count(*) from "ol_data_lake_production"."ol_warehouse_production_rlougee_reporting".course_staff_report

---23080
select count(*) from "ol_data_lake_production"."ol_warehouse_production_reporting".course_staff_report
```

### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->


<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
