### PR TITLE
fix(dbt): fix 3 buggy starrocks__ cross-db macro variants

### DIFF
--- a/src/ol_dbt/macros/cross_db_functions.sql
+++ b/src/ol_dbt/macros/cross_db_functions.sql
@@ -76,8 +76,10 @@
     {#
         StarRocks: DATETIME is zone-less, and a bare cast() returns NULL for strings with
         a trailing 'Z' or '+HH:MM'/'-HH:MM' offset. Strip any such suffix and the 'T'
-        separator before casting. Non-UTC offsets are dropped rather than applied, which
-        is acceptable since this project's source data is UTC/naive.
+        separator before casting. Truncate to 26 chars to keep at most microsecond
+        precision (and avoid cast() failures on nanosecond-precision inputs). Non-UTC
+        offsets are dropped rather than applied, which is acceptable since this project's
+        source data is UTC/naive.
     #}
     cast(
         substr(

--- a/src/ol_dbt/macros/cross_db_functions.sql
+++ b/src/ol_dbt/macros/cross_db_functions.sql
@@ -33,8 +33,8 @@
 {%- endmacro %}
 
 {% macro starrocks__json_extract_value(json_col, json_path) -%}
-    {# StarRocks: json_extract returns a JSON value #}
-    json_extract({{ json_col }}, {{ json_path }})
+    {# StarRocks: json_extract does not exist; use json_query on a parsed JSON value #}
+    json_query(parse_json({{ json_col }}), {{ json_path }})
 {%- endmacro %}
 
 
@@ -73,8 +73,18 @@
 {%- endmacro %}
 
 {% macro starrocks__from_iso8601_timestamp(timestamp_str) -%}
-    {# StarRocks: use str_to_date or cast #}
-    cast({{ timestamp_str }} as datetime)
+    {#
+        StarRocks: DATETIME is zone-less, and a bare cast() returns NULL for strings with
+        a trailing 'Z' or '+HH:MM'/'-HH:MM' offset. Strip any such suffix and the 'T'
+        separator before casting. Non-UTC offsets are dropped rather than applied, which
+        is acceptable since this project's source data is UTC/naive.
+    #}
+    cast(
+        substr(
+            replace(regexp_replace({{ timestamp_str }}, '([Zz]|[+-][0-9]{2}:?[0-9]{2})$', ''), 'T', ' ')
+            , 1, 26
+        ) as datetime
+    )
 {%- endmacro %}
 
 
@@ -112,8 +122,12 @@
 {%- endmacro %}
 
 {% macro starrocks__array_join(array_expr, delimiter, null_replacement='') -%}
-    {# StarRocks: array_join with different signature #}
-    array_join({{ array_expr }}, '{{ delimiter }}')
+    {# StarRocks: native support, including the 3rd null_replace_str arg #}
+    {% if null_replacement %}
+        array_join({{ array_expr }}, '{{ delimiter }}', '{{ null_replacement }}')
+    {% else %}
+        array_join({{ array_expr }}, '{{ delimiter }}')
+    {% endif %}
 {%- endmacro %}
 
 


### PR DESCRIPTION
### What are the relevant tickets?
Closes #2397

### Description (What does it do?)
Fixes 3 correctness bugs in the `starrocks__` dispatch variants of `macros/cross_db_functions.sql`, doc-verified against docs.starrocks.io as part of the dbt warehouse semantic-accuracy audit's StarRocks cross-database macro epic:

1. **`starrocks__json_extract_value`** used `json_extract()`, which does not exist in StarRocks. Switched to `json_query(parse_json(x), path)`.
2. **`starrocks__from_iso8601_timestamp`** did a bare `cast(x as datetime)`. StarRocks `DATETIME` is zone-less, so any string with a trailing `Z` or `±HH:MM` offset made the cast silently return `NULL`. Now strips a trailing zone suffix and normalizes the `T` separator to a space before casting. Non-UTC offsets are dropped rather than applied — acceptable since this project's data is UTC/naive.
3. **`starrocks__array_join`** silently dropped the `null_replacement` argument even though StarRocks' `array_join` supports the same 3-arg `null_replace_str` signature as Trino (per StarRocks docs: `array_join([1,3,5,null],'_','NULL')`). Mirrored the `default__` (Trino) branch structure.

### How can this be tested?
- `dbt parse` against the `dev_local` DuckDB target succeeds (verified) — these macros aren't dispatched today since no model targets StarRocks yet, so this is Jinja-syntax + doc-verification, not a live StarRocks run.
- Once a StarRocks target/profile exists, exercise each macro directly, e.g.:
  - `select {{ json_extract_value("'{\"a\":1}'", "'$.a'") }}`
  - `select {{ from_iso8601_timestamp("'2024-01-01T00:00:00Z'") }}`
  - `select {{ array_join('array(1,3,5,null)', '_', 'NULL') }}`
  against a live StarRocks warehouse and confirm non-NULL, correctly-formatted results.

### Additional Context
Part of `tk-epic-starrocks-support-for-cross-database-dbt-ma-968247` in the dbt warehouse audit — a sibling task (`tk-implement-18-missing-starrocks-macro-variants-do-57059b`) tracks implementing the 18 currently-missing `starrocks__` macro variants; not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)