### PR TITLE
fix(legacy_openedx): restore launchpad default config for IRx jobs

### DIFF
--- a/dg_projects/legacy_openedx/legacy_openedx/definitions.py
+++ b/dg_projects/legacy_openedx/legacy_openedx/definitions.py
@@ -196,12 +196,32 @@ _base_production_resources = {
 # directly (matching the ApiClientFactory pattern used throughout this project).
 # The resource fetches fresh Vault credentials on first use and reconnects
 # automatically if the credential expires mid-run.
+#
+# When Vault is reachable at code-location load time (i.e. in production), each
+# job is also given a default config so the Dagster launchpad is pre-populated
+# for ad-hoc manual runs.  The schedule's run_config= always overrides this with
+# freshly fetched values at schedule-evaluation time.
+
+
+def _job_default_config(
+    deployment: Literal["mitx", "mitxonline", "xpro"],
+) -> dict[str, object]:
+    """Return a default run config for the launchpad when Vault is available."""
+    if not vault_authenticated:
+        return {}
+    try:
+        return open_edx_export_irx_job_config(deployment, DAGSTER_ENV)
+    except Exception:  # noqa: BLE001
+        return {}
+
+
 residential_edx_job = edx_course_pipeline.to_job(
     name="residential_edx_course_pipeline",
     resource_defs={
         "sqldb": _mysql_resource("mitx", DAGSTER_ENV),
         **_base_production_resources,
     },
+    config=_job_default_config("mitx"),
 )
 
 xpro_edx_job = edx_course_pipeline.to_job(
@@ -210,6 +230,7 @@ xpro_edx_job = edx_course_pipeline.to_job(
         "sqldb": _mysql_resource("xpro", DAGSTER_ENV),
         **_base_production_resources,
     },
+    config=_job_default_config("xpro"),
 )
 
 mitxonline_edx_job = edx_course_pipeline.to_job(
@@ -218,6 +239,7 @@ mitxonline_edx_job = edx_course_pipeline.to_job(
         "sqldb": _mysql_resource("mitxonline", DAGSTER_ENV),
         **_base_production_resources,
     },
+    config=_job_default_config("mitxonline"),
 )
 
 

--- a/dg_projects/legacy_openedx/legacy_openedx/definitions.py
+++ b/dg_projects/legacy_openedx/legacy_openedx/definitions.py
@@ -7,6 +7,7 @@ that were defined using repository-based patterns. These include:
 2. IRx course data exports for 3 deployments (mitx, xpro, mitxonline)
 """
 
+import logging
 import os
 from typing import Literal
 
@@ -23,6 +24,8 @@ from ol_orchestrate.resources.secrets.vault import Vault
 from legacy_openedx.jobs.open_edx import edx_course_pipeline
 from legacy_openedx.resources.healthchecks import HealthchecksIO
 from legacy_openedx.resources.mysql_db import VaultMySQLClientFactory
+
+log = logging.getLogger(__name__)
 
 # Initialize vault with resilient loading
 try:
@@ -212,6 +215,13 @@ def _job_default_config(
     try:
         return open_edx_export_irx_job_config(deployment, DAGSTER_ENV)
     except Exception:  # noqa: BLE001
+        log.warning(
+            "Failed to build default job config for '%s' at code-location load "
+            "time; launchpad will not be pre-populated. "
+            "Scheduled runs are unaffected.",
+            deployment,
+            exc_info=True,
+        )
         return {}
 
 


### PR DESCRIPTION
### What are the relevant tickets?
Follow-up to #2289 (merged).

### Description (What does it do?)

After the Vault MySQL credential refactor (#2288 / #2289), the `to_job()` calls no longer carried a default `config=`, so the Dagster launchpad had nothing pre-populated for the three IRx jobs and surfaced validation errors:

```
Missing required config entry "collect_edx_course_exports" at path root:ops
Missing required config entries ['edx_mongodb_forum_database_name', 'edx_mongodb_uri'] at path root:ops:export_edx_forum_database:config
Missing required config entries ['base_url', 'client_id', 'client_secret', 'token_url'] at path root:resources:openedx:config
```

**Fix:** adds a small `_job_default_config(deployment)` helper that calls `open_edx_export_irx_job_config` at code-location load time and passes the result as `config=` to each `to_job()`.

**Why this is safe:**
- MySQL credentials are no longer part of the job config at all — they are owned entirely by `VaultMySQLClientFactory`, which fetches them lazily at run time. There is no TTL concern here.
- The remaining config (Mongo creds, edX OAuth, bucket names, healthcheck ID) comes from Vault KV v1 static secrets that do not have a short dynamic TTL.
- `vault_authenticated=False` (dev / CI without Vault) returns an empty dict so the launchpad gracefully falls back to prompting for all values manually.

The schedule's `run_config=open_edx_export_irx_job_config(...)` is unchanged and continues to call Vault at schedule-evaluation time, so all scheduled production runs always receive freshly fetched credentials regardless of the load-time default.

### How can this be tested?

1. Deploy the `legacy_openedx` code location.
2. Open the Dagster UI launchpad for any of the three IRx jobs (`residential_edx_course_pipeline`, `xpro_edx_course_pipeline`, `mitxonline_edx_course_pipeline`).
3. Confirm the config pane is pre-populated (bucket names, resource configs) with no missing-field validation errors.