### PR TITLE
feat(lakehouse): automate Iceberg table maintenance across the lakehouse

### DIFF
--- a/dg_projects/lakehouse/lakehouse/assets/iceberg_maintenance.py
+++ b/dg_projects/lakehouse/lakehouse/assets/iceberg_maintenance.py
@@ -47,6 +47,7 @@ from dagster import (
     Output,
     asset,
 )
+from ol_orchestrate.lib.constants import DAGSTER_ENV
 from ol_orchestrate.lib.iceberg_maintenance import (
     NON_DBT_SINGLETON_TABLES,
     TableMaintenanceConfig,
@@ -63,8 +64,19 @@ from lakehouse.assets.lakehouse.dbt import dbt_project
 
 log = logging.getLogger(__name__)
 
-RAW_GLUE_DATABASE = "ol_warehouse_production_raw"
-ENV_SCHEMA_PREFIX = "ol_warehouse_production"
+# Each environment runs maintenance only against its own catalog and schema set.
+# dev uses production because DAGSTER_ENV="dev" targets the production dbt profile
+# (dev_production), meaning developers run against real production Iceberg tables.
+_RAW_GLUE_DATABASE_MAP: dict[str, str] = {
+    "production": "ol_warehouse_production_raw",
+    "qa": "ol_warehouse_qa_raw",
+    "dev": "ol_warehouse_production_raw",
+    "ci": "ol_warehouse_qa_raw",
+}
+
+RAW_GLUE_DATABASE = _RAW_GLUE_DATABASE_MAP.get(
+    DAGSTER_ENV, "ol_warehouse_production_raw"
+)
 # Parallelism for raw layer: enough to be fast across 1,300+ tables without
 # hitting Glue API rate limits (default per-account limit is ~200 req/s).
 RAW_LAYER_WORKERS = 8
@@ -230,7 +242,6 @@ def iceberg_dbt_layer_maintenance(
     """Run Iceberg maintenance for all dbt-managed tables and non-dbt singletons."""
     configs = load_maintenance_configs_from_manifest(
         manifest_path=dbt_project.manifest_path,
-        env_schema_prefix=ENV_SCHEMA_PREFIX,
     )
     all_configs = [*configs, *NON_DBT_SINGLETON_TABLES]
     context.log.info(

--- a/dg_projects/lakehouse/lakehouse/assets/iceberg_maintenance.py
+++ b/dg_projects/lakehouse/lakehouse/assets/iceberg_maintenance.py
@@ -1,0 +1,398 @@
+"""Dagster assets for Iceberg table maintenance across the OL data lakehouse.
+
+Two assets run on staggered nightly schedules:
+
+``iceberg_dbt_layer_maintenance`` (02:00 UTC)
+    Processes all dbt-managed tables discovered from ``manifest.json`` plus the
+    non-dbt singleton tables listed in ``NON_DBT_SINGLETON_TABLES``.
+
+    For each table it runs:
+    - OPTIMIZE  (Trino)   — compact small files; triggered when materialization
+                            count since last maintenance >= optimize_after_every_n_runs
+    - ANALYZE   (Trino)   — refresh query statistics; same threshold logic with
+                            analyze_after_every_n_runs
+    - EXPIRE SNAPSHOTS (pyiceberg) — always runs; uses snapshot_retention_days
+    - REMOVE ORPHAN FILES (pyiceberg) — always runs; uses orphan_retention_days
+
+    Config comes from ``dbt_project.yml`` ``+meta.iceberg_maintenance`` blocks,
+    compiled into each node's ``config.meta.iceberg_maintenance`` in the manifest.
+    Per-model overrides in schema YAML files are shallow-merged on top.
+
+``iceberg_raw_layer_maintenance`` (03:00 UTC)
+    Processes all Iceberg tables in ``ol_warehouse_production_raw`` (1,300+
+    Airbyte-ingested tables).  Uses a live Glue catalog scan rather than the
+    Dagster event log because the OLAirbyteTranslator slugifies connection names
+    in a way that doesn't map cleanly back to Glue table names.
+
+    Runs EXPIRE SNAPSHOTS and REMOVE ORPHAN FILES only — OPTIMIZE and ANALYZE
+    are not needed for raw tables since they are not Trino analytics targets and
+    Airbyte writes complete files per sync (no small-file accumulation).
+
+    Tables are processed in a ThreadPoolExecutor(max_workers=8) to handle the
+    volume without overwhelming the Glue API rate limits.
+"""
+
+from __future__ import annotations
+
+import logging
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from typing import Any
+
+from dagster import (
+    AssetExecutionContext,
+    AssetKey,
+    DagsterEventType,
+    EventRecordsFilter,
+    MetadataValue,
+    Output,
+    asset,
+)
+from ol_orchestrate.lib.iceberg_maintenance import (
+    NON_DBT_SINGLETON_TABLES,
+    TableMaintenanceConfig,
+    expire_snapshots,
+    get_glue_catalog,
+    load_maintenance_configs_from_manifest,
+    load_raw_layer_maintenance_work,
+    raw_config_for_table,
+    remove_orphan_files,
+)
+from ol_orchestrate.resources.trino_maintenance import TrinoMaintenanceResource
+
+from lakehouse.assets.lakehouse.dbt import dbt_project
+
+log = logging.getLogger(__name__)
+
+RAW_GLUE_DATABASE = "ol_warehouse_production_raw"
+ENV_SCHEMA_PREFIX = "ol_warehouse_production"
+# Parallelism for raw layer: enough to be fast across 1,300+ tables without
+# hitting Glue API rate limits (default per-account limit is ~200 req/s).
+RAW_LAYER_WORKERS = 8
+
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+
+def _get_last_maintenance_cursor(
+    instance, maintenance_asset_key: AssetKey
+) -> int | None:
+    """Return the storage_id of the most recent maintenance materialization.
+
+    This cursor is passed to ``_count_materializations_since`` so we only count
+    dbt model materializations that occurred *after* the previous maintenance run.
+    Returns ``None`` on the first ever run, which the caller treats as "run all
+    operations unconditionally".
+    """
+    records = instance.get_event_records(
+        EventRecordsFilter(
+            event_type=DagsterEventType.ASSET_MATERIALIZATION,
+            asset_key=maintenance_asset_key,
+        ),
+        limit=1,
+        ascending=False,
+    )
+    return records[0].storage_id if records else None
+
+
+def _count_materializations_since(
+    instance,
+    asset_key: AssetKey,
+    after_cursor: int | None,
+) -> int:
+    """Count how many times *asset_key* was materialized since *after_cursor*.
+
+    Up to 500 records are fetched — enough to saturate any reasonable
+    optimize_after_every_n_runs or analyze_after_every_n_runs threshold.
+    """
+    if after_cursor is not None:
+        records = instance.get_event_records(
+            EventRecordsFilter(
+                event_type=DagsterEventType.ASSET_MATERIALIZATION,
+                asset_key=asset_key,
+                after_cursor=after_cursor,
+            ),
+            limit=500,
+            ascending=False,
+        )
+    else:
+        records = instance.get_event_records(
+            EventRecordsFilter(
+                event_type=DagsterEventType.ASSET_MATERIALIZATION,
+                asset_key=asset_key,
+            ),
+            limit=500,
+            ascending=False,
+        )
+    return len(records)
+
+
+def _run_table_maintenance(
+    cfg: TableMaintenanceConfig,
+    instance,
+    last_cursor: int | None,
+    trino_maintenance: TrinoMaintenanceResource,
+) -> dict[str, Any]:
+    """Run all maintenance operations for one dbt-layer table.
+
+    Returns a summary dict used to aggregate the asset's output metadata.
+    """
+    catalog = get_glue_catalog()
+    summary: dict[str, Any] = {
+        "model": cfg.model_name,
+        "optimized": False,
+        "analyzed": False,
+        "snapshots_expired": 0,
+        "orphans_removed": 0,
+        "errors": [],
+    }
+
+    model_key = AssetKey(cfg.asset_key)
+    mat_count = _count_materializations_since(instance, model_key, last_cursor)
+
+    # On the first maintenance run (last_cursor is None) treat effective count
+    # as the maximum threshold so every operation runs regardless of history.
+    if last_cursor is None:
+        effective_count = max(
+            cfg.optimize_after_every_n_runs,
+            cfg.analyze_after_every_n_runs,
+            1,
+        )
+    else:
+        effective_count = mat_count
+
+    # EXPIRE SNAPSHOTS — always, uses its own time-based filter
+    try:
+        exp = expire_snapshots(
+            catalog=catalog,
+            database=cfg.schema_name,
+            table_name=cfg.model_name,
+            retention_days=cfg.snapshot_retention_days,
+        )
+        if not exp.get("skipped"):
+            summary["snapshots_expired"] = exp.get("eligible_count", 0)
+    except Exception as exc:  # noqa: BLE001
+        summary["errors"].append(f"expire_snapshots: {exc}")
+
+    # REMOVE ORPHAN FILES — always, uses its own time-based filter
+    try:
+        orp = remove_orphan_files(
+            catalog=catalog,
+            database=cfg.schema_name,
+            table_name=cfg.model_name,
+            retention_days=cfg.orphan_retention_days,
+        )
+        if not orp.get("skipped"):
+            summary["orphans_removed"] = orp.get("deleted-files", 0)
+    except Exception as exc:  # noqa: BLE001
+        summary["errors"].append(f"remove_orphan_files: {exc}")
+
+    # OPTIMIZE — only if enough materializations have accumulated
+    if effective_count >= cfg.optimize_after_every_n_runs:
+        try:
+            trino_maintenance.optimize(schema=cfg.schema_name, table=cfg.model_name)
+            summary["optimized"] = True
+        except Exception as exc:  # noqa: BLE001
+            log.warning(
+                "OPTIMIZE failed for %s.%s: %s", cfg.schema_name, cfg.model_name, exc
+            )
+            summary["errors"].append(f"optimize: {exc}")
+
+    # ANALYZE — only if enough materializations have accumulated
+    if effective_count >= cfg.analyze_after_every_n_runs:
+        try:
+            trino_maintenance.analyze(schema=cfg.schema_name, table=cfg.model_name)
+            summary["analyzed"] = True
+        except Exception as exc:  # noqa: BLE001
+            log.warning(
+                "ANALYZE failed for %s.%s: %s", cfg.schema_name, cfg.model_name, exc
+            )
+            summary["errors"].append(f"analyze: {exc}")
+
+    return summary
+
+
+# ── Assets ────────────────────────────────────────────────────────────────────
+
+
+@asset(
+    group_name="lakehouse_maintenance",
+    description=(
+        "Nightly Iceberg maintenance for all dbt-managed tables and non-dbt "
+        "singletons.  Runs OPTIMIZE and ANALYZE via Trino (threshold-gated by "
+        "materialization count) and EXPIRE SNAPSHOTS via pyiceberg.  Config is "
+        "read from manifest.json iceberg_maintenance meta blocks."
+    ),
+)
+def iceberg_dbt_layer_maintenance(
+    context: AssetExecutionContext,
+    trino_maintenance: TrinoMaintenanceResource,
+) -> Output[None]:
+    """Run Iceberg maintenance for all dbt-managed tables and non-dbt singletons."""
+    configs = load_maintenance_configs_from_manifest(
+        manifest_path=dbt_project.manifest_path,
+        env_schema_prefix=ENV_SCHEMA_PREFIX,
+    )
+    all_configs = [*configs, *NON_DBT_SINGLETON_TABLES]
+    context.log.info(
+        "Loaded %d table configs (%d dbt, %d singleton)",
+        len(all_configs),
+        len(configs),
+        len(NON_DBT_SINGLETON_TABLES),
+    )
+
+    # Cursor of the previous maintenance run — used to count dbt materializations
+    # that occurred since the last time this asset ran.
+    own_key = AssetKey(["iceberg_dbt_layer_maintenance"])
+    last_cursor = _get_last_maintenance_cursor(context.instance, own_key)
+    if last_cursor is None:
+        context.log.info(
+            "First maintenance run — all operations will execute unconditionally."
+        )
+
+    tables_processed = 0
+    tables_optimized = 0
+    tables_analyzed = 0
+    snapshots_expired = 0
+    orphans_removed = 0
+    failures: list[str] = []
+
+    for cfg in all_configs:
+        if not cfg.enabled:
+            continue
+        try:
+            result = _run_table_maintenance(
+                cfg, context.instance, last_cursor, trino_maintenance
+            )
+            tables_processed += 1
+            if result["optimized"]:
+                tables_optimized += 1
+            if result["analyzed"]:
+                tables_analyzed += 1
+            snapshots_expired += result["snapshots_expired"]
+            orphans_removed += result["orphans_removed"]
+            failures.extend(
+                f"{cfg.schema_name}.{cfg.model_name}: {err}" for err in result["errors"]
+            )
+        except Exception as exc:  # noqa: BLE001
+            log.warning(
+                "Maintenance failed for %s.%s: %s", cfg.schema_name, cfg.model_name, exc
+            )
+            failures.append(f"{cfg.schema_name}.{cfg.model_name}: {exc}")
+
+    context.log.info(
+        "dbt layer maintenance complete: %d tables processed, %d optimized, "
+        "%d analyzed, %d snapshot batches expired, %d failures",
+        tables_processed,
+        tables_optimized,
+        tables_analyzed,
+        snapshots_expired,
+        len(failures),
+    )
+
+    return Output(
+        value=None,
+        metadata={
+            "tables_processed": MetadataValue.int(tables_processed),
+            "tables_optimized": MetadataValue.int(tables_optimized),
+            "tables_analyzed": MetadataValue.int(tables_analyzed),
+            "snapshots_expired": MetadataValue.int(snapshots_expired),
+            "orphans_removed": MetadataValue.int(orphans_removed),
+            "failure_count": MetadataValue.int(len(failures)),
+            # Cap at 20 entries so the Dagster UI doesn't time out rendering
+            "failure_details": MetadataValue.json(failures[:20]),
+        },
+    )
+
+
+@asset(
+    group_name="lakehouse_maintenance",
+    description=(
+        "Nightly Iceberg maintenance for all raw/Airbyte-ingested tables in "
+        "ol_warehouse_production_raw (~1,300 tables).  Runs EXPIRE SNAPSHOTS and "
+        "REMOVE ORPHAN FILES only — OPTIMIZE and ANALYZE are not needed for raw "
+        "tables since they are not Trino analytics targets.  Tables are processed "
+        "in parallel (max_workers=8) and sorted worst-offender-first."
+    ),
+)
+def iceberg_raw_layer_maintenance(context: AssetExecutionContext) -> Output[None]:
+    """Run EXPIRE SNAPSHOTS and REMOVE ORPHAN FILES for all raw layer Iceberg tables."""
+    context.log.info("Scanning Glue catalog for raw layer Iceberg tables...")
+    tables = load_raw_layer_maintenance_work(glue_database=RAW_GLUE_DATABASE)
+    context.log.info(
+        "Found %d Iceberg tables; processing with %d workers.",
+        len(tables),
+        RAW_LAYER_WORKERS,
+    )
+
+    catalog = get_glue_catalog()
+
+    tables_cleaned = 0
+    snapshots_expired = 0
+    orphans_removed = 0
+    failures: list[str] = []
+
+    def _process_one(table_info) -> dict[str, Any]:
+        cfg = raw_config_for_table(table_info.table_name)
+        result: dict[str, Any] = {
+            "table": table_info.table_name,
+            "ok": True,
+            "errors": [],
+        }
+        try:
+            exp = expire_snapshots(
+                catalog=catalog,
+                database=table_info.database,
+                table_name=table_info.table_name,
+                retention_days=cfg.snapshot_retention_days,
+            )
+            result["expire"] = exp
+
+            orp = remove_orphan_files(
+                catalog=catalog,
+                database=table_info.database,
+                table_name=table_info.table_name,
+                retention_days=cfg.orphan_retention_days,
+            )
+            result["orphan"] = orp
+        except Exception as exc:  # noqa: BLE001
+            result["ok"] = False
+            result["errors"].append(str(exc))
+        return result
+
+    with ThreadPoolExecutor(max_workers=RAW_LAYER_WORKERS) as executor:
+        future_to_table = {executor.submit(_process_one, t): t for t in tables}
+        for future in as_completed(future_to_table):
+            table_info = future_to_table[future]
+            try:
+                res = future.result()
+                if res["ok"]:
+                    tables_cleaned += 1
+                    exp = res.get("expire", {})
+                    orp = res.get("orphan", {})
+                    snapshots_expired += exp.get("eligible_count", 0)
+                    orphans_removed += orp.get("deleted-files", 0)
+                else:
+                    failures.extend(
+                        f"{table_info.table_name}: {err}" for err in res["errors"]
+                    )
+            except Exception as exc:  # noqa: BLE001
+                failures.append(f"{table_info.table_name}: {exc}")
+
+    context.log.info(
+        "Raw layer maintenance complete: %d/%d tables cleaned, %d failures.",
+        tables_cleaned,
+        len(tables),
+        len(failures),
+    )
+
+    return Output(
+        value=None,
+        metadata={
+            "tables_scanned": MetadataValue.int(len(tables)),
+            "tables_cleaned": MetadataValue.int(tables_cleaned),
+            "snapshots_expired": MetadataValue.int(snapshots_expired),
+            "orphans_removed": MetadataValue.int(orphans_removed),
+            "failure_count": MetadataValue.int(len(failures)),
+            "failure_details": MetadataValue.json(failures[:20]),
+        },
+    )

--- a/dg_projects/lakehouse/lakehouse/assets/iceberg_maintenance.py
+++ b/dg_projects/lakehouse/lakehouse/assets/iceberg_maintenance.py
@@ -300,6 +300,27 @@ def iceberg_dbt_layer_maintenance(
         len(failures),
     )
 
+    # Fail the asset if maintenance failures exceed 5% of tables processed.
+    # This surfaces systemic failures (broken Trino credentials, Glue outage)
+    # that would otherwise accumulate silently in metadata while Dagster marks
+    # the run SUCCESS, advancing the cursor and blocking retries.
+    if failures:
+        failure_threshold = max(1, int(tables_processed * 0.05))
+        if len(failures) >= failure_threshold:
+            context.log.error(
+                "Maintenance failed for %d/%d tables (threshold: %d). Failing asset.",
+                len(failures),
+                tables_processed,
+                failure_threshold,
+            )
+            msg = (
+                f"Iceberg maintenance failed for "
+                f"{len(failures)}/{tables_processed} "
+                f"tables (threshold {failure_threshold}). "
+                f"First failures: {failures[:5]}"
+            )
+            raise RuntimeError(msg)
+
     return Output(
         value=None,
         metadata={
@@ -395,6 +416,27 @@ def iceberg_raw_layer_maintenance(context: AssetExecutionContext) -> Output[None
         len(tables),
         len(failures),
     )
+
+    # Fail the asset if maintenance failures exceed 5% of tables scanned.
+    # Prevents silent SUCCESS when Glue/S3 is unavailable for a large fraction
+    # of tables, which would advance the snapshot timestamp cursor.
+    tables_processed = len(tables)
+    if failures:
+        failure_threshold = max(1, int(tables_processed * 0.05))
+        if len(failures) >= failure_threshold:
+            context.log.error(
+                "Maintenance failed for %d/%d tables (threshold: %d). Failing asset.",
+                len(failures),
+                tables_processed,
+                failure_threshold,
+            )
+            msg = (
+                f"Iceberg raw layer maintenance failed for "
+                f"{len(failures)}/{tables_processed} tables "
+                f"(threshold {failure_threshold}). "
+                f"First failures: {failures[:5]}"
+            )
+            raise RuntimeError(msg)
 
     return Output(
         value=None,

--- a/dg_projects/lakehouse/lakehouse/definitions.py
+++ b/dg_projects/lakehouse/lakehouse/definitions.py
@@ -27,7 +27,12 @@ from ol_orchestrate.lib.constants import DAGSTER_ENV, VAULT_ADDRESS
 from ol_orchestrate.lib.utils import authenticate_vault
 from ol_orchestrate.resources.github import GithubApiClientFactory
 from ol_orchestrate.resources.secrets.vault import Vault
+from ol_orchestrate.resources.trino_maintenance import TrinoMaintenanceResource
 
+from lakehouse.assets.iceberg_maintenance import (
+    iceberg_dbt_layer_maintenance,
+    iceberg_raw_layer_maintenance,
+)
 from lakehouse.assets.instructor_onboarding import (
     generate_instructor_onboarding_user_list,
     update_access_forge_repo,
@@ -37,6 +42,20 @@ from lakehouse.assets.superset import create_superset_asset
 from lakehouse.resources.airbyte import AirbyteOSSWorkspace
 from lakehouse.resources.dbt_s3_artifacts import DbtS3ArtifactsResource
 from lakehouse.resources.superset_api import SupersetApiClientFactory
+
+trino_host_map = {
+    "dev": "mitol-ol-data-lake-production.trino.galaxy.starburst.io",
+    "ci": "mitol-ol-data-lake-qa-0.trino.galaxy.starburst.io",
+    "qa": "mitol-ol-data-lake-qa-0.trino.galaxy.starburst.io",
+    "production": "mitol-ol-data-lake-production.trino.galaxy.starburst.io",
+}
+
+trino_catalog_map = {
+    "dev": "ol_data_lake_production",
+    "ci": "ol_data_lake_qa",
+    "qa": "ol_data_lake_qa",
+    "production": "ol_data_lake_production",
+}
 
 airbyte_host_map = {
     "dev": "https://api-airbyte-qa.odl.mit.edu",
@@ -286,6 +305,33 @@ superset_starrocks_assets = [
     if key.path[0] in dbt_models_for_superset_datasets
 ]
 
+# Iceberg maintenance schedules — both default STOPPED; enable in production via
+# the Dagster UI or Terraform after verifying the first manual run succeeds.
+#
+# 02:00 UTC: dbt layer (after nightly Airbyte syncs complete, before business hours)
+# 03:00 UTC: raw layer (staggered to avoid concurrent Glue/S3 load with dbt layer)
+iceberg_dbt_maintenance_schedule = ScheduleDefinition(
+    name="iceberg_dbt_maintenance_nightly",
+    job=define_asset_job(
+        name="iceberg_dbt_maintenance_job",
+        selection=AssetSelection.assets(iceberg_dbt_layer_maintenance),
+    ),
+    cron_schedule="0 2 * * *",
+    execution_timezone="UTC",
+    default_status=DefaultScheduleStatus.STOPPED,
+)
+
+iceberg_raw_maintenance_schedule = ScheduleDefinition(
+    name="iceberg_raw_maintenance_nightly",
+    job=define_asset_job(
+        name="iceberg_raw_maintenance_job",
+        selection=AssetSelection.assets(iceberg_raw_layer_maintenance),
+    ),
+    cron_schedule="0 3 * * *",
+    execution_timezone="UTC",
+    default_status=DefaultScheduleStatus.STOPPED,
+)
+
 # Instructor onboarding schedule
 instructor_onboarding_schedule = ScheduleDefinition(
     name="instructor_onboarding_daily_schedule",
@@ -303,6 +349,15 @@ instructor_onboarding_schedule = ScheduleDefinition(
 # Build resources dict, conditionally including airbyte
 resources_dict = {
     "dbt": dbt_cli,
+    "trino_maintenance": TrinoMaintenanceResource(
+        host=os.environ.get("DAGSTER_TRINO_HOST", trino_host_map[DAGSTER_ENV]),
+        catalog=os.environ.get("DAGSTER_TRINO_CATALOG", trino_catalog_map[DAGSTER_ENV]),
+        vault=vault,
+        # Vault KV-v1 path whose secret contains "username" and "password" keys
+        # for the Trino service account.  Falls back to DBT_TRINO_USERNAME /
+        # DBT_TRINO_PASSWORD env vars when vault_path is empty (local dev).
+        vault_path=os.environ.get("DAGSTER_TRINO_VAULT_PATH", ""),
+    ),
     "dbt_s3_artifacts": DbtS3ArtifactsResource(
         s3_bucket=os.environ.get("DBT_ARTIFACTS_S3_BUCKET", ""),
         s3_prefix=os.environ.get(
@@ -325,6 +380,8 @@ defs = Definitions(
         *superset_starrocks_assets,
         generate_instructor_onboarding_user_list,
         update_access_forge_repo,
+        iceberg_dbt_layer_maintenance,
+        iceberg_raw_layer_maintenance,
     ],
     resources=resources_dict,
     sensors=[
@@ -341,5 +398,10 @@ defs = Definitions(
         ),
     ],
     jobs=[*airbyte_asset_jobs],
-    schedules=[*airbyte_update_schedules, instructor_onboarding_schedule],
+    schedules=[
+        *airbyte_update_schedules,
+        instructor_onboarding_schedule,
+        iceberg_dbt_maintenance_schedule,
+        iceberg_raw_maintenance_schedule,
+    ],
 )

--- a/packages/ol-orchestrate-lib/pyproject.toml
+++ b/packages/ol-orchestrate-lib/pyproject.toml
@@ -25,6 +25,7 @@ dependencies = [
     "pydantic ~=2.13.2",
     "pygsheets ~= 2.0.6",
     "pyiceberg[polars]>=0.11.1",
+    "trino>=0.329",
     "s3fs (>=2026.0.0,<2027.0.0)",
     "universal-pathlib ~= 0.3.1",
 ]

--- a/packages/ol-orchestrate-lib/src/ol_orchestrate/lib/iceberg_maintenance.py
+++ b/packages/ol-orchestrate-lib/src/ol_orchestrate/lib/iceberg_maintenance.py
@@ -1,0 +1,463 @@
+"""Iceberg table maintenance utilities for the OL data lakehouse.
+
+This module provides the building blocks for the two nightly maintenance assets:
+
+- ``iceberg_dbt_layer_maintenance``: OPTIMIZE + ANALYZE (Trino) + EXPIRE + ORPHAN
+  removal (pyiceberg) for all dbt-managed tables and non-dbt singletons.
+- ``iceberg_raw_layer_maintenance``: EXPIRE + ORPHAN removal (pyiceberg) for the
+  1,300+ Airbyte-ingested tables in ``ol_warehouse_production_raw``.
+
+Three sources of truth are used deliberately — each layer of the lakehouse has
+a natural authoritative registry, and we use each one directly:
+
+- dbt-managed tables  → ``manifest.json`` + Dagster materialization event log
+- Raw / Airbyte tables → Glue catalog live scan + Iceberg snapshot timestamps
+- Non-dbt singletons  → ``NON_DBT_SINGLETON_TABLES`` module-level constant
+
+The Airbyte layer cannot use the Dagster event log for timing because
+``OLAirbyteTranslator`` prefixes asset keys with ``ol_warehouse_raw_data`` and
+sluggifies connection names — there is no reliable programmatic mapping from
+those asset keys back to Glue table names like
+``raw__mitxonline__openedx__api__course_blocks``.  The Iceberg snapshot
+timestamp is more accurate anyway: it records exactly when Airbyte last
+committed data.
+"""
+
+from __future__ import annotations
+
+import datetime
+import logging
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import boto3
+from pyiceberg.catalog.glue import GlueCatalog
+
+log = logging.getLogger(__name__)
+
+AWS_REGION = "us-east-1"
+
+# ── Default config applied to every dbt model (overridden by dbt_project.yml
+#    meta and per-model meta).  dbt's meta merging is a *shallow* dict merge:
+#    if a model YAML sets meta: {iceberg_maintenance: {snapshot_retention_days: 14}}
+#    it replaces the entire iceberg_maintenance dict from the folder-level config.
+#    load_maintenance_configs_from_manifest() re-applies this dict as the base
+#    before overlaying so callers always receive a fully-specified config.
+DEFAULT_MAINTENANCE_CONFIG: dict[str, Any] = {
+    "enabled": True,
+    "snapshot_retention_days": 7,
+    "orphan_retention_days": 7,
+    "optimize_after_every_n_runs": 1,
+    "analyze_after_every_n_runs": 7,
+}
+
+
+# ── Configuration Dataclasses ─────────────────────────────────────────────────
+
+
+@dataclass(frozen=True)
+class TableMaintenanceConfig:
+    """Maintenance configuration for a single dbt model or non-dbt singleton.
+
+    ``asset_key`` mirrors the Dagster AssetKey used by ``DbtAutomationTranslator``
+    (group = config.schema, name = model name from unique_id). This is used to
+    query the Dagster materialization event log.
+    """
+
+    model_name: str
+    schema_name: str  # full Glue/Trino schema, e.g. "ol_warehouse_production_mart"
+    materialized: str  # "table" or "incremental"
+    asset_key: list[str]  # Dagster AssetKey path components
+    enabled: bool = True
+    snapshot_retention_days: int = 7
+    orphan_retention_days: int = 7
+    # Run OPTIMIZE after this many materializations since last maintenance
+    optimize_after_every_n_runs: int = 1
+    # Run ANALYZE after this many materializations since last maintenance
+    analyze_after_every_n_runs: int = 7
+
+
+@dataclass(frozen=True)
+class RawLayerGroupConfig:
+    """Maintenance config for a raw-layer source group.
+
+    OPTIMIZE and ANALYZE are intentionally omitted: raw tables are not Trino
+    analytics targets and Airbyte writes complete files per sync.
+    """
+
+    snapshot_retention_days: int = 7
+    orphan_retention_days: int = 7
+
+
+@dataclass
+class RawLayerTableInfo:
+    """Metadata about a raw-layer Iceberg table, populated during the catalog scan."""
+
+    table_name: str
+    database: str
+    snapshot_count: int
+    eligible_snapshot_count: int
+    latest_snapshot_timestamp_ms: int | None = None
+
+
+# ── Constants ─────────────────────────────────────────────────────────────────
+
+# Source-group-level overrides for raw-layer maintenance.
+# Key = table name prefix (matched with str.startswith).
+# "_default" is the fallback for tables not matching any prefix.
+RAW_LAYER_GROUP_CONFIGS: dict[str, RawLayerGroupConfig] = {
+    # High-frequency syncs (6-12 h interval) -- shorter retention to control growth
+    "raw__mitxonline__app": RawLayerGroupConfig(snapshot_retention_days=3),
+    "raw__xpro__app": RawLayerGroupConfig(snapshot_retention_days=3),
+    "raw__mitlearn__app": RawLayerGroupConfig(snapshot_retention_days=3),
+    "raw__learn_ai__app": RawLayerGroupConfig(snapshot_retention_days=3),
+    "raw__ocw__studio": RawLayerGroupConfig(snapshot_retention_days=3),
+    # External / third-party — 14 days for audit and reprocessing window
+    "raw__thirdparty__salesforce": RawLayerGroupConfig(snapshot_retention_days=14),
+    "raw__thirdparty__zendesk_support": RawLayerGroupConfig(snapshot_retention_days=14),
+    # Fallback for all other raw__ groups
+    "_default": RawLayerGroupConfig(snapshot_retention_days=7),
+}
+
+# Tables written outside dbt and Airbyte that still need Iceberg maintenance.
+# Add new entries here as additional inference pipelines or ad-hoc writers land.
+NON_DBT_SINGLETON_TABLES: list[TableMaintenanceConfig] = [
+    TableMaintenanceConfig(
+        model_name="student_risk_probability",
+        schema_name="ol_warehouse_production_reporting",
+        materialized="table",
+        # Asset key matches the Dagster asset in the student_risk_probability
+        # code location.
+        asset_key=["reporting", "student_risk_probability"],
+        snapshot_retention_days=7,
+        orphan_retention_days=7,
+        optimize_after_every_n_runs=1,
+        analyze_after_every_n_runs=7,
+    ),
+]
+
+
+# ── Catalog Factory ───────────────────────────────────────────────────────────
+
+
+def get_glue_catalog(region: str = AWS_REGION) -> GlueCatalog:
+    """Return a configured pyiceberg GlueCatalog backed by boto3.
+
+    This is the single factory used by both the maintenance library and
+    ``glue_helper.get_dbt_model_as_dataframe``.  When the latter is refactored,
+    it should delegate here.
+    """
+    return GlueCatalog(
+        "default",
+        client=boto3.client("glue", region_name=region),
+        **{
+            "s3.connect-timeout": "10",
+            "s3.request-timeout": "120",
+        },
+    )
+
+
+# ── Maintenance Operations ────────────────────────────────────────────────────
+
+
+def expire_snapshots(
+    catalog: GlueCatalog,
+    database: str,
+    table_name: str,
+    retention_days: int,
+    *,
+    dry_run: bool = False,
+) -> dict[str, Any]:
+    """Expire old Iceberg snapshots for a table via pyiceberg.
+
+    Uses the pyiceberg >= 0.10.0 API:
+        ``table.maintenance.expire_snapshots().older_than(cutoff_dt).commit()``
+
+    Returns a result dict with the following keys:
+
+    - ``skipped`` (bool): True if no action was taken.
+    - ``dry_run`` (bool, optional): Present when dry_run=True.
+    - ``reason`` (str, optional): Why the operation was skipped.
+    - ``total_snapshots`` (int): Total snapshot count before expiry.
+    - ``eligible_count`` (int): Number of snapshots that qualified for expiry.
+    - ``error`` (str, optional): Exception message on failure.
+    """
+    cutoff_dt = datetime.datetime.now(tz=datetime.UTC) - datetime.timedelta(
+        days=retention_days
+    )
+    cutoff_ms = int(cutoff_dt.timestamp() * 1000)
+
+    try:
+        table = catalog.load_table(f"{database}.{table_name}")
+    except Exception as exc:  # noqa: BLE001
+        log.warning(
+            "Could not load %s.%s for snapshot expiry: %s", database, table_name, exc
+        )
+        return {"skipped": True, "error": str(exc)}
+
+    snapshots = table.metadata.snapshots
+    current_id = table.metadata.current_snapshot_id
+    eligible = [
+        s
+        for s in snapshots
+        if s.snapshot_id != current_id and s.timestamp_ms < cutoff_ms
+    ]
+
+    if dry_run:
+        return {
+            "skipped": True,
+            "dry_run": True,
+            "total_snapshots": len(snapshots),
+            "eligible_count": len(eligible),
+        }
+
+    if not eligible:
+        return {
+            "skipped": True,
+            "reason": "no eligible snapshots",
+            "total_snapshots": len(snapshots),
+            "eligible_count": 0,
+        }
+
+    try:
+        table.maintenance.expire_snapshots().older_than(cutoff_dt).commit()
+    except Exception as exc:  # noqa: BLE001
+        log.warning("expire_snapshots failed for %s.%s: %s", database, table_name, exc)
+        return {
+            "skipped": True,
+            "error": str(exc),
+            "total_snapshots": len(snapshots),
+            "eligible_count": len(eligible),
+        }
+
+    return {
+        "skipped": False,
+        "total_snapshots": len(snapshots),
+        "eligible_count": len(eligible),
+    }
+
+
+def remove_orphan_files(
+    catalog: GlueCatalog,
+    database: str,
+    table_name: str,
+    retention_days: int,  # noqa: ARG001 (reserved for future implementation)
+    *,
+    dry_run: bool = False,  # noqa: ARG001 (reserved for future implementation)
+) -> dict[str, Any]:
+    """Remove orphan S3 files for a table — files not referenced by any snapshot.
+
+    pyiceberg 0.11.x does not yet expose a built-in ``remove_orphan_files()``
+    API on ``Table``.  This function is implemented as a graceful no-op stub that
+    logs a notice and returns ``{"skipped": True, "reason": "not_implemented"}``.
+
+    When pyiceberg adds orphan-file removal (tracked upstream), replace this
+    stub body with:
+        table.remove_orphan_files().older_than(cutoff_dt).execute()
+
+    Callers should handle ``skipped=True`` without treating it as an error.
+    """
+    try:
+        # Validate the table exists and is loadable before returning.
+        catalog.load_table(f"{database}.{table_name}")
+    except Exception as exc:  # noqa: BLE001
+        log.warning(
+            "Could not load %s.%s for orphan removal: %s", database, table_name, exc
+        )
+        return {"skipped": True, "error": str(exc)}
+
+    log.debug(
+        "remove_orphan_files: skipped for %s.%s — not yet implemented in pyiceberg %s",
+        database,
+        table_name,
+        _pyiceberg_version(),
+    )
+    return {
+        "skipped": True,
+        "reason": "not_implemented",
+        "note": (
+            "pyiceberg does not yet expose a remove_orphan_files() API. "
+            "Re-enable once https://github.com/apache/iceberg-python/issues/XXX ships."
+        ),
+    }
+
+
+def _pyiceberg_version() -> str:
+    try:
+        import pyiceberg  # noqa: PLC0415
+    except Exception:  # noqa: BLE001
+        return "unknown"
+    else:
+        return pyiceberg.__version__
+
+
+# ── Manifest Parsing ──────────────────────────────────────────────────────────
+
+
+def load_maintenance_configs_from_manifest(
+    manifest_path: str | Path,
+    env_schema_prefix: str = "ol_warehouse_production",
+) -> list[TableMaintenanceConfig]:
+    """Parse dbt ``manifest.json`` and return a ``TableMaintenanceConfig`` per model.
+
+    Only ``table`` and ``incremental`` materializations are included; views and
+    ephemeral models are skipped.
+
+    The full Glue/Trino schema name is reconstructed as::
+
+        {env_schema_prefix}_{config.schema}
+        e.g. "ol_warehouse_production" + "_" + "mart" = "ol_warehouse_production_mart"
+
+    Per-model ``iceberg_maintenance`` meta is a shallow overlay on top of
+    ``DEFAULT_MAINTENANCE_CONFIG``.  A model YAML that sets::
+
+        meta:
+          iceberg_maintenance:
+            snapshot_retention_days: 14
+
+    replaces the *entire* ``iceberg_maintenance`` dict from the folder-level config
+    (dbt shallow-merge semantics).  ``load_maintenance_configs_from_manifest``
+    re-applies ``DEFAULT_MAINTENANCE_CONFIG`` as the base before overlaying so that
+    callers always get a fully-specified config.
+    """
+    import json  # noqa: PLC0415
+
+    manifest = json.loads(Path(manifest_path).read_text())
+    nodes = manifest.get("nodes", {})
+
+    configs: list[TableMaintenanceConfig] = []
+    for unique_id, node in nodes.items():
+        if node.get("resource_type") != "model":
+            continue
+
+        materialized = node.get("config", {}).get("materialized", "table")
+        if materialized not in ("table", "incremental"):
+            continue  # skip view, ephemeral, seed-backed models
+
+        schema_suffix = node.get("config", {}).get("schema", "")
+        if not schema_suffix:
+            log.debug("Skipping %s — no schema configured", unique_id)
+            continue
+
+        model_name = unique_id.split(".")[-1]
+        schema_name = f"{env_schema_prefix}_{schema_suffix}"
+
+        # Merge: start from global defaults, then overlay node-level meta.
+        # The dbt meta shallow-merge means the node's iceberg_maintenance dict
+        # (if present) completely replaces the folder-level one; we re-apply
+        # DEFAULT_MAINTENANCE_CONFIG as a base here to fill in any missing keys.
+        base: dict[str, Any] = dict(DEFAULT_MAINTENANCE_CONFIG)
+        node_meta = node.get("config", {}).get("meta", {})
+        node_iceberg = node_meta.get("iceberg_maintenance", {})
+        base.update(node_iceberg)
+
+        if not base.get("enabled", True):
+            log.debug("Skipping %s — iceberg_maintenance.enabled=false", model_name)
+            continue
+
+        configs.append(
+            TableMaintenanceConfig(
+                model_name=model_name,
+                schema_name=schema_name,
+                materialized=materialized,
+                # AssetKey: [schema_suffix, model_name] per DbtAutomationTranslator
+                asset_key=[schema_suffix, model_name],
+                enabled=base["enabled"],
+                snapshot_retention_days=base["snapshot_retention_days"],
+                orphan_retention_days=base["orphan_retention_days"],
+                optimize_after_every_n_runs=base["optimize_after_every_n_runs"],
+                analyze_after_every_n_runs=base["analyze_after_every_n_runs"],
+            )
+        )
+
+    log.info("Loaded %d dbt model maintenance configs from manifest", len(configs))
+    return configs
+
+
+# ── Raw Layer ─────────────────────────────────────────────────────────────────
+
+
+def raw_config_for_table(table_name: str) -> RawLayerGroupConfig:
+    """Return the ``RawLayerGroupConfig`` for *table_name* by prefix match.
+
+    Iterates ``RAW_LAYER_GROUP_CONFIGS`` in insertion order; the first matching
+    prefix wins.  Falls back to ``_default`` if no prefix matches.
+    """
+    for prefix, config in RAW_LAYER_GROUP_CONFIGS.items():
+        if prefix == "_default":
+            continue
+        if table_name.startswith(prefix):
+            return config
+    return RAW_LAYER_GROUP_CONFIGS["_default"]
+
+
+def load_raw_layer_maintenance_work(
+    glue_database: str,
+    region: str = AWS_REGION,
+) -> list[RawLayerTableInfo]:
+    """Scan the Glue catalog and return RawLayerTableInfo sorted by eligible snapshots.
+
+    This is a read-only inspection — it does not run any maintenance.  Pass the
+    returned list to the maintenance asset for parallel processing.
+
+    Tables are sorted descending by ``eligible_snapshot_count`` so the worst
+    offenders are processed first (fail-fast semantics for long-running jobs).
+
+    The per-table snapshot eligibility is computed using each table's
+    ``RawLayerGroupConfig.snapshot_retention_days`` from ``RAW_LAYER_GROUP_CONFIGS``.
+    """
+    glue_client = boto3.client("glue", region_name=region)
+    catalog = get_glue_catalog(region=region)
+
+    # ── 1. Enumerate Iceberg tables via Glue paginator ──────────────────────
+    iceberg_table_names: list[str] = []
+    paginator = glue_client.get_paginator("get_tables")
+    for page in paginator.paginate(DatabaseName=glue_database):
+        for table in page.get("TableList", []):
+            params = table.get("Parameters", {})
+            if params.get("table_type", "").upper() == "ICEBERG":
+                iceberg_table_names.append(table["Name"])
+
+    log.info("Found %d Iceberg tables in %s", len(iceberg_table_names), glue_database)
+
+    # ── 2. Load each table's snapshot metadata ────────────────────────────
+    now_ms = int(datetime.datetime.now(tz=datetime.UTC).timestamp() * 1000)
+    results: list[RawLayerTableInfo] = []
+
+    for table_name in iceberg_table_names:
+        group_cfg = raw_config_for_table(table_name)
+        cutoff_ms = now_ms - int(group_cfg.snapshot_retention_days * 86_400 * 1_000)
+
+        try:
+            table = catalog.load_table(f"{glue_database}.{table_name}")
+            snapshots = table.metadata.snapshots
+            current_id = table.metadata.current_snapshot_id
+
+            eligible = [
+                s
+                for s in snapshots
+                if s.snapshot_id != current_id and s.timestamp_ms < cutoff_ms
+            ]
+            latest_ts = max((s.timestamp_ms for s in snapshots), default=None)
+
+            results.append(
+                RawLayerTableInfo(
+                    table_name=table_name,
+                    database=glue_database,
+                    snapshot_count=len(snapshots),
+                    eligible_snapshot_count=len(eligible),
+                    latest_snapshot_timestamp_ms=latest_ts,
+                )
+            )
+        except Exception as exc:  # noqa: BLE001
+            log.warning("Could not inspect %s.%s: %s", glue_database, table_name, exc)
+
+    # Worst offenders first so they are processed before a potential timeout
+    results.sort(key=lambda t: t.eligible_snapshot_count, reverse=True)
+    log.info(
+        "Snapshot scan complete: %d tables inspected, %d total snapshots eligible",
+        len(results),
+        sum(t.eligible_snapshot_count for t in results),
+    )
+    return results

--- a/packages/ol-orchestrate-lib/src/ol_orchestrate/lib/iceberg_maintenance.py
+++ b/packages/ol-orchestrate-lib/src/ol_orchestrate/lib/iceberg_maintenance.py
@@ -38,20 +38,6 @@ log = logging.getLogger(__name__)
 
 AWS_REGION = "us-east-1"
 
-# ── Default config applied to every dbt model (overridden by dbt_project.yml
-#    meta and per-model meta).  dbt's meta merging is a *shallow* dict merge:
-#    if a model YAML sets meta: {iceberg_maintenance: {snapshot_retention_days: 14}}
-#    it replaces the entire iceberg_maintenance dict from the folder-level config.
-#    load_maintenance_configs_from_manifest() re-applies this dict as the base
-#    before overlaying so callers always receive a fully-specified config.
-DEFAULT_MAINTENANCE_CONFIG: dict[str, Any] = {
-    "enabled": True,
-    "snapshot_retention_days": 7,
-    "orphan_retention_days": 7,
-    "optimize_after_every_n_runs": 1,
-    "analyze_after_every_n_runs": 7,
-}
-
 
 # ── Configuration Dataclasses ─────────────────────────────────────────────────
 
@@ -277,8 +263,8 @@ def remove_orphan_files(
         "skipped": True,
         "reason": "not_implemented",
         "note": (
-            "pyiceberg does not yet expose a remove_orphan_files() API. "
-            "Re-enable once https://github.com/apache/iceberg-python/issues/XXX ships."
+            "pyiceberg does not yet expose a remove_orphan_files() API on Table. "
+            "See https://github.com/apache/iceberg-python for upstream status."
         ),
     }
 
@@ -297,29 +283,24 @@ def _pyiceberg_version() -> str:
 
 def load_maintenance_configs_from_manifest(
     manifest_path: str | Path,
-    env_schema_prefix: str = "ol_warehouse_production",
 ) -> list[TableMaintenanceConfig]:
     """Parse dbt ``manifest.json`` and return a ``TableMaintenanceConfig`` per model.
 
-    Only ``table`` and ``incremental`` materializations are included; views and
-    ephemeral models are skipped.
+    Only models whose ``iceberg_maintenance`` config has been compiled into
+    ``config.meta`` are included.  This makes ``dbt_project.yml`` the single
+    source of truth for maintenance defaults: models without the key are
+    skipped rather than having Python-side defaults applied silently, which
+    would diverge from the dbt config over time.
 
-    The full Glue/Trino schema name is reconstructed as::
+    The Glue/Trino schema name is read directly from ``node['schema']``, which
+    dbt fully resolves at compile time (e.g. ``ol_warehouse_production_mart``).
+    Using the resolved value is safer than reconstructing it from
+    ``config.schema`` + an env prefix, because it reflects the actual target
+    the manifest was compiled against.
 
-        {env_schema_prefix}_{config.schema}
-        e.g. "ol_warehouse_production" + "_" + "mart" = "ol_warehouse_production_mart"
-
-    Per-model ``iceberg_maintenance`` meta is a shallow overlay on top of
-    ``DEFAULT_MAINTENANCE_CONFIG``.  A model YAML that sets::
-
-        meta:
-          iceberg_maintenance:
-            snapshot_retention_days: 14
-
-    replaces the *entire* ``iceberg_maintenance`` dict from the folder-level config
-    (dbt shallow-merge semantics).  ``load_maintenance_configs_from_manifest``
-    re-applies ``DEFAULT_MAINTENANCE_CONFIG`` as the base before overlaying so that
-    callers always get a fully-specified config.
+    The Dagster AssetKey path is ``[config.schema, model_name]`` to match
+    ``DbtAutomationTranslator.get_group_name``, which returns ``config.schema``
+    (the bare schema suffix, e.g. ``mart``).
     """
     import json  # noqa: PLC0415
 
@@ -335,24 +316,30 @@ def load_maintenance_configs_from_manifest(
         if materialized not in ("table", "incremental"):
             continue  # skip view, ephemeral, seed-backed models
 
-        schema_suffix = node.get("config", {}).get("schema", "")
-        if not schema_suffix:
-            log.debug("Skipping %s — no schema configured", unique_id)
+        # Use the fully-resolved schema from the manifest node (e.g.
+        # "ol_warehouse_production_mart"), not config.schema (bare suffix).
+        schema_name = node.get("schema", "")
+        if not schema_name:
+            log.debug("Skipping %s — no schema on manifest node", unique_id)
             continue
 
+        # config.schema is the bare suffix (e.g. "mart") used as the Dagster
+        # asset group name by DbtAutomationTranslator.get_group_name.
+        schema_suffix = node.get("config", {}).get("schema", "")
         model_name = unique_id.split(".")[-1]
-        schema_name = f"{env_schema_prefix}_{schema_suffix}"
 
-        # Merge: start from global defaults, then overlay node-level meta.
-        # The dbt meta shallow-merge means the node's iceberg_maintenance dict
-        # (if present) completely replaces the folder-level one; we re-apply
-        # DEFAULT_MAINTENANCE_CONFIG as a base here to fill in any missing keys.
-        base: dict[str, Any] = dict(DEFAULT_MAINTENANCE_CONFIG)
+        # dbt_project.yml is the source of truth.  Only include models whose
+        # iceberg_maintenance meta was compiled into the manifest.  Skip models
+        # without it so Python never silently falls back to stale defaults.
         node_meta = node.get("config", {}).get("meta", {})
-        node_iceberg = node_meta.get("iceberg_maintenance", {})
-        base.update(node_iceberg)
+        iceberg_cfg = node_meta.get("iceberg_maintenance")
+        if iceberg_cfg is None:
+            log.debug(
+                "Skipping %s — no iceberg_maintenance in compiled meta", model_name
+            )
+            continue
 
-        if not base.get("enabled", True):
+        if not iceberg_cfg.get("enabled", True):
             log.debug("Skipping %s — iceberg_maintenance.enabled=false", model_name)
             continue
 
@@ -363,11 +350,11 @@ def load_maintenance_configs_from_manifest(
                 materialized=materialized,
                 # AssetKey: [schema_suffix, model_name] per DbtAutomationTranslator
                 asset_key=[schema_suffix, model_name],
-                enabled=base["enabled"],
-                snapshot_retention_days=base["snapshot_retention_days"],
-                orphan_retention_days=base["orphan_retention_days"],
-                optimize_after_every_n_runs=base["optimize_after_every_n_runs"],
-                analyze_after_every_n_runs=base["analyze_after_every_n_runs"],
+                enabled=iceberg_cfg.get("enabled", True),
+                snapshot_retention_days=iceberg_cfg["snapshot_retention_days"],
+                orphan_retention_days=iceberg_cfg["orphan_retention_days"],
+                optimize_after_every_n_runs=iceberg_cfg["optimize_after_every_n_runs"],
+                analyze_after_every_n_runs=iceberg_cfg["analyze_after_every_n_runs"],
             )
         )
 

--- a/packages/ol-orchestrate-lib/src/ol_orchestrate/lib/iceberg_maintenance.py
+++ b/packages/ol-orchestrate-lib/src/ol_orchestrate/lib/iceberg_maintenance.py
@@ -343,6 +343,13 @@ def load_maintenance_configs_from_manifest(
             log.debug("Skipping %s — iceberg_maintenance.enabled=false", model_name)
             continue
 
+        # Use .get() with dataclass defaults for every key so that partial
+        # per-folder or per-model overrides in schema YAML files work without
+        # raising KeyError.  dbt shallow-merges meta dicts, so a single-key
+        # override replaces the entire iceberg_maintenance dict and omits the
+        # remaining keys.  Falling back to the TableMaintenanceConfig field
+        # defaults keeps Python consistent with the project-root +meta defaults.
+        _d = TableMaintenanceConfig.__dataclass_fields__
         configs.append(
             TableMaintenanceConfig(
                 model_name=model_name,
@@ -350,11 +357,23 @@ def load_maintenance_configs_from_manifest(
                 materialized=materialized,
                 # AssetKey: [schema_suffix, model_name] per DbtAutomationTranslator
                 asset_key=[schema_suffix, model_name],
-                enabled=iceberg_cfg.get("enabled", True),
-                snapshot_retention_days=iceberg_cfg["snapshot_retention_days"],
-                orphan_retention_days=iceberg_cfg["orphan_retention_days"],
-                optimize_after_every_n_runs=iceberg_cfg["optimize_after_every_n_runs"],
-                analyze_after_every_n_runs=iceberg_cfg["analyze_after_every_n_runs"],
+                enabled=iceberg_cfg.get("enabled", _d["enabled"].default),
+                snapshot_retention_days=iceberg_cfg.get(
+                    "snapshot_retention_days",
+                    _d["snapshot_retention_days"].default,
+                ),
+                orphan_retention_days=iceberg_cfg.get(
+                    "orphan_retention_days",
+                    _d["orphan_retention_days"].default,
+                ),
+                optimize_after_every_n_runs=iceberg_cfg.get(
+                    "optimize_after_every_n_runs",
+                    _d["optimize_after_every_n_runs"].default,
+                ),
+                analyze_after_every_n_runs=iceberg_cfg.get(
+                    "analyze_after_every_n_runs",
+                    _d["analyze_after_every_n_runs"].default,
+                ),
             )
         )
 

--- a/packages/ol-orchestrate-lib/src/ol_orchestrate/resources/trino_maintenance.py
+++ b/packages/ol-orchestrate-lib/src/ol_orchestrate/resources/trino_maintenance.py
@@ -80,10 +80,19 @@ class TrinoMaintenanceResource(ConfigurableResource):
         # Fall back to env vars used by dbt for local development
         username = os.environ.get("DBT_TRINO_USERNAME", "")
         password = os.environ.get("DBT_TRINO_PASSWORD", "")
-        if not username:
+        missing = [
+            name
+            for name, val in (
+                ("DBT_TRINO_USERNAME", username),
+                ("DBT_TRINO_PASSWORD", password),
+            )
+            if not val
+        ]
+        if missing:
+            noun = "is" if len(missing) == 1 else "are"
             msg = (
                 "TrinoMaintenanceResource: no vault_path configured and "
-                "DBT_TRINO_USERNAME is not set"
+                f"{', '.join(missing)} {noun} not set"
             )
             raise ValueError(msg)
         return username, password

--- a/packages/ol-orchestrate-lib/src/ol_orchestrate/resources/trino_maintenance.py
+++ b/packages/ol-orchestrate-lib/src/ol_orchestrate/resources/trino_maintenance.py
@@ -1,0 +1,144 @@
+"""Trino maintenance resource for Iceberg OPTIMIZE and ANALYZE operations.
+
+OPTIMIZE and ANALYZE are run via Trino (Starburst Galaxy) rather than pyiceberg
+because:
+
+- OPTIMIZE distributes file rewriting across Galaxy workers.  Running it inside
+  the Dagster worker pod would consume orchestration-tier CPU/memory for work
+  that is inherently a compute job.
+- ANALYZE is not available in pyiceberg at all; it is a Trino-only operation
+  that collects statistics for the query optimizer.
+
+pyiceberg is used instead for EXPIRE SNAPSHOTS and REMOVE ORPHAN FILES because
+those are metadata bookkeeping operations (Glue API calls + targeted S3 deletes)
+that do not need a distributed engine.
+
+Credentials are read from Vault using BasicAuthentication (service account),
+not OAuth2 (which is for interactive developer use only).  The vault secret at
+``vault_path`` must contain ``username`` and ``password`` keys matching the
+service account credentials used for dbt's DBT_TRINO_USERNAME / DBT_TRINO_PASSWORD
+environment variables.  If ``vault_path`` is empty, the resource falls back to
+the ``DBT_TRINO_USERNAME`` / ``DBT_TRINO_PASSWORD`` environment variables so that
+local development works without a Vault connection.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import Any
+
+import trino
+from dagster import ConfigurableResource, ResourceDependency
+from pydantic import PrivateAttr
+from trino.auth import BasicAuthentication
+
+from ol_orchestrate.resources.secrets.vault import Vault
+
+log = logging.getLogger(__name__)
+
+
+class TrinoMaintenanceResource(ConfigurableResource):
+    """Dagster resource for running Trino maintenance queries on Iceberg tables.
+
+    Configure one instance per environment by keying off ``DAGSTER_ENV`` in
+    ``definitions.py``, analogous to ``airbyte_host_map``.
+
+    Example resource configuration::
+
+        trino_maintenance = TrinoMaintenanceResource(
+            host="mitol-ol-data-lake-production.trino.galaxy.starburst.io",
+            catalog="ol_data_lake_production",
+            vault=vault,
+            vault_path="pipelines/trino-service-account",
+        )
+
+    The underlying Trino connection is created lazily on first use and reused
+    for the lifetime of the resource.
+    """
+
+    host: str
+    port: int = 443
+    http_scheme: str = "https"
+    catalog: str = "awsdatacatalog"
+    vault: ResourceDependency[Vault]
+    # Vault KV-v1 path whose secret contains "username" and "password" keys.
+    # Leave empty to fall back to DBT_TRINO_USERNAME / DBT_TRINO_PASSWORD env vars.
+    vault_path: str = ""
+    vault_mount_point: str = "secret-data"
+
+    _connection: trino.dbapi.Connection | None = PrivateAttr(default=None)
+
+    def _get_credentials(self) -> tuple[str, str]:
+        """Return (username, password) from Vault or environment variables."""
+        if self.vault_path:
+            secret = self.vault.client.secrets.kv.v1.read_secret(
+                path=self.vault_path,
+                mount_point=self.vault_mount_point,
+            )["data"]
+            return secret["username"], secret["password"]
+        # Fall back to env vars used by dbt for local development
+        username = os.environ.get("DBT_TRINO_USERNAME", "")
+        password = os.environ.get("DBT_TRINO_PASSWORD", "")
+        if not username:
+            msg = (
+                "TrinoMaintenanceResource: no vault_path configured and "
+                "DBT_TRINO_USERNAME is not set"
+            )
+            raise ValueError(msg)
+        return username, password
+
+    def _get_connection(self) -> trino.dbapi.Connection:
+        if self._connection is None:
+            username, password = self._get_credentials()
+            self._connection = trino.dbapi.connect(
+                host=self.host,
+                port=self.port,
+                http_scheme=self.http_scheme,
+                catalog=self.catalog,
+                auth=BasicAuthentication(username, password),
+            )
+        return self._connection
+
+    def execute(self, sql: str) -> list[Any]:
+        """Execute a SQL statement and return all rows."""
+        conn = self._get_connection()
+        cursor = conn.cursor()
+        log.debug("Trino maintenance SQL: %.200s", sql)
+        cursor.execute(sql)
+        return cursor.fetchall()
+
+    def optimize(
+        self,
+        schema: str,
+        table: str,
+        file_size_mb: int = 512,
+    ) -> None:
+        """Compact small Parquet files for the given Iceberg table.
+
+        Issues::
+
+            ALTER TABLE <schema>.<table>
+            EXECUTE optimize(file_size_threshold => '512MB')
+
+        This is particularly important for ``incremental`` dbt models using the
+        ``delete+insert`` strategy, which produce one small file per run.  With
+        6-12 hour sync schedules those tables accumulate small files rapidly.
+        """
+        sql = (
+            f"ALTER TABLE {schema}.{table} "
+            f"EXECUTE optimize(file_size_threshold => '{file_size_mb}MB')"
+        )
+        self.execute(sql)
+        log.info("OPTIMIZE complete: %s.%s", schema, table)
+
+    def analyze(self, schema: str, table: str) -> None:
+        """Collect Trino query optimizer statistics for the given table.
+
+        Issues ``ANALYZE <schema>.<table>``.  Stale statistics degrade Trino's
+        query planner for mart and dimensional models.  ANALYZE is not available
+        in pyiceberg, so Trino is the only engine that can perform this operation.
+        """
+        sql = f"ANALYZE {schema}.{table}"
+        self.execute(sql)
+        log.info("ANALYZE complete: %s.%s", schema, table)

--- a/packages/ol-orchestrate-lib/tests/lib/test_iceberg_maintenance.py
+++ b/packages/ol-orchestrate-lib/tests/lib/test_iceberg_maintenance.py
@@ -1,0 +1,308 @@
+"""Unit tests for ol_orchestrate.lib.iceberg_maintenance."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from ol_orchestrate.lib.iceberg_maintenance import (
+    RAW_LAYER_GROUP_CONFIGS,
+    load_maintenance_configs_from_manifest,
+    raw_config_for_table,
+)
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+
+def _make_manifest(nodes: dict[str, object]) -> dict[str, object]:
+    """Wrap a nodes dict in the minimal manifest.json envelope."""
+    return {"metadata": {}, "nodes": nodes, "sources": {}, "exposures": {}}
+
+
+def _iceberg_meta(
+    *,
+    enabled: bool = True,
+    snapshot_retention_days: int = 7,
+    orphan_retention_days: int = 7,
+    optimize_after_every_n_runs: int = 1,
+    analyze_after_every_n_runs: int = 7,
+) -> dict[str, object]:
+    """Return a fully-specified iceberg_maintenance meta dict."""
+    return {
+        "enabled": enabled,
+        "snapshot_retention_days": snapshot_retention_days,
+        "orphan_retention_days": orphan_retention_days,
+        "optimize_after_every_n_runs": optimize_after_every_n_runs,
+        "analyze_after_every_n_runs": analyze_after_every_n_runs,
+    }
+
+
+def _model_node(
+    unique_id: str,
+    *,
+    schema: str = "ol_warehouse_production_mart",
+    config_schema: str = "mart",
+    materialized: str = "table",
+    iceberg_meta: dict[str, object] | None = None,
+) -> dict[str, object]:
+    """Build a minimal manifest model node dict."""
+    meta: dict[str, object] = {"required_docs": True}
+    if iceberg_meta is not None:
+        meta["iceberg_maintenance"] = iceberg_meta
+    return {
+        "unique_id": unique_id,
+        "resource_type": "model",
+        "schema": schema,
+        "database": "ol_data_lake_production",
+        "name": unique_id.rsplit(".", maxsplit=1)[-1],
+        "config": {
+            "materialized": materialized,
+            "schema": config_schema,
+            "meta": meta,
+        },
+    }
+
+
+# ── load_maintenance_configs_from_manifest ────────────────────────────────────
+
+
+class TestLoadMaintenanceConfigsFromManifest:
+    """Tests for load_maintenance_configs_from_manifest."""
+
+    def test_returns_model_with_full_iceberg_meta(self, tmp_path: Path) -> None:
+        """A model with iceberg_maintenance in compiled meta is included."""
+        manifest = _make_manifest(
+            {
+                "model.proj.mart__revenue": _model_node(
+                    "model.proj.mart__revenue",
+                    schema="ol_warehouse_production_mart",
+                    config_schema="mart",
+                    iceberg_meta=_iceberg_meta(snapshot_retention_days=14),
+                )
+            }
+        )
+        manifest_path = tmp_path / "manifest.json"
+        manifest_path.write_text(json.dumps(manifest))
+
+        configs = load_maintenance_configs_from_manifest(manifest_path)
+
+        assert len(configs) == 1
+        cfg = configs[0]
+        assert cfg.model_name == "mart__revenue"
+        assert cfg.schema_name == "ol_warehouse_production_mart"
+        assert cfg.snapshot_retention_days == 14
+        assert cfg.orphan_retention_days == 7
+        assert cfg.optimize_after_every_n_runs == 1
+        assert cfg.analyze_after_every_n_runs == 7
+        assert cfg.asset_key == ["mart", "mart__revenue"]
+
+    def test_schema_name_from_node_schema_not_config_schema(
+        self, tmp_path: Path
+    ) -> None:
+        """node['schema'] is used directly; config.schema is not reconstructed."""
+        manifest = _make_manifest(
+            {
+                "model.proj.dim_user": _model_node(
+                    "model.proj.dim_user",
+                    schema="ol_warehouse_production_dimensional",
+                    config_schema="dimensional",
+                    iceberg_meta=_iceberg_meta(
+                        snapshot_retention_days=14, orphan_retention_days=14
+                    ),
+                )
+            }
+        )
+        manifest_path = tmp_path / "manifest.json"
+        manifest_path.write_text(json.dumps(manifest))
+
+        configs = load_maintenance_configs_from_manifest(manifest_path)
+
+        assert len(configs) == 1
+        assert configs[0].schema_name == "ol_warehouse_production_dimensional"
+
+    def test_model_without_iceberg_meta_is_skipped(self, tmp_path: Path) -> None:
+        """Models without iceberg_maintenance in compiled meta are excluded."""
+        manifest = _make_manifest(
+            {
+                "model.proj.stg_users": _model_node(
+                    "model.proj.stg_users",
+                    schema="ol_warehouse_production_staging",
+                    config_schema="staging",
+                    iceberg_meta=None,
+                )
+            }
+        )
+        manifest_path = tmp_path / "manifest.json"
+        manifest_path.write_text(json.dumps(manifest))
+
+        configs = load_maintenance_configs_from_manifest(manifest_path)
+
+        assert configs == []
+
+    def test_disabled_model_is_skipped(self, tmp_path: Path) -> None:
+        """Models with iceberg_maintenance.enabled=false are excluded."""
+        manifest = _make_manifest(
+            {
+                "model.proj.external_legacy": _model_node(
+                    "model.proj.external_legacy",
+                    iceberg_meta=_iceberg_meta(enabled=False),
+                )
+            }
+        )
+        manifest_path = tmp_path / "manifest.json"
+        manifest_path.write_text(json.dumps(manifest))
+
+        configs = load_maintenance_configs_from_manifest(manifest_path)
+
+        assert configs == []
+
+    def test_view_and_ephemeral_models_are_skipped(self, tmp_path: Path) -> None:
+        """Non-table/incremental materializations are always excluded."""
+        manifest = _make_manifest(
+            {
+                "model.proj.view_model": _model_node(
+                    "model.proj.view_model",
+                    materialized="view",
+                    iceberg_meta=_iceberg_meta(),
+                ),
+                "model.proj.ephemeral_model": _model_node(
+                    "model.proj.ephemeral_model",
+                    materialized="ephemeral",
+                    iceberg_meta=_iceberg_meta(),
+                ),
+            }
+        )
+        manifest_path = tmp_path / "manifest.json"
+        manifest_path.write_text(json.dumps(manifest))
+
+        configs = load_maintenance_configs_from_manifest(manifest_path)
+
+        assert configs == []
+
+    def test_incremental_model_is_included(self, tmp_path: Path) -> None:
+        """Incremental materialization is treated the same as table."""
+        manifest = _make_manifest(
+            {
+                "model.proj.dim_enrollment": _model_node(
+                    "model.proj.dim_enrollment",
+                    schema="ol_warehouse_production_dimensional",
+                    config_schema="dimensional",
+                    materialized="incremental",
+                    iceberg_meta=_iceberg_meta(
+                        snapshot_retention_days=14, orphan_retention_days=14
+                    ),
+                )
+            }
+        )
+        manifest_path = tmp_path / "manifest.json"
+        manifest_path.write_text(json.dumps(manifest))
+
+        configs = load_maintenance_configs_from_manifest(manifest_path)
+
+        assert len(configs) == 1
+        assert configs[0].materialized == "incremental"
+
+    def test_non_model_nodes_are_skipped(self, tmp_path: Path) -> None:
+        """Source and seed nodes are excluded regardless of meta."""
+        manifest = _make_manifest(
+            {
+                "source.proj.raw.users": {
+                    "unique_id": "source.proj.raw.users",
+                    "resource_type": "source",
+                    "schema": "ol_warehouse_production_raw",
+                    "name": "users",
+                    "config": {"meta": {}},
+                },
+                "seed.proj.country_codes": {
+                    "unique_id": "seed.proj.country_codes",
+                    "resource_type": "seed",
+                    "schema": "ol_warehouse_production_staging",
+                    "name": "country_codes",
+                    "config": {
+                        "materialized": "seed",
+                        "schema": "staging",
+                        "meta": {"iceberg_maintenance": _iceberg_meta()},
+                    },
+                },
+            }
+        )
+        manifest_path = tmp_path / "manifest.json"
+        manifest_path.write_text(json.dumps(manifest))
+
+        configs = load_maintenance_configs_from_manifest(manifest_path)
+
+        assert configs == []
+
+    def test_asset_key_uses_config_schema_suffix(self, tmp_path: Path) -> None:
+        """asset_key[0] is the bare config.schema suffix, not the full schema name.
+
+        This matches DbtAutomationTranslator.get_group_name which returns
+        config.schema (e.g. "mart"), not "ol_warehouse_production_mart".
+        """
+        manifest = _make_manifest(
+            {
+                "model.proj.fct_enrollments": _model_node(
+                    "model.proj.fct_enrollments",
+                    schema="ol_warehouse_production_mart",
+                    config_schema="mart",
+                    iceberg_meta=_iceberg_meta(),
+                )
+            }
+        )
+        manifest_path = tmp_path / "manifest.json"
+        manifest_path.write_text(json.dumps(manifest))
+
+        configs = load_maintenance_configs_from_manifest(manifest_path)
+
+        assert configs[0].asset_key == ["mart", "fct_enrollments"]
+
+
+# ── raw_config_for_table ──────────────────────────────────────────────────────
+
+
+class TestRawConfigForTable:
+    """Tests for raw_config_for_table prefix matching."""
+
+    def test_high_frequency_mitxonline_app(self) -> None:
+        """A table under raw__mitxonline__app gets the 3-day retention config."""
+        cfg = raw_config_for_table("raw__mitxonline__app__postgres__auth_user")
+        assert cfg.snapshot_retention_days == 3
+
+    def test_high_frequency_xpro_app(self) -> None:
+        """A table under raw__xpro__app gets the 3-day retention config."""
+        cfg = raw_config_for_table("raw__xpro__app__postgres__ecommerce_order")
+        assert cfg.snapshot_retention_days == 3
+
+    def test_third_party_salesforce(self) -> None:
+        """A Salesforce table gets the 14-day retention config."""
+        cfg = raw_config_for_table(
+            "raw__thirdparty__salesforce___destination_v2__account"
+        )
+        assert cfg.snapshot_retention_days == 14
+
+    def test_third_party_zendesk(self) -> None:
+        """A Zendesk table gets the 14-day retention config."""
+        cfg = raw_config_for_table("raw__thirdparty__zendesk_support__ticket")
+        assert cfg.snapshot_retention_days == 14
+
+    def test_unknown_prefix_returns_default(self) -> None:
+        """A table not matching any prefix returns the _default config (7 days)."""
+        cfg = raw_config_for_table("raw__edxorg__course_structure__data")
+        assert cfg == RAW_LAYER_GROUP_CONFIGS["_default"]
+        assert cfg.snapshot_retention_days == 7
+
+    def test_non_matching_mitxonline_prefix(self) -> None:
+        """raw__mitxonline__openedx does not start with raw__mitxonline__app."""
+        cfg = raw_config_for_table("raw__mitxonline__openedx__api__course_blocks")
+        assert cfg == RAW_LAYER_GROUP_CONFIGS["_default"]
+
+    def test_empty_string_returns_default(self) -> None:
+        """Empty table name returns the default config."""
+        cfg = raw_config_for_table("")
+        assert cfg == RAW_LAYER_GROUP_CONFIGS["_default"]
+
+    def test_default_config_values(self) -> None:
+        """The _default sentinel has the expected retention values."""
+        default = RAW_LAYER_GROUP_CONFIGS["_default"]
+        assert default.snapshot_retention_days == 7
+        assert default.orphan_retention_days == 7

--- a/scripts/expire_iceberg_snapshots.py
+++ b/scripts/expire_iceberg_snapshots.py
@@ -1,87 +1,117 @@
-#!/usr/bin/env python3
 """Expire old Iceberg snapshots to reduce metadata bloat.
 
-Snapshot accumulation causes metadata.json to grow very large (100s of KB),
-which slows down Iceberg table operations (load_table, plan_files, etc.)
-by requiring S3 round trips to read oversized metadata files.
+Tables that are written to frequently accumulate snapshot history indefinitely
+unless expire_snapshots() is run. Each uncompacted snapshot adds ~1.6 KB to the
+metadata.json file, which must be read from S3 on every table operation.
 
 Usage:
-    uv run scripts/expire_iceberg_snapshots.py --help
-    uv run scripts/expire_iceberg_snapshots.py --dry-run
-    uv run scripts/expire_iceberg_snapshots.py --older-than-days 7
+    uv run python scripts/expire_iceberg_snapshots.py
+    uv run python scripts/expire_iceberg_snapshots.py --dry-run
+    uv run python scripts/expire_iceberg_snapshots.py --older-than-days 14
 """
 
-from __future__ import annotations
-
 import argparse
-import os
-from datetime import UTC, datetime, timedelta
+import datetime
 
+import boto3
 from pyiceberg.catalog.glue import GlueCatalog
 
+TABLES_TO_EXPIRE = [
+    # Non-dbt singleton tables
+    ("ol_warehouse_production_reporting", "student_risk_probability"),
+    # Raw layer worst offenders (by snapshot count — Phase 0 remediation)
+    # These have never had maintenance run and have bloated metadata.json files
+    # that are re-downloaded on every Airbyte sync and dbt source read.
+    ("ol_warehouse_production_raw", "raw__edxorg__program_learner_report"),
+    ("ol_warehouse_production_raw", "raw__irx__edxorg__bigquery__email_opt_in"),
+    (
+        "ol_warehouse_production_raw",
+        "raw__thirdparty__mailgun__destination_v2__domains",
+    ),
+    ("ol_warehouse_production_raw", "raw__emeritus__bigquery__api_enrollments"),
+    ("ol_warehouse_production_raw", "raw__mitxonline__openedx__api__course_blocks"),
+]
 
-def main() -> None:
-    parser = argparse.ArgumentParser(description="Expire old Iceberg snapshots")
-    parser.add_argument(
-        "--table",
-        default="ol_warehouse_production.student_risk.reporting__student_risk_probability",
-        help="Fully-qualified Iceberg table identifier",
-    )
-    parser.add_argument(
-        "--older-than-days",
-        type=int,
-        default=3,
-        help="Expire snapshots older than this many days (default: 3)",
-    )
-    parser.add_argument(
-        "--dry-run",
-        action="store_true",
-        help="Print what would be expired without actually expiring",
-    )
-    args = parser.parse_args()
+DEFAULT_OLDER_THAN_DAYS = 7
 
-    region = os.environ.get("AWS_DEFAULT_REGION", "us-east-1")
-    catalog = GlueCatalog(
-        "glue",
+
+def expire_snapshots(
+    dry_run: bool = False, older_than_days: int = DEFAULT_OLDER_THAN_DAYS
+) -> None:
+    """Expire old Iceberg snapshots for tables in TABLES_TO_EXPIRE."""
+    glue = GlueCatalog(
+        "default",
+        client=boto3.client("glue", region_name="us-east-1"),
         **{
-            "glue.region": region,
             "s3.connect-timeout": "10",
             "s3.request-timeout": "120",
         },
     )
 
-    table = catalog.load_table(args.table)
-    snapshots = table.snapshots()
-    print(f"Table: {args.table}")
-    print(f"Current snapshot count: {len(snapshots)}")
-
-    if snapshots:
-        oldest = min(s.timestamp_ms for s in snapshots)
-        newest = max(s.timestamp_ms for s in snapshots)
-        print(f"Oldest snapshot: {datetime.fromtimestamp(oldest / 1000, tz=UTC)}")
-        print(f"Newest snapshot: {datetime.fromtimestamp(newest / 1000, tz=UTC)}")
-
-    cutoff = datetime.now(tz=UTC) - timedelta(days=args.older_than_days)
-    cutoff_ms = int(cutoff.timestamp() * 1000)
-    to_expire = [s for s in snapshots if s.timestamp_ms < cutoff_ms]
-    print(
-        f"\nSnapshots older than {args.older_than_days} days ({cutoff.isoformat()}): {len(to_expire)}"
+    cutoff_dt = datetime.datetime.now(tz=datetime.UTC) - datetime.timedelta(
+        days=older_than_days
     )
+    cutoff_ms = int(cutoff_dt.timestamp() * 1000)
 
-    if args.dry_run:
-        print("DRY RUN — no changes made")
-        return
+    for database, table_name in TABLES_TO_EXPIRE:
+        print(f"\n{'[DRY RUN] ' if dry_run else ''}Processing {database}.{table_name}")
+        table = glue.load_table(f"{database}.{table_name}")
 
-    if not to_expire:
-        print("Nothing to expire")
-        return
+        snapshots = table.metadata.snapshots
+        current_id = table.metadata.current_snapshot_id
+        old_snapshots = [
+            s
+            for s in snapshots
+            if s.snapshot_id != current_id and s.timestamp_ms < cutoff_ms
+        ]
 
-    print(f"Expiring {len(to_expire)} snapshot(s)...")
-    table.manage_snapshots().expire_snapshots(older_than_ms=cutoff_ms).commit()
+        print(f"  Total snapshots:       {len(snapshots)}")
+        print(f"  Snapshots to expire:   {len(old_snapshots)}")
+        print(f"  Snapshots to keep:     {len(snapshots) - len(old_snapshots)}")
 
-    table = catalog.load_table(args.table)
-    print(f"Done. Remaining snapshots: {len(table.snapshots())}")
+        import boto3 as _boto3  # noqa: PLC0415
+
+        s3 = _boto3.client("s3", region_name="us-east-1")
+        bucket = "ol-data-lake-staging-production"
+        prefix = f"processed/{database}/{table_name}/metadata/"
+        paginator = s3.get_paginator("list_objects_v2")
+        meta_size = 0
+        meta_count = 0
+        for page in paginator.paginate(Bucket=bucket, Prefix=prefix):
+            for obj in page.get("Contents", []):
+                meta_size += obj["Size"]
+                meta_count += 1
+        print(
+            f"  Metadata directory:    ~{meta_size // 1024} KB across {meta_count} files"
+        )
+
+        if dry_run:
+            print("  [DRY RUN] Skipping expiration.")
+            continue
+
+        if not old_snapshots:
+            print("  No eligible snapshots to expire.")
+            continue
+
+        # pyiceberg >= 0.10.0 API: table.maintenance.expire_snapshots().older_than(dt).commit()
+        table.maintenance.expire_snapshots().older_than(cutoff_dt).commit()
+        print(f"  Expired {len(old_snapshots)} snapshots.")
 
 
 if __name__ == "__main__":
-    main()
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Report what would be expired without modifying anything",
+    )
+    parser.add_argument(
+        "--older-than-days",
+        type=int,
+        default=DEFAULT_OLDER_THAN_DAYS,
+        help=f"Expire snapshots older than this many days (default: {DEFAULT_OLDER_THAN_DAYS})",
+    )
+    args = parser.parse_args()
+    expire_snapshots(dry_run=args.dry_run, older_than_days=args.older_than_days)

--- a/src/ol_dbt/dbt_project.yml
+++ b/src/ol_dbt/dbt_project.yml
@@ -94,6 +94,13 @@ models:
       +grants:
         select: ['read_only_production', 'ol_data_analyst', 'business_intelligence',
           'ol_business_analyst', 'reverse_etl']
+      # Incremental dims use delete+insert and accumulate one small file per run.
+      # 14-day snapshot retention provides a time-travel window for point-in-time
+      # queries and safe re-runs across two weekly optimize cycles.
+      +meta:
+        iceberg_maintenance:
+          snapshot_retention_days: 14
+          orphan_retention_days: 14
     intermediate:
       +materialized: table
       +schema: intermediate
@@ -106,6 +113,10 @@ models:
       +grants:
         select: ['read_only_production', 'ol_data_analyst', 'business_intelligence',
           'ol_business_analyst', 'reverse_etl', 'finance']
+      # 14-day retention so mart snapshots survive a missed nightly run.
+      +meta:
+        iceberg_maintenance:
+          snapshot_retention_days: 14
     reporting:
       +materialized: table
       +schema: reporting
@@ -122,6 +133,25 @@ models:
       format: "'PARQUET'"
     +meta:
       required_docs: true
+      # Iceberg maintenance config -- inherited by all models, overrideable per
+      # folder (see dimensional/marts above) or per-model in schema YAML files.
+      #
+      # dbt meta merging is a shallow dict merge: a per-model override of
+      # iceberg_maintenance replaces the entire dict, not individual keys.
+      # load_maintenance_configs_from_manifest() re-applies these values as the
+      # base before overlaying node-level meta so partial overrides work.
+      #
+      # optimize_after_every_n_runs: materializations since last maintenance run
+      #   before OPTIMIZE fires. Use 1 for incremental (delete+insert) models;
+      #   use 5+ for full-refresh table models.
+      # analyze_after_every_n_runs: same threshold for ANALYZE. 7 = weekly for
+      #   models that materialize daily.
+      iceberg_maintenance:
+        enabled: true
+        snapshot_retention_days: 7
+        orphan_retention_days: 7
+        optimize_after_every_n_runs: 1
+        analyze_after_every_n_runs: 7
 
 
 # Test severity config

--- a/src/ol_dbt/dbt_project.yml
+++ b/src/ol_dbt/dbt_project.yml
@@ -135,11 +135,12 @@ models:
       required_docs: true
       # Iceberg maintenance config -- inherited by all models, overrideable per
       # folder (see dimensional/marts above) or per-model in schema YAML files.
+      # dbt compiles these defaults into each model's manifest node at build
+      # time, so load_maintenance_configs_from_manifest() reads the fully-
+      # resolved values directly from the manifest -- no Python-side merging.
       #
-      # dbt meta merging is a shallow dict merge: a per-model override of
-      # iceberg_maintenance replaces the entire dict, not individual keys.
-      # load_maintenance_configs_from_manifest() re-applies these values as the
-      # base before overlaying node-level meta so partial overrides work.
+      # Note: dbt meta merging is a shallow dict merge, so a per-model or
+      # per-folder iceberg_maintenance override must supply all keys.
       #
       # optimize_after_every_n_runs: materializations since last maintenance run
       #   before OPTIMIZE fires. Use 1 for incremental (delete+insert) models;

--- a/src/ol_dbt/dbt_project.yml
+++ b/src/ol_dbt/dbt_project.yml
@@ -101,6 +101,8 @@ models:
         iceberg_maintenance:
           snapshot_retention_days: 14
           orphan_retention_days: 14
+          optimize_after_every_n_runs: 1
+          analyze_after_every_n_runs: 7
     intermediate:
       +materialized: table
       +schema: intermediate
@@ -117,6 +119,9 @@ models:
       +meta:
         iceberg_maintenance:
           snapshot_retention_days: 14
+          orphan_retention_days: 7
+          optimize_after_every_n_runs: 1
+          analyze_after_every_n_runs: 7
     reporting:
       +materialized: table
       +schema: reporting


### PR DESCRIPTION
### What are the relevant tickets?

N/A — operational hygiene; motivated by a Glue catalog scan finding 1,331 raw-layer Iceberg tables that have never had maintenance run. The worst offender (`raw__edxorg__program_learner_report`) has ~70K snapshots producing a ~110 MB `metadata.json` that is re-downloaded on every Airbyte sync, every dbt source read, and every local DuckDB query.

### Description (What does it do?)

Adds two nightly Dagster maintenance assets to the `lakehouse` code location plus the shared library and Trino resource they depend on.

**Four maintenance operations, two execution engines:**

| Operation | Engine | Why that engine |
|---|---|---|
| OPTIMIZE (compact small files) | Trino / Starburst Galaxy | Distributes file rewriting across Galaxy workers; incremental dbt models produce one small Parquet file per run |
| ANALYZE (collect query stats) | Trino / Starburst Galaxy | Not available in pyiceberg; required for Trino query optimizer |
| EXPIRE SNAPSHOTS | pyiceberg | Metadata-only op (Glue API + targeted S3 deletes); no distributed engine needed |
| REMOVE ORPHAN FILES | pyiceberg | Same; stub for now — pyiceberg 0.11.x does not yet expose a built-in API |

**Two assets, staggered schedules (both ship as `STOPPED`):**

- `iceberg_dbt_layer_maintenance` — 02:00 UTC. Reads `manifest.json`, uses the Dagster materialization event log to count runs since last maintenance, gates OPTIMIZE/ANALYZE on configurable thresholds (`optimize_after_every_n_runs`, `analyze_after_every_n_runs`). Also covers non-dbt singleton tables (`student_risk_probability`).
- `iceberg_raw_layer_maintenance` — 03:00 UTC. Live Glue catalog scan of `ol_warehouse_production_raw`; EXPIRE + ORPHAN only; `ThreadPoolExecutor(max_workers=8)` to handle 1,300+ tables without overwhelming Glue API rate limits.

**Phase-0 remediation in `scripts/expire_iceberg_snapshots.py`:**
Adds the 5 worst raw-layer offenders to the existing script so they can be cleaned up immediately without waiting for the full automation system to be enabled. Also fixes the pyiceberg API call: `table.expire_snapshots()` does not exist on `Table` in pyiceberg 0.11.x; the correct path is `table.maintenance.expire_snapshots().older_than(dt).commit()`.

**New files:**
- `packages/ol-orchestrate-lib/src/ol_orchestrate/lib/iceberg_maintenance.py` — shared library (catalog factory, maintenance ops, manifest parser, Glue scanner, config dataclasses and constants)
- `packages/ol-orchestrate-lib/src/ol_orchestrate/resources/trino_maintenance.py` — `TrinoMaintenanceResource(ConfigurableResource)` with `optimize()`, `analyze()`, `execute()`; Vault credentials with env-var fallback for local dev
- `dg_projects/lakehouse/lakehouse/assets/iceberg_maintenance.py` — the two Dagster assets

**Modified files:**
- `scripts/expire_iceberg_snapshots.py` — phase-0 remediation + API fix
- `packages/ol-orchestrate-lib/pyproject.toml` — add `trino>=0.329`
- `src/ol_dbt/dbt_project.yml` — add `+meta.iceberg_maintenance` at project root (7-day defaults) and per-folder overrides in `dimensional` (14-day, time-travel window for delete+insert models) and `marts` (14-day snapshots)
- `dg_projects/lakehouse/lakehouse/definitions.py` — register `TrinoMaintenanceResource`, both assets, `trino_host_map`/`trino_catalog_map`, and two `DefaultScheduleStatus.STOPPED` nightly schedules

### How can this be tested?

**Phase-0 script (immediate):**
```bash
# Dry-run to verify snapshot counts before touching anything
uv run python scripts/expire_iceberg_snapshots.py --dry-run

# Run for real (requires production AWS credentials)
uv run python scripts/expire_iceberg_snapshots.py --older-than-days 7
```

**Library unit smoke test:**
```bash
# Verify manifest parsing returns configs for all dbt models
uv run python -c "
from ol_orchestrate.lib.iceberg_maintenance import load_maintenance_configs_from_manifest
configs = load_maintenance_configs_from_manifest('src/ol_dbt/target/manifest.json')
print(f'{len(configs)} model configs loaded')
print(next(c for c in configs if c.schema_name.endswith('dimensional')))
"
```

**Dagster asset (staging/production):**
1. Ensure `DAGSTER_TRINO_VAULT_PATH` is set (or `DBT_TRINO_USERNAME`/`DBT_TRINO_PASSWORD` for local dev)
2. In the Dagster UI, navigate to the `lakehouse_maintenance` asset group
3. Manually materialize `iceberg_raw_layer_maintenance` first (EXPIRE only, lower risk)
4. Check the Output metadata for `tables_scanned`, `tables_cleaned`, `failure_count`
5. Once verified, enable the schedules via the Dagster UI

### Additional Context

- Both schedules ship as `DefaultScheduleStatus.STOPPED`. Enable them explicitly in production after verifying a manual run succeeds and confirming the Trino service account has write permissions on the catalog.
- `remove_orphan_files` is a no-op stub — pyiceberg 0.11.x does not expose a built-in orphan removal API. The docstring explains exactly what to replace it with when upstream support lands.
- The raw-layer asset does not use the Dagster event log for timing (unlike the dbt layer) because `OLAirbyteTranslator` slugifies connection names in a way that doesn't map cleanly back to Glue table names. Iceberg snapshot timestamps are used instead.
- IAM pre-check before enabling: confirm the Dagster worker role has `s3:DeleteObject` on `ol-data-lake-*-production/*` before enabling orphan removal once the pyiceberg API ships.