### PR TITLE
Revert fix: use PyArrowFileIO for S3 access in get_dbt_model_as_dataframe

### DIFF
--- a/packages/ol-orchestrate-lib/src/ol_orchestrate/lib/glue_helper.py
+++ b/packages/ol-orchestrate-lib/src/ol_orchestrate/lib/glue_helper.py
@@ -90,34 +90,23 @@ def create_or_update_table(
 
 
 def get_dbt_model_as_dataframe(database_name: str, table_name: str) -> pl.LazyFrame:
-    """Retrieve a dbt model from AWS Glue as a Polars LazyFrame.
+    """Retrieve a dbt model from AWS Glue as a Polars DataFrame.
 
     This function fetches table metadata from AWS Glue and loads the Iceberg
-    table data into a Polars LazyFrame.
-
-    ``PyArrowFileIO`` is used so that PyIceberg reads S3 data via PyArrow's
-    native C++ S3 client instead of the default ``FsspecFileIO`` (which relies
-    on aiobotocore / aiohttp).  After the aiobotocore 3.4.0 → 3.5.0 bump
-    deployed around 2026-04-27, botocore's lazy loader cache was populated
-    inside aiobotocore's async event loop thread, blocking all pending S3
-    coroutines and causing Dagster runs to hang indefinitely.
-    ``PyArrowFileIO`` bypasses aiobotocore entirely and is not affected.
+    table data into a Polars DataFrame.
 
     Args:
         database_name: The Glue database name containing the table
         table_name: The name of the table to retrieve
 
     Returns:
-        A Polars LazyFrame containing the table data
+        A Polars DataFrame containing the table data
 
     Raises:
-        Exception: If loading the Iceberg table from Glue or converting it to
-            a Polars LazyFrame fails.
+        KeyError: If the table metadata doesn't contain the expected fields
+        boto3 exceptions: If the AWS Glue API call fails
     """
-    glue = GlueCatalog(
-        "default",
-        client=boto3.client("glue", region_name="us-east-1"),
-        **{"py-io-impl": "pyiceberg.io.pyarrow.PyArrowFileIO"},
-    )
+    glue = GlueCatalog("default", client=boto3.client("glue", region_name="us-east-1"))
     table = glue.load_table(f"{database_name}.{table_name}")
+
     return table.to_polars()


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->

  Reverts PR #2218.

   The `py-io-impl: pyiceberg.io.pyarrow.PyArrowFileIO` property added in #2218
   is redundant — PyIceberg 0.11.1 already prefers PyArrowFileIO for S3 paths
   by default (see SCHEMA_TO_FILE_IO in pyiceberg/io/__init__.py). The explicit
   setting has no effect and is dead code.


### Description (What does it do?)
<!--- Describe your changes in detail -->

### Screenshots (if appropriate):
<!--- optional - delete if empty --->
- [ ] Desktop screenshots
- [ ] Mobile width screenshots

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->


<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
