### PR TITLE
fix(sql): deduplicate program entitlements 

### DIFF
--- a/src/ol_dbt/models/migration/edxorg_to_mitxonline_program_entitlements.sql
+++ b/src/ol_dbt/models/migration/edxorg_to_mitxonline_program_entitlements.sql
@@ -24,6 +24,29 @@ with mitxonline_programs as (
         , number_of_redeemed_entitlements
     from {{ ref('stg__edxorg__program_entitlement') }}
     where user_email is not null
+        and (expiration_date is null or expiration_date >= current_date)
+)
+
+, deduped_program_entitlements as (
+    select
+        program_title
+        , user_email
+        , user_id
+        , program_type
+        , purchase_date
+        , expiration_date
+        , number_of_entitlements
+        , number_of_redeemed_entitlements
+    from (
+        select
+            *
+            , row_number() over (
+                partition by lower(user_email), program_title
+                order by purchase_date desc nulls last, expiration_date desc nulls last
+            ) as _row_num
+        from program_entitlements
+    ) as ranked_program_entitlements
+    where _row_num = 1
 )
 
 , mitx_user as (
@@ -98,7 +121,7 @@ select
         mitx_user.user_mitxonline_id
         , mitx_user_by_edxorg_id.user_mitxonline_id
     ) as user_mitxonline_id
-from program_entitlements
+from deduped_program_entitlements as program_entitlements
 left join mitxonline_programs
     on mitxonline_programs.program_title = program_entitlements.program_title
 left join program_product_versions

--- a/src/ol_dbt/models/staging/edxorg/stg__edxorg__program_entitlement.sql
+++ b/src/ol_dbt/models/staging/edxorg/stg__edxorg__program_entitlement.sql
@@ -2,7 +2,10 @@ with source as (
     select * from {{ source('ol_warehouse_raw_data', 'raw__edxorg__program_entitlement') }}
 )
 
-{{ deduplicate_raw_table(order_by='_airbyte_extracted_at' , partition_columns='"program title", email') }}
+{{ deduplicate_raw_table(
+    order_by="_airbyte_extracted_at desc, cast(date_parse(\"purchase date\", '%m/%d/%Y') as date)",
+    partition_columns='"program title", email'
+) }}
 
 , cleaned as (
     select


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
https://github.com/mitodl/hq/issues/10382

### Description (What does it do?)
<!--- Describe your changes in detail -->
  1. Updated stg__edxorg__program_entitlement dedupe to keep the latest extracted record per  (program title, email) , with purchase date as secondary ordering.
   2. Updates edxorg_to_mitxonline_program_entitlements to include only non-expired rows and dedupe per  (email, normalized program title)  using the most recent purchase/expiration dates. 


### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->
 
dbt build --select stg__edxorg__program_entitlement edxorg_to_mitxonline_program_entitlements

### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->


<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
