### PR TITLE
fix(edxorg_s3_ingest): deduplicate source rows before pyiceberg upsert

### DIFF
--- a/dg_projects/data_loading/data_loading/defs/edxorg_s3_ingest/loads.py
+++ b/dg_projects/data_loading/data_loading/defs/edxorg_s3_ingest/loads.py
@@ -27,12 +27,65 @@ import os
 from pathlib import Path
 
 import dlt
+import pyarrow as pa
 import s3fs
 from dlt.sources import incremental
 from dlt.sources.filesystem import filesystem, read_csv_duckdb
 from ol_orchestrate.lib.constants import EDXORG_DB_TABLES
 
 logger = logging.getLogger(__name__)
+
+_EDXORG_PRIMARY_KEY = ["row_hash", "extracted_course_key"]
+
+
+def _make_deduplicator():
+    """
+    Return a stateful per-run deduplication function for use with add_map.
+
+    Tracks seen (row_hash, extracted_course_key) pairs and drops rows whose
+    key was already seen earlier in the same extraction run.  Scoped per
+    call, so each edxorg_s3_source() invocation (one table, one pipeline run)
+    starts with an empty seen-set.
+
+    pyiceberg's upsert raises ValueError when the source DataFrame contains
+    duplicate join-key rows, even if those rows are identical.  This happens
+    when multiple TSV files from overlapping archive runs are extracted in one
+    dlt run and combined into a single normalised parquet file.
+    """
+    seen: set[tuple[str | None, ...]] = set()
+
+    def _dedup(item: object) -> object:
+        if not isinstance(item, (pa.Table, pa.RecordBatch)):
+            return item
+
+        tbl = item if isinstance(item, pa.Table) else pa.Table.from_batches([item])
+
+        active_pk = [k for k in _EDXORG_PRIMARY_KEY if k in tbl.schema.names]
+        if not active_pk:
+            return tbl
+
+        key_cols = [tbl.column(k).to_pylist() for k in active_pk]
+        row_keys = (
+            list(zip(*key_cols)) if len(key_cols) > 1 else [(v,) for v in key_cols[0]]
+        )
+
+        keep = []
+        for key in row_keys:
+            keep.append(key not in seen)
+            seen.add(key)
+
+        if all(keep):
+            return tbl
+        if not any(keep):
+            # Return an empty table (same schema) rather than None.
+            # The add_map docs say to use add_filter for dropping records;
+            # returning None from add_map is undefined and may propagate as data.
+            return tbl.slice(0, 0)
+
+        return tbl.filter(pa.array(keep, type=pa.bool_()))
+
+    return _dedup
+
 
 # Set dlt project directory to the data_loading project root
 # This ensures .dlt/config.toml is found when running from repo root
@@ -135,6 +188,12 @@ def edxorg_s3_source(
                 )
             )
             .with_name(resource_name)
+            # Drop rows whose (row_hash, extracted_course_key) was already seen earlier
+            # in this extraction run.  Multiple TSV files from overlapping archive runs
+            # can carry the same logical row; dlt's normaliser combines them into one
+            # parquet file, and pyiceberg's upsert raises ValueError on duplicate
+            # join-key rows in the source DataFrame.
+            .add_map(_make_deduplicator())
             # All edxorg TSV exports include a row_hash column. Use a composite key
             # with extracted_course_key because row_hash is computed from only the
             # original CSV columns (excluding the extracted_* fields added during
@@ -143,7 +202,7 @@ def edxorg_s3_source(
             .apply_hints(
                 table_name=resource_name,
                 write_disposition="merge",
-                primary_key=["row_hash", "extracted_course_key"],
+                primary_key=_EDXORG_PRIMARY_KEY,
                 table_format=table_format,
             )
         )

--- a/dg_projects/data_loading/data_loading/defs/edxorg_s3_ingest/loads.py
+++ b/dg_projects/data_loading/data_loading/defs/edxorg_s3_ingest/loads.py
@@ -60,17 +60,16 @@ def _make_deduplicator():
 
         tbl = item if isinstance(item, pa.Table) else pa.Table.from_batches([item])
 
-        active_pk = [k for k in _EDXORG_PRIMARY_KEY if k in tbl.schema.names]
-        if not active_pk:
+        # Require ALL primary key columns to be present.  Partial-key
+        # deduplication (e.g. on row_hash alone) would silently drop valid rows
+        # because row_hash is not course-unique on its own.
+        if not all(k in tbl.schema.names for k in _EDXORG_PRIMARY_KEY):
             return tbl
 
-        key_cols = [tbl.column(k).to_pylist() for k in active_pk]
-        row_keys = (
-            list(zip(*key_cols)) if len(key_cols) > 1 else [(v,) for v in key_cols[0]]
-        )
+        key_cols = [tbl.column(k).to_pylist() for k in _EDXORG_PRIMARY_KEY]
 
         keep = []
-        for key in row_keys:
+        for key in zip(*key_cols):
             keep.append(key not in seen)
             seen.add(key)
 


### PR DESCRIPTION
### What are the relevant tickets?
N/A

### Description (What does it do?)

`pyiceberg`'s `upsert` raises `ValueError: Duplicate rows found in source dataset based on the key columns` when the source parquet file contains rows with duplicate `(row_hash, extracted_course_key)` pairs.

**Root cause**: When multiple TSV files from overlapping archive export runs become new since the last dlt cursor, they are all extracted in a single dlt run. dlt's normaliser concatenates every extracted batch into one parquet file. If two TSV files carry the same logical row (identical content, same course), the resulting parquet file has duplicate join-key rows. `pyiceberg` refuses to `upsert` a source DataFrame with duplicate join keys—even when the row values are identical—so the load job retries 5 times then aborts.

**Fix**: Add `_make_deduplicator()` in `loads.py`, which returns a stateful closure for use with `dlt`'s `add_map()`. The closure maintains a `seen` set of `(row_hash, extracted_course_key)` tuples and filters out duplicate rows before they reach dlt's normaliser. Each call to `edxorg_s3_source()` (one table, one pipeline run) creates a fresh `seen` set, so there is no cross-table or cross-run contamination. Sequential extraction (`workers=1` in `.dlt/config.toml`) makes the stateful closure safe without any locking.

Also extracts the primary key list into the module-level constant `_EDXORG_PRIMARY_KEY` to avoid repeating the literal.

**Why not use dlt's built-in `delete-insert` deduplication?** For SQL destinations, dlt's `delete-insert` merge strategy deduplicates staging data automatically. For the `filesystem` destination with `iceberg` table format, dlt bypasses the generic merge strategy and calls `dlt.common.libs.pyiceberg.merge_iceberg_table` directly, which delegates straight to `pyiceberg.Table.upsert`—no deduplication step is applied before that call.

### Screenshots (if appropriate):
N/A

### How can this be tested?

The error requires production/QA S3 data with overlapping archive exports to reproduce, so the fix was not verified locally. To validate in QA:

1. Deploy the branch to QA.
2. Re-run the `edxorg_s3_tables` Dagster asset for `assessment_peerworkflow` (the table that triggered the error).
3. Confirm the asset materialises successfully without the `ValueError: Duplicate rows found in source dataset based on the key columns` error.
4. Optionally: inspect Dagster logs and confirm the deduplicator silently drops zero or more duplicate rows.

### Additional Context

The original error trace:
```
ValueError: Duplicate rows found in source dataset based on the key columns. No upsert executed
  File ".../dlt/common/libs/pyiceberg.py", line 115, in merge_iceberg_table
      table.upsert(df=batch_tbl, join_cols=primary_key, ...)
```

After 5 retries, dlt aborted the load job with:
```
dlt.load.exceptions.LoadClientJobRetry: Job with job_id=raw__edxorg__s3__tables__assessment_peerworkflow.f694bfc69d.reference had 5 retries which is a multiple of max_retry_count=5.
```

**Uncertainty**: The dlt docs show `add_map` working on dict records. If dlt ever decomposes a PyArrow Table into row-by-row dicts before calling `add_map`, the `isinstance(item, (pa.Table, pa.RecordBatch))` guard would be False and all rows would pass through unchanged (silent no-op, no crash). This can be confirmed by checking Dagster run logs for the next execution—if duplicates still reach pyiceberg, a fallback approach (e.g. monkey-patching `merge_iceberg_table` to deduplicate `batch_tbl` before calling `upsert`) would be needed.