### PR TITLE
Exclude certificates without an awarded date from edxorg_to_mitxonline_program_certificates

### DIFF
--- a/src/ol_dbt/models/migration/_migration__models.yml
+++ b/src/ol_dbt/models/migration/_migration__models.yml
@@ -139,6 +139,8 @@ models:
   - name: program_certificate_issued_on
     data_type: timestamp
     description: date and time when the program certificate was awarded on edX.org.
+    tests:
+    - not_null
   - name: certificate_page_revision_id
     data_type: integer
     description: the live wagtail page revision ID for the program certificate page

--- a/src/ol_dbt/models/migration/edxorg_to_mitxonline_program_certificates.sql
+++ b/src/ol_dbt/models/migration/edxorg_to_mitxonline_program_certificates.sql
@@ -101,3 +101,6 @@ where
     --- Exclude certificates already present on MITx Online (matched by user ID or email)
     mitxonline_program_certificates.user_id is null
     and mitxonline_program_certificates_by_email.user_email is null
+    --- Exclude certificates without an awarded date, as this likely indicates a certificate that
+     -- should not be migrated
+    and edxorg_program_certificates.program_certificate_awarded_on is not null

--- a/src/ol_dbt/models/migration/edxorg_to_mitxonline_program_certificates.sql
+++ b/src/ol_dbt/models/migration/edxorg_to_mitxonline_program_certificates.sql
@@ -8,6 +8,9 @@ with edxorg_program_certificates_raw as (
         end as normalized_program_title
     from {{ ref('int__edxorg__mitx_program_certificates') }}
     where user_username not like 'retired__user%'
+     --- Exclude certificates without an awarded date, as this likely indicates a certificate that
+     -- should not be migrated
+    and program_certificate_awarded_on is not null
 )
 
 , edxorg_program_certificates as (
@@ -101,6 +104,3 @@ where
     --- Exclude certificates already present on MITx Online (matched by user ID or email)
     mitxonline_program_certificates.user_id is null
     and mitxonline_program_certificates_by_email.user_email is null
-    --- Exclude certificates without an awarded date, as this likely indicates a certificate that
-     -- should not be migrated
-    and edxorg_program_certificates.program_certificate_awarded_on is not null


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
https://github.com/mitodl/hq/issues/11115#issuecomment-4499342046

### Description (What does it do?)
<!--- Describe your changes in detail -->
Excludes certificates without an awarded date from edxorg_to_mitxonline_program_certificates

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

dbt build --select edxorg_to_mitxonline_program_certificates

### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->


<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
