### PR TITLE
fix: remove unique test from product_pk in dim_product

### DIFF
--- a/src/ol_dbt/models/dimensional/_dim_product.yml
+++ b/src/ol_dbt/models/dimensional/_dim_product.yml
@@ -17,7 +17,6 @@ models:
   - name: product_pk
     description: Surrogate key primary key
     tests:
-    - unique
     - not_null
   - name: source_product_id
     description: Product ID from source system

--- a/src/ol_dbt/models/dimensional/_dim_product.yml
+++ b/src/ol_dbt/models/dimensional/_dim_product.yml
@@ -15,7 +15,11 @@ models:
       where: "is_current = true"
   columns:
   - name: product_pk
-    description: Surrogate key primary key
+    description: >
+      Surrogate key for the product, stable across SCD Type 2 history rows for the
+      same source product and platform. This value is not unique across historical
+      versions; filter on is_current = true or include effective_date when looking
+      up a single row.
     tests:
     - not_null
   - name: source_product_id


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
https://github.com/mitodl/ol-data-platform/issues/2073

### Description (What does it do?)
<!--- Describe your changes in detail -->

dim_product — Fix incorrect SCD Type 2 test

   - _dim_product.yml: Removed the unique test on product_pk. dim_product is SCD Type 2 so product_pk repeats across history rows by design; data integrity is
  already enforced by the unique_combination_of_columns test on (source_product_id, platform, is_current) where is_current = true.


### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

`dbt test --select dim_product` now passes

### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->


<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
