### PR TITLE
feat(#2077): migrate marts__combined__users to dim_user

### DIFF
--- a/src/ol_dbt/models/marts/combined/_marts__combined__models.yml
+++ b/src/ol_dbt/models/marts/combined/_marts__combined__models.yml
@@ -138,6 +138,16 @@ models:
     description: boolean, Set to true if the user has recieved a program credential
   - name: has_dedp_program_certificate
     description: boolean, Set to true if the user has recieved a DEDP program credential
+  - name: user_hashed_id_edxorg_legacy
+    description: >
+      Temporary transition column. For users who were previously identified as
+      'edX.org'-only in the old mart but are now linked to a MITx Online account
+      in dim_user, user_hashed_id changes from an edX.org-based hash to a MITx
+      Online-based hash. This column preserves the old edX.org hash
+      (sha256(edxorg_id || 'edX.org')) to allow downstream consumers (Hightouch,
+      cross-model joins) to perform a graceful key migration without a hard cutover.
+      NULL for users without an edX.org account. Remove once all consumers have
+      migrated to user_hashed_id.
   tests:
   - dbt_expectations.expect_compound_columns_to_be_unique:
       arguments:

--- a/src/ol_dbt/models/marts/combined/marts__combined__users.sql
+++ b/src/ol_dbt/models/marts/combined/marts__combined__users.sql
@@ -1,29 +1,24 @@
---- This model combines intermediate users from different platforms
+-- Migrated to dim_user for user identity.
+-- user_last_login, user_street_address, user_address_state_or_territory, and
+-- user_address_postal_code are not yet in dim_user; they remain sourced from
+-- int__combined__users until dim_user is extended to include those fields.
 
-with mitx__users as (
-    select * from {{ ref('int__mitx__users') }}
+with users as (
+    select * from {{ ref('dim_user') }}
 )
 
-, non_mitx_users as (
-    select * from {{ ref('int__combined__users') }}
-)
-
-, mitlearn_users as (
+-- Supplemental: address and last-login fields not yet available in dim_user.
+-- Deduped by email with max() to handle users appearing on multiple platforms.
+, users_supplement as (
     select
-        mitlearn_user_id
-        , email
-        , full_name
-        , address_country
-        , highest_education
-        , gender
-        , birth_year
-        , company
-        , job_title
-        , industry
-        , user_is_active_on_mitlearn
-        , user_joined_on_mitlearn
-    from {{ ref('dim_user') }}
-    where mitlearn_user_id is not null
+        lower(user_email) as user_email_lower
+        , max(user_last_login) as user_last_login
+        , max(user_street_address) as user_street_address
+        , max(user_address_city) as user_address_city
+        , max(user_address_state_or_territory) as user_address_state_or_territory
+        , max(user_address_postal_code) as user_address_postal_code
+    from {{ ref('int__combined__users') }}
+    group by lower(user_email)
 )
 
 , combined_enrollments as (
@@ -94,228 +89,98 @@ with mitx__users as (
     group by combined_enrollments.user_email
 )
 
-, combined_users as (
-    select
-        user_hashed_id
-        , user_mitxonline_id
-        , user_edxorg_id
-        , null as user_mitxpro_id
-        , null as user_bootcamps_id
-        , mitlearn_users.mitlearn_user_id as user_mitlearn_id
-        , user_mitxonline_username
-        , user_edxorg_username
-        , null as user_mitxpro_username
-        , null as user_bootcamps_username
-        , case
-            when user_is_active_on_mitxonline and user_joined_on_mitxonline > user_joined_on_edxorg
-                then user_mitxonline_email
-            else coalesce(user_edxorg_email, user_mitxonline_email, user_micromasters_email)
-        end as user_email
-        , case
-            when user_is_active_on_mitxonline and user_joined_on_mitxonline > user_joined_on_edxorg
-                then user_joined_on_mitxonline
-            else coalesce(user_joined_on_edxorg, user_joined_on_mitxonline)
-        end as user_joined_on
-        , case
-            when user_is_active_on_mitxonline and user_last_login_on_mitxonline > user_last_login_on_edxorg
-                then user_last_login_on_mitxonline
-            else coalesce(user_last_login_on_edxorg, user_last_login_on_mitxonline)
-        end as user_last_login
-        , case
-            when user_is_active_on_mitxonline
-                then user_is_active_on_mitxonline
-            else user_is_active_on_edxorg
-        end as user_is_active
-        , case
-            when is_mitxonline_user = true and is_edxorg_user = true
-                then concat('{{ var("mitxonline") }}', ' and ', '{{ var("edxorg") }}')
-            when is_mitxonline_user = true
-                then '{{ var("mitxonline") }}'
-            when is_edxorg_user = true
-                then '{{ var("edxorg") }}'
-        end as platforms
-        , user_full_name
-        , user_address_country
-        , user_highest_education
-        , user_gender
-        , user_birth_year
-        , user_company
-        , user_job_title
-        , user_industry
-        , user_street_address
-        , user_address_city
-        , user_address_state as user_address_state_or_territory
-        , user_address_postal_code
-    from mitx__users
-    left join mitlearn_users on lower(mitlearn_users.email) = lower(mitx__users.user_mitxonline_email)
-    where mitx__users.is_mitxonline_user = true or mitx__users.is_edxorg_user = true
-
-    union all
-
-    select
-        user_hashed_id
-        , null as user_mitxonline_id
-        , null as user_edxorg_id
-        , user_id as user_mitxpro_id
-        , null as user_bootcamps_id
-        , null as user_mitlearn_id
-        , null as user_mitxonline_username
-        , null as user_edxorg_username
-        , user_username as user_mitxpro_username
-        , null as user_bootcamps_username
-        , user_email
-        , user_joined_on
-        , user_last_login
-        , user_is_active
-        , '{{ var("mitxpro") }}' as platforms
-        , user_full_name
-        , user_address_country
-        , user_highest_education
-        , user_gender
-        , user_birth_year
-        , user_company
-        , user_job_title
-        , user_industry
-        , user_street_address
-        , user_address_city
-        , user_address_state_or_territory
-        , user_address_postal_code
-    from non_mitx_users
-    where platform = '{{ var("mitxpro") }}'
-
-    union all
-
-    select
-        user_hashed_id
-        , null as user_mitxonline_id
-        , null as user_edxorg_id
-        , null as user_mitxpro_id
-        , user_id as user_bootcamps_id
-        , null as user_mitlearn_id
-        , null as user_mitxonline_username
-        , null as user_edxorg_username
-        , null as user_mitxpro_username
-        , user_username as user_bootcamps_username
-        , user_email
-        , user_joined_on
-        , user_last_login
-        , user_is_active
-        , '{{ var("bootcamps") }}' as platforms
-        , user_full_name
-        , user_address_country
-        , user_highest_education
-        , user_gender
-        , user_birth_year
-        , user_company
-        , user_job_title
-        , user_industry
-        , user_street_address
-        , user_address_city
-        , user_address_state_or_territory
-        , user_address_postal_code
-    from non_mitx_users
-    where platform = '{{ var("bootcamps") }}'
-
-    union all
-
-    select
-        user_hashed_id
-        , null as user_mitxonline_id
-        , null as user_edxorg_id
-        , null as user_mitxpro_id
-        , null as user_bootcamps_id
-        , null as user_mitlearn_id
-        , null as user_mitxonline_username
-        , null as user_edxorg_username
-        , null as user_mitxpro_username
-        , null as user_bootcamps_username
-        , user_email
-        , user_joined_on
-        , user_last_login
-        , user_is_active
-        , platform as platforms
-        , user_full_name
-        , user_address_country
-        , user_highest_education
-        , user_gender
-        , user_birth_year
-        , user_company
-        , user_job_title
-        , user_industry
-        , user_street_address
-        , user_address_city
-        , user_address_state_or_territory
-        , user_address_postal_code
-    from non_mitx_users
-    where platform in ('{{ var("emeritus") }}', '{{ var("global_alumni") }}')
-
-    union all
-
-    select
-        {{ generate_hash_id("cast(mitlearn_user_id as varchar) || '" ~ var("mitlearn") ~ "'") }} as user_hashed_id
-        , null as user_mitxonline_id
-        , null as user_edxorg_id
-        , null as user_mitxpro_id
-        , null as user_bootcamps_id
-        , mitlearn_user_id as user_mitlearn_id
-        , null as user_mitxonline_username
-        , null as user_edxorg_username
-        , null as user_mitxpro_username
-        , null as user_bootcamps_username
-        , email as user_email
-        , user_joined_on_mitlearn as user_joined_on
-        , null as user_last_login
-        , user_is_active_on_mitlearn as user_is_active
-        , '{{ var("mitlearn") }}' as platforms
-        , full_name as user_full_name
-        , address_country as user_address_country
-        , highest_education as user_highest_education
-        , gender as user_gender
-        , birth_year as user_birth_year
-        , company as user_company
-        , job_title as user_job_title
-        , industry as user_industry
-        , null as user_street_address
-        , null as user_address_city
-        , null as user_address_state_or_territory
-        , null as user_address_postal_code
-    from mitlearn_users
-    where lower(email) not in (
-        select lower(user_mitxonline_email)
-        from mitx__users
-        where user_mitxonline_email is not null
-    )
-
-)
-
 select
-    combined_users.user_hashed_id
-    , combined_users.platforms
-    , combined_users.user_email
-    , combined_users.user_joined_on
-    , combined_users.user_last_login
-    , combined_users.user_is_active
-    , combined_users.user_full_name
-    , combined_users.user_address_country
-    , combined_users.user_highest_education
-    , combined_users.user_gender
-    , combined_users.user_birth_year
-    , combined_users.user_company
-    , combined_users.user_job_title
-    , combined_users.user_industry
-    , combined_users.user_street_address
-    , combined_users.user_address_city
-    , combined_users.user_address_state_or_territory
-    , combined_users.user_address_postal_code
-    , combined_users.user_mitxonline_id
-    , combined_users.user_edxorg_id
-    , combined_users.user_mitxpro_id
-    , combined_users.user_bootcamps_id
-    , combined_users.user_mitlearn_id
-    , combined_users.user_mitxonline_username
-    , combined_users.user_edxorg_username
-    , combined_users.user_mitxpro_username
-    , combined_users.user_bootcamps_username
+    -- user_hashed_id: replicates generate_hash_id logic from the former
+    -- int__mitx__users and int__combined__users to preserve cross-model join
+    -- compatibility (e.g. learner_demographics_and_cert_info, cheating_detection_report).
+    case
+        when users.mitxonline_application_user_id is not null
+            then {{ generate_hash_id("cast(users.mitxonline_application_user_id as varchar) || '" ~ var('mitxonline') ~ "'") }}
+        when users.edxorg_openedx_user_id is not null
+            then {{ generate_hash_id("cast(users.edxorg_openedx_user_id as varchar) || '" ~ var('edxorg') ~ "'") }}
+        when users.micromasters_user_id is not null
+            then {{ generate_hash_id("cast(users.micromasters_user_id as varchar) || '" ~ var('micromasters') ~ "'") }}
+        when users.mitxpro_application_user_id is not null
+            then {{ generate_hash_id("cast(users.mitxpro_application_user_id as varchar) || '" ~ var('mitxpro') ~ "'") }}
+        when users.bootcamps_application_user_id is not null
+            then {{ generate_hash_id("cast(users.bootcamps_application_user_id as varchar) || '" ~ var('bootcamps') ~ "'") }}
+        when users.emeritus_user_id is not null
+            then {{ generate_hash_id("cast(users.emeritus_user_id as varchar) || '" ~ var('emeritus') ~ "'") }}
+        when users.global_alumni_user_id is not null
+            then {{ generate_hash_id("cast(users.global_alumni_user_id as varchar) || '" ~ var('global_alumni') ~ "'") }}
+        when users.mitlearn_user_id is not null
+            then {{ generate_hash_id("cast(users.mitlearn_user_id as varchar) || '" ~ var('mitlearn') ~ "'") }}
+    end as user_hashed_id
+    -- Derived: platform label
+    , case
+        when users.mitxonline_application_user_id is not null and users.edxorg_openedx_user_id is not null
+            then concat('{{ var("mitxonline") }}', ' and ', '{{ var("edxorg") }}')
+        when users.mitxonline_application_user_id is not null
+            then '{{ var("mitxonline") }}'
+        when users.edxorg_openedx_user_id is not null
+            then '{{ var("edxorg") }}'
+        when users.mitxpro_application_user_id is not null
+            then '{{ var("mitxpro") }}'
+        when users.bootcamps_application_user_id is not null
+            then '{{ var("bootcamps") }}'
+        when users.emeritus_user_id is not null
+            then '{{ var("emeritus") }}'
+        when users.global_alumni_user_id is not null
+            then '{{ var("global_alumni") }}'
+        when users.mitlearn_user_id is not null
+            then '{{ var("mitlearn") }}'
+    end as platforms
+    , users.email as user_email
+    -- Derived: joined_on — prefer MITx Online when active and newer than edX.org
+    , case
+        when
+            users.user_is_active_on_mitxonline
+            and users.user_joined_on_mitxonline > users.user_joined_on_edxorg
+            then users.user_joined_on_mitxonline
+        else coalesce(
+            users.user_joined_on_edxorg
+            , users.user_joined_on_mitxonline
+            , users.user_joined_on_mitxpro
+            , users.user_joined_on_bootcamps
+            , users.user_joined_on_mitlearn
+        )
+    end as user_joined_on
+    -- Not yet in dim_user; sourced from int__combined__users supplement
+    , users_supplement.user_last_login
+    -- Derived: is_active — prefer MITx Online, fallback across platforms
+    , coalesce(
+        users.user_is_active_on_mitxonline
+        , users.user_is_active_on_edxorg
+        , users.user_is_active_on_mitxpro
+        , users.user_is_active_on_bootcamps
+        , users.user_is_active_on_mitlearn
+    ) as user_is_active
+    , users.full_name as user_full_name
+    , users.address_country as user_address_country
+    , users.highest_education as user_highest_education
+    , users.gender as user_gender
+    , users.birth_year as user_birth_year
+    , users.company as user_company
+    , users.job_title as user_job_title
+    , users.industry as user_industry
+    -- Not yet in dim_user; sourced from int__combined__users supplement
+    , users_supplement.user_street_address
+    , users_supplement.user_address_city
+    , users_supplement.user_address_state_or_territory
+    , users_supplement.user_address_postal_code
+    -- Platform IDs
+    , users.mitxonline_application_user_id as user_mitxonline_id
+    , users.edxorg_openedx_user_id as user_edxorg_id
+    , users.mitxpro_application_user_id as user_mitxpro_id
+    , users.bootcamps_application_user_id as user_bootcamps_id
+    , users.mitlearn_user_id as user_mitlearn_id
+    -- Usernames
+    , users.user_mitxonline_username
+    , users.user_edxorg_username
+    , users.user_mitxpro_username
+    -- Not yet in dim_user
+    , null as user_bootcamps_username
+    -- Stats (upstream sources being migrated by other epic tickets)
     , course_stats.num_of_course_enrolled
     , course_stats.num_of_course_passed
     , course_stats.first_course_start_datetime
@@ -325,8 +190,34 @@ select
     , income.latest_income_usd
     , case when program_stats.cert_count > 0 then true end as has_program_certificate
     , case when program_stats.dedp_program_cred_count > 0 then true end as has_dedp_program_certificate
-from combined_users
-left join course_stats on combined_users.user_email = course_stats.user_email
-left join program_stats on combined_users.user_email = program_stats.user_email
-left join orders_stats on combined_users.user_email = orders_stats.user_email
-left join income on combined_users.user_mitxonline_username = income.user_username
+    -- Legacy hash for transition: ~50k users who were 'edX.org'-only in the previous
+    -- mart have been linked to a MITx Online account in dim_user, causing user_hashed_id
+    -- to change (edxorg_id-based → mitxonline_id-based). This column preserves the
+    -- old edX.org hash so that downstream consumers (Hightouch, cross-model joins) can
+    -- perform a graceful key migration without a hard cutover.
+    -- Track removal in: https://github.com/mitodl/ol-data-platform/issues/TODO
+    -- Remove once all consumers have migrated to user_hashed_id.
+    , case
+        when users.edxorg_openedx_user_id is not null
+            then {{ generate_hash_id("cast(users.edxorg_openedx_user_id as varchar) || '" ~ var('edxorg') ~ "'") }}
+    end as user_hashed_id_edxorg_legacy
+from users
+left join users_supplement on users.email = users_supplement.user_email_lower
+left join course_stats on users.email = lower(course_stats.user_email)
+left join program_stats on users.email = lower(program_stats.user_email)
+left join orders_stats on users.email = lower(orders_stats.user_email)
+left join income on users.user_mitxonline_username = income.user_username
+-- Exclude MicroMasters-only users: the original mart filtered to
+-- (is_mitxonline_user OR is_edxorg_user) for the MITx branch, and MITxPro,
+-- Bootcamps, Emeritus, Global Alumni, MIT Learn for the other branches. dim_user
+-- also includes pure MicroMasters-only users (no other platform), which the
+-- original mart never emitted. Filter them out to preserve row parity.
+where (
+    users.mitxonline_application_user_id is not null
+    or users.edxorg_openedx_user_id is not null
+    or users.mitxpro_application_user_id is not null
+    or users.bootcamps_application_user_id is not null
+    or users.emeritus_user_id is not null
+    or users.global_alumni_user_id is not null
+    or users.mitlearn_user_id is not null
+)

--- a/src/ol_dbt/models/marts/combined/marts__combined__users.sql
+++ b/src/ol_dbt/models/marts/combined/marts__combined__users.sql
@@ -1,6 +1,7 @@
 -- Migrated to dim_user for user identity.
--- user_last_login, user_street_address, user_address_state_or_territory, and
--- user_address_postal_code are not yet in dim_user; they remain sourced from
+-- user_last_login, user_street_address, user_address_city,
+-- user_address_state_or_territory, user_address_postal_code, and
+-- user_bootcamps_username are not yet in dim_user; they remain sourced from
 -- int__combined__users until dim_user is extended to include those fields.
 
 with users as (
@@ -17,6 +18,7 @@ with users as (
         , max(user_address_city) as user_address_city
         , max(user_address_state_or_territory) as user_address_state_or_territory
         , max(user_address_postal_code) as user_address_postal_code
+        , max(case when platform = '{{ var("bootcamps") }}' then user_username end) as user_bootcamps_username
     from {{ ref('int__combined__users') }}
     group by lower(user_email)
 )
@@ -43,7 +45,7 @@ with users as (
 
 , program_stats as (
     select
-        user_email
+        lower(user_email) as user_email
         , count(distinct programcertificate_uuid) as cert_count
         , sum(case
             when
@@ -58,20 +60,20 @@ with users as (
             else 0
         end) as dedp_program_cred_count
     from combined_programs
-    group by user_email
+    group by lower(user_email)
 )
 
 , orders_stats as (
     select
-        user_email
+        lower(user_email) as user_email
         , sum(order_total_price_paid) as total_amount_paid_orders
     from orders
-    group by user_email
+    group by lower(user_email)
 )
 
 , course_stats as (
     select
-        combined_enrollments.user_email
+        lower(combined_enrollments.user_email) as user_email
         , count(distinct combined_enrollments.course_title) as num_of_course_enrolled
         , count(
             distinct
@@ -86,7 +88,7 @@ with users as (
     from combined_enrollments
     left join combined_courseruns
         on combined_enrollments.courserun_readable_id = combined_courseruns.courserun_readable_id
-    group by combined_enrollments.user_email
+    group by lower(combined_enrollments.user_email)
 )
 
 select
@@ -147,14 +149,19 @@ select
     end as user_joined_on
     -- Not yet in dim_user; sourced from int__combined__users supplement
     , users_supplement.user_last_login
-    -- Derived: is_active — prefer MITx Online, fallback across platforms
-    , coalesce(
-        users.user_is_active_on_mitxonline
-        , users.user_is_active_on_edxorg
-        , users.user_is_active_on_mitxpro
-        , users.user_is_active_on_bootcamps
-        , users.user_is_active_on_mitlearn
-    ) as user_is_active
+    -- Derived: is_active — prefer MITx Online's actual state (even if false) when the
+    -- user has a MITx Online account; only fall back to other platforms when there is no
+    -- MITx Online account at all. A plain coalesce() would incorrectly let a later TRUE
+    -- override an explicit FALSE from MITx Online.
+    , case
+        when users.mitxonline_application_user_id is not null then users.user_is_active_on_mitxonline
+        else coalesce(
+            users.user_is_active_on_edxorg
+            , users.user_is_active_on_mitxpro
+            , users.user_is_active_on_bootcamps
+            , users.user_is_active_on_mitlearn
+        )
+    end as user_is_active
     , users.full_name as user_full_name
     , users.address_country as user_address_country
     , users.highest_education as user_highest_education
@@ -178,8 +185,8 @@ select
     , users.user_mitxonline_username
     , users.user_edxorg_username
     , users.user_mitxpro_username
-    -- Not yet in dim_user
-    , null as user_bootcamps_username
+    -- Not yet in dim_user; sourced from int__combined__users supplement
+    , users_supplement.user_bootcamps_username as user_bootcamps_username
     -- Stats (upstream sources being migrated by other epic tickets)
     , course_stats.num_of_course_enrolled
     , course_stats.num_of_course_passed
@@ -195,7 +202,7 @@ select
     -- to change (edxorg_id-based → mitxonline_id-based). This column preserves the
     -- old edX.org hash so that downstream consumers (Hightouch, cross-model joins) can
     -- perform a graceful key migration without a hard cutover.
-    -- Track removal in: https://github.com/mitodl/ol-data-platform/issues/TODO
+    -- Track removal in: https://github.com/mitodl/ol-data-platform/issues/2409
     -- Remove once all consumers have migrated to user_hashed_id.
     , case
         when users.edxorg_openedx_user_id is not null
@@ -203,9 +210,9 @@ select
     end as user_hashed_id_edxorg_legacy
 from users
 left join users_supplement on users.email = users_supplement.user_email_lower
-left join course_stats on users.email = lower(course_stats.user_email)
-left join program_stats on users.email = lower(program_stats.user_email)
-left join orders_stats on users.email = lower(orders_stats.user_email)
+left join course_stats on users.email = course_stats.user_email
+left join program_stats on users.email = program_stats.user_email
+left join orders_stats on users.email = orders_stats.user_email
 left join income on users.user_mitxonline_username = income.user_username
 -- Exclude MicroMasters-only users: the original mart filtered to
 -- (is_mitxonline_user OR is_edxorg_user) for the MITx branch, and MITxPro,


### PR DESCRIPTION
### What are the relevant tickets?
Closes #2077
Part of epic #2072

### Description (What does it do?)

Migrates `marts__combined__users` from a 4-way `UNION ALL` over `int__mitx__users` + `int__combined__users` to use `dim_user` as the single canonical user identity source. This is part of the epic to migrate mart and reporting models to the dimensional layer.

**What changed:**

- `dim_user` replaces the old user identity UNIONs as the source of truth for all user-level fields
- A `users_supplement` CTE is added from `int__combined__users` to supply 5 fields not yet promoted to `dim_user`: `user_last_login`, `user_street_address`, `user_address_city`, `user_address_state_or_territory`, `user_address_postal_code`
- `user_hashed_id`, `platforms`, `user_joined_on`, `user_is_active` are re-derived from `dim_user`'s per-platform fields using the same priority logic as the original
- A `WHERE` clause excludes MicroMasters-only users from `dim_user` (who the original mart never emitted) to preserve row-level population scope
- All stats CTEs (`course_stats`, `program_stats`, `orders_stats`) are unchanged

**Side effects (see ⚠️ note below):**

- The old mart double-counted cross-platform users (e.g., a user on both MITx Online and xPro appeared in two UNION branches). `dim_user` correctly deduplicates these to one row per user — total row count drops ~6.6% (~524k rows), but only ~9k of those are genuinely different email-level users
- ~417k users gain the more accurate `platforms = 'MITx Online and edX.org'` label (previously incorrectly labeled `'MITx Online'` because their edX link wasn't detected by the old mart)
- Stats join coverage improves slightly (94.24% → 94.52%) because `dim_user.email` is already lowercased, making the enrollment join more robust

---

## ⚠️ Breaking Migration Side Effect — Requires Team Discussion Before Merge

**~49,852 users will have their `user_hashed_id` change after this migration.**

These users were labeled `'edX.org'` in the old mart (edX-only, no MITx Online account detected). `dim_user` now correctly links them to a MITx Online account (`mitxonline_application_user_id IS NOT NULL`). Because the new mart checks MITx Online first in the `user_hashed_id` CASE, their hash changes:

```
Old: sha256(cast(edxorg_openedx_user_id AS VARCHAR) || 'edX.org')
New: sha256(cast(mitxonline_application_user_id AS VARCHAR) || 'MITx Online')
```

This is intentionally correct behavior — these users genuinely have MITx Online accounts that the old mart missed. However, `user_hashed_id` is used as a primary key by Hightouch and as a join key in `learner_demographics_and_cert_info` and `cheating_detection_report`. A hard cutover would orphan Hightouch records for these ~50k users.

**Mitigation included in this PR:**

A `user_hashed_id_edxorg_legacy` column has been added. For any user with an edX.org account, it emits the edX.org-based hash regardless of their MITx Online status:

```sql
case
    when users.edxorg_openedx_user_id is not null
        then sha256(cast(edxorg_openedx_user_id AS VARCHAR) || 'edX.org')
end as user_hashed_id_edxorg_legacy
```

This allows a graceful migration:
1. Deploy this PR — both the new `user_hashed_id` and legacy column are available
2. Hightouch team updates their sync to reconcile old edX-based PKs via `user_hashed_id_edxorg_legacy`
3. Downstream models (`learner_demographics_and_cert_info`, `cheating_detection_report`) are updated to join on `user_hashed_id`
4. Legacy column is removed in a follow-up PR once all consumers are migrated

**Suggested follow-up ticket:** Open a new issue to track removal of `user_hashed_id_edxorg_legacy` and coordinate the Hightouch key migration. Suggested title: _"Remove `user_hashed_id_edxorg_legacy` from `marts__combined__users` after Hightouch migration"_.

**Do not merge this PR until the migration plan for the ~49,852 affected users is agreed with the team.**

---

### How can this be tested?

The following 4 queries can be run directly against production Trino to validate the migration logic **without deploying to QA**. They compare the current production `marts__combined__users` against the new logic sourced directly from `dim_user`.

> Connection: `trino --server https://mitol-ol-data-lake-production.trino.galaxy.starburst.io:443 --external-authentication --catalog ol_data_lake_production`

---

**Q1 — Row count parity by platform**

What to look for: The MITx Online + "MITx Online and edX.org" combined totals should be nearly identical between old and new (~813k each). Other platforms will drop slightly due to cross-platform deduplication (expected). A large drop in any single platform that cannot be explained by deduplication would be a regression.

```sql
WITH new_logic AS (
    SELECT
        CASE
            WHEN mitxonline_application_user_id IS NOT NULL
                AND edxorg_openedx_user_id IS NOT NULL
                THEN 'MITx Online and edX.org'
            WHEN mitxonline_application_user_id IS NOT NULL THEN 'MITx Online'
            WHEN edxorg_openedx_user_id IS NOT NULL THEN 'edX.org'
            WHEN mitxpro_application_user_id IS NOT NULL THEN 'xPro'
            WHEN bootcamps_application_user_id IS NOT NULL THEN 'Bootcamps'
            WHEN emeritus_user_id IS NOT NULL THEN 'xPRO Emeritus'
            WHEN global_alumni_user_id IS NOT NULL THEN 'xPRO Global Alumni'
        END AS platforms
    FROM ol_data_lake_production.ol_warehouse_production_dimensional.dim_user
    WHERE
        mitxonline_application_user_id IS NOT NULL
        OR edxorg_openedx_user_id IS NOT NULL
        OR mitxpro_application_user_id IS NOT NULL
        OR bootcamps_application_user_id IS NOT NULL
        OR emeritus_user_id IS NOT NULL
        OR global_alumni_user_id IS NOT NULL
)
SELECT 'new' AS version, platforms, COUNT(*) AS user_count
FROM new_logic
GROUP BY platforms
UNION ALL
SELECT 'old' AS version, platforms, COUNT(*) AS user_count
FROM ol_data_lake_production.ol_warehouse_production_mart.marts__combined__users
GROUP BY platforms
ORDER BY platforms, version
```

---

**Q2 — Email-level population delta**

What to look for: `in_old_not_new` should be 0 or very small. These are users in the production mart whose email is genuinely absent from `dim_user` — they would be lost after migration. `in_new_not_old` may be a small positive number (new users `dim_user` now surfaces).

```sql
SELECT
    'in_old_not_new' AS direction,
    COUNT(*) AS user_count,
    APPROX_PERCENTILE(LENGTH(old_mart.user_email), 0.5) AS sanity_check_avg_email_len
FROM ol_data_lake_production.ol_warehouse_production_mart.marts__combined__users AS old_mart
WHERE NOT EXISTS (
    SELECT 1
    FROM ol_data_lake_production.ol_warehouse_production_dimensional.dim_user AS du
    WHERE
        du.email = LOWER(old_mart.user_email)
        AND (
            du.mitxonline_application_user_id IS NOT NULL
            OR du.edxorg_openedx_user_id IS NOT NULL
            OR du.mitxpro_application_user_id IS NOT NULL
            OR du.bootcamps_application_user_id IS NOT NULL
            OR du.emeritus_user_id IS NOT NULL
            OR du.global_alumni_user_id IS NOT NULL
        )
)
UNION ALL
SELECT
    'in_new_not_old' AS direction,
    COUNT(*) AS user_count,
    NULL AS sanity_check_avg_email_len
FROM ol_data_lake_production.ol_warehouse_production_dimensional.dim_user AS du
WHERE
    (
        du.mitxonline_application_user_id IS NOT NULL
        OR du.edxorg_openedx_user_id IS NOT NULL
        OR du.mitxpro_application_user_id IS NOT NULL
        OR du.bootcamps_application_user_id IS NOT NULL
        OR du.emeritus_user_id IS NOT NULL
        OR du.global_alumni_user_id IS NOT NULL
    )
    AND NOT EXISTS (
        SELECT 1
        FROM ol_data_lake_production.ol_warehouse_production_mart.marts__combined__users AS old_mart
        WHERE LOWER(old_mart.user_email) = du.email
    )
```

---

**Q3 — `user_hashed_id` stability for MITx users (critical for Hightouch)**

What to look for: `pct_hash_match = 1.0` for `MITx Online` and `MITx Online and edX.org`. For `edX.org`, expect ~0.9928 — the ~0.72% mismatch corresponds to the ~49,852 users documented in the ⚠️ section above whose hash legitimately changes. These users can be migrated using `user_hashed_id_edxorg_legacy`.

```sql
SELECT
    old_mart.platforms,
    COUNT(*) AS matched_users,
    SUM(CASE
        WHEN old_mart.platforms LIKE '%MITx Online%'
            THEN CASE WHEN old_mart.user_hashed_id = lower(to_hex(sha256(cast(
                    CAST(du.mitxonline_application_user_id AS VARCHAR) || 'MITx Online'
                    AS VARBINARY)))) THEN 1 ELSE 0 END
        WHEN old_mart.platforms = 'edX.org'
            THEN CASE WHEN old_mart.user_hashed_id = lower(to_hex(sha256(cast(
                    CAST(du.edxorg_openedx_user_id AS VARCHAR) || 'edX.org'
                    AS VARBINARY)))) THEN 1 ELSE 0 END
        ELSE 1
    END) AS hash_matches,
    CAST(SUM(CASE
        WHEN old_mart.platforms LIKE '%MITx Online%'
            THEN CASE WHEN old_mart.user_hashed_id = lower(to_hex(sha256(cast(
                    CAST(du.mitxonline_application_user_id AS VARCHAR) || 'MITx Online'
                    AS VARBINARY)))) THEN 1 ELSE 0 END
        WHEN old_mart.platforms = 'edX.org'
            THEN CASE WHEN old_mart.user_hashed_id = lower(to_hex(sha256(cast(
                    CAST(du.edxorg_openedx_user_id AS VARCHAR) || 'edX.org'
                    AS VARBINARY)))) THEN 1 ELSE 0 END
        ELSE 1
    END) AS DOUBLE) / COUNT(*) AS pct_hash_match
FROM ol_data_lake_production.ol_warehouse_production_mart.marts__combined__users AS old_mart
JOIN ol_data_lake_production.ol_warehouse_production_dimensional.dim_user AS du
    ON du.email = LOWER(old_mart.user_email)
WHERE old_mart.platforms IN ('MITx Online', 'edX.org', 'MITx Online and edX.org')
GROUP BY old_mart.platforms
ORDER BY old_mart.platforms
```

---

**Q4 — Enrollment stats join coverage**

What to look for: `new_coverage_rate` should be greater than or equal to `old_coverage_rate`. A lower new rate would indicate the canonical email from `dim_user` is causing more missed enrollment joins than the old per-branch email logic.

```sql
WITH enrollment_emails AS (
    SELECT LOWER(user_email) AS email
    FROM ol_data_lake_production.ol_warehouse_production_intermediate.int__combined__courserun_enrollments
    GROUP BY LOWER(user_email)
),
new_users AS (
    SELECT email
    FROM ol_data_lake_production.ol_warehouse_production_dimensional.dim_user
    WHERE
        mitxonline_application_user_id IS NOT NULL
        OR edxorg_openedx_user_id IS NOT NULL
        OR mitxpro_application_user_id IS NOT NULL
        OR bootcamps_application_user_id IS NOT NULL
        OR emeritus_user_id IS NOT NULL
        OR global_alumni_user_id IS NOT NULL
)
SELECT
    'new' AS version,
    COUNT(nu.email) AS total_users,
    COUNT(ee.email) AS users_with_enrollments,
    ROUND(CAST(COUNT(ee.email) AS DOUBLE) / NULLIF(COUNT(nu.email), 0), 4) AS coverage_rate
FROM new_users nu
LEFT JOIN enrollment_emails ee ON nu.email = ee.email
UNION ALL
SELECT
    'old' AS version,
    COUNT(m.user_email) AS total_users,
    COUNT(ee.email) AS users_with_enrollments,
    ROUND(CAST(COUNT(ee.email) AS DOUBLE) / NULLIF(COUNT(m.user_email), 0), 4) AS coverage_rate
FROM ol_data_lake_production.ol_warehouse_production_mart.marts__combined__users m
LEFT JOIN enrollment_emails ee ON LOWER(m.user_email) = ee.email
ORDER BY version
```

### Additional Context

**Do not merge until the Hightouch key migration plan is agreed.** See the ⚠️ section above.

The follow-up ticket to remove `user_hashed_id_edxorg_legacy` should be created and linked here before this PR is marked ready for review.