### PR TITLE
remove Salesforce dependency from xPro B2B order model

### DIFF
--- a/src/ol_dbt/models/intermediate/mitxpro/_int_mitxpro__models.yml
+++ b/src/ol_dbt/models/intermediate/mitxpro/_int_mitxpro__models.yml
@@ -344,8 +344,6 @@ models:
     description: string, readable product type
     tests:
     - not_null
-  - name: salesforce_opportunity_id
-    description: string, ID of Salesforce Opportunity
   tests:
   - dbt_expectations.expect_table_row_count_to_equal_other_table:
       arguments:

--- a/src/ol_dbt/models/intermediate/mitxpro/int__mitxpro__b2becommerce_b2border.sql
+++ b/src/ol_dbt/models/intermediate/mitxpro/int__mitxpro__b2becommerce_b2border.sql
@@ -13,26 +13,6 @@ with b2borders as (
     from {{ ref('int__mitxpro__ecommerce_product') }}
 )
 
-, salesforce_opportunity as (
-    select * from {{ ref('int__salesforce__opportunity') }}
-)
-
-, couponpaymentversion as (
-    select *
-    from {{ ref('int__mitxpro__ecommerce_couponpaymentversion') }}
-)
-
-, salesforce_b2border as (
-    select
-        b2borders.b2border_id
-        , salesforce_opportunity.opportunity_id
-    from b2borders
-    inner join couponpaymentversion
-        on b2borders.couponpaymentversion_id = couponpaymentversion.couponpaymentversion_id
-    inner join salesforce_opportunity
-        on b2borders.b2border_contract_number like '%' || salesforce_opportunity.opportunity_id
-)
-
 select
     b2borders.b2border_id
     , b2borders.b2border_updated_on
@@ -53,8 +33,6 @@ select
     , products.courserun_id
     , products.program_id
     , products.product_type
-    , salesforce_b2border.opportunity_id as salesforce_opportunity_id
 from b2borders
 inner join productversions on b2borders.productversion_id = productversions.productversion_id
 inner join products on productversions.product_id = products.product_id
-left join salesforce_b2border on b2borders.b2border_id = salesforce_b2border.b2border_id

--- a/src/ol_dbt/models/staging/salesforce/_salesforce__sources.yml
+++ b/src/ol_dbt/models/staging/salesforce/_salesforce__sources.yml
@@ -8,7 +8,13 @@ sources:
   schema: '{{ target.schema.replace(var("schema_suffix", ""), "").rstrip("_") }}_raw'
   tables:
   - name: raw__thirdparty__salesforce___destination_v2__Opportunity
-    description: Salesforce opportunity, which is a sale or pending deal
+    description: >
+      Salesforce opportunity, which is a sale or pending deal.
+
+      WARNING: This source is unreliable. The Salesforce seat license used for the
+      Airbyte integration is periodically revoked to control costs, which causes
+      syncs to fail and leaves data stale. Do not build hard dependencies on this
+      source without confirming the integration is currently active.
     columns:
     - name: id
       description: string, globally unique string that identifies an opportunity
@@ -180,7 +186,13 @@ sources:
         records.
 
   - name: raw__thirdparty__salesforce___destination_v2__OpportunityLineItem
-    description: Salesforce opportunity product line items
+    description: >
+      Salesforce opportunity product line items.
+
+      WARNING: This source is unreliable. The Salesforce seat license used for the
+      Airbyte integration is periodically revoked to control costs, which causes
+      syncs to fail and leaves data stale. Do not build hard dependencies on this
+      source without confirming the integration is currently active.
     columns:
     - name: id
       description: string, unique string that identifies this opportunity product

--- a/src/ol_dbt/models/staging/salesforce/_stg_salesforce__models.yml
+++ b/src/ol_dbt/models/staging/salesforce/_stg_salesforce__models.yml
@@ -3,7 +3,12 @@ version: 2
 
 models:
 - name: stg__salesforce__opportunity
-  description: Salesforce opportunity data which can be a sale or pending deal
+  description: >
+    Salesforce opportunity data which can be a sale or pending deal.
+
+    WARNING: The Salesforce seat license used for the Airbyte integration is
+    periodically revoked for cost reasons, causing syncs to fail and data to go
+    stale. This model should not be used as a hard dependency in downstream logic.
   columns:
   - name: opportunity_id
     description: string, globally unique string that identifies an opportunity
@@ -96,7 +101,12 @@ models:
     - not_null
 
 - name: stg__salesforce__opportunitylineitem
-  description: Salesforce opportunity product line items
+  description: >
+    Salesforce opportunity product line items.
+
+    WARNING: The Salesforce seat license used for the Airbyte integration is
+    periodically revoked for cost reasons, causing syncs to fail and data to go
+    stale. This model should not be used as a hard dependency in downstream logic.
   columns:
   - name: opportunitylineitem_id
     description: string, unique string that identifies this opportunity product line


### PR DESCRIPTION
### What are the relevant tickets?
N/A

### Description (What does it do?)
The Salesforce Airbyte integration uses a seat license that is periodically
revoked for cost reasons, making `stg__salesforce__opportunity` (and its
downstream intermediate) an unreliable dependency. This PR removes the only
hard dependency on that data and documents the reliability issue.

**Changes:**

- `int__mitxpro__b2becommerce_b2border` — removes the `salesforce_opportunity`,
  `couponpaymentversion`, and `salesforce_b2border` CTEs, and drops
  `salesforce_opportunity_id` from the SELECT. The `couponpaymentversion` CTE
  existed solely to support the Salesforce fuzzy join and had no other use.
- `_int_mitxpro__models.yml` — removes the `salesforce_opportunity_id` column
  entry from the `int__mitxpro__b2becommerce_b2border` definition.
- `_salesforce__sources.yml` and `_stg_salesforce__models.yml` — adds WARNING
  text to all four descriptions (two sources, two staging models) explaining
  the license revocation issue and advising against hard dependencies.

**Impact:** `salesforce_opportunity_id` was only ever present in
`int__mitxpro__b2becommerce_b2border`; it was not propagated into
`int__mitxpro__ecommerce_allorders`, `marts__combined__orders`, or any
reporting model. No end-user-visible fields change. `int__salesforce__opportunitylineitem`
has no downstream consumers and is also left in place with a warning.

### How can this be tested?
- Run `dbt compile --select int__mitxpro__b2becommerce_b2border+` and confirm
  no compilation errors.
- Run `dbt test --select int__mitxpro__b2becommerce_b2border` and confirm the
  row-count parity test against `stg__mitxpro__app__postgres__b2becommerce_b2border`
  still passes.
- Confirm `salesforce_opportunity_id` no longer appears in the compiled SQL or
  the materialized table schema.