### PR TITLE
feat: add synced flag for MITx Online users in edxorg_to_mitxonline_enrollments

### DIFF
--- a/src/ol_dbt/models/migration/_migration__models.yml
+++ b/src/ol_dbt/models/migration/_migration__models.yml
@@ -101,6 +101,9 @@ models:
     description: int, the discount ID for the 'purchased-on-edx' discount code on
       MITx Online. Populated only for verified future enrollments (null for certificate
       records and audit enrollments).
+  - name: openedxuser_has_been_synced
+    description: boolean, whether the MITx Online user has been synced to edX. Null
+      if no matching MITx Online account was found for the edx.org user.
   tests:
   - dbt_expectations.expect_compound_columns_to_be_unique:
       arguments:

--- a/src/ol_dbt/models/migration/edxorg_to_mitxonline_enrollments.sql
+++ b/src/ol_dbt/models/migration/edxorg_to_mitxonline_enrollments.sql
@@ -210,6 +210,11 @@ with combined_enrollments as (
     select * from {{ ref('int__mitxonline__courserunenrollments') }}
 )
 
+, openedx_users as (
+    select user_id, openedxuser_has_been_synced
+    from {{ ref('stg__mitxonline__app__postgres__openedx_openedxuser') }}
+)
+
 , edxorg_enrollment as (
     select
         combined_enrollments.courserunenrollment_created_on
@@ -275,6 +280,7 @@ select
             and edxorg_enrollment.courserunenrollment_enrollment_mode = 'verified'
             then purchased_on_edx_discount.discount_id
     end as discount_id
+    , openedx_users.openedxuser_has_been_synced
 from edxorg_enrollment
 left join edxorg_grade
     on edxorg_enrollment.user_id = edxorg_grade.user_id
@@ -312,6 +318,8 @@ left join retired_users
 left join courserun_product_version
     on mitxonline__course_runs.courserun_id = courserun_product_version.courserun_id
 left join purchased_on_edx_discount on true
+left join openedx_users
+    on coalesce(mitx_users_by_email.user_mitxonline_id, mitx__users.user_mitxonline_id) = openedx_users.user_id
 where
     (
         edxorg_enrollment.courseruncertificate_created_on is not null


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
https://github.com/mitodl/hq/issues/11545

### Description (What does it do?)
<!--- Describe your changes in detail -->
adds `openedxuser_has_been_synced` to the `edxorg_to_mitxonline_enrollments` migration model. This helps reduce the number of calls to `repair_faulty_edx_user` in the migration script, making future entitlement migrations faster.

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

dbt build --select edxorg_to_mitxonline_enrollments

### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->


<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
