### PR TITLE
fix(data_loading): fix dlt edxorg S3 loading failures (ExpiredToken + ContainerInjectableContextMangled)

### DIFF
--- a/dg_projects/data_loading/.dlt/config.toml
+++ b/dg_projects/data_loading/.dlt/config.toml
@@ -6,6 +6,17 @@
 log_level = "INFO"
 dlthub_telemetry = true
 
+# Limit extraction parallelism to 1 worker.
+#
+# dlt's default workers=5 launches concurrent threads that all share a single
+# non-thread-safe injectable-context dict.  When threads race to enter/exit
+# their own context managers the dict ends up in an inconsistent state and
+# dlt raises ContainerInjectableContextMangled.  Using a single worker makes
+# the context stack strictly sequential and eliminates the race.
+[extract]
+workers = 1
+max_parallel_items = 20
+
 # EdX.org S3 Source Configuration
 # Path matches dlt's lookup: sources.<module_name>.<source_name>.<param>
 [sources.loads.edxorg_s3_source]

--- a/dg_projects/data_loading/data_loading/defs/edxorg_s3_ingest/dagster_assets.py
+++ b/dg_projects/data_loading/data_loading/defs/edxorg_s3_ingest/dagster_assets.py
@@ -14,10 +14,13 @@ from dagster import (
 )
 from dagster_dlt import DagsterDltResource, DagsterDltTranslator, dlt_assets
 from dagster_dlt.translator import DltResourceTranslatorData
+from ol_orchestrate.lib.constants import EDXORG_DB_TABLES
 
 from .loads import (
     edxorg_s3_pipeline,
+    edxorg_s3_source,
     edxorg_s3_source_instance,
+    table_format,
 )
 
 
@@ -50,7 +53,15 @@ class EdxorgDltTranslator(DagsterDltTranslator):
         )
 
 
-# Create dlt assets with upstream dependencies
+def _asset_key_for_table(table_name: str) -> AssetKey:
+    """Return the Dagster AssetKey used for a given edxorg table."""
+    return AssetKey(["ol_warehouse_raw_data", f"raw__edxorg__s3__tables__{table_name}"])
+
+
+# Create dlt assets with upstream dependencies.
+# edxorg_s3_source_instance (with all tables) is used here only so that the
+# @dlt_assets decorator can discover the full set of asset specs at import
+# time.  The execution function below overrides the source per-table.
 @dlt_assets(
     dlt_source=edxorg_s3_source_instance,
     dlt_pipeline=edxorg_s3_pipeline,
@@ -69,10 +80,33 @@ def edxorg_s3_consolidated_tables(
     partitioned asset. Filters to only 'prod' source data and consolidates across
     all courses into non-partitioned Iceberg/Parquet tables.
 
-    The dlt source automatically uses incremental loading based on file modification
-    dates, so only new/modified files are processed on each run.
+    The dlt source uses incremental loading based on file modification dates,
+    so only new or modified files are processed on each run.
+
+    Tables are processed sequentially, one per dlt.run() call, so that:
+    * The AWS boto3 credential chain refreshes STS tokens between tables.
+    * Large tables (e.g. auth_user) do not exhaust a single token's TTL.
+    * dlt's non-thread-safe injectable-context dict is never accessed
+      concurrently (see also [extract] workers=1 in .dlt/config.toml).
     """
-    yield from dlt.run(context=context)
+    # Determine which tables to process, honouring any asset-key sub-selection
+    # that Dagster may have applied (e.g. "re-materialise auth_user only").
+    if context.is_subset:
+        selected_tables = [
+            t
+            for t in EDXORG_DB_TABLES
+            if _asset_key_for_table(t) in context.selected_asset_keys
+        ]
+    else:
+        selected_tables = list(EDXORG_DB_TABLES)
+
+    # Run the dlt pipeline once per table.  This keeps each run short enough
+    # that STS credentials issued at the start of the run do not expire before
+    # it finishes, and gives the boto3 credential chain a chance to refresh
+    # between tables via AssumeRoleWithWebIdentity (IRSA).
+    for table_name in selected_tables:
+        table_source = edxorg_s3_source(tables=[table_name], table_format=table_format)
+        yield from dlt.run(context=context, dlt_source=table_source)
 
 
 __all__ = ["edxorg_s3_consolidated_tables"]

--- a/dg_projects/data_loading/data_loading/defs/edxorg_s3_ingest/loads.py
+++ b/dg_projects/data_loading/data_loading/defs/edxorg_s3_ingest/loads.py
@@ -27,6 +27,7 @@ import os
 from pathlib import Path
 
 import dlt
+import s3fs
 from dlt.extract import DltResource
 from dlt.sources import incremental
 from dlt.sources.filesystem import filesystem, read_csv_duckdb
@@ -94,22 +95,38 @@ def edxorg_s3_source(
             # Excludes: db_table/{table_name}/edge/*/*.tsv (edge staging files)
             file_glob = f"db_table/{table}/prod/**/*.tsv"
 
-            # Use dlt's filesystem source to discover files.
-            # AWS credentials are automatically discovered from:
-            # 1. Environment variables (AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY)
-            # 2. ~/.aws/credentials (local development)
-            # 3. IAM role (IRSA in Kubernetes)
+            # Create an s3fs filesystem WITHOUT explicit credentials.
             #
-            # Do NOT pass extract_content=True.  That flag reads the entire file
-            # into Python bytes in a single blocking s3fs request before passing
-            # it to read_csv_duckdb.  For large tables (e.g. auth_user) this can
-            # exceed the AWS STS session-token TTL and raise ExpiredToken.  By
-            # leaving it False (the default), read_csv_duckdb streams the file
-            # content chunk-by-chunk via PyArrow's own S3 reader, which is both
-            # more memory-efficient and more resilient to long-running transfers.
+            # dlt's AwsCredentials.to_session_credentials() calls
+            # get_frozen_credentials(), which snapshots the live IRSA
+            # RefreshableCredentials object as static strings and passes
+            # them to s3fs.S3FileSystem(key=..., secret=..., token=...).
+            # Once s3fs holds explicit static strings there is no refresh
+            # path: when the STS session token expires (~1 hour by default)
+            # every subsequent GetObject call fails with ExpiredToken.
+            #
+            # By constructing S3FileSystem with no explicit key/secret/token
+            # we bypass dlt's credential snapshotting entirely.  aiobotocore
+            # then uses its own credential chain which, for IRSA pods, invokes
+            # AioAssumeRoleWithWebIdentityFetcher and wraps the result in
+            # AioRefreshableCredentials.  Those credentials automatically call
+            # AssumeRoleWithWebIdentity again whenever the token expires, so
+            # the pipeline can run indefinitely without hitting ExpiredToken.
+            #
+            # dlt's filesystem() source accepts an AbstractFileSystem instance
+            # as its `credentials` parameter and uses it directly, skipping
+            # its own credential-dispatch logic.
+            #
+            # Do NOT pass extract_content=True.  That flag reads the entire
+            # file into Python bytes in a single blocking request before
+            # passing it to read_csv_duckdb, which can itself exceed a token
+            # lifetime for very large tables.  Leaving it False lets
+            # read_csv_duckdb stream the content chunk-by-chunk via PyArrow.
+            fs = s3fs.S3FileSystem()
             files = filesystem(
                 bucket_url=bucket_url,
                 file_glob=file_glob,
+                credentials=fs,
             )
 
             # Enable incremental loading based on file modification date

--- a/dg_projects/data_loading/data_loading/defs/edxorg_s3_ingest/loads.py
+++ b/dg_projects/data_loading/data_loading/defs/edxorg_s3_ingest/loads.py
@@ -94,15 +94,22 @@ def edxorg_s3_source(
             # Excludes: db_table/{table_name}/edge/*/*.tsv (edge staging files)
             file_glob = f"db_table/{table}/prod/**/*.tsv"
 
-            # Use dlt's filesystem source to discover files
-            # AWS credentials will be automatically discovered from:
+            # Use dlt's filesystem source to discover files.
+            # AWS credentials are automatically discovered from:
             # 1. Environment variables (AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY)
             # 2. ~/.aws/credentials (local development)
             # 3. IAM role (IRSA in Kubernetes)
+            #
+            # Do NOT pass extract_content=True.  That flag reads the entire file
+            # into Python bytes in a single blocking s3fs request before passing
+            # it to read_csv_duckdb.  For large tables (e.g. auth_user) this can
+            # exceed the AWS STS session-token TTL and raise ExpiredToken.  By
+            # leaving it False (the default), read_csv_duckdb streams the file
+            # content chunk-by-chunk via PyArrow's own S3 reader, which is both
+            # more memory-efficient and more resilient to long-running transfers.
             files = filesystem(
                 bucket_url=bucket_url,
                 file_glob=file_glob,
-                extract_content=True,
             )
 
             # Enable incremental loading based on file modification date


### PR DESCRIPTION
### What are the relevant tickets?
N/A

### Description (What does it do?)

Fixes two runtime errors that occur when running the `edxorg_s3_tables` dlt pipeline against large tables such as `auth_user`.

---

#### Error 1 — `ContainerInjectableContextMangled`

dlt's injectable-context dict (`Container`) is a single shared object that is **not thread-safe**. The default `workers=5` spawns five concurrent extraction threads that all race to read and write the same dict. When threads race — especially if a Dagster interrupt signal arrives while a thread is mid-context — the dict ends up with the wrong value in a slot and dlt raises `ContainerInjectableContextMangled`.

**Fix:** Added an `[extract]` section to `.dlt/config.toml` with `workers = 1`. This makes the context stack strictly sequential (enter → yield → exit, no concurrent modifications) and eliminates the race entirely.

---

#### Error 2 — `botocore.exceptions.ClientError: ExpiredToken`

**Root cause (traced to dlt internals)**

dlt's `AwsCredentials.to_session_credentials()` calls `get_frozen_credentials()`, which snapshots the live botocore `RefreshableCredentials` object into static strings:

```python
# dlt/common/configuration/specs/aws_credentials.py
frozen = self.default_credentials().get_credentials().get_frozen_credentials()
return dict(
    aws_access_key_id=frozen.access_key,   # ← static string
    aws_secret_access_key=frozen.secret_key,
    aws_session_token=frozen.token,         # ← static string, expires ~1 hr
)
```

Those static strings are then passed to `s3fs.S3FileSystem(key=..., secret=..., token=...)`. Once s3fs holds explicit static credentials it has **no refresh path**: aiobotocore only activates `AioRefreshableCredentials` when credentials are *absent*, not when they are explicitly supplied. When the STS session token expires the next `GetObject` call fails with `ExpiredToken`.

**Three complementary fixes:**

1. **Remove `extract_content=True`** — that flag read the entire file into Python bytes via a single blocking s3fs request before `read_csv_duckdb` ran. For large tables this one request could outlast the token TTL. Removing it lets `read_csv_duckdb` stream the file in chunks via PyArrow.

2. **Process tables one at a time with separate `dlt.run()` calls** — each call creates a fresh `DltSource`, which creates a fresh `S3FileSystem`, which snapshots *current* credentials. This ensures IRSA tokens are at most ~seconds old at the start of each table's run.

3. **Bypass dlt's credential freeze entirely** — dlt's `filesystem()` source accepts a pre-built `AbstractFileSystem` instance as its `credentials` parameter and uses it directly, skipping its own credential-dispatch logic. By passing `s3fs.S3FileSystem()` with **no** explicit `key/secret/token`, aiobotocore uses its own credential chain. For IRSA pods this invokes `AioAssumeRoleWithWebIdentityFetcher` → `AioRefreshableCredentials` → automatic `AssumeRoleWithWebIdentity` renewal whenever the token expires. The pipeline can now run indefinitely without hitting `ExpiredToken`.

---

#### Files changed

| File | Change |
|------|--------|
| `dg_projects/data_loading/.dlt/config.toml` | Add `[extract]` section with `workers = 1` |
| `dg_projects/data_loading/data_loading/defs/edxorg_s3_ingest/loads.py` | Remove `extract_content=True`; create `s3fs.S3FileSystem()` with no explicit credentials and pass it as `credentials` to `filesystem()` |
| `dg_projects/data_loading/data_loading/defs/edxorg_s3_ingest/dagster_assets.py` | Iterate one table per `dlt.run()` call; add subset-selection guard |

---

#### Infrastructure note

While the code changes above make the pipeline resilient for any individual table, it is still worth increasing the IRSA role's `sts:RoleSessionDuration` from the 1-hour AWS default to 4–12 hours (the IAM role's trust policy `maxSessionDuration` field). This provides headroom in environments where boto3 is not in the credential chain (e.g. locally with static `~/.aws/credentials`).

### How can this be tested?

1. Deploy the `data_loading` code location to QA.
2. In the Dagster UI, trigger a materialisation of **`edxorg_s3_tables` for a single large table** (e.g. `raw__edxorg__s3__tables__auth_user`) and confirm it completes without `ExpiredToken` or `ContainerInjectableContextMangled`.
3. Trigger a full run of all 44 tables and confirm each table materialises sequentially with no context errors.
4. Re-run with a subset selection of 2–3 tables and confirm only those tables are processed.

### Additional Context

- dlt version: 1.27.2. The `get_frozen_credentials()` / non-thread-safe context issues are dlt design limitations; setting `workers=1` and bypassing credential snapshotting are the recommended workarounds.
- The per-table iteration does issue 44 separate `pipeline.run()` calls (extract → normalise → load each time). Each individual table's run is much shorter than a single all-tables run, so wall-clock time for incremental runs should be similar or better.