### PR TITLE
docs(dbt): document edxorg QUALIFY collapse pattern in dim_course

### DIFF
--- a/src/ol_dbt/models/dimensional/_dim_course.yml
+++ b/src/ol_dbt/models/dimensional/_dim_course.yml
@@ -9,8 +9,11 @@ models:
     Tracks historical changes to course metadata.
     Note: edxorg has no native course-level table. edxorg courses are derived from
     courserun records, with one row per course_readable_id using the most-recent course
-    run to supply attributes (title, course_number, is_live). source_id is null
-    for edxorg and OCW courses.
+    run (by courserun_start_date desc nulls last) to supply attributes (title,
+    course_number, is_live). source_id is null for edxorg and OCW courses.
+    The most-recent-run collapse uses a ROW_NUMBER subquery (WHERE _row_num = 1) rather
+    than a QUALIFY clause because Trino does not support QUALIFY; the semantics are
+    identical — exactly one row is retained per course_readable_id.
   meta:
     owner: data_team
   columns:

--- a/src/ol_dbt/models/dimensional/dim_course.sql
+++ b/src/ol_dbt/models/dimensional/dim_course.sql
@@ -36,9 +36,18 @@ with mitxonline_courses as (
 
 , edxorg_courses as (
     -- edxorg has no native course table — courses are represented only at the courserun level.
-    -- One row per course_readable_id, using the most-recent course run to supply course-level
-    -- attributes (title, course_number, is_live). source_id is always null for edxorg courses.
-    -- Note: QUALIFY is not supported by Trino; using ROW_NUMBER subquery instead.
+    -- One row per course_readable_id is synthesized by collapsing all course runs for a given
+    -- course_readable_id down to the single most-recent run (by courserun_start_date desc nulls
+    -- last), which supplies the course-level attributes (title, course_number, is_live).
+    -- source_id is always null for edxorg courses because edxorg exposes no integer course ID.
+    --
+    -- Implementation note — QUALIFY collapse via ROW_NUMBER subquery:
+    -- The natural way to write this in DuckDB/Snowflake/BigQuery would be:
+    --   QUALIFY row_number() OVER (PARTITION BY course_readable_id
+    --                              ORDER BY courserun_start_date DESC NULLS LAST) = 1
+    -- Trino does not support the QUALIFY clause, so the equivalent pattern is used instead:
+    -- ROW_NUMBER() is computed in an inner subquery and the outer query filters WHERE _row_num = 1.
+    -- The semantics are identical — exactly one row is kept per course_readable_id.
     select
         course_readable_id
         , source_id


### PR DESCRIPTION
### What are the relevant tickets?
Closes #2133

### Description (What does it do?)
Documentation-only change — no behavior or logic changes.

Expands the single-line comment on the `edxorg_courses` CTE in `dim_course.sql` into a full explanation of the ROW_NUMBER collapse pattern used to derive one course row per `course_readable_id` from edxorg course run data:

- edxorg has no native course table; courses are synthesized by collapsing all runs for a given `course_readable_id` down to the single most-recent run (ordered by `courserun_start_date DESC NULLS LAST`)
- The natural SQL idiom for this is `QUALIFY row_number() OVER (...) = 1`, but **Trino does not support the QUALIFY clause**
- The equivalent pattern — compute `ROW_NUMBER()` in an inner subquery and filter `WHERE _row_num = 1` in the outer query — is used instead; the semantics are identical

Also updates the `_dim_course.yml` model description to document the same pattern for readers consulting dbt docs rather than SQL source.

**Files changed:**
- [`src/ol_dbt/models/dimensional/dim_course.sql`](https://github.com/mitodl/ol-data-platform/blob/copilot/2133-document-dim-course-edxorg-qualify-collapse/src/ol_dbt/models/dimensional/dim_course.sql) — expanded comment on `edxorg_courses` CTE
- [`src/ol_dbt/models/dimensional/_dim_course.yml`](https://github.com/mitodl/ol-data-platform/blob/copilot/2133-document-dim-course-edxorg-qualify-collapse/src/ol_dbt/models/dimensional/_dim_course.yml) — updated model description

### How can this be tested?
This is documentation only. Review the diff to confirm:
1. The SQL comment accurately describes the QUALIFY-equivalent pattern (inner subquery + `WHERE _row_num = 1`)
2. The YAML description matches the SQL comment
3. No logic changes were made to the model

Optionally validate the model still produces correct output:
```sql
-- Confirm no duplicate course_readable_id per platform in the current records
select primary_platform, course_readable_id, count(*)
from ol_data_lake_production.marts_dimensional.dim_course
where is_current = true
group by 1, 2
having count(*) > 1
limit 10
```
Expected: 0 rows.

### Additional Context
Part of Phase G grain audit (#2073). This is G6 — documentation only, no behavior change.