### PR TITLE
feat: add migration model for edX.org to MITx Online program certificates

### DIFF
--- a/src/ol_dbt/models/migration/_migration__models.yml
+++ b/src/ol_dbt/models/migration/_migration__models.yml
@@ -136,9 +136,13 @@ models:
   - name: program_readable_id
     data_type: varchar
     description: readable ID of the program on MITx Online.
-  - name: program_certificate_awarded_on
+  - name: program_certificate_issued_on
     data_type: timestamp
     description: date and time when the program certificate was awarded on edX.org.
+  - name: certificate_page_revision_id
+    data_type: integer
+    description: the live wagtail page revision ID for the program certificate page
+      on MITx Online, used when creating the migrated certificate.
   tests:
   - dbt_expectations.expect_compound_columns_to_be_unique:
       arguments:

--- a/src/ol_dbt/models/migration/_migration__models.yml
+++ b/src/ol_dbt/models/migration/_migration__models.yml
@@ -107,6 +107,43 @@ models:
   - name: user_country
     description: string, user address country
 
+- name: edxorg_to_mitxonline_program_certificates
+  description: edX.org MITx program certificates not yet migrated to MITx Online
+  columns:
+  - name: user_edxorg_id
+    data_type: integer
+    description: user ID on the edX.org platform.
+  - name: user_mitxonline_id
+    data_type: integer
+    description: user ID on the MITx Online platform, if the user has a MITx Online
+      account.
+  - name: user_email
+    data_type: varchar
+    description: user email, preferring the MITx Online email when available, otherwise
+      the edX.org email.
+  - name: program_title
+    data_type: varchar
+    description: title of the program for which the certificate was awarded on edX.org.
+    tests:
+    - not_null
+  - name: program_type
+    data_type: varchar
+    description: type of program (e.g. MicroMasters).
+  - name: program_id
+    data_type: integer
+    description: program ID on MITx Online, populated when the program title matches
+      an existing MITx Online program.
+  - name: program_readable_id
+    data_type: varchar
+    description: readable ID of the program on MITx Online.
+  - name: program_certificate_awarded_on
+    data_type: timestamp
+    description: date and time when the program certificate was awarded on edX.org.
+  tests:
+  - dbt_expectations.expect_compound_columns_to_be_unique:
+      arguments:
+        column_list: ["user_email", "program_title"]
+
 - name: edxorg_to_mitxonline_program_entitlements
   description: Program entitlements to program orders to be migrated to MITx Online
   columns:

--- a/src/ol_dbt/models/migration/edxorg_to_mitxonline_program_certificates.sql
+++ b/src/ol_dbt/models/migration/edxorg_to_mitxonline_program_certificates.sql
@@ -1,13 +1,24 @@
-with edxorg_program_certificates as (
+with edxorg_program_certificates_raw as (
+    select
+        *
+        , case
+            when program_title = 'MIT Finance' then 'Finance'
+            when program_title = 'Supply Chain Management' then 'MITx MicroMasters® Program in Supply Chain Management'
+            else program_title
+        end as normalized_program_title
+    from {{ ref('int__edxorg__mitx_program_certificates') }}
+    where user_username not like 'retired__user%'
+)
+
+, edxorg_program_certificates as (
     select * from (
         select
             *
             , row_number() over (
-                partition by user_id, program_title
+                partition by user_id, normalized_program_title
                 order by program_certificate_awarded_on
             ) as row_num
-        from {{ ref('int__edxorg__mitx_program_certificates') }}
-        where user_username not like 'retired__user%'
+        from edxorg_program_certificates_raw
     )
     where row_num = 1
 )
@@ -43,7 +54,7 @@ with edxorg_program_certificates as (
 , mitxonline_program_certificate_page as (
     select
         program_pages.program_id
-        , certificate_page.wagtail_page_live_pagerevision_id as certificate_page_revision_id
+        , min(certificate_page.wagtail_page_live_pagerevision_id) as certificate_page_revision_id
     from program_pages
     join wagtail_page
         on program_pages.wagtail_page_id = wagtail_page.wagtail_page_id
@@ -51,6 +62,7 @@ with edxorg_program_certificates as (
         on certificate_page.wagtail_page_path like wagtail_page.wagtail_page_path || '%'
         and certificate_page.wagtail_page_path <> wagtail_page.wagtail_page_path
         and certificate_page.wagtail_page_slug like 'certificate%'
+    group by program_pages.program_id
 )
 
 select
@@ -69,7 +81,7 @@ select
     , mitxonline_program_certificate_page.certificate_page_revision_id
 from edxorg_program_certificates
 left join mitxonline_programs
-    on lower(mitxonline_programs.program_title) = lower(edxorg_program_certificates.program_title)
+    on lower(mitxonline_programs.program_title) = lower(edxorg_program_certificates.normalized_program_title)
 left join mitx__users
     on edxorg_program_certificates.user_id = mitx__users.user_edxorg_id
 left join mitx__users as mitx_users_by_email

--- a/src/ol_dbt/models/migration/edxorg_to_mitxonline_program_certificates.sql
+++ b/src/ol_dbt/models/migration/edxorg_to_mitxonline_program_certificates.sql
@@ -32,15 +32,41 @@ with edxorg_program_certificates as (
     from {{ ref('int__mitxonline__program_certificates') }}
 )
 
+, program_pages as (
+    select * from {{ ref('stg__mitxonline__app__postgres__cms_programpage') }}
+)
+
+, wagtail_page as (
+    select * from {{ ref('stg__mitxonline__app__postgres__cms_wagtail_page') }}
+)
+
+, mitxonline_program_certificate_page as (
+    select
+        program_pages.program_id
+        , certificate_page.wagtail_page_live_pagerevision_id as certificate_page_revision_id
+    from program_pages
+    join wagtail_page
+        on program_pages.wagtail_page_id = wagtail_page.wagtail_page_id
+    join wagtail_page as certificate_page
+        on certificate_page.wagtail_page_path like wagtail_page.wagtail_page_path || '%'
+        and certificate_page.wagtail_page_path <> wagtail_page.wagtail_page_path
+        and certificate_page.wagtail_page_slug like 'certificate%'
+)
+
 select
     edxorg_program_certificates.user_id as user_edxorg_id
     , coalesce(mitx_users_by_email.user_mitxonline_id, mitx__users.user_mitxonline_id) as user_mitxonline_id
-    , coalesce(mitx__users.user_mitxonline_email, mitx__users.user_edxorg_email) as user_email
+    , coalesce(
+        mitx_users_by_email.user_mitxonline_email
+        , mitx__users.user_mitxonline_email
+        , mitx__users.user_edxorg_email
+    ) as user_email
     , edxorg_program_certificates.program_title
     , edxorg_program_certificates.program_type
     , mitxonline_programs.program_id
     , mitxonline_programs.program_readable_id
     , edxorg_program_certificates.program_certificate_awarded_on as program_certificate_issued_on
+    , mitxonline_program_certificate_page.certificate_page_revision_id
 from edxorg_program_certificates
 left join mitxonline_programs
     on lower(mitxonline_programs.program_title) = lower(edxorg_program_certificates.program_title)
@@ -53,8 +79,12 @@ left join mitxonline_program_certificates
         = mitxonline_program_certificates.user_id
     and mitxonline_programs.program_id = mitxonline_program_certificates.program_id
 left join mitxonline_program_certificates as mitxonline_program_certificates_by_email
-    on lower(mitx__users.user_mitxonline_email) = lower(mitxonline_program_certificates_by_email.user_email)
+    on lower(
+        coalesce(mitx_users_by_email.user_mitxonline_email, mitx__users.user_mitxonline_email)
+    ) = lower(mitxonline_program_certificates_by_email.user_email)
     and mitxonline_programs.program_id = mitxonline_program_certificates_by_email.program_id
+left join mitxonline_program_certificate_page
+    on mitxonline_programs.program_id = mitxonline_program_certificate_page.program_id
 where
     --- Exclude certificates already present on MITx Online (matched by user ID or email)
     mitxonline_program_certificates.user_id is null

--- a/src/ol_dbt/models/migration/edxorg_to_mitxonline_program_certificates.sql
+++ b/src/ol_dbt/models/migration/edxorg_to_mitxonline_program_certificates.sql
@@ -1,0 +1,58 @@
+with edxorg_program_certificates as (
+    select * from (
+        select
+            *
+            , row_number() over (
+                partition by user_id, program_title
+                order by program_certificate_awarded_on
+            ) as row_num
+        from {{ ref('int__edxorg__mitx_program_certificates') }}
+        where user_username not like 'retired__user%'
+    )
+    where row_num = 1
+)
+
+, mitxonline_programs as (
+    select
+        program_id
+        , program_title
+        , program_readable_id
+    from {{ ref('int__mitxonline__programs') }}
+)
+
+, mitx__users as (
+    select * from {{ ref('int__mitx__users') }}
+)
+
+, mitxonline_program_certificates as (
+    select
+        user_id
+        , program_id
+        , user_email
+    from {{ ref('int__mitxonline__program_certificates') }}
+)
+
+select
+    edxorg_program_certificates.user_id as user_edxorg_id
+    , mitx__users.user_mitxonline_id
+    , coalesce(mitx__users.user_mitxonline_email, mitx__users.user_edxorg_email) as user_email
+    , edxorg_program_certificates.program_title
+    , edxorg_program_certificates.program_type
+    , mitxonline_programs.program_id
+    , mitxonline_programs.program_readable_id
+    , edxorg_program_certificates.program_certificate_awarded_on as program_certificate_issued_on
+from edxorg_program_certificates
+left join mitxonline_programs
+    on lower(mitxonline_programs.program_title) = lower(edxorg_program_certificates.program_title)
+left join mitx__users
+    on edxorg_program_certificates.user_id = mitx__users.user_edxorg_id
+left join mitxonline_program_certificates
+    on mitx__users.user_mitxonline_id = mitxonline_program_certificates.user_id
+    and mitxonline_programs.program_id = mitxonline_program_certificates.program_id
+left join mitxonline_program_certificates as mitxonline_program_certificates_by_email
+    on lower(mitx__users.user_mitxonline_email) = lower(mitxonline_program_certificates_by_email.user_email)
+    and mitxonline_programs.program_id = mitxonline_program_certificates_by_email.program_id
+where
+    --- Exclude certificates already present on MITx Online (matched by user ID or email)
+    mitxonline_program_certificates.user_id is null
+    and mitxonline_program_certificates_by_email.user_email is null

--- a/src/ol_dbt/models/migration/edxorg_to_mitxonline_program_certificates.sql
+++ b/src/ol_dbt/models/migration/edxorg_to_mitxonline_program_certificates.sql
@@ -34,7 +34,7 @@ with edxorg_program_certificates as (
 
 select
     edxorg_program_certificates.user_id as user_edxorg_id
-    , mitx__users.user_mitxonline_id
+    , coalesce(mitx_users_by_email.user_mitxonline_id, mitx__users.user_mitxonline_id) as user_mitxonline_id
     , coalesce(mitx__users.user_mitxonline_email, mitx__users.user_edxorg_email) as user_email
     , edxorg_program_certificates.program_title
     , edxorg_program_certificates.program_type
@@ -46,8 +46,11 @@ left join mitxonline_programs
     on lower(mitxonline_programs.program_title) = lower(edxorg_program_certificates.program_title)
 left join mitx__users
     on edxorg_program_certificates.user_id = mitx__users.user_edxorg_id
+left join mitx__users as mitx_users_by_email
+    on lower(mitx__users.user_edxorg_email) = lower(mitx_users_by_email.user_mitxonline_email)
 left join mitxonline_program_certificates
-    on mitx__users.user_mitxonline_id = mitxonline_program_certificates.user_id
+    on coalesce(mitx_users_by_email.user_mitxonline_id, mitx__users.user_mitxonline_id)
+        = mitxonline_program_certificates.user_id
     and mitxonline_programs.program_id = mitxonline_program_certificates.program_id
 left join mitxonline_program_certificates as mitxonline_program_certificates_by_email
     on lower(mitx__users.user_mitxonline_email) = lower(mitxonline_program_certificates_by_email.user_email)


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
https://github.com/mitodl/hq/issues/11115

### Description (What does it do?)
<!--- Describe your changes in detail -->
Creates a dbt model edxorg_to_mitxonline_program_certificates to migrate edx program certificate to mitxonline

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

dbt build --select edxorg_to_mitxonline_program_certificates

### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->


<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
