### PR TITLE
 fix: use PyArrowFileIO for S3 access in get_dbt_model_as_dataframe

### DIFF
--- a/packages/ol-orchestrate-lib/src/ol_orchestrate/lib/glue_helper.py
+++ b/packages/ol-orchestrate-lib/src/ol_orchestrate/lib/glue_helper.py
@@ -90,23 +90,34 @@ def create_or_update_table(
 
 
 def get_dbt_model_as_dataframe(database_name: str, table_name: str) -> pl.LazyFrame:
-    """Retrieve a dbt model from AWS Glue as a Polars DataFrame.
+    """Retrieve a dbt model from AWS Glue as a Polars LazyFrame.
 
     This function fetches table metadata from AWS Glue and loads the Iceberg
-    table data into a Polars DataFrame.
+    table data into a Polars LazyFrame.
+
+    ``PyArrowFileIO`` is used so that PyIceberg reads S3 data via PyArrow's
+    native C++ S3 client instead of the default ``FsspecFileIO`` (which relies
+    on aiobotocore / aiohttp).  After the aiobotocore 3.4.0 → 3.5.0 bump
+    deployed around 2026-04-27, botocore's lazy loader cache was populated
+    inside aiobotocore's async event loop thread, blocking all pending S3
+    coroutines and causing Dagster runs to hang indefinitely.
+    ``PyArrowFileIO`` bypasses aiobotocore entirely and is not affected.
 
     Args:
         database_name: The Glue database name containing the table
         table_name: The name of the table to retrieve
 
     Returns:
-        A Polars DataFrame containing the table data
+        A Polars LazyFrame containing the table data
 
     Raises:
         KeyError: If the table metadata doesn't contain the expected fields
         boto3 exceptions: If the AWS Glue API call fails
     """
-    glue = GlueCatalog("default", client=boto3.client("glue", region_name="us-east-1"))
+    glue = GlueCatalog(
+        "default",
+        client=boto3.client("glue", region_name="us-east-1"),
+        **{"py-io-impl": "pyiceberg.io.pyarrow.PyArrowFileIO"},
+    )
     table = glue.load_table(f"{database_name}.{table_name}")
-
     return table.to_polars()

--- a/packages/ol-orchestrate-lib/src/ol_orchestrate/lib/glue_helper.py
+++ b/packages/ol-orchestrate-lib/src/ol_orchestrate/lib/glue_helper.py
@@ -111,8 +111,8 @@ def get_dbt_model_as_dataframe(database_name: str, table_name: str) -> pl.LazyFr
         A Polars LazyFrame containing the table data
 
     Raises:
-        KeyError: If the table metadata doesn't contain the expected fields
-        boto3 exceptions: If the AWS Glue API call fails
+        Exception: If loading the Iceberg table from Glue or converting it to
+            a Polars LazyFrame fails.
     """
     glue = GlueCatalog(
         "default",

--- a/src/ol_dbt/models/dimensional/tfact_certificate.sql
+++ b/src/ol_dbt/models/dimensional/tfact_certificate.sql
@@ -271,7 +271,7 @@ with mitxonline_certificates as (
         on w.watermark_platform = cwf.platform
         and w.watermark_certificate_type = cwf.certificate_scope
     where (
-        w.max_created_on is null  -- platform/type not yet in target, include all
+        w.max_activity_on is null  -- platform/type not yet in target, include all
         or coalesce(cwf.certificate_updated_on, cwf.certificate_created_on) >= w.max_activity_on
         or cwf.certificate_created_on is null
     )

--- a/src/ol_dbt/models/dimensional/tfact_certificate.sql
+++ b/src/ol_dbt/models/dimensional/tfact_certificate.sql
@@ -271,7 +271,7 @@ with mitxonline_certificates as (
         on w.watermark_platform = cwf.platform
         and w.watermark_certificate_type = cwf.certificate_scope
     where (
-        w.max_activity_on is null  -- platform/type not yet in target, include all
+        w.max_created_on is null  -- platform/type not yet in target, include all
         or coalesce(cwf.certificate_updated_on, cwf.certificate_created_on) >= w.max_activity_on
         or cwf.certificate_created_on is null
     )


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
NA 

These dagster runs hang on production

https://pipelines.odl.mit.edu/locations/lakehouse/jobs/instructor_onboarding_daily_job/runs
https://pipelines.odl.mit.edu/assets/reporting/student_risk_probability?view=events

### Description (What does it do?)
<!--- Describe your changes in detail -->

 **Problem**

   After the aiobotocore upgrade from 3.4.0 → 3.5.0 (introduced in (https://github.com/mitodl/ol-data-platform/pull/2178)), Dagster runs using get_dbt_model_as_dataframe would hang indefinitely. 
The root cause: aiobotocore's async event loop thread was populating botocore's lazy-loader cache, blocking all pending S3 coroutines with no timeout or error.

**Fix**

  Switch GlueCatalog to use PyArrowFileIO (pyiceberg.io.pyarrow.PyArrowFileIO) instead of the default FsspecFileIO. PyArrow uses a native C++ S3 client and bypasses aiobotocore entirely, eliminating the hang.


### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->
  The hang only reproduces in a live Dagster environment with aiobotocore 3.5.0+, so this cannot be fully covered by local docker compose up: To verify manually:

   1. Deploy this branch to the QA Dagster environment
   2. Trigger any asset that calls get_dbt_model_as_dataframe (e.g. a lakehouse asset that reads an Iceberg table via Glue)
   3. Confirm the run completes without hanging — previously it would stall indefinitely on S3 reads
   4. Check Dagster run logs for no FsspecFileIO / aiobotocore references in stack traces


### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->


<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
