### PR TITLE
Add OCW to dim_course

### DIFF
--- a/src/ol_dbt/models/dimensional/_dim_course.yml
+++ b/src/ol_dbt/models/dimensional/_dim_course.yml
@@ -9,9 +9,8 @@ models:
     Tracks historical changes to course metadata.
     Note: edxorg has no native course-level table. edxorg courses are derived from
     courserun records, with one row per course_readable_id using the most-recent course
-    run to supply attributes (title, course_number, is_live). source_id is always
-    null
-    for edxorg courses.
+    run to supply attributes (title, course_number, is_live). source_id is null
+    for edxorg and OCW courses.
   meta:
     owner: data_team
   columns:
@@ -33,7 +32,8 @@ models:
     description: >
       Integer source system ID for this course. Null for edxorg courses — edxorg
       exposes no native integer course ID; course records are synthesized from the
-      most-recent course run sharing the same course_readable_id.
+      most-recent course run sharing the same course_readable_id. Null for OCW
+      courses because OCW exposes a string UUID, not an integer source ID.
   - name: course_number
     description: Course number (e.g., 6.00.1x)
   - name: course_title

--- a/src/ol_dbt/models/dimensional/dim_course.sql
+++ b/src/ol_dbt/models/dimensional/dim_course.sql
@@ -65,12 +65,26 @@ with mitxonline_courses as (
     where _row_num = 1
 )
 
+, ocw_courses as (
+    select
+        course_readable_id
+        , cast(null as integer) as source_id
+        , course_title
+        , course_primary_course_number as course_number
+        , course_description
+        , course_is_live
+        , 'ocw' as platform
+    from {{ ref('int__ocw__courses') }}
+)
+
 , combined_courses as (
     select * from mitxonline_courses
     union all
     select * from mitxpro_courses
     union all
     select * from edxorg_courses
+    union all
+    select * from ocw_courses
 )
 
 -- All (platform, course_readable_id) combinations are kept as distinct rows.


### PR DESCRIPTION
### What are the relevant tickets?
Closes https://github.com/mitodl/ol-data-platform/issues/2122.

### Description (What does it do?)
This PR adds OCW courses to the dimensional layer.

### How can this be tested?
First, run
```
uv run dbt run \
  --select +dim_course \
  --full-refresh \
  --vars 'schema_suffix: <your name>' \
  --project-dir src/ol_dbt/ \
  --profiles-dir src/ol_dbt/ \
  --target dev_production
 ```
 filling in `<your name>` as appropriate.

Then, run
```
uv run dbt test \
  --select dim_course \
  --indirect-selection cautious \
  --vars 'schema_suffix: <your name>' \
  --project-dir src/ol_dbt/ \
  --profiles-dir src/ol_dbt/ \
  --target dev_production
 ```
which avoids `TABLE_NOT_FOUND` errors for unrelated tests.

Finally, smoke-test this in https://mitol.galaxy.starburst.io/query-editor by running a query such as

```
select
    course_readable_id,
    source_id,
    course_number,
    course_title,
    substr(course_description, 1, 200) as course_description_preview,
    course_is_live,
    primary_platform
from ol_data_lake_production.ol_warehouse_production_<your name>_dimensional.dim_course
where primary_platform = 'ocw'
  and is_current = true
order by course_readable_id
limit 20;
```