### PR TITLE
feat(b2b): add user-to-organization membership bridge and staging models

### DIFF
--- a/src/ol_dbt/models/dimensional/_bridge_tables.yml
+++ b/src/ol_dbt/models/dimensional/_bridge_tables.yml
@@ -144,3 +144,34 @@ models:
       combination_of_columns:
       - course_fk
       - department_fk
+
+- name: bridge_user_organization
+  description: >
+    MITx Online B2B user-to-organization membership bridge.
+    Grain: one row per (user, organization) membership.
+  tests:
+  - dbt_utils.unique_combination_of_columns:
+      combination_of_columns:
+      - user_fk
+      - organization_fk
+  columns:
+  - name: user_fk
+    description: Foreign key to dim_user.user_pk.
+    tests:
+    - not_null
+    - relationships:
+        to: ref('dim_user')
+        field: user_pk
+  - name: organization_fk
+    description: Foreign key to dim_organization.organization_pk.
+    tests:
+    - not_null
+    - relationships:
+        to: ref('dim_organization')
+        field: organization_pk
+  - name: userorganization_keep_until_seen
+    description: If true, the user is retained in the organization until their SSO
+      data is next observed.
+  - name: userorganization_is_manager
+    description: If true, the user is a manager of this organization and can access
+      organization dashboard features.

--- a/src/ol_dbt/models/dimensional/bridge_user_organization.sql
+++ b/src/ol_dbt/models/dimensional/bridge_user_organization.sql
@@ -1,0 +1,35 @@
+{{ config(
+    materialized='table'
+) }}
+
+-- User to B2B organization membership bridge.
+-- Grain: one row per (user, organization) membership.
+with user_organizations as (
+    select
+        user_id
+        , organization_id
+        , userorganization_keep_until_seen
+        , userorganization_is_manager
+    from {{ ref('stg__mitxonline__app__postgres__b2b_userorganization') }}
+)
+
+, dim_user as (
+    select user_pk, mitxonline_application_user_id
+    from {{ ref('dim_user') }}
+    where mitxonline_application_user_id is not null
+)
+
+, dim_organization as (
+    select organization_pk, organization_id
+    from {{ ref('dim_organization') }}
+    where platform = 'mitxonline'
+)
+
+select
+    du.user_pk as user_fk
+    , orgs.organization_pk as organization_fk
+    , uo.userorganization_keep_until_seen
+    , uo.userorganization_is_manager
+from user_organizations as uo
+inner join dim_user as du on uo.user_id = du.mitxonline_application_user_id
+inner join dim_organization as orgs on cast(uo.organization_id as varchar) = orgs.organization_id

--- a/src/ol_dbt/models/staging/mitxonline/_mitxonline__sources.yml
+++ b/src/ol_dbt/models/staging/mitxonline/_mitxonline__sources.yml
@@ -2101,6 +2101,27 @@ sources:
       description: the method to use to manage membership in the contract. e.g. SSO,
         Non-SSO
 
+  - name: raw__mitxonline__app__postgres__b2b_userorganization
+    description: MITx Online B2B user-to-organization membership records
+    columns:
+    - name: id
+      data_type: bigint
+      description: primary key for this table
+    - name: user_id
+      data_type: bigint
+      description: foreign key to users_user
+    - name: organization_id
+      data_type: bigint
+      description: foreign key to b2b_organizationpage (page_ptr_id)
+    - name: keep_until_seen
+      data_type: boolean
+      description: if true, the user is retained in the organization until their SSO
+        data is next observed
+    - name: is_manager
+      data_type: boolean
+      description: if true, the user is a manager of this organization and can access
+        organization dashboard features
+
   - name: raw__mitxonline__app__postgres__wagtailimages_image
     description: Images uploaded to MITx Online Wagtail CMS image library. NOTE -
       this table must be added to the MITx Online Airbyte ingest before this source

--- a/src/ol_dbt/models/staging/mitxonline/_stg_mitxonline__models.yml
+++ b/src/ol_dbt/models/staging/mitxonline/_stg_mitxonline__models.yml
@@ -2100,6 +2100,34 @@ models:
     description: the method to use to manage membership in the contract. e.g. SSO,
       Non-SSO
 
+- name: stg__mitxonline__app__postgres__b2b_userorganization
+  description: MITx Online B2B user-to-organization membership records
+  columns:
+  - name: userorganization_id
+    data_type: bigint
+    description: primary key for this table
+    data_tests:
+    - not_null
+    - unique
+  - name: user_id
+    data_type: bigint
+    description: foreign key to users_user
+    data_tests:
+    - not_null
+  - name: organization_id
+    data_type: bigint
+    description: foreign key to b2b_organizationpage
+    data_tests:
+    - not_null
+  - name: userorganization_keep_until_seen
+    data_type: boolean
+    description: if true, the user is retained in the organization until their SSO
+      data is next observed
+  - name: userorganization_is_manager
+    data_type: boolean
+    description: if true, the user is a manager of this organization and can access
+      organization dashboard features
+
 - name: stg__mitxonline__app__postgres__wagtailimages_image
   description: Images uploaded to MITx Online's Wagtail CMS image library. Used to
     resolve image_id foreign keys on CMS page tables to their file paths. Requires

--- a/src/ol_dbt/models/staging/mitxonline/stg__mitxonline__app__postgres__b2b_userorganization.sql
+++ b/src/ol_dbt/models/staging/mitxonline/stg__mitxonline__app__postgres__b2b_userorganization.sql
@@ -1,0 +1,15 @@
+with source as (
+    select * from {{ source('ol_warehouse_raw_data', 'raw__mitxonline__app__postgres__b2b_userorganization') }}
+)
+
+, cleaned as (
+    select
+        id as userorganization_id,
+        user_id,
+        organization_id,
+        keep_until_seen as userorganization_keep_until_seen,
+        is_manager as userorganization_is_manager
+    from source
+)
+
+select * from cleaned


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
close https://github.com/mitodl/ol-data-platform/issues/2207

### Description (What does it do?)
<!--- Describe your changes in detail -->
adds a new `bridge_user_organization` table to maps Learn users to their organizations. 

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

dbt build --select  stg__mitxonline__app__postgres__b2b_userorganization bridge_user_organization

### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->


<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
