### PR TITLE
feat(dimensional): add semester + passing_grade to dim_course_run from MicroMasters exam runs

### DIFF
--- a/src/ol_dbt/models/dimensional/_dim_course_run.yml
+++ b/src/ol_dbt/models/dimensional/_dim_course_run.yml
@@ -79,7 +79,7 @@ models:
       mitxonline, mitxpro, and residential platforms. Null for edxorg and bootcamps.
   - name: semester
     description: >
-      Academic term label for a MicroMasters proctored exam run (e.g. "Fall 2023").
+      Academic term identifier for a MicroMasters proctored exam run (e.g. "2T2022").
       Populated only for MITxOnline course runs that correspond to a MicroMasters
       exam
       run. Null for all other platforms and non-exam MITxOnline course runs.

--- a/src/ol_dbt/models/dimensional/_dim_course_run.yml
+++ b/src/ol_dbt/models/dimensional/_dim_course_run.yml
@@ -77,6 +77,21 @@ models:
     description: >
       Timestamp when the course run was created in the source system. Populated for
       mitxonline, mitxpro, and residential platforms. Null for edxorg and bootcamps.
+  - name: semester
+    description: >
+      Academic term label for a MicroMasters proctored exam run (e.g. "Fall 2023").
+      Populated only for MITxOnline course runs that correspond to a MicroMasters
+      exam
+      run. Null for all other platforms and non-exam MITxOnline course runs.
+  - name: passing_grade
+    description: >
+      Passing score threshold (0.0–1.0) set per MicroMasters proctored exam run.
+      Populated only for MITxOnline course runs that correspond to a MicroMasters
+      exam
+      run. Null for all other platforms and non-exam MITxOnline course runs. Note:
+      a
+      stored value of null and an actual passing grade of 0.0 are distinct; -1.0 is
+      used as the SCD2 change-detection sentinel to distinguish them.
   - name: effective_date
     description: >
       Timestamp (UTC) when this SCD Type 2 version became effective. Always set for

--- a/src/ol_dbt/models/dimensional/dim_course_run.sql
+++ b/src/ol_dbt/models/dimensional/dim_course_run.sql
@@ -21,7 +21,7 @@ with
                     examrun_semester,
                     examrun_passing_grade,
                     row_number() over (
-                        partition by examrun_readable_id order by examrun_updated_on desc nulls last
+                        partition by examrun_readable_id order by examrun_updated_on desc nulls last, examrun_id desc
                     ) as _row_num
                 from {{ ref("stg__micromasters__app__postgres__exams_examrun") }}
             )

--- a/src/ol_dbt/models/dimensional/dim_course_run.sql
+++ b/src/ol_dbt/models/dimensional/dim_course_run.sql
@@ -294,5 +294,7 @@ with
 
     select *
     from combined
-{% else %} select * from final
+{% else %}
+    select *
+    from final
 {% endif %}

--- a/src/ol_dbt/models/dimensional/dim_course_run.sql
+++ b/src/ol_dbt/models/dimensional/dim_course_run.sql
@@ -1,292 +1,288 @@
-{{ config(
-    materialized='incremental',
-    unique_key=['courserun_pk', 'effective_date'],
-    incremental_strategy='delete+insert',
-    on_schema_change='append_new_columns'
-) }}
+{{
+    config(
+        materialized="incremental",
+        unique_key=["courserun_pk", "effective_date"],
+        incremental_strategy="delete+insert",
+        on_schema_change="append_new_columns",
+    )
+}}
 
 -- MicroMasters stores exam run metadata (semester label and passing grade threshold)
 -- keyed by examrun_readable_id, which matches the MITxOnline courserun_readable_id for
 -- proctored exam course runs. These are the only platform-specific dimensional attributes
 -- that originate outside the platform's own course run record.
-with micromasters_examruns as (
-    select examrun_readable_id, examrun_semester, examrun_passing_grade
-    from {{ ref('stg__micromasters__app__postgres__exams_examrun') }}
-)
+with
+    micromasters_examruns as (
+        select examrun_readable_id, examrun_semester, examrun_passing_grade
+        from {{ ref("stg__micromasters__app__postgres__exams_examrun") }}
+        qualify row_number() over (partition by examrun_readable_id order by examrun_updated_on desc nulls last) = 1
+    ),
+    mitxonline_courseruns as (
+        select
+            cr.courserun_readable_id,
+            cr.courserun_id as source_id,
+            cr.course_id,
+            cr.courserun_title,
+            cr.courserun_start_on,
+            cr.courserun_end_on,
+            cr.courserun_enrollment_start_on as enrollment_start,
+            cr.courserun_enrollment_end_on as enrollment_end,
+            cr.courserun_is_live,
+            cr.courserun_created_on,
+            cast(null as varchar) as course_readable_id,
+            er.examrun_semester as semester,
+            er.examrun_passing_grade as passing_grade,
+            'mitxonline' as platform
+        from {{ ref("int__mitxonline__course_runs") }} as cr
+        left join micromasters_examruns as er on cr.courserun_readable_id = er.examrun_readable_id
+    ),
+    mitxpro_courseruns as (
+        select
+            courserun_readable_id,
+            courserun_id as source_id,
+            course_id,
+            courserun_title,
+            courserun_start_on,
+            courserun_end_on,
+            courserun_enrollment_start_on as enrollment_start,
+            courserun_enrollment_end_on as enrollment_end,
+            courserun_is_live,
+            courserun_created_on,
+            cast(null as varchar) as course_readable_id,
+            cast(null as varchar) as semester,
+            cast(null as double) as passing_grade,
+            'mitxpro' as platform
+        from {{ ref("int__mitxpro__course_runs") }}
+    ),
+    edxorg_courseruns as (
+        select
+            courserun_readable_id,
+            cast(null as integer) as source_id,
+            cast(null as integer) as course_id,
+            courserun_title,
+            courserun_start_date as courserun_start_on,  -- edxorg uses _date suffix
+            courserun_end_date as courserun_end_on,
+            courserun_enrollment_start_date as enrollment_start,
+            courserun_enrollment_end_date as enrollment_end,
+            courserun_is_published as courserun_is_live,
+            cast(null as varchar) as courserun_created_on,
+            cast(null as varchar) as course_readable_id,
+            cast(null as varchar) as semester,
+            cast(null as double) as passing_grade,
+            'edxorg' as platform
+        from {{ ref("int__edxorg__mitx_courseruns") }}
+    ),
+    residential_courseruns as (
+        select
+            courserun_readable_id,
+            cast(null as integer) as source_id,
+            cast(null as integer) as course_id,
+            courserun_title,
+            courserun_start_on,
+            courserun_end_on,
+            courserun_enrollment_start_on as enrollment_start,
+            courserun_enrollment_end_on as enrollment_end,
+            cast(null as boolean) as courserun_is_live,
+            courserun_created_on,
+            cast(null as varchar) as course_readable_id,
+            cast(null as varchar) as semester,
+            cast(null as double) as passing_grade,
+            'residential' as platform
+        from {{ ref("int__mitxresidential__courseruns") }}
+    ),
+    bootcamps_courseruns as (
+        select
+            runs.courserun_readable_id,
+            runs.courserun_id as source_id,
+            runs.course_id,
+            runs.courserun_title,
+            runs.courserun_start_on,
+            runs.courserun_end_on,
+            cast(null as varchar) as enrollment_start,
+            cast(null as varchar) as enrollment_end,
+            false as courserun_is_live,
+            cast(null as varchar) as courserun_created_on,
+            runs.course_readable_id,
+            cast(null as varchar) as semester,
+            cast(null as double) as passing_grade,
+            'bootcamps' as platform
+        from {{ ref("int__bootcamps__course_runs") }} as runs
+    ),
+    combined_courseruns as (
+        select *
+        from mitxonline_courseruns
+        union all
+        select *
+        from mitxpro_courseruns
+        union all
+        select *
+        from edxorg_courseruns
+        union all
+        select *
+        from residential_courseruns
+        union all
+        select *
+        from bootcamps_courseruns
+    ),
+    -- Pre-compute course_readable_id for all platforms so the dim_course join is a simple equality
+    combined_courseruns_resolved as (
+        select
+            courserun_readable_id,
+            source_id,
+            course_id,
+            courserun_title,
+            courserun_start_on,
+            courserun_end_on,
+            enrollment_start,
+            enrollment_end,
+            courserun_is_live,
+            courserun_created_on,
+            platform,
+            semester,
+            passing_grade,
+            coalesce(
+                course_readable_id,
+                case
+                    when courserun_readable_id like 'course-v1:%'
+                    then
+                        substring(
+                            courserun_readable_id,
+                            1,
+                            length(courserun_readable_id) - strpos(reverse(courserun_readable_id), '+')
+                        )
+                    when regexp_like(courserun_readable_id, '^[^/]+/[^/]+/[^/]+')
+                    then
+                        substring(
+                            courserun_readable_id,
+                            1,
+                            length(courserun_readable_id) - strpos(reverse(courserun_readable_id), '/')
+                        )
+                    else courserun_readable_id
+                end
+            ) as course_readable_id
+        from combined_courseruns
+    ),
+    -- Join to dim_course to get course_fk
+    dim_course as (
+        select course_pk, course_readable_id, primary_platform from {{ ref("dim_course") }} where is_current = true
+    ),
+    courseruns_with_fk as (
+        select combined_courseruns_resolved.*, dim_course.course_pk as course_fk
+        from combined_courseruns_resolved
+        left join
+            dim_course
+            on combined_courseruns_resolved.platform = dim_course.primary_platform
+            and combined_courseruns_resolved.course_readable_id = dim_course.course_readable_id
+    ),
+    courseruns_with_all_fks as (
+        select
+            courseruns_with_fk.*,
+            dim_platform_lookup.platform_pk as platform_fk,
+            -- Create date keys for date dimension joins (parse to timestamp then format as YYYYMMDD)
+            {{ iso8601_to_date_key("courserun_start_on") }} as courserun_start_date_key,
+            {{ iso8601_to_date_key("courserun_end_on") }} as courserun_end_date_key,
+            {{ iso8601_to_date_key("enrollment_start") }} as enrollment_start_date_key,
+            {{ iso8601_to_date_key("enrollment_end") }} as enrollment_end_date_key
+        from courseruns_with_fk
+        left join
+            (select platform_pk, platform_readable_id from {{ ref("dim_platform") }}) as dim_platform_lookup
+            on courseruns_with_fk.platform = dim_platform_lookup.platform_readable_id
+    ),
+    final as (
+        select
+            {{ dbt_utils.generate_surrogate_key(["platform", "courserun_readable_id"]) }} as courserun_pk,
+            courserun_readable_id,
+            source_id,
+            course_fk,
+            platform_fk,
+            platform,
+            courserun_title,
+            courserun_start_date_key,
+            courserun_end_date_key,
+            enrollment_start_date_key,
+            enrollment_end_date_key,
+            courserun_start_on,
+            courserun_end_on,
+            enrollment_start,
+            enrollment_end,
+            courserun_is_live,
+            courserun_created_on,
+            semester,
+            passing_grade,
+            current_timestamp as effective_date,
+            cast(null as timestamp) as end_date,
+            true as is_current
+        from courseruns_with_all_fks
 
-, mitxonline_courseruns as (
-    select
-        cr.courserun_readable_id
-        , cr.courserun_id as source_id
-        , cr.course_id
-        , cr.courserun_title
-        , cr.courserun_start_on
-        , cr.courserun_end_on
-        , cr.courserun_enrollment_start_on as enrollment_start
-        , cr.courserun_enrollment_end_on as enrollment_end
-        , cr.courserun_is_live
-        , cr.courserun_created_on
-        , cast(null as varchar) as course_readable_id
-        , er.examrun_semester as semester
-        , er.examrun_passing_grade as passing_grade
-        , 'mitxonline' as platform
-    from {{ ref('int__mitxonline__course_runs') }} as cr
-    left join micromasters_examruns as er on cr.courserun_readable_id = er.examrun_readable_id
-)
-
-, mitxpro_courseruns as (
-    select
-        courserun_readable_id
-        , courserun_id as source_id
-        , course_id
-        , courserun_title
-        , courserun_start_on
-        , courserun_end_on
-        , courserun_enrollment_start_on as enrollment_start
-        , courserun_enrollment_end_on as enrollment_end
-        , courserun_is_live
-        , courserun_created_on
-        , cast(null as varchar) as course_readable_id
-        , cast(null as varchar) as semester
-        , cast(null as double) as passing_grade
-        , 'mitxpro' as platform
-    from {{ ref('int__mitxpro__course_runs') }}
-)
-
-, edxorg_courseruns as (
-    select
-        courserun_readable_id
-        , cast(null as integer) as source_id
-        , cast(null as integer) as course_id
-        , courserun_title
-        , courserun_start_date as courserun_start_on  -- edxorg uses _date suffix
-        , courserun_end_date as courserun_end_on
-        , courserun_enrollment_start_date as enrollment_start
-        , courserun_enrollment_end_date as enrollment_end
-        , courserun_is_published as courserun_is_live
-        , cast(null as varchar) as courserun_created_on
-        , cast(null as varchar) as course_readable_id
-        , cast(null as varchar) as semester
-        , cast(null as double) as passing_grade
-        , 'edxorg' as platform
-    from {{ ref('int__edxorg__mitx_courseruns') }}
-)
-
-, residential_courseruns as (
-    select
-        courserun_readable_id
-        , cast(null as integer) as source_id
-        , cast(null as integer) as course_id
-        , courserun_title
-        , courserun_start_on
-        , courserun_end_on
-        , courserun_enrollment_start_on as enrollment_start
-        , courserun_enrollment_end_on as enrollment_end
-        , cast(null as boolean) as courserun_is_live
-        , courserun_created_on
-        , cast(null as varchar) as course_readable_id
-        , cast(null as varchar) as semester
-        , cast(null as double) as passing_grade
-        , 'residential' as platform
-    from {{ ref('int__mitxresidential__courseruns') }}
-)
-
-, bootcamps_courseruns as (
-    select
-        runs.courserun_readable_id
-        , runs.courserun_id as source_id
-        , runs.course_id
-        , runs.courserun_title
-        , runs.courserun_start_on
-        , runs.courserun_end_on
-        , cast(null as varchar) as enrollment_start
-        , cast(null as varchar) as enrollment_end
-        , false as courserun_is_live
-        , cast(null as varchar) as courserun_created_on
-        , runs.course_readable_id
-        , cast(null as varchar) as semester
-        , cast(null as double) as passing_grade
-        , 'bootcamps' as platform
-    from {{ ref('int__bootcamps__course_runs') }} as runs
-)
-
-, combined_courseruns as (
-    select * from mitxonline_courseruns
-    union all
-    select * from mitxpro_courseruns
-    union all
-    select * from edxorg_courseruns
-    union all
-    select * from residential_courseruns
-    union all
-    select * from bootcamps_courseruns
-)
-
--- Pre-compute course_readable_id for all platforms so the dim_course join is a simple equality
-, combined_courseruns_resolved as (
-    select
-        courserun_readable_id
-        , source_id
-        , course_id
-        , courserun_title
-        , courserun_start_on
-        , courserun_end_on
-        , enrollment_start
-        , enrollment_end
-        , courserun_is_live
-        , courserun_created_on
-        , platform
-        , semester
-        , passing_grade
-        , coalesce(
-            course_readable_id,
-            case
-                when courserun_readable_id like 'course-v1:%'
-                    then substring(
-                        courserun_readable_id,
-                        1,
-                        length(courserun_readable_id)
-                        - strpos(reverse(courserun_readable_id), '+')
-                    )
-                when regexp_like(courserun_readable_id, '^[^/]+/[^/]+/[^/]+')
-                    then substring(
-                        courserun_readable_id,
-                        1,
-                        length(courserun_readable_id)
-                        - strpos(reverse(courserun_readable_id), '/')
-                    )
-                else courserun_readable_id
-            end
-        ) as course_readable_id
-    from combined_courseruns
-)
-
--- Join to dim_course to get course_fk
-, dim_course as (
-    select
-        course_pk
-        , course_readable_id
-        , primary_platform
-    from {{ ref('dim_course') }}
-    where is_current = true
-)
-
-, courseruns_with_fk as (
-    select
-        combined_courseruns_resolved.*
-        , dim_course.course_pk as course_fk
-    from combined_courseruns_resolved
-    left join dim_course
-        on combined_courseruns_resolved.platform = dim_course.primary_platform
-        and combined_courseruns_resolved.course_readable_id = dim_course.course_readable_id
-)
-
-, courseruns_with_all_fks as (
-    select
-        courseruns_with_fk.*
-        , dim_platform_lookup.platform_pk as platform_fk
-        -- Create date keys for date dimension joins (parse to timestamp then format as YYYYMMDD)
-        , {{ iso8601_to_date_key('courserun_start_on') }} as courserun_start_date_key
-        , {{ iso8601_to_date_key('courserun_end_on') }} as courserun_end_date_key
-        , {{ iso8601_to_date_key('enrollment_start') }} as enrollment_start_date_key
-        , {{ iso8601_to_date_key('enrollment_end') }} as enrollment_end_date_key
-    from courseruns_with_fk
-    left join (
-        select platform_pk, platform_readable_id
-        from {{ ref('dim_platform') }}
-    ) as dim_platform_lookup
-        on courseruns_with_fk.platform = dim_platform_lookup.platform_readable_id
-)
-
-, final as (
-    select
-        {{ dbt_utils.generate_surrogate_key([
-            'platform',
-            'courserun_readable_id'
-        ]) }} as courserun_pk
-        , courserun_readable_id
-        , source_id
-        , course_fk
-        , platform_fk
-        , platform
-        , courserun_title
-        , courserun_start_date_key
-        , courserun_end_date_key
-        , enrollment_start_date_key
-        , enrollment_end_date_key
-        , courserun_start_on
-        , courserun_end_on
-        , enrollment_start
-        , enrollment_end
-        , courserun_is_live
-        , courserun_created_on
-        , semester
-        , passing_grade
-        , current_timestamp as effective_date
-        , cast(null as timestamp) as end_date
-        , true as is_current
-    from courseruns_with_all_fks
-
-    {% if is_incremental() %}
-    where not exists (
-        select 1
-        from {{ this }} as existing
-        where
-            existing.courserun_readable_id = courseruns_with_all_fks.courserun_readable_id
-            and existing.platform = courseruns_with_all_fks.platform
-            and existing.is_current = true
-            and existing.courserun_title = courseruns_with_all_fks.courserun_title
-            and coalesce(existing.courserun_start_on, '') = coalesce(courseruns_with_all_fks.courserun_start_on, '')
-            and coalesce(existing.courserun_end_on, '') = coalesce(courseruns_with_all_fks.courserun_end_on, '')
-            and coalesce(existing.enrollment_start, '') = coalesce(courseruns_with_all_fks.enrollment_start, '')
-            and coalesce(existing.enrollment_end, '') = coalesce(courseruns_with_all_fks.enrollment_end, '')
-            and coalesce(existing.courserun_is_live, false) = coalesce(courseruns_with_all_fks.courserun_is_live, false)
-            and coalesce(existing.semester, '') = coalesce(courseruns_with_all_fks.semester, '')
-            and coalesce(existing.passing_grade, -1.0) = coalesce(courseruns_with_all_fks.passing_grade, -1.0)
+        {% if is_incremental() %}
+            where
+                not exists (
+                    select 1
+                    from {{ this }} as existing
+                    where
+                        existing.courserun_readable_id = courseruns_with_all_fks.courserun_readable_id
+                        and existing.platform = courseruns_with_all_fks.platform
+                        and existing.is_current = true
+                        and existing.courserun_title = courseruns_with_all_fks.courserun_title
+                        and coalesce(existing.courserun_start_on, '')
+                        = coalesce(courseruns_with_all_fks.courserun_start_on, '')
+                        and coalesce(existing.courserun_end_on, '')
+                        = coalesce(courseruns_with_all_fks.courserun_end_on, '')
+                        and coalesce(existing.enrollment_start, '')
+                        = coalesce(courseruns_with_all_fks.enrollment_start, '')
+                        and coalesce(existing.enrollment_end, '') = coalesce(courseruns_with_all_fks.enrollment_end, '')
+                        and coalesce(existing.courserun_is_live, false)
+                        = coalesce(courseruns_with_all_fks.courserun_is_live, false)
+                        and coalesce(existing.semester, '') = coalesce(courseruns_with_all_fks.semester, '')
+                        and coalesce(existing.passing_grade, -1.0)
+                        = coalesce(courseruns_with_all_fks.passing_grade, -1.0)
+                )
+        {% endif %}
     )
-    {% endif %}
-)
 
 {% if is_incremental() %}
--- Expire prior current rows that have changed
-, records_to_expire as (
-    select
-        existing.courserun_pk
-        , existing.courserun_readable_id
-        , existing.source_id
-        , existing.course_fk
-        , existing.platform_fk
-        , existing.platform
-        , existing.courserun_title
-        , existing.courserun_start_date_key
-        , existing.courserun_end_date_key
-        , existing.enrollment_start_date_key
-        , existing.enrollment_end_date_key
-        , existing.courserun_start_on
-        , existing.courserun_end_on
-        , existing.enrollment_start
-        , existing.enrollment_end
-        , existing.courserun_is_live
-        , existing.courserun_created_on
-        , existing.semester
-        , existing.passing_grade
-        , existing.effective_date
-        , current_timestamp as end_date
-        , false as is_current
-    from {{ this }} as existing
-    inner join final as new_records
-        on existing.courserun_readable_id = new_records.courserun_readable_id
-        and existing.platform = new_records.platform
-    where existing.is_current = true
-)
+        ,
+        -- Expire prior current rows that have changed
+        records_to_expire as (
+            select
+                existing.courserun_pk,
+                existing.courserun_readable_id,
+                existing.source_id,
+                existing.course_fk,
+                existing.platform_fk,
+                existing.platform,
+                existing.courserun_title,
+                existing.courserun_start_date_key,
+                existing.courserun_end_date_key,
+                existing.enrollment_start_date_key,
+                existing.enrollment_end_date_key,
+                existing.courserun_start_on,
+                existing.courserun_end_on,
+                existing.enrollment_start,
+                existing.enrollment_end,
+                existing.courserun_is_live,
+                existing.courserun_created_on,
+                existing.semester,
+                existing.passing_grade,
+                existing.effective_date,
+                current_timestamp as end_date,
+                false as is_current
+            from {{ this }} as existing
+            inner join
+                final as new_records
+                on existing.courserun_readable_id = new_records.courserun_readable_id
+                and existing.platform = new_records.platform
+            where existing.is_current = true
+        ),
+        combined as (
+            select *
+            from final
+            union all
+            select *
+            from records_to_expire
+        )
 
-, combined as (
-    select * from final
-    union all
-    select * from records_to_expire
-)
-
-select * from combined
-{% else %}
-select * from final
+    select *
+    from combined
+{% else %} select * from final
 {% endif %}

--- a/src/ol_dbt/models/dimensional/dim_course_run.sql
+++ b/src/ol_dbt/models/dimensional/dim_course_run.sql
@@ -14,8 +14,18 @@
 with
     micromasters_examruns as (
         select examrun_readable_id, examrun_semester, examrun_passing_grade
-        from {{ ref("stg__micromasters__app__postgres__exams_examrun") }}
-        qualify row_number() over (partition by examrun_readable_id order by examrun_updated_on desc nulls last) = 1
+        from
+            (
+                select
+                    examrun_readable_id,
+                    examrun_semester,
+                    examrun_passing_grade,
+                    row_number() over (
+                        partition by examrun_readable_id order by examrun_updated_on desc nulls last
+                    ) as _row_num
+                from {{ ref("stg__micromasters__app__postgres__exams_examrun") }}
+            )
+        where _row_num = 1
     ),
     mitxonline_courseruns as (
         select

--- a/src/ol_dbt/models/dimensional/dim_course_run.sql
+++ b/src/ol_dbt/models/dimensional/dim_course_run.sql
@@ -21,7 +21,8 @@ with
                     examrun_semester,
                     examrun_passing_grade,
                     row_number() over (
-                        partition by examrun_readable_id order by examrun_updated_on desc nulls last, examrun_id desc
+                        partition by examrun_readable_id
+                        order by examrun_updated_on desc nulls last, examrun_id desc
                     ) as _row_num
                 from {{ ref("stg__micromasters__app__postgres__exams_examrun") }}
             ) as deduped_examruns

--- a/src/ol_dbt/models/dimensional/dim_course_run.sql
+++ b/src/ol_dbt/models/dimensional/dim_course_run.sql
@@ -24,7 +24,7 @@ with
                         partition by examrun_readable_id order by examrun_updated_on desc nulls last, examrun_id desc
                     ) as _row_num
                 from {{ ref("stg__micromasters__app__postgres__exams_examrun") }}
-            )
+            ) as deduped_examruns
         where _row_num = 1
     ),
     mitxonline_courseruns as (

--- a/src/ol_dbt/models/dimensional/dim_course_run.sql
+++ b/src/ol_dbt/models/dimensional/dim_course_run.sql
@@ -1,301 +1,304 @@
-{{
-    config(
-        materialized="incremental",
-        unique_key=["courserun_pk", "effective_date"],
-        incremental_strategy="delete+insert",
-        on_schema_change="append_new_columns",
-    )
-}}
+{{ config(
+    materialized='incremental',
+    unique_key=['courserun_pk', 'effective_date'],
+    incremental_strategy='delete+insert',
+    on_schema_change='append_new_columns'
+) }}
 
 -- MicroMasters stores exam run metadata (semester label and passing grade threshold)
 -- keyed by examrun_readable_id, which matches the MITxOnline courserun_readable_id for
 -- proctored exam course runs. These are the only platform-specific dimensional attributes
 -- that originate outside the platform's own course run record.
-with
-    micromasters_examruns as (
-        select examrun_readable_id, examrun_semester, examrun_passing_grade
-        from
-            (
-                select
-                    examrun_readable_id,
-                    examrun_semester,
-                    examrun_passing_grade,
-                    row_number() over (
-                        partition by examrun_readable_id
-                        order by examrun_updated_on desc nulls last, examrun_id desc
-                    ) as _row_num
-                from {{ ref("stg__micromasters__app__postgres__exams_examrun") }}
-            ) as deduped_examruns
-        where _row_num = 1
-    ),
-    mitxonline_courseruns as (
+with micromasters_examruns as (
+    select examrun_readable_id, examrun_semester, examrun_passing_grade
+    from (
         select
-            cr.courserun_readable_id,
-            cr.courserun_id as source_id,
-            cr.course_id,
-            cr.courserun_title,
-            cr.courserun_start_on,
-            cr.courserun_end_on,
-            cr.courserun_enrollment_start_on as enrollment_start,
-            cr.courserun_enrollment_end_on as enrollment_end,
-            cr.courserun_is_live,
-            cr.courserun_created_on,
-            cast(null as varchar) as course_readable_id,
-            er.examrun_semester as semester,
-            er.examrun_passing_grade as passing_grade,
-            'mitxonline' as platform
-        from {{ ref("int__mitxonline__course_runs") }} as cr
-        left join micromasters_examruns as er on cr.courserun_readable_id = er.examrun_readable_id
-    ),
-    mitxpro_courseruns as (
-        select
-            courserun_readable_id,
-            courserun_id as source_id,
-            course_id,
-            courserun_title,
-            courserun_start_on,
-            courserun_end_on,
-            courserun_enrollment_start_on as enrollment_start,
-            courserun_enrollment_end_on as enrollment_end,
-            courserun_is_live,
-            courserun_created_on,
-            cast(null as varchar) as course_readable_id,
-            cast(null as varchar) as semester,
-            cast(null as double) as passing_grade,
-            'mitxpro' as platform
-        from {{ ref("int__mitxpro__course_runs") }}
-    ),
-    edxorg_courseruns as (
-        select
-            courserun_readable_id,
-            cast(null as integer) as source_id,
-            cast(null as integer) as course_id,
-            courserun_title,
-            courserun_start_date as courserun_start_on,  -- edxorg uses _date suffix
-            courserun_end_date as courserun_end_on,
-            courserun_enrollment_start_date as enrollment_start,
-            courserun_enrollment_end_date as enrollment_end,
-            courserun_is_published as courserun_is_live,
-            cast(null as varchar) as courserun_created_on,
-            cast(null as varchar) as course_readable_id,
-            cast(null as varchar) as semester,
-            cast(null as double) as passing_grade,
-            'edxorg' as platform
-        from {{ ref("int__edxorg__mitx_courseruns") }}
-    ),
-    residential_courseruns as (
-        select
-            courserun_readable_id,
-            cast(null as integer) as source_id,
-            cast(null as integer) as course_id,
-            courserun_title,
-            courserun_start_on,
-            courserun_end_on,
-            courserun_enrollment_start_on as enrollment_start,
-            courserun_enrollment_end_on as enrollment_end,
-            cast(null as boolean) as courserun_is_live,
-            courserun_created_on,
-            cast(null as varchar) as course_readable_id,
-            cast(null as varchar) as semester,
-            cast(null as double) as passing_grade,
-            'residential' as platform
-        from {{ ref("int__mitxresidential__courseruns") }}
-    ),
-    bootcamps_courseruns as (
-        select
-            runs.courserun_readable_id,
-            runs.courserun_id as source_id,
-            runs.course_id,
-            runs.courserun_title,
-            runs.courserun_start_on,
-            runs.courserun_end_on,
-            cast(null as varchar) as enrollment_start,
-            cast(null as varchar) as enrollment_end,
-            false as courserun_is_live,
-            cast(null as varchar) as courserun_created_on,
-            runs.course_readable_id,
-            cast(null as varchar) as semester,
-            cast(null as double) as passing_grade,
-            'bootcamps' as platform
-        from {{ ref("int__bootcamps__course_runs") }} as runs
-    ),
-    combined_courseruns as (
-        select *
-        from mitxonline_courseruns
-        union all
-        select *
-        from mitxpro_courseruns
-        union all
-        select *
-        from edxorg_courseruns
-        union all
-        select *
-        from residential_courseruns
-        union all
-        select *
-        from bootcamps_courseruns
-    ),
-    -- Pre-compute course_readable_id for all platforms so the dim_course join is a simple equality
-    combined_courseruns_resolved as (
-        select
-            courserun_readable_id,
-            source_id,
-            course_id,
-            courserun_title,
-            courserun_start_on,
-            courserun_end_on,
-            enrollment_start,
-            enrollment_end,
-            courserun_is_live,
-            courserun_created_on,
-            platform,
-            semester,
-            passing_grade,
-            coalesce(
-                course_readable_id,
-                case
-                    when courserun_readable_id like 'course-v1:%'
-                    then
-                        substring(
-                            courserun_readable_id,
-                            1,
-                            length(courserun_readable_id) - strpos(reverse(courserun_readable_id), '+')
-                        )
-                    when regexp_like(courserun_readable_id, '^[^/]+/[^/]+/[^/]+')
-                    then
-                        substring(
-                            courserun_readable_id,
-                            1,
-                            length(courserun_readable_id) - strpos(reverse(courserun_readable_id), '/')
-                        )
-                    else courserun_readable_id
-                end
-            ) as course_readable_id
-        from combined_courseruns
-    ),
-    -- Join to dim_course to get course_fk
-    dim_course as (
-        select course_pk, course_readable_id, primary_platform from {{ ref("dim_course") }} where is_current = true
-    ),
-    courseruns_with_fk as (
-        select combined_courseruns_resolved.*, dim_course.course_pk as course_fk
-        from combined_courseruns_resolved
-        left join
-            dim_course
-            on combined_courseruns_resolved.platform = dim_course.primary_platform
-            and combined_courseruns_resolved.course_readable_id = dim_course.course_readable_id
-    ),
-    courseruns_with_all_fks as (
-        select
-            courseruns_with_fk.*,
-            dim_platform_lookup.platform_pk as platform_fk,
-            -- Create date keys for date dimension joins (parse to timestamp then format as YYYYMMDD)
-            {{ iso8601_to_date_key("courserun_start_on") }} as courserun_start_date_key,
-            {{ iso8601_to_date_key("courserun_end_on") }} as courserun_end_date_key,
-            {{ iso8601_to_date_key("enrollment_start") }} as enrollment_start_date_key,
-            {{ iso8601_to_date_key("enrollment_end") }} as enrollment_end_date_key
-        from courseruns_with_fk
-        left join
-            (select platform_pk, platform_readable_id from {{ ref("dim_platform") }}) as dim_platform_lookup
-            on courseruns_with_fk.platform = dim_platform_lookup.platform_readable_id
-    ),
-    final as (
-        select
-            {{ dbt_utils.generate_surrogate_key(["platform", "courserun_readable_id"]) }} as courserun_pk,
-            courserun_readable_id,
-            source_id,
-            course_fk,
-            platform_fk,
-            platform,
-            courserun_title,
-            courserun_start_date_key,
-            courserun_end_date_key,
-            enrollment_start_date_key,
-            enrollment_end_date_key,
-            courserun_start_on,
-            courserun_end_on,
-            enrollment_start,
-            enrollment_end,
-            courserun_is_live,
-            courserun_created_on,
-            semester,
-            passing_grade,
-            current_timestamp as effective_date,
-            cast(null as timestamp) as end_date,
-            true as is_current
-        from courseruns_with_all_fks
+            examrun_readable_id
+            , examrun_semester
+            , examrun_passing_grade
+            , row_number() over (
+                partition by examrun_readable_id
+                order by examrun_updated_on desc nulls last, examrun_id desc
+            ) as _row_num
+        from {{ ref('stg__micromasters__app__postgres__exams_examrun') }}
+    ) as deduped_examruns
+    where _row_num = 1
+)
 
-        {% if is_incremental() %}
-            where
-                not exists (
-                    select 1
-                    from {{ this }} as existing
-                    where
-                        existing.courserun_readable_id = courseruns_with_all_fks.courserun_readable_id
-                        and existing.platform = courseruns_with_all_fks.platform
-                        and existing.is_current = true
-                        and existing.courserun_title = courseruns_with_all_fks.courserun_title
-                        and coalesce(existing.courserun_start_on, '')
-                        = coalesce(courseruns_with_all_fks.courserun_start_on, '')
-                        and coalesce(existing.courserun_end_on, '')
-                        = coalesce(courseruns_with_all_fks.courserun_end_on, '')
-                        and coalesce(existing.enrollment_start, '')
-                        = coalesce(courseruns_with_all_fks.enrollment_start, '')
-                        and coalesce(existing.enrollment_end, '') = coalesce(courseruns_with_all_fks.enrollment_end, '')
-                        and coalesce(existing.courserun_is_live, false)
-                        = coalesce(courseruns_with_all_fks.courserun_is_live, false)
-                        and coalesce(existing.semester, '') = coalesce(courseruns_with_all_fks.semester, '')
-                        and coalesce(existing.passing_grade, -1.0)
-                        = coalesce(courseruns_with_all_fks.passing_grade, -1.0)
-                )
-        {% endif %}
+, mitxonline_courseruns as (
+    select
+        cr.courserun_readable_id
+        , cr.courserun_id as source_id
+        , cr.course_id
+        , cr.courserun_title
+        , cr.courserun_start_on
+        , cr.courserun_end_on
+        , cr.courserun_enrollment_start_on as enrollment_start
+        , cr.courserun_enrollment_end_on as enrollment_end
+        , cr.courserun_is_live
+        , cr.courserun_created_on
+        , cast(null as varchar) as course_readable_id
+        , er.examrun_semester as semester
+        , er.examrun_passing_grade as passing_grade
+        , 'mitxonline' as platform
+    from {{ ref('int__mitxonline__course_runs') }} as cr
+    left join micromasters_examruns as er
+        on cr.courserun_readable_id = er.examrun_readable_id
+)
+
+, mitxpro_courseruns as (
+    select
+        courserun_readable_id
+        , courserun_id as source_id
+        , course_id
+        , courserun_title
+        , courserun_start_on
+        , courserun_end_on
+        , courserun_enrollment_start_on as enrollment_start
+        , courserun_enrollment_end_on as enrollment_end
+        , courserun_is_live
+        , courserun_created_on
+        , cast(null as varchar) as course_readable_id
+        , cast(null as varchar) as semester
+        , cast(null as double) as passing_grade
+        , 'mitxpro' as platform
+    from {{ ref('int__mitxpro__course_runs') }}
+)
+
+, edxorg_courseruns as (
+    select
+        courserun_readable_id
+        , cast(null as integer) as source_id
+        , cast(null as integer) as course_id
+        , courserun_title
+        , courserun_start_date as courserun_start_on  -- edxorg uses _date suffix
+        , courserun_end_date as courserun_end_on
+        , courserun_enrollment_start_date as enrollment_start
+        , courserun_enrollment_end_date as enrollment_end
+        , courserun_is_published as courserun_is_live
+        , cast(null as varchar) as courserun_created_on
+        , cast(null as varchar) as course_readable_id
+        , cast(null as varchar) as semester
+        , cast(null as double) as passing_grade
+        , 'edxorg' as platform
+    from {{ ref('int__edxorg__mitx_courseruns') }}
+)
+
+, residential_courseruns as (
+    select
+        courserun_readable_id
+        , cast(null as integer) as source_id
+        , cast(null as integer) as course_id
+        , courserun_title
+        , courserun_start_on
+        , courserun_end_on
+        , courserun_enrollment_start_on as enrollment_start
+        , courserun_enrollment_end_on as enrollment_end
+        , cast(null as boolean) as courserun_is_live
+        , courserun_created_on
+        , cast(null as varchar) as course_readable_id
+        , cast(null as varchar) as semester
+        , cast(null as double) as passing_grade
+        , 'residential' as platform
+    from {{ ref('int__mitxresidential__courseruns') }}
+)
+
+, bootcamps_courseruns as (
+    select
+        runs.courserun_readable_id
+        , runs.courserun_id as source_id
+        , runs.course_id
+        , runs.courserun_title
+        , runs.courserun_start_on
+        , runs.courserun_end_on
+        , cast(null as varchar) as enrollment_start
+        , cast(null as varchar) as enrollment_end
+        , false as courserun_is_live
+        , cast(null as varchar) as courserun_created_on
+        , runs.course_readable_id
+        , cast(null as varchar) as semester
+        , cast(null as double) as passing_grade
+        , 'bootcamps' as platform
+    from {{ ref('int__bootcamps__course_runs') }} as runs
+)
+
+, combined_courseruns as (
+    select * from mitxonline_courseruns
+    union all
+    select * from mitxpro_courseruns
+    union all
+    select * from edxorg_courseruns
+    union all
+    select * from residential_courseruns
+    union all
+    select * from bootcamps_courseruns
+)
+
+-- Pre-compute course_readable_id for all platforms so the dim_course join is a simple equality
+, combined_courseruns_resolved as (
+    select
+        courserun_readable_id
+        , source_id
+        , course_id
+        , courserun_title
+        , courserun_start_on
+        , courserun_end_on
+        , enrollment_start
+        , enrollment_end
+        , courserun_is_live
+        , courserun_created_on
+        , platform
+        , semester
+        , passing_grade
+        , coalesce(
+            course_readable_id,
+            case
+                when courserun_readable_id like 'course-v1:%'
+                    then substring(
+                        courserun_readable_id,
+                        1,
+                        length(courserun_readable_id)
+                        - strpos(reverse(courserun_readable_id), '+')
+                    )
+                when regexp_like(courserun_readable_id, '^[^/]+/[^/]+/[^/]+')
+                    then substring(
+                        courserun_readable_id,
+                        1,
+                        length(courserun_readable_id)
+                        - strpos(reverse(courserun_readable_id), '/')
+                    )
+                else courserun_readable_id
+            end
+        ) as course_readable_id
+    from combined_courseruns
+)
+
+-- Join to dim_course to get course_fk
+, dim_course as (
+    select
+        course_pk
+        , course_readable_id
+        , primary_platform
+    from {{ ref('dim_course') }}
+    where is_current = true
+)
+
+, courseruns_with_fk as (
+    select
+        combined_courseruns_resolved.*
+        , dim_course.course_pk as course_fk
+    from combined_courseruns_resolved
+    left join dim_course
+        on combined_courseruns_resolved.platform = dim_course.primary_platform
+        and combined_courseruns_resolved.course_readable_id = dim_course.course_readable_id
+)
+
+, courseruns_with_all_fks as (
+    select
+        courseruns_with_fk.*
+        , dim_platform_lookup.platform_pk as platform_fk
+        -- Create date keys for date dimension joins (parse to timestamp then format as YYYYMMDD)
+        , {{ iso8601_to_date_key('courserun_start_on') }} as courserun_start_date_key
+        , {{ iso8601_to_date_key('courserun_end_on') }} as courserun_end_date_key
+        , {{ iso8601_to_date_key('enrollment_start') }} as enrollment_start_date_key
+        , {{ iso8601_to_date_key('enrollment_end') }} as enrollment_end_date_key
+    from courseruns_with_fk
+    left join (
+        select platform_pk, platform_readable_id
+        from {{ ref('dim_platform') }}
+    ) as dim_platform_lookup
+        on courseruns_with_fk.platform = dim_platform_lookup.platform_readable_id
+)
+
+, final as (
+    select
+        {{ dbt_utils.generate_surrogate_key([
+            'platform',
+            'courserun_readable_id'
+        ]) }} as courserun_pk
+        , courserun_readable_id
+        , source_id
+        , course_fk
+        , platform_fk
+        , platform
+        , courserun_title
+        , courserun_start_date_key
+        , courserun_end_date_key
+        , enrollment_start_date_key
+        , enrollment_end_date_key
+        , courserun_start_on
+        , courserun_end_on
+        , enrollment_start
+        , enrollment_end
+        , courserun_is_live
+        , courserun_created_on
+        , semester
+        , passing_grade
+        , current_timestamp as effective_date
+        , cast(null as timestamp) as end_date
+        , true as is_current
+    from courseruns_with_all_fks
+
+    {% if is_incremental() %}
+    where not exists (
+        select 1
+        from {{ this }} as existing
+        where
+            existing.courserun_readable_id = courseruns_with_all_fks.courserun_readable_id
+            and existing.platform = courseruns_with_all_fks.platform
+            and existing.is_current = true
+            and existing.courserun_title = courseruns_with_all_fks.courserun_title
+            and coalesce(existing.courserun_start_on, '') = coalesce(courseruns_with_all_fks.courserun_start_on, '')
+            and coalesce(existing.courserun_end_on, '') = coalesce(courseruns_with_all_fks.courserun_end_on, '')
+            and coalesce(existing.enrollment_start, '') = coalesce(courseruns_with_all_fks.enrollment_start, '')
+            and coalesce(existing.enrollment_end, '') = coalesce(courseruns_with_all_fks.enrollment_end, '')
+            and coalesce(existing.courserun_is_live, false) = coalesce(courseruns_with_all_fks.courserun_is_live, false)
+            and coalesce(existing.semester, '') = coalesce(courseruns_with_all_fks.semester, '')
+            and coalesce(existing.passing_grade, -1.0) = coalesce(courseruns_with_all_fks.passing_grade, -1.0)
     )
+    {% endif %}
+)
 
 {% if is_incremental() %}
-        ,
-        -- Expire prior current rows that have changed
-        records_to_expire as (
-            select
-                existing.courserun_pk,
-                existing.courserun_readable_id,
-                existing.source_id,
-                existing.course_fk,
-                existing.platform_fk,
-                existing.platform,
-                existing.courserun_title,
-                existing.courserun_start_date_key,
-                existing.courserun_end_date_key,
-                existing.enrollment_start_date_key,
-                existing.enrollment_end_date_key,
-                existing.courserun_start_on,
-                existing.courserun_end_on,
-                existing.enrollment_start,
-                existing.enrollment_end,
-                existing.courserun_is_live,
-                existing.courserun_created_on,
-                existing.semester,
-                existing.passing_grade,
-                existing.effective_date,
-                current_timestamp as end_date,
-                false as is_current
-            from {{ this }} as existing
-            inner join
-                final as new_records
-                on existing.courserun_readable_id = new_records.courserun_readable_id
-                and existing.platform = new_records.platform
-            where existing.is_current = true
-        ),
-        combined as (
-            select *
-            from final
-            union all
-            select *
-            from records_to_expire
-        )
+-- Expire prior current rows that have changed
+, records_to_expire as (
+    select
+        existing.courserun_pk
+        , existing.courserun_readable_id
+        , existing.source_id
+        , existing.course_fk
+        , existing.platform_fk
+        , existing.platform
+        , existing.courserun_title
+        , existing.courserun_start_date_key
+        , existing.courserun_end_date_key
+        , existing.enrollment_start_date_key
+        , existing.enrollment_end_date_key
+        , existing.courserun_start_on
+        , existing.courserun_end_on
+        , existing.enrollment_start
+        , existing.enrollment_end
+        , existing.courserun_is_live
+        , existing.courserun_created_on
+        , existing.semester
+        , existing.passing_grade
+        , existing.effective_date
+        , current_timestamp as end_date
+        , false as is_current
+    from {{ this }} as existing
+    inner join final as new_records
+        on existing.courserun_readable_id = new_records.courserun_readable_id
+        and existing.platform = new_records.platform
+    where existing.is_current = true
+)
 
-    select *
-    from combined
+, combined as (
+    select * from final
+    union all
+    select * from records_to_expire
+)
+
+select * from combined
 {% else %}
-    select *
-    from final
+select * from final
 {% endif %}

--- a/src/ol_dbt/models/dimensional/dim_course_run.sql
+++ b/src/ol_dbt/models/dimensional/dim_course_run.sql
@@ -1,284 +1,292 @@
-{{
-    config(
-        materialized="incremental",
-        unique_key=["courserun_pk", "effective_date"],
-        incremental_strategy="delete+insert",
-        on_schema_change="append_new_columns",
-    )
-}}
+{{ config(
+    materialized='incremental',
+    unique_key=['courserun_pk', 'effective_date'],
+    incremental_strategy='delete+insert',
+    on_schema_change='append_new_columns'
+) }}
 
 -- MicroMasters stores exam run metadata (semester label and passing grade threshold)
 -- keyed by examrun_readable_id, which matches the MITxOnline courserun_readable_id for
 -- proctored exam course runs. These are the only platform-specific dimensional attributes
 -- that originate outside the platform's own course run record.
-with
-    micromasters_examruns as (
-        select examrun_readable_id, examrun_semester, examrun_passing_grade
-        from {{ ref("stg__micromasters__app__postgres__exams_examrun") }}
-    ),
-    mitxonline_courseruns as (
-        select
-            cr.courserun_readable_id,
-            cr.courserun_id as source_id,
-            cr.course_id,
-            cr.courserun_title,
-            cr.courserun_start_on,
-            cr.courserun_end_on,
-            cr.courserun_enrollment_start_on as enrollment_start,
-            cr.courserun_enrollment_end_on as enrollment_end,
-            cr.courserun_is_live,
-            cr.courserun_created_on,
-            cast(null as varchar) as course_readable_id,
-            er.examrun_semester as semester,
-            er.examrun_passing_grade as passing_grade,
-            'mitxonline' as platform
-        from {{ ref("int__mitxonline__course_runs") }} as cr
-        left join micromasters_examruns as er on cr.courserun_readable_id = er.examrun_readable_id
-    ),
-    mitxpro_courseruns as (
-        select
-            courserun_readable_id,
-            courserun_id as source_id,
-            course_id,
-            courserun_title,
-            courserun_start_on,
-            courserun_end_on,
-            courserun_enrollment_start_on as enrollment_start,
-            courserun_enrollment_end_on as enrollment_end,
-            courserun_is_live,
-            courserun_created_on,
-            cast(null as varchar) as course_readable_id,
-            cast(null as varchar) as semester,
-            cast(null as double) as passing_grade,
-            'mitxpro' as platform
-        from {{ ref("int__mitxpro__course_runs") }}
-    ),
-    edxorg_courseruns as (
-        select
-            courserun_readable_id,
-            cast(null as integer) as source_id,
-            cast(null as integer) as course_id,
-            courserun_title,
-            courserun_start_date as courserun_start_on,  -- edxorg uses _date suffix
-            courserun_end_date as courserun_end_on,
-            courserun_enrollment_start_date as enrollment_start,
-            courserun_enrollment_end_date as enrollment_end,
-            courserun_is_published as courserun_is_live,
-            cast(null as varchar) as courserun_created_on,
-            cast(null as varchar) as course_readable_id,
-            cast(null as varchar) as semester,
-            cast(null as double) as passing_grade,
-            'edxorg' as platform
-        from {{ ref("int__edxorg__mitx_courseruns") }}
-    ),
-    residential_courseruns as (
-        select
-            courserun_readable_id,
-            cast(null as integer) as source_id,
-            cast(null as integer) as course_id,
-            courserun_title,
-            courserun_start_on,
-            courserun_end_on,
-            courserun_enrollment_start_on as enrollment_start,
-            courserun_enrollment_end_on as enrollment_end,
-            cast(null as boolean) as courserun_is_live,
-            courserun_created_on,
-            cast(null as varchar) as course_readable_id,
-            cast(null as varchar) as semester,
-            cast(null as double) as passing_grade,
-            'residential' as platform
-        from {{ ref("int__mitxresidential__courseruns") }}
-    ),
-    bootcamps_courseruns as (
-        select
-            runs.courserun_readable_id,
-            runs.courserun_id as source_id,
-            runs.course_id,
-            runs.courserun_title,
-            runs.courserun_start_on,
-            runs.courserun_end_on,
-            cast(null as varchar) as enrollment_start,
-            cast(null as varchar) as enrollment_end,
-            false as courserun_is_live,
-            cast(null as varchar) as courserun_created_on,
-            runs.course_readable_id,
-            cast(null as varchar) as semester,
-            cast(null as double) as passing_grade,
-            'bootcamps' as platform
-        from {{ ref("int__bootcamps__course_runs") }} as runs
-    ),
-    combined_courseruns as (
-        select *
-        from mitxonline_courseruns
-        union all
-        select *
-        from mitxpro_courseruns
-        union all
-        select *
-        from edxorg_courseruns
-        union all
-        select *
-        from residential_courseruns
-        union all
-        select *
-        from bootcamps_courseruns
-    ),
-    -- Pre-compute course_readable_id for all platforms so the dim_course join is a simple equality
-    combined_courseruns_resolved as (
-        select
-            courserun_readable_id,
-            source_id,
-            course_id,
-            courserun_title,
-            courserun_start_on,
-            courserun_end_on,
-            enrollment_start,
-            enrollment_end,
-            courserun_is_live,
-            courserun_created_on,
-            platform,
-            coalesce(
-                course_readable_id,
-                case
-                    when courserun_readable_id like 'course-v1:%'
-                    then
-                        substring(
-                            courserun_readable_id,
-                            1,
-                            length(courserun_readable_id) - strpos(reverse(courserun_readable_id), '+')
-                        )
-                    when regexp_like(courserun_readable_id, '^[^/]+/[^/]+/[^/]+')
-                    then
-                        substring(
-                            courserun_readable_id,
-                            1,
-                            length(courserun_readable_id) - strpos(reverse(courserun_readable_id), '/')
-                        )
-                    else courserun_readable_id
-                end
-            ) as course_readable_id
-        from combined_courseruns
-    ),
-    -- Join to dim_course to get course_fk
-    dim_course as (
-        select course_pk, course_readable_id, primary_platform from {{ ref("dim_course") }} where is_current = true
-    ),
-    courseruns_with_fk as (
-        select combined_courseruns_resolved.*, dim_course.course_pk as course_fk
-        from combined_courseruns_resolved
-        left join
-            dim_course
-            on combined_courseruns_resolved.platform = dim_course.primary_platform
-            and combined_courseruns_resolved.course_readable_id = dim_course.course_readable_id
-    ),
-    courseruns_with_all_fks as (
-        select
-            courseruns_with_fk.*,
-            dim_platform_lookup.platform_pk as platform_fk,
-            -- Create date keys for date dimension joins (parse to timestamp then format as YYYYMMDD)
-            {{ iso8601_to_date_key("courserun_start_on") }} as courserun_start_date_key,
-            {{ iso8601_to_date_key("courserun_end_on") }} as courserun_end_date_key,
-            {{ iso8601_to_date_key("enrollment_start") }} as enrollment_start_date_key,
-            {{ iso8601_to_date_key("enrollment_end") }} as enrollment_end_date_key
-        from courseruns_with_fk
-        left join
-            (select platform_pk, platform_readable_id from {{ ref("dim_platform") }}) as dim_platform_lookup
-            on courseruns_with_fk.platform = dim_platform_lookup.platform_readable_id
-    ),
-    final as (
-        select
-            {{ dbt_utils.generate_surrogate_key(["platform", "courserun_readable_id"]) }} as courserun_pk,
-            courserun_readable_id,
-            source_id,
-            course_fk,
-            platform_fk,
-            platform,
-            courserun_title,
-            courserun_start_date_key,
-            courserun_end_date_key,
-            enrollment_start_date_key,
-            enrollment_end_date_key,
-            courserun_start_on,
-            courserun_end_on,
-            enrollment_start,
-            enrollment_end,
-            courserun_is_live,
-            courserun_created_on,
-            semester,
-            passing_grade,
-            current_timestamp as effective_date,
-            cast(null as timestamp) as end_date,
-            true as is_current
-        from courseruns_with_all_fks
+with micromasters_examruns as (
+    select examrun_readable_id, examrun_semester, examrun_passing_grade
+    from {{ ref('stg__micromasters__app__postgres__exams_examrun') }}
+)
 
-        {% if is_incremental() %}
-            where
-                not exists (
-                    select 1
-                    from {{ this }} as existing
-                    where
-                        existing.courserun_readable_id = courseruns_with_all_fks.courserun_readable_id
-                        and existing.platform = courseruns_with_all_fks.platform
-                        and existing.is_current = true
-                        and existing.courserun_title = courseruns_with_all_fks.courserun_title
-                        and coalesce(existing.courserun_start_on, '')
-                        = coalesce(courseruns_with_all_fks.courserun_start_on, '')
-                        and coalesce(existing.courserun_end_on, '')
-                        = coalesce(courseruns_with_all_fks.courserun_end_on, '')
-                        and coalesce(existing.enrollment_start, '')
-                        = coalesce(courseruns_with_all_fks.enrollment_start, '')
-                        and coalesce(existing.enrollment_end, '') = coalesce(courseruns_with_all_fks.enrollment_end, '')
-                        and coalesce(existing.courserun_is_live, false)
-                        = coalesce(courseruns_with_all_fks.courserun_is_live, false)
-                        and coalesce(existing.semester, '') = coalesce(courseruns_with_all_fks.semester, '')
-                        and coalesce(existing.passing_grade, 0.0) = coalesce(courseruns_with_all_fks.passing_grade, 0.0)
-                )
-        {% endif %}
+, mitxonline_courseruns as (
+    select
+        cr.courserun_readable_id
+        , cr.courserun_id as source_id
+        , cr.course_id
+        , cr.courserun_title
+        , cr.courserun_start_on
+        , cr.courserun_end_on
+        , cr.courserun_enrollment_start_on as enrollment_start
+        , cr.courserun_enrollment_end_on as enrollment_end
+        , cr.courserun_is_live
+        , cr.courserun_created_on
+        , cast(null as varchar) as course_readable_id
+        , er.examrun_semester as semester
+        , er.examrun_passing_grade as passing_grade
+        , 'mitxonline' as platform
+    from {{ ref('int__mitxonline__course_runs') }} as cr
+    left join micromasters_examruns as er on cr.courserun_readable_id = er.examrun_readable_id
+)
+
+, mitxpro_courseruns as (
+    select
+        courserun_readable_id
+        , courserun_id as source_id
+        , course_id
+        , courserun_title
+        , courserun_start_on
+        , courserun_end_on
+        , courserun_enrollment_start_on as enrollment_start
+        , courserun_enrollment_end_on as enrollment_end
+        , courserun_is_live
+        , courserun_created_on
+        , cast(null as varchar) as course_readable_id
+        , cast(null as varchar) as semester
+        , cast(null as double) as passing_grade
+        , 'mitxpro' as platform
+    from {{ ref('int__mitxpro__course_runs') }}
+)
+
+, edxorg_courseruns as (
+    select
+        courserun_readable_id
+        , cast(null as integer) as source_id
+        , cast(null as integer) as course_id
+        , courserun_title
+        , courserun_start_date as courserun_start_on  -- edxorg uses _date suffix
+        , courserun_end_date as courserun_end_on
+        , courserun_enrollment_start_date as enrollment_start
+        , courserun_enrollment_end_date as enrollment_end
+        , courserun_is_published as courserun_is_live
+        , cast(null as varchar) as courserun_created_on
+        , cast(null as varchar) as course_readable_id
+        , cast(null as varchar) as semester
+        , cast(null as double) as passing_grade
+        , 'edxorg' as platform
+    from {{ ref('int__edxorg__mitx_courseruns') }}
+)
+
+, residential_courseruns as (
+    select
+        courserun_readable_id
+        , cast(null as integer) as source_id
+        , cast(null as integer) as course_id
+        , courserun_title
+        , courserun_start_on
+        , courserun_end_on
+        , courserun_enrollment_start_on as enrollment_start
+        , courserun_enrollment_end_on as enrollment_end
+        , cast(null as boolean) as courserun_is_live
+        , courserun_created_on
+        , cast(null as varchar) as course_readable_id
+        , cast(null as varchar) as semester
+        , cast(null as double) as passing_grade
+        , 'residential' as platform
+    from {{ ref('int__mitxresidential__courseruns') }}
+)
+
+, bootcamps_courseruns as (
+    select
+        runs.courserun_readable_id
+        , runs.courserun_id as source_id
+        , runs.course_id
+        , runs.courserun_title
+        , runs.courserun_start_on
+        , runs.courserun_end_on
+        , cast(null as varchar) as enrollment_start
+        , cast(null as varchar) as enrollment_end
+        , false as courserun_is_live
+        , cast(null as varchar) as courserun_created_on
+        , runs.course_readable_id
+        , cast(null as varchar) as semester
+        , cast(null as double) as passing_grade
+        , 'bootcamps' as platform
+    from {{ ref('int__bootcamps__course_runs') }} as runs
+)
+
+, combined_courseruns as (
+    select * from mitxonline_courseruns
+    union all
+    select * from mitxpro_courseruns
+    union all
+    select * from edxorg_courseruns
+    union all
+    select * from residential_courseruns
+    union all
+    select * from bootcamps_courseruns
+)
+
+-- Pre-compute course_readable_id for all platforms so the dim_course join is a simple equality
+, combined_courseruns_resolved as (
+    select
+        courserun_readable_id
+        , source_id
+        , course_id
+        , courserun_title
+        , courserun_start_on
+        , courserun_end_on
+        , enrollment_start
+        , enrollment_end
+        , courserun_is_live
+        , courserun_created_on
+        , platform
+        , semester
+        , passing_grade
+        , coalesce(
+            course_readable_id,
+            case
+                when courserun_readable_id like 'course-v1:%'
+                    then substring(
+                        courserun_readable_id,
+                        1,
+                        length(courserun_readable_id)
+                        - strpos(reverse(courserun_readable_id), '+')
+                    )
+                when regexp_like(courserun_readable_id, '^[^/]+/[^/]+/[^/]+')
+                    then substring(
+                        courserun_readable_id,
+                        1,
+                        length(courserun_readable_id)
+                        - strpos(reverse(courserun_readable_id), '/')
+                    )
+                else courserun_readable_id
+            end
+        ) as course_readable_id
+    from combined_courseruns
+)
+
+-- Join to dim_course to get course_fk
+, dim_course as (
+    select
+        course_pk
+        , course_readable_id
+        , primary_platform
+    from {{ ref('dim_course') }}
+    where is_current = true
+)
+
+, courseruns_with_fk as (
+    select
+        combined_courseruns_resolved.*
+        , dim_course.course_pk as course_fk
+    from combined_courseruns_resolved
+    left join dim_course
+        on combined_courseruns_resolved.platform = dim_course.primary_platform
+        and combined_courseruns_resolved.course_readable_id = dim_course.course_readable_id
+)
+
+, courseruns_with_all_fks as (
+    select
+        courseruns_with_fk.*
+        , dim_platform_lookup.platform_pk as platform_fk
+        -- Create date keys for date dimension joins (parse to timestamp then format as YYYYMMDD)
+        , {{ iso8601_to_date_key('courserun_start_on') }} as courserun_start_date_key
+        , {{ iso8601_to_date_key('courserun_end_on') }} as courserun_end_date_key
+        , {{ iso8601_to_date_key('enrollment_start') }} as enrollment_start_date_key
+        , {{ iso8601_to_date_key('enrollment_end') }} as enrollment_end_date_key
+    from courseruns_with_fk
+    left join (
+        select platform_pk, platform_readable_id
+        from {{ ref('dim_platform') }}
+    ) as dim_platform_lookup
+        on courseruns_with_fk.platform = dim_platform_lookup.platform_readable_id
+)
+
+, final as (
+    select
+        {{ dbt_utils.generate_surrogate_key([
+            'platform',
+            'courserun_readable_id'
+        ]) }} as courserun_pk
+        , courserun_readable_id
+        , source_id
+        , course_fk
+        , platform_fk
+        , platform
+        , courserun_title
+        , courserun_start_date_key
+        , courserun_end_date_key
+        , enrollment_start_date_key
+        , enrollment_end_date_key
+        , courserun_start_on
+        , courserun_end_on
+        , enrollment_start
+        , enrollment_end
+        , courserun_is_live
+        , courserun_created_on
+        , semester
+        , passing_grade
+        , current_timestamp as effective_date
+        , cast(null as timestamp) as end_date
+        , true as is_current
+    from courseruns_with_all_fks
+
+    {% if is_incremental() %}
+    where not exists (
+        select 1
+        from {{ this }} as existing
+        where
+            existing.courserun_readable_id = courseruns_with_all_fks.courserun_readable_id
+            and existing.platform = courseruns_with_all_fks.platform
+            and existing.is_current = true
+            and existing.courserun_title = courseruns_with_all_fks.courserun_title
+            and coalesce(existing.courserun_start_on, '') = coalesce(courseruns_with_all_fks.courserun_start_on, '')
+            and coalesce(existing.courserun_end_on, '') = coalesce(courseruns_with_all_fks.courserun_end_on, '')
+            and coalesce(existing.enrollment_start, '') = coalesce(courseruns_with_all_fks.enrollment_start, '')
+            and coalesce(existing.enrollment_end, '') = coalesce(courseruns_with_all_fks.enrollment_end, '')
+            and coalesce(existing.courserun_is_live, false) = coalesce(courseruns_with_all_fks.courserun_is_live, false)
+            and coalesce(existing.semester, '') = coalesce(courseruns_with_all_fks.semester, '')
+            and coalesce(existing.passing_grade, -1.0) = coalesce(courseruns_with_all_fks.passing_grade, -1.0)
     )
+    {% endif %}
+)
 
 {% if is_incremental() %}
-        ,
-        -- Expire prior current rows that have changed
-        records_to_expire as (
-            select
-                existing.courserun_pk,
-                existing.courserun_readable_id,
-                existing.source_id,
-                existing.course_fk,
-                existing.platform_fk,
-                existing.platform,
-                existing.courserun_title,
-                existing.courserun_start_date_key,
-                existing.courserun_end_date_key,
-                existing.enrollment_start_date_key,
-                existing.enrollment_end_date_key,
-                existing.courserun_start_on,
-                existing.courserun_end_on,
-                existing.enrollment_start,
-                existing.enrollment_end,
-                existing.courserun_is_live,
-                existing.courserun_created_on,
-                existing.semester,
-                existing.passing_grade,
-                existing.effective_date,
-                current_timestamp as end_date,
-                false as is_current
-            from {{ this }} as existing
-            inner join
-                final as new_records
-                on existing.courserun_readable_id = new_records.courserun_readable_id
-                and existing.platform = new_records.platform
-            where existing.is_current = true
-        ),
-        combined as (
-            select *
-            from final
-            union all
-            select *
-            from records_to_expire
-        )
+-- Expire prior current rows that have changed
+, records_to_expire as (
+    select
+        existing.courserun_pk
+        , existing.courserun_readable_id
+        , existing.source_id
+        , existing.course_fk
+        , existing.platform_fk
+        , existing.platform
+        , existing.courserun_title
+        , existing.courserun_start_date_key
+        , existing.courserun_end_date_key
+        , existing.enrollment_start_date_key
+        , existing.enrollment_end_date_key
+        , existing.courserun_start_on
+        , existing.courserun_end_on
+        , existing.enrollment_start
+        , existing.enrollment_end
+        , existing.courserun_is_live
+        , existing.courserun_created_on
+        , existing.semester
+        , existing.passing_grade
+        , existing.effective_date
+        , current_timestamp as end_date
+        , false as is_current
+    from {{ this }} as existing
+    inner join final as new_records
+        on existing.courserun_readable_id = new_records.courserun_readable_id
+        and existing.platform = new_records.platform
+    where existing.is_current = true
+)
 
-    select *
-    from combined
-{% else %} select * from final
+, combined as (
+    select * from final
+    union all
+    select * from records_to_expire
+)
+
+select * from combined
+{% else %}
+select * from final
 {% endif %}

--- a/src/ol_dbt/models/dimensional/dim_course_run.sql
+++ b/src/ol_dbt/models/dimensional/dim_course_run.sql
@@ -1,264 +1,284 @@
-{{ config(
-    materialized='incremental',
-    unique_key=['courserun_pk', 'effective_date'],
-    incremental_strategy='delete+insert',
-    on_schema_change='append_new_columns'
-) }}
-
-with mitxonline_courseruns as (
-    select
-        courserun_readable_id
-        , courserun_id as source_id
-        , course_id
-        , courserun_title
-        , courserun_start_on
-        , courserun_end_on
-        , courserun_enrollment_start_on as enrollment_start
-        , courserun_enrollment_end_on as enrollment_end
-        , courserun_is_live
-        , courserun_created_on
-        , cast(null as varchar) as course_readable_id
-        , 'mitxonline' as platform
-    from {{ ref('int__mitxonline__course_runs') }}
-)
-
-, mitxpro_courseruns as (
-    select
-        courserun_readable_id
-        , courserun_id as source_id
-        , course_id
-        , courserun_title
-        , courserun_start_on
-        , courserun_end_on
-        , courserun_enrollment_start_on as enrollment_start
-        , courserun_enrollment_end_on as enrollment_end
-        , courserun_is_live
-        , courserun_created_on
-        , cast(null as varchar) as course_readable_id
-        , 'mitxpro' as platform
-    from {{ ref('int__mitxpro__course_runs') }}
-)
-
-, edxorg_courseruns as (
-    select
-        courserun_readable_id
-        , cast(null as integer) as source_id
-        , cast(null as integer) as course_id
-        , courserun_title
-        , courserun_start_date as courserun_start_on  -- edxorg uses _date suffix
-        , courserun_end_date as courserun_end_on
-        , courserun_enrollment_start_date as enrollment_start
-        , courserun_enrollment_end_date as enrollment_end
-        , courserun_is_published as courserun_is_live
-        , cast(null as varchar) as courserun_created_on
-        , cast(null as varchar) as course_readable_id
-        , 'edxorg' as platform
-    from {{ ref('int__edxorg__mitx_courseruns') }}
-)
-
-, residential_courseruns as (
-    select
-        courserun_readable_id
-        , cast(null as integer) as source_id
-        , cast(null as integer) as course_id
-        , courserun_title
-        , courserun_start_on
-        , courserun_end_on
-        , courserun_enrollment_start_on as enrollment_start
-        , courserun_enrollment_end_on as enrollment_end
-        , cast(null as boolean) as courserun_is_live
-        , courserun_created_on
-        , cast(null as varchar) as course_readable_id
-        , 'residential' as platform
-    from {{ ref('int__mitxresidential__courseruns') }}
-)
-
-, bootcamps_courseruns as (
-    select
-        runs.courserun_readable_id
-        , runs.courserun_id as source_id
-        , runs.course_id
-        , runs.courserun_title
-        , runs.courserun_start_on
-        , runs.courserun_end_on
-        , cast(null as varchar) as enrollment_start
-        , cast(null as varchar) as enrollment_end
-        , false as courserun_is_live
-        , cast(null as varchar) as courserun_created_on
-        , runs.course_readable_id
-        , 'bootcamps' as platform
-    from {{ ref('int__bootcamps__course_runs') }} as runs
-)
-
-, combined_courseruns as (
-    select * from mitxonline_courseruns
-    union all
-    select * from mitxpro_courseruns
-    union all
-    select * from edxorg_courseruns
-    union all
-    select * from residential_courseruns
-    union all
-    select * from bootcamps_courseruns
-)
-
--- Pre-compute course_readable_id for all platforms so the dim_course join is a simple equality
-, combined_courseruns_resolved as (
-    select
-        courserun_readable_id
-        , source_id
-        , course_id
-        , courserun_title
-        , courserun_start_on
-        , courserun_end_on
-        , enrollment_start
-        , enrollment_end
-        , courserun_is_live
-        , courserun_created_on
-        , platform
-        , coalesce(
-            course_readable_id,
-            case
-                when courserun_readable_id like 'course-v1:%'
-                    then substring(
-                        courserun_readable_id,
-                        1,
-                        length(courserun_readable_id)
-                        - strpos(reverse(courserun_readable_id), '+')
-                    )
-                when regexp_like(courserun_readable_id, '^[^/]+/[^/]+/[^/]+')
-                    then substring(
-                        courserun_readable_id,
-                        1,
-                        length(courserun_readable_id)
-                        - strpos(reverse(courserun_readable_id), '/')
-                    )
-                else courserun_readable_id
-            end
-        ) as course_readable_id
-    from combined_courseruns
-)
-
--- Join to dim_course to get course_fk
-, dim_course as (
-    select
-        course_pk
-        , course_readable_id
-        , primary_platform
-    from {{ ref('dim_course') }}
-    where is_current = true
-)
-
-, courseruns_with_fk as (
-    select
-        combined_courseruns_resolved.*
-        , dim_course.course_pk as course_fk
-    from combined_courseruns_resolved
-    left join dim_course
-        on combined_courseruns_resolved.platform = dim_course.primary_platform
-        and combined_courseruns_resolved.course_readable_id = dim_course.course_readable_id
-)
-
-, courseruns_with_all_fks as (
-    select
-        courseruns_with_fk.*
-        , dim_platform_lookup.platform_pk as platform_fk
-        -- Create date keys for date dimension joins (parse to timestamp then format as YYYYMMDD)
-        , {{ iso8601_to_date_key('courserun_start_on') }} as courserun_start_date_key
-        , {{ iso8601_to_date_key('courserun_end_on') }} as courserun_end_date_key
-        , {{ iso8601_to_date_key('enrollment_start') }} as enrollment_start_date_key
-        , {{ iso8601_to_date_key('enrollment_end') }} as enrollment_end_date_key
-    from courseruns_with_fk
-    left join (
-        select platform_pk, platform_readable_id
-        from {{ ref('dim_platform') }}
-    ) as dim_platform_lookup
-        on courseruns_with_fk.platform = dim_platform_lookup.platform_readable_id
-)
-
-, final as (
-    select
-        {{ dbt_utils.generate_surrogate_key([
-            'platform',
-            'courserun_readable_id'
-        ]) }} as courserun_pk
-        , courserun_readable_id
-        , source_id
-        , course_fk
-        , platform_fk
-        , platform
-        , courserun_title
-        , courserun_start_date_key
-        , courserun_end_date_key
-        , enrollment_start_date_key
-        , enrollment_end_date_key
-        , courserun_start_on
-        , courserun_end_on
-        , enrollment_start
-        , enrollment_end
-        , courserun_is_live
-        , courserun_created_on
-        , current_timestamp as effective_date
-        , cast(null as timestamp) as end_date
-        , true as is_current
-    from courseruns_with_all_fks
-
-    {% if is_incremental() %}
-    where not exists (
-        select 1
-        from {{ this }} as existing
-        where
-            existing.courserun_readable_id = courseruns_with_all_fks.courserun_readable_id
-            and existing.platform = courseruns_with_all_fks.platform
-            and existing.is_current = true
-            and existing.courserun_title = courseruns_with_all_fks.courserun_title
-            and coalesce(existing.courserun_start_on, '') = coalesce(courseruns_with_all_fks.courserun_start_on, '')
-            and coalesce(existing.courserun_end_on, '') = coalesce(courseruns_with_all_fks.courserun_end_on, '')
-            and coalesce(existing.enrollment_start, '') = coalesce(courseruns_with_all_fks.enrollment_start, '')
-            and coalesce(existing.enrollment_end, '') = coalesce(courseruns_with_all_fks.enrollment_end, '')
-            and coalesce(existing.courserun_is_live, false) = coalesce(courseruns_with_all_fks.courserun_is_live, false)
+{{
+    config(
+        materialized="incremental",
+        unique_key=["courserun_pk", "effective_date"],
+        incremental_strategy="delete+insert",
+        on_schema_change="append_new_columns",
     )
-    {% endif %}
-)
+}}
+
+-- MicroMasters stores exam run metadata (semester label and passing grade threshold)
+-- keyed by examrun_readable_id, which matches the MITxOnline courserun_readable_id for
+-- proctored exam course runs. These are the only platform-specific dimensional attributes
+-- that originate outside the platform's own course run record.
+with
+    micromasters_examruns as (
+        select examrun_readable_id, examrun_semester, examrun_passing_grade
+        from {{ ref("stg__micromasters__app__postgres__exams_examrun") }}
+    ),
+    mitxonline_courseruns as (
+        select
+            cr.courserun_readable_id,
+            cr.courserun_id as source_id,
+            cr.course_id,
+            cr.courserun_title,
+            cr.courserun_start_on,
+            cr.courserun_end_on,
+            cr.courserun_enrollment_start_on as enrollment_start,
+            cr.courserun_enrollment_end_on as enrollment_end,
+            cr.courserun_is_live,
+            cr.courserun_created_on,
+            cast(null as varchar) as course_readable_id,
+            er.examrun_semester as semester,
+            er.examrun_passing_grade as passing_grade,
+            'mitxonline' as platform
+        from {{ ref("int__mitxonline__course_runs") }} as cr
+        left join micromasters_examruns as er on cr.courserun_readable_id = er.examrun_readable_id
+    ),
+    mitxpro_courseruns as (
+        select
+            courserun_readable_id,
+            courserun_id as source_id,
+            course_id,
+            courserun_title,
+            courserun_start_on,
+            courserun_end_on,
+            courserun_enrollment_start_on as enrollment_start,
+            courserun_enrollment_end_on as enrollment_end,
+            courserun_is_live,
+            courserun_created_on,
+            cast(null as varchar) as course_readable_id,
+            cast(null as varchar) as semester,
+            cast(null as double) as passing_grade,
+            'mitxpro' as platform
+        from {{ ref("int__mitxpro__course_runs") }}
+    ),
+    edxorg_courseruns as (
+        select
+            courserun_readable_id,
+            cast(null as integer) as source_id,
+            cast(null as integer) as course_id,
+            courserun_title,
+            courserun_start_date as courserun_start_on,  -- edxorg uses _date suffix
+            courserun_end_date as courserun_end_on,
+            courserun_enrollment_start_date as enrollment_start,
+            courserun_enrollment_end_date as enrollment_end,
+            courserun_is_published as courserun_is_live,
+            cast(null as varchar) as courserun_created_on,
+            cast(null as varchar) as course_readable_id,
+            cast(null as varchar) as semester,
+            cast(null as double) as passing_grade,
+            'edxorg' as platform
+        from {{ ref("int__edxorg__mitx_courseruns") }}
+    ),
+    residential_courseruns as (
+        select
+            courserun_readable_id,
+            cast(null as integer) as source_id,
+            cast(null as integer) as course_id,
+            courserun_title,
+            courserun_start_on,
+            courserun_end_on,
+            courserun_enrollment_start_on as enrollment_start,
+            courserun_enrollment_end_on as enrollment_end,
+            cast(null as boolean) as courserun_is_live,
+            courserun_created_on,
+            cast(null as varchar) as course_readable_id,
+            cast(null as varchar) as semester,
+            cast(null as double) as passing_grade,
+            'residential' as platform
+        from {{ ref("int__mitxresidential__courseruns") }}
+    ),
+    bootcamps_courseruns as (
+        select
+            runs.courserun_readable_id,
+            runs.courserun_id as source_id,
+            runs.course_id,
+            runs.courserun_title,
+            runs.courserun_start_on,
+            runs.courserun_end_on,
+            cast(null as varchar) as enrollment_start,
+            cast(null as varchar) as enrollment_end,
+            false as courserun_is_live,
+            cast(null as varchar) as courserun_created_on,
+            runs.course_readable_id,
+            cast(null as varchar) as semester,
+            cast(null as double) as passing_grade,
+            'bootcamps' as platform
+        from {{ ref("int__bootcamps__course_runs") }} as runs
+    ),
+    combined_courseruns as (
+        select *
+        from mitxonline_courseruns
+        union all
+        select *
+        from mitxpro_courseruns
+        union all
+        select *
+        from edxorg_courseruns
+        union all
+        select *
+        from residential_courseruns
+        union all
+        select *
+        from bootcamps_courseruns
+    ),
+    -- Pre-compute course_readable_id for all platforms so the dim_course join is a simple equality
+    combined_courseruns_resolved as (
+        select
+            courserun_readable_id,
+            source_id,
+            course_id,
+            courserun_title,
+            courserun_start_on,
+            courserun_end_on,
+            enrollment_start,
+            enrollment_end,
+            courserun_is_live,
+            courserun_created_on,
+            platform,
+            coalesce(
+                course_readable_id,
+                case
+                    when courserun_readable_id like 'course-v1:%'
+                    then
+                        substring(
+                            courserun_readable_id,
+                            1,
+                            length(courserun_readable_id) - strpos(reverse(courserun_readable_id), '+')
+                        )
+                    when regexp_like(courserun_readable_id, '^[^/]+/[^/]+/[^/]+')
+                    then
+                        substring(
+                            courserun_readable_id,
+                            1,
+                            length(courserun_readable_id) - strpos(reverse(courserun_readable_id), '/')
+                        )
+                    else courserun_readable_id
+                end
+            ) as course_readable_id
+        from combined_courseruns
+    ),
+    -- Join to dim_course to get course_fk
+    dim_course as (
+        select course_pk, course_readable_id, primary_platform from {{ ref("dim_course") }} where is_current = true
+    ),
+    courseruns_with_fk as (
+        select combined_courseruns_resolved.*, dim_course.course_pk as course_fk
+        from combined_courseruns_resolved
+        left join
+            dim_course
+            on combined_courseruns_resolved.platform = dim_course.primary_platform
+            and combined_courseruns_resolved.course_readable_id = dim_course.course_readable_id
+    ),
+    courseruns_with_all_fks as (
+        select
+            courseruns_with_fk.*,
+            dim_platform_lookup.platform_pk as platform_fk,
+            -- Create date keys for date dimension joins (parse to timestamp then format as YYYYMMDD)
+            {{ iso8601_to_date_key("courserun_start_on") }} as courserun_start_date_key,
+            {{ iso8601_to_date_key("courserun_end_on") }} as courserun_end_date_key,
+            {{ iso8601_to_date_key("enrollment_start") }} as enrollment_start_date_key,
+            {{ iso8601_to_date_key("enrollment_end") }} as enrollment_end_date_key
+        from courseruns_with_fk
+        left join
+            (select platform_pk, platform_readable_id from {{ ref("dim_platform") }}) as dim_platform_lookup
+            on courseruns_with_fk.platform = dim_platform_lookup.platform_readable_id
+    ),
+    final as (
+        select
+            {{ dbt_utils.generate_surrogate_key(["platform", "courserun_readable_id"]) }} as courserun_pk,
+            courserun_readable_id,
+            source_id,
+            course_fk,
+            platform_fk,
+            platform,
+            courserun_title,
+            courserun_start_date_key,
+            courserun_end_date_key,
+            enrollment_start_date_key,
+            enrollment_end_date_key,
+            courserun_start_on,
+            courserun_end_on,
+            enrollment_start,
+            enrollment_end,
+            courserun_is_live,
+            courserun_created_on,
+            semester,
+            passing_grade,
+            current_timestamp as effective_date,
+            cast(null as timestamp) as end_date,
+            true as is_current
+        from courseruns_with_all_fks
+
+        {% if is_incremental() %}
+            where
+                not exists (
+                    select 1
+                    from {{ this }} as existing
+                    where
+                        existing.courserun_readable_id = courseruns_with_all_fks.courserun_readable_id
+                        and existing.platform = courseruns_with_all_fks.platform
+                        and existing.is_current = true
+                        and existing.courserun_title = courseruns_with_all_fks.courserun_title
+                        and coalesce(existing.courserun_start_on, '')
+                        = coalesce(courseruns_with_all_fks.courserun_start_on, '')
+                        and coalesce(existing.courserun_end_on, '')
+                        = coalesce(courseruns_with_all_fks.courserun_end_on, '')
+                        and coalesce(existing.enrollment_start, '')
+                        = coalesce(courseruns_with_all_fks.enrollment_start, '')
+                        and coalesce(existing.enrollment_end, '') = coalesce(courseruns_with_all_fks.enrollment_end, '')
+                        and coalesce(existing.courserun_is_live, false)
+                        = coalesce(courseruns_with_all_fks.courserun_is_live, false)
+                        and coalesce(existing.semester, '') = coalesce(courseruns_with_all_fks.semester, '')
+                        and coalesce(existing.passing_grade, 0.0) = coalesce(courseruns_with_all_fks.passing_grade, 0.0)
+                )
+        {% endif %}
+    )
 
 {% if is_incremental() %}
--- Expire prior current rows that have changed
-, records_to_expire as (
-    select
-        existing.courserun_pk
-        , existing.courserun_readable_id
-        , existing.source_id
-        , existing.course_fk
-        , existing.platform_fk
-        , existing.platform
-        , existing.courserun_title
-        , existing.courserun_start_date_key
-        , existing.courserun_end_date_key
-        , existing.enrollment_start_date_key
-        , existing.enrollment_end_date_key
-        , existing.courserun_start_on
-        , existing.courserun_end_on
-        , existing.enrollment_start
-        , existing.enrollment_end
-        , existing.courserun_is_live
-        , existing.courserun_created_on
-        , existing.effective_date
-        , current_timestamp as end_date
-        , false as is_current
-    from {{ this }} as existing
-    inner join final as new_records
-        on existing.courserun_readable_id = new_records.courserun_readable_id
-        and existing.platform = new_records.platform
-    where existing.is_current = true
-)
+        ,
+        -- Expire prior current rows that have changed
+        records_to_expire as (
+            select
+                existing.courserun_pk,
+                existing.courserun_readable_id,
+                existing.source_id,
+                existing.course_fk,
+                existing.platform_fk,
+                existing.platform,
+                existing.courserun_title,
+                existing.courserun_start_date_key,
+                existing.courserun_end_date_key,
+                existing.enrollment_start_date_key,
+                existing.enrollment_end_date_key,
+                existing.courserun_start_on,
+                existing.courserun_end_on,
+                existing.enrollment_start,
+                existing.enrollment_end,
+                existing.courserun_is_live,
+                existing.courserun_created_on,
+                existing.semester,
+                existing.passing_grade,
+                existing.effective_date,
+                current_timestamp as end_date,
+                false as is_current
+            from {{ this }} as existing
+            inner join
+                final as new_records
+                on existing.courserun_readable_id = new_records.courserun_readable_id
+                and existing.platform = new_records.platform
+            where existing.is_current = true
+        ),
+        combined as (
+            select *
+            from final
+            union all
+            select *
+            from records_to_expire
+        )
 
-, combined as (
-    select * from final
-    union all
-    select * from records_to_expire
-)
-
-select * from combined
-{% else %}
-select * from final
+    select *
+    from combined
+{% else %} select * from final
 {% endif %}

--- a/src/ol_dbt/models/marts/micromasters/_marts_micromasters__models.yml
+++ b/src/ol_dbt/models/marts/micromasters/_marts_micromasters__models.yml
@@ -39,9 +39,8 @@ models:
     tests:
     - not_null
   - name: semester
-    description: str, semester for the exam, e.g., 2T2022.
-    tests:
-    - not_null
+    description: str, semester for the exam, e.g., 2T2022. Null for MITx Online exam
+      runs that do not have a corresponding MicroMasters exam run record.
   tests:
   - dbt_expectations.expect_compound_columns_to_be_unique:
       arguments:

--- a/src/ol_dbt/models/marts/micromasters/marts__micromasters_dedp_exam_grades.sql
+++ b/src/ol_dbt/models/marts/micromasters/marts__micromasters_dedp_exam_grades.sql
@@ -1,49 +1,50 @@
-with micromasters_exam_grades as (
-    select * from {{ ref('int__micromasters__dedp_proctored_exam_grades') }}
-)
-
-, mitxonline_exam_grades as (
-    select * from {{ ref('int__mitxonline__proctored_exam_grades') }}
-)
-
-, micromasters_users as (
-    select * from {{ ref('int__micromasters__users') }}
-)
+-- semester and passing_grade sourced from dim_course_run (dimensional layer).
+-- Grade data still sourced from intermediates pending MicroMasters being added to
+-- tfact_grade (tracked in epic #2072).
+with
+    micromasters_exam_grades as (select * from {{ ref("int__micromasters__dedp_proctored_exam_grades") }}),
+    mitxonline_exam_grades as (select * from {{ ref("int__mitxonline__proctored_exam_grades") }}),
+    micromasters_users as (select * from {{ ref("int__micromasters__users") }}),
+    course_run_dim as (
+        select courserun_readable_id, semester, passing_grade from {{ ref("dim_course_run") }} where is_current = true
+    )
 
 select
-    course_number
-    , course_title
-    , examrun_readable_id as examrun_courserun_readable_id
-    , user_edxorg_username
-    , user_mitxonline_username
-    , user_full_name
-    , user_micromasters_email
-    , user_mitxonline_email
-    , examrun_passing_grade as proctoredexamgrade_passing_grade
-    , proctoredexamgrade_percentage_grade
-    , proctoredexamgrade_created_on
-    , examrun_semester as semester
+    course_number,
+    course_title,
+    micromasters_exam_grades.examrun_readable_id as examrun_courserun_readable_id,
+    user_edxorg_username,
+    user_mitxonline_username,
+    user_full_name,
+    user_micromasters_email,
+    user_mitxonline_email,
+    course_run_dim.passing_grade as proctoredexamgrade_passing_grade,
+    proctoredexamgrade_percentage_grade,
+    proctoredexamgrade_created_on,
+    course_run_dim.semester
 from micromasters_exam_grades
+left join course_run_dim on micromasters_exam_grades.examrun_readable_id = course_run_dim.courserun_readable_id
 
 union all
 
 select
-    mitxonline_exam_grades.course_number
-    , mitxonline_exam_grades.course_title
-    , mitxonline_exam_grades.courserun_readable_id as examrun_courserun_readable_id
-    , mitxonline_exam_grades.user_edxorg_username
-    , mitxonline_exam_grades.user_username as user_mitxonline_username
-    , mitxonline_exam_grades.user_full_name
-    , micromasters_users.user_email as user_micromasters_email
-    , mitxonline_exam_grades.user_email as user_mitxonline_email
-    , mitxonline_exam_grades.proctoredexamgrade_passing_grade
-    , mitxonline_exam_grades.proctoredexamgrade_grade as proctoredexamgrade_percentage_grade
-    , mitxonline_exam_grades.proctoredexamgrade_created_on
-    , mitxonline_exam_grades.semester
+    mitxonline_exam_grades.course_number,
+    mitxonline_exam_grades.course_title,
+    mitxonline_exam_grades.courserun_readable_id as examrun_courserun_readable_id,
+    mitxonline_exam_grades.user_edxorg_username,
+    mitxonline_exam_grades.user_username as user_mitxonline_username,
+    mitxonline_exam_grades.user_full_name,
+    micromasters_users.user_email as user_micromasters_email,
+    mitxonline_exam_grades.user_email as user_mitxonline_email,
+    course_run_dim.passing_grade as proctoredexamgrade_passing_grade,
+    mitxonline_exam_grades.proctoredexamgrade_grade as proctoredexamgrade_percentage_grade,
+    mitxonline_exam_grades.proctoredexamgrade_created_on,
+    course_run_dim.semester
 from mitxonline_exam_grades
 left join micromasters_users on mitxonline_exam_grades.user_username = micromasters_users.user_mitxonline_username
-left join micromasters_exam_grades
-    on
-        mitxonline_exam_grades.courserun_readable_id = micromasters_exam_grades.examrun_readable_id
-        and mitxonline_exam_grades.user_username = micromasters_exam_grades.user_mitxonline_username
+left join course_run_dim on mitxonline_exam_grades.courserun_readable_id = course_run_dim.courserun_readable_id
+left join
+    micromasters_exam_grades
+    on mitxonline_exam_grades.courserun_readable_id = micromasters_exam_grades.examrun_readable_id
+    and mitxonline_exam_grades.user_username = micromasters_exam_grades.user_mitxonline_username
 where micromasters_exam_grades.user_mitxonline_username is null and micromasters_exam_grades.examrun_readable_id is null

--- a/src/ol_dbt/models/marts/micromasters/marts__micromasters_dedp_exam_grades.sql
+++ b/src/ol_dbt/models/marts/micromasters/marts__micromasters_dedp_exam_grades.sql
@@ -1,13 +1,11 @@
--- semester and passing_grade sourced from dim_course_run (dimensional layer).
--- Grade data still sourced from intermediates pending MicroMasters being added to
--- tfact_grade (tracked in epic #2072).
+-- semester and passing_grade are now available on dim_course_run (dimensional layer),
+-- sourced via the micromasters_examruns join added in this PR.
+-- Grade data and exam run metadata still sourced from intermediates pending MicroMasters
+-- being added to tfact_grade (tracked in epic #2072).
 with
     micromasters_exam_grades as (select * from {{ ref("int__micromasters__dedp_proctored_exam_grades") }}),
     mitxonline_exam_grades as (select * from {{ ref("int__mitxonline__proctored_exam_grades") }}),
-    micromasters_users as (select * from {{ ref("int__micromasters__users") }}),
-    course_run_dim as (
-        select courserun_readable_id, semester, passing_grade from {{ ref("dim_course_run") }} where is_current = true
-    )
+    micromasters_users as (select * from {{ ref("int__micromasters__users") }})
 
 select
     course_number,
@@ -18,12 +16,11 @@ select
     user_full_name,
     user_micromasters_email,
     user_mitxonline_email,
-    course_run_dim.passing_grade as proctoredexamgrade_passing_grade,
+    micromasters_exam_grades.examrun_passing_grade as proctoredexamgrade_passing_grade,
     proctoredexamgrade_percentage_grade,
     proctoredexamgrade_created_on,
-    course_run_dim.semester
+    micromasters_exam_grades.examrun_semester as semester
 from micromasters_exam_grades
-left join course_run_dim on micromasters_exam_grades.examrun_readable_id = course_run_dim.courserun_readable_id
 
 union all
 
@@ -36,13 +33,12 @@ select
     mitxonline_exam_grades.user_full_name,
     micromasters_users.user_email as user_micromasters_email,
     mitxonline_exam_grades.user_email as user_mitxonline_email,
-    course_run_dim.passing_grade as proctoredexamgrade_passing_grade,
+    mitxonline_exam_grades.proctoredexamgrade_passing_grade,
     mitxonline_exam_grades.proctoredexamgrade_grade as proctoredexamgrade_percentage_grade,
     mitxonline_exam_grades.proctoredexamgrade_created_on,
-    course_run_dim.semester
+    mitxonline_exam_grades.semester
 from mitxonline_exam_grades
 left join micromasters_users on mitxonline_exam_grades.user_username = micromasters_users.user_mitxonline_username
-left join course_run_dim on mitxonline_exam_grades.courserun_readable_id = course_run_dim.courserun_readable_id
 left join
     micromasters_exam_grades
     on mitxonline_exam_grades.courserun_readable_id = micromasters_exam_grades.examrun_readable_id

--- a/src/ol_dbt/models/marts/micromasters/marts__micromasters_dedp_exam_grades.sql
+++ b/src/ol_dbt/models/marts/micromasters/marts__micromasters_dedp_exam_grades.sql
@@ -1,46 +1,49 @@
--- semester and passing_grade are now available on dim_course_run (dimensional layer),
--- sourced via the micromasters_examruns join added in this PR.
--- Grade data and exam run metadata still sourced from intermediates pending MicroMasters
--- being added to tfact_grade (tracked in epic #2072).
-with
-    micromasters_exam_grades as (select * from {{ ref("int__micromasters__dedp_proctored_exam_grades") }}),
-    mitxonline_exam_grades as (select * from {{ ref("int__mitxonline__proctored_exam_grades") }}),
-    micromasters_users as (select * from {{ ref("int__micromasters__users") }})
+with micromasters_exam_grades as (
+    select * from {{ ref('int__micromasters__dedp_proctored_exam_grades') }}
+)
+
+, mitxonline_exam_grades as (
+    select * from {{ ref('int__mitxonline__proctored_exam_grades') }}
+)
+
+, micromasters_users as (
+    select * from {{ ref('int__micromasters__users') }}
+)
 
 select
-    course_number,
-    course_title,
-    micromasters_exam_grades.examrun_readable_id as examrun_courserun_readable_id,
-    user_edxorg_username,
-    user_mitxonline_username,
-    user_full_name,
-    user_micromasters_email,
-    user_mitxonline_email,
-    micromasters_exam_grades.examrun_passing_grade as proctoredexamgrade_passing_grade,
-    proctoredexamgrade_percentage_grade,
-    proctoredexamgrade_created_on,
-    micromasters_exam_grades.examrun_semester as semester
+    course_number
+    , course_title
+    , examrun_readable_id as examrun_courserun_readable_id
+    , user_edxorg_username
+    , user_mitxonline_username
+    , user_full_name
+    , user_micromasters_email
+    , user_mitxonline_email
+    , examrun_passing_grade as proctoredexamgrade_passing_grade
+    , proctoredexamgrade_percentage_grade
+    , proctoredexamgrade_created_on
+    , examrun_semester as semester
 from micromasters_exam_grades
 
 union all
 
 select
-    mitxonline_exam_grades.course_number,
-    mitxonline_exam_grades.course_title,
-    mitxonline_exam_grades.courserun_readable_id as examrun_courserun_readable_id,
-    mitxonline_exam_grades.user_edxorg_username,
-    mitxonline_exam_grades.user_username as user_mitxonline_username,
-    mitxonline_exam_grades.user_full_name,
-    micromasters_users.user_email as user_micromasters_email,
-    mitxonline_exam_grades.user_email as user_mitxonline_email,
-    mitxonline_exam_grades.proctoredexamgrade_passing_grade,
-    mitxonline_exam_grades.proctoredexamgrade_grade as proctoredexamgrade_percentage_grade,
-    mitxonline_exam_grades.proctoredexamgrade_created_on,
-    mitxonline_exam_grades.semester
+    mitxonline_exam_grades.course_number
+    , mitxonline_exam_grades.course_title
+    , mitxonline_exam_grades.courserun_readable_id as examrun_courserun_readable_id
+    , mitxonline_exam_grades.user_edxorg_username
+    , mitxonline_exam_grades.user_username as user_mitxonline_username
+    , mitxonline_exam_grades.user_full_name
+    , micromasters_users.user_email as user_micromasters_email
+    , mitxonline_exam_grades.user_email as user_mitxonline_email
+    , mitxonline_exam_grades.proctoredexamgrade_passing_grade
+    , mitxonline_exam_grades.proctoredexamgrade_grade as proctoredexamgrade_percentage_grade
+    , mitxonline_exam_grades.proctoredexamgrade_created_on
+    , mitxonline_exam_grades.semester
 from mitxonline_exam_grades
 left join micromasters_users on mitxonline_exam_grades.user_username = micromasters_users.user_mitxonline_username
-left join
-    micromasters_exam_grades
-    on mitxonline_exam_grades.courserun_readable_id = micromasters_exam_grades.examrun_readable_id
-    and mitxonline_exam_grades.user_username = micromasters_exam_grades.user_mitxonline_username
+left join micromasters_exam_grades
+    on
+        mitxonline_exam_grades.courserun_readable_id = micromasters_exam_grades.examrun_readable_id
+        and mitxonline_exam_grades.user_username = micromasters_exam_grades.user_mitxonline_username
 where micromasters_exam_grades.user_mitxonline_username is null and micromasters_exam_grades.examrun_readable_id is null


### PR DESCRIPTION
### What are the relevant tickets?
Partially addresses #2088

> **Scope note**: This PR only adds `semester` and `passing_grade` to `dim_course_run` as the dimensional
> source of truth. The mart (`marts__micromasters_dedp_exam_grades`) is **not migrated in this PR** — it
> still reads `examrun_semester`/`examrun_passing_grade` from intermediate models. Fully migrating the
> mart requires MicroMasters exam grade data to be added to `tfact_grade` (the larger remaining work in
> epic #2072), tracked as a follow-on to close #2088.

### Description (What does it do?)

Adds two nullable columns to `dim_course_run`:

- `semester` (varchar) — academic term identifier for a proctored exam run (e.g. `2T2022`)
- `passing_grade` (double) — passing score threshold set per exam run

Sourced from `stg__micromasters__app__postgres__exams_examrun` via a new `micromasters_examruns` CTE, left-joined onto MITxOnline course runs on `courserun_readable_id = examrun_readable_id`. All other platforms get NULL. Both fields are included in the SCD2 change-detection predicate (using `-1.0` as sentinel for `passing_grade` to distinguish NULL from an actual `0.0` value).

### How can this be tested?

```bash
ol-dbt run --target dev_qa --select dim_course_run
```

```sql
-- Should return rows for MITxOnline proctored exam runs
select semester, passing_grade, count(*)
from dim_course_run
where semester is not null
group by 1, 2
```

### Additional Context

`semester` and `passing_grade` belong on `dim_course_run` (not `tfact_grade`) because they describe the exam run configuration, not the individual grade event.