### PR TITLE
Add user info to edx future enrollment migration

### DIFF
--- a/src/ol_dbt/models/migration/_migration__models.yml
+++ b/src/ol_dbt/models/migration/_migration__models.yml
@@ -108,7 +108,9 @@ models:
 
 
 - name: edxorg_to_mitxonline_users
-  description: edX.org certificate learners who not yet have account on MITx Online
+  description: >
+    edX.org learners (certificate holders, program entitlement holders, and future
+    enrollment users) who do not yet have an account on MITx Online
   columns:
   - name: user_email
     description: string, user email that user registered on edX.org platform.

--- a/src/ol_dbt/models/migration/_migration__models.yml
+++ b/src/ol_dbt/models/migration/_migration__models.yml
@@ -60,6 +60,14 @@ models:
     description: int, user ID on the mitxonline platform.
   - name: user_email
     description: string, user email that user registered on the corresponding platform.
+  - name: user_full_name
+    description: string, user full name from edX.org
+  - name: user_gender
+    description: string, user gender from edX.org
+  - name: user_birth_year
+    description: int, user birth year from edX.org
+  - name: user_country
+    description: string, user address country from edX.org
   - name: courserun_id
     description: int, foreign key representing a single course run on the corresponding
       platform.

--- a/src/ol_dbt/models/migration/edxorg_to_mitxonline_enrollments.sql
+++ b/src/ol_dbt/models/migration/edxorg_to_mitxonline_enrollments.sql
@@ -232,6 +232,12 @@ select
     edxorg_enrollment.user_id as user_edxorg_id
     , coalesce(mitx_users_by_email.user_mitxonline_id, mitx__users.user_mitxonline_id) as user_mitxonline_id
     , edxorg_enrollment.user_email
+    , coalesce(mitx_users_by_email.user_full_name, mitx__users.user_full_name) as user_full_name
+    , coalesce(mitx_users_by_email.user_gender, mitx__users.user_gender) as user_gender
+    , coalesce(mitx_users_by_email.user_birth_year, mitx__users.user_birth_year) as user_birth_year
+    , coalesce(
+        mitx_users_by_email.user_address_country, mitx__users.user_address_country
+    ) as user_country
     , mitxonline__course_runs.courserun_id
     , edxorg_enrollment.courserun_readable_id
     , edxorg_enrollment.courserunenrollment_enrollment_mode

--- a/src/ol_dbt/models/migration/edxorg_to_mitxonline_users.sql
+++ b/src/ol_dbt/models/migration/edxorg_to_mitxonline_users.sql
@@ -87,7 +87,7 @@ with edx_certificate as (
 
 , future_enrollment_users as (
     select distinct
-        user_email
+        lower(user_email) as user_email
         , user_full_name
         , user_gender
         , user_birth_year
@@ -99,7 +99,7 @@ with edx_certificate as (
 
 select * from cert_entitlement_users
 
-union
+union all
 
 select * from future_enrollment_users
 where not exists (

--- a/src/ol_dbt/models/migration/edxorg_to_mitxonline_users.sql
+++ b/src/ol_dbt/models/migration/edxorg_to_mitxonline_users.sql
@@ -73,12 +73,36 @@ with edx_certificate as (
         and mitx_user2.user_mitxonline_email is null
 )
 
-select
-    coalesce(cert_users.user_email, entitlement_users.user_email) as user_email
-    , coalesce(cert_users.user_full_name, entitlement_users.user_full_name) as user_full_name
-    , coalesce(cert_users.user_gender, entitlement_users.user_gender) as user_gender
-    , coalesce(cert_users.user_birth_year, entitlement_users.user_birth_year) as user_birth_year
-    , coalesce(cert_users.user_country, entitlement_users.user_country) as user_country
-from cert_users
-full outer join entitlement_users
-    on cert_users.user_email = entitlement_users.user_email
+, cert_entitlement_users as (
+    select
+        coalesce(cert_users.user_email, entitlement_users.user_email) as user_email
+        , coalesce(cert_users.user_full_name, entitlement_users.user_full_name) as user_full_name
+        , coalesce(cert_users.user_gender, entitlement_users.user_gender) as user_gender
+        , coalesce(cert_users.user_birth_year, entitlement_users.user_birth_year) as user_birth_year
+        , coalesce(cert_users.user_country, entitlement_users.user_country) as user_country
+    from cert_users
+    full outer join entitlement_users
+        on cert_users.user_email = entitlement_users.user_email
+)
+
+, future_enrollment_users as (
+    select distinct
+        user_email
+        , user_full_name
+        , user_gender
+        , user_birth_year
+        , user_country
+    from {{ ref('edxorg_to_mitxonline_enrollments') }}
+    where user_mitxonline_id is null
+        and courseruncertificate_created_on is null
+)
+
+select * from cert_entitlement_users
+
+union
+
+select * from future_enrollment_users
+where not exists (
+    select 1 from cert_entitlement_users
+    where cert_entitlement_users.user_email = future_enrollment_users.user_email
+)


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
https://github.com/mitodl/hq/issues/11545

### Description (What does it do?)
<!--- Describe your changes in detail -->
adds future enrollments user data to edxorg_to_mitxonline_users and edxorg_to_mitxonline_enrollments


### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

dbt build --select edxorg_to_mitxonline_users edxorg_to_mitxonline_enrollments

### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->


<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
