### PR TITLE
fix: Exclude legacy course IDs and normalize program titles in edX migration models

### DIFF
--- a/src/ol_dbt/models/migration/edxorg_to_mitxonline_course_runs.sql
+++ b/src/ol_dbt/models/migration/edxorg_to_mitxonline_course_runs.sql
@@ -21,6 +21,13 @@ with mitx_courses as (
         , {{ element_at_array('split(course_number, \'.\')', 1) }} as extracted_department_number
         , {{ format_course_id('courserun_readable_id', false) }} as courseware_id
     from {{ ref('int__edxorg__mitx_courseruns') }}
+    -- Exclude MITx/15.390.1x_SPA/1T1015. In edX it uses the legacy course ID
+    --   source (edx.org) courserun_readable_id: MITx/15.390.1x_SPA/1T1015
+    --   normalized (MITx Online) course-v1 ID: course-v1:MITx+15.390.1x_SPA+1T2015
+    -- This run has already been migrated under the normalized ID, so we exclude
+    -- the legacy ID here to avoid attempting a duplicate migration with the
+    -- outdated courserun_readable_id.
+    where courserun_readable_id != 'MITx/15.390.1x_SPA/1T1015'
 )
 
 , edx_signatories as (
@@ -90,7 +97,10 @@ left join mitxonline_courseruns
     on
         edx_courseruns.course_number = mitxonline_courseruns.course_number
         and edx_courseruns.run_tag = mitxonline_courseruns.courserun_tag
+left join mitxonline_courseruns as mitxonline_courserun_by_id
+    on edx_courseruns.courseware_id = mitxonline_courserun_by_id.courserun_readable_id
 left join edx_signatories
     on edx_courseruns.courseware_id = edx_signatories.courserun_readable_id
 where
     mitxonline_courseruns.course_number is null
+    and mitxonline_courserun_by_id.courserun_readable_id is null

--- a/src/ol_dbt/models/migration/edxorg_to_mitxonline_program_entitlements.sql
+++ b/src/ol_dbt/models/migration/edxorg_to_mitxonline_program_entitlements.sql
@@ -8,7 +8,10 @@ with mitxonline_programs as (
           --- Handle titles such as Statistics and Data Science (General track) - RETIRED "old version"
           when program_title like 'Statistics and Data Science (General track)%'
               then 'Statistics and Data Science (General Track)'
-           else program_title
+          -- Supply Chain Management: edX.org uses short title, MITx Online uses full branding
+          when program_title like 'Supply Chain Management'
+              then 'MITx MicroMasters® Program in Supply Chain Management'
+          else program_title
         end as program_title
         , user_email
         , user_id


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->

### Description (What does it do?)
<!--- Describe your changes in detail -->
 - **edxorg_to_mitxonline_course_runs**: Exclude runs that are already migrated to MITx Online by checking courseware_id
- **edxorg_to_mitxonline_program_entitlements**: Add program title mapping for Supply Chain Management (SCM) to handle differences between edX.org and MITx 


### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

dbt build --select edxorg_to_mitxonline_course_runs edxorg_to_mitxonline_program_entitlements

### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->


<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
