### PR TITLE
feat: add marimo-jupyterlab Docker image and GH Actions build pipeline

### DIFF
--- a/.github/workflows/build_marimo_jupyterlab.yaml
+++ b/.github/workflows/build_marimo_jupyterlab.yaml
@@ -1,0 +1,52 @@
+---
+name: Build and Publish marimo-jupyterlab Image
+
+on:
+  push:
+    branches:
+    - main
+    paths:
+    - images/marimo-jupyterlab/**
+    - .github/workflows/build_marimo_jupyterlab.yaml
+  workflow_dispatch:
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v6
+
+    - name: Log in to GitHub Container Registry
+      uses: docker/login-action@v3
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Extract image metadata
+      id: meta
+      uses: docker/metadata-action@v5
+      with:
+        images: ghcr.io/mitodl/marimo-jupyterlab
+        tags: |
+          type=sha,prefix=sha-
+          type=raw,value=latest,enable={{is_default_branch}}
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+
+    - name: Build and push image
+      uses: docker/build-push-action@v6
+      with:
+        context: images/marimo-jupyterlab
+        platforms: linux/amd64
+        push: true
+        tags: ${{ steps.meta.outputs.tags }}
+        labels: ${{ steps.meta.outputs.labels }}
+        cache-from: type=gha
+        cache-to: type=gha,mode=max

--- a/images/marimo-jupyterlab/Dockerfile
+++ b/images/marimo-jupyterlab/Dockerfile
@@ -1,0 +1,15 @@
+# syntax=docker/dockerfile:1
+# Base: Jupyter scipy-notebook provides JupyterLab, jupyterhub-singleuser,
+# and common data science packages (pandas, numpy, scipy, matplotlib, scikit-learn).
+# All quay.io/jupyter/* images are built for Z2JH single-user server use.
+FROM quay.io/jupyter/scipy-notebook:latest
+
+# Install marimo with sandbox (uv) support and the JupyterLab extension.
+# Both must be in the same environment so JupyterLab can import and proxy marimo.
+# trino connects to Starburst Galaxy; TRINO_TOKEN is injected at pod launch by KubeSpawner.
+# pyiceberg[s3fs,glue] enables direct Iceberg table reads from the OL data lake via IRSA.
+RUN pip install --no-cache-dir \
+    'marimo[sandbox]>=0.19.11' \
+    marimo-jupyter-extension \
+    trino \
+    'pyiceberg[s3fs,glue]>=0.9'


### PR DESCRIPTION
### What are the relevant tickets?

N/A

### Description (What does it do?)

Adds the `images/marimo-jupyterlab/Dockerfile` and a GitHub Actions workflow
(`.github/workflows/build_marimo_jupyterlab.yaml`) that builds and publishes
`ghcr.io/mitodl/marimo-jupyterlab` to the GitHub Container Registry on every
push to `main` that touches the image directory.

**Image contents:**
- Base: `quay.io/jupyter/scipy-notebook` — a standard [Zero to JupyterHub](https://z2jh.jupyter.org/) single-user server image that includes `jupyterhub-singleuser`, JupyterLab, pandas, numpy, scipy, matplotlib, and scikit-learn
- `marimo[sandbox]>=0.19.11` — marimo with uv/uvx sandbox support for isolated notebook environments
- `marimo-jupyter-extension` — the [JupyterLab extension](https://github.com/marimo-team/marimo-jupyter-extension) that adds a marimo launcher tile and session manager to JupyterLab
- `trino` — Python client for Starburst Galaxy; the OIDC access token is injected as `TRINO_TOKEN` at pod launch by KubeSpawner
- `pyiceberg[s3fs,glue]>=0.9` — direct Iceberg table reads from the OL data lake; AWS credentials provided via IRSA

**Build workflow:**
- Triggers on push to `main` when `images/marimo-jupyterlab/**` or the workflow file itself changes, plus `workflow_dispatch` for manual builds
- Publishes two tags: `ghcr.io/mitodl/marimo-jupyterlab:latest` (main branch) and `ghcr.io/mitodl/marimo-jupyterlab:sha-<sha>` (every build)
- Uses GHA layer cache

**After merge:** The image contains no secrets and is intended to be a public GHCR package. Once the first workflow run completes and the package is created, set visibility to **Public** via GitHub → Packages → `marimo-jupyterlab` → Package Settings.

### How can this be tested?

1. Merge this PR and confirm the `Build and Publish marimo-jupyterlab Image` workflow completes successfully in the Actions tab
2. Verify `ghcr.io/mitodl/marimo-jupyterlab:latest` is visible in https://github.com/orgs/mitodl/packages
3. `docker pull ghcr.io/mitodl/marimo-jupyterlab:latest` locally (after making the package public)
4. `docker run --rm -p 8888:8888 ghcr.io/mitodl/marimo-jupyterlab:latest start-notebook.sh` — JupyterLab should start and the marimo launcher tile should appear

### Additional Context

This image was previously referenced in the `ol-infrastructure` JupyterHub Data Pulumi deployment (`src/ol_infrastructure/applications/jupyterhub_data/deployment.py`) as `ghcr.io/mitodl/marimo-jupyterlab:latest` but the image was never built or published, causing `ImagePullBackOff` errors when launching notebook servers.

A companion PR in `ol-infrastructure` adds a GHCR pull secret as a short-term fix for the private-package 403; that PR can be reverted once this package is made public.