### PR TITLE
Add OCW pages report

### DIFF
--- a/src/ol_dbt/models/intermediate/ocw/_int_ocw__models.yml
+++ b/src/ol_dbt/models/intermediate/ocw/_int_ocw__models.yml
@@ -57,11 +57,11 @@ models:
       updated on OCW production. The publish date is updated by the webhook to Concourse
       pipeline (it rebuilds every site) whenever we do a release in ocw repos.
   - name: course_created_on
-    description: timestamp, date and time when the course record was created
+    description: timestamp, date and time when the course was created
     tests:
     - not_null
   - name: course_updated_on
-    description: timestamp, date and time when the course record was last updated
+    description: timestamp, date and time when the course was last updated
     tests:
     - not_null
   - name: course_description
@@ -168,11 +168,88 @@ models:
       arguments:
         column_list: ["course_uuid", "course_department_number"]
 
+- name: int__ocw__pages
+  description: OCW course pages (navigable content pages) for ocw-course sites
+  columns:
+  - name: course_uuid
+    description: str, UUID of the course containing the page
+    tests:
+    - not_null
+  - name: course_name
+    description: str, unique name of the OCW course
+    tests:
+    - not_null
+  - name: course_live_url
+    description: str, URL of the OCW course on production
+  - name: course_number
+    description: str, primary course number of the course
+  - name: course_term
+    description: str, term the course was taught
+  - name: course_title
+    description: str, title of the course
+  - name: course_year
+    description: str, year the course was taught
+  - name: website_title
+    description: str, title of the course website
+    tests:
+    - not_null
+  - name: content_type
+    description: str, WebsiteContent type of the page (always 'page')
+    tests:
+    - not_null
+  - name: page_uuid
+    description: str, UUID of the page (WebsiteContent text_id)
+    tests:
+    - not_null
+  - name: page_title
+    description: str, title of the page
+  - name: page_filename
+    description: str, filename of the page
+    tests:
+    - not_null
+  - name: page_dirpath
+    description: str, directory path of the page within the site
+  - name: page_parent_id
+    description: int, ID of the parent WebsiteContent
+  - name: page_is_page_content
+    description: boolean, whether the page is page content
+  - name: page_draft
+    description: boolean, whether the page is in draft state
+  - name: page_body
+    description: str, the markdown body content of the page (from the markdown column,
+      not metadata)
+  - name: page_description
+    description: str, description of the page
+  - name: page_legacy_type
+    description: str, legacy OCW type from Plone import (ocw_type field)
+  - name: learning_resource_types
+    description: str, learning resource types associated with the page
+  - name: metadata
+    description: json, raw metadata of the page
+    tests:
+    - not_null
+  - name: page_live_url
+    description: str, live URL of the page on production
+  - name: studio_url
+    description: str, OCW Studio URL for the page
+  - name: page_created_on
+    description: timestamp, date and time when the page was created
+    tests:
+    - not_null
+  - name: page_updated_on
+    description: timestamp, date and time when the page was last updated
+    tests:
+    - not_null
+  tests:
+  - dbt_expectations.expect_compound_columns_to_be_unique:
+      arguments:
+        column_list: ["course_uuid", "page_uuid"]
+
 - name: int__ocw__resources
   description: supporting table for resources in OCW
   columns:
   - name: content_type
-    description: str, websitecontent type of the resource (e.g., resource, external-resource)
+    description: str, WebsiteContent type of the resource (e.g., resource, external-resource)
     tests:
     - not_null
   - name: course_live_url

--- a/src/ol_dbt/models/intermediate/ocw/int__ocw__pages.sql
+++ b/src/ol_dbt/models/intermediate/ocw/int__ocw__pages.sql
@@ -1,0 +1,65 @@
+with websites as (
+    select * from {{ ref('stg__ocw__studio__postgres__websites_website') }}
+)
+
+, websitecontents as (
+    select * from {{ ref('stg__ocw__studio__postgres__websites_websitecontent') }}
+)
+
+, websitestarters as (
+    select * from {{ ref('stg__ocw__studio__postgres__websites_websitestarter') }}
+)
+
+, sitemetadata as (
+    select
+        website_uuid
+        , course_primary_course_number as sitemetadata_primary_course_number
+        , course_term as sitemetadata_course_term
+        , course_title as sitemetadata_course_title
+        , course_year as sitemetadata_course_year
+    from websitecontents
+    where websitecontent_type = 'sitemetadata'
+)
+
+select
+    websites.website_name as course_name
+    , websites.website_live_url as course_live_url
+    , websites.website_uuid as course_uuid
+    , websitecontents.websitecontent_type as content_type
+    , websitecontents.websitecontent_text_id as page_uuid
+    , websitecontents.websitecontent_title as page_title
+    , websitecontents.websitecontent_filename as page_filename
+    , websitecontents.websitecontent_dirpath as page_dirpath
+    , websitecontents.websitecontent_parent_id as page_parent_id
+    , websitecontents.websitecontent_is_page as page_is_page_content
+    , websitecontents.metadata_draft as page_draft
+    , websitecontents.websitecontent_markdown as page_body
+    , websitecontents.metadata_description as page_description
+    , websitecontents.metadata_legacy_type as page_legacy_type
+    , websitecontents.learning_resource_types
+    , websitecontents.websitecontent_metadata as metadata --noqa: disable=RF04
+    , websites.website_title
+    , coalesce(sitemetadata.sitemetadata_primary_course_number, websites.primary_course_number) as course_number
+    , coalesce(sitemetadata.sitemetadata_course_term, websites.metadata_course_term) as course_term
+    , coalesce(sitemetadata.sitemetadata_course_title, websites.metadata_course_title) as course_title
+    , coalesce(sitemetadata.sitemetadata_course_year, websites.metadata_course_year) as course_year
+    , websitecontents.websitecontent_created_on as page_created_on
+    , websitecontents.websitecontent_updated_on as page_updated_on
+    , websites.website_live_url || '/pages/' || websitecontents.websitecontent_filename as page_live_url
+    , 'https://ocw-studio.odl.mit.edu/sites/'
+    || websites.website_name
+    || '/type/'
+    || websitecontents.websitecontent_type
+    || '/edit/'
+    || websitecontents.websitecontent_text_id
+    || '/' as studio_url
+from websites
+inner join websitecontents
+    on websites.website_uuid = websitecontents.website_uuid
+left join sitemetadata
+    on websites.website_uuid = sitemetadata.website_uuid
+inner join websitestarters
+    on websites.websitestarter_id = websitestarters.websitestarter_id
+where
+    websitecontents.websitecontent_type = 'page'
+    and websitestarters.websitestarter_name = 'ocw-course'

--- a/src/ol_dbt/models/staging/ocw/_stg_ocw__models.yml
+++ b/src/ol_dbt/models/staging/ocw/_stg_ocw__models.yml
@@ -138,6 +138,9 @@ models:
     - not_null
   - name: websitecontent_file
     description: str, url path for the page content.
+  - name: websitecontent_markdown
+    description: str, the markdown body content of the page (stored separately from
+      metadata; populated for page and other markdown-based content types)
   - name: websitecontent_parent_id
     description: int, foreign key to websites_websitecontent, indicating the parent
       of this content

--- a/src/ol_dbt/models/staging/ocw/stg__ocw__studio__postgres__websites_websitecontent.sql
+++ b/src/ol_dbt/models/staging/ocw/stg__ocw__studio__postgres__websites_websitecontent.sql
@@ -16,6 +16,7 @@ with source as (
         , filename as websitecontent_filename
         , dirpath as websitecontent_dirpath
         , file as websitecontent_file
+        , markdown as websitecontent_markdown
         , parent_id as websitecontent_parent_id
         , owner_id as websitecontent_owner_user_id
         , updated_by_id as websitecontent_updated_by_user_id


### PR DESCRIPTION
### What are the relevant tickets?
Related to https://github.com/mitodl/hq/issues/10401.

### Description (What does it do?)
This PR adds an OCW pages report, in addition to the existing OCW resources report.

### How can this be tested?

Run the following commands; the tests should all pass
```
dbt build --select staging.ocw  --vars 'schema_suffix: <your name>' --target dev_production
dbt build --select intermediate.ocw --vars 'schema_suffix: <your name>' --target dev_production
```

Run the following query in https://mitol.galaxy.starburst.io/query-editor to see the pages data:
```
SELECT * FROM ol_data_lake_production.ol_warehouse_production_<your name>_intermediate.int__ocw__pages
```