### PR TITLE
fix: finalize PyArrow S3 threads after Iceberg read in instructor_onboarding

### DIFF
--- a/dg_projects/lakehouse/lakehouse/assets/instructor_onboarding.py
+++ b/dg_projects/lakehouse/lakehouse/assets/instructor_onboarding.py
@@ -10,6 +10,7 @@ from io import StringIO
 from typing import Any
 
 import polars as pl
+import pyarrow.fs as pa_fs
 from dagster import (
     AssetExecutionContext,
     AssetIn,
@@ -77,8 +78,19 @@ def generate_instructor_onboarding_user_list(
     # Reorder columns: email, role, sent_invite
     user_data = user_data.select(["email", "role", "sent_invite"])
 
-    # Collect the LazyFrame before operations that need materialization
+    # Collect the LazyFrame to materialize the Iceberg scan.
+    # After collect() returns, this asset performs no further PyArrow S3 reads;
+    # the subsequent CSV generation uses StringIO and the IO manager output is a
+    # plain string (not Iceberg-backed). finalize_s3() shuts down the C++ S3
+    # thread pool so the step subprocess can exit cleanly — PyArrow non-daemon
+    # threads otherwise block Python's shutdown sequence.
+    # NOTE: finalize_s3() is irreversible in PyArrow 24+; no PyArrow S3 usage
+    # must follow this call in the same subprocess.
     user_data_collected = user_data.collect()
+    try:
+        pa_fs.finalize_s3()
+    except Exception:  # noqa: BLE001
+        context.log.warning("Failed to finalize PyArrow S3", exc_info=True)
 
     # Convert to CSV string using StringIO (no file I/O)
     csv_buffer = StringIO()


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
NA 

https://pipelines.odl.mit.edu/locations/lakehouse/jobs/instructor_onboarding_daily_job/runs
### Description (What does it do?)
<!--- Describe your changes in detail -->
Fixes a subprocess hang in the `instructor_onboarding` job where the Dagster
   step subprocess never exits after `STEP_SUCCESS`, preventing `PIPELINE_SUCCESS`
   from firing.

   **Fix:** Call `pa_fs.finalize_s3()` immediately after `user_data.collect()` — the
   last PyArrow S3 read in this asset. This shuts down the C++ thread pool and allows
   the subprocess to exit cleanly.


### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->


<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
