### PR TITLE
 fix: b2b org export runs hang after step completes on production

### DIFF
--- a/dg_projects/b2b_organization/b2b_organization/assets/data_export.py
+++ b/dg_projects/b2b_organization/b2b_organization/assets/data_export.py
@@ -28,12 +28,13 @@ def export_b2b_organization_data(context: AssetExecutionContext):
     organization_key = context.partition_key
     dbt_report_name = "organization_administration_report"
 
-    data_df = get_dbt_model_as_dataframe(
-        database_name="ol_warehouse_production_reporting",
-        table_name=dbt_report_name,
-    ).collect()
-    organizational_data_df = data_df.filter(
-        pl.col("organization_key").eq(organization_key)
+    organizational_data_df = (
+        get_dbt_model_as_dataframe(
+            database_name="ol_warehouse_production_reporting",
+            table_name=dbt_report_name,
+        )
+        .filter(pl.col("organization_key").eq(organization_key))
+        .collect()
     )
     num_rows = len(organizational_data_df)
     context.log.info(

--- a/dg_projects/b2b_organization/b2b_organization/assets/data_export.py
+++ b/dg_projects/b2b_organization/b2b_organization/assets/data_export.py
@@ -31,11 +31,11 @@ def export_b2b_organization_data(context: AssetExecutionContext):
     data_df = get_dbt_model_as_dataframe(
         database_name="ol_warehouse_production_reporting",
         table_name=dbt_report_name,
-    )
+    ).collect()
     organizational_data_df = data_df.filter(
         pl.col("organization_key").eq(organization_key)
     )
-    num_rows = organizational_data_df.select(pl.len()).collect().item()
+    num_rows = len(organizational_data_df)
     context.log.info(
         "%d rows in organization_administration_report for %s",
         num_rows,
@@ -47,7 +47,7 @@ def export_b2b_organization_data(context: AssetExecutionContext):
     organizational_data_file = Path(
         f"{organization_key}_{dbt_report_name}_{export_date}.csv"
     )
-    organizational_data_df.sink_csv(str(organizational_data_file))
+    organizational_data_df.write_csv(str(organizational_data_file))
 
     with organizational_data_file.open("rb") as f:
         organizational_data_version = hashlib.file_digest(f, "sha256").hexdigest()

--- a/src/ol_dbt/models/dimensional/_dim_course_run.yml
+++ b/src/ol_dbt/models/dimensional/_dim_course_run.yml
@@ -73,6 +73,10 @@ models:
     description: Foreign key to dim_date for enrollment period end
   - name: courserun_is_live
     description: Boolean indicating if course run is live
+  - name: courserun_created_on
+    description: >
+      Timestamp when the course run was created in the source system. Populated for
+      mitxonline, mitxpro, and residential platforms. Null for edxorg.
   - name: effective_date
     description: >
       Timestamp (UTC) when this SCD Type 2 version became effective. Always set for

--- a/src/ol_dbt/models/dimensional/_dim_course_run.yml
+++ b/src/ol_dbt/models/dimensional/_dim_course_run.yml
@@ -73,10 +73,6 @@ models:
     description: Foreign key to dim_date for enrollment period end
   - name: courserun_is_live
     description: Boolean indicating if course run is live
-  - name: courserun_created_on
-    description: >
-      Timestamp when the course run was created in the source system. Populated for
-      mitxonline, mitxpro, and residential platforms. Null for edxorg.
   - name: effective_date
     description: >
       Timestamp (UTC) when this SCD Type 2 version became effective. Always set for


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
NA
https://pipelines.odl.mit.edu/runs/d5f2ae84-895c-4ef3-b061-bb359ea73505

### Description (What does it do?)
<!--- Describe your changes in detail -->
   Fixes b2b organization data export runs hang on production after the export step completes.

   **Root cause:** `sink_csv` uses Polars' streaming engine, which spawns
   non-daemon background threads via PyIceberg's `aiobotocore` async S3 reader.
   On production (larger Iceberg table with more S3 files), these threads outlive
   the step and prevent the Dagster run process from exiting — requiring manual
   cancellation every time.

   **Fix:** Replace the two-pass approach (`sink_csv` + separate `.collect()` for
   row count) with a single eager `.collect()` followed by `write_csv()`. This
   avoids the streaming engine entirely, ensures all data is in memory before
   writing, and allows the process to exit cleanly after the step finishes.


### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->
docker compose up
Turn on the sensor `/locations/b2b_organization/sensors/b2b_organization_list_sensor`


### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->


<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
