### PR TITLE
fix(iceberg): use fsspec FileIO and serialize student_risk writes

### DIFF
--- a/dg_projects/lakehouse/lakehouse/assets/iceberg_maintenance.py
+++ b/dg_projects/lakehouse/lakehouse/assets/iceberg_maintenance.py
@@ -33,6 +33,7 @@ Two assets run on staggered nightly schedules:
 """
 
 import logging
+import threading
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from typing import Any
 
@@ -57,6 +58,7 @@ from ol_orchestrate.lib.iceberg_maintenance import (
     remove_orphan_files,
 )
 from ol_orchestrate.resources.trino_maintenance import TrinoMaintenanceResource
+from pyiceberg.catalog.glue import GlueCatalog
 
 from lakehouse.assets.lakehouse.dbt import dbt_project
 
@@ -141,12 +143,16 @@ def _run_table_maintenance(
     instance,
     last_cursor: int | None,
     trino_maintenance: TrinoMaintenanceResource,
+    catalog: GlueCatalog,
 ) -> dict[str, Any]:
     """Run all maintenance operations for one dbt-layer table.
 
+    The shared ``catalog`` is created once by the asset and reused across all
+    tables: constructing a fresh GlueCatalog (and its S3 FileIO) per table is
+    both wasteful and a known trigger for native-client hangs.
+
     Returns a summary dict used to aggregate the asset's output metadata.
     """
-    catalog = get_glue_catalog()
     summary: dict[str, Any] = {
         "model": cfg.model_name,
         "optimized": False,
@@ -258,6 +264,8 @@ def iceberg_dbt_layer_maintenance(
             "First maintenance run — all operations will execute unconditionally."
         )
 
+    catalog = get_glue_catalog()
+
     tables_processed = 0
     tables_optimized = 0
     tables_analyzed = 0
@@ -270,7 +278,7 @@ def iceberg_dbt_layer_maintenance(
             continue
         try:
             result = _run_table_maintenance(
-                cfg, context.instance, last_cursor, trino_maintenance
+                cfg, context.instance, last_cursor, trino_maintenance, catalog
             )
             tables_processed += 1
             if result["optimized"]:
@@ -354,15 +362,26 @@ def iceberg_raw_layer_maintenance(context: AssetExecutionContext) -> Output[None
         RAW_LAYER_WORKERS,
     )
 
-    catalog = get_glue_catalog()
-
     tables_cleaned = 0
     snapshots_expired = 0
     orphans_removed = 0
     failures: list[str] = []
 
+    # A GlueCatalog (and its underlying S3 FileIO / boto3 client) must not be
+    # shared across worker threads: concurrent commits mutate catalog state and
+    # the native client deadlocks under the nested ThreadPoolExecutor. Give each
+    # of the RAW_LAYER_WORKERS threads its own catalog, created once and reused
+    # for every table that thread processes.
+    _thread_local = threading.local()
+
+    def _worker_catalog():
+        if not hasattr(_thread_local, "catalog"):
+            _thread_local.catalog = get_glue_catalog()
+        return _thread_local.catalog
+
     def _process_one(table_info) -> dict[str, Any]:
         cfg = raw_config_for_table(table_info.table_name)
+        catalog = _worker_catalog()
         result: dict[str, Any] = {
             "table": table_info.table_name,
             "ok": True,

--- a/dg_projects/student_risk_probability/student_risk_probability/assets/risk_probability.py
+++ b/dg_projects/student_risk_probability/student_risk_probability/assets/risk_probability.py
@@ -23,6 +23,7 @@ from student_risk_probability.lib.helper import (
     automation_condition=upstream_or_code_changes(),
     io_manager_key="io_manager",
     key=AssetKey(["reporting", "student_risk_probability"]),
+    pool="student_risk_probability",
 )
 def student_risk_probability(context: AssetExecutionContext) -> pl.DataFrame:
     """

--- a/dg_projects/student_risk_probability/student_risk_probability/definitions.py
+++ b/dg_projects/student_risk_probability/student_risk_probability/definitions.py
@@ -56,6 +56,7 @@ defs = Definitions(
                     # K8s in handle_output and ignore the configured S3 timeouts.
                     # reader_override above only covers the Polars read path.
                     "py-io-impl": "pyiceberg.io.fsspec.FsspecFileIO",
+                    "s3.region": "us-east-1",
                     "s3.connect-timeout": "10",
                     "s3.request-timeout": "120",
                 }

--- a/dg_projects/student_risk_probability/student_risk_probability/definitions.py
+++ b/dg_projects/student_risk_probability/student_risk_probability/definitions.py
@@ -51,6 +51,11 @@ defs = Definitions(
                 properties={
                     "type": "glue",
                     "glue.region": "us-east-1",
+                    # Write/commit via fsspec/s3fs (aiobotocore) instead of the
+                    # default PyArrow S3 FileIO, whose native threads deadlock on
+                    # K8s in handle_output and ignore the configured S3 timeouts.
+                    # reader_override above only covers the Polars read path.
+                    "py-io-impl": "pyiceberg.io.fsspec.FsspecFileIO",
                     "s3.connect-timeout": "10",
                     "s3.request-timeout": "120",
                 }

--- a/packages/ol-orchestrate-lib/src/ol_orchestrate/lib/glue_helper.py
+++ b/packages/ol-orchestrate-lib/src/ol_orchestrate/lib/glue_helper.py
@@ -106,8 +106,12 @@ def get_dbt_model_as_dataframe(database_name: str, table_name: str) -> pl.LazyFr
         KeyError: If the table metadata doesn't contain the expected fields
         boto3 exceptions: If the AWS Glue API call fails
     """
-    # pyiceberg's PyArrowFileIO expects timeout values as plain numeric seconds strings.
+    # Route pyiceberg I/O through fsspec/s3fs (aiobotocore) instead of the default
+    # PyArrow S3 FileIO (aws-sdk-cpp). The native PyArrow reader leaves wedged
+    # threads/connections on K8s that no S3 timeout interrupts, deadlocking the
+    # run. fsspec honors the same s3.connect-timeout / s3.request-timeout keys.
     pyiceberg_s3_properties = {
+        "py-io-impl": "pyiceberg.io.fsspec.FsspecFileIO",
         "s3.region": "us-east-1",
         "s3.connect-timeout": "10",
         "s3.request-timeout": "120",

--- a/packages/ol-orchestrate-lib/src/ol_orchestrate/lib/iceberg_maintenance.py
+++ b/packages/ol-orchestrate-lib/src/ol_orchestrate/lib/iceberg_maintenance.py
@@ -138,6 +138,11 @@ def get_glue_catalog(region: str = AWS_REGION) -> GlueCatalog:
         "default",
         client=boto3.client("glue", region_name=region),
         **{
+            # Route pyiceberg I/O through fsspec/s3fs (aiobotocore) rather than the
+            # default PyArrow S3 FileIO (aws-sdk-cpp), whose native threads deadlock
+            # on K8s during commits (expire_snapshots) and are not interrupted by
+            # the configured S3 timeouts.
+            "py-io-impl": "pyiceberg.io.fsspec.FsspecFileIO",
             "s3.connect-timeout": "10",
             "s3.request-timeout": "120",
         },

--- a/packages/ol-orchestrate-lib/src/ol_orchestrate/lib/iceberg_maintenance.py
+++ b/packages/ol-orchestrate-lib/src/ol_orchestrate/lib/iceberg_maintenance.py
@@ -143,6 +143,7 @@ def get_glue_catalog(region: str = AWS_REGION) -> GlueCatalog:
             # on K8s during commits (expire_snapshots) and are not interrupted by
             # the configured S3 timeouts.
             "py-io-impl": "pyiceberg.io.fsspec.FsspecFileIO",
+            "s3.region": region,
             "s3.connect-timeout": "10",
             "s3.request-timeout": "120",
         },


### PR DESCRIPTION
### What are the relevant tickets?
N/A

### Description (What does it do?)
Several Dagster runs that interact with Iceberg on S3 were hanging indefinitely (6–10h+) on Kubernetes after their compute completed. Investigation of the wedged run pods (`data-production` `dagster` namespace) showed:

- Two `student_risk_probability` runs stuck right after `STEP_OUTPUT` with no `HANDLED_OUTPUT` — hung inside `PolarsIcebergIOManager.handle_output` (the Iceberg write).
- `iceberg_dbt_maintenance_job` silent for ~10.5h mid-loop; `iceberg_raw_maintenance_job` completed 0 of 1335 tables in ~10h after submitting to its 8-worker pool.
- No OOM/eviction; the configured `s3.request-timeout=120` was **not** interrupting the hangs → a thread/connection deadlock, not a network stall.

Root cause: every Iceberg **write/commit** (and reads where the Polars `reader_override` didn't help) goes through pyiceberg's default **PyArrow S3 FileIO (aws-sdk-cpp)**, whose native threads deadlock on K8s and are not bounded by the S3 timeouts. The existing `reader_override="pyiceberg"` only addressed the Polars native-Rust **read** path.

This PR:

- Routes pyiceberg I/O through **fsspec/s3fs (aiobotocore)** via `py-io-impl=pyiceberg.io.fsspec.FsspecFileIO` at every catalog construction site:
  - `glue_helper.get_dbt_model_as_dataframe` (reads — used by `student_risk_probability` and `b2b_organization`)
  - `iceberg_maintenance.get_glue_catalog` (`expire_snapshots` commits — both nightly maintenance jobs)
  - `PolarsIcebergIOManager` in `student_risk_probability/definitions.py` (the `handle_output` write)
  - fsspec honors the same `s3.connect-timeout`/`s3.request-timeout` keys; `s3fs` is already a declared dependency.
- Hardens the maintenance assets: reuse a single catalog across the dbt-layer loop instead of building one per table (613×), and give each raw-layer worker thread its own catalog (thread-local) instead of sharing one `GlueCatalog`/FileIO across the `ThreadPoolExecutor`.
- Adds a `student_risk_probability` concurrency pool to the asset (mirroring `edxorg_archive`) so a hung run is not retried into a second concurrent writer against the same Iceberg table.

### How can this be tested?
- `ruff format`/`ruff check` and `mypy` pass on all changed files; pre-commit passed on commit.
- Functional validation requires a real run (these execute on nightly schedules and the readonly cluster role blocks `exec`/metrics), so it should be confirmed against:
  - a manual materialization of `student_risk_probability` — verify the run reaches `HANDLED_OUTPUT`/`STEP_SUCCESS` and the pod exits.
  - the next `iceberg_dbt_maintenance_job` / `iceberg_raw_maintenance_job` runs — verify per-table progress and completion rather than indefinite silence.

### Additional Context
- The `student_risk_probability` pool enforces a limit only once a slot count is registered on the production Dagster instance (DB-backed, e.g. `dagster instance concurrency set student_risk_probability 1`), the same as `edxorg_archive`. The `pool=` tag alone defaults to unlimited.
- `src/ol_dlt/edxorg_tsv.py` also commits via the default PyArrow FileIO and would hit the same hang, but it's an untracked experimental dlt script and was intentionally left out of this fix.
- The four currently-wedged run pods should be terminated by someone with write access to free the run queue.