### PR TITLE
fix(legacy_openedx): regenerate Vault MySQL credentials on expiry

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -50,7 +50,7 @@ repos:
     - src/ol_dbt/package-lock.yml
 - repo: https://github.com/astral-sh/ruff-pre-commit
   # Ruff version.
-  rev: 'v0.15.15'
+  rev: 'v0.15.16'
   hooks:
   - id: ruff-format
   - id: ruff-check
@@ -71,7 +71,7 @@ repos:
     - types-pymysql
     - types-requests
 - repo: https://github.com/sqlfluff/sqlfluff
-  rev: 4.2.1
+  rev: 4.2.2
   hooks:
   - id: sqlfluff-fix
       # Arbitrary arguments to show an example

--- a/dg_projects/legacy_openedx/legacy_openedx/definitions.py
+++ b/dg_projects/legacy_openedx/legacy_openedx/definitions.py
@@ -10,7 +10,7 @@ that were defined using repository-based patterns. These include:
 import os
 from typing import Literal
 
-from dagster import Definitions
+from dagster import Definitions, RunRequest, ScheduleEvaluationContext, schedule
 from dagster_aws.s3 import S3Resource
 from dagster_aws.s3.resources import s3_resource
 from ol_orchestrate.lib.constants import DAGSTER_ENV, VAULT_ADDRESS
@@ -22,13 +22,8 @@ from ol_orchestrate.resources.secrets.vault import Vault
 
 from legacy_openedx.jobs.open_edx import edx_course_pipeline
 from legacy_openedx.resources.healthchecks import HealthchecksIO
-from legacy_openedx.resources.mysql_db import mysql_db_resource
+from legacy_openedx.resources.mysql_db import VaultMySQLClientFactory
 from legacy_openedx.resources.sqlite_db import sqlite_db_resource
-from legacy_openedx.schedules.open_edx import (
-    mitxonline_edx_daily_schedule,
-    residential_edx_daily_schedule,
-    xpro_edx_daily_schedule,
-)
 
 # Initialize vault with resilient loading
 try:
@@ -139,14 +134,16 @@ def open_edx_export_irx_job_config(
         "token_url": f"{edx_creds['url']}/oauth2/access_token",
     }
 
-    db_creds = vault.client.secrets.database.generate_credentials(
-        mount_point=f"mariadb-{deployment}", name="readonly"
-    )["data"]
+    db_hostname = (
+        f"edxapp-db-{deployment}-{dagster_env}"
+        f"{'-replica' if dagster_env == 'production' else ''}"
+        ".cbnm7ajau6mi.us-east-1.rds.amazonaws.com"
+    )
     edx_db_config = {
         "mysql_db_name": "edxapp",
-        "mysql_hostname": f"edxapp-db-{deployment}-{dagster_env}{'-replica' if dagster_env == 'production' else ''}.cbnm7ajau6mi.us-east-1.rds.amazonaws.com",  # noqa: E501
-        "mysql_username": db_creds["username"],
-        "mysql_password": db_creds["password"],
+        "mysql_hostname": db_hostname,
+        "vault_mount_point": f"mariadb-{deployment}",
+        "vault_role": "readonly",
     }
 
     return {
@@ -184,39 +181,93 @@ qa_resources = {
 }
 
 production_resources = {
-    "sqldb": mysql_db_resource,
+    "sqldb": VaultMySQLClientFactory.configure_at_launch(),
+    "vault": vault,
     "s3": S3Resource(),
     "results_dir": DailyResultsDir.configure_at_launch(),
     "healthchecks": HealthchecksIO.configure_at_launch(),
     "openedx": OpenEdxApiClient.configure_at_launch(),
 }
 
-# Create jobs for each deployment
+# Create jobs for each deployment.
+# NOTE: config is intentionally omitted here — it is generated at schedule-fire time
+# (not at code-location load time) so that Vault dynamic DB credentials are always
+# fresh when the job runs.  See the @schedule definitions below.
 residential_edx_job = edx_course_pipeline.to_job(
     name="residential_edx_course_pipeline",
     resource_defs=production_resources,
-    config=open_edx_export_irx_job_config("mitx", DAGSTER_ENV),
 )
 
 xpro_edx_job = edx_course_pipeline.to_job(
     name="xpro_edx_course_pipeline",
     resource_defs=production_resources,
-    config=open_edx_export_irx_job_config("xpro", DAGSTER_ENV),
 )
 
 mitxonline_edx_job = edx_course_pipeline.to_job(
     name="mitxonline_edx_course_pipeline",
     resource_defs=production_resources,
-    config=open_edx_export_irx_job_config("mitxonline", DAGSTER_ENV),
 )
+
+
+# Schedules
+# ---------
+# Config (including Vault dynamic DB credentials) is generated inside each schedule
+# function so it is fetched at schedule-evaluation time, not at code-location load
+# time.  Vault database credentials have a short TTL (~1 h).  Baking them into the
+# static job config via `to_job(config=...)` caused "Access denied" failures when the
+# Dagster daemon had been running longer than the credential TTL before the daily job
+# fired.
+
+
+@schedule(
+    job=residential_edx_job,
+    cron_schedule="@daily",
+    execution_timezone="Etc/UTC",
+)
+def residential_edx_daily_schedule(_context: ScheduleEvaluationContext) -> RunRequest:
+    """Daily schedule for the residential (MITx) edX course pipeline."""
+    return RunRequest(
+        run_key="residential_edx_course_pipeline",
+        run_config=open_edx_export_irx_job_config("mitx", DAGSTER_ENV),
+        tags={"business_unit": "residential"},
+    )
+
+
+@schedule(
+    job=xpro_edx_job,
+    cron_schedule="@daily",
+    execution_timezone="Etc/UTC",
+)
+def xpro_edx_daily_schedule(_context: ScheduleEvaluationContext) -> RunRequest:
+    """Daily schedule for the xPRO edX course pipeline."""
+    return RunRequest(
+        run_key="xpro_edx_course_pipeline",
+        run_config=open_edx_export_irx_job_config("xpro", DAGSTER_ENV),
+        tags={"business_unit": "mitxpro"},
+    )
+
+
+@schedule(
+    job=mitxonline_edx_job,
+    cron_schedule="@daily",
+    execution_timezone="Etc/UTC",
+)
+def mitxonline_edx_daily_schedule(_context: ScheduleEvaluationContext) -> RunRequest:
+    """Daily schedule for the MITx Online edX course pipeline."""
+    return RunRequest(
+        run_key="mitxonline_edx_course_pipeline",
+        run_config=open_edx_export_irx_job_config("mitxonline", DAGSTER_ENV),
+        tags={"business_unit": "mitxonline"},
+    )
+
 
 # Create unified definitions
 defs = Definitions(
     jobs=[residential_edx_job, xpro_edx_job, mitxonline_edx_job],
     schedules=[
-        residential_edx_daily_schedule.with_updated_job(residential_edx_job),
-        xpro_edx_daily_schedule.with_updated_job(xpro_edx_job),
-        mitxonline_edx_daily_schedule.with_updated_job(mitxonline_edx_job),
+        residential_edx_daily_schedule,
+        xpro_edx_daily_schedule,
+        mitxonline_edx_daily_schedule,
     ],
     resources={
         "gcp_gcs": gcs_connection,

--- a/dg_projects/legacy_openedx/legacy_openedx/resources/mysql_db.py
+++ b/dg_projects/legacy_openedx/legacy_openedx/resources/mysql_db.py
@@ -1,9 +1,36 @@
+"""MySQL / MariaDB database resources for legacy Open edX pipelines."""
+
+import contextlib
+import logging
 import ssl
-from typing import Any
+from collections.abc import Generator
+from contextlib import contextmanager
+from typing import Any, Self
 
 import pymysql
-from dagster import Field, InitResourceContext, Int, String, resource
+import pymysql.err
+from dagster import (
+    ConfigurableResource,
+    Field,
+    InitResourceContext,
+    Int,
+    ResourceDependency,
+    String,
+    resource,
+)
+from ol_orchestrate.resources.secrets.vault import Vault
+from pydantic import Field as PydanticField
+from pydantic import PrivateAttr
 from pymysql.cursors import DictCursor
+
+log = logging.getLogger(__name__)
+
+# MySQL / MariaDB error codes that warrant a credential refresh and reconnect.
+# 1044 ER_DBACCESS_DENIED_ERROR - Vault dynamic credential revoked / expired
+# 1045 ER_ACCESS_DENIED_ERROR   - bad username or password
+# 2006 CR_SERVER_GONE_ERROR     - server gone away (restart / idle timeout)
+# 2013 CR_SERVER_LOST           - connection lost mid-query
+_RETRIABLE_MYSQL_ERRORS: frozenset[int] = frozenset({1044, 1045, 2006, 2013})
 
 DEFAULT_MYSQL_PORT = 3306
 
@@ -67,7 +94,7 @@ class MySQLClient:
         with self.connection.cursor() as db_cursor:
             db_cursor.execute(query)
             query_fields = [field[0] for field in db_cursor.description]
-            return query_fields, db_cursor.fetchall()  # type: ignore[return-value]
+            return query_fields, list(db_cursor.fetchall())
 
 
 @resource(
@@ -108,3 +135,109 @@ def mysql_db_resource(resource_context: InitResourceContext):
     )
     yield client
     client.connection.close()
+
+
+class VaultMySQLClientFactory(ConfigurableResource["VaultMySQLClientFactory"]):
+    """MySQL resource that fetches credentials from Vault at runtime.
+
+    Unlike the low-level :func:`mysql_db_resource`, this resource holds **no**
+    passwords in its Dagster config.  Credentials are generated via Vault's
+    database secrets engine when the resource is first used and are automatically
+    re-generated whenever a query fails due to an expired or revoked dynamic
+    credential (error codes 1044/1045) or a dropped connection (2006/2013).
+
+    Configure the non-secret fields in the run ``resources`` section::
+
+        resources:
+          sqldb:
+            config:
+              mysql_hostname: "edxapp-db-mitx-production.example.rds.amazonaws.com"
+              mysql_db_name: "edxapp"
+              vault_mount_point: "mariadb-mitx"
+              vault_role: "readonly"
+    """
+
+    vault: ResourceDependency[Vault]
+    vault_mount_point: str = PydanticField(
+        description="Vault database secrets engine mount point, e.g. 'mariadb-mitx'."
+    )
+    vault_role: str = PydanticField(
+        default="readonly",
+        description="Vault database role to generate credentials for.",
+    )
+    mysql_hostname: str = PydanticField(
+        description="MySQL / MariaDB host name or IP address."
+    )
+    mysql_db_name: str = PydanticField(
+        description="Database name to connect to for executing queries."
+    )
+    mysql_port: int = PydanticField(
+        default=DEFAULT_MYSQL_PORT,
+        description="TCP port number for MySQL / MariaDB server.",
+    )
+
+    _client: MySQLClient | None = PrivateAttr(default=None)
+
+    def _generate_credentials(self) -> tuple[str, str]:
+        """Fetch a fresh set of dynamic credentials from Vault."""
+        creds = self.vault.client.secrets.database.generate_credentials(
+            mount_point=self.vault_mount_point,
+            name=self.vault_role,
+        )["data"]
+        return creds["username"], creds["password"]
+
+    def _connect(self) -> None:
+        """Open a new database connection using freshly generated Vault credentials."""
+        with contextlib.suppress(Exception):
+            if self._client is not None:
+                self._client.connection.close()
+        username, password = self._generate_credentials()
+        self._client = MySQLClient(
+            hostname=self.mysql_hostname,
+            username=username,
+            password=password,
+            db_name=self.mysql_db_name,
+            port=self.mysql_port,
+        )
+
+    def run_query(self, query: str) -> tuple[list[str], list[dict[Any, Any]]]:
+        """Execute *query*, regenerating Vault credentials on auth/connection failure.
+
+        On the first :class:`pymysql.err.OperationalError` with a retriable error
+        code (expired credential, connection dropped), fresh credentials are fetched
+        from Vault and the query is retried exactly once.
+
+        :param query: SQL query string to execute
+        :returns: ``(column_names, rows)``
+        :raises pymysql.err.OperationalError: if the retry also fails or the error
+            code is not retriable.
+        """
+        if self._client is None:
+            self._connect()
+        try:
+            return self._client.run_query(query)  # type: ignore[union-attr]
+        except pymysql.err.OperationalError as exc:
+            if exc.args[0] in _RETRIABLE_MYSQL_ERRORS:
+                log.warning(
+                    "MySQL OperationalError %s (%s) - regenerating Vault credentials "
+                    "and retrying.",
+                    exc.args[0],
+                    exc.args[1] if len(exc.args) > 1 else "",
+                )
+                self._connect()
+                return self._client.run_query(query)  # type: ignore[union-attr]
+            raise
+
+    @contextmanager
+    def yield_for_execution(
+        self,
+        context: InitResourceContext,  # noqa: ARG002
+    ) -> Generator[Self, None, None]:
+        """Yield *self* and close the database connection on teardown."""
+        try:
+            yield self
+        finally:
+            if self._client is not None:
+                with contextlib.suppress(Exception):
+                    self._client.connection.close()
+                self._client = None

--- a/dg_projects/legacy_openedx/legacy_openedx/schedules/open_edx.py
+++ b/dg_projects/legacy_openedx/legacy_openedx/schedules/open_edx.py
@@ -1,37 +1,6 @@
-from dagster import RunRequest, schedule
+"""Legacy Open edX pipeline schedule stubs.
 
-
-@schedule(
-    job_name="dummy_job",
-    cron_schedule="@daily",
-    execution_timezone="Etc/UTC",
-)
-def residential_edx_daily_schedule(execution_date):  # noqa: ARG001
-    return RunRequest(
-        run_key="residential_edx_course_pipeline",
-        tags={"business_unit": "residential"},
-    )
-
-
-@schedule(
-    job_name="dummy_job",
-    cron_schedule="@daily",
-    execution_timezone="Etc/UTC",
-)
-def xpro_edx_daily_schedule(execution_date):  # noqa: ARG001
-    return RunRequest(
-        run_key="xpro_edx_course_pipeline",
-        tags={"business_unit": "mitxpro"},
-    )
-
-
-@schedule(
-    job_name="dummy_job",
-    cron_schedule="@daily",
-    execution_timezone="Etc/UTC",
-)
-def mitxonline_edx_daily_schedule(execution_date):  # noqa: ARG001
-    return RunRequest(
-        run_key="mitxonline_edx_course_pipeline",
-        tags={"business_unit": "mitxonline"},
-    )
+Schedules for the legacy Open edX pipelines are defined in definitions.py
+(alongside the jobs they target) so that Vault dynamic DB credentials are fetched
+at schedule-evaluation time rather than at code-location load time.
+"""


### PR DESCRIPTION
### What are the relevant tickets?
N/A

### Description (What does it do?)

Vault's database secrets engine issues short-lived dynamic credentials (TTL ~1 h). The previous code called `vault.client.secrets.database.generate_credentials()` inside `open_edx_export_irx_job_config()`, which was invoked at **code-location load time** via `to_job(config=...)`. By the time a `@daily` schedule fired, those credentials had expired, causing intermittent failures:

```
pymysql.err.OperationalError: (1044, "Access denied for user 'v-read-TEHGkf30X'@'%' to database 'edxapp'")
```

The error was intermittent because jobs that happened to run shortly after daemon startup (while credentials were still valid) succeeded, while jobs that ran after the TTL window failed.

**Fix 1 — Move schedule config to run time**

The three `@schedule` functions are now defined inline in `definitions.py` (previously imported from `schedules/open_edx.py`). Each schedule calls `open_edx_export_irx_job_config()` inside the schedule function body and passes the result as `run_config=` to `RunRequest`. This means credentials are generated at schedule-evaluation time (i.e. when the job actually fires), not at code-location load time.

**Fix 2 — `VaultMySQLClientFactory` ConfigurableResource**

Adds a new `VaultMySQLClientFactory(ConfigurableResource)` in `resources/mysql_db.py` that replaces `mysql_db_resource` in `production_resources`:

- **No secrets in config** — fields are `vault_mount_point`, `vault_role`, `mysql_hostname`, `mysql_db_name` only
- **Lazy credential fetch** — calls `generate_credentials()` on first use, not at load time
- **Automatic retry on failure** — catches `pymysql.err.OperationalError` with retriable codes (1044 `ER_DBACCESS_DENIED_ERROR`, 1045 `ER_ACCESS_DENIED_ERROR`, 2006 `CR_SERVER_GONE_ERROR`, 2013 `CR_SERVER_LOST`), generates fresh Vault credentials, reconnects, and retries the query exactly once
- **Clean teardown** — `yield_for_execution` closes the connection when the Dagster run ends

`open_edx_export_irx_job_config` no longer calls `generate_credentials()` at all; the resource owns the full credential lifecycle.

### How can this be tested?

**Unit / static:**
- Pre-commit hooks pass (ruff, mypy) — verified locally on all three changed files.

**Integration (in a staging/QA environment):**
1. Deploy the `legacy_openedx` code location.
2. Manually trigger one of the IRx jobs (e.g. `residential_edx_course_pipeline`) from the Dagster UI.
3. Confirm the `sqldb` resource initialises without error and the MySQL queries succeed — the Dagster event log should show a Vault credential username (`v-read-*`) in the resource initialisation logs.
4. To verify the retry path: temporarily lower the Vault credential TTL on the `mariadb-<deployment>/readonly` role to 30 s, run the job, and confirm it reconnects automatically rather than failing.

**Regression:**
- Jobs that ran before this change were producing the intermittent 1044 error; the fix eliminates the root cause by ensuring credentials are never stale at the time of use.