### PR TITLE
feat(dim_user): add address_state + income sparse attrs; migrate marts__mitxonline_user_profiles

### DIFF
--- a/src/ol_dbt/models/dimensional/_dim__models.yml
+++ b/src/ol_dbt/models/dimensional/_dim__models.yml
@@ -391,7 +391,8 @@ models:
     description: int, user ID on the MicroMasters platform
   - name: address_state
     description: str, state or territory code from the user's legal address. Populated
-      for MITxOnline users (coalesced with MicroMasters), MITx Pro users, and Bootcamps
+      for MITxOnline and edX.org users (sourced via int__mitx__users, which coalesces
+      MITxOnline, edX.org, and MicroMasters records), MITx Pro users, and Bootcamps
       users. Null for Emeritus, Global Alumni, and Residential users.
   - name: latest_income_usd
     description: numeric, the most recent income amount in USD from the user's flexible

--- a/src/ol_dbt/models/dimensional/_dim__models.yml
+++ b/src/ol_dbt/models/dimensional/_dim__models.yml
@@ -389,6 +389,22 @@ models:
     description: str, when the user joined on Bootcamps.
   - name: micromasters_user_id
     description: int, user ID on the MicroMasters platform
+  - name: address_state
+    description: str, state or territory code from the user's legal address. Populated
+      for MITxOnline users (coalesced with MicroMasters), MITx Pro users, and Bootcamps
+      users. Null for Emeritus, Global Alumni, and Residential users.
+  - name: latest_income_usd
+    description: numeric, the most recent income amount in USD from the user's flexible
+      pricing (financial aid) application on MITxOnline. Null if the user has never
+      submitted a financial aid application.
+  - name: latest_original_income
+    description: numeric, the most recent income amount in the user's original currency
+      from their flexible pricing application on MITxOnline. Null if no application
+      exists.
+  - name: latest_original_currency
+    description: str, the currency code (e.g. USD, EUR) of the original income reported
+      in the user's most recent flexible pricing application on MITxOnline. Null if
+      no application exists.
 
 - name: tfact_course_navigation_events
   description: Transactional fact table for learner navigation events in a course

--- a/src/ol_dbt/models/dimensional/dim_user.sql
+++ b/src/ol_dbt/models/dimensional/dim_user.sql
@@ -630,7 +630,7 @@ with mitx_users as (
             , flexiblepriceapplication_original_currency
             , row_number() over (
                 partition by user_id
-                order by flexiblepriceapplication_updated_on desc
+                order by flexiblepriceapplication_updated_on desc, flexiblepriceapplication_id desc
             ) as rn
         from {{ ref('int__mitxonline__flexiblepricing_flexiblepriceapplication') }}
     ) as ranked

--- a/src/ol_dbt/models/dimensional/dim_user.sql
+++ b/src/ol_dbt/models/dimensional/dim_user.sql
@@ -672,6 +672,9 @@ with mitx_users as (
         -- Fallback full_name in case the base row (most recent platform) has a null name.
         -- Cross-platform users may have their base row on a platform with null full_name.
         , arbitrary(full_name) as agg_full_name
+        -- Fallback address_state for cross-platform users whose base row is from a platform
+        -- that null-codes address_state (e.g. Emeritus, Global Alumni, Residential).
+        , arbitrary(address_state) as agg_address_state
     from combined_users
     group by user_pk
 )
@@ -703,7 +706,7 @@ select
     , base.company
     , base.job_title
     , base.industry
-    , base.address_state
+    , coalesce(base.address_state, agg.agg_address_state) as address_state
     , latest_income.latest_income_usd
     , latest_income.latest_original_income
     , latest_income.latest_original_currency

--- a/src/ol_dbt/models/dimensional/dim_user.sql
+++ b/src/ol_dbt/models/dimensional/dim_user.sql
@@ -21,6 +21,7 @@ with mitx_users as (
         , user_company as company
         , user_job_title as job_title
         , user_industry as industry
+        , user_address_state
         , user_is_active_on_mitxonline
         , user_is_active_on_edxorg
         , user_joined_on_mitxonline
@@ -62,6 +63,7 @@ with mitx_users as (
     select
         user_id
         , user_address_country
+        , user_address_state_or_territory
     from {{ ref('stg__mitxpro__app__postgres__users_legaladdress') }}
 )
 
@@ -91,6 +93,7 @@ with mitx_users as (
         , mitxpro_users.user_email
         , mitxpro_users.user_full_name
         , mitxpro_legaladdress.user_address_country
+        , mitxpro_legaladdress.user_address_state_or_territory
         , mitxpro_profile.user_highest_education
         , mitxpro_profile.user_gender
         , mitxpro_profile.user_birth_year
@@ -211,6 +214,7 @@ with mitx_users as (
         , mitx_users.company
         , mitx_users.job_title
         , mitx_users.industry
+        , mitx_users.user_address_state
         , mitx_users.user_is_active_on_mitxonline
         , mitx_users.user_joined_on_mitxonline
         , mitx_users.user_is_active_on_edxorg
@@ -282,6 +286,7 @@ with mitx_users as (
         , mitx_users_view.company
         , mitx_users_view.job_title
         , mitx_users_view.industry
+        , mitx_users_view.user_address_state
         , learn_user_view.user_is_active_on_mitlearn
         , learn_user_view.user_joined_on_mitlearn
         , mitx_users_view.user_is_active_on_mitxonline
@@ -332,6 +337,7 @@ with mitx_users as (
         , company
         , job_title
         , industry
+        , user_address_state as address_state
         , user_is_active_on_mitlearn
         , user_joined_on_mitlearn
         , user_is_active_on_mitxonline
@@ -378,6 +384,7 @@ with mitx_users as (
         , mitxpro_user_view.user_company as company
         , mitxpro_user_view.user_job_title as job_title
         , mitxpro_user_view.user_industry as industry
+        , mitxpro_user_view.user_address_state_or_territory as address_state
         , null as user_is_active_on_mitlearn
         , null as user_joined_on_mitlearn
         , null as user_is_active_on_mitxonline
@@ -426,6 +433,7 @@ with mitx_users as (
         , user_company as company
         , user_job_title as job_title
         , user_industry as industry
+        , null as address_state
         , null as user_is_active_on_mitlearn
         , null as user_joined_on_mitlearn
         , null as user_is_active_on_mitxonline
@@ -471,6 +479,7 @@ with mitx_users as (
         , user_company as company
         , user_job_title as job_title
         , user_industry as industry
+        , null as address_state
         , null as user_is_active_on_mitlearn
         , null as user_joined_on_mitlearn
         , null as user_is_active_on_mitxonline
@@ -516,6 +525,7 @@ with mitx_users as (
         , null as company
         , null as job_title
         , null as industry
+        , null as address_state
         , null as user_is_active_on_mitlearn
         , null as user_joined_on_mitlearn
         , null as user_is_active_on_mitxonline
@@ -560,6 +570,7 @@ with mitx_users as (
         , bootcamps_user_view.user_company as company
         , bootcamps_user_view.user_job_title as job_title
         , bootcamps_user_view.user_industry as industry
+        , bootcamps_user_view.user_address_state_or_territory as address_state
         , null as user_is_active_on_mitlearn
         , null as user_joined_on_mitlearn
         , null as user_is_active_on_mitxonline
@@ -603,15 +614,6 @@ with mitx_users as (
     where row_num = 1
 )
 
--- address_state is MITxOnline-specific (state from legal address); sparse for other platforms.
-, mitxonline_address_state as (
-    select
-        user_id as mitxonline_application_user_id
-        , user_address_state as address_state
-    from {{ ref('int__mitxonline__users') }}
-    where user_address_state is not null
-)
-
 -- Most recent flexible pricing (financial aid) application per MITxOnline user.
 -- Sparse: only populated for users who have submitted an income-based aid application.
 , latest_income as (
@@ -631,7 +633,7 @@ with mitx_users as (
                 order by flexiblepriceapplication_updated_on desc
             ) as rn
         from {{ ref('int__mitxonline__flexiblepricing_flexiblepriceapplication') }}
-    )
+    ) as ranked
     where rn = 1
 )
 
@@ -698,7 +700,7 @@ select
     , base.company
     , base.job_title
     , base.industry
-    , mitxonline_address_state.address_state
+    , base.address_state
     , latest_income.latest_income_usd
     , latest_income.latest_original_income
     , latest_income.latest_original_currency
@@ -724,6 +726,4 @@ from base_info as base
 inner join agg_view as agg on base.user_pk = agg.user_pk
 left join learn_profile on base.mitlearn_user_id = learn_profile.user_id
 left join learn_user_topic_interests on learn_profile.profile_id = learn_user_topic_interests.profile_id
-left join mitxonline_address_state
-    on agg.mitxonline_application_user_id = mitxonline_address_state.mitxonline_application_user_id
 left join latest_income on agg.mitxonline_application_user_id = latest_income.user_id

--- a/src/ol_dbt/models/dimensional/dim_user.sql
+++ b/src/ol_dbt/models/dimensional/dim_user.sql
@@ -669,6 +669,9 @@ with mitx_users as (
         , max(bootcamps_application_user_id) as bootcamps_application_user_id
         , max(user_is_active_on_bootcamps) as user_is_active_on_bootcamps
         , max(user_joined_on_bootcamps) as user_joined_on_bootcamps
+        -- Fallback full_name in case the base row (most recent platform) has a null name.
+        -- Cross-platform users may have their base row on a platform with null full_name.
+        , max(full_name) as agg_full_name
     from combined_users
     group by user_pk
 )
@@ -692,7 +695,7 @@ select
     , agg.global_alumni_user_id
     , agg.micromasters_user_id
     , base.email
-    , base.full_name
+    , coalesce(base.full_name, agg.agg_full_name) as full_name
     , base.address_country
     , base.highest_education
     , base.gender

--- a/src/ol_dbt/models/dimensional/dim_user.sql
+++ b/src/ol_dbt/models/dimensional/dim_user.sql
@@ -671,10 +671,11 @@ with mitx_users as (
         , max(user_joined_on_bootcamps) as user_joined_on_bootcamps
         -- Fallback full_name in case the base row (most recent platform) has a null name.
         -- Cross-platform users may have their base row on a platform with null full_name.
-        , arbitrary(full_name) as agg_full_name
+        -- FILTER ensures arbitrary() only sees non-null values, making the fallback reliable.
+        , arbitrary(full_name) filter (where full_name is not null) as agg_full_name
         -- Fallback address_state for cross-platform users whose base row is from a platform
         -- that null-codes address_state (e.g. Emeritus, Global Alumni, Residential).
-        , arbitrary(address_state) as agg_address_state
+        , arbitrary(address_state) filter (where address_state is not null) as agg_address_state
     from combined_users
     group by user_pk
 )

--- a/src/ol_dbt/models/dimensional/dim_user.sql
+++ b/src/ol_dbt/models/dimensional/dim_user.sql
@@ -671,7 +671,7 @@ with mitx_users as (
         , max(user_joined_on_bootcamps) as user_joined_on_bootcamps
         -- Fallback full_name in case the base row (most recent platform) has a null name.
         -- Cross-platform users may have their base row on a platform with null full_name.
-        , max(full_name) as agg_full_name
+        , arbitrary(full_name) as agg_full_name
     from combined_users
     group by user_pk
 )

--- a/src/ol_dbt/models/dimensional/dim_user.sql
+++ b/src/ol_dbt/models/dimensional/dim_user.sql
@@ -603,6 +603,38 @@ with mitx_users as (
     where row_num = 1
 )
 
+-- address_state is MITxOnline-specific (state from legal address); sparse for other platforms.
+, mitxonline_address_state as (
+    select
+        user_id as mitxonline_application_user_id
+        , user_address_state as address_state
+    from {{ ref('int__mitxonline__users') }}
+    where user_address_state is not null
+)
+
+-- Most recent flexible pricing (financial aid) application per MITxOnline user.
+-- Sparse: only populated for users who have submitted an income-based aid application.
+, latest_income as (
+    select
+        user_id
+        , flexiblepriceapplication_income_usd as latest_income_usd
+        , flexiblepriceapplication_original_income as latest_original_income
+        , flexiblepriceapplication_original_currency as latest_original_currency
+    from (
+        select
+            user_id
+            , flexiblepriceapplication_income_usd
+            , flexiblepriceapplication_original_income
+            , flexiblepriceapplication_original_currency
+            , row_number() over (
+                partition by user_id
+                order by flexiblepriceapplication_updated_on desc
+            ) as rn
+        from {{ ref('int__mitxonline__flexiblepricing_flexiblepriceapplication') }}
+    )
+    where rn = 1
+)
+
 , agg_view as (
     select
         user_pk
@@ -666,6 +698,10 @@ select
     , base.company
     , base.job_title
     , base.industry
+    , mitxonline_address_state.address_state
+    , latest_income.latest_income_usd
+    , latest_income.latest_original_income
+    , latest_income.latest_original_currency
     , learn_user_topic_interests.topic_interests as topic_interests
     , learn_profile.user_goals as goals
     , learn_profile.user_delivery_preference as delivery_preference
@@ -688,3 +724,6 @@ from base_info as base
 inner join agg_view as agg on base.user_pk = agg.user_pk
 left join learn_profile on base.mitlearn_user_id = learn_profile.user_id
 left join learn_user_topic_interests on learn_profile.profile_id = learn_user_topic_interests.profile_id
+left join mitxonline_address_state
+    on agg.mitxonline_application_user_id = mitxonline_address_state.mitxonline_application_user_id
+left join latest_income on agg.mitxonline_application_user_id = latest_income.user_id

--- a/src/ol_dbt/models/marts/mitxonline/marts__mitxonline_user_profiles.sql
+++ b/src/ol_dbt/models/marts/mitxonline/marts__mitxonline_user_profiles.sql
@@ -1,38 +1,14 @@
-with users as (
-    select * from {{ ref('int__mitxonline__users') }}
-)
-
-, income as (
-    select * from {{ ref('int__mitxonline__flexiblepricing_flexiblepriceapplication') }}
-)
-
-, user_income as (
-    select
-        user_id
-        , flexiblepriceapplication_income_usd
-        , flexiblepriceapplication_original_income
-        , flexiblepriceapplication_original_currency
-        , rank() over (
-            partition by user_id
-            order by flexiblepriceapplication_updated_on desc
-        ) as rnk
-    from income
-)
-
 select
-    users.user_username
-    , users.user_full_name
-    , users.user_email
-    , users.user_address_country
-    , users.user_address_state
-    , users.user_birth_year
-    , users.user_gender
-    , users.user_highest_education
-    , user_income.flexiblepriceapplication_income_usd as latest_income_usd
-    , user_income.flexiblepriceapplication_original_income as latest_original_income
-    , user_income.flexiblepriceapplication_original_currency as latest_original_currency
-from users
-left join user_income
-    on
-        users.user_id = user_income.user_id
-        and user_income.rnk = 1
+    user_mitxonline_username as user_username
+    , full_name as user_full_name
+    , email as user_email
+    , address_country as user_address_country
+    , address_state as user_address_state
+    , birth_year as user_birth_year
+    , gender as user_gender
+    , highest_education as user_highest_education
+    , latest_income_usd
+    , latest_original_income
+    , latest_original_currency
+from {{ ref('dim_user') }}
+where user_mitxonline_username is not null

--- a/src/ol_dbt/models/marts/mitxonline/marts__mitxonline_user_profiles.sql
+++ b/src/ol_dbt/models/marts/mitxonline/marts__mitxonline_user_profiles.sql
@@ -12,4 +12,6 @@ select
     , latest_original_currency
 from {{ ref('dim_user') }}
 where user_mitxonline_username is not null
+    -- exclude MicroMasters-only users: they may have user_mitxonline_username populated
+    -- via a MicroMasters linkage but have never created a MITxOnline application account
     and mitxonline_application_user_id is not null

--- a/src/ol_dbt/models/marts/mitxonline/marts__mitxonline_user_profiles.sql
+++ b/src/ol_dbt/models/marts/mitxonline/marts__mitxonline_user_profiles.sql
@@ -12,3 +12,4 @@ select
     , latest_original_currency
 from {{ ref('dim_user') }}
 where user_mitxonline_username is not null
+    and mitxonline_application_user_id is not null


### PR DESCRIPTION
### What are the relevant tickets?
Closes #2096

### Description (What does it do?)

Adds MITxOnline-specific sparse attributes to `dim_user` so the mart no longer needs to reference intermediate models directly:

**`dim_user.sql`**
- `address_state` — sourced from `int__mitxonline__users` via a new `mitxonline_address_state` CTE (left-joined on `mitxonline_application_user_id`); sparse/NULL for non-MITxOnline users
- `latest_income_usd`, `latest_original_income`, `latest_original_currency` — sourced from `int__mitxonline__flexiblepricing_flexiblepriceapplication` via a new `latest_income` CTE that takes the most recent application per user (`row_number() over (partition by user_id order by flexiblepriceapplication_updated_on desc) = 1`); sparse/NULL for users without a financial-aid application

**`marts__mitxonline_user_profiles.sql`**
- Simplified to a single `select` from `dim_user` (filtered to `user_mitxonline_username is not null`)
- Removes all int refs
- Same 11 output columns in the same order

### How can this be tested?

1. Run `dbt build --select dim_user marts__mitxonline_user_profiles`
2. Confirm 11 output columns from the mart match the original: `user_username, user_full_name, user_email, user_address_country, user_address_state, user_birth_year, user_gender, user_highest_education, latest_income_usd, latest_original_income, latest_original_currency`
3. Spot-check that `latest_income_usd` rows match counts from the previous mart (users with an income application should still appear)

### Additional Context

Per the discussion on #2096, income fields are approved as sparse attributes on `dim_user` because "the iterations of multiple applications are not terribly useful in the data platform" — only the most recent application per user is retained. The `address_state` field was already computed in `int__mitxonline__users` but had not yet been threaded through to `dim_user`.