### PR TITLE
feat: auto-repair Iceberg snapshot pointer lag from Airbyte full-refresh pin bug

### DIFF
--- a/dg_projects/lakehouse/lakehouse/definitions.py
+++ b/dg_projects/lakehouse/lakehouse/definitions.py
@@ -42,6 +42,10 @@ from lakehouse.assets.superset import create_superset_asset
 from lakehouse.resources.airbyte import AirbyteOSSWorkspace
 from lakehouse.resources.dbt_s3_artifacts import DbtS3ArtifactsResource
 from lakehouse.resources.superset_api import SupersetApiClientFactory
+from lakehouse.sensors import (
+    iceberg_snapshot_pointer_lag_sensor,
+    iceberg_snapshot_pointer_repair_job,
+)
 
 trino_host_map = {
     "dev": "mitol-ol-data-lake-production.trino.galaxy.starburst.io",
@@ -385,6 +389,7 @@ defs = Definitions(
     ],
     resources=resources_dict,
     sensors=[
+        iceberg_snapshot_pointer_lag_sensor,
         AutomationConditionSensorDefinition(
             "dbt_automation_sensor",
             minimum_interval_seconds=14400,  # 4 hours - reduced from 1 hour
@@ -397,7 +402,7 @@ defs = Definitions(
             | AssetSelection.groups("superset_starrocks_dataset"),
         ),
     ],
-    jobs=[*airbyte_asset_jobs],
+    jobs=[*airbyte_asset_jobs, iceberg_snapshot_pointer_repair_job],
     schedules=[
         *airbyte_update_schedules,
         instructor_onboarding_schedule,

--- a/dg_projects/lakehouse/lakehouse/sensors.py
+++ b/dg_projects/lakehouse/lakehouse/sensors.py
@@ -33,17 +33,6 @@ _RAW_DATABASE_BY_ENV: dict[str, str] = {
 }
 RAW_DATABASE = _RAW_DATABASE_BY_ENV.get(DAGSTER_ENV, "ol_warehouse_production_raw")
 
-# Explicit list of high-frequency (6 h) Airbyte source groups to scan.
-# The thirdparty groups (salesforce, zendesk) sync much less often and are
-# deliberately excluded to keep the sensor fast and the alert signal clean.
-_HIGH_FREQUENCY_PREFIXES = [
-    "raw__mitxonline__app",
-    "raw__xpro__app",
-    "raw__mitlearn__app",
-    "raw__learn_ai__app",
-    "raw__ocw__studio",
-]
-
 # Alert when the pointer lags behind the latest snapshot by more than this.
 # Two hours provides a buffer for the normal write window without masking a
 # genuine stuck-pointer condition (which gaps by days, not minutes).
@@ -61,7 +50,6 @@ def repair_lagging_snapshot_pointers(context):
     """
     lagging = find_snapshot_pointer_lag(
         glue_database=RAW_DATABASE,
-        table_prefixes=_HIGH_FREQUENCY_PREFIXES,
         min_lag_hours=_MIN_LAG_HOURS,
     )
 
@@ -144,7 +132,6 @@ def iceberg_snapshot_pointer_lag_sensor(
 ) -> SensorResult:
     lagging = find_snapshot_pointer_lag(
         glue_database=RAW_DATABASE,
-        table_prefixes=_HIGH_FREQUENCY_PREFIXES,
         min_lag_hours=_MIN_LAG_HOURS,
     )
 

--- a/dg_projects/lakehouse/lakehouse/sensors.py
+++ b/dg_projects/lakehouse/lakehouse/sensors.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import datetime
 import json
 import logging
 
@@ -14,20 +15,33 @@ from dagster import (
     op,
     sensor,
 )
+from ol_orchestrate.lib.constants import DAGSTER_ENV
 from ol_orchestrate.lib.iceberg_maintenance import (
-    RAW_LAYER_GROUP_CONFIGS,
     advance_snapshot_pointer,
     find_snapshot_pointer_lag,
 )
 
 log = logging.getLogger(__name__)
 
-RAW_DATABASE = "ol_warehouse_production_raw"
+# dev mirrors production so engineers can test against live data without a
+# separate QA raw database (same pattern as the iceberg_maintenance asset).
+_RAW_DATABASE_BY_ENV: dict[str, str] = {
+    "production": "ol_warehouse_production_raw",
+    "qa": "ol_warehouse_qa_raw",
+    "dev": "ol_warehouse_production_raw",
+    "ci": "ol_warehouse_qa_raw",
+}
+RAW_DATABASE = _RAW_DATABASE_BY_ENV.get(DAGSTER_ENV, "ol_warehouse_production_raw")
 
-# Only scan the high-frequency groups (≤ 12 h sync interval).  Pointer lag in
-# low-frequency tables is less urgent and would generate noise.
+# Explicit list of high-frequency (6 h) Airbyte source groups to scan.
+# The thirdparty groups (salesforce, zendesk) sync much less often and are
+# deliberately excluded to keep the sensor fast and the alert signal clean.
 _HIGH_FREQUENCY_PREFIXES = [
-    prefix for prefix in RAW_LAYER_GROUP_CONFIGS if prefix != "_default"
+    "raw__mitxonline__app",
+    "raw__xpro__app",
+    "raw__mitlearn__app",
+    "raw__learn_ai__app",
+    "raw__ocw__studio",
 ]
 
 # Alert when the pointer lags behind the latest snapshot by more than this.
@@ -77,11 +91,21 @@ def repair_lagging_snapshot_pointers(context):
             continue
 
         if result.get("skipped"):
-            context.log.warning(
-                "Skipped %s: %s",
-                info.table_name,
-                result.get("reason", "unknown"),
-            )
+            reason = result.get("reason", "unknown")
+            if reason == "already current":
+                # Resolved between sensor tick and job run — harmless.
+                context.log.info(
+                    "%s pointer is already current, skipping.", info.table_name
+                )
+            else:
+                # Unexpected skip: treat as failure so the Slack run-failure
+                # alert fires and the issue is not silently masked.
+                context.log.error(
+                    "Unexpected skip for %s: %s — treating as failure.",
+                    info.table_name,
+                    reason,
+                )
+                failed.append(info.table_name)
         else:
             context.log.info(
                 "Repaired %s: %s → %s",
@@ -131,25 +155,32 @@ def iceberg_snapshot_pointer_lag_sensor(
     new_lagging = currently_lagging - previously_lagging
     recovered = previously_lagging - currently_lagging
 
-    run_requests = []
     if new_lagging:
         context.log.warning(
-            "Snapshot pointer lag detected in %d new table(s): %s — "
-            "triggering repair run.",
+            "Snapshot pointer lag detected in %d new table(s): %s",
             len(new_lagging),
             ", ".join(sorted(new_lagging)),
         )
-        # run_key deduplicates: one repair run per unique set of newly-lagging tables.
-        run_requests.append(
-            RunRequest(run_key=f"repair-{'_'.join(sorted(new_lagging))}")
+    if currently_lagging - new_lagging:
+        context.log.warning(
+            "Snapshot pointer lag persists in %d table(s): %s",
+            len(currently_lagging - new_lagging),
+            ", ".join(sorted(currently_lagging - new_lagging)),
         )
-
     if recovered:
         context.log.info(
             "Snapshot pointer lag resolved for %d table(s): %s",
             len(recovered),
             ", ".join(sorted(recovered)),
         )
+
+    run_requests = []
+    if currently_lagging:
+        # Include the UTC hour in the run_key so that failed repair runs are
+        # retried on the next hourly tick rather than being silently skipped
+        # (Dagster's run_key deduplication prevents re-running the same key).
+        hour_bucket = datetime.datetime.now(datetime.UTC).strftime("%Y%m%d%H")
+        run_requests.append(RunRequest(run_key=f"repair-{hour_bucket}"))
 
     return SensorResult(
         run_requests=run_requests,

--- a/dg_projects/lakehouse/lakehouse/sensors.py
+++ b/dg_projects/lakehouse/lakehouse/sensors.py
@@ -1,0 +1,157 @@
+"""Dagster sensors for the data lakehouse."""
+
+from __future__ import annotations
+
+import json
+import logging
+
+from dagster import (
+    DefaultSensorStatus,
+    RunRequest,
+    SensorEvaluationContext,
+    SensorResult,
+    job,
+    op,
+    sensor,
+)
+from ol_orchestrate.lib.iceberg_maintenance import (
+    RAW_LAYER_GROUP_CONFIGS,
+    advance_snapshot_pointer,
+    find_snapshot_pointer_lag,
+)
+
+log = logging.getLogger(__name__)
+
+RAW_DATABASE = "ol_warehouse_production_raw"
+
+# Only scan the high-frequency groups (≤ 12 h sync interval).  Pointer lag in
+# low-frequency tables is less urgent and would generate noise.
+_HIGH_FREQUENCY_PREFIXES = [
+    prefix for prefix in RAW_LAYER_GROUP_CONFIGS if prefix != "_default"
+]
+
+# Alert when the pointer lags behind the latest snapshot by more than this.
+# Two hours provides a buffer for the normal write window without masking a
+# genuine stuck-pointer condition (which gaps by days, not minutes).
+_MIN_LAG_HOURS = 2.0
+
+
+@op
+def repair_lagging_snapshot_pointers(context):
+    """Find and repair all raw-layer Iceberg tables with a stale current-snapshot-id.
+
+    Re-discovers lagging tables at run time so the repair is always applied to
+    the current state, even if some tables cleared between the sensor tick and
+    this run.  Raises at the end if any table could not be repaired, which
+    triggers the existing Slack run-failure alert.
+    """
+    lagging = find_snapshot_pointer_lag(
+        glue_database=RAW_DATABASE,
+        table_prefixes=_HIGH_FREQUENCY_PREFIXES,
+        min_lag_hours=_MIN_LAG_HOURS,
+    )
+
+    if not lagging:
+        context.log.info("No snapshot pointer lag detected — nothing to repair.")
+        return
+
+    context.log.info("Repairing snapshot pointer for %d table(s)...", len(lagging))
+
+    failed: list[str] = []
+    for info in lagging:
+        context.log.info(
+            "Advancing %s (%.1fh lag, current=%s, latest=%s)",
+            info.table_name,
+            info.lag_hours,
+            info.current_snapshot_id,
+            info.latest_snapshot_id,
+        )
+        try:
+            result = advance_snapshot_pointer(
+                glue_database=info.database,
+                table_name=info.table_name,
+            )
+        except Exception:
+            context.log.exception("Failed to repair %s", info.table_name)
+            failed.append(info.table_name)
+            continue
+
+        if result.get("skipped"):
+            context.log.warning(
+                "Skipped %s: %s",
+                info.table_name,
+                result.get("reason", "unknown"),
+            )
+        else:
+            context.log.info(
+                "Repaired %s: %s → %s",
+                info.table_name,
+                result["old_snapshot_id"],
+                result["new_snapshot_id"],
+            )
+
+    if failed:
+        raise Exception(  # noqa: TRY002
+            f"Snapshot pointer repair failed for {len(failed)} table(s): "
+            + ", ".join(failed)
+            + " — check the run logs for details."
+        )
+
+
+@job(name="iceberg_snapshot_pointer_repair")
+def iceberg_snapshot_pointer_repair_job():
+    repair_lagging_snapshot_pointers()
+
+
+@sensor(
+    name="iceberg_snapshot_pointer_lag",
+    job=iceberg_snapshot_pointer_repair_job,
+    minimum_interval_seconds=3600,
+    default_status=DefaultSensorStatus.RUNNING,
+    description=(
+        "Detects Iceberg tables in the raw layer where current-snapshot-id lags "
+        "behind the latest snapshot (the Airbyte full-refresh pin bug) and "
+        "triggers an automatic repair run.  If the repair run itself fails, the "
+        "existing Slack run-failure alert fires."
+    ),
+)
+def iceberg_snapshot_pointer_lag_sensor(
+    context: SensorEvaluationContext,
+) -> SensorResult:
+    lagging = find_snapshot_pointer_lag(
+        glue_database=RAW_DATABASE,
+        table_prefixes=_HIGH_FREQUENCY_PREFIXES,
+        min_lag_hours=_MIN_LAG_HOURS,
+    )
+
+    cursor_data: dict[str, list[str]] = json.loads(context.cursor or "{}")
+    previously_lagging: set[str] = set(cursor_data.get("lagging", []))
+    currently_lagging: set[str] = {t.table_name for t in lagging}
+
+    new_lagging = currently_lagging - previously_lagging
+    recovered = previously_lagging - currently_lagging
+
+    run_requests = []
+    if new_lagging:
+        context.log.warning(
+            "Snapshot pointer lag detected in %d new table(s): %s — "
+            "triggering repair run.",
+            len(new_lagging),
+            ", ".join(sorted(new_lagging)),
+        )
+        # run_key deduplicates: one repair run per unique set of newly-lagging tables.
+        run_requests.append(
+            RunRequest(run_key=f"repair-{'_'.join(sorted(new_lagging))}")
+        )
+
+    if recovered:
+        context.log.info(
+            "Snapshot pointer lag resolved for %d table(s): %s",
+            len(recovered),
+            ", ".join(sorted(recovered)),
+        )
+
+    return SensorResult(
+        run_requests=run_requests,
+        cursor=json.dumps({"lagging": sorted(currently_lagging)}),
+    )

--- a/packages/ol-orchestrate-lib/src/ol_orchestrate/lib/iceberg_maintenance.py
+++ b/packages/ol-orchestrate-lib/src/ol_orchestrate/lib/iceberg_maintenance.py
@@ -87,6 +87,28 @@ class RawLayerTableInfo:
     latest_snapshot_timestamp_ms: int | None = None
 
 
+@dataclass(frozen=True)
+class SnapshotPointerLag:
+    """A table whose Iceberg current-snapshot-id lags behind the latest snapshot.
+
+    This indicates that Airbyte wrote new snapshots to the history but did not
+    advance the current-snapshot-id pointer, leaving dbt/Trino reading stale data.
+    """
+
+    table_name: str
+    database: str
+    current_snapshot_id: int
+    current_snapshot_timestamp_ms: int
+    latest_snapshot_id: int
+    latest_snapshot_timestamp_ms: int
+
+    @property
+    def lag_hours(self) -> float:
+        return (
+            self.latest_snapshot_timestamp_ms - self.current_snapshot_timestamp_ms
+        ) / 3_600_000
+
+
 # ── Constants ─────────────────────────────────────────────────────────────────
 
 # Source-group-level overrides for raw-layer maintenance.
@@ -473,3 +495,219 @@ def load_raw_layer_maintenance_work(
         sum(t.eligible_snapshot_count for t in results),
     )
     return results
+
+
+def find_snapshot_pointer_lag(  # noqa: C901
+    glue_database: str,
+    table_prefixes: list[str],
+    min_lag_hours: float = 2.0,
+    region: str = AWS_REGION,
+) -> list[SnapshotPointerLag]:
+    """Scan Iceberg tables and return those whose current-snapshot-id is stale.
+
+    Airbyte incremental syncs append new snapshots to the Iceberg history but
+    occasionally fail to advance ``current-snapshot-id`` — a bug observed when
+    a connection reset triggers a full-refresh that pins the pointer, after which
+    subsequent incremental syncs accumulate in the history without becoming
+    visible to Trino/dbt.
+
+    Only tables whose names start with one of *table_prefixes* are scanned, which
+    keeps this fast when called from a sensor.  Pass the high-frequency group
+    prefixes (e.g. ``["raw__xpro__app", "raw__mitxonline__app"]``) to limit scope.
+
+    A table is reported only when the gap between the current-snapshot timestamp
+    and the latest-snapshot timestamp exceeds *min_lag_hours*.  Short gaps (< 2 h)
+    are expected during the write window and should not alert.
+    """
+    glue_client = boto3.client("glue", region_name=region)
+    catalog = get_glue_catalog(region=region)
+    min_lag_ms = int(min_lag_hours * 3_600_000)
+
+    iceberg_table_names: list[str] = []
+    paginator = glue_client.get_paginator("get_tables")
+    for page in paginator.paginate(DatabaseName=glue_database):
+        for table in page.get("TableList", []):
+            name = table["Name"]
+            if not any(name.startswith(p) for p in table_prefixes):
+                continue
+            if table.get("Parameters", {}).get("table_type", "").upper() == "ICEBERG":
+                iceberg_table_names.append(name)
+
+    log.info(
+        "Snapshot pointer scan: checking %d tables in %s",
+        len(iceberg_table_names),
+        glue_database,
+    )
+
+    lagging: list[SnapshotPointerLag] = []
+    for table_name in iceberg_table_names:
+        try:
+            table = catalog.load_table(f"{glue_database}.{table_name}")
+            snapshots = table.metadata.snapshots
+            if not snapshots:
+                continue
+
+            current_id = table.metadata.current_snapshot_id
+            current_snap = next(
+                (s for s in snapshots if s.snapshot_id == current_id), None
+            )
+            latest_snap = max(snapshots, key=lambda s: s.timestamp_ms)
+
+            if current_id == latest_snap.snapshot_id:
+                continue
+
+            if current_snap is None:
+                log.warning(
+                    "%s: current_snapshot_id %s not found in snapshot list",
+                    table_name,
+                    current_id,
+                )
+                continue
+
+            lag_ms = latest_snap.timestamp_ms - current_snap.timestamp_ms
+            if lag_ms < min_lag_ms:
+                continue
+
+            lagging.append(
+                SnapshotPointerLag(
+                    table_name=table_name,
+                    database=glue_database,
+                    current_snapshot_id=current_snap.snapshot_id,
+                    current_snapshot_timestamp_ms=current_snap.timestamp_ms,
+                    latest_snapshot_id=latest_snap.snapshot_id,
+                    latest_snapshot_timestamp_ms=latest_snap.timestamp_ms,
+                )
+            )
+        except Exception as exc:  # noqa: BLE001
+            log.warning("Could not check snapshot pointer for %s: %s", table_name, exc)
+
+    lagging.sort(key=lambda t: t.lag_hours, reverse=True)
+    log.info(
+        "Snapshot pointer scan complete: %d/%d tables have stale pointer",
+        len(lagging),
+        len(iceberg_table_names),
+    )
+    return lagging
+
+
+def advance_snapshot_pointer(
+    glue_database: str,
+    table_name: str,
+    region: str = AWS_REGION,
+) -> dict[str, Any]:
+    """Advance ``current-snapshot-id`` to the latest snapshot for a lagging table.
+
+    This repairs the Airbyte bug where incremental syncs append new Iceberg
+    snapshots to the history but do not advance the ``current-snapshot-id``
+    pointer.  Trino and dbt always read the current snapshot, so without this
+    fix they see stale data even though newer snapshots exist.
+
+    The repair is a safe, additive operation:
+
+    1. Read the existing Iceberg metadata JSON from S3.
+    2. Write a *new* metadata JSON (with a fresh UUID filename) that sets
+       ``current-snapshot-id`` to the latest snapshot and appends an entry to
+       ``snapshot-log`` if one is missing.
+    3. Update the Glue ``metadata_location`` parameter to point at the new file.
+
+    Returns a result dict with keys ``skipped``, ``old_snapshot_id``,
+    ``new_snapshot_id``, ``lag_hours``, and ``new_metadata_location``.
+    """
+    import json  # noqa: PLC0415
+    import uuid  # noqa: PLC0415
+
+    glue_client = boto3.client("glue", region_name=region)
+    s3_client = boto3.client("s3", region_name=region)
+    catalog = get_glue_catalog(region=region)
+
+    table = catalog.load_table(f"{glue_database}.{table_name}")
+    snapshots = table.metadata.snapshots
+    current_id = table.metadata.current_snapshot_id
+
+    if not snapshots:
+        return {"skipped": True, "reason": "no snapshots"}
+
+    latest_snap = max(snapshots, key=lambda s: s.timestamp_ms)
+
+    if current_id == latest_snap.snapshot_id:
+        return {"skipped": True, "reason": "already current"}
+
+    current_snap = next((s for s in snapshots if s.snapshot_id == current_id), None)
+    lag_hours: float | None = (
+        (latest_snap.timestamp_ms - current_snap.timestamp_ms) / 3_600_000
+        if current_snap
+        else None
+    )
+
+    glue_response = glue_client.get_table(DatabaseName=glue_database, Name=table_name)
+    params = glue_response["Table"].get("Parameters", {})
+    metadata_location = params.get("metadata_location", "")
+    if not metadata_location.startswith("s3://"):
+        return {
+            "skipped": True,
+            "reason": f"unexpected metadata_location: {metadata_location}",
+        }
+
+    bucket, old_key = metadata_location[5:].split("/", 1)
+    metadata_dir = old_key.rsplit("/", 1)[0]
+
+    obj = s3_client.get_object(Bucket=bucket, Key=old_key)
+    metadata: dict[str, Any] = json.loads(obj["Body"].read())
+
+    metadata["current-snapshot-id"] = latest_snap.snapshot_id
+
+    existing_log_ids = {
+        entry.get("snapshot-id") for entry in metadata.get("snapshot-log", [])
+    }
+    if latest_snap.snapshot_id not in existing_log_ids:
+        metadata.setdefault("snapshot-log", []).append(
+            {
+                "snapshot-id": latest_snap.snapshot_id,
+                "timestamp-ms": latest_snap.timestamp_ms,
+            }
+        )
+
+    new_key = f"{metadata_dir}/{uuid.uuid4()}.metadata.json"
+    s3_client.put_object(
+        Bucket=bucket,
+        Key=new_key,
+        Body=json.dumps(metadata),
+        ContentType="application/json",
+    )
+    new_metadata_location = f"s3://{bucket}/{new_key}"
+
+    # Build the minimal TableInput Glue needs for an update call — strip
+    # read-only fields that the API rejects.
+    _read_only = {
+        "DatabaseName",
+        "CreateTime",
+        "UpdateTime",
+        "IsRegisteredWithLakeFormation",
+        "CatalogId",
+        "VersionId",
+        "IsMultiDialectView",
+    }
+    table_input = {
+        k: v for k, v in glue_response["Table"].items() if k not in _read_only
+    }
+    table_input.setdefault("Parameters", {})["metadata_location"] = (
+        new_metadata_location
+    )
+
+    glue_client.update_table(DatabaseName=glue_database, TableInput=table_input)
+
+    log.info(
+        "Advanced snapshot pointer for %s.%s: %s → %s (%.1fh lag resolved)",
+        glue_database,
+        table_name,
+        current_id,
+        latest_snap.snapshot_id,
+        lag_hours or 0,
+    )
+    return {
+        "skipped": False,
+        "old_snapshot_id": current_id,
+        "new_snapshot_id": latest_snap.snapshot_id,
+        "lag_hours": lag_hours,
+        "new_metadata_location": new_metadata_location,
+    }

--- a/packages/ol-orchestrate-lib/src/ol_orchestrate/lib/iceberg_maintenance.py
+++ b/packages/ol-orchestrate-lib/src/ol_orchestrate/lib/iceberg_maintenance.py
@@ -676,6 +676,21 @@ def advance_snapshot_pointer(  # noqa: PLR0915
             }
         )
 
+    # Per the Iceberg spec, each new metadata file must record the previous
+    # metadata file in metadata-log so that history traversal tools and
+    # expire_snapshots can reconstruct the full chain.
+    old_metadata_location = f"s3://{bucket}/{old_key}"
+    existing_meta_log_files = {
+        e.get("metadata-file") for e in metadata.get("metadata-log", [])
+    }
+    if old_metadata_location not in existing_meta_log_files:
+        metadata.setdefault("metadata-log", []).append(
+            {
+                "metadata-file": old_metadata_location,
+                "timestamp-ms": latest_snap.timestamp_ms,
+            }
+        )
+
     # Iceberg requires metadata files named {version}-{uuid}.metadata.json.
     # Trino rejects files whose names don't match this pattern.  Derive the
     # next version from the current filename or fall back to the metadata-log.

--- a/packages/ol-orchestrate-lib/src/ol_orchestrate/lib/iceberg_maintenance.py
+++ b/packages/ol-orchestrate-lib/src/ol_orchestrate/lib/iceberg_maintenance.py
@@ -595,7 +595,7 @@ def find_snapshot_pointer_lag(  # noqa: C901
     return lagging
 
 
-def advance_snapshot_pointer(  # noqa: PLR0915, C901
+def advance_snapshot_pointer(  # noqa: PLR0912, PLR0915, C901
     glue_database: str,
     table_name: str,
     region: str = AWS_REGION,
@@ -646,6 +646,7 @@ def advance_snapshot_pointer(  # noqa: PLR0915, C901
     )
 
     glue_response = glue_client.get_table(DatabaseName=glue_database, Name=table_name)
+    glue_version_id = glue_response["Table"].get("VersionId")
     params = glue_response["Table"].get("Parameters", {})
     metadata_location = params.get("metadata_location", "")
     if not metadata_location.startswith("s3://"):
@@ -717,7 +718,10 @@ def advance_snapshot_pointer(  # noqa: PLR0915, C901
 
     # Iceberg requires metadata files named {version}-{uuid}.metadata.json.
     # Trino rejects files whose names don't match this pattern.  Derive the
-    # next version from the current filename or fall back to the metadata-log.
+    # next version from the current filename; if that doesn't match (legacy
+    # non-versioned names), fall back to an S3 listing of the metadata prefix
+    # so the version stays monotonically increasing even when the metadata-log
+    # has gaps.  The UUID suffix guarantees uniqueness regardless of version.
     _ver_re = re.compile(r"^(\d+)-[0-9a-f-]+\.metadata\.json$")
     old_filename = old_key.rsplit("/", 1)[-1]
     prev_version = 0
@@ -725,11 +729,13 @@ def advance_snapshot_pointer(  # noqa: PLR0915, C901
     if m:
         prev_version = int(m.group(1))
     else:
-        for entry in metadata.get("metadata-log", []):
-            mf = entry.get("metadata-file", "").rsplit("/", 1)[-1]
-            mv = _ver_re.match(mf)
-            if mv:
-                prev_version = max(prev_version, int(mv.group(1)))
+        paginator = s3_client.get_paginator("list_objects_v2")
+        for page in paginator.paginate(Bucket=bucket, Prefix=f"{metadata_dir}/"):
+            for obj_meta in page.get("Contents", []):
+                fname = obj_meta["Key"].rsplit("/", 1)[-1]
+                mv = _ver_re.match(fname)
+                if mv:
+                    prev_version = max(prev_version, int(mv.group(1)))
     new_filename = f"{prev_version + 1:05d}-{uuid.uuid4()}.metadata.json"
     new_key = f"{metadata_dir}/{new_filename}"
     s3_client.put_object(
@@ -765,7 +771,16 @@ def advance_snapshot_pointer(  # noqa: PLR0915, C901
         new_metadata_location
     )
 
-    glue_client.update_table(DatabaseName=glue_database, TableInput=table_input)
+    # Pass VersionId for optimistic locking — Glue raises
+    # ConcurrentModificationException if another writer advanced the pointer
+    # between our get_table and update_table calls, preventing a stale overwrite.
+    update_kwargs: dict[str, Any] = {
+        "DatabaseName": glue_database,
+        "TableInput": table_input,
+    }
+    if glue_version_id is not None:
+        update_kwargs["VersionId"] = glue_version_id
+    glue_client.update_table(**update_kwargs)
 
     log.info(
         "Advanced snapshot pointer for %s.%s: %s → %s (%.1fh lag resolved)",

--- a/packages/ol-orchestrate-lib/src/ol_orchestrate/lib/iceberg_maintenance.py
+++ b/packages/ol-orchestrate-lib/src/ol_orchestrate/lib/iceberg_maintenance.py
@@ -657,6 +657,13 @@ def advance_snapshot_pointer(
 
     metadata["current-snapshot-id"] = latest_snap.snapshot_id
 
+    # Keep refs.main in sync with current-snapshot-id.  The Java Iceberg library
+    # (used by the Airbyte destination connector) validates that these are equal
+    # and throws IllegalArgumentException if they differ.  PyIceberg does not
+    # enforce this, so mismatches go undetected until Airbyte tries to write.
+    if "refs" in metadata and "main" in metadata["refs"]:
+        metadata["refs"]["main"]["snapshot-id"] = latest_snap.snapshot_id
+
     existing_log_ids = {
         entry.get("snapshot-id") for entry in metadata.get("snapshot-log", [])
     }

--- a/packages/ol-orchestrate-lib/src/ol_orchestrate/lib/iceberg_maintenance.py
+++ b/packages/ol-orchestrate-lib/src/ol_orchestrate/lib/iceberg_maintenance.py
@@ -643,10 +643,11 @@ def advance_snapshot_pointer(
     params = glue_response["Table"].get("Parameters", {})
     metadata_location = params.get("metadata_location", "")
     if not metadata_location.startswith("s3://"):
-        return {
-            "skipped": True,
-            "reason": f"unexpected metadata_location: {metadata_location}",
-        }
+        msg = (
+            f"{glue_database}.{table_name}: unexpected metadata_location "
+            f"{metadata_location!r} — cannot repair safely"
+        )
+        raise ValueError(msg)
 
     bucket, old_key = metadata_location[5:].split("/", 1)
     metadata_dir = old_key.rsplit("/", 1)[0]
@@ -671,7 +672,7 @@ def advance_snapshot_pointer(
     s3_client.put_object(
         Bucket=bucket,
         Key=new_key,
-        Body=json.dumps(metadata),
+        Body=json.dumps(metadata).encode("utf-8"),
         ContentType="application/json",
     )
     new_metadata_location = f"s3://{bucket}/{new_key}"

--- a/packages/ol-orchestrate-lib/src/ol_orchestrate/lib/iceberg_maintenance.py
+++ b/packages/ol-orchestrate-lib/src/ol_orchestrate/lib/iceberg_maintenance.py
@@ -595,7 +595,7 @@ def find_snapshot_pointer_lag(  # noqa: C901
     return lagging
 
 
-def advance_snapshot_pointer(  # noqa: PLR0915
+def advance_snapshot_pointer(  # noqa: PLR0915, C901
     glue_database: str,
     table_name: str,
     region: str = AWS_REGION,
@@ -684,7 +684,16 @@ def advance_snapshot_pointer(  # noqa: PLR0915
     # Per the Iceberg spec, each new metadata file must record the previous
     # metadata file in metadata-log so that history traversal tools and
     # expire_snapshots can reconstruct the full chain.
+    #
+    # The timestamp for the log entry must be the OLD file's own last-updated-ms
+    # (i.e. when that file was the active metadata), NOT the latest snapshot
+    # timestamp.  Using the snapshot timestamp can produce unsorted entries when
+    # current-snapshot-id is stuck at an old snapshot whose timestamp predates
+    # newer staging-branch metadata written by the connector.  Iceberg 1.11.0
+    # validates that metadata-log is sorted and throws IllegalArgumentException
+    # if entries are out of order.
     old_metadata_location = f"s3://{bucket}/{old_key}"
+    old_last_updated_ms = metadata.get("last-updated-ms", latest_snap.timestamp_ms)
     existing_meta_log_files = {
         e.get("metadata-file") for e in metadata.get("metadata-log", [])
     }
@@ -692,9 +701,19 @@ def advance_snapshot_pointer(  # noqa: PLR0915
         metadata.setdefault("metadata-log", []).append(
             {
                 "metadata-file": old_metadata_location,
-                "timestamp-ms": latest_snap.timestamp_ms,
+                "timestamp-ms": old_last_updated_ms,
             }
         )
+    # Sort the metadata-log by timestamp so the invariant enforced by Iceberg
+    # 1.11.0 (entries must be non-decreasing) is always satisfied after repair.
+    # Duplicate file paths can accumulate from repeated repairs; deduplicate
+    # keeping the LAST occurrence (most recent timestamp for a given file).
+    seen_files: dict[str, dict[str, Any]] = {}
+    for entry in metadata.get("metadata-log", []):
+        seen_files[entry.get("metadata-file", "")] = entry
+    metadata["metadata-log"] = sorted(
+        seen_files.values(), key=lambda e: e.get("timestamp-ms", 0)
+    )
 
     # Iceberg requires metadata files named {version}-{uuid}.metadata.json.
     # Trino rejects files whose names don't match this pattern.  Derive the

--- a/packages/ol-orchestrate-lib/src/ol_orchestrate/lib/iceberg_maintenance.py
+++ b/packages/ol-orchestrate-lib/src/ol_orchestrate/lib/iceberg_maintenance.py
@@ -499,21 +499,24 @@ def load_raw_layer_maintenance_work(
 
 def find_snapshot_pointer_lag(  # noqa: C901
     glue_database: str,
-    table_prefixes: list[str],
+    table_prefixes: list[str] | None = None,
     min_lag_hours: float = 2.0,
     region: str = AWS_REGION,
 ) -> list[SnapshotPointerLag]:
     """Scan Iceberg tables and return those whose current-snapshot-id is stale.
 
-    Airbyte incremental syncs append new snapshots to the Iceberg history but
-    occasionally fail to advance ``current-snapshot-id`` — a bug observed when
-    a connection reset triggers a full-refresh that pins the pointer, after which
-    subsequent incremental syncs accumulate in the history without becoming
-    visible to Trino/dbt.
+    The Airbyte S3 Data Lake connector uses a staging branch pattern: data is
+    written to ``refs.airbyte_staging_<id>`` and promoted to ``refs.main`` via
+    ``replaceBranch`` in ``teardown(true)``.  When a sync fails, ``teardown(false)``
+    is called instead, leaving the staging branch un-promoted and
+    ``current-snapshot-id`` stuck at an earlier snapshot.  Iceberg 1.11.0 (used
+    by the connector) also validates that ``refs.main.snapshot-id ==
+    current-snapshot-id`` on table load, so any pre-existing inconsistency
+    (written by an older connector version) causes every subsequent sync to fail
+    with ``IllegalArgumentException``, compounding the lag.
 
-    Only tables whose names start with one of *table_prefixes* are scanned, which
-    keeps this fast when called from a sensor.  Pass the high-frequency group
-    prefixes (e.g. ``["raw__xpro__app", "raw__mitxonline__app"]``) to limit scope.
+    If *table_prefixes* is ``None`` (the default), all Iceberg tables in the
+    database are scanned.  Pass a list of name prefixes to restrict the scan.
 
     A table is reported only when the gap between the current-snapshot timestamp
     and the latest-snapshot timestamp exceeds *min_lag_hours*.  Short gaps (< 2 h)
@@ -528,7 +531,9 @@ def find_snapshot_pointer_lag(  # noqa: C901
     for page in paginator.paginate(DatabaseName=glue_database):
         for table in page.get("TableList", []):
             name = table["Name"]
-            if not any(name.startswith(p) for p in table_prefixes):
+            if table_prefixes is not None and not any(
+                name.startswith(p) for p in table_prefixes
+            ):
                 continue
             if table.get("Parameters", {}).get("table_type", "").upper() == "ICEBERG":
                 iceberg_table_names.append(name)

--- a/packages/ol-orchestrate-lib/src/ol_orchestrate/lib/iceberg_maintenance.py
+++ b/packages/ol-orchestrate-lib/src/ol_orchestrate/lib/iceberg_maintenance.py
@@ -590,7 +590,7 @@ def find_snapshot_pointer_lag(  # noqa: C901
     return lagging
 
 
-def advance_snapshot_pointer(
+def advance_snapshot_pointer(  # noqa: PLR0915
     glue_database: str,
     table_name: str,
     region: str = AWS_REGION,
@@ -614,6 +614,7 @@ def advance_snapshot_pointer(
     ``new_snapshot_id``, ``lag_hours``, and ``new_metadata_location``.
     """
     import json  # noqa: PLC0415
+    import re  # noqa: PLC0415
     import uuid  # noqa: PLC0415
 
     glue_client = boto3.client("glue", region_name=region)
@@ -675,7 +676,23 @@ def advance_snapshot_pointer(
             }
         )
 
-    new_key = f"{metadata_dir}/{uuid.uuid4()}.metadata.json"
+    # Iceberg requires metadata files named {version}-{uuid}.metadata.json.
+    # Trino rejects files whose names don't match this pattern.  Derive the
+    # next version from the current filename or fall back to the metadata-log.
+    _ver_re = re.compile(r"^(\d+)-[0-9a-f-]+\.metadata\.json$")
+    old_filename = old_key.rsplit("/", 1)[-1]
+    prev_version = 0
+    m = _ver_re.match(old_filename)
+    if m:
+        prev_version = int(m.group(1))
+    else:
+        for entry in metadata.get("metadata-log", []):
+            mf = entry.get("metadata-file", "").rsplit("/", 1)[-1]
+            mv = _ver_re.match(mf)
+            if mv:
+                prev_version = max(prev_version, int(mv.group(1)))
+    new_filename = f"{prev_version + 1:05d}-{uuid.uuid4()}.metadata.json"
+    new_key = f"{metadata_dir}/{new_filename}"
     s3_client.put_object(
         Bucket=bucket,
         Key=new_key,
@@ -684,19 +701,26 @@ def advance_snapshot_pointer(
     )
     new_metadata_location = f"s3://{bucket}/{new_key}"
 
-    # Build the minimal TableInput Glue needs for an update call — strip
-    # read-only fields that the API rejects.
-    _read_only = {
-        "DatabaseName",
-        "CreateTime",
-        "UpdateTime",
-        "IsRegisteredWithLakeFormation",
-        "CatalogId",
-        "VersionId",
-        "IsMultiDialectView",
+    # Use an allowlist rather than a blocklist — Glue occasionally adds new
+    # read-only fields that would cause update_table to fail if passed through.
+    _valid_table_input = {
+        "Name",
+        "Description",
+        "Owner",
+        "LastAccessTime",
+        "LastAnalyzedTime",
+        "Retention",
+        "StorageDescriptor",
+        "PartitionKeys",
+        "ViewOriginalText",
+        "ViewExpandedText",
+        "TableType",
+        "Parameters",
+        "TargetTable",
+        "ViewDefinition",
     }
     table_input = {
-        k: v for k, v in glue_response["Table"].items() if k not in _read_only
+        k: v for k, v in glue_response["Table"].items() if k in _valid_table_input
     }
     table_input.setdefault("Parameters", {})["metadata_location"] = (
         new_metadata_location


### PR DESCRIPTION
### What are the relevant tickets?

N/A — this is a self-contained reliability improvement discovered during incident investigation on 2026-06-24.

### Description (What does it do?)

Adds automatic detection and repair of an Airbyte Iceberg bug where `current-snapshot-id` gets frozen after a full-refresh and subsequent incremental syncs stop becoming visible to Trino/dbt.

**The bug:** When an Airbyte connection is reset and performs a full-refresh, it creates a large snapshot and pins `current-snapshot-id` to it. Subsequent incremental syncs append new snapshots to the Iceberg history but do not advance the pointer. Trino and dbt always read the `current-snapshot-id` snapshot, so all downstream models see stale data even though newer records exist in the history.

**Observed impact:** On 2026-06-24, this affected 9 xPRO raw tables (`ecommerce_order`, `ecommerce_line`, `ecommerce_receipt`, `ecommerce_couponredemption`, `ecommerce_coupon`, `b2becommerce_b2border`, `b2becommerce_b2borderline`, `b2becommerce_contractpage`, `ecommerce_couponpaymentversion`). The pointer was frozen at the June 17 snapshot while 14 newer snapshots had accumulated — causing xPRO order data in `marts__combined__orders` to appear stale despite successful dbt rebuilds.

**New components:**

- **`packages/ol-orchestrate-lib/src/ol_orchestrate/lib/iceberg_maintenance.py`**
  - `SnapshotPointerLag` dataclass — represents a table with a stale pointer, with a `lag_hours` property
  - `find_snapshot_pointer_lag(glue_database, table_prefixes, min_lag_hours)` — scans Iceberg tables matching given prefixes and returns those where `current-snapshot-id` is not the latest snapshot and the gap exceeds the threshold
  - `advance_snapshot_pointer(glue_database, table_name)` — repairs a lagging table by writing a new Iceberg metadata JSON with the pointer advanced to the latest snapshot and updating the Glue `metadata_location` parameter

- **`dg_projects/lakehouse/lakehouse/sensors.py`** (new file)
  - `repair_lagging_snapshot_pointers` op — re-discovers lagging tables at run time and calls `advance_snapshot_pointer` for each; raises at the end if any failed (triggering the Slack run-failure alert)
  - `iceberg_snapshot_pointer_repair` job — wraps the op
  - `iceberg_snapshot_pointer_lag` sensor — runs hourly, scans the high-frequency Airbyte groups (xPRO, MITx Online, MIT Learn, Learn AI, OCW), yields a `RunRequest` to the repair job when new lag is detected; cursor-based deduplication prevents repeated repair runs for the same batch of stuck tables

- **`dg_projects/lakehouse/lakehouse/definitions.py`** — registers the sensor and repair job

### How can this be tested?

1. Deploy to QA and confirm the `iceberg_snapshot_pointer_lag` sensor appears in the Dagster UI in `RUNNING` state.
2. To simulate the bug: use `aws glue update-table` to set `metadata_location` on a raw table to point at an older metadata JSON (one where `current-snapshot-id` is behind the latest snapshot). Wait for the next sensor tick (≤ 1 hour) and confirm a `iceberg_snapshot_pointer_repair` run is triggered and completes successfully.
3. After the repair run, verify with `aws glue get-table --database-name ol_warehouse_production_raw --name <table>` that `metadata_location` now points at the new metadata file and `current-snapshot-id` matches the latest snapshot.

In production, the sensor will fire automatically if the condition recurs.

### Additional Context

The `advance_snapshot_pointer` repair is safe and additive — it writes a new metadata JSON file (UUID-named) rather than modifying the existing one, so the prior state is preserved. Glue is updated atomically via a single `update_table` call pointing at the new file.

The sensor scans only tables in `RAW_LAYER_GROUP_CONFIGS` prefixes (excluding `_default`) to limit Glue API calls. Low-frequency sync groups are excluded because pointer lag there is less urgent and would add noise.