### PR TITLE
Migrate OCW course mart to use dimensional layer

### DIFF
--- a/dimensional_warehouse_todo.md
+++ b/dimensional_warehouse_todo.md
@@ -487,6 +487,19 @@ WHERE is_current = true GROUP BY primary_platform;
 
 ---
 
+### B2b · Add `dim_ocw_course` ✅
+
+**File:** `src/ol_dbt/models/dimensional/dim_ocw_course.sql`
+
+**Depends on:** B2
+
+OCW-specific course attributes not in conformed `dim_course` (term, year, level, publish
+state, learning resource types, etc.). Lets `marts__ocw_courses` reference only the
+dimensional layer, dropping its `int__ocw__courses` ref
+(epic: [#2072](https://github.com/mitodl/ol-data-platform/issues/2072)).
+
+---
+
 ### B3 · Fix `tfact_enrollment` Incremental Watermark ⏳
 
 **File:** `src/ol_dbt/models/dimensional/tfact_enrollment.sql`

--- a/src/ol_dbt/models/dimensional/_dim_ocw_course.yml
+++ b/src/ol_dbt/models/dimensional/_dim_ocw_course.yml
@@ -49,7 +49,7 @@ models:
       json format
   - name: course_learning_resource_types
     description: str, course learning resource types or features in comma-separated
-      list. e.g. Lecture Notes, Problem Sets with Solutions...
+      list. e.g., Lecture Notes, Problem Sets with Solutions
   - name: course_department_numbers
     description: str, course department numbers in comma-separated list. e.g., STS,
       8

--- a/src/ol_dbt/models/dimensional/_dim_ocw_course.yml
+++ b/src/ol_dbt/models/dimensional/_dim_ocw_course.yml
@@ -48,8 +48,7 @@ models:
     description: json, hierarchical course topics (topic, subtopic, speciality) in
       json format
   - name: course_learning_resource_types
-    description: |
-      str, course learning resource types or features in comma-separated
+    description: str, course learning resource types or features in comma-separated
       list. e.g. Lecture Notes, Problem Sets with Solutions...
   - name: course_department_numbers
     description: str, course department numbers in comma-separated list. e.g., STS,

--- a/src/ol_dbt/models/dimensional/_dim_ocw_course.yml
+++ b/src/ol_dbt/models/dimensional/_dim_ocw_course.yml
@@ -26,8 +26,8 @@ models:
   - name: course_year
     description: int, course year
   - name: course_level
-    description: str, course level in comma-separated list. Possible values are Undergraduate
-      , Graduate, Non-Credit, High School, or blank
+    description: str, course level in comma-separated list. Possible values are Undergraduate,
+      Graduate, Non-Credit, High School, or blank
   - name: course_extra_course_numbers
     description: str, the extra course number e.g., STS.484J
   - name: course_is_unpublished

--- a/src/ol_dbt/models/dimensional/_dim_ocw_course.yml
+++ b/src/ol_dbt/models/dimensional/_dim_ocw_course.yml
@@ -1,0 +1,56 @@
+---
+version: 2
+
+models:
+- name: dim_ocw_course
+  description: >
+    OCW-specific course attributes that are not part of the conformed dim_course
+    (term, year, level, publish state, learning resource types, etc.). One row per
+    OCW course, keyed by course_readable_id; extends dim_course for OCW.
+  meta:
+    owner: data_team
+  columns:
+  - name: course_readable_id
+    description: >
+      Business key - OCW course readable id (URL slug). Joins to
+      dim_course.course_readable_id for OCW courses.
+    tests:
+    - not_null
+    - unique
+  - name: course_name
+    description: str, unique name of the OCW course. It appears as part of OCW Studio
+      URLs
+  - name: course_term
+    description: str, course term. Possible values are Spring, Summer, Fall, January
+      IAP, or blank
+  - name: course_year
+    description: int, course year
+  - name: course_level
+    description: str, course level in comma-separated list. Possible values are Undergraduate
+      , Graduate, Non-Credit, High School, or blank
+  - name: course_extra_course_numbers
+    description: str, the extra course number e.g., STS.484J
+  - name: course_is_unpublished
+    description: boolean, indicating if the course website is currently unpublished
+      on OCW production.
+  - name: course_has_never_published
+    description: boolean, indicating if the course website has never been published
+      on OCW production.
+  - name: course_live_url
+    description: str, URL of the OCW course in production.
+  - name: course_first_published_on
+    description: timestamp, date and time when the course website was first published
+      to OCW production
+  - name: course_publish_date_updated_on
+    description: timestamp, date and time when the publish date was most recently
+      updated on OCW production.
+  - name: course_topics
+    description: json, hierarchical course topics (topic, subtopic, speciality) in
+      json format
+  - name: course_learning_resource_types
+    description: |
+      str, course learning resource types or features in comma-separated
+      list. e.g. Lecture Notes, Problem Sets with Solutions...
+  - name: course_department_numbers
+    description: str, course department numbers in comma-separated list. e.g., STS,
+      8

--- a/src/ol_dbt/models/dimensional/bridge_course_instructor.sql
+++ b/src/ol_dbt/models/dimensional/bridge_course_instructor.sql
@@ -3,7 +3,6 @@
 ) }}
 
 -- Map courses to instructors (many-to-many)
--- Note: OCW courses not yet in dim_course (Phase 1-2), so omitted here
 with mitxonline_course_instructors as (
     select
         course_id
@@ -20,35 +19,72 @@ with mitxonline_course_instructors as (
     from {{ ref('int__mitxpro__coursesfaculty') }}
 )
 
-, combined_course_instructors as (
+, source_id_course_instructors as (
     select * from mitxonline_course_instructors
     union all
     select * from mitxpro_course_instructors
 )
 
+-- OCW source_id is null in dim_course; join on course_readable_id
+, ocw_course_instructors as (
+    select
+        ocw_courses.course_readable_id
+        , ocw_instructors.course_instructor_title as instructor_name
+        , 'ocw' as platform
+    from {{ ref('int__ocw__course_instructors') }} as ocw_instructors
+    inner join {{ ref('int__ocw__courses') }} as ocw_courses
+        on ocw_instructors.course_uuid = ocw_courses.course_uuid
+)
+
 -- Join to dimensions to get FKs
 , dim_course as (
-    select course_pk, source_id, primary_platform
+    select
+        course_pk
+        , course_readable_id
+        , source_id
+        , primary_platform
     from {{ ref('dim_course') }}
     where is_current = true
 )
 
 , dim_instructor as (
-    select instructor_pk, instructor_name, primary_platform
+    select
+        instructor_pk
+        , instructor_name
+        , primary_platform
     from {{ ref('dim_instructor') }}
 )
 
-, bridge as (
+, source_id_bridge as (
     select
         dim_course.course_pk as course_fk
         , dim_instructor.instructor_pk as instructor_fk
-    from combined_course_instructors
+    from source_id_course_instructors
     left join dim_course
-        on combined_course_instructors.course_id = dim_course.source_id
-        and combined_course_instructors.platform = dim_course.primary_platform
+        on source_id_course_instructors.course_id = dim_course.source_id
+        and source_id_course_instructors.platform = dim_course.primary_platform
     left join dim_instructor
-        on combined_course_instructors.instructor_name = dim_instructor.instructor_name
-        and combined_course_instructors.platform = dim_instructor.primary_platform
+        on source_id_course_instructors.instructor_name = dim_instructor.instructor_name
+        and source_id_course_instructors.platform = dim_instructor.primary_platform
+)
+
+, ocw_bridge as (
+    select
+        dim_course.course_pk as course_fk
+        , dim_instructor.instructor_pk as instructor_fk
+    from ocw_course_instructors
+    left join dim_course
+        on ocw_course_instructors.course_readable_id = dim_course.course_readable_id
+        and ocw_course_instructors.platform = dim_course.primary_platform
+    left join dim_instructor
+        on ocw_course_instructors.instructor_name = dim_instructor.instructor_name
+        and ocw_course_instructors.platform = dim_instructor.primary_platform
+)
+
+, bridge as (
+    select * from source_id_bridge
+    union all
+    select * from ocw_bridge
 )
 
 -- Include only fully-resolved rows; unresolved FKs indicate dim coverage gaps

--- a/src/ol_dbt/models/dimensional/dim_ocw_course.sql
+++ b/src/ol_dbt/models/dimensional/dim_ocw_course.sql
@@ -1,0 +1,20 @@
+{{ config(
+    materialized='table'
+) }}
+
+select
+    course_readable_id
+    , course_name
+    , course_term
+    , course_year
+    , course_level
+    , course_extra_course_numbers
+    , course_is_unpublished
+    , course_has_never_published
+    , course_live_url
+    , course_first_published_on
+    , course_publish_date_updated_on
+    , course_topics
+    , course_learning_resource_types
+    , course_department_numbers
+from {{ ref('int__ocw__courses') }}

--- a/src/ol_dbt/models/marts/ocw/marts__ocw_courses.sql
+++ b/src/ol_dbt/models/marts/ocw/marts__ocw_courses.sql
@@ -1,33 +1,65 @@
-with courses as (
-    select * from {{ ref('int__ocw__courses') }}
+with ocw_courses as (
+    select
+        course_pk
+        , course_readable_id
+        , course_title
+        , course_number
+        , course_is_live
+    from {{ ref('dim_course') }}
+    where primary_platform = 'ocw'
+        and is_current = true
+)
+
+, ocw_course_details as (
+    select
+        course_readable_id
+        , course_name
+        , course_term
+        , course_year
+        , course_level
+        , course_extra_course_numbers
+        , course_is_unpublished
+        , course_has_never_published
+        , course_live_url
+        , course_first_published_on
+        , course_publish_date_updated_on
+        , course_topics
+        , course_learning_resource_types
+        , course_department_numbers
+    from {{ ref('dim_ocw_course') }}
 )
 
 , instructors as (
     select
-        course_uuid
-        , {{ array_join('array_agg(course_instructor_title)', ", ") }} as course_instructors
-    from {{ ref('int__ocw__course_instructors') }}
-    group by course_uuid
+        bridge_course_instructor.course_fk
+        , {{ array_join('array_agg(dim_instructor.instructor_name)', ", ") }} as course_instructors
+    from {{ ref('bridge_course_instructor') }}
+    inner join {{ ref('dim_instructor') }}
+        on bridge_course_instructor.instructor_fk = dim_instructor.instructor_pk
+    group by bridge_course_instructor.course_fk
 )
 
 select
-    courses.course_readable_id as course_short_id
-    , courses.course_name
-    , courses.course_title
-    , courses.course_term
-    , courses.course_year
-    , courses.course_level
-    , courses.course_primary_course_number
-    , courses.course_extra_course_numbers
-    , courses.course_is_live
-    , courses.course_is_unpublished
-    , courses.course_has_never_published
-    , courses.course_live_url
-    , courses.course_first_published_on
-    , courses.course_publish_date_updated_on
-    , courses.course_topics
-    , courses.course_learning_resource_types
-    , courses.course_department_numbers
+    ocw_courses.course_readable_id as course_short_id
+    , ocw_course_details.course_name
+    , ocw_courses.course_title
+    , ocw_course_details.course_term
+    , ocw_course_details.course_year
+    , ocw_course_details.course_level
+    , ocw_courses.course_number as course_primary_course_number
+    , ocw_course_details.course_extra_course_numbers
+    , ocw_courses.course_is_live
+    , ocw_course_details.course_is_unpublished
+    , ocw_course_details.course_has_never_published
+    , ocw_course_details.course_live_url
+    , ocw_course_details.course_first_published_on
+    , ocw_course_details.course_publish_date_updated_on
+    , ocw_course_details.course_topics
+    , ocw_course_details.course_learning_resource_types
+    , ocw_course_details.course_department_numbers
     , instructors.course_instructors
-from courses
-left join instructors on courses.course_uuid = instructors.course_uuid
+from ocw_courses
+inner join ocw_course_details
+    on ocw_courses.course_readable_id = ocw_course_details.course_readable_id
+left join instructors
+    on ocw_courses.course_pk = instructors.course_fk


### PR DESCRIPTION
### What are the relevant tickets?
Closes https://github.com/mitodl/ol-data-platform/issues/2100.

### Description (What does it do?)
This PR migrates `marts__ocw_courses` to source entirely from the dimensional layer, with
no `int__*` references. Conformed attributes come from `dim_course`; instructors via
`bridge_course_instructor` + `dim_instructor` (the bridge is extended to cover OCW,
resolving on `course_readable_id` since OCW's `source_id` is null). OCW-specific columns
(term, year, level, link/publish metadata, learning resource types, topics, departments)
are moved into a new `dim_ocw_course` dimension, which encapsulates the `int__ocw__courses`
read in the dimensional layer. Output columns are unchanged.

### How can this be tested?
First, run

```
uv run dbt run \
  --select +marts__ocw_courses \
  --full-refresh \
  --vars 'schema_suffix: <your name>' \
  --project-dir src/ol_dbt/ \
  --profiles-dir src/ol_dbt/ \
  --target dev_production
```
filling in `<your name>` as appropriate.

Then, run
```
uv run dbt test \
  --select dim_ocw_course marts__ocw_courses bridge_course_instructor \
  --vars 'schema_suffix: <your name>' \
  --project-dir src/ol_dbt/ \
  --profiles-dir src/ol_dbt/ \
  --target dev_production
```

Finally, smoke-test this in Starburst Galaxy (https://mitol.galaxy.starburst.io/query-editor) by running a query such as

```
select
    course_short_id,
    course_title,
    course_primary_course_number,
    course_is_live,
    course_term,
    course_year,
    course_learning_resource_types,
    course_instructors
from ol_data_lake_production.ol_warehouse_production_<your name>_mart.marts__ocw_courses
order by course_short_id
limit 20;
```