### PR TITLE
feat(migration): migrate edX future-run verified upgrades for existing MITx Online audit enrollments

### DIFF
--- a/src/ol_dbt/models/migration/edxorg_to_mitxonline_enrollments.sql
+++ b/src/ol_dbt/models/migration/edxorg_to_mitxonline_enrollments.sql
@@ -302,6 +302,17 @@ where
         edxorg_enrollment.courseruncertificate_created_on is not null
         or future_run_id_mapping.edxorg_courserun_readable_id is not null
     )
-    and mitxonline_enrollment.user_email is null
-    and mitxonline_enrollment_by_userid.user_id is null
+    and (
+        (mitxonline_enrollment.user_email is null and mitxonline_enrollment_by_userid.user_id is null)
+        -- Include future-run enrollments where edX mode was upgraded to verified but the
+        -- existing MITx Online enrollment is still audit
+        or (
+            future_run_id_mapping.edxorg_courserun_readable_id is not null
+            and edxorg_enrollment.courserunenrollment_enrollment_mode = 'verified'
+            and coalesce(
+                mitxonline_enrollment.courserunenrollment_enrollment_mode
+                , mitxonline_enrollment_by_userid.courserunenrollment_enrollment_mode
+            ) = 'audit'
+        )
+    )
     and retired_users.user_id is null


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
https://github.com/mitodl/hq/issues/11545

### Description (What does it do?)
<!--- Describe your changes in detail -->
Updates edxorg_to_mitxonline_enrollments to Include future run edX enrollments that upgraded to verified where the existing MITx Online enrollment is still audit.


### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

dbt build --select edxorg_to_mitxonline_enrollments

### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->


<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
