### PR TITLE
edxorg to mitxonline program entitlements

### DIFF
--- a/src/ol_dbt/models/migration/edxorg_to_mitxonline_program_entitlements.sql
+++ b/src/ol_dbt/models/migration/edxorg_to_mitxonline_program_entitlements.sql
@@ -5,6 +5,9 @@ with mitxonline_programs as (
 , program_entitlements as (
     select
         case
+          --- Handle titles such as Statistics and Data Science (Social Sciences Track) -Retired "old version"
+          when program_title like 'Statistics and Data Science (Social Sciences Track)%'
+              then 'Statistics and Data Science (Social Sciences Track)'
           --- Handle titles such as Statistics and Data Science (General track) - RETIRED "old version"
           when program_title like 'Statistics and Data Science (General track)%'
               then 'Statistics and Data Science (General Track)'


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->

### Description (What does it do?)
<!--- Describe your changes in detail -->
Adds a  CASE  branch in the program title normalization logic to handle edX.org entitlements for the "Statistics and Data Science (Social Sciences Track)"  program whose titles include a trailing retired-version suffix (e.g.  Statistics and Data Science (Social Sciences Track) -Retired "old version" ). 


### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

dbt build --select edxorg_to_mitxonline_program_entitlements

### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->


<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
