### PR TITLE
B3: Fix tfact_enrollment incremental watermark to capture status updates

### DIFF
--- a/src/ol_dbt/models/dimensional/tfact_enrollment.sql
+++ b/src/ol_dbt/models/dimensional/tfact_enrollment.sql
@@ -254,6 +254,9 @@ with mitxonline_enrollments as (
         w.max_activity_on is null  -- platform/type not yet in target, include all
         -- Use >= for updated_on watermark: updated_on can equal max on state changes within same second
         or coalesce(ewf.enrollment_updated_on, ewf.enrollment_created_on) >= w.max_activity_on
+        -- For platforms without updated_on (edxorg, residential), apply a 7-day lookback to catch
+        -- status changes (deactivations, mode upgrades) that don't bump enrollment_created_on
+        or (ewf.enrollment_updated_on is null and ewf.enrollment_created_on >= current_timestamp - interval '7' day)
         or ewf.enrollment_created_on is null
     )
     {% endif %}

--- a/src/ol_dbt/models/dimensional/tfact_enrollment.sql
+++ b/src/ol_dbt/models/dimensional/tfact_enrollment.sql
@@ -256,7 +256,11 @@ with mitxonline_enrollments as (
         or coalesce(ewf.enrollment_updated_on, ewf.enrollment_created_on) >= w.max_activity_on
         -- For platforms without updated_on (edxorg, residential), apply a 7-day lookback to catch
         -- status changes (deactivations, mode upgrades) that don't bump enrollment_created_on
-        or (ewf.enrollment_updated_on is null and ewf.enrollment_created_on >= current_timestamp - interval '7' day)
+        or (
+            ewf.enrollment_updated_on is null
+            and ewf.enrollment_created_on is not null
+            and {{ from_iso8601_timestamp('ewf.enrollment_created_on') }} >= current_timestamp - interval '7' day
+        )
         or ewf.enrollment_created_on is null
     )
     {% endif %}

--- a/src/ol_dbt/models/dimensional/tfact_enrollment.sql
+++ b/src/ol_dbt/models/dimensional/tfact_enrollment.sql
@@ -259,7 +259,7 @@ with mitxonline_enrollments as (
         or (
             ewf.enrollment_updated_on is null
             and ewf.enrollment_created_on is not null
-            and {{ from_iso8601_timestamp('ewf.enrollment_created_on') }} >= current_timestamp - interval '7' day
+            and ewf.enrollment_created_on >= {{ cast_timestamp_to_iso8601("current_timestamp - interval '7' day") }}
         )
         or ewf.enrollment_created_on is null
     )


### PR DESCRIPTION
### What are the relevant tickets?
Closes #2123
Epic: #2073

### Description (What does it do?)
The incremental filter for `tfact_enrollment` used only `enrollment_created_on` as the watermark for platforms that have no `updated_on` column (edxorg, residential). This silently missed status changes such as enrollment deactivations (`is_active: true → false`) and mode upgrades (`audit → verified`).

Platforms that already expose an `updated_on` timestamp (MITxOnline, MITxPro, program enrollments) use the existing `coalesce(enrollment_updated_on, enrollment_created_on)` watermark and are unaffected.

The fix adds a targeted 7-day lookback clause scoped to rows where `enrollment_updated_on is null`:

```sql
-- For platforms without updated_on (edxorg, residential), apply a 7-day lookback to catch
-- status changes (deactivations, mode upgrades) that don't bump enrollment_created_on
or (ewf.enrollment_updated_on is null and ewf.enrollment_created_on >= current_timestamp - interval '7' day)
```

Source audit (confirmed via OpenMetadata):
- `raw__mitx__openedx__mysql__student_courseenrollment` (residential) — columns: `id, mode, created, user_id, course_id, is_active` — no `updated` column in source
- `stg__edxorg__bigquery__mitx_person_course` (edxorg) — BigQuery snapshot, no `updated_on`

### How can this be tested?
Run the model incrementally against production and verify that deactivated enrollments for edxorg/residential are correctly captured:

```bash
uv run dbt run --select tfact_enrollment --vars 'schema_suffix: qhoque' --target dev_production
```

Then spot-check that a known deactivated residential or edxorg enrollment (where `enrollment_is_active = false` and `enrollment_created_on` predates the previous watermark) now appears in the output:

```sql
select platform, enrollment_is_active, enrollment_mode, enrollment_created_on, enrollment_updated_on
from ol_warehouse_production_qhoque_dimensional.tfact_enrollment
where platform in ('edxorg', 'residential')
  and enrollment_is_active = false
order by enrollment_created_on desc
limit 20;
```

### Additional Context
`tfact_enrollment` is a leaf node with no downstream dbt models (confirmed via OpenMetadata lineage). The `delete+insert` incremental strategy with `unique_key='enrollment_key'` safely handles re-processing of rows within the lookback window.