### PR TITLE
fix: dedupe in int__mitxpro__coursesinprogram

### DIFF
--- a/src/ol_dbt/models/intermediate/mitxpro/int__mitxpro__coursesinprogram.sql
+++ b/src/ol_dbt/models/intermediate/mitxpro/int__mitxpro__coursesinprogram.sql
@@ -40,9 +40,10 @@ with coursesinprogram as (
 )
 
 select
-    coursepages.course_id
-    , programpageswithpath.program_id
-    , unnestedcoursesinprogram.course_order
+    distinct
+    course_id
+    , program_id
+    , course_order
 from unnestedcoursesinprogram
 left join coursepages
     on unnestedcoursesinprogram.coursepage_wagtail_page_id = coursepages.wagtail_page_id

--- a/src/ol_dbt/models/intermediate/mitxpro/int__mitxpro__coursesinprogram.sql
+++ b/src/ol_dbt/models/intermediate/mitxpro/int__mitxpro__coursesinprogram.sql
@@ -41,9 +41,9 @@ with coursesinprogram as (
 
 select
     distinct
-    course_id
-    , program_id
-    , course_order
+    coursepages.course_id
+    , programpageswithpath.program_id
+    , unnestedcoursesinprogram.course_order
 from unnestedcoursesinprogram
 left join coursepages
     on unnestedcoursesinprogram.coursepage_wagtail_page_id = coursepages.wagtail_page_id

--- a/src/ol_dbt/models/staging/mitxpro/stg__mitxpro__app__postgres__cms_coursesinprogrampage.sql
+++ b/src/ol_dbt/models/staging/mitxpro/stg__mitxpro__app__postgres__cms_coursesinprogrampage.sql
@@ -2,6 +2,8 @@ with source as (
     select * from {{ source('ol_warehouse_raw_data','raw__xpro__app__postgres__cms_coursesinprogrampage') }}
 )
 
+{{ deduplicate_raw_table(order_by='_airbyte_extracted_at' , partition_columns = 'page_ptr_id') }}
+
 , cleaned as (
     select
         page_ptr_id as wagtail_page_id
@@ -9,7 +11,7 @@ with source as (
         , body as cms_coursesinprogrampage_body
         , cast(json_parse(json_query(contents, 'lax $[*].value' with array wrapper)) as array(integer)) --noqa
             as cms_coursesinprogrampage_coursepage_wagtail_page_ids
-    from source
+    from most_recent_source
 )
 
 select * from cleaned


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
https://pipelines.odl.mit.edu/runs/b9b212cb-af5f-410d-b142-baf8bd098668

```
[31mFailure in test dbt_expectations_expect_compound_columns_to_be_unique_int__mitxpro__coursesinprogram_course_id__program_id (models/intermediate/mitxpro/_int_mitxpro__models.yml)[0m

  Got 21 results, configured to fail if >10

```

### Description (What does it do?)
<!--- Describe your changes in detail -->
Deduplicate MIT xPro CMS courses-in-program staging data and remove duplicate (course_id, program_id) rows from int__mitxpro__coursesinprogram.


### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

dbt build --select +int__mitxpro__coursesinprogram

### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->


<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
