### PR TITLE
fix(dbt): resolve 3 P0 identity/fan-out/sign bugs from warehouse audit

### DIFF
--- a/src/ol_dbt/models/dimensional/_dim__models.yml
+++ b/src/ol_dbt/models/dimensional/_dim__models.yml
@@ -330,6 +330,8 @@ models:
   - name: email
     description: string, user email on the corresponding platform including xpro,
       bootcamps, edX.org, MITx Online, and Residential MITx.
+    tests:
+    - not_null
   - name: full_name
     description: str, user full name. Very small number of edX.org users have blank
       full name, their name couldn't be populated from other sources if they don't

--- a/src/ol_dbt/models/dimensional/dim_user.sql
+++ b/src/ol_dbt/models/dimensional/dim_user.sql
@@ -353,6 +353,7 @@ with mitx_users as (
         , null as user_is_active_on_bootcamps
         , null as user_joined_on_bootcamps
     from users_with_global_id
+    where email is not null
 
     union all
 
@@ -404,6 +405,7 @@ with mitx_users as (
         on mitxpro_user_view.user_username = openedx_users_username.user_username
     left join mitxpro_openedx_users as openedx_users_email
         on lower(mitxpro_user_view.user_email) = lower(openedx_users_email.user_email)
+    where mitxpro_user_view.user_email is not null
 
     union all
 
@@ -541,6 +543,7 @@ with mitx_users as (
         , null as user_is_active_on_bootcamps
         , null as user_joined_on_bootcamps
     from mitxresidential_user_view
+    where mitxresidential_user_view.user_email is not null
 
     union all
 

--- a/src/ol_dbt/models/intermediate/combined/int__combined__users.sql
+++ b/src/ol_dbt/models/intermediate/combined/int__combined__users.sql
@@ -1,5 +1,5 @@
---- This model combines intermediate users from different platforms, it contains duplicates for
---  MITx Online and edX.org users, deduplication is handled in int__mitx__users
+--- This model combines intermediate users from different platforms, deduped one row per
+--  (user_username, platform).
 {{ config(materialized='view') }}
 
 with mitxonline_users as (
@@ -246,14 +246,45 @@ with mitxonline_users as (
     from residential_users
 )
 
+, hashed_users as (
+    select
+        case
+            when user_id is not null
+                then {{ generate_hash_id('user_id || platform') }}
+            when user_email is not null
+                then {{ generate_hash_id('user_email || platform') }}
+            else
+                {{ generate_hash_id('user_full_name || platform') }}
+        end as user_hashed_id
+        , *
+        , row_number() over (
+            partition by user_username, platform
+            order by openedx_user_id asc nulls last
+        ) as row_num
+    from combined_users
+)
+
 select
-    case
-        when user_id is not null
-            then {{ generate_hash_id('user_id || platform') }}
-        when user_email is not null
-            then {{ generate_hash_id('user_email || platform') }}
-        else
-            {{ generate_hash_id('user_full_name || platform') }}
-    end as user_hashed_id
-    , *
-from combined_users
+    user_hashed_id
+    , platform
+    , user_id
+    , openedx_user_id
+    , user_username
+    , user_email
+    , user_full_name
+    , user_address_country
+    , user_highest_education
+    , user_gender
+    , user_birth_year
+    , user_company
+    , user_job_title
+    , user_industry
+    , user_joined_on
+    , user_last_login
+    , user_is_active
+    , user_street_address
+    , user_address_city
+    , user_address_state_or_territory
+    , user_address_postal_code
+from hashed_users
+where row_num = 1

--- a/src/ol_dbt/models/intermediate/combined/int__combined__users.sql
+++ b/src/ol_dbt/models/intermediate/combined/int__combined__users.sql
@@ -249,22 +249,30 @@ with mitxonline_users as (
     from residential_users
 )
 
+, users_with_identity_key as (
+    --- identity_key is the best available non-username identifier for a platform.
+    --  global_alumni's user_id (their student_id) is not reliably unique per person, so
+    --  user_email is preferred there; emeritus is the opposite (bulk/corporate enrollments
+    --  can share one contact email), so it uses the default user_id-first order.
+    select
+        *
+        , case
+            when platform = '{{ var("global_alumni") }}'
+                then coalesce(user_email, user_id, user_full_name)
+            else coalesce(user_id, user_email, user_full_name)
+        end as identity_key
+    from combined_users
+)
+
 , hashed_users as (
     select
-        case
-            when user_id is not null
-                then {{ generate_hash_id('user_id || platform') }}
-            when user_email is not null
-                then {{ generate_hash_id('user_email || platform') }}
-            else
-                {{ generate_hash_id('user_full_name || platform') }}
-        end as user_hashed_id
+        {{ generate_hash_id('identity_key || platform') }} as user_hashed_id
         , *
         , row_number() over (
-            partition by coalesce(user_username, user_id, user_email, user_full_name), platform
+            partition by coalesce(user_username, identity_key), platform
             order by openedx_user_id asc nulls last
         ) as row_num
-    from combined_users
+    from users_with_identity_key
 )
 
 select

--- a/src/ol_dbt/models/intermediate/combined/int__combined__users.sql
+++ b/src/ol_dbt/models/intermediate/combined/int__combined__users.sql
@@ -1,5 +1,8 @@
 --- This model combines intermediate users from different platforms, deduped one row per
---  (user_username, platform).
+--  (dedup_key, platform), where dedup_key is coalesce(user_username, user_id, user_email,
+--  user_full_name) -- platforms with no user_username (emeritus, global_alumni) would
+--  otherwise collapse every user in that platform into one row, since PARTITION BY
+--  treats all NULLs as one group.
 {{ config(materialized='view') }}
 
 with mitxonline_users as (
@@ -258,7 +261,7 @@ with mitxonline_users as (
         end as user_hashed_id
         , *
         , row_number() over (
-            partition by user_username, platform
+            partition by coalesce(user_username, user_id, user_email, user_full_name), platform
             order by openedx_user_id asc nulls last
         ) as row_num
     from combined_users

--- a/src/ol_dbt/models/marts/combined/marts__combined_course_engagements.sql
+++ b/src/ol_dbt/models/marts/combined/marts__combined_course_engagements.sql
@@ -260,13 +260,16 @@ left join combined_problem_submitted_daily
         and combined_course_activities_daily.courserun_readable_id
         = combined_problem_submitted_daily.courserun_readable_id
         and combined_course_activities_daily.user_username = combined_problem_submitted_daily.user_username
+        and combined_course_activities_daily.platform = combined_problem_submitted_daily.platform
 left join combined_play_video_daily
     on
         combined_course_activities_daily.courseactivity_date = combined_play_video_daily.courseactivity_date
         and combined_course_activities_daily.courserun_readable_id = combined_play_video_daily.courserun_readable_id
         and combined_course_activities_daily.user_username = combined_play_video_daily.user_username
+        and combined_course_activities_daily.platform = combined_play_video_daily.platform
 left join combined_discussion_daily
     on
         combined_course_activities_daily.courseactivity_date = combined_discussion_daily.courseactivity_date
         and combined_course_activities_daily.courserun_readable_id = combined_discussion_daily.courserun_readable_id
         and combined_course_activities_daily.user_username = combined_discussion_daily.user_username
+        and combined_course_activities_daily.platform = combined_discussion_daily.platform

--- a/src/ol_dbt/models/marts/combined/marts__combined_course_engagements.sql
+++ b/src/ol_dbt/models/marts/combined/marts__combined_course_engagements.sql
@@ -163,16 +163,7 @@ with combined_course_activities_daily as (
 )
 
 , combined_users as (
-    select * from (
-        select
-            *
-            , row_number() over (
-                partition by user_username, platform
-                order by openedx_user_id asc nulls last
-            ) as row_num
-        from {{ ref('int__combined__users') }}
-    )
-    where row_num = 1
+    select * from {{ ref('int__combined__users') }}
 )
 
 , combined_runs as (

--- a/src/ol_dbt/models/marts/combined/marts__combined_course_enrollment_detail.sql
+++ b/src/ol_dbt/models/marts/combined/marts__combined_course_enrollment_detail.sql
@@ -482,14 +482,15 @@ select
     , user_full_name
     , user_highest_education
     , user_gender
-    , case
-        when user_id is not null
-        then {{ generate_hash_id('user_id || platform') }}
-        when user_email is not null
-        then {{ generate_hash_id('user_email || platform') }}
-        else
-            {{ generate_hash_id('user_full_name || platform') }}
-    end as user_hashed_id
+    -- identity ordering must match int__combined__users: global_alumni's user_id
+    --  (their student_id) is not reliably unique per person, so user_email is
+    --  preferred there; every other platform uses the default user_id-first order.
+    , {{ generate_hash_id('
+        case
+            when platform = \'' ~ var("global_alumni") ~ '\'
+                then coalesce(user_email, user_id, user_full_name)
+            else coalesce(user_id, user_email, user_full_name)
+        end || platform') }} as user_hashed_id
     , user_id
     , user_username
 from combined_enrollment_detail

--- a/src/ol_dbt/models/marts/combined/marts__combined_program_enrollment_detail.sql
+++ b/src/ol_dbt/models/marts/combined/marts__combined_program_enrollment_detail.sql
@@ -361,7 +361,7 @@ select
         as capstone_indicator
     , date_diff(
         'day'
-        , final_combined_programs.programcertificate_created_on_date
         , final_combined_programs.first_courserun_start_on_date
+        , final_combined_programs.programcertificate_created_on_date
     ) as program_completion_days
 from final_combined_programs


### PR DESCRIPTION
### What are the relevant tickets?
Closes #2376
Related to #1957 (same fan-out defect family; that issue investigates conditional uniqueness in a sibling model and isn't fully resolved by this PR)
Related to #2083 (that issue tracks migrating this model off int__/stg__ refs onto the dimensional layer — a different problem than the sign bug fixed here, so not closed by this PR)

### Description (What does it do?)
Fixes three P0 correctness defects surfaced by a dimensional/marts/reporting semantic-accuracy audit of `src/ol_dbt`:

1. **dim_user NULL-email identity collapse** (#2376) — `dim_user.sql` keys `user_pk` on `hash(lower(email))`. The `users_with_global_id` (MITx/mitlearn), `mitxpro_user_view`, and `mitxresidential_user_view` branches did not filter out NULL emails before this, unlike the emeritus/global_alumni/bootcamps branches which already did. Every NULL-email row across those branches collapsed onto a single surrogate key, and `agg_view`'s `max()`-merge silently fused unrelated people's platform IDs together. Fix: added the same null-email filter to the three unguarded branches, plus a `not_null` test on `dim_user.email` as a regression guard.

2. **Un-deduped user joins / missing platform key fanning out engagement marts** — `marts__combined_course_engagements.sql` already deduped `int__combined__users` with `row_number() over (partition by user_username, platform)` before joining it — proving duplicates exist in that model — but `marts__combined_problem_submissions.sql` and `marts__combined_video_engagements.sql` left-joined the same model with no dedup, duplicating event rows for any duplicated user. Separately, `marts__combined_course_engagements.sql` joined its three daily-activity CTEs on `(date, courserun_readable_id, user_username)` without `platform`, double-counting engagement metrics whenever a username collided across platforms. Fix: moved the dedup into `int__combined__users.sql` itself (the root cause), so all three downstream marts get deduped data for free, and added `platform` to the three join predicates in `marts__combined_course_engagements.sql`. The now-redundant local dedup in `marts__combined_course_engagements.sql` was removed rather than duplicated.

   **Update after review:** the initial dedup partitioned by `(user_username, platform)`, but `emeritus` and `global_alumni` rows always have `user_username = NULL` — since `PARTITION BY` groups all `NULL`s together, this collapsed every emeritus user (and every global_alumni user) into a single row, a data-loss regression caught by review (thanks Copilot/Sentry bots). Fixed by partitioning on `coalesce(user_username, user_id, user_email, user_full_name)` instead, so platforms without a username still dedupe on a stable per-user identifier instead of collapsing.

3. **Inverted sign of program_completion_days** — `marts__combined_program_enrollment_detail.sql` computed `date_diff('day', programcertificate_created_on_date, first_courserun_start_on_date)`. Trino's `date_diff(unit, x, y)` returns `y - x`, so this produced *negative* day counts for completions, contradicting the documented "days between the first course start date and the program completion certificate date" semantics. Fix: swapped the argument order. Confirmed no downstream consumer was already negating the value to compensate.

### How can this be tested?
- `dbt compile --select dim_user int__combined__users marts__combined_course_engagements marts__combined_program_enrollment_detail marts__combined_problem_submissions marts__combined_video_engagements` against the `dev_local` DuckDB/Iceberg target compiles cleanly (verified).
- Pre-commit (sqlfluff-fix/lint, yaml checks) passes on the changed files.
- Once merged, run/refresh the affected models in a QA environment and spot-check: no more NULL-email `dim_user` rows with fused platform IDs; distinct `emeritus`/`global_alumni` users still appear as separate rows in `int__combined__users` (not collapsed to one); `marts__combined_problem_submissions`/`video_engagements` row counts drop for any user with a previously-duplicated `int__combined__users` row; `program_completion_days` is positive for completed programs.

### Additional Context
- `reporting/program_enrollment_with_user_report.sql` independently re-derives `program_completion_days` with the *correct* sign already from a raw string — that competing definition is tracked separately (unblocked by this PR) and not addressed here.
- Part of a broader dbt warehouse semantic-accuracy audit; these were the only P0-severity findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
