### PR TITLE
fix: normalize email casing in dim_user

### DIFF
--- a/src/ol_dbt/models/dimensional/dim_user.sql
+++ b/src/ol_dbt/models/dimensional/dim_user.sql
@@ -298,7 +298,7 @@ with mitx_users as (
 
 , combined_users as (
     select
-        {{ dbt_utils.generate_surrogate_key(['email']) }} as user_pk
+        {{ dbt_utils.generate_surrogate_key(['lower(email)']) }} as user_pk
         , user_global_id
         , mitlearn_user_id
         , mitlearn_openedx_user_id
@@ -314,7 +314,7 @@ with mitx_users as (
         , user_edxorg_username
         , null as emeritus_user_id
         , null as global_alumni_user_id
-        , email
+        , lower(email) as email
         , full_name
         , address_country
         , highest_education
@@ -339,7 +339,7 @@ with mitx_users as (
     union all
 
     select
-        {{ dbt_utils.generate_surrogate_key(['mitxpro_user_view.user_email']) }} as user_pk
+        {{ dbt_utils.generate_surrogate_key(['lower(mitxpro_user_view.user_email)']) }} as user_pk
         , null as user_global_id
         , null as mitlearn_user_id
         , null as mitlearn_openedx_user_id
@@ -357,7 +357,7 @@ with mitx_users as (
         , null as user_edxorg_username
         , null as emeritus_user_id
         , null as global_alumni_user_id
-        , mitxpro_user_view.user_email as email
+        , lower(mitxpro_user_view.user_email) as email
         , mitxpro_user_view.user_full_name as full_name
         , mitxpro_user_view.user_address_country as address_country
         , mitxpro_user_view.user_highest_education as highest_education
@@ -386,7 +386,7 @@ with mitx_users as (
     union all
 
     select
-        {{ dbt_utils.generate_surrogate_key(['user_email']) }} as user_pk
+        {{ dbt_utils.generate_surrogate_key(['lower(user_email)']) }} as user_pk
         , null as user_global_id
         , null as mitlearn_user_id
         , null as mitlearn_openedx_user_id
@@ -402,7 +402,7 @@ with mitx_users as (
         , null as user_edxorg_username
         , user_id as emeritus_user_id
         , null as global_alumni_user_id
-        , user_email as email
+        , lower(user_email) as email
         , user_full_name as full_name
         , user_address_country as address_country
         , null as highest_education
@@ -428,7 +428,7 @@ with mitx_users as (
     union all
 
     select
-        {{ dbt_utils.generate_surrogate_key(['user_email']) }} as user_pk
+        {{ dbt_utils.generate_surrogate_key(['lower(user_email)']) }} as user_pk
         , null as user_global_id
         , null as mitlearn_user_id
         , null as mitlearn_openedx_user_id
@@ -444,7 +444,7 @@ with mitx_users as (
         , null as user_edxorg_username
         , null as emeritus_user_id
         , user_id as global_alumni_user_id
-        , user_email as email
+        , lower(user_email) as email
         , user_full_name as full_name
         , user_address_country as address_country
         , null as highest_education
@@ -470,7 +470,7 @@ with mitx_users as (
     union all
 
     select
-        {{ dbt_utils.generate_surrogate_key(['mitxresidential_user_view.user_email']) }} as user_pk
+        {{ dbt_utils.generate_surrogate_key(['lower(mitxresidential_user_view.user_email)']) }} as user_pk
         , null as user_global_id
         , null as mitlearn_user_id
         , null as mitlearn_openedx_user_id
@@ -486,7 +486,7 @@ with mitx_users as (
         , null as user_edxorg_username
         , null as emeritus_user_id
         , null as global_alumni_user_id
-        , mitxresidential_user_view.user_email as email
+        , lower(mitxresidential_user_view.user_email) as email
         , mitxresidential_user_view.user_full_name as full_name
         , mitxresidential_user_view.user_address_country as address_country
         , mitxresidential_user_view.user_highest_education as highest_education

--- a/src/ol_dbt/models/dimensional/dim_user.sql
+++ b/src/ol_dbt/models/dimensional/dim_user.sql
@@ -381,7 +381,7 @@ with mitx_users as (
     left join mitxpro_openedx_users as openedx_users_username
         on mitxpro_user_view.user_username = openedx_users_username.user_username
     left join mitxpro_openedx_users as openedx_users_email
-        on mitxpro_user_view.user_email = openedx_users_email.user_email
+        on lower(mitxpro_user_view.user_email) = lower(openedx_users_email.user_email)
 
     union all
 


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
Noticed when working on https://github.com/mitodl/ol-data-platform/pull/2190

15k duplicate emails caused by casing differences in dim_user. 
```
select lower(email), count(*) 
from "ol_data_lake_production"."ol_warehouse_production_dimensional".dim_user
group by lower(email)
having count(*)>1
```

### Description (What does it do?)
<!--- Describe your changes in detail -->
   Email addresses stored across source systems are not consistently cased, causing ~15k users to appear as duplicates in `dim_user` because their surrogate keys hash to different values for the same address.

   ## Changes

   - Wrap `email` output with `lower()` in all 5 `UNION ALL` branches of
     `combined_users`
   - Pass `lower(email)` into `generate_surrogate_key()` in each branch so
     deduplication works correctly regardless of source casing


### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

dbt build --select dim_user tfact_certificate tfact_enrollment tfact_order tfact_payment tfact_problem_events tfact_studentmodule_problems --full-refresh

```
---0
select lower(email), count(*) 
from dim_user
group by lower(email)
having count(*)>1
```



### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->


<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
