### PR TITLE
fix: Add warning severity configuration to courserun enrollments model

### DIFF
--- a/src/ol_dbt/models/intermediate/mitx/_int_mitx__models.yml
+++ b/src/ol_dbt/models/intermediate/mitx/_int_mitx__models.yml
@@ -397,6 +397,9 @@ models:
       arguments:
         column_list: ["user_mitxonline_username", "user_edxorg_username", "courserun_readable_id",
           "micromasters_program_id", "mitxonline_program_id"]
+      config:
+        severity: warn
+
 - name: int__mitx__courserun_certificates
   description: MITx course certificates combined from MITx Online and edX.org. It
     includes certificates that are not revoked from MITx Online, and downloadable


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
NA 
https://pipelines.odl.mit.edu/runs/9af475cf-ccd7-4d24-a13f-3d5cc5df3384
```
[31mFailure in test dbt_expectations_expect_compound_columns_to_be_unique_int__mitx__courserun_enrollments_with_programs_user_mitxonline_username__user_edxorg_username__courserun_readable_id__micromasters_program_id__mitxonline_program_id (models/intermediate/mitx/_int_mitx__models.yml)[0m

  Got 12 results, configured to fail if >10
```

### Description (What does it do?)
<!--- Describe your changes in detail -->

Due to enrollment deletions in mitxonline, apply this fix to prevent test failures from blocking other models. Added severity: warn to the expect_compound_columns_to_be_unique test on int__mitx__courserun_enrollments_with_programs so that duplicate records generate warnings instead of failing the test and blocking dependent models


### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->
dbt test --select int__mitx__courserun_enrollments_with_programs

### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->


<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
