### PR TITLE
fix(sql): update expiration date filter for program entitlements

### DIFF
--- a/src/ol_dbt/models/migration/edxorg_to_mitxonline_program_entitlements.sql
+++ b/src/ol_dbt/models/migration/edxorg_to_mitxonline_program_entitlements.sql
@@ -24,7 +24,7 @@ with mitxonline_programs as (
         , number_of_redeemed_entitlements
     from {{ ref('stg__edxorg__program_entitlement') }}
     where user_email is not null
-        and (expiration_date is null or expiration_date >= current_date)
+        and (expiration_date is null or expiration_date >= date '2026-01-01')
 )
 
 , deduped_program_entitlements as (


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
followup https://github.com/mitodl/ol-data-platform/pull/2373

https://github.com/mitodl/hq/issues/10382

### Description (What does it do?)
<!--- Describe your changes in detail -->
updates `edxorg_to_mitxonline_program_entitlements` to use '2026-01-01' as cut-off expiration date


### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

dbt build --select edxorg_to_mitxonline_program_entitlements

### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->


<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
