### PR TITLE
feat(dimensional): add tfact_program_certificate fact table

### DIFF
--- a/src/ol_dbt/models/dimensional/_fact_tables.yml
+++ b/src/ol_dbt/models/dimensional/_fact_tables.yml
@@ -430,3 +430,98 @@ models:
   - name: grade_updated_on
     description: Grade last update timestamp (for incremental processing). Null for
       edX.org.
+
+- name: tfact_program_certificate
+  description: >
+    Transaction fact table for program-level certificate issuance events.
+    Grain: One row per (certificate_id, platform) — one certificate per learner per
+    program per platform.
+
+    Platforms covered: MITx Online, MITx Pro, edX.org, MicroMasters.
+    MicroMasters rows apply DEDP-era split logic: certs awarded before 2022-10-01
+    come
+    from the MicroMasters DB; certs from 2022-10-01 onward come from MITx Online DB.
+
+    Note: unlike tfact_certificate (which covers both course and program certs in
+    one table),
+    this model is program-certificates-only and provides a cleaner grain for program-level
+    reporting without filtering on certificate_scope.
+  tests:
+  - dbt_utils.unique_combination_of_columns:
+      combination_of_columns:
+      - certificate_id
+      - platform
+  columns:
+  - name: program_certificate_key
+    description: Surrogate primary key. Generated from (certificate_id, platform).
+    tests:
+    - unique
+    - not_null
+  - name: certificate_id
+    description: >
+      Source system certificate ID. Integer for MITx Online and MITx Pro;
+      hashed ID (program_certificate_hashed_id) for edX.org and MicroMasters.
+    tests:
+    - not_null
+  - name: certificate_issued_date_key
+    description: >
+      Foreign key to dim_date for the certificate issuance date (YYYYMMDD integer).
+      Null for records where no issued date is available in the source system.
+    tests:
+    - relationships:
+        to: ref('dim_date')
+        field: date_key
+        where: "certificate_issued_date_key is not null"
+  - name: user_fk
+    description: Foreign key to dim_user. Resolved via platform-specific user ID joins.
+      Null when the learner cannot be matched to a dim_user record.
+    tests:
+    - relationships:
+        to: ref('dim_user')
+        field: user_pk
+        where: "user_fk is not null"
+        config:
+          severity: warn
+  - name: program_fk
+    description: >
+      Foreign key to dim_program. Null when the program cannot be matched
+      (e.g. MicroMasters programs not yet in dim_program).
+    tests:
+    - relationships:
+        to: ref('dim_program')
+        field: program_pk
+        where: "program_fk is not null"
+        config:
+          severity: warn
+  - name: platform_fk
+    description: Foreign key to dim_platform
+    tests:
+    - not_null
+    - relationships:
+        to: ref('dim_platform')
+        field: platform_pk
+  - name: platform
+    description: Platform identifier string
+    tests:
+    - not_null
+    - accepted_values:
+        values: ['mitxonline', 'mitxpro', 'edxorg', 'micromasters']
+  - name: certificate_uuid
+    description: >
+      UUID for the certificate. Null for edX.org (where hashed_id is used instead)
+      and MicroMasters (no UUID in source).
+  - name: certificate_is_revoked
+    description: Boolean — true if certificate has been revoked. Always false for
+      edX.org and MicroMasters (revocations not tracked in source data).
+    tests:
+    - not_null
+  - name: certificate_created_on
+    description: Certificate creation timestamp (for incremental processing)
+  - name: certificate_updated_on
+    description: Certificate last update timestamp. Null for edX.org and MicroMasters
+      where only a single awarded/completion timestamp is available.
+  - name: certificate_issued_on
+    description: >
+      Certificate issuance timestamp. For MITx Online this is the actual issued_on
+      from the source; for MITx Pro and MicroMasters this falls back to created_on;
+      for edX.org this is program_certificate_awarded_on.

--- a/src/ol_dbt/models/dimensional/tfact_program_certificate.sql
+++ b/src/ol_dbt/models/dimensional/tfact_program_certificate.sql
@@ -1,0 +1,288 @@
+{{ config(
+    materialized='incremental',
+    unique_key='program_certificate_key',
+    incremental_strategy='delete+insert',
+    on_schema_change='append_new_columns'
+) }}
+
+-- Consolidate program certificates from all platforms.
+-- Grain: one row per (certificate_id, platform). Each row represents a single
+-- program-level certificate earned by a learner.
+--
+-- Platforms covered: MITx Online, MITx Pro, edX.org (MicroMasters), MicroMasters.
+-- Note: micromasters program certificates are sourced from int__micromasters__program_certificates
+-- which applies DEDP-era logic (pre-2022-10-01 from MicroMasters DB, post from MITx Online).
+
+with mitxonline_program_certificates as (
+    select
+        cast(programcertificate_id as varchar) as certificate_id
+        , user_id
+        , program_id
+        , programcertificate_uuid as certificate_uuid
+        , programcertificate_is_revoked as certificate_is_revoked
+        , programcertificate_created_on as certificate_created_on
+        , programcertificate_updated_on as certificate_updated_on
+        , programcertificate_issued_on as certificate_issued_on
+        , 'mitxonline' as platform
+        , user_email
+        , cast(program_id as varchar) as program_source_id
+    from {{ ref('int__mitxonline__program_certificates') }}
+)
+
+, mitxpro_program_certificates as (
+    select
+        cast(programcertificate_id as varchar) as certificate_id
+        , user_id
+        , program_id
+        , programcertificate_uuid as certificate_uuid
+        , programcertificate_is_revoked as certificate_is_revoked
+        , programcertificate_created_on as certificate_created_on
+        , programcertificate_updated_on as certificate_updated_on
+        , programcertificate_created_on as certificate_issued_on  -- mitxpro has no separate issued_on
+        , 'mitxpro' as platform
+        , user_email
+        , cast(program_id as varchar) as program_source_id
+    from {{ ref('int__mitxpro__program_certificates') }}
+)
+
+, edxorg_program_certificates as (
+    select
+        program_certificate_hashed_id as certificate_id
+        , user_id
+        , cast(null as integer) as program_id
+        , program_certificate_hashed_id as certificate_uuid  -- no separate UUID; hashed ID doubles as identifier
+        , false as certificate_is_revoked  -- edxorg doesn't track revocations
+        , program_certificate_awarded_on as certificate_created_on
+        , program_certificate_awarded_on as certificate_updated_on  -- only awarded_on available
+        , program_certificate_awarded_on as certificate_issued_on
+        , 'edxorg' as platform
+        , cast(null as varchar) as user_email
+        , program_uuid as program_source_id  -- edxorg uses UUID, not integer ID
+    from {{ ref('int__edxorg__mitx_program_certificates') }}
+)
+
+-- MicroMasters program certificates use a complex DEDP-era union (pre/post 2022-10-01 cutoff).
+-- These are sourced from micromasters DB for older certs and mitxonline DB for newer ones.
+-- User resolution uses user_edxorg_id as the join key to dim_user.
+, micromasters_program_certificates as (
+    select
+        program_certificate_hashed_id as certificate_id
+        , cast(null as integer) as user_id  -- resolved via user_edxorg_id below
+        , micromasters_program_id as program_id
+        , cast(null as varchar) as certificate_uuid
+        , false as certificate_is_revoked
+        , program_completion_timestamp as certificate_created_on
+        , program_completion_timestamp as certificate_updated_on
+        , program_completion_timestamp as certificate_issued_on
+        , 'micromasters' as platform
+        , user_email
+        , cast(micromasters_program_id as varchar) as program_source_id
+        , user_edxorg_id
+    from {{ ref('int__micromasters__program_certificates') }}
+)
+
+, combined as (
+    select
+        certificate_id
+        , user_id
+        , program_id
+        , certificate_uuid
+        , certificate_is_revoked
+        , certificate_created_on
+        , certificate_updated_on
+        , certificate_issued_on
+        , platform
+        , user_email
+        , program_source_id
+        , cast(null as integer) as user_edxorg_id
+    from mitxonline_program_certificates
+    union all
+    select
+        certificate_id
+        , user_id
+        , program_id
+        , certificate_uuid
+        , certificate_is_revoked
+        , certificate_created_on
+        , certificate_updated_on
+        , certificate_issued_on
+        , platform
+        , user_email
+        , program_source_id
+        , cast(null as integer) as user_edxorg_id
+    from mitxpro_program_certificates
+    union all
+    select
+        certificate_id
+        , user_id
+        , program_id
+        , certificate_uuid
+        , certificate_is_revoked
+        , certificate_created_on
+        , certificate_updated_on
+        , certificate_issued_on
+        , platform
+        , user_email
+        , program_source_id
+        , cast(null as integer) as user_edxorg_id
+    from edxorg_program_certificates
+    union all
+    select
+        certificate_id
+        , user_id
+        , program_id
+        , certificate_uuid
+        , certificate_is_revoked
+        , certificate_created_on
+        , certificate_updated_on
+        , certificate_issued_on
+        , platform
+        , user_email
+        , program_source_id
+        , user_edxorg_id
+    from micromasters_program_certificates
+)
+
+, user_lookup as (
+    select
+        user_pk
+        , email
+        , mitxonline_application_user_id
+        , mitxpro_application_user_id
+        , edxorg_openedx_user_id
+    from {{ ref('dim_user') }}
+    where user_pk is not null
+)
+
+, dim_program as (
+    select program_pk, source_id, platform_code
+    from {{ ref('dim_program') }}
+)
+
+, dim_platform_lookup as (
+    select platform_pk, platform_readable_id
+    from {{ ref('dim_platform') }}
+)
+
+, combined_with_fks as (
+    select
+        combined.*
+        , coalesce(
+            case when combined.platform = 'mitxonline'
+                then ul_mitxonline.user_pk
+            end,
+            case when combined.platform = 'mitxpro'
+                then ul_mitxpro.user_pk
+            end,
+            case when combined.platform = 'edxorg'
+                then ul_edxorg_userid.user_pk
+            end,
+            case when combined.platform = 'micromasters'
+                then ul_micromasters_edxorg.user_pk
+            end
+        ) as user_fk
+        , dim_program.program_pk as program_fk
+        , dim_platform_lookup.platform_pk as platform_fk
+        , {{ iso8601_to_date_key('certificate_issued_on') }} as certificate_issued_date_key
+    from combined
+    left join user_lookup as ul_mitxonline
+        on combined.platform = 'mitxonline'
+        and combined.user_id = ul_mitxonline.mitxonline_application_user_id
+    left join user_lookup as ul_mitxpro
+        on combined.platform = 'mitxpro'
+        and combined.user_id = ul_mitxpro.mitxpro_application_user_id
+    -- edxorg: join via openedx_user_id (integer user_id from source)
+    left join user_lookup as ul_edxorg_userid
+        on combined.platform = 'edxorg'
+        and combined.user_id = ul_edxorg_userid.edxorg_openedx_user_id
+    -- micromasters: join via edxorg_openedx_user_id (user_edxorg_id from source)
+    left join user_lookup as ul_micromasters_edxorg
+        on combined.platform = 'micromasters'
+        and combined.user_edxorg_id = ul_micromasters_edxorg.edxorg_openedx_user_id
+    left join dim_program
+        on combined.program_source_id = dim_program.source_id
+        and combined.platform = dim_program.platform_code
+    left join dim_platform_lookup
+        on combined.platform = dim_platform_lookup.platform_readable_id
+)
+
+{% if is_incremental() %}
+-- Pre-compute per-platform watermarks in a single scan of {{ this }} to avoid
+-- correlated subquery fan-out in Trino. Pattern mirrors tfact_certificate.sql.
+, incremental_watermarks as (
+    select
+        platform as watermark_platform
+        , max(coalesce(certificate_updated_on, certificate_created_on)) as max_activity_on
+    from {{ this }}
+    group by platform
+)
+{% endif %}
+
+, final as (
+    select
+        {{ dbt_utils.generate_surrogate_key([
+            'cast(certificate_id as varchar)',
+            'platform'
+        ]) }} as program_certificate_key
+        , certificate_id
+        , certificate_issued_date_key
+        , user_fk
+        , program_fk
+        , platform_fk
+        , platform
+        , certificate_uuid
+        , certificate_is_revoked
+        , certificate_created_on
+        , certificate_updated_on
+        , certificate_issued_on
+    from combined_with_fks
+
+    {% if is_incremental() %}
+    left join incremental_watermarks w
+        on w.watermark_platform = combined_with_fks.platform
+    where (
+        w.max_activity_on is null
+        or coalesce(combined_with_fks.certificate_updated_on, combined_with_fks.certificate_created_on) >= w.max_activity_on
+        or combined_with_fks.certificate_created_on is null
+    )
+    {% endif %}
+)
+
+-- Defensive dedup: guard against grain drift in upstream intermediates.
+-- Note: QUALIFY is not supported by Trino; using ROW_NUMBER subquery instead.
+, final_deduped as (
+    select
+        program_certificate_key
+        , certificate_id
+        , certificate_issued_date_key
+        , user_fk
+        , program_fk
+        , platform_fk
+        , platform
+        , certificate_uuid
+        , certificate_is_revoked
+        , certificate_created_on
+        , certificate_updated_on
+        , certificate_issued_on
+        , row_number() over (
+            partition by program_certificate_key
+            order by coalesce(certificate_updated_on, certificate_created_on) desc nulls last
+        ) as _row_num
+    from final
+)
+
+select
+    program_certificate_key
+    , certificate_id
+    , certificate_issued_date_key
+    , user_fk
+    , program_fk
+    , platform_fk
+    , platform
+    , certificate_uuid
+    , certificate_is_revoked
+    , certificate_created_on
+    , certificate_updated_on
+    , certificate_issued_on
+from final_deduped
+where _row_num = 1


### PR DESCRIPTION
### What are the relevant tickets?
Closes #2296
Part of epic #2072

### Description (What does it do?)
Creates `tfact_program_certificate` — a dedicated dimensional fact table for program-level certificate issuance, consolidating data across all platforms.

**Grain:** one row per `(certificate_id, platform)`

**Platforms covered:** MITx Online, MITx Pro, edX.org, MicroMasters

**Key design decisions:**
- FKs to `dim_user`, `dim_program`, `dim_platform`, `dim_date`
- Incremental (`delete+insert`) with pre-computed per-platform watermarks to avoid Trino correlated-subquery fan-out (mirrors the pattern in `tfact_certificate`)
- Defensive `ROW_NUMBER` dedup guard (`QUALIFY` is not supported by Trino)
- MicroMasters rows join to `dim_user` via `edxorg_openedx_user_id` and apply the DEDP-era pre/post 2022-10-01 split logic from `int__micromasters__program_certificates`
- Separate from `tfact_certificate` (which mixes course + program certs) to provide a clean program-only grain for reporting

**Unblocks mart migrations:** #2083, #2085, #2086, #2089

### How can this be tested?
```bash
ol-dbt run --select tfact_program_certificate --target dev_qa
```
Verify row count, no duplicate `program_certificate_key` values, and FK integrity against `dim_user`, `dim_program`, `dim_platform`.

### Additional Context
Follows the same structural pattern as `tfact_certificate.sql`. See `_fact_tables.yml` for full column documentation.