### PR TITLE
fix: Prevent infinite loop in legacy edX course export op

### DIFF
--- a/dg_projects/legacy_openedx/legacy_openedx/ops/open_edx.py
+++ b/dg_projects/legacy_openedx/legacy_openedx/ops/open_edx.py
@@ -31,6 +31,8 @@ from pydantic import Field
 from pypika import MySQLQuery as Query
 from pypika import Table, Tables
 
+COURSE_EXPORT_TIMEOUT = timedelta(minutes=60)
+
 
 class ListCoursesConfig(Config):
     edx_course_api_page_size: int = Field(
@@ -568,7 +570,7 @@ def export_edx_forum_database(
         ),
     },
 )
-def export_edx_courses(
+def export_edx_courses(  # noqa: C901
     context: OpExecutionContext,
     edx_course_ids: list[str],
     daily_extracts_dir: str,
@@ -577,23 +579,48 @@ def export_edx_courses(
     exported_courses = context.resources.openedx.export_courses(
         course_ids=edx_course_ids,
     )
+    failed_initial = exported_courses.get("failed_uploads", {})
+    if failed_initial:
+        context.log.warning(
+            "The following courses failed to queue for export and will be skipped: %s",
+            list(failed_initial.keys()),
+        )
     successful_exports: set[str] = set()
     failed_exports: set[str] = set()
     tasks = exported_courses["upload_task_ids"]
     context.log.info("Exporting %s tasks from Open edX", len(tasks))
     # Possible status values found here:
     # https://github.com/openedx/django-user-tasks/blob/master/user_tasks/models.py
+    start_time = datetime.now(tz=UTC)
     while len(successful_exports.union(failed_exports)) < len(tasks):
+        if datetime.now(tz=UTC) - start_time > COURSE_EXPORT_TIMEOUT:
+            timed_out = set(tasks.keys()) - successful_exports - failed_exports
+            err_msg = (
+                f"Timed out waiting for course exports after {COURSE_EXPORT_TIMEOUT}. "
+                f"Unresolved courses: {timed_out}"
+            )
+            raise TimeoutError(err_msg)
         time.sleep(timedelta(seconds=60).seconds)
         for course_id, task_id in tasks.items():
+            if course_id in successful_exports or course_id in failed_exports:
+                continue
             try:
                 task_status = context.resources.openedx.check_course_export_status(
                     course_id,
                     task_id,
                 )
-            except httpx.HTTPStatusError:
-                # Don't fail the whole job if one task status yields an error
-                continue
+            except httpx.HTTPStatusError as e:
+                if e.response.status_code == 404:  # noqa: PLR2004
+                    context.log.warning(
+                        "Export task not found (HTTP 404) for course %s "
+                        "(task %s), marking as failed",
+                        course_id,
+                        task_id,
+                    )
+                    failed_exports.add(course_id)
+                    continue
+                else:
+                    raise
             if task_status["state"] == "Succeeded":
                 successful_exports.add(course_id)
             if task_status["state"] in {"Failed", "Canceled", "Retrying"}:

--- a/packages/ol-orchestrate-lib/src/ol_orchestrate/resources/openedx.py
+++ b/packages/ol-orchestrate-lib/src/ol_orchestrate/resources/openedx.py
@@ -64,6 +64,15 @@ class OpenEdxApiClient(OAuthApiClient):
 
         :returns: A dictionary of course IDs and the S3 URL where it will be exported
                   to.
+
+        .. note::
+            The ol_openedx_course_export plugin returns HTTP 400 when some (but
+            not all) courses fail to queue. We allow 400 through only when the
+            response body contains the expected partial-failure schema
+            (``upload_task_ids`` key present), so callers can still process
+            successfully-queued tasks. A 400 with an unrecognised body (e.g. a
+            bad-request error from a malformed payload) still raises so the
+            caller gets a clear error instead of a later ``KeyError``.
         """
         request_url = f"{self.studio_url}/api/courses/v0/export/"
         response = self.http_client.post(
@@ -72,6 +81,16 @@ class OpenEdxApiClient(OAuthApiClient):
             headers={"Authorization": f"JWT {self._fetch_access_token()}"},
             timeout=60,
         )
+        if response.status_code == 400:  # noqa: PLR2004
+            # Partial-failure: some courses failed to queue but others succeeded.
+            # Only suppress the error when the body matches the expected schema.
+            try:
+                body = response.json()
+            except ValueError:
+                response.raise_for_status()
+            if "upload_task_ids" not in body:
+                response.raise_for_status()
+            return body
         response.raise_for_status()
         return response.json()
 


### PR DESCRIPTION
### What are the relevant tickets?
Fixes https://github.com/mitodl/hq/issues/11104

### Description (What does it do?)
The `export_edx_courses` op in the legacy IRx pipeline (which populates `s3://mitx-etl-mitxonline-production/<date>/courses/`) had two bugs that caused the `courses/` folder to silently go missing since ~2026-01-21.

**Bug 1 — Infinite loop in the status-polling while loop (primary cause)**

When `check_course_export_status()` returned HTTP 404 (e.g. the `django-user-tasks` record was cleaned up after a retention window, or a course was deleted from Studio), the bare `continue` inside the `except httpx.HTTPStatusError` block swallowed the error without ever adding the course to `failed_exports`. The while-loop condition `len(successful ∪ failed) < len(tasks)` was therefore never satisfied, so the job hung indefinitely. The Dagster run would eventually be killed and the `courses/` folder was never written to S3.

Fix: catch `HTTPStatusError`, log the HTTP status code and course ID for observability, and add the course to `failed_exports` so the loop can make progress. A 60-minute hard timeout (matching the pattern in the newer asset-based `openedx` code location) is also added as a safety net, and already-resolved courses are skipped to avoid redundant API calls.

**Bug 2 — Premature abort on partial-failure from the export trigger API**

The `ol_openedx_course_export` plugin returns **HTTP 400** (not 200) when *any* course fails to queue during the initial trigger phase — even when other courses were queued successfully. The unconditional `raise_for_status()` in `OpenEdxApiClient.export_courses()` caused the method to raise immediately, aborting the entire op before any successfully-queued tarballs could be processed.

Fix: allow HTTP 400 through without raising; log the initially-failed courses as a warning via `failed_uploads` in the response body. All other non-2xx codes still raise as before.

### How can this be tested?
1. Run the `mitxonline_edx_course_pipeline` Dagster job in staging/QA.
2. Confirm the `courses/` sub-folder appears in the dated S3 prefix (e.g. `s3://mitx-etl-mitxonline-qa/<date>/courses/`) with the expected course tarballs.
3. To reproduce Bug 1 locally: mock `check_course_export_status` to always raise `httpx.HTTPStatusError` with a 404 response and verify the op now terminates (previously it would loop forever).
4. To reproduce Bug 2 locally: mock `export_courses` to return a 400 with a mix of `upload_task_ids` and `failed_uploads`, and verify the op continues to process the successful tasks instead of aborting.

### Additional Context
- The same timeout pattern (`COURSE_EXPORT_GET_TASKS_STATUS_TIMEOUT = timedelta(minutes=60)`) already exists in the newer asset-based `openedx` code location (`dg_projects/openedx/openedx/assets/openedx.py`); this PR aligns the legacy op with that approach.
- Once merged and deployed, historical data since 2026-01-21 will need to be backfilled by manually triggering the pipeline with a `date_override` for each missing date.