### PR TITLE
feat: add edX programs to dim_program

### DIFF
--- a/src/ol_dbt/models/dimensional/_dim_program.yml
+++ b/src/ol_dbt/models/dimensional/_dim_program.yml
@@ -22,7 +22,8 @@ models:
     description: >
       Program ID from the source system. This is used as a join key when linking
       platform-specific fact tables (e.g., tfact_enrollment) to this dimension.
-      May be an integer (MITx Online, xPro, MicroMasters) or a UUID string (edX.org).
+      May be a stringified integer(MITx Online, xPro, MicroMasters) or a UUID string
+      (edX.org).
       Not the same as program_readable_id which is the business-facing identifier.
     tests:
     - not_null

--- a/src/ol_dbt/models/dimensional/_dim_program.yml
+++ b/src/ol_dbt/models/dimensional/_dim_program.yml
@@ -20,15 +20,15 @@ models:
     - not_null
   - name: source_id
     description: >
-      Program ID from the source system (integer). This is used as a join key when
-      linking platform-specific fact tables (e.g., tfact_enrollment) to this dimension.
+      Program ID from the source system. This is used as a join key when linking
+      platform-specific fact tables (e.g., tfact_enrollment) to this dimension.
+      May be an integer (MITx Online, xPro, MicroMasters) or a UUID string (edX.org).
       Not the same as program_readable_id which is the business-facing identifier.
     tests:
     - not_null
   - name: program_readable_id
-    description: Business key - readable program identifier
-    tests:
-    - not_null
+    description: Business key - readable program identifier. Null for edX.org programs
+      which do not have a consistent program identifier across sources.
   - name: program_name
     description: Program name
   - name: program_title
@@ -36,10 +36,8 @@ models:
     tests:
     - not_null
   - name: program_type
-    description: Type of program (MicroMasters, Professional, etc.)
-    tests:
-    - accepted_values:
-        values: ['MicroMasters', 'Series', 'Professional', 'Certificate']
+    description: Type of program (MicroMasters, Professional, Series, Universal AI,
+      etc.)
   - name: program_track
     description: Specific track within program
   - name: program_certification_type

--- a/src/ol_dbt/models/dimensional/bridge_program_course.sql
+++ b/src/ol_dbt/models/dimensional/bridge_program_course.sql
@@ -80,7 +80,7 @@ with micromasters_course_keys as (
         , combined_requirements.course_order
     from combined_requirements
     left join dim_program
-        on combined_requirements.program_id = dim_program.source_id
+        on cast(combined_requirements.program_id as varchar) = dim_program.source_id
         and combined_requirements.platform_code = dim_program.platform_code
     left join dim_course
         on (

--- a/src/ol_dbt/models/dimensional/dim_product.sql
+++ b/src/ol_dbt/models/dimensional/dim_product.sql
@@ -83,7 +83,7 @@ with mitxonline_products as (
         on combined_products.courserun_id = dim_course_run.source_id
         and combined_products.platform = dim_course_run.platform
     left join dim_program
-        on combined_products.program_id = dim_program.source_id
+        on cast(combined_products.program_id as varchar) = dim_program.source_id
         and combined_products.platform_code = dim_program.platform_code
     left join dim_platform_lookup
         on combined_products.platform = dim_platform_lookup.platform_readable_id

--- a/src/ol_dbt/models/dimensional/dim_program.sql
+++ b/src/ol_dbt/models/dimensional/dim_program.sql
@@ -3,7 +3,7 @@
 with
     mitxonline_programs as (
         select
-            program_id as source_id,
+            cast(program_id as varchar) as source_id,
             program_readable_id,
             program_name,
             program_title,
@@ -32,7 +32,7 @@ with
     ),
     mitxpro_programs as (
         select
-            program_id as source_id,
+            cast(program_id as varchar) as source_id,
             program_readable_id,
             program_title as program_name,
             program_title,
@@ -58,9 +58,38 @@ with
             cast(null as varchar) as enrollment_end_date
         from {{ ref("int__mitxpro__programs") }}
     ),
+    edxorg_programs as (
+        select
+            program_uuid as source_id,
+            cast(null as varchar) as program_readable_id, -- edX.org doesn't have a readable ID
+            program_title as program_name,
+            program_title,
+            program_type,
+            cast(null as varchar) as program_track,
+            cast(null as varchar) as program_certification_type,
+            false as program_is_dedp,
+            false as program_is_micromasters,
+            cast(null as varchar) as program_availability,
+            cast(null as varchar) as program_price,
+            cast(null as varchar) as program_length,
+            cast(null as varchar) as program_effort,
+            program_subtitle as program_description,
+            cast(null as varchar) as program_what_you_learn,
+            cast(null as varchar) as program_prerequisites,
+            program_status = 'active' as is_active,
+            true as is_external,
+            cast(null as varchar) as partner_platform_name,
+            '{{ var("edxorg") }}' as platform_readable_id,
+            'edxorg' as platform_code,
+            cast(null as varchar) as first_published_date,
+            cast(null as varchar) as enrollment_start_date,
+            cast(null as varchar) as enrollment_end_date
+        from {{ ref("stg__edxorg__s3__programs") }}
+        where program_organization = 'MITx'
+    ),
     micromasters_programs as (
         select
-            program_id as source_id,
+            cast(program_id as varchar) as source_id,
             {{ generate_micromasters_program_readable_id('program_id', 'program_title') }} as program_readable_id,
             program_title as program_name,
             program_title,
@@ -92,6 +121,9 @@ with
         union all
         select *
         from mitxpro_programs
+        union all
+        select *
+        from edxorg_programs
         union all
         select *
         from micromasters_programs

--- a/src/ol_dbt/models/dimensional/tfact_enrollment.sql
+++ b/src/ol_dbt/models/dimensional/tfact_enrollment.sql
@@ -198,7 +198,7 @@ with mitxonline_enrollments as (
             or (combined_enrollments.platform in ('edxorg', 'residential') and combined_enrollments.courserun_readable_id = dim_course_run.courserun_readable_id and combined_enrollments.platform = dim_course_run.platform)
         )
     left join dim_program
-        on combined_enrollments.program_id = dim_program.source_id
+        on cast(combined_enrollments.program_id as varchar) = dim_program.source_id
         and combined_enrollments.platform_code = dim_program.platform_code
     left join micromasters_program_lookup
         on combined_enrollments.courserun_readable_id = micromasters_program_lookup.courserun_readable_id


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
https://github.com/mitodl/ol-data-platform/issues/2073

### Description (What does it do?)
<!--- Describe your changes in detail -->

This PR is to add the missing edX programs to dim_program

  dim_program.sql

   - Added edxorg_programs CTE sourcing from stg__edxorg__s3__programs
 
 _dim_program.yml

   - Updated source_id description — removed "(integer)", noted it can be integer or UUID string depending on platform
   - Updated program_readable_id description to note it's null for edX.org programs; removed not_null test
   - Updated program_type description and removed the accepted_values test as the list can grow



### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

dbt build --select dim_program bridge_program_course dim_product 
