### PR TITLE
fix(edxorg-s3): fix dlt resource naming, incremental loading, and schema metadata

### DIFF
--- a/dg_projects/data_loading/data_loading/defs/edxorg_s3_ingest/dagster_assets.py
+++ b/dg_projects/data_loading/data_loading/defs/edxorg_s3_ingest/dagster_assets.py
@@ -63,7 +63,7 @@ class EdxorgDltTranslator(DagsterDltTranslator):
             metadata={
                 **default_spec.metadata,
                 **table_name_meta,
-                **TableMetadataSet(storage_kind=_STORAGE_KIND),
+                **dict(TableMetadataSet(storage_kind=_STORAGE_KIND)),
             },
         )
 

--- a/dg_projects/data_loading/data_loading/defs/edxorg_s3_ingest/dagster_assets.py
+++ b/dg_projects/data_loading/data_loading/defs/edxorg_s3_ingest/dagster_assets.py
@@ -12,44 +12,59 @@ from dagster import (
     AssetKey,
     AssetSpec,
 )
+from dagster._core.definitions.metadata.metadata_set import TableMetadataSet
 from dagster_dlt import DagsterDltResource, DagsterDltTranslator, dlt_assets
 from dagster_dlt.translator import DltResourceTranslatorData
 from ol_orchestrate.lib.constants import EDXORG_DB_TABLES
 
 from .loads import (
+    dagster_env,
     edxorg_s3_pipeline,
     edxorg_s3_source,
     edxorg_s3_source_instance,
     table_format,
 )
 
+_STORAGE_KIND = "iceberg" if dagster_env in ("qa", "production") else "filesystem"
+
 
 class EdxorgDltTranslator(DagsterDltTranslator):
     """Custom translator for edxorg dlt assets with upstream dependencies."""
 
     def get_asset_spec(self, data: DltResourceTranslatorData) -> AssetSpec:
-        """
-        Map dlt resource to Dagster asset spec with one-to-one upstream deps.
-        """
-        # Get the default spec from parent
         default_spec = super().get_asset_spec(data)
 
         # The resource name is raw__edxorg__s3__tables__{table}
         resource_name = data.resource.name
-
-        # Create asset key with ol_warehouse_raw_data prefix
         asset_key = AssetKey(["ol_warehouse_raw_data", resource_name])
 
-        # Extract table name and create upstream dependency
         deps = []
+        table_name_meta = {}
         if resource_name.startswith("raw__edxorg__s3__tables__"):
-            table_name = resource_name.replace("raw__edxorg__s3__tables__", "")
-            # Add non-blocking dependency on upstream partitioned asset
-            deps = [AssetDep(AssetKey(["edxorg", "raw_data", "db_table", table_name]))]
+            short_name = resource_name.replace("raw__edxorg__s3__tables__", "")
+            deps = [AssetDep(AssetKey(["edxorg", "raw_data", "db_table", short_name]))]
+            # Assemble the Glue catalog fully-qualified name.  dlt does not
+            # populate schema_name in load_info for filesystem+Iceberg
+            # destinations, so extract_resource_metadata leaves table_name
+            # as None.  Set it explicitly here from the pipeline dataset_name.
+            if data.pipeline and data.pipeline.dataset_name:
+                table_name_meta = dict(
+                    TableMetadataSet(
+                        table_name=f"{data.pipeline.dataset_name}.{resource_name}"
+                    )
+                )
 
         return default_spec.replace_attributes(
             key=asset_key,
             deps=deps,
+            # storage_kind defaults to the named destination ("production"),
+            # not the actual storage type.  Override with the real kind.
+            kinds={"dlt", _STORAGE_KIND},
+            metadata={
+                **default_spec.metadata,
+                **table_name_meta,
+                **TableMetadataSet(storage_kind=_STORAGE_KIND),
+            },
         )
 
 
@@ -106,7 +121,11 @@ def edxorg_s3_consolidated_tables(
     # between tables via AssumeRoleWithWebIdentity (IRSA).
     for table_name in selected_tables:
         table_source = edxorg_s3_source(tables=[table_name], table_format=table_format)
-        yield from dlt.run(context=context, dlt_source=table_source)
+        yield from dlt.run(
+            context=context,
+            dlt_source=table_source,
+            loader_file_format="parquet",
+        )
 
 
 __all__ = ["edxorg_s3_consolidated_tables"]

--- a/dg_projects/data_loading/data_loading/defs/edxorg_s3_ingest/loads.py
+++ b/dg_projects/data_loading/data_loading/defs/edxorg_s3_ingest/loads.py
@@ -28,7 +28,6 @@ from pathlib import Path
 
 import dlt
 import s3fs
-from dlt.extract import DltResource
 from dlt.sources import incremental
 from dlt.sources.filesystem import filesystem, read_csv_duckdb
 from ol_orchestrate.lib.constants import EDXORG_DB_TABLES
@@ -68,94 +67,96 @@ def edxorg_s3_source(
     tables_to_load = tables if tables is not None else EDXORG_DB_TABLES
 
     for table_name in tables_to_load:
-        # Create a resource for each table with standardized naming
-        @dlt.resource(
-            name=f"raw__edxorg__s3__tables__{table_name}",
-            write_disposition="merge",
+        resource_name = f"raw__edxorg__s3__tables__{table_name}"
+        # Pattern to match ONLY prod TSV files for this table
+        # Matches: db_table/{table_name}/prod/*/*.tsv
+        # Excludes: db_table/{table_name}/edge/*/*.tsv (edge staging files)
+        file_glob = f"db_table/{table_name}/prod/**/*.tsv"
+
+        # Create an s3fs filesystem WITHOUT explicit credentials.
+        #
+        # dlt's AwsCredentials.to_session_credentials() calls
+        # get_frozen_credentials(), which snapshots the live IRSA
+        # RefreshableCredentials object as static strings and passes
+        # them to s3fs.S3FileSystem(key=..., secret=..., token=...).
+        # Once s3fs holds explicit static strings there is no refresh
+        # path: when the STS session token expires (~1 hour by default)
+        # every subsequent GetObject call fails with ExpiredToken.
+        #
+        # By constructing S3FileSystem with no explicit key/secret/token
+        # we bypass dlt's credential snapshotting entirely.  aiobotocore
+        # then uses its own credential chain which, for IRSA pods, invokes
+        # AioAssumeRoleWithWebIdentityFetcher and wraps the result in
+        # AioRefreshableCredentials.  Those credentials automatically call
+        # AssumeRoleWithWebIdentity again whenever the token expires, so
+        # the pipeline can run indefinitely without hitting ExpiredToken.
+        #
+        # dlt's filesystem() source accepts an AbstractFileSystem instance
+        # as its `credentials` parameter and uses it directly, skipping
+        # its own credential-dispatch logic.
+        #
+        # Do NOT pass extract_content=True.  That flag reads the entire
+        # file into Python bytes in a single blocking request before
+        # passing it to read_csv_duckdb, which can itself exceed a token
+        # lifetime for very large tables.  Leaving it False lets
+        # read_csv_duckdb stream the content chunk-by-chunk via PyArrow.
+        fs = s3fs.S3FileSystem()
+
+        # Pass incremental directly to filesystem() so dlt tracks the
+        # modification_date cursor per-resource.  Only files newer than
+        # the cursor from the last successful run are processed.
+        files = filesystem(
+            bucket_url=bucket_url,
+            file_glob=file_glob,
+            credentials=fs,
+            incremental=incremental("modification_date"),
+        )
+
+        # Pipe filesystem items through read_csv_duckdb, then rename and
+        # configure the resulting resource.  Using with_name() + apply_hints()
+        # is required here: a @dlt.resource wrapper that *returns* another
+        # DltResource causes dlt to replace the outer resource entirely,
+        # discarding its name, write_disposition, primary_key, and
+        # table_format hints.  The resulting writes land under the
+        # transformer's own name ("read_csv_duckdb"), making schema and job
+        # lookups fail.  Applying hints directly on the pipe avoids this.
+        yield (
+            (
+                files
+                | read_csv_duckdb(
+                    use_pyarrow=True,
+                    delimiter="\t",  # TSV files use tabs
+                    ignore_errors=True,
+                    # Force all columns to VARCHAR to prevent pyarrow schema mismatches.
+                    # This occurs when DuckDB infers different types for the same column
+                    # across files (e.g., TIMESTAMP vs. VARCHAR for columns that are
+                    # empty in some files). Downstream dbt models handle type casting.
+                    all_varchar=True,
+                )
+            )
+            .with_name(resource_name)
             # All edxorg TSV exports include a row_hash column. Use a composite key
             # with extracted_course_key because row_hash is computed from only the
             # original CSV columns (excluding the extracted_* fields added during
             # archive processing), so identical rows from different courses would
             # otherwise collide on row_hash alone.
-            primary_key=["row_hash", "extracted_course_key"],
-            table_format=table_format,
+            .apply_hints(
+                write_disposition="merge",
+                primary_key=["row_hash", "extracted_course_key"],
+                table_format=table_format,
+            )
         )
-        def load_table(table=table_name) -> DltResource:
-            """
-            Load TSV files for a specific table from S3.
-
-            Uses incremental loading based on file modification_date to avoid
-            reprocessing unchanged files on subsequent runs.
-
-            Only processes 'prod' source files, excluding 'edge' staging environment.
-            """
-
-            # Pattern to match ONLY prod TSV files for this table
-            # Matches: db_table/{table_name}/prod/*/*.tsv (prod/course_id/*.tsv)
-            # Excludes: db_table/{table_name}/edge/*/*.tsv (edge staging files)
-            file_glob = f"db_table/{table}/prod/**/*.tsv"
-
-            # Create an s3fs filesystem WITHOUT explicit credentials.
-            #
-            # dlt's AwsCredentials.to_session_credentials() calls
-            # get_frozen_credentials(), which snapshots the live IRSA
-            # RefreshableCredentials object as static strings and passes
-            # them to s3fs.S3FileSystem(key=..., secret=..., token=...).
-            # Once s3fs holds explicit static strings there is no refresh
-            # path: when the STS session token expires (~1 hour by default)
-            # every subsequent GetObject call fails with ExpiredToken.
-            #
-            # By constructing S3FileSystem with no explicit key/secret/token
-            # we bypass dlt's credential snapshotting entirely.  aiobotocore
-            # then uses its own credential chain which, for IRSA pods, invokes
-            # AioAssumeRoleWithWebIdentityFetcher and wraps the result in
-            # AioRefreshableCredentials.  Those credentials automatically call
-            # AssumeRoleWithWebIdentity again whenever the token expires, so
-            # the pipeline can run indefinitely without hitting ExpiredToken.
-            #
-            # dlt's filesystem() source accepts an AbstractFileSystem instance
-            # as its `credentials` parameter and uses it directly, skipping
-            # its own credential-dispatch logic.
-            #
-            # Do NOT pass extract_content=True.  That flag reads the entire
-            # file into Python bytes in a single blocking request before
-            # passing it to read_csv_duckdb, which can itself exceed a token
-            # lifetime for very large tables.  Leaving it False lets
-            # read_csv_duckdb stream the content chunk-by-chunk via PyArrow.
-            fs = s3fs.S3FileSystem()
-            files = filesystem(
-                bucket_url=bucket_url,
-                file_glob=file_glob,
-                credentials=fs,
-            )
-
-            # Enable incremental loading based on file modification date
-            # Only processes files modified since the last successful run
-            files.apply_hints(incremental=incremental("modification_date"))
-
-            return files | read_csv_duckdb(
-                use_pyarrow=True,
-                delimiter="\t",  # TSV files use tabs
-                ignore_errors=True,
-                # Force all columns to VARCHAR to prevent pyarrow schema mismatches.
-                # This occurs when DuckDB infers different types for the same column
-                # across files (e.g., TIMESTAMP vs. VARCHAR for columns that are
-                # empty in some files). Downstream dbt models handle type casting.
-                all_varchar=True,
-            )
-
-        yield load_table
 
 
 # Determine environment and destination
 # Use DAGSTER_ENVIRONMENT to determine destination and Glue database
-dagster_env = os.getenv("DAGSTER_ENVIRONMENT", "dev")
+dagster_env: str = os.getenv("DAGSTER_ENVIRONMENT", "dev")
 
 # Map DAGSTER_ENVIRONMENT to destination config
 # dev/ci -> local filesystem (Parquet, no Iceberg, no Glue)
 # qa -> filesystem + Iceberg (S3 + ol_warehouse_qa_raw Glue database)
 # production -> filesystem + Iceberg (S3 + ol_warehouse_production_raw Glue database)
-table_format = "iceberg"
+table_format = "iceberg" if dagster_env in ("qa", "production") else "parquet"
 if dagster_env in ("qa", "production"):
     destination_env = dagster_env
     dataset_name = f"ol_warehouse_{dagster_env}_raw"

--- a/dg_projects/data_loading/data_loading/defs/edxorg_s3_ingest/loads.py
+++ b/dg_projects/data_loading/data_loading/defs/edxorg_s3_ingest/loads.py
@@ -141,6 +141,7 @@ def edxorg_s3_source(
             # archive processing), so identical rows from different courses would
             # otherwise collide on row_hash alone.
             .apply_hints(
+                table_name=resource_name,
                 write_disposition="merge",
                 primary_key=["row_hash", "extracted_course_key"],
                 table_format=table_format,


### PR DESCRIPTION
### What are the relevant tickets?
N/A

### Description (What does it do?)

Fixes three related bugs in the EdX.org S3 dlt ingest pipeline.

**Root cause: wrong destination table name**

A `@dlt.resource` wrapper whose function body *returns* another `DltResource` causes dlt to discard the outer resource entirely — its `name`, `write_disposition`, `primary_key`, and `table_format` are all dropped. Every table was therefore being written to a table named `read_csv_duckdb` (the transformer's own name). The schema and job lookups in `DagsterDltResource.extract_resource_metadata` searched for `raw_edxorg_s3_tables_*` and found nothing, producing:

- `jobs: []`
- `dagster/column_schema: { "columns": [] }`

**`loads.py` changes**

- Replace the `@dlt.resource` wrapper + `return pipe` antipattern with `.with_name()` + `.apply_hints()` applied directly on the `filesystem | read_csv_duckdb` pipe. This is the documented way to attach hints to a transformer-based resource.
- Pass `incremental=incremental("modification_date")` natively to `filesystem()` (it has a first-class `incremental` parameter) rather than via `apply_hints()`. Each per-table resource gets its own `modification_date` cursor keyed by resource name, so subsequent runs only process files whose modification date is newer than the last successful run.
- Fix `table_format`: was always `"iceberg"` even for `dev`/`local` environments where there is no `[iceberg_catalog.local]` stanza in `config.toml`. Now conditional: `"iceberg"` for `qa`/`production`, `"parquet"` otherwise.

**`dagster_assets.py` changes**

- Add `loader_file_format="parquet"` to every `dlt.run()` call to match the standalone `run_pipeline()` and produce the correct staging format for filesystem+Iceberg destinations.
- Set `storage_kind` and `kinds` to `"iceberg"` (qa/prod) or `"filesystem"` (local) rather than the named destination name (`"production"`). `data.destination.destination_name` returns the named destination, not the storage type, so catalog badges were misleading.
- Explicitly compute `dagster/table_name` from `pipeline.dataset_name` because dlt does not populate `schema_name` in `load_info` for filesystem+Iceberg destinations, causing `extract_resource_metadata` to always leave `table_name=None`.

### How can this be tested?

1. Trigger a materialization of one or more `edxorg_s3_consolidated_tables` assets in the Dagster UI.
2. After the run completes, verify in the asset metadata:
   - `dagster/column_schema` has a non-empty `columns` list reflecting the TSV file schema.
   - `jobs` contains at least one entry with a matching `table_name`.
   - `dagster/storage_kind` shows `iceberg` (not `production`).
3. Trigger a second materialization immediately after. Verify the run completes quickly (no files to process) — the `modification_date` incremental cursor should prevent reprocessing unchanged files.
4. Locally: `DAGSTER_ENVIRONMENT=dev python -m data_loading.defs.edxorg_s3_ingest.loads` should write Parquet (not Iceberg) without error.