### PR TITLE
Feat: add bootcamps to dimensional models

### DIFF
--- a/src/ol_dbt/models/dimensional/_dim__models.yml
+++ b/src/ol_dbt/models/dimensional/_dim__models.yml
@@ -309,6 +309,8 @@ models:
       which is their email address.
   - name: mitxpro_openedx_user_id
     description: int, openedx user id for MITx Pro
+  - name: bootcamps_application_user_id
+    description: int, user id on Bootcamps application
   - name: mitxpro_application_user_id
     description: string, user id on MITx Pro application
   - name: user_mitxpro_username
@@ -361,6 +363,8 @@ models:
   - name: completed_onboarding
     description: boolean, indicating whether the user has completed the platform onboarding
       process on MIT Learn
+  - name: user_is_active_on_bootcamps
+    description: boolean, indicating if user's account is active on Bootcamps.
   - name: user_is_active_on_mitlearn
     description: boolean, indicating if user's account is active on MIT Learn.
   - name: user_joined_on_mitlearn
@@ -381,6 +385,8 @@ models:
     description: str, when the user joined on MITx Pro.
   - name: user_joined_on_residential
     description: str, when the user joined on Residential MITx.
+  - name: user_joined_on_bootcamps
+    description: str, when the user joined on Bootcamps.
   - name: micromasters_user_id
     description: int, user ID on the MicroMasters platform
 

--- a/src/ol_dbt/models/dimensional/_dim_course.yml
+++ b/src/ol_dbt/models/dimensional/_dim_course.yml
@@ -49,7 +49,7 @@ models:
     tests:
     - not_null
     - accepted_values:
-        values: ['mitxonline', 'mitxpro', 'edxorg', 'ocw', 'residential']
+        values: ['mitxonline', 'mitxpro', 'edxorg', 'ocw', 'residential', 'bootcamps']
   - name: effective_date
     description: >
       Timestamp (UTC) when this SCD Type 2 version became effective. Populated as

--- a/src/ol_dbt/models/dimensional/_dim_course_run.yml
+++ b/src/ol_dbt/models/dimensional/_dim_course_run.yml
@@ -72,11 +72,11 @@ models:
   - name: enrollment_end_date_key
     description: Foreign key to dim_date for enrollment period end
   - name: courserun_is_live
-    description: Boolean indicating if course run is live
+    description: Boolean indicating if course run is live. False for bootcamps.
   - name: courserun_created_on
     description: >
       Timestamp when the course run was created in the source system. Populated for
-      mitxonline, mitxpro, and residential platforms. Null for edxorg.
+      mitxonline, mitxpro, and residential platforms. Null for edxorg and bootcamps.
   - name: effective_date
     description: >
       Timestamp (UTC) when this SCD Type 2 version became effective. Always set for

--- a/src/ol_dbt/models/dimensional/dim_course.sql
+++ b/src/ol_dbt/models/dimensional/dim_course.sql
@@ -77,6 +77,33 @@ with mitxonline_courses as (
     from {{ ref('int__ocw__courses') }}
 )
 
+, bootcamps_course_numbers as (
+    select distinct
+        course_id
+        , case
+            when cardinality(split(courserun_readable_id, '+')) >= 2
+                then split(courserun_readable_id, '+')[2]
+        end as course_number
+        -- Use course_readable_id from int__bootcamps__course_runs which already has course_id
+        -- appended for uniqueness — no need to extract from courserun_readable_id here
+        , course_readable_id
+    from {{ ref('int__bootcamps__course_runs') }}
+    where course_readable_id is not null
+)
+
+, bootcamps_courses as (
+    select
+        coalesce(course_numbers.course_readable_id, courses.course_readable_id) as course_readable_id
+        , courses.course_id as source_id
+        , courses.course_title
+        , course_numbers.course_number
+        , cast(null as varchar) as course_description
+        , cast(null as boolean) as course_is_live
+        , 'bootcamps' as platform
+    from {{ ref('int__bootcamps__courses') }} as courses
+    left join bootcamps_course_numbers as course_numbers on courses.course_id = course_numbers.course_id
+)
+
 , combined_courses as (
     select * from mitxonline_courses
     union all
@@ -85,6 +112,8 @@ with mitxonline_courses as (
     select * from edxorg_courses
     union all
     select * from ocw_courses
+    union all
+    select * from bootcamps_courses
 )
 
 -- All (platform, course_readable_id) combinations are kept as distinct rows.

--- a/src/ol_dbt/models/dimensional/dim_course_run.sql
+++ b/src/ol_dbt/models/dimensional/dim_course_run.sql
@@ -17,6 +17,7 @@ with mitxonline_courseruns as (
         , courserun_enrollment_end_on as enrollment_end
         , courserun_is_live
         , courserun_created_on
+        , cast(null as varchar) as course_readable_id
         , 'mitxonline' as platform
     from {{ ref('int__mitxonline__course_runs') }}
 )
@@ -33,6 +34,7 @@ with mitxonline_courseruns as (
         , courserun_enrollment_end_on as enrollment_end
         , courserun_is_live
         , courserun_created_on
+        , cast(null as varchar) as course_readable_id
         , 'mitxpro' as platform
     from {{ ref('int__mitxpro__course_runs') }}
 )
@@ -49,6 +51,7 @@ with mitxonline_courseruns as (
         , courserun_enrollment_end_date as enrollment_end
         , courserun_is_published as courserun_is_live
         , cast(null as varchar) as courserun_created_on
+        , cast(null as varchar) as course_readable_id
         , 'edxorg' as platform
     from {{ ref('int__edxorg__mitx_courseruns') }}
 )
@@ -65,8 +68,26 @@ with mitxonline_courseruns as (
         , courserun_enrollment_end_on as enrollment_end
         , cast(null as boolean) as courserun_is_live
         , courserun_created_on
+        , cast(null as varchar) as course_readable_id
         , 'residential' as platform
     from {{ ref('int__mitxresidential__courseruns') }}
+)
+
+, bootcamps_courseruns as (
+    select
+        runs.courserun_readable_id
+        , runs.courserun_id as source_id
+        , runs.course_id
+        , runs.courserun_title
+        , runs.courserun_start_on
+        , runs.courserun_end_on
+        , cast(null as varchar) as enrollment_start
+        , cast(null as varchar) as enrollment_end
+        , false as courserun_is_live
+        , cast(null as varchar) as courserun_created_on
+        , runs.course_readable_id
+        , 'bootcamps' as platform
+    from {{ ref('int__bootcamps__course_runs') }} as runs
 )
 
 , combined_courseruns as (
@@ -77,6 +98,45 @@ with mitxonline_courseruns as (
     select * from edxorg_courseruns
     union all
     select * from residential_courseruns
+    union all
+    select * from bootcamps_courseruns
+)
+
+-- Pre-compute course_readable_id for all platforms so the dim_course join is a simple equality
+, combined_courseruns_resolved as (
+    select
+        courserun_readable_id
+        , source_id
+        , course_id
+        , courserun_title
+        , courserun_start_on
+        , courserun_end_on
+        , enrollment_start
+        , enrollment_end
+        , courserun_is_live
+        , courserun_created_on
+        , platform
+        , coalesce(
+            course_readable_id,
+            case
+                when courserun_readable_id like 'course-v1:%'
+                    then substring(
+                        courserun_readable_id,
+                        1,
+                        length(courserun_readable_id)
+                        - strpos(reverse(courserun_readable_id), '+')
+                    )
+                when regexp_like(courserun_readable_id, '^[^/]+/[^/]+/[^/]+')
+                    then substring(
+                        courserun_readable_id,
+                        1,
+                        length(courserun_readable_id)
+                        - strpos(reverse(courserun_readable_id), '/')
+                    )
+                else courserun_readable_id
+            end
+        ) as course_readable_id
+    from combined_courseruns
 )
 
 -- Join to dim_course to get course_fk
@@ -91,32 +151,12 @@ with mitxonline_courseruns as (
 
 , courseruns_with_fk as (
     select
-        combined_courseruns.*
+        combined_courseruns_resolved.*
         , dim_course.course_pk as course_fk
-    from combined_courseruns
+    from combined_courseruns_resolved
     left join dim_course
-        on combined_courseruns.platform = dim_course.primary_platform
-        and
-            -- Extract course ID from course run ID
-            -- course-v1 format: course-v1:{org}+{course}+{run} → strip the last +{run} segment
-            -- edxorg slash format: {org}/{course}/{run} → strip the last /{run} segment
-            case
-                when combined_courseruns.courserun_readable_id like 'course-v1:%'
-                    then substring(
-                        combined_courseruns.courserun_readable_id,
-                        1,
-                        length(combined_courseruns.courserun_readable_id)
-                        - strpos(reverse(combined_courseruns.courserun_readable_id), '+')
-                    )
-                when regexp_like(combined_courseruns.courserun_readable_id, '^[^/]+/[^/]+/[^/]+')
-                    then substring(
-                        combined_courseruns.courserun_readable_id,
-                        1,
-                        length(combined_courseruns.courserun_readable_id)
-                        - strpos(reverse(combined_courseruns.courserun_readable_id), '/')
-                    )
-                else combined_courseruns.courserun_readable_id
-            end = dim_course.course_readable_id
+        on combined_courseruns_resolved.platform = dim_course.primary_platform
+        and combined_courseruns_resolved.course_readable_id = dim_course.course_readable_id
 )
 
 , courseruns_with_all_fks as (

--- a/src/ol_dbt/models/dimensional/dim_user.sql
+++ b/src/ol_dbt/models/dimensional/dim_user.sql
@@ -185,6 +185,10 @@ with mitx_users as (
     left join mitxresidential_profile on mitxresidential_openedx_users.user_id = mitxresidential_profile.user_id
 )
 
+, bootcamps_user_view as (
+    select * from {{ ref('int__bootcamps__users') }}
+)
+
 , mitx_users_view as (
     select
         mitx_users.user_global_id
@@ -339,6 +343,9 @@ with mitx_users as (
         , null as user_is_active_on_residential
         , null as user_joined_on_residential
         , user_micromasters_id as micromasters_user_id
+        , null as bootcamps_application_user_id
+        , null as user_is_active_on_bootcamps
+        , null as user_joined_on_bootcamps
     from users_with_global_id
 
     union all
@@ -382,6 +389,9 @@ with mitx_users as (
         , null as user_is_active_on_residential
         , null as user_joined_on_residential
         , null as micromasters_user_id
+        , null as bootcamps_application_user_id
+        , null as user_is_active_on_bootcamps
+        , null as user_joined_on_bootcamps
     from mitxpro_user_view
     left join mitxpro_openedx_users as openedx_users_username
         on mitxpro_user_view.user_username = openedx_users_username.user_username
@@ -427,6 +437,9 @@ with mitx_users as (
         , null as user_is_active_on_residential
         , null as user_joined_on_residential
         , null as micromasters_user_id
+        , null as bootcamps_application_user_id
+        , null as user_is_active_on_bootcamps
+        , null as user_joined_on_bootcamps
     from emeritus_users
     where user_email is not null
 
@@ -469,6 +482,9 @@ with mitx_users as (
         , null as user_is_active_on_residential
         , null as user_joined_on_residential
         , null as micromasters_user_id
+        , null as bootcamps_application_user_id
+        , null as user_is_active_on_bootcamps
+        , null as user_joined_on_bootcamps
     from global_alumni_users
     where user_email is not null
 
@@ -511,7 +527,55 @@ with mitx_users as (
         , mitxresidential_user_view.user_is_active as user_is_active_on_residential
         , mitxresidential_user_view.user_joined_on as user_joined_on_residential
         , null as micromasters_user_id
+        , null as bootcamps_application_user_id
+        , null as user_is_active_on_bootcamps
+        , null as user_joined_on_bootcamps
     from mitxresidential_user_view
+
+    union all
+
+    select
+        {{ dbt_utils.generate_surrogate_key(['lower(bootcamps_user_view.user_email)']) }} as user_pk
+        , null as user_global_id
+        , null as mitlearn_user_id
+        , null as mitlearn_openedx_user_id
+        , null as mitxonline_openedx_user_id
+        , null as mitxonline_application_user_id
+        , null as user_mitxonline_username
+        , null as mitxpro_openedx_user_id
+        , null as mitxpro_application_user_id
+        , null as user_mitxpro_username
+        , null as residential_openedx_user_id
+        , null as user_residential_username
+        , null as edxorg_openedx_user_id
+        , null as user_edxorg_username
+        , null as emeritus_user_id
+        , null as global_alumni_user_id
+        , lower(bootcamps_user_view.user_email) as email
+        , bootcamps_user_view.user_full_name as full_name
+        , bootcamps_user_view.user_address_country as address_country
+        , bootcamps_user_view.user_highest_education as highest_education
+        , bootcamps_user_view.user_gender as gender
+        , bootcamps_user_view.user_birth_year as birth_year
+        , bootcamps_user_view.user_company as company
+        , bootcamps_user_view.user_job_title as job_title
+        , bootcamps_user_view.user_industry as industry
+        , null as user_is_active_on_mitlearn
+        , null as user_joined_on_mitlearn
+        , null as user_is_active_on_mitxonline
+        , null as user_joined_on_mitxonline
+        , null as user_is_active_on_edxorg
+        , null as user_joined_on_edxorg
+        , null as user_is_active_on_mitxpro
+        , null as user_joined_on_mitxpro
+        , null as user_is_active_on_residential
+        , null as user_joined_on_residential
+        , null as micromasters_user_id
+        , bootcamps_user_view.user_id as bootcamps_application_user_id
+        , bootcamps_user_view.user_is_active as user_is_active_on_bootcamps
+        , bootcamps_user_view.user_joined_on as user_joined_on_bootcamps
+    from bootcamps_user_view
+    where bootcamps_user_view.user_email is not null
 
 )
 
@@ -527,6 +591,7 @@ with mitx_users as (
                     , user_joined_on_edxorg
                     , user_joined_on_mitxpro
                     , user_joined_on_residential
+                    , user_joined_on_bootcamps
                 ) desc
         ) as row_num
     from combined_users
@@ -567,6 +632,9 @@ with mitx_users as (
         , max(user_joined_on_mitxpro) as user_joined_on_mitxpro
         , max(user_is_active_on_residential) as user_is_active_on_residential
         , max(user_joined_on_residential) as user_joined_on_residential
+        , max(bootcamps_application_user_id) as bootcamps_application_user_id
+        , max(user_is_active_on_bootcamps) as user_is_active_on_bootcamps
+        , max(user_joined_on_bootcamps) as user_joined_on_bootcamps
     from combined_users
     group by user_pk
 )
@@ -613,6 +681,9 @@ select
     , agg.user_joined_on_mitxpro
     , agg.user_is_active_on_residential
     , agg.user_joined_on_residential
+    , agg.bootcamps_application_user_id
+    , agg.user_is_active_on_bootcamps
+    , agg.user_joined_on_bootcamps
 from base_info as base
 inner join agg_view as agg on base.user_pk = agg.user_pk
 left join learn_profile on base.mitlearn_user_id = learn_profile.user_id

--- a/src/ol_dbt/models/dimensional/tfact_certificate.sql
+++ b/src/ol_dbt/models/dimensional/tfact_certificate.sql
@@ -132,6 +132,24 @@ with mitxonline_certificates as (
     from {{ ref('int__edxorg__mitx_program_certificates') }}
 )
 
+, bootcamps_certificates as (
+    select
+        cast(courseruncertificate_id as varchar) as certificate_id
+        , user_id
+        , courserun_id
+        , cast(null as varchar) as courserun_readable_id
+        , courseruncertificate_uuid as certificate_uuid
+        , courseruncertificate_is_revoked as certificate_is_revoked
+        , courseruncertificate_created_on as certificate_created_on
+        , courseruncertificate_updated_on as certificate_updated_on
+        , courseruncertificate_created_on as certificate_issued_on  -- no issued_on; fall back to created_on
+        , 'verified' as certificate_type_code
+        , 'bootcamps' as platform
+        , user_email
+        , cast(null as varchar) as program_id
+    from {{ ref('int__bootcamps__courserun_certificates') }}
+)
+
 , combined_certificates as (
     select * from mitxonline_certificates
     union all
@@ -146,6 +164,8 @@ with mitxonline_certificates as (
     select * from mitxpro_program_certificates
     union all
     select * from edxorg_program_certificates
+    union all
+    select * from bootcamps_certificates
 )
 
 , user_lookup as (
@@ -155,6 +175,7 @@ with mitxonline_certificates as (
         , mitxonline_application_user_id
         , mitxpro_application_user_id
         , edxorg_openedx_user_id
+        , bootcamps_application_user_id
     from {{ ref('dim_user') }}
     where user_pk is not null
 )
@@ -196,6 +217,9 @@ with mitxonline_certificates as (
             end,
             case when combined_certificates.platform = 'micromasters'
                 then ul_micromasters.user_pk
+            end,
+            case when combined_certificates.platform = 'bootcamps'
+                then ul_bootcamps.user_pk
             end
         ) as user_fk
         , dim_course_run.courserun_pk as courserun_fk
@@ -217,9 +241,12 @@ with mitxonline_certificates as (
     left join user_lookup as ul_micromasters
         on combined_certificates.platform = 'micromasters'
         and combined_certificates.user_email = ul_micromasters.email
+    left join user_lookup as ul_bootcamps
+        on combined_certificates.platform = 'bootcamps'
+        and combined_certificates.user_id = ul_bootcamps.bootcamps_application_user_id
     left join dim_course_run
         on (
-            (combined_certificates.platform in ('mitxonline', 'mitxpro')
+            (combined_certificates.platform in ('mitxonline', 'mitxpro', 'bootcamps')
                 and combined_certificates.courserun_id = dim_course_run.source_id
                 and combined_certificates.platform = dim_course_run.platform)
             or (combined_certificates.platform in ('edxorg', 'micromasters')

--- a/src/ol_dbt/models/dimensional/tfact_enrollment.sql
+++ b/src/ol_dbt/models/dimensional/tfact_enrollment.sql
@@ -97,6 +97,23 @@ with mitxonline_enrollments as (
     from {{ ref('int__mitxresidential__courserun_enrollments') }}
 )
 
+, bootcamps_enrollments as (
+    select
+        cast(courserunenrollment_id as varchar) as enrollment_id
+        , user_id
+        , courserun_id
+        , courserun_readable_id
+        , null as program_id
+        , courserunenrollment_created_on as enrollment_created_on
+        , courserunenrollment_updated_on as enrollment_updated_on
+        , courserunenrollment_is_active as enrollment_is_active
+        , cast(null as varchar) as enrollment_mode
+        , courserunenrollment_enrollment_status as enrollment_status
+        , 'bootcamps' as platform
+        , 'bootcamps' as platform_code
+    from {{ ref('int__bootcamps__courserunenrollments') }}
+)
+
 , combined_enrollments as (
     select * from mitxonline_enrollments
     union all
@@ -107,6 +124,8 @@ with mitxonline_enrollments as (
     select * from residential_enrollments
     union all
     select * from program_enrollments
+    union all
+    select * from bootcamps_enrollments
 )
 
 -- Join to dimensions for FKs
@@ -120,6 +139,7 @@ with mitxonline_enrollments as (
         , edxorg_openedx_user_id
         , micromasters_user_id
         , residential_openedx_user_id
+        , bootcamps_application_user_id
     from {{ ref('dim_user') }}
     where user_pk is not null
 )
@@ -169,6 +189,9 @@ with mitxonline_enrollments as (
             end,
             case when combined_enrollments.platform = 'residential'
                 then ul_residential.user_pk
+            end,
+            case when combined_enrollments.platform = 'bootcamps'
+                then ul_bootcamps.user_pk
             end
         ) as user_fk
         , dim_course_run.courserun_pk as courserun_fk
@@ -188,10 +211,13 @@ with mitxonline_enrollments as (
     left join user_lookup as ul_residential
         on combined_enrollments.platform = 'residential'
         and combined_enrollments.user_id = ul_residential.residential_openedx_user_id
+    left join user_lookup as ul_bootcamps
+        on combined_enrollments.platform = 'bootcamps'
+        and combined_enrollments.user_id = ul_bootcamps.bootcamps_application_user_id
     left join dim_course_run
         on (
-            -- mitxonline/mitxpro: join on integer source_id
-            (combined_enrollments.platform in ('mitxonline', 'mitxpro') and combined_enrollments.courserun_id = dim_course_run.source_id and combined_enrollments.platform = dim_course_run.platform)
+            -- mitxonline/mitxpro/bootcamps: join on integer source_id
+            (combined_enrollments.platform in ('mitxonline', 'mitxpro', 'bootcamps') and combined_enrollments.courserun_id = dim_course_run.source_id and combined_enrollments.platform = dim_course_run.platform)
             -- edxorg, residential: join on readable_id + platform to prevent fan-out
             -- (dim_course_run grain is (platform, courserun_readable_id); same readable_id
             -- can exist across platforms)

--- a/src/ol_dbt/models/dimensional/tfact_order.sql
+++ b/src/ol_dbt/models/dimensional/tfact_order.sql
@@ -70,6 +70,31 @@ with mitxonline_orders as (
         on orders.order_id = lines.order_id
 )
 
+, bootcamps_orders as (
+    -- int__bootcamps__ecommerce_order grain: (order_id, line_id)
+    -- Bootcamps uses personal pricing; discounts are not modeled — revenue is in line_price / order_total_price_paid only.
+    select
+        cast(line_id as varchar) as line_id
+        , order_id
+        , order_purchaser_user_id as user_id
+        , cast(null as bigint) as product_id  -- no dim_product coverage for bootcamps
+        , line_price
+        , order_state
+        , order_total_price_paid
+        , order_total_price_paid as order_total_price_paid_plus_tax
+        , cast(null as decimal(38, 2)) as order_tax_amount
+        , cast(null as decimal(38, 4)) as order_tax_rate
+        , cast(null as varchar) as order_tax_country_code
+        , order_reference_number
+        , order_created_on
+        , order_updated_on
+        , 'bootcamps' as platform
+        , cast(null as bigint) as discount_id
+        , cast(null as varchar) as discount_code
+        , cast(null as varchar) as discount_type_code
+    from {{ ref('int__bootcamps__ecommerce_order') }}
+)
+
 , micromasters_orders as (
     -- int__micromasters__orders grain: (order_id, line_id)
     select
@@ -99,6 +124,8 @@ with mitxonline_orders as (
     union all
     select * from mitxpro_orders
     union all
+    select * from bootcamps_orders
+    union all
     select * from micromasters_orders
 )
 
@@ -108,6 +135,7 @@ with mitxonline_orders as (
         , mitxonline_application_user_id
         , mitxpro_application_user_id
         , micromasters_user_id
+        , bootcamps_application_user_id
     from {{ ref('dim_user') }}
     where user_pk is not null
 )
@@ -148,6 +176,9 @@ with mitxonline_orders as (
             case when combined_orders.platform = 'mitxpro'
                 then ul_mitxpro.user_pk
             end,
+            case when combined_orders.platform = 'bootcamps'
+                then ul_bootcamps.user_pk
+            end,
             case when combined_orders.platform = 'micromasters'
                 then ul_micromasters.user_pk
             end
@@ -166,6 +197,9 @@ with mitxonline_orders as (
     left join user_lookup as ul_mitxpro
         on combined_orders.platform = 'mitxpro'
         and combined_orders.user_id = ul_mitxpro.mitxpro_application_user_id
+    left join user_lookup as ul_bootcamps
+        on combined_orders.platform = 'bootcamps'
+        and combined_orders.user_id = ul_bootcamps.bootcamps_application_user_id
     left join user_lookup as ul_micromasters
         on combined_orders.platform = 'micromasters'
         and combined_orders.user_id = ul_micromasters.micromasters_user_id

--- a/src/ol_dbt/models/intermediate/bootcamps/_int_bootcamps__models.yml
+++ b/src/ol_dbt/models/intermediate/bootcamps/_int_bootcamps__models.yml
@@ -160,8 +160,8 @@ models:
     tests:
     - not_null
   - name: courserun_readable_id
-    description: str, unique string to identify a bootcamp course run (could be blank
-      for older runs)
+    description: str, unique string to identify a bootcamp course run. Older runs
+      lacking a source value are backfilled via a manual mapping on courserun_id.
   - name: line_price
     description: numeric, list price for the order line
     tests:
@@ -221,6 +221,10 @@ models:
     description: timestamp, specifying when an enrollment was initially created
     tests:
     - not_null
+  - name: courserunenrollment_updated_on
+    description: timestamp, specifying when an enrollment was most recently updated
+    tests:
+    - not_null
   - name: courserunenrollment_enrollment_status
     description: str, enrollment status for users whose enrollment changed. Options
       are 'deferred', 'refunded'
@@ -233,8 +237,8 @@ models:
     tests:
     - not_null
   - name: courserun_readable_id
-    description: str, unique string to identify a bootcamp course run (could be blank
-      for older runs)
+    description: str, unique string to identify a bootcamp course run. Older runs
+      lacking a source value are backfilled via a manual mapping on courserun_id.
   - name: courserun_start_on
     description: timestamp, date and time when the course starts
   - name: user_username
@@ -290,14 +294,25 @@ models:
   - name: courserun_title
     description: str, title of the bootcamp course run
   - name: courserun_readable_id
-    description: str, unique string to identify a bootcamp course run (could be blank
-      for older runs)
+    description: str, unique string to identify a bootcamp course run. Older runs
+      lacking a source value are backfilled via a manual mapping on courserun_id.
     tests:
     - unique
+    - not_null
   - name: courserun_start_on
     description: timestamp, specifying when the course run begins
   - name: courserun_end_on
     description: timestamp, specifying when the course run ends
+  - name: course_readable_id
+    description: >
+      str, unique string identifying the parent course for this run, derived from
+      courserun_readable_id by joining the first two '+'-delimited segments (e.g.
+      'bootcamp-v1:public+HI-f2f'). Because multiple bootcamp source course_ids can
+      share the same topic/format code, the numeric course_id is appended with a
+      hyphen (e.g. 'bootcamp-v1:public+HI-f2f-12') to guarantee uniqueness across
+      all runs. Downstream dimensional models use this value to join to dim_course.
+    tests:
+    - not_null
 
 - name: int__bootcamps__users
   description: denormalized bootcamps users

--- a/src/ol_dbt/models/intermediate/bootcamps/int__bootcamps__course_runs.sql
+++ b/src/ol_dbt/models/intermediate/bootcamps/int__bootcamps__course_runs.sql
@@ -10,6 +10,10 @@ select
     , course_id
     , courserun_title
     , courserun_readable_id
+    -- Derived from courserun_readable_id by stripping the run suffix (+R{n}), with course_id
+    -- appended to ensure uniqueness across courses sharing the same topic/format code
+    , split_part(courserun_readable_id, '+', 1) || '+' || split_part(courserun_readable_id, '+', 2)
+     || '-' || cast(course_id as varchar) as course_readable_id
     , courserun_start_on
     , courserun_end_on
 from runs

--- a/src/ol_dbt/models/intermediate/bootcamps/int__bootcamps__courserunenrollments.sql
+++ b/src/ol_dbt/models/intermediate/bootcamps/int__bootcamps__courserunenrollments.sql
@@ -19,6 +19,7 @@ with enrollments as (
         , enrollments.user_id
         , enrollments.courserun_id
         , enrollments.courserunenrollment_created_on
+        , enrollments.courserunenrollment_updated_on
         , enrollments.courserunenrollment_enrollment_status
         , runs.courserun_readable_id
         , runs.courserun_title

--- a/src/ol_dbt/models/intermediate/combined/_combined_models.yml
+++ b/src/ol_dbt/models/intermediate/combined/_combined_models.yml
@@ -281,7 +281,7 @@ models:
       runs.
   - name: courserun_is_live
     description: boolean, indicating whether the course run is available to users
-      on MITx Online and xPro. Null for Bootcamps and edx.org.
+      on MITx Online and xPro. False for Bootcamps. Null for edx.org.
   - name: course_number
     description: str, unique string for the course. It can contain letters, numbers,
       or periods. e.g. 6.002.1x

--- a/src/ol_dbt/models/intermediate/combined/int__combined__course_runs.sql
+++ b/src/ol_dbt/models/intermediate/combined/int__combined__course_runs.sql
@@ -184,7 +184,7 @@ with mitx_courses as (
         , bootcamps_runs.courserun_start_on
         , bootcamps_runs.courserun_end_on
         , null as courserun_upgrade_deadline
-        , null as courserun_is_live
+        , false as courserun_is_live
         , case
             when cardinality(split(bootcamps_runs.courserun_readable_id, '+')) >= 2
                 then split(bootcamps_runs.courserun_readable_id, '+')[2]

--- a/src/ol_dbt/models/staging/bootcamps/_stg_bootcamps__models.yml
+++ b/src/ol_dbt/models/staging/bootcamps/_stg_bootcamps__models.yml
@@ -363,10 +363,12 @@ models:
   - name: courserun_title
     description: str, title of the bootcamp course run
   - name: courserun_readable_id
-    description: str, unique string to identify a bootcamp course run (could be blank
-      for older runs)
+    description: str, unique string to identify a bootcamp course run. Older runs
+      that lack a value in the source database are backfilled via a manual mapping
+      keyed on courserun_id (ids 2, 4, 11, 14, 16, 17, 18, 19).
     tests:
     - unique
+    - not_null
   - name: courserun_start_on
     description: timestamp, specifying when the course run begins
   - name: courserun_end_on

--- a/src/ol_dbt/models/staging/bootcamps/stg__bootcamps__app__postgres__courses_courserun.sql
+++ b/src/ol_dbt/models/staging/bootcamps/stg__bootcamps__app__postgres__courses_courserun.sql
@@ -9,7 +9,19 @@ with source as (
         id as courserun_id
         , bootcamp_id as course_id
         , title as courserun_title
-        , bootcamp_run_id as courserun_readable_id
+        -- Manual backfill for runs predating the bootcamp_run_id field being populated
+        , coalesce(
+            bootcamp_run_id
+            , case id
+                when 2 then 'bootcamp-v1:public+culture-f2f+R1'
+                when 4 then 'bootcamp-v1:public+sustainability-f2f+R1'
+                when 11 then 'bootcamp-v1:public+DT-f2f+R1'
+                when 14 then 'bootcamp-v1:public+HI-f2f+R3'
+                when 16 then 'bootcamp-v1:public+IE-f2f+R10'
+                when 17 then 'bootcamp-v1:public+DT-f2f+R2'
+                when 18 then 'bootcamp-v1:public+FC-f2f+R1'
+                when 19 then 'bootcamp-v1:public+design-f2f+R1'
+         end) as courserun_readable_id
         ,{{ cast_timestamp_to_iso8601('start_date') }} as courserun_start_on
         ,{{ cast_timestamp_to_iso8601('end_date') }} as courserun_end_on
     from source


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
closes https://github.com/mitodl/ol-data-platform/issues/2121

### Description (What does it do?)
<!--- Describe your changes in detail -->

adds bootcamps data to the dimensional layer 

  Staging & Intermediate

   - stg__bootcamps__courses_courserun — backfills courserun_readable_id for a few legacy runs that predate the field being populated in source (https://github.com/mitodl/ol-data-platform/issues/2121#issuecomment-4614746440)
   - int__bootcamps__course_runs — adds derived course_readable_id (strips run suffix + appends course_id for uniqueness) and documents
  courserunenrollment_updated_on

  Dimensional Models

   - dim_course — adds bootcamps courses, deriving course_readable_id from the int model (no extraction needed here)
   - dim_course_run — adds bootcamps course runs with courserun_is_live = false; refactors the dim_course join to pre-compute course_readable_id in a CTE so the join is a simple equality
   - dim_user — adds bootcamps users
   - tfact_order — adds bootcamps e-commerce orders (personal pricing, no discounts)
   - tfact_enrollment / tfact_certificate — adds bootcamps enrollments and certificates
   - int__combined__course_runs — includes bootcamps with courserun_is_live = false

  YML / Documentation

   - Updated column descriptions across staging, intermediate, and dimensional YML files to reflect bootcamps-specific behavior


### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

dbt build  --select stg__bootcamps__app__postgres__courses_courserun+ dim_user tfact_order tfact_enrollment tfact_certificate --full-refresh

Note that the warning in dim_course_run is unrelated to this PR
```
20:11:34  Warning in test not_null_dim_course_run_course_fk (models/dimensional/_dim_course_run.yml)
20:11:34  Got 3159 results, configured to warn if != 0
```
