### PR TITLE
fix: Prevent infinite loop in legacy edX course export op

### DIFF
--- a/dg_projects/legacy_openedx/legacy_openedx/ops/open_edx.py
+++ b/dg_projects/legacy_openedx/legacy_openedx/ops/open_edx.py
@@ -31,6 +31,8 @@ from pydantic import Field
 from pypika import MySQLQuery as Query
 from pypika import Table, Tables
 
+COURSE_EXPORT_TIMEOUT = timedelta(minutes=60)
+
 
 class ListCoursesConfig(Config):
     edx_course_api_page_size: int = Field(
@@ -577,22 +579,47 @@ def export_edx_courses(
     exported_courses = context.resources.openedx.export_courses(
         course_ids=edx_course_ids,
     )
+    failed_initial = exported_courses.get("failed_uploads", {})
+    if failed_initial:
+        context.log.warning(
+            "The following courses failed to queue for export and will be skipped: %s",
+            list(failed_initial.keys()),
+        )
     successful_exports: set[str] = set()
     failed_exports: set[str] = set()
     tasks = exported_courses["upload_task_ids"]
     context.log.info("Exporting %s tasks from Open edX", len(tasks))
     # Possible status values found here:
     # https://github.com/openedx/django-user-tasks/blob/master/user_tasks/models.py
+    start_time = datetime.now(tz=UTC)
     while len(successful_exports.union(failed_exports)) < len(tasks):
+        if datetime.now(tz=UTC) - start_time > COURSE_EXPORT_TIMEOUT:
+            timed_out = set(tasks.keys()) - successful_exports - failed_exports
+            context.log.error(
+                "Timed out waiting for course exports after %s. Unresolved courses: %s",
+                COURSE_EXPORT_TIMEOUT,
+                timed_out,
+            )
+            break
         time.sleep(timedelta(seconds=60).seconds)
         for course_id, task_id in tasks.items():
+            if course_id in successful_exports or course_id in failed_exports:
+                continue
             try:
                 task_status = context.resources.openedx.check_course_export_status(
                     course_id,
                     task_id,
                 )
-            except httpx.HTTPStatusError:
-                # Don't fail the whole job if one task status yields an error
+            except httpx.HTTPStatusError as e:
+                context.log.warning(
+                    "HTTP %s error checking export status for course %s "
+                    "(task %s), marking as failed: %s",
+                    e.response.status_code,
+                    course_id,
+                    task_id,
+                    e,
+                )
+                failed_exports.add(course_id)
                 continue
             if task_status["state"] == "Succeeded":
                 successful_exports.add(course_id)

--- a/packages/ol-orchestrate-lib/src/ol_orchestrate/resources/openedx.py
+++ b/packages/ol-orchestrate-lib/src/ol_orchestrate/resources/openedx.py
@@ -64,6 +64,13 @@ class OpenEdxApiClient(OAuthApiClient):
 
         :returns: A dictionary of course IDs and the S3 URL where it will be exported
                   to.
+
+        .. note::
+            The ol_openedx_course_export plugin returns HTTP 400 when some (but
+            not all) courses fail to queue. We intentionally allow 400 through so
+            that callers can still process the successfully-queued tasks from the
+            ``upload_task_ids`` field and inspect ``failed_uploads`` themselves.
+            Any other non-2xx status is still raised as an error.
         """
         request_url = f"{self.studio_url}/api/courses/v0/export/"
         response = self.http_client.post(
@@ -72,7 +79,10 @@ class OpenEdxApiClient(OAuthApiClient):
             headers={"Authorization": f"JWT {self._fetch_access_token()}"},
             timeout=60,
         )
-        response.raise_for_status()
+        # HTTP 400 is returned on partial failure (some courses failed to queue);
+        # allow the caller to handle failed_uploads gracefully.
+        if response.status_code != 400:  # noqa: PLR2004
+            response.raise_for_status()
         return response.json()
 
     def check_course_export_status(

--- a/src/ol_dbt/models/dimensional/_dim_contract.yml
+++ b/src/ol_dbt/models/dimensional/_dim_contract.yml
@@ -1,0 +1,48 @@
+---
+version: 2
+
+models:
+- name: dim_contract
+  description: >
+    MITx Online B2B contracts dimension. Each contract defines the terms under which
+    an organization gains access to one or more course runs. Grain: one row per contract.
+  columns:
+  - name: contract_pk
+    description: Surrogate primary key derived from b2b_contract_id.
+    tests:
+    - unique
+    - not_null
+  - name: contract_id
+    description: Source system contract ID (bigint).
+    tests:
+    - unique
+    - not_null
+  - name: organization_fk
+    description: Foreign key to dim_organization.organization_pk.
+    tests:
+    - not_null
+    - relationships:
+        to: ref('dim_organization')
+        field: organization_pk
+  - name: b2b_contract_name
+    description: Human-readable name of the contract.
+    tests:
+    - not_null
+  - name: b2b_contract_is_active
+    description: Whether the contract is marked active. Date rules still apply.
+  - name: b2b_contract_description
+    description: Long-form description of the contract terms.
+  - name: b2b_contract_start_date
+    description: Start date of the contract.
+  - name: b2b_contract_end_date
+    description: End date of the contract (null if open-ended).
+  - name: b2b_contract_max_learners
+    description: Maximum number of seats allowed under this contract. Zero or null
+      means unlimited.
+  - name: b2b_contract_integration_type
+    description: Integration type for the contract (e.g. SSO, Non-SSO).
+  - name: b2b_contract_enrollment_fixed_price
+    description: Fixed price per enrollment under this contract. Zero or null for
+      no fixed price.
+  - name: b2b_contract_membership_type
+    description: Membership management method for the contract (e.g. SSO, Non-SSO).

--- a/src/ol_dbt/models/dimensional/_dim_contract.yml
+++ b/src/ol_dbt/models/dimensional/_dim_contract.yml
@@ -20,7 +20,6 @@ models:
   - name: organization_fk
     description: Foreign key to dim_organization.organization_pk.
     tests:
-    - not_null
     - relationships:
         to: ref('dim_organization')
         field: organization_pk

--- a/src/ol_dbt/models/dimensional/_dim_organization.yml
+++ b/src/ol_dbt/models/dimensional/_dim_organization.yml
@@ -41,9 +41,9 @@ models:
 
 - name: bridge_organization_courserun
   description: >
-    Many-to-many bridge between B2B organizations and course runs.
+    Bridge between B2B organizations and course runs via contracts.
     Currently covers MITx Online organizations linked via B2B contracts.
-    Grain: one row per (organization, course_run, contract).
+    Grain: one row per (organization, contract, course_run).
   columns:
   - name: organization_fk
     description: Foreign key to dim_organization.organization_pk.
@@ -52,6 +52,13 @@ models:
     - relationships:
         to: ref('dim_organization')
         field: organization_pk
+  - name: contract_fk
+    description: Foreign key to dim_contract.contract_pk.
+    tests:
+    - not_null
+    - relationships:
+        to: ref('dim_contract')
+        field: contract_pk
   - name: courserun_fk
     description: Foreign key to dim_course_run.courserun_pk.
     tests:
@@ -59,12 +66,3 @@ models:
     - relationships:
         to: ref('dim_course_run')
         field: courserun_pk
-  - name: b2b_contract_name
-    description: Human-readable name of the B2B contract linking this organization
-      to the course run.
-  - name: b2b_contract_is_active
-    description: Whether the B2B contract is currently active.
-  - name: b2b_contract_start_date
-    description: Start date of the B2B contract.
-  - name: b2b_contract_end_date
-    description: End date of the B2B contract (null if open-ended).

--- a/src/ol_dbt/models/dimensional/_dim_organization.yml
+++ b/src/ol_dbt/models/dimensional/_dim_organization.yml
@@ -44,6 +44,12 @@ models:
     Bridge between B2B organizations and course runs via contracts.
     Currently covers MITx Online organizations linked via B2B contracts.
     Grain: one row per (organization, contract, course_run).
+  tests:
+  - dbt_utils.unique_combination_of_columns:
+      combination_of_columns:
+      - organization_fk
+      - contract_fk
+      - courserun_fk
   columns:
   - name: organization_fk
     description: Foreign key to dim_organization.organization_pk.

--- a/src/ol_dbt/models/dimensional/bridge_organization_courserun.sql
+++ b/src/ol_dbt/models/dimensional/bridge_organization_courserun.sql
@@ -2,25 +2,20 @@
     materialized='table'
 ) }}
 
--- Maps MITx Online B2B organizations to course runs via B2B contracts.
--- Grain: one row per (organization, course_run, contract).
+-- Maps MITx Online B2B organizations to course runs via contracts.
+-- Grain: one row per (organization, contract, course_run).
 -- Note: xPro B2B purchases are tracked via orders (see int__mitxpro__b2becommerce_b2border).
-with b2b_mappings as (
+with contracts_to_courseruns as (
     select
-        courserun_readable_id
-        , organization_key
-        , organization_name
-        , b2b_contract_name
-        , b2b_contract_is_active
-        , b2b_contract_start_date
-        , b2b_contract_end_date
-    from {{ ref('int__mitxonline__b2b_contract_to_courseruns') }}
+        b2b_contract_id as contract_id
+        , courserun_readable_id
+    from {{ ref('stg__mitxonline__app__postgres__courses_courserun') }}
+    where b2b_contract_id is not null
 )
 
-, dim_organization as (
-    select organization_pk, organization_key, platform
-    from {{ ref('dim_organization') }}
-    where platform = 'mitxonline'
+, dim_contract as (
+    select contract_pk, contract_id, organization_fk
+    from {{ ref('dim_contract') }}
 )
 
 , dim_course_run as (
@@ -31,16 +26,9 @@ with b2b_mappings as (
 )
 
 select
-    org.organization_pk as organization_fk
+    dc.organization_fk
+    , dc.contract_pk as contract_fk
     , cr.courserun_pk as courserun_fk
-    , b2b_mappings.b2b_contract_name
-    , b2b_mappings.b2b_contract_is_active
-    , b2b_mappings.b2b_contract_start_date
-    , b2b_mappings.b2b_contract_end_date
-from b2b_mappings
-left join dim_organization as org
-    on b2b_mappings.organization_key = org.organization_key
-left join dim_course_run as cr
-    on b2b_mappings.courserun_readable_id = cr.courserun_readable_id
-where org.organization_pk is not null
-    and cr.courserun_pk is not null
+from contracts_to_courseruns as ctc
+inner join dim_contract as dc on ctc.contract_id = dc.contract_id
+inner join dim_course_run as cr on ctc.courserun_readable_id = cr.courserun_readable_id

--- a/src/ol_dbt/models/dimensional/dim_contract.sql
+++ b/src/ol_dbt/models/dimensional/dim_contract.sql
@@ -1,0 +1,32 @@
+{{ config(
+    materialized='table'
+) }}
+
+-- MITx Online B2B contracts dimension.
+-- Grain: one row per contract.
+with contracts as (
+    select * from {{ ref('stg__mitxonline__app__postgres__b2b_contractpage') }}
+)
+
+, dim_organization as (
+    select organization_pk, organization_id
+    from {{ ref('dim_organization') }}
+    where platform = 'mitxonline'
+)
+
+select
+    {{ dbt_utils.generate_surrogate_key(['b2b_contract_id']) }} as contract_pk
+    , b2b_contract_id as contract_id
+    , b2b_contract_name
+    , b2b_contract_is_active
+    , b2b_contract_description
+    , b2b_contract_start_date
+    , b2b_contract_end_date
+    , b2b_contract_max_learners
+    , b2b_contract_integration_type
+    , b2b_contract_enrollment_fixed_price
+    , b2b_contract_membership_type
+    , org.organization_pk as organization_fk
+from contracts
+left join dim_organization as org
+    on cast(contracts.organization_id as varchar) = org.organization_id


### PR DESCRIPTION
### What are the relevant tickets?
Fixes https://github.com/mitodl/hq/issues/11104

### Description (What does it do?)
The `export_edx_courses` op in the legacy IRx pipeline (which populates `s3://mitx-etl-mitxonline-production/<date>/courses/`) had two bugs that caused the `courses/` folder to silently go missing since ~2026-01-21.

**Bug 1 — Infinite loop in the status-polling while loop (primary cause)**

When `check_course_export_status()` returned HTTP 404 (e.g. the `django-user-tasks` record was cleaned up after a retention window, or a course was deleted from Studio), the bare `continue` inside the `except httpx.HTTPStatusError` block swallowed the error without ever adding the course to `failed_exports`. The while-loop condition `len(successful ∪ failed) < len(tasks)` was therefore never satisfied, so the job hung indefinitely. The Dagster run would eventually be killed and the `courses/` folder was never written to S3.

Fix: catch `HTTPStatusError`, log the HTTP status code and course ID for observability, and add the course to `failed_exports` so the loop can make progress. A 60-minute hard timeout (matching the pattern in the newer asset-based `openedx` code location) is also added as a safety net, and already-resolved courses are skipped to avoid redundant API calls.

**Bug 2 — Premature abort on partial-failure from the export trigger API**

The `ol_openedx_course_export` plugin returns **HTTP 400** (not 200) when *any* course fails to queue during the initial trigger phase — even when other courses were queued successfully. The unconditional `raise_for_status()` in `OpenEdxApiClient.export_courses()` caused the method to raise immediately, aborting the entire op before any successfully-queued tarballs could be processed.

Fix: allow HTTP 400 through without raising; log the initially-failed courses as a warning via `failed_uploads` in the response body. All other non-2xx codes still raise as before.

### How can this be tested?
1. Run the `mitxonline_edx_course_pipeline` Dagster job in staging/QA.
2. Confirm the `courses/` sub-folder appears in the dated S3 prefix (e.g. `s3://mitx-etl-mitxonline-qa/<date>/courses/`) with the expected course tarballs.
3. To reproduce Bug 1 locally: mock `check_course_export_status` to always raise `httpx.HTTPStatusError` with a 404 response and verify the op now terminates (previously it would loop forever).
4. To reproduce Bug 2 locally: mock `export_courses` to return a 400 with a mix of `upload_task_ids` and `failed_uploads`, and verify the op continues to process the successful tasks instead of aborting.

### Additional Context
- The same timeout pattern (`COURSE_EXPORT_GET_TASKS_STATUS_TIMEOUT = timedelta(minutes=60)`) already exists in the newer asset-based `openedx` code location (`dg_projects/openedx/openedx/assets/openedx.py`); this PR aligns the legacy op with that approach.
- Once this is merged and deployed, historical data for dates since 2026-01-21 will need to be backfilled by manually triggering the pipeline with a `date_override` for each missing date.