### PR TITLE
feat(marimo-jupyterlab): switch to minimal-notebook base, remove conda stack

### DIFF
--- a/.github/workflows/build_marimo_jupyterlab.yaml
+++ b/.github/workflows/build_marimo_jupyterlab.yaml
@@ -1,0 +1,52 @@
+---
+name: Build and Publish marimo-jupyterlab Image
+
+on:
+  push:
+    branches:
+    - main
+    paths:
+    - images/marimo-jupyterlab/**
+    - .github/workflows/build_marimo_jupyterlab.yaml
+  workflow_dispatch:
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v6
+
+    - name: Log in to GitHub Container Registry
+      uses: docker/login-action@v3
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Extract image metadata
+      id: meta
+      uses: docker/metadata-action@v5
+      with:
+        images: ghcr.io/mitodl/marimo-jupyterlab
+        tags: |
+          type=sha,prefix=sha-
+          type=raw,value=latest,enable={{is_default_branch}}
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+
+    - name: Build and push image
+      uses: docker/build-push-action@v6
+      with:
+        context: images/marimo-jupyterlab
+        platforms: linux/amd64
+        push: true
+        tags: ${{ steps.meta.outputs.tags }}
+        labels: ${{ steps.meta.outputs.labels }}
+        cache-from: type=gha
+        cache-to: type=gha,mode=max

--- a/images/marimo-jupyterlab/Dockerfile
+++ b/images/marimo-jupyterlab/Dockerfile
@@ -10,10 +10,15 @@ FROM quay.io/jupyter/scipy-notebook:latest
 COPY --from=ghcr.io/astral-sh/uv:latest /uv /usr/local/bin/uv
 COPY --from=ghcr.io/astral-sh/uv:latest /uvx /usr/local/bin/uvx
 
-# Install marimo with sandbox (uv) support and the JupyterLab extension.
-# Both must be in the same environment so JupyterLab can import and proxy marimo.
-# trino connects to Starburst Galaxy; TRINO_TOKEN is injected at pod launch by KubeSpawner.
-# pyiceberg[s3fs,glue] enables direct Iceberg table reads from the OL data lake via IRSA.
+# Install the JupyterLab extension (must be importable by JupyterLab) and
+# marimo with sandbox extras so the marimo CLI is available for direct use.
+# In sandbox mode (uvx_path configured), the extension runs each notebook via
+# `uvx marimo edit --headless <file>` which installs marimo independently and
+# creates a per-notebook venv from the file's `/// script` PEP 723 header.
+# The conda-environment packages below are therefore NOT automatically available
+# inside sandbox notebooks — each notebook must declare its own dependencies.
+# They are kept here so users can reference exact version pins in their headers
+# and so the marimo CLI works for non-sandbox ad-hoc use.
 RUN pip install --no-cache-dir \
     'marimo[sandbox]>=0.19.11' \
     marimo-jupyter-extension \

--- a/images/marimo-jupyterlab/Dockerfile
+++ b/images/marimo-jupyterlab/Dockerfile
@@ -1,26 +1,19 @@
 # syntax=docker/dockerfile:1
-# Base: Jupyter scipy-notebook provides JupyterLab, jupyterhub-singleuser,
-# and common data science packages (pandas, numpy, scipy, matplotlib, scikit-learn).
-# All quay.io/jupyter/* images are built for Z2JH single-user server use.
-FROM quay.io/jupyter/scipy-notebook:latest
+# minimal-notebook provides JupyterLab, jupyterhub-singleuser, and the Z2JH
+# user/entrypoint setup (jovyan, NB_UID, start.sh hooks) without the conda
+# data-science stack. All notebook-level packages (pandas, trino, pyiceberg,
+# etc.) are declared per-notebook via PEP 723 `/// script` inline metadata.
+FROM quay.io/jupyter/minimal-notebook:latest
 
-# Install uv/uvx so marimo-jupyter-extension can run notebooks in sandbox
-# (isolated virtual environment) mode. Copied from the official uv image to
-# avoid curl-pipe-sh; this is the pattern used elsewhere in the org.
+# Install uv/uvx so marimo-jupyter-extension can spawn sandbox notebook
+# processes. Copied from the official uv image to avoid curl-pipe-sh.
 COPY --from=ghcr.io/astral-sh/uv:latest /uv /usr/local/bin/uv
 COPY --from=ghcr.io/astral-sh/uv:latest /uvx /usr/local/bin/uvx
 
-# Install the JupyterLab extension (must be importable by JupyterLab) and
-# marimo with sandbox extras so the marimo CLI is available for direct use.
-# In sandbox mode (uvx_path configured), the extension runs each notebook via
-# `uvx marimo edit --headless <file>` which installs marimo independently and
-# creates a per-notebook venv from the file's `/// script` PEP 723 header.
-# The conda-environment packages below are therefore NOT automatically available
-# inside sandbox notebooks — each notebook must declare its own dependencies.
-# They are kept here so users can reference exact version pins in their headers
-# and so the marimo CLI works for non-sandbox ad-hoc use.
+# marimo-jupyter-extension must be importable by JupyterLab — it registers
+# the proxy server that forwards requests to per-notebook marimo processes.
+# marimo[sandbox] installs the marimo CLI that uvx invokes per notebook.
+# No data-science packages here: each notebook declares its own via /// script.
 RUN pip install --no-cache-dir \
     'marimo[sandbox]>=0.19.11' \
-    marimo-jupyter-extension \
-    trino \
-    'pyiceberg[s3fs,glue]>=0.9'
+    marimo-jupyter-extension

--- a/images/marimo-jupyterlab/Dockerfile
+++ b/images/marimo-jupyterlab/Dockerfile
@@ -1,0 +1,15 @@
+# syntax=docker/dockerfile:1
+# Base: Jupyter scipy-notebook provides JupyterLab, jupyterhub-singleuser,
+# and common data science packages (pandas, numpy, scipy, matplotlib, scikit-learn).
+# All quay.io/jupyter/* images are built for Z2JH single-user server use.
+FROM quay.io/jupyter/scipy-notebook:latest
+
+# Install marimo with sandbox (uv) support and the JupyterLab extension.
+# Both must be in the same environment so JupyterLab can import and proxy marimo.
+# trino connects to Starburst Galaxy; TRINO_TOKEN is injected at pod launch by KubeSpawner.
+# pyiceberg[s3fs,glue] enables direct Iceberg table reads from the OL data lake via IRSA.
+RUN pip install --no-cache-dir \
+    'marimo[sandbox]>=0.19.11' \
+    marimo-jupyter-extension \
+    trino \
+    'pyiceberg[s3fs,glue]>=0.9'

--- a/images/marimo-jupyterlab/Dockerfile
+++ b/images/marimo-jupyterlab/Dockerfile
@@ -4,6 +4,12 @@
 # All quay.io/jupyter/* images are built for Z2JH single-user server use.
 FROM quay.io/jupyter/scipy-notebook:latest
 
+# Install uv/uvx so marimo-jupyter-extension can run notebooks in sandbox
+# (isolated virtual environment) mode. Copied from the official uv image to
+# avoid curl-pipe-sh; this is the pattern used elsewhere in the org.
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /usr/local/bin/uv
+COPY --from=ghcr.io/astral-sh/uv:latest /uvx /usr/local/bin/uvx
+
 # Install marimo with sandbox (uv) support and the JupyterLab extension.
 # Both must be in the same environment so JupyterLab can import and proxy marimo.
 # trino connects to Starburst Galaxy; TRINO_TOKEN is injected at pod launch by KubeSpawner.

--- a/images/marimo-jupyterlab/Dockerfile
+++ b/images/marimo-jupyterlab/Dockerfile
@@ -17,3 +17,6 @@ COPY --from=ghcr.io/astral-sh/uv:latest /uvx /usr/local/bin/uvx
 RUN pip install --no-cache-dir \
     'marimo[sandbox]>=0.19.11' \
     marimo-jupyter-extension
+
+# Seed notebook copied to ~/notebooks/ on first user login via postStart hook.
+COPY templates/ /usr/local/share/marimo/templates/

--- a/images/marimo-jupyterlab/templates/getting_started.py
+++ b/images/marimo-jupyterlab/templates/getting_started.py
@@ -1,0 +1,109 @@
+# /// script
+# requires-python = ">=3.11"
+# dependencies = [
+#   "pandas>=2.0",
+#   "trino>=0.330",
+# ]
+# ///
+# ruff: noqa: PLC0415, B018
+# PLC0415/B018: marimo requires imports inside cell functions and bare
+# expressions for cell output — these are intentional patterns, not errors.
+
+import marimo
+
+__generated_with = "0.19.11"
+app = marimo.App(width="medium")
+
+
+@app.cell
+def _():
+    import marimo as mo
+
+    return (mo,)
+
+
+@app.cell
+def _(mo):
+    mo.md(r"""
+    # OL Data Platform
+
+    This notebook runs in **sandbox mode**: each notebook gets its own isolated
+    Python environment. Packages are declared in the `/// script` header at the
+    top of the file. Add a package there and restart the kernel to use it.
+
+    Connection credentials are injected as environment variables by JupyterHub:
+
+    | Variable | Value |
+    |---|---|
+    | `TRINO_HOST` | Starburst Galaxy endpoint |
+    | `TRINO_PORT` | 443 |
+    | `TRINO_TOKEN` | Your Keycloak OIDC access token (rotated per session) |
+
+    AWS credentials for S3 and Glue are provided automatically via IRSA
+    (no `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` needed).
+    """)
+
+
+@app.cell
+def _(mo):
+    mo.md("## Connect to Starburst")
+
+
+@app.cell
+def _():
+    import os
+
+    import trino
+
+    conn = trino.dbapi.connect(
+        host=os.environ["TRINO_HOST"],
+        port=int(os.environ.get("TRINO_PORT", "443")),
+        http_scheme="https",
+        auth=trino.auth.JWTAuthentication(os.environ["TRINO_TOKEN"]),
+    )
+    cur = conn.cursor()
+    return conn, cur, os, trino
+
+
+@app.cell
+def _(cur, mo):
+    cur.execute("SHOW CATALOGS")
+    catalogs = [row[0] for row in cur.fetchall()]
+    mo.md(f"**Available catalogs:** {', '.join(catalogs)}")
+    return (catalogs,)
+
+
+@app.cell
+def _(mo):
+    mo.md(r"""
+    ## Query example
+
+    Replace `<catalog>`, `<schema>`, and `<table>` with real names from the
+    catalog list above, then run the cell.
+    """)
+
+
+@app.cell
+def _(cur, pd):
+    _query = """
+    SELECT *
+    FROM <catalog>.<schema>.<table>
+    LIMIT 100
+    """
+    cur.execute(_query)
+    rows = cur.fetchall()
+    cols = [d[0] for d in cur.description]
+    df = pd.DataFrame(rows, columns=cols)
+    df
+    return cols, df, rows
+
+
+@app.cell
+def _():
+    import pandas as pd
+
+    return (pd,)
+
+
+if __name__ == "__main__":
+    app.run()


### PR DESCRIPTION
### What are the relevant tickets?
N/A

### Description (What does it do?)
Switches the marimo-jupyterlab singleuser image from `quay.io/jupyter/scipy-notebook` to `quay.io/jupyter/minimal-notebook` and removes the conda data-science packages (marimo[sandbox], trino, pyiceberg) from the base image.

In sandbox mode (configured via `c.MarimoProxyConfig.uvx_path` in ol-infrastructure), every notebook declares its own dependencies via a [PEP 723](https://peps.python.org/pep-0723/) `/// script` inline metadata header. `uvx marimo edit --headless` creates an isolated venv per notebook from that header. The conda-level packages were therefore unused and wasted ~2–3 GB of image size.

The base image now contains only what JupyterLab and Z2JH actually require:
- `quay.io/jupyter/minimal-notebook` — JupyterLab, `jupyterhub-singleuser`, Z2JH user/entrypoint setup
- `uv` / `uvx` — to spawn per-notebook sandbox processes
- `marimo[sandbox]` — marimo CLI invoked by the extension
- `marimo-jupyter-extension` — JupyterLab extension that proxies marimo sessions

### How can this be tested?
1. Merge this PR to trigger the GH Actions build (`build_marimo_jupyterlab.yaml`)
2. Confirm `ghcr.io/mitodl/marimo-jupyterlab:latest` is published
3. In the JupyterHub Data deployment (EKS data cluster, `jupyter-data` namespace), open a marimo notebook with a `/// script` header declaring `trino` and `pyiceberg` dependencies
4. Confirm the notebook kernel starts and the packages are available (installed into the per-notebook venv by uvx)

### Additional Context
The corresponding sandbox mode configuration in ol-infrastructure is on `feat/jupyterhub-data-ghcr-pull-secret` (PR #4772).

Notebook authors should include a header like:
```python
# /// script
# requires-python = ">=3.11"
# dependencies = [
#   "pandas>=2.0",
#   "trino>=0.330",
#   "pyiceberg[s3fs,glue]>=0.9",
# ]
# ///
```