### PR TITLE
refactor: update courserun_readable_id joins in tfact_certificate and tfact_enrollment

### DIFF
--- a/src/ol_dbt/models/dimensional/tfact_certificate.sql
+++ b/src/ol_dbt/models/dimensional/tfact_certificate.sql
@@ -11,7 +11,7 @@ with mitxonline_certificates as (
         cast(courseruncertificate_id as varchar) as certificate_id
         , user_id
         , courserun_id
-        , cast(null as varchar) as courserun_readable_id  -- edxorg join key only
+        , courserun_readable_id
         , courseruncertificate_uuid as certificate_uuid
         , courseruncertificate_is_revoked as certificate_is_revoked
         , courseruncertificate_created_on as certificate_created_on
@@ -29,7 +29,7 @@ with mitxonline_certificates as (
         cast(courseruncertificate_id as varchar) as certificate_id
         , user_id
         , courserun_id
-        , cast(null as varchar) as courserun_readable_id  -- edxorg join key only
+        , courserun_readable_id
         , courseruncertificate_uuid as certificate_uuid
         , courseruncertificate_is_revoked as certificate_is_revoked
         , courseruncertificate_created_on as certificate_created_on
@@ -137,7 +137,7 @@ with mitxonline_certificates as (
         cast(courseruncertificate_id as varchar) as certificate_id
         , user_id
         , courserun_id
-        , cast(null as varchar) as courserun_readable_id
+        , courserun_readable_id
         , courseruncertificate_uuid as certificate_uuid
         , courseruncertificate_is_revoked as certificate_is_revoked
         , courseruncertificate_created_on as certificate_created_on
@@ -181,7 +181,7 @@ with mitxonline_certificates as (
 )
 
 , dim_course_run as (
-    select courserun_pk, source_id, courserun_readable_id, platform
+    select courserun_pk, courserun_readable_id, platform
     from {{ ref('dim_course_run') }}
     where is_current = true
 )
@@ -245,14 +245,11 @@ with mitxonline_certificates as (
         on combined_certificates.platform = 'bootcamps'
         and combined_certificates.user_id = ul_bootcamps.bootcamps_application_user_id
     left join dim_course_run
-        on (
-            (combined_certificates.platform in ('mitxonline', 'mitxpro', 'bootcamps')
-                and combined_certificates.courserun_id = dim_course_run.source_id
-                and combined_certificates.platform = dim_course_run.platform)
-            or (combined_certificates.platform in ('edxorg', 'micromasters')
-                and combined_certificates.courserun_readable_id = dim_course_run.courserun_readable_id
-                and dim_course_run.platform = 'edxorg')
-        )
+        on combined_certificates.courserun_readable_id = dim_course_run.courserun_readable_id
+        and case
+            when combined_certificates.platform = 'micromasters' then 'edxorg'
+            else combined_certificates.platform
+        end = dim_course_run.platform
     left join dim_platform_lookup
         on combined_certificates.platform = dim_platform_lookup.platform_readable_id
     left join dim_certificate_type

--- a/src/ol_dbt/models/dimensional/tfact_enrollment.sql
+++ b/src/ol_dbt/models/dimensional/tfact_enrollment.sql
@@ -11,7 +11,7 @@ with mitxonline_enrollments as (
         cast(courserunenrollment_id as varchar) as enrollment_id
         , user_id
         , courserun_id
-        , cast(null as varchar) as courserun_readable_id  -- join key for edxorg only
+        , courserun_readable_id
         , null as program_id
         , courserunenrollment_created_on as enrollment_created_on
         , courserunenrollment_updated_on as enrollment_updated_on
@@ -28,7 +28,7 @@ with mitxonline_enrollments as (
         cast(courserunenrollment_id as varchar) as enrollment_id
         , user_id
         , courserun_id
-        , cast(null as varchar) as courserun_readable_id  -- join key for edxorg only
+        , courserun_readable_id
         , null as program_id
         , courserunenrollment_created_on as enrollment_created_on
         , courserunenrollment_updated_on as enrollment_updated_on
@@ -45,7 +45,7 @@ with mitxonline_enrollments as (
         -- Stable surrogate key: edxorg has no enrollment_id; use natural key (user + course run)
         {{ dbt_utils.generate_surrogate_key(['cast(user_id as varchar)', 'courserun_readable_id']) }} as enrollment_id
         , user_id
-        , null as courserun_id  -- edxorg has no integer source_id; join on readable_id instead
+        , null as courserun_id  -- edxorg has no integer source_id
         , courserun_readable_id
         , null as program_id
         , courserunenrollment_created_on as enrollment_created_on
@@ -68,7 +68,7 @@ with mitxonline_enrollments as (
         cast(programenrollment_id as varchar) as enrollment_id
         , user_id
         , null as courserun_id
-        , cast(null as varchar) as courserun_readable_id  -- join key for edxorg only
+        , cast(null as varchar) as courserun_readable_id
         , program_id
         , programenrollment_created_on as enrollment_created_on
         , programenrollment_updated_on as enrollment_updated_on
@@ -145,7 +145,7 @@ with mitxonline_enrollments as (
 )
 
 , dim_course_run as (
-    select courserun_pk, source_id, courserun_readable_id, platform_fk, platform
+    select courserun_pk, courserun_readable_id, platform
     from {{ ref('dim_course_run') }}
     where is_current = true
 )
@@ -215,14 +215,8 @@ with mitxonline_enrollments as (
         on combined_enrollments.platform = 'bootcamps'
         and combined_enrollments.user_id = ul_bootcamps.bootcamps_application_user_id
     left join dim_course_run
-        on (
-            -- mitxonline/mitxpro/bootcamps: join on integer source_id
-            (combined_enrollments.platform in ('mitxonline', 'mitxpro', 'bootcamps') and combined_enrollments.courserun_id = dim_course_run.source_id and combined_enrollments.platform = dim_course_run.platform)
-            -- edxorg, residential: join on readable_id + platform to prevent fan-out
-            -- (dim_course_run grain is (platform, courserun_readable_id); same readable_id
-            -- can exist across platforms)
-            or (combined_enrollments.platform in ('edxorg', 'residential') and combined_enrollments.courserun_readable_id = dim_course_run.courserun_readable_id and combined_enrollments.platform = dim_course_run.platform)
-        )
+        on combined_enrollments.courserun_readable_id = dim_course_run.courserun_readable_id
+        and combined_enrollments.platform = dim_course_run.platform
     left join dim_program
         on cast(combined_enrollments.program_id as varchar) = dim_program.source_id
         and combined_enrollments.platform_code = dim_program.platform_code


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
NA

Noticed when reviewing https://github.com/mitodl/ol-data-platform/pull/2259

### Description (What does it do?)
<!--- Describe your changes in detail -->
 Simplify the joins in `tfact_enrollment` and `tfact_certificate`.Previously, mitxonline, mitxpro, and bootcamps joined to dim_course_run on the integer source_id, while edxorg/residential/micromasters joined on courserun_readable_id. This dual-path logic was unnecessary because all source intermediates expose courserun_readable_id.

   - Populate courserun_readable_id for all platforms in the combined CTEs (previously hardcoded to null for non-edxorg platforms)
   - Simplify the left join dim_course_run to a single condition: courserun_readable_id + platform match (with a CASE for micromasters → edxorg in the 
  certificate fact)
   - Drop the now-unused source_id and platform_fk columns from the dim_course_run CTE selects

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

dbt build --select tfact_enrollment tfact_certificate --full-refresh

### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->


<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
