### PR TITLE
fix(dlt): wire pyiceberg Glue catalog so Iceberg tables register in AWS Glue

### DIFF
--- a/dg_projects/data_loading/.dlt/.pyiceberg.yaml
+++ b/dg_projects/data_loading/.dlt/.pyiceberg.yaml
@@ -1,0 +1,5 @@
+---
+catalog:
+  aws_glue:
+    type: glue
+    py-io-impl: pyiceberg.io.pyarrow.PyArrowFileIO

--- a/dg_projects/data_loading/.dlt/config.toml
+++ b/dg_projects/data_loading/.dlt/config.toml
@@ -59,23 +59,15 @@ destination_type = "filesystem"
 bucket_url = "s3://ol-data-lake-raw-production/edxorg"
 layout = "{table_name}/{load_id}.{file_id}.{ext}"
 
-# Iceberg Catalog Configuration for QA
-[iceberg_catalog.qa]
-iceberg_catalog_name = "ol_warehouse_qa_raw"
-iceberg_catalog_type = "glue"
-
-[iceberg_catalog.qa.iceberg_catalog_config]
-type = "glue"
-warehouse = "s3://ol-data-lake-raw-qa/edxorg"
-
-# Iceberg Catalog Configuration for Production
-[iceberg_catalog.production]
-iceberg_catalog_name = "ol_warehouse_production_raw"
-iceberg_catalog_type = "glue"
-
-[iceberg_catalog.production.iceberg_catalog_config]
-type = "glue"
-warehouse = "s3://ol-data-lake-raw-production/edxorg"
+# Iceberg Catalog Configuration
+#
+# dlt reads [iceberg_catalog] (flat, not named sub-sections).
+# The "aws_glue" catalog is defined in .dlt/.pyiceberg.yaml; pyiceberg's
+# load_catalog mechanism handles Glue natively via boto3/IRSA.
+# The target Glue database is determined by dataset_name at pipeline
+# runtime (e.g. "ol_warehouse_production_raw"), not here.
+[iceberg_catalog]
+iceberg_catalog_name = "aws_glue"
 
 # Note: Destination is auto-selected based on DAGSTER_ENVIRONMENT:
 # - dev/ci -> local (filesystem, local disk, no Iceberg)
@@ -151,84 +143,3 @@ layout = "{table_name}/{load_id}.{file_id}.{ext}"
 destination_type = "filesystem"
 bucket_url = "s3://ol-data-lake-raw-production/mit_edx_programs"
 layout = "{table_name}/{load_id}.{file_id}.{ext}"
-
-# Shared Iceberg catalog config for QA/production REST API source destinations
-[iceberg_catalog.mit_climate_qa]
-iceberg_catalog_name = "ol_warehouse_qa_raw"
-iceberg_catalog_type = "glue"
-
-[iceberg_catalog.mit_climate_qa.iceberg_catalog_config]
-type = "glue"
-warehouse = "s3://ol-data-lake-raw-qa/mit_climate"
-
-[iceberg_catalog.mit_climate_production]
-iceberg_catalog_name = "ol_warehouse_production_raw"
-iceberg_catalog_type = "glue"
-
-[iceberg_catalog.mit_climate_production.iceberg_catalog_config]
-type = "glue"
-warehouse = "s3://ol-data-lake-raw-production/mit_climate"
-
-[iceberg_catalog.mitpe_qa]
-iceberg_catalog_name = "ol_warehouse_qa_raw"
-iceberg_catalog_type = "glue"
-
-[iceberg_catalog.mitpe_qa.iceberg_catalog_config]
-type = "glue"
-warehouse = "s3://ol-data-lake-raw-qa/mitpe"
-
-[iceberg_catalog.mitpe_production]
-iceberg_catalog_name = "ol_warehouse_production_raw"
-iceberg_catalog_type = "glue"
-
-[iceberg_catalog.mitpe_production.iceberg_catalog_config]
-type = "glue"
-warehouse = "s3://ol-data-lake-raw-production/mitpe"
-
-[iceberg_catalog.oll_qa]
-iceberg_catalog_name = "ol_warehouse_qa_raw"
-iceberg_catalog_type = "glue"
-
-[iceberg_catalog.oll_qa.iceberg_catalog_config]
-type = "glue"
-warehouse = "s3://ol-data-lake-raw-qa/oll"
-
-[iceberg_catalog.oll_production]
-iceberg_catalog_name = "ol_warehouse_production_raw"
-iceberg_catalog_type = "glue"
-
-[iceberg_catalog.oll_production.iceberg_catalog_config]
-type = "glue"
-warehouse = "s3://ol-data-lake-raw-production/oll"
-
-[iceberg_catalog.mit_edx_programs_qa]
-iceberg_catalog_name = "ol_warehouse_qa_raw"
-iceberg_catalog_type = "glue"
-
-[iceberg_catalog.mit_edx_programs_qa.iceberg_catalog_config]
-type = "glue"
-warehouse = "s3://ol-data-lake-raw-qa/mit_edx_programs"
-
-[iceberg_catalog.mit_edx_programs_production]
-iceberg_catalog_name = "ol_warehouse_production_raw"
-iceberg_catalog_type = "glue"
-
-[iceberg_catalog.mit_edx_programs_production.iceberg_catalog_config]
-type = "glue"
-warehouse = "s3://ol-data-lake-raw-production/mit_edx_programs"
-
-[iceberg_catalog.podcast_qa]
-iceberg_catalog_name = "ol_warehouse_qa_raw"
-iceberg_catalog_type = "glue"
-
-[iceberg_catalog.podcast_qa.iceberg_catalog_config]
-type = "glue"
-warehouse = "s3://ol-data-lake-raw-qa/podcast"
-
-[iceberg_catalog.podcast_production]
-iceberg_catalog_name = "ol_warehouse_production_raw"
-iceberg_catalog_type = "glue"
-
-[iceberg_catalog.podcast_production.iceberg_catalog_config]
-type = "glue"
-warehouse = "s3://ol-data-lake-raw-production/podcast"

--- a/dg_projects/data_loading/data_loading/defs/mit_climate_ingest/loads.py
+++ b/dg_projects/data_loading/data_loading/defs/mit_climate_ingest/loads.py
@@ -83,14 +83,15 @@ def mit_climate_source(
 # ---------------------------------------------------------------------------
 
 _dagster_env = os.getenv("DAGSTER_ENVIRONMENT", "dev")
-_table_format = "iceberg"
 
 if _dagster_env in ("qa", "production"):
     _destination_name = f"mit_climate_{_dagster_env}"
     _dataset_name = f"ol_warehouse_{_dagster_env}_raw"
+    _table_format = "iceberg"
 else:
     _destination_name = "mit_climate_local"
     _dataset_name = "mit_climate_local"
+    _table_format = "parquet"
 
 mit_climate_load_source = mit_climate_source(
     explainers_url=os.getenv("MIT_CLIMATE_EXPLAINERS_API_URL", _EXPLAINERS_URL_DEFAULT),

--- a/dg_projects/data_loading/data_loading/defs/mit_edx_programs_ingest/loads.py
+++ b/dg_projects/data_loading/data_loading/defs/mit_edx_programs_ingest/loads.py
@@ -176,14 +176,15 @@ def mit_edx_programs_source(
 # or environment variables when the source is actually executed.
 
 _dagster_env = os.getenv("DAGSTER_ENVIRONMENT", "dev")
-_table_format = "iceberg"
 
 if _dagster_env in ("qa", "production"):
     _destination_name = f"mit_edx_programs_{_dagster_env}"
     _dataset_name = f"ol_warehouse_{_dagster_env}_raw"
+    _table_format = "iceberg"
 else:
     _destination_name = "mit_edx_programs_local"
     _dataset_name = "mit_edx_programs_local"
+    _table_format = "parquet"
 
 mit_edx_programs_load_source = mit_edx_programs_source()
 

--- a/dg_projects/data_loading/data_loading/defs/mitpe_ingest/loads.py
+++ b/dg_projects/data_loading/data_loading/defs/mitpe_ingest/loads.py
@@ -79,14 +79,15 @@ def mitpe_source(
 # ---------------------------------------------------------------------------
 
 _dagster_env = os.getenv("DAGSTER_ENVIRONMENT", "dev")
-_table_format = "iceberg"
 
 if _dagster_env in ("qa", "production"):
     _destination_name = f"mitpe_{_dagster_env}"
     _dataset_name = f"ol_warehouse_{_dagster_env}_raw"
+    _table_format = "iceberg"
 else:
     _destination_name = "mitpe_local"
     _dataset_name = "mitpe_local"
+    _table_format = "parquet"
 
 mitpe_load_source = mitpe_source(
     base_url=os.getenv("MITPE_BASE_URL", _MITPE_BASE_URL_DEFAULT),

--- a/dg_projects/data_loading/data_loading/defs/oll_ingest/loads.py
+++ b/dg_projects/data_loading/data_loading/defs/oll_ingest/loads.py
@@ -67,14 +67,15 @@ def oll_source(
 # ---------------------------------------------------------------------------
 
 _dagster_env = os.getenv("DAGSTER_ENVIRONMENT", "dev")
-_table_format = "iceberg"
 
 if _dagster_env in ("qa", "production"):
     _destination_name = f"oll_{_dagster_env}"
     _dataset_name = f"ol_warehouse_{_dagster_env}_raw"
+    _table_format = "iceberg"
 else:
     _destination_name = "oll_local"
     _dataset_name = "oll_local"
+    _table_format = "parquet"
 
 oll_load_source = oll_source()
 

--- a/dg_projects/data_loading/data_loading/defs/podcast_rss_ingest/loads.py
+++ b/dg_projects/data_loading/data_loading/defs/podcast_rss_ingest/loads.py
@@ -302,14 +302,15 @@ def podcast_rss_source(  # noqa: C901
 # ---------------------------------------------------------------------------
 
 _dagster_env = os.getenv("DAGSTER_ENVIRONMENT", "dev")
-_table_format = "iceberg"
 
 if _dagster_env in ("qa", "production"):
     _destination_name = f"podcast_{_dagster_env}"
     _dataset_name = f"ol_warehouse_{_dagster_env}_raw"
+    _table_format = "iceberg"
 else:
     _destination_name = "podcast_local"
     _dataset_name = "podcast_rss_local"
+    _table_format = "parquet"
 
 podcast_rss_load_source = podcast_rss_source()
 

--- a/dg_projects/data_loading/pyproject.toml
+++ b/dg_projects/data_loading/pyproject.toml
@@ -9,6 +9,7 @@ dependencies = [
     "dagster-k8s>=0.27.15",
     "dagster-postgres>=0.27.13",
     "dlt[filesystem,parquet,pyiceberg]>=1.21.0",
+    "pyiceberg[glue]>=0.11.1",
     "duckdb>=1.2.0",
     "ol-orchestrate-lib",
     "sqlalchemy>=2.0.46",


### PR DESCRIPTION
### What are the relevant tickets?

N/A

### Description (What does it do?)

Fixes silent Iceberg table registration failure in the dlt filesystem destination pipelines (mitpe, oll, mit_climate, mit_edx_programs, podcast_rss, edxorg).

**Root cause — two independent bugs:**

1. `dlt/common/libs/pyiceberg.py` `get_catalog()` only accepts `"sql"` or `"rest"` as `iceberg_catalog_type`, raising `ValueError` for `"glue"`. Since the exception is unhandled in the filesystem job client, dlt falls through to a final fallback: an **in-memory SQLite catalog** that loses all registrations between runs.

2. The config.toml used named TOML sub-sections like `[iceberg_catalog.mitpe_production]`. dlt's `@with_config(sections="iceberg_catalog")` reads only the **flat** `[iceberg_catalog]` section — named sub-sections are invisible to it. All 17 named sections were dead config since day one.

The result: Iceberg parquet + metadata files were written to S3 correctly (pipelines reported `status: 0`), but no Glue table entry was ever created, so the tables were invisible to Starburst Galaxy / dbt.

**Fix:**

- **`.dlt/.pyiceberg.yaml`** (new file): defines an `aws_glue` catalog (`type: glue`). pyiceberg's native `load_catalog` mechanism supports Glue via boto3/IRSA and is the right path — `get_catalog()` reaches it via priority-2 (YAML lookup) without hitting the unsupported-type guard. A single Glue catalog handles all environments because the Glue *database* is determined at runtime by `dataset_name` (e.g. `ol_warehouse_production_raw` vs `ol_warehouse_qa_raw`), not by catalog config.

- **`.dlt/config.toml`**: collapses all 17 dead named `[iceberg_catalog.*]` sections into a single `[iceberg_catalog]` with `iceberg_catalog_name = "aws_glue"`.

- **All REST API + podcast `loads.py` files**: gates `_table_format = "iceberg"` to `qa`/`production` only; local dev now uses `"parquet"` to avoid Glue API calls against local filesystem destinations. The edxorg pipeline already did this correctly.

- **`pyproject.toml`**: adds `pyiceberg[glue]` as an explicit dependency so boto3 is a declared (not just transitive) requirement.

**On next pipeline run:** `evolve_table()` will find the existing S3 Iceberg metadata for mitpe and oll, call `register_table()` against the Glue catalog, and the tables will appear in `ol_warehouse_production_raw`.

### How can this be tested?

1. Deploy to QA with `DAGSTER_ENVIRONMENT=qa` and trigger the mitpe or oll Dagster job manually.
2. After the run, verify the Glue table exists:
   ```
   aws glue get-table --database-name ol_warehouse_qa_raw --name raw__mitpe__api__courses
   ```
3. Verify the table is queryable via Starburst Galaxy / Trino:
   ```sql
   SELECT count(*) FROM ol_warehouse_qa_raw.raw__mitpe__api__courses;
   ```
4. For production, the mitpe and oll pipelines already have S3 Iceberg metadata from prior runs (8 successful runs since 2026-06-17). The first run after this deploy should register those existing tables in Glue without re-fetching data.

### Additional Context

- `boto3` was already installed transitively (via `dagster-aws`); this change makes it an explicit pyiceberg dep.
- The `py-io-impl: pyiceberg.io.pyarrow.PyArrowFileIO` setting in `.pyiceberg.yaml` matches what dlt uses for S3 reads/writes.
- The mit_climate and mit_edx_programs pipelines had no production runs prior to this fix; they will need first-time Glue registration on next run.