### PR TITLE
feat: upload dbt artifacts to S3 after each run for OpenMetadata ingestion

### DIFF
--- a/dg_projects/lakehouse/lakehouse/assets/lakehouse/dbt.py
+++ b/dg_projects/lakehouse/lakehouse/assets/lakehouse/dbt.py
@@ -14,6 +14,8 @@ from dagster_dbt import (
 from ol_orchestrate.lib.automation_policies import upstream_or_code_changes
 from ol_orchestrate.lib.constants import DAGSTER_ENV
 
+from lakehouse.resources.dbt_s3_artifacts import DbtS3ArtifactsResource
+
 DBT_REPO_DIR = (
     Path(__file__).parents[5].joinpath("src/ol_dbt")
     if DAGSTER_ENV == "dev"
@@ -48,15 +50,39 @@ class DbtAutomationTranslator(DagsterDbtTranslator):
         settings=DagsterDbtTranslatorSettings(enable_code_references=True)
     ),
 )
-def full_dbt_project(context: AssetExecutionContext, dbt: DbtCliResource):
+def full_dbt_project(
+    context: AssetExecutionContext,
+    dbt: DbtCliResource,
+    dbt_s3_artifacts: DbtS3ArtifactsResource,
+):
     dbt_build_args = ["build"]
     if DAGSTER_ENV == "dev":
         schema_suffix = os.getenv("DBT_SCHEMA_SUFFIX", "dev")
         dbt_build_args += ["--vars", f"schema_suffix: {schema_suffix}"]
 
-    yield from (
-        dbt.cli(dbt_build_args, context=context)
-        .stream()
-        .fetch_column_metadata()
-        .fetch_row_counts()
-    )
+    build_invocation = dbt.cli(dbt_build_args, context=context)
+    yield from (build_invocation.stream().fetch_column_metadata().fetch_row_counts())
+
+    if DAGSTER_ENV != "dev" and dbt_s3_artifacts.s3_bucket:
+        # Run docs generate without context so it covers the full project (not just
+        # the subset being materialized) and doesn't emit redundant Dagster events.
+        # Re-use the build's target_path so all three artifacts land together.
+        docs_invocation = dbt.cli(
+            ["docs", "generate"],
+            target_path=build_invocation.target_path,
+            raise_on_error=False,
+        )
+        docs_invocation.wait()
+
+        artifacts = ["manifest.json", "run_results.json"]
+        if (build_invocation.target_path / "catalog.json").exists():
+            artifacts.append("catalog.json")
+        else:
+            context.log.warning(
+                "dbt docs generate did not produce catalog.json; "
+                "it will be omitted from the OpenMetadata artifact upload"
+            )
+
+        dbt_s3_artifacts.upload_artifacts(
+            build_invocation.target_path, artifacts, context
+        )

--- a/dg_projects/lakehouse/lakehouse/assets/lakehouse/dbt.py
+++ b/dg_projects/lakehouse/lakehouse/assets/lakehouse/dbt.py
@@ -63,26 +63,36 @@ def full_dbt_project(
     build_invocation = dbt.cli(dbt_build_args, context=context)
     yield from (build_invocation.stream().fetch_column_metadata().fetch_row_counts())
 
-    if DAGSTER_ENV != "dev" and dbt_s3_artifacts.s3_bucket:
-        # Run docs generate without context so it covers the full project (not just
-        # the subset being materialized) and doesn't emit redundant Dagster events.
-        # Re-use the build's target_path so all three artifacts land together.
-        docs_invocation = dbt.cli(
-            ["docs", "generate"],
-            target_path=build_invocation.target_path,
-            raise_on_error=False,
-        )
-        docs_invocation.wait()
-
-        artifacts = ["manifest.json", "run_results.json"]
-        if (build_invocation.target_path / "catalog.json").exists():
-            artifacts.append("catalog.json")
-        else:
+    if DAGSTER_ENV != "dev":
+        if not dbt_s3_artifacts.s3_bucket:
             context.log.warning(
-                "dbt docs generate did not produce catalog.json; "
-                "it will be omitted from the OpenMetadata artifact upload"
+                "DBT_ARTIFACTS_S3_BUCKET is not configured; dbt artifacts will not "
+                "be uploaded to S3 for OpenMetadata ingestion."
             )
+        else:
+            # Run docs generate without context so it covers the full project and
+            # doesn't emit redundant Dagster events. Re-use the build's target_path
+            # so all artifacts land in the same directory.
+            # run_results.json is uploaded to a per-run versioned key so results
+            # from every incremental and full run are captured. manifest.json and
+            # catalog.json are deduplicated by content hash and only uploaded when
+            # their content has changed.
+            docs_invocation = dbt.cli(
+                ["docs", "generate"],
+                target_path=build_invocation.target_path,
+                raise_on_error=False,
+            )
+            docs_invocation.wait()
 
-        dbt_s3_artifacts.upload_artifacts(
-            build_invocation.target_path, artifacts, context
-        )
+            artifacts = ["manifest.json", "run_results.json"]
+            if (build_invocation.target_path / "catalog.json").exists():
+                artifacts.append("catalog.json")
+            else:
+                context.log.warning(
+                    "dbt docs generate did not produce catalog.json; "
+                    "it will be omitted from the OpenMetadata artifact upload"
+                )
+
+            dbt_s3_artifacts.upload_artifacts(
+                build_invocation.target_path, artifacts, context
+            )

--- a/dg_projects/lakehouse/lakehouse/definitions.py
+++ b/dg_projects/lakehouse/lakehouse/definitions.py
@@ -35,6 +35,7 @@ from lakehouse.assets.instructor_onboarding import (
 from lakehouse.assets.lakehouse.dbt import DBT_REPO_DIR, full_dbt_project
 from lakehouse.assets.superset import create_superset_asset
 from lakehouse.resources.airbyte import AirbyteOSSWorkspace
+from lakehouse.resources.dbt_s3_artifacts import DbtS3ArtifactsResource
 from lakehouse.resources.superset_api import SupersetApiClientFactory
 
 airbyte_host_map = {
@@ -302,6 +303,12 @@ instructor_onboarding_schedule = ScheduleDefinition(
 # Build resources dict, conditionally including airbyte
 resources_dict = {
     "dbt": dbt_cli,
+    "dbt_s3_artifacts": DbtS3ArtifactsResource(
+        s3_bucket=os.environ.get("DBT_ARTIFACTS_S3_BUCKET", ""),
+        s3_prefix=os.environ.get(
+            "DBT_ARTIFACTS_S3_PREFIX", "openmetadata/dbt-artifacts"
+        ),
+    ),
     "vault": vault,
     "superset_api": SupersetApiClientFactory(deployment="superset", vault=vault),
     "github_api": GithubApiClientFactory(vault=vault),

--- a/dg_projects/lakehouse/lakehouse/resources/dbt_s3_artifacts.py
+++ b/dg_projects/lakehouse/lakehouse/resources/dbt_s3_artifacts.py
@@ -1,6 +1,8 @@
+import hashlib
 from pathlib import Path
 
 import boto3
+from botocore.exceptions import ClientError
 from dagster import AssetExecutionContext, ConfigurableResource
 from pydantic import Field, field_validator
 
@@ -29,10 +31,18 @@ class DbtS3ArtifactsResource(ConfigurableResource):
         artifacts: list[str],
         context: AssetExecutionContext,
     ) -> None:
-        """Upload named artifact files from *target_path* to S3.
+        """Upload artifact files from *target_path* to S3 with content-based versioning.
 
-        Raises FileNotFoundError if any requested artifact is absent so that
-        callers get a hard failure rather than silently stale metadata in S3.
+        - ``run_results.json`` is stored at a per-run versioned key
+          (``<prefix>/runs/<run_id>/run_results.json``) so every incremental and
+          full run is captured without overwriting prior results.
+
+        - Other artifacts (``manifest.json``, ``catalog.json``) are uploaded only
+          when their content has changed. S3's ETag equals the hex MD5 of the body
+          for single-part objects (all small JSON files), so a ``HeadObject`` ETag
+          comparison is sufficient to skip redundant writes.
+
+        Raises ``FileNotFoundError`` if any requested artifact is absent.
         """
         s3 = boto3.client("s3")
         for artifact in artifacts:
@@ -40,6 +50,40 @@ class DbtS3ArtifactsResource(ConfigurableResource):
             if not local_path.exists():
                 msg = f"dbt artifact not found at {local_path}"
                 raise FileNotFoundError(msg)
-            key = f"{self.s3_prefix}/{artifact}"
-            context.log.info(f"Uploading {artifact} to s3://{self.s3_bucket}/{key}")  # noqa: G004
-            s3.upload_file(str(local_path), self.s3_bucket, key)
+
+            content = local_path.read_bytes()
+
+            if artifact == "run_results.json":
+                # Each run's results are stored at a unique key so that results
+                # from incremental subset runs are all captured and never
+                # overwrite each other.
+                key = f"{self.s3_prefix}/runs/{context.run_id}/{artifact}"
+                context.log.info(
+                    "Uploading %s to s3://%s/%s", artifact, self.s3_bucket, key
+                )
+                s3.put_object(Body=content, Bucket=self.s3_bucket, Key=key)
+            else:
+                # Skip upload when the object content is unchanged.  For
+                # single-part uploads (all files here are small JSON), S3's ETag
+                # equals the hex-encoded MD5 of the body.
+                key = f"{self.s3_prefix}/{artifact}"
+                content_md5 = hashlib.md5(content).hexdigest()  # noqa: S324
+                try:
+                    head = s3.head_object(Bucket=self.s3_bucket, Key=key)
+                    if head["ETag"].strip('"') == content_md5:
+                        context.log.info(
+                            "%s is unchanged (md5=%s), skipping upload",
+                            artifact,
+                            content_md5,
+                        )
+                        continue
+                except ClientError:
+                    pass  # Object does not yet exist; proceed with upload.
+                context.log.info(
+                    "Uploading %s (md5=%s) to s3://%s/%s",
+                    artifact,
+                    content_md5,
+                    self.s3_bucket,
+                    key,
+                )
+                s3.put_object(Body=content, Bucket=self.s3_bucket, Key=key)

--- a/dg_projects/lakehouse/lakehouse/resources/dbt_s3_artifacts.py
+++ b/dg_projects/lakehouse/lakehouse/resources/dbt_s3_artifacts.py
@@ -2,7 +2,7 @@ from pathlib import Path
 
 import boto3
 from dagster import AssetExecutionContext, ConfigurableResource
-from pydantic import Field
+from pydantic import Field, field_validator
 
 
 class DbtS3ArtifactsResource(ConfigurableResource):
@@ -11,8 +11,17 @@ class DbtS3ArtifactsResource(ConfigurableResource):
     s3_bucket: str = Field(description="S3 bucket to upload dbt artifacts into.")
     s3_prefix: str = Field(
         default="openmetadata/dbt-artifacts",
-        description="Key prefix under which artifacts are stored in the bucket.",
+        description=(
+            "Key prefix under which artifacts are stored in the bucket. "
+            "Trailing slashes are stripped automatically."
+        ),
     )
+
+    @field_validator("s3_prefix")
+    @classmethod
+    def strip_trailing_slash(cls, v: str) -> str:
+        """Normalize prefix so keys are always constructed as prefix/filename."""
+        return v.rstrip("/")
 
     def upload_artifacts(
         self,

--- a/dg_projects/lakehouse/lakehouse/resources/dbt_s3_artifacts.py
+++ b/dg_projects/lakehouse/lakehouse/resources/dbt_s3_artifacts.py
@@ -1,0 +1,36 @@
+from pathlib import Path
+
+import boto3
+from dagster import AssetExecutionContext, ConfigurableResource
+from pydantic import Field
+
+
+class DbtS3ArtifactsResource(ConfigurableResource):
+    """Uploads dbt build artifacts to S3 for consumption by OpenMetadata OMJobs."""
+
+    s3_bucket: str = Field(description="S3 bucket to upload dbt artifacts into.")
+    s3_prefix: str = Field(
+        default="openmetadata/dbt-artifacts",
+        description="Key prefix under which artifacts are stored in the bucket.",
+    )
+
+    def upload_artifacts(
+        self,
+        target_path: Path,
+        artifacts: list[str],
+        context: AssetExecutionContext,
+    ) -> None:
+        """Upload named artifact files from *target_path* to S3.
+
+        Raises FileNotFoundError if any requested artifact is absent so that
+        callers get a hard failure rather than silently stale metadata in S3.
+        """
+        s3 = boto3.client("s3")
+        for artifact in artifacts:
+            local_path = target_path / artifact
+            if not local_path.exists():
+                msg = f"dbt artifact not found at {local_path}"
+                raise FileNotFoundError(msg)
+            key = f"{self.s3_prefix}/{artifact}"
+            context.log.info(f"Uploading {artifact} to s3://{self.s3_bucket}/{key}")  # noqa: G004
+            s3.upload_file(str(local_path), self.s3_bucket, key)


### PR DESCRIPTION
### What are the relevant tickets?
Part of https://github.com/mitodl/ol-data-platform/issues/1355

### Description (What does it do?)
Enables OpenMetadata OMJobs to ingest dbt metadata by uploading the three required artifact files (`manifest.json`, `run_results.json`, `catalog.json`) to S3 after every `full_dbt_project` Dagster run.

**New: `lakehouse/resources/dbt_s3_artifacts.py`**

`DbtS3ArtifactsResource` — a `ConfigurableResource` that uploads named artifact files from a local dbt target directory to S3. Configured by two environment variables:

- `DBT_ARTIFACTS_S3_BUCKET` — destination bucket (required in non-dev envs)
- `DBT_ARTIFACTS_S3_PREFIX` — key prefix, defaults to `openmetadata/dbt-artifacts`

**Modified: `lakehouse/assets/lakehouse/dbt.py`**

After `dbt build` completes, the asset now runs `dbt docs generate` to produce `catalog.json` and uploads all three artifacts to S3. The block is gated on `DAGSTER_ENV != "dev"` and a non-empty bucket, so local development is unaffected.

**Modified: `lakehouse/definitions.py`**

Wires `DbtS3ArtifactsResource` into `resources_dict`.

**Design notes**

- `dbt docs generate` runs without `context=context` because passing context injects `--select` filters that `docs generate` does not support.
- Catalog generation failure is non-fatal (`raise_on_error=False`); a warning is logged and the other two artifacts still upload.
- `manifest.json` is always the full project manifest regardless of which asset subset ran — safe to upload from any run.

### How can this be tested?
Verify that a dbt build produces S3 files.

### Checklist:
- [ ] Set the environment variables in the dagster deployment via ol-infrastructure