### PR TITLE
fix: add deduplication to tfact_order SQL query for order_id and line_id

### DIFF
--- a/src/ol_dbt/models/dimensional/tfact_order.sql
+++ b/src/ol_dbt/models/dimensional/tfact_order.sql
@@ -269,4 +269,39 @@ with mitxonline_orders as (
     {% endif %}
 )
 
-select * from final
+-- Dimension joins can fan out rows when a source dimension has multiple qualifying
+-- rows for the same key. Deduplicate to one row per (order_id, line_id, platform),
+-- keeping the most recently updated row.
+, deduped as (
+    select
+        *
+        , row_number() over (
+            partition by order_key
+            order by order_updated_on desc nulls last
+        ) as _row_num
+    from final
+)
+
+select
+    order_key
+    , order_id
+    , line_id
+    , order_date_key
+    , order_updated_date_key
+    , user_fk
+    , platform_fk
+    , discount_fk
+    , discount_type_fk
+    , product_fk
+    , platform
+    , order_state
+    , line_price
+    , order_total_price_paid
+    , tax_rate_fk
+    , order_total_price_paid_plus_tax
+    , order_tax_amount
+    , order_tax_rate
+    , order_reference_number
+    , order_updated_on
+from deduped
+where _row_num = 1


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
https://pipelines.odl.mit.edu/runs/4e69bd4b-86cf-48bb-a4c9-3b6af19a906b
```
31mFailure in test dbt_utils_unique_combination_of_columns_tfact_order_order_id__line_id__platform (models/dimensional/_fact_tables.yml)[0m

  Got 2217 results, configured to fail if >10

[31mFailure in test unique_tfact_order_order_key (models/dimensional/_fact_tables.yml)[0m

  Got 2217 results, configured to fail if >10
```

### Description (What does it do?)
<!--- Describe your changes in detail -->
  Dimension joins can produce multiple rows for the same (order_id, line_id, platform), causing the unique_tfact_order_order_key and unique_combination_of_columns tests to fail.                                                                                                                   
                                                                                                                                                                 
  Adds a deduped CTE using ROW_NUMBER() OVER (PARTITION BY order_key ORDER BY order_updated_on DESC NULLS LAST) to keep one row per grain, preferring the most recently updated.


### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

dbt build --select tfact_order --full-refresh

### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->


<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
