### PR TITLE
 refactor: derive bootcamps course_readable_id from course runs

### DIFF
--- a/src/ol_dbt/models/dimensional/dim_course.sql
+++ b/src/ol_dbt/models/dimensional/dim_course.sql
@@ -93,7 +93,7 @@ with mitxonline_courses as (
 
 , bootcamps_courses as (
     select
-        coalesce(course_numbers.course_readable_id, courses.course_readable_id) as course_readable_id
+        course_numbers.course_readable_id as course_readable_id
         , courses.course_id as source_id
         , courses.course_title
         , course_numbers.course_number

--- a/src/ol_dbt/models/intermediate/bootcamps/_int_bootcamps__models.yml
+++ b/src/ol_dbt/models/intermediate/bootcamps/_int_bootcamps__models.yml
@@ -271,12 +271,6 @@ models:
     - not_null
   - name: course_title
     description: str, title of the bootcamp course
-  - name: course_readable_id
-    description: str, readable ID formatted as bootcamp-v1:{type}+{topic}-{format}.
-      type is either 'public' or 'private', format is either ol (online) or f2f (face
-      to face). May be null until data is populated in bootcamps application database.
-    tests:
-    - unique
 
 - name: int__bootcamps__course_runs
   description: Intermediate model for Bootcamps course runs

--- a/src/ol_dbt/models/intermediate/bootcamps/int__bootcamps__courses.sql
+++ b/src/ol_dbt/models/intermediate/bootcamps/int__bootcamps__courses.sql
@@ -8,5 +8,4 @@ with courses as (
 select
     course_id
     , course_title
-    , course_readable_id
 from courses

--- a/src/ol_dbt/models/intermediate/combined/int__combined__course_runs.sql
+++ b/src/ol_dbt/models/intermediate/combined/int__combined__course_runs.sql
@@ -177,7 +177,7 @@ with mitx_courses as (
     select
         '{{ var("bootcamps") }}' as platform
         , bootcamps_courses.course_title
-        , bootcamps_courses.course_readable_id
+        , bootcamps_runs.course_readable_id
         , bootcamps_runs.courserun_title
         , bootcamps_runs.courserun_readable_id
         , null as courserun_url


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
NA

### Description (What does it do?)
<!--- Describe your changes in detail -->
Updates dim_course and int__combined__course_runs to populate course_readable_id from bootcamps_runs, and deprecates course_readable_id in int__bootcamps__courses due to all NULL.


### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->
dbt build --full-refresh int__bootcamps__courses int__combined__course_runs dim_course
