### PR TITLE
feat(users): add Learn users to marts__combined__users

### DIFF
--- a/src/ol_dbt/dbt_project.yml
+++ b/src/ol_dbt/dbt_project.yml
@@ -44,6 +44,7 @@ vars:
     mitxpro: "xPro"
     micromasters: "MicroMasters"
     mitxonline: "MITx Online"
+    mitlearn: "MIT Learn"
     residential: "Residential MITx"
     emeritus: "xPRO Emeritus"
     global_alumni: "xPRO Global Alumni"

--- a/src/ol_dbt/dbt_project.yml
+++ b/src/ol_dbt/dbt_project.yml
@@ -38,7 +38,7 @@ vars:
 
   open_learning:
     platforms: ["Bootcamps", "xPro", "xPRO Emeritus", "xPRO Global Alumni", "MITx\
-        \ Online", "MicroMasters", "edX.org", "Residential MITx"]
+        \ Online", "MicroMasters", "edX.org", "Residential MITx", "MIT Learn"]
     bootcamps: "Bootcamps"
     edxorg: "edX.org"
     mitxpro: "xPro"

--- a/src/ol_dbt/models/marts/combined/_marts__combined__models.yml
+++ b/src/ol_dbt/models/marts/combined/_marts__combined__models.yml
@@ -43,9 +43,9 @@ models:
     - unique
   - name: user_email
     description: string, user email on the corresponding platform including xpro,
-      bootcamps, edX.org, MITx Online, and Residential MITx. If the user is on edX.org
-      and MITx Online then the email will be chosen from the last platform they joined
-      if their account is active. May be null for some xPRO Emeritus learners.
+      bootcamps, edX.org, MITx Online, Residential MITx, and MIT Learn. If the user
+      is on edX.org and MITx Online then the email will be chosen from the last platform
+      they joined if their account is active. May be null for some xPRO Emeritus learners.
     tests:
     - dbt_expectations.expect_column_values_to_not_be_null:
         arguments:

--- a/src/ol_dbt/models/marts/combined/_marts__combined__models.yml
+++ b/src/ol_dbt/models/marts/combined/_marts__combined__models.yml
@@ -143,7 +143,8 @@ models:
       arguments:
         column_list: ["user_mitxonline_username", "user_edxorg_username", "user_mitxpro_username",
           "user_bootcamps_username", "platforms"]
-        row_condition: "platforms not in ('xPRO Emeritus', 'xPRO Global Alumni')"
+        row_condition: "platforms not in ('xPRO Emeritus', 'xPRO Global Alumni', 'MIT\
+          \ Learn')"
 - name: marts__combined__orders
   description: ecommerce regular b2c orders
   columns:

--- a/src/ol_dbt/models/marts/combined/_marts__combined__models.yml
+++ b/src/ol_dbt/models/marts/combined/_marts__combined__models.yml
@@ -105,6 +105,8 @@ models:
     description: int, user ID on MITxPRO
   - name: user_bootcamps_id
     description: int, user ID on bootcamps
+  - name: user_mitlearn_id
+    description: int, user ID on MIT Learn
   - name: user_mitxonline_username
     description: string, username on MITxOnline
   - name: user_edxorg_username

--- a/src/ol_dbt/models/marts/combined/marts__combined__users.sql
+++ b/src/ol_dbt/models/marts/combined/marts__combined__users.sql
@@ -8,6 +8,24 @@ with mitx__users as (
     select * from {{ ref('int__combined__users') }}
 )
 
+, mitlearn_users as (
+    select
+        mitlearn_user_id
+        , email
+        , full_name
+        , address_country
+        , highest_education
+        , gender
+        , birth_year
+        , company
+        , job_title
+        , industry
+        , user_is_active_on_mitlearn
+        , user_joined_on_mitlearn
+    from {{ ref('dim_user') }}
+    where mitlearn_user_id is not null
+)
+
 , combined_enrollments as (
     select * from {{ ref('int__combined__courserun_enrollments') }}
 )
@@ -83,6 +101,7 @@ with mitx__users as (
         , user_edxorg_id
         , null as user_mitxpro_id
         , null as user_bootcamps_id
+        , null as user_mitlearn_id
         , user_mitxonline_username
         , user_edxorg_username
         , null as user_mitxpro_username
@@ -138,6 +157,7 @@ with mitx__users as (
         , null as user_edxorg_id
         , user_id as user_mitxpro_id
         , null as user_bootcamps_id
+        , null as user_mitlearn_id
         , null as user_mitxonline_username
         , null as user_edxorg_username
         , user_username as user_mitxpro_username
@@ -170,6 +190,7 @@ with mitx__users as (
         , null as user_edxorg_id
         , null as user_mitxpro_id
         , user_id as user_bootcamps_id
+        , null as user_mitlearn_id
         , null as user_mitxonline_username
         , null as user_edxorg_username
         , null as user_mitxpro_username
@@ -202,6 +223,7 @@ with mitx__users as (
         , null as user_edxorg_id
         , null as user_mitxpro_id
         , null as user_bootcamps_id
+        , null as user_mitlearn_id
         , null as user_mitxonline_username
         , null as user_edxorg_username
         , null as user_mitxpro_username
@@ -225,6 +247,38 @@ with mitx__users as (
         , user_address_postal_code
     from non_mitx_users
     where platform in ('{{ var("emeritus") }}', '{{ var("global_alumni") }}')
+
+    union all
+
+    select
+        {{ generate_hash_id("cast(mitlearn_user_id as varchar) || '" ~ var("mitlearn") ~ "'") }} as user_hashed_id
+        , null as user_mitxonline_id
+        , null as user_edxorg_id
+        , null as user_mitxpro_id
+        , null as user_bootcamps_id
+        , mitlearn_user_id as user_mitlearn_id
+        , null as user_mitxonline_username
+        , null as user_edxorg_username
+        , null as user_mitxpro_username
+        , null as user_bootcamps_username
+        , email as user_email
+        , user_joined_on_mitlearn as user_joined_on
+        , null as user_last_login
+        , user_is_active_on_mitlearn as user_is_active
+        , '{{ var("mitlearn") }}' as platforms
+        , full_name as user_full_name
+        , address_country as user_address_country
+        , highest_education as user_highest_education
+        , gender as user_gender
+        , birth_year as user_birth_year
+        , company as user_company
+        , job_title as user_job_title
+        , industry as user_industry
+        , null as user_street_address
+        , null as user_address_city
+        , null as user_address_state_or_territory
+        , null as user_address_postal_code
+    from mitlearn_users
 
 )
 
@@ -251,6 +305,7 @@ select
     , combined_users.user_edxorg_id
     , combined_users.user_mitxpro_id
     , combined_users.user_bootcamps_id
+    , combined_users.user_mitlearn_id
     , combined_users.user_mitxonline_username
     , combined_users.user_edxorg_username
     , combined_users.user_mitxpro_username

--- a/src/ol_dbt/models/marts/combined/marts__combined__users.sql
+++ b/src/ol_dbt/models/marts/combined/marts__combined__users.sql
@@ -101,7 +101,7 @@ with mitx__users as (
         , user_edxorg_id
         , null as user_mitxpro_id
         , null as user_bootcamps_id
-        , null as user_mitlearn_id
+        , mitlearn_users.mitlearn_user_id as user_mitlearn_id
         , user_mitxonline_username
         , user_edxorg_username
         , null as user_mitxpro_username
@@ -147,7 +147,8 @@ with mitx__users as (
         , user_address_state as user_address_state_or_territory
         , user_address_postal_code
     from mitx__users
-    where is_mitxonline_user = true or is_edxorg_user = true
+    left join mitlearn_users on lower(mitlearn_users.email) = lower(mitx__users.user_mitxonline_email)
+    where mitx__users.is_mitxonline_user = true or mitx__users.is_edxorg_user = true
 
     union all
 
@@ -279,6 +280,11 @@ with mitx__users as (
         , null as user_address_state_or_territory
         , null as user_address_postal_code
     from mitlearn_users
+    where lower(email) not in (
+        select lower(user_mitxonline_email)
+        from mitx__users
+        where user_mitxonline_email is not null
+    )
 
 )
 


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
NA

### Description (What does it do?)
<!--- Describe your changes in detail -->
MIT Learn users is currently absent in any mart tables. The mart business users can't associate learn accounts with our enrollment data. This PR adds MIT Learn users to marts__combined__users for business users.


### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

dbt build --select marts__combined__users

### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->


<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
