### PR TITLE
feat(data_loading): schedule mit_climate + mit_edx_programs dlt ingest

### DIFF
--- a/dg_projects/data_loading/data_loading/defs/ingestion/schedules.py
+++ b/dg_projects/data_loading/data_loading/defs/ingestion/schedules.py
@@ -20,6 +20,29 @@ mitpe_ingest_schedule = dg.ScheduleDefinition(
     execution_timezone="Etc/UTC",
 )
 
+mit_climate_ingest_schedule = dg.ScheduleDefinition(
+    name="mit_climate_ingest_daily_schedule",
+    target=dg.AssetSelection.keys(
+        ["ol_warehouse_raw_data", "raw__mit_climate__api__articles"]
+    ),
+    cron_schedule="30 3 * * *",
+    execution_timezone="Etc/UTC",
+)
+
+mit_edx_programs_ingest_schedule = dg.ScheduleDefinition(
+    name="mit_edx_programs_ingest_daily_schedule",
+    target=dg.AssetSelection.keys(
+        ["ol_warehouse_raw_data", "raw__edxorg__discovery__api__programs"]
+    ),
+    cron_schedule="45 3 * * *",
+    execution_timezone="Etc/UTC",
+)
+
 defs = dg.Definitions(
-    schedules=[oll_ingest_schedule, mitpe_ingest_schedule],
+    schedules=[
+        oll_ingest_schedule,
+        mitpe_ingest_schedule,
+        mit_climate_ingest_schedule,
+        mit_edx_programs_ingest_schedule,
+    ],
 )

--- a/dg_projects/data_loading/data_loading_tests/test_definitions.py
+++ b/dg_projects/data_loading/data_loading_tests/test_definitions.py
@@ -30,6 +30,8 @@ def test_schedules_and_sensors_load() -> None:
     assert {s.name for s in _REPO.schedule_defs} >= {
         "oll_ingest_daily_schedule",
         "mitpe_ingest_daily_schedule",
+        "mit_climate_ingest_daily_schedule",
+        "mit_edx_programs_ingest_daily_schedule",
     }
     assert "edxorg_upstream_changes_sensor" in {s.name for s in _REPO.sensor_defs}
 


### PR DESCRIPTION
## What

Adds daily ingest schedules for the `mit_climate` and `mit_edx_programs` dlt pipelines.

## Why

These two pipelines were wired as Dagster ingestion assets in #2347 but **never scheduled** — only `oll` and `mitpe` had entries in `defs/ingestion/schedules.py`. As a result their raw Iceberg tables (`raw__mit_climate__api__articles`, `raw__edxorg__discovery__api__programs`) were never materialized in Glue, which blocks the downstream Cohort 2 `integrations__learn__mit_climate_articles` / `integrations__learn__mit_edx_programs` models (PR #2277) from being built or validated.

Verified against production Glue: `raw__mitpe__api__courses` and `raw__oll__google_sheets__courses` exist (they are scheduled); the mit_climate and edx-programs raw tables do not.

## What changed

- `mit_climate_ingest_daily_schedule` — `raw__mit_climate__api__articles`, 03:30 UTC
- `mit_edx_programs_ingest_daily_schedule` — `raw__edxorg__discovery__api__programs`, 03:45 UTC

Staggered after the existing oll (03:00) / mitpe (03:15) schedules, mirroring their exact pattern.

## Validation

`dagster definitions validate -m data_loading.definitions` → **passed** (schedule asset-key targets resolve). pre-commit (ruff, mypy) passed.

## Prerequisites for the pipelines to succeed once scheduled

- `mit_edx_programs` needs the edX API secrets in the deployment env (`EDX_API_CLIENT_ID`, `EDX_API_CLIENT_SECRET`, `EDX_API_ACCESS_TOKEN_URL`, `EDX_PROGRAMS_API_URL`).
- `mit_climate` fetches public MIT Climate JSON feeds (Akamai-fronted) — confirm the Dagster egress IP is permitted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)