### PR TITLE
fix(legacy_openedx): wire vault to VaultMySQLClientFactory via constructor

### DIFF
--- a/dg_projects/legacy_openedx/legacy_openedx/definitions.py
+++ b/dg_projects/legacy_openedx/legacy_openedx/definitions.py
@@ -23,7 +23,6 @@ from ol_orchestrate.resources.secrets.vault import Vault
 from legacy_openedx.jobs.open_edx import edx_course_pipeline
 from legacy_openedx.resources.healthchecks import HealthchecksIO
 from legacy_openedx.resources.mysql_db import VaultMySQLClientFactory
-from legacy_openedx.resources.sqlite_db import sqlite_db_resource
 
 # Initialize vault with resilient loading
 try:
@@ -190,11 +189,6 @@ _base_production_resources = {
     "results_dir": DailyResultsDir.configure_at_launch(),
     "healthchecks": HealthchecksIO.configure_at_launch(),
     "openedx": OpenEdxApiClient.configure_at_launch(),
-}
-
-qa_resources = {
-    "sqldb": sqlite_db_resource,
-    **_base_production_resources,
 }
 
 # Create jobs for each deployment.

--- a/dg_projects/legacy_openedx/legacy_openedx/definitions.py
+++ b/dg_projects/legacy_openedx/legacy_openedx/definitions.py
@@ -134,18 +134,6 @@ def open_edx_export_irx_job_config(
         "token_url": f"{edx_creds['url']}/oauth2/access_token",
     }
 
-    db_hostname = (
-        f"edxapp-db-{deployment}-{dagster_env}"
-        f"{'-replica' if dagster_env == 'production' else ''}"
-        ".cbnm7ajau6mi.us-east-1.rds.amazonaws.com"
-    )
-    edx_db_config = {
-        "mysql_db_name": "edxapp",
-        "mysql_hostname": db_hostname,
-        "vault_mount_point": f"mariadb-{deployment}",
-        "vault_role": "readonly",
-    }
-
     return {
         "ops": {
             "collect_edx_course_exports": {
@@ -166,46 +154,76 @@ def open_edx_export_irx_job_config(
             "results_dir": {
                 "config": {"date_format": "%Y%m%d", "dir_prefix": deployment}
             },
-            "sqldb": {"config": edx_db_config},
         },
     }
 
 
+def _mysql_resource(
+    deployment: Literal["mitx", "mitxonline", "xpro"],
+    dagster_env: Literal["dev", "ci", "qa", "production"],
+) -> VaultMySQLClientFactory:
+    """Build a VaultMySQLClientFactory pre-wired with the module-level vault instance.
+
+    Vault is passed directly as a constructor argument (the pattern used by all
+    other Vault-backed resources in this project, e.g. ApiClientFactory).  This
+    ensures Dagster injects the live vault object rather than relying on
+    ResourceDependency registry look-up, which fails when the resource is
+    configured at launch.
+    """
+    db_hostname = (
+        f"edxapp-db-{deployment}-{dagster_env}"
+        f"{'-replica' if dagster_env == 'production' else ''}"
+        ".cbnm7ajau6mi.us-east-1.rds.amazonaws.com"
+    )
+    return VaultMySQLClientFactory(
+        vault=vault,
+        vault_mount_point=f"mariadb-{deployment}",
+        vault_role="readonly",
+        mysql_hostname=db_hostname,
+        mysql_db_name="edxapp",
+    )
+
+
 # Resource definitions for IRx jobs
-qa_resources = {
-    "sqldb": sqlite_db_resource,
+_base_production_resources = {
     "s3": S3Resource(),
     "results_dir": DailyResultsDir.configure_at_launch(),
     "healthchecks": HealthchecksIO.configure_at_launch(),
     "openedx": OpenEdxApiClient.configure_at_launch(),
 }
 
-production_resources = {
-    "sqldb": VaultMySQLClientFactory.configure_at_launch(),
-    "vault": vault,
-    "s3": S3Resource(),
-    "results_dir": DailyResultsDir.configure_at_launch(),
-    "healthchecks": HealthchecksIO.configure_at_launch(),
-    "openedx": OpenEdxApiClient.configure_at_launch(),
+qa_resources = {
+    "sqldb": sqlite_db_resource,
+    **_base_production_resources,
 }
 
 # Create jobs for each deployment.
-# NOTE: config is intentionally omitted here — it is generated at schedule-fire time
-# (not at code-location load time) so that Vault dynamic DB credentials are always
-# fresh when the job runs.  See the @schedule definitions below.
+# Each job gets its own VaultMySQLClientFactory instance with vault wired in
+# directly (matching the ApiClientFactory pattern used throughout this project).
+# The resource fetches fresh Vault credentials on first use and reconnects
+# automatically if the credential expires mid-run.
 residential_edx_job = edx_course_pipeline.to_job(
     name="residential_edx_course_pipeline",
-    resource_defs=production_resources,
+    resource_defs={
+        "sqldb": _mysql_resource("mitx", DAGSTER_ENV),
+        **_base_production_resources,
+    },
 )
 
 xpro_edx_job = edx_course_pipeline.to_job(
     name="xpro_edx_course_pipeline",
-    resource_defs=production_resources,
+    resource_defs={
+        "sqldb": _mysql_resource("xpro", DAGSTER_ENV),
+        **_base_production_resources,
+    },
 )
 
 mitxonline_edx_job = edx_course_pipeline.to_job(
     name="mitxonline_edx_course_pipeline",
-    resource_defs=production_resources,
+    resource_defs={
+        "sqldb": _mysql_resource("mitxonline", DAGSTER_ENV),
+        **_base_production_resources,
+    },
 )
 
 


### PR DESCRIPTION
### What are the relevant tickets?
Follow-up to #2288 (merged).

### Description (What does it do?)

After #2288 was deployed, the new `VaultMySQLClientFactory` resource failed at runtime with:

```
AttributeError: 'NoneType' object has no attribute 'client'

  File "/app/legacy_openedx/resources/mysql_db.py", line 183, in _generate_credentials
    creds = self.vault.client.secrets.database.generate_credentials(
            ^^^^^^^^^^^^^^^^^
```

**Root cause:** `ResourceDependency[Vault]` is resolved by passing `vault=` directly to the `ConfigurableResource` constructor — this is the pattern every other Vault-backed resource in this project uses (e.g. `ApiClientFactory`, `OpenEdxApiClientFactory`, `GithubApiClientFactory`). The previous approach of `configure_at_launch()` + a side-channel `"vault"` key in `resource_defs` does **not** inject the dependency; `self.vault` arrives as `None` at run time.

**Fix:**
- Replaces the shared `production_resources` dict with a `_mysql_resource(deployment, env)` helper that builds a fully-wired `VaultMySQLClientFactory(vault=vault, ...)` instance per deployment (hostname and vault mount point differ between mitx, xpro, and mitxonline).
- Each of the three jobs now gets its own `resource_defs` dict with the appropriate `sqldb` instance.
- Removes the now-dead `db_hostname` / `edx_db_config` block from `open_edx_export_irx_job_config`; the `sqldb` resource no longer needs any run-config entry since it is fully configured at definition time.

### How can this be tested?

1. Deploy the `legacy_openedx` code location.
2. Manually trigger any of the three IRx jobs (`residential_edx_course_pipeline`, `xpro_edx_course_pipeline`, `mitxonline_edx_course_pipeline`) from the Dagster UI.
3. Confirm the `sqldb` resource initialises without error — the `_generate_credentials()` call should succeed and the MySQL queries in ops like `course_roles`, `enrolled_users`, etc. should complete normally.

### Additional Context

The `_mysql_resource` helper is called at code-location load time (so each job's `resource_defs` is built once at startup), but credentials are **not** fetched at load time — `VaultMySQLClientFactory._connect()` is called lazily on first query, preserving the runtime-only credential behaviour introduced in #2288.