### PR TITLE
fix(deps): pin grpcio-health-checking below 1.82.0 to stop crash loop

### DIFF
--- a/dg_deployments/local/pyproject.toml
+++ b/dg_deployments/local/pyproject.toml
@@ -13,3 +13,12 @@ dependencies = [
 
 [tool.dg]
 directory_type = "deployment"
+
+# Pin grpcio-health-checking below 1.82.0: that release bundles health_pb2.py
+# pre-generated with protobuf 7.35.0 gencode while declaring protobuf>=6.33.5,
+# so it crashes at import time under dagster's required protobuf<7 (upstream
+# metadata/gencode mismatch in the 1.82.0 release).
+[tool.uv]
+override-dependencies = [
+    "grpcio-health-checking<1.82.0",
+]

--- a/dg_deployments/local/uv.lock
+++ b/dg_deployments/local/uv.lock
@@ -2,6 +2,9 @@ version = 1
 revision = 3
 requires-python = "==3.14.*"
 
+[manifest]
+overrides = [{ name = "grpcio-health-checking", specifier = "<1.82.0" }]
+
 [[package]]
 name = "alembic"
 version = "1.18.5"
@@ -625,15 +628,15 @@ wheels = [
 
 [[package]]
 name = "grpcio-health-checking"
-version = "1.82.0"
+version = "1.81.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "grpcio" },
     { name = "protobuf" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d5/92/bd7b524a41b18668c5d59e2a1bd1940da76cfcc1f0888e681e2dcab5425a/grpcio_health_checking-1.82.0.tar.gz", hash = "sha256:0c78ede1bb324b1967a1e79d18b1a45908634896d1ca56b790fa87c25109d43b", size = 17118, upload-time = "2026-07-06T04:26:49.412Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/65/46/6b6678b5a922765ae7637205bb6d0618a4da8b35f2ce6116f8bcff262370/grpcio_health_checking-1.81.1.tar.gz", hash = "sha256:ecc61480e25058a4a04e11e4ab6900ad7439b32e60a8ce4ece7d9f219221c85d", size = 17107, upload-time = "2026-06-11T12:58:49.632Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/6c/cb/8e4a95ee66b51b1b71d80892c41d803186d4e240a09b975b594a2298d78b/grpcio_health_checking-1.82.0-py3-none-any.whl", hash = "sha256:c4daa80b6b28caad1bb1a45cb124b1f8861b00524e39276026937e1af9bc5002", size = 19118, upload-time = "2026-07-06T04:26:36.039Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/87/174bbfb5613794862c45b5cdf567fcfb478ad5a3a7b594e11d998656b2f9/grpcio_health_checking-1.81.1-py3-none-any.whl", hash = "sha256:cbc6a4171825ec64389de2f062d296ba129a5c27eefd0dd55fa837909184bdf9", size = 19120, upload-time = "2026-06-11T12:58:38.008Z" },
 ]
 
 [[package]]

--- a/dg_projects/b2b_organization/pyproject.toml
+++ b/dg_projects/b2b_organization/pyproject.toml
@@ -40,3 +40,12 @@ exclude=["b2b_organization_tests"]
 
 [tool.uv.sources]
 ol-orchestrate-lib = { path = "../../packages/ol-orchestrate-lib", editable = true }
+
+# Pin grpcio-health-checking below 1.82.0: that release bundles health_pb2.py
+# pre-generated with protobuf 7.35.0 gencode while declaring protobuf>=6.33.5,
+# so it crashes at import time under dagster's required protobuf<7 (upstream
+# metadata/gencode mismatch in the 1.82.0 release).
+[tool.uv]
+override-dependencies = [
+    "grpcio-health-checking<1.82.0",
+]

--- a/dg_projects/b2b_organization/uv.lock
+++ b/dg_projects/b2b_organization/uv.lock
@@ -7,6 +7,9 @@ resolution-markers = [
     "sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
 
+[manifest]
+overrides = [{ name = "grpcio-health-checking", specifier = "<1.82.0" }]
+
 [[package]]
 name = "agate"
 version = "1.9.1"
@@ -1278,15 +1281,15 @@ wheels = [
 
 [[package]]
 name = "grpcio-health-checking"
-version = "1.82.0"
+version = "1.81.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "grpcio" },
     { name = "protobuf" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d5/92/bd7b524a41b18668c5d59e2a1bd1940da76cfcc1f0888e681e2dcab5425a/grpcio_health_checking-1.82.0.tar.gz", hash = "sha256:0c78ede1bb324b1967a1e79d18b1a45908634896d1ca56b790fa87c25109d43b", size = 17118, upload-time = "2026-07-06T04:26:49.412Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/65/46/6b6678b5a922765ae7637205bb6d0618a4da8b35f2ce6116f8bcff262370/grpcio_health_checking-1.81.1.tar.gz", hash = "sha256:ecc61480e25058a4a04e11e4ab6900ad7439b32e60a8ce4ece7d9f219221c85d", size = 17107, upload-time = "2026-06-11T12:58:49.632Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/6c/cb/8e4a95ee66b51b1b71d80892c41d803186d4e240a09b975b594a2298d78b/grpcio_health_checking-1.82.0-py3-none-any.whl", hash = "sha256:c4daa80b6b28caad1bb1a45cb124b1f8861b00524e39276026937e1af9bc5002", size = 19118, upload-time = "2026-07-06T04:26:36.039Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/87/174bbfb5613794862c45b5cdf567fcfb478ad5a3a7b594e11d998656b2f9/grpcio_health_checking-1.81.1-py3-none-any.whl", hash = "sha256:cbc6a4171825ec64389de2f062d296ba129a5c27eefd0dd55fa837909184bdf9", size = 19120, upload-time = "2026-06-11T12:58:38.008Z" },
 ]
 
 [[package]]

--- a/dg_projects/canvas/pyproject.toml
+++ b/dg_projects/canvas/pyproject.toml
@@ -40,3 +40,12 @@ exclude=["canvas_tests"]
 
 [tool.uv.sources]
 ol-orchestrate-lib = { path = "../../packages/ol-orchestrate-lib", editable = true }
+
+# Pin grpcio-health-checking below 1.82.0: that release bundles health_pb2.py
+# pre-generated with protobuf 7.35.0 gencode while declaring protobuf>=6.33.5,
+# so it crashes at import time under dagster's required protobuf<7 (upstream
+# metadata/gencode mismatch in the 1.82.0 release).
+[tool.uv]
+override-dependencies = [
+    "grpcio-health-checking<1.82.0",
+]

--- a/dg_projects/canvas/uv.lock
+++ b/dg_projects/canvas/uv.lock
@@ -7,6 +7,9 @@ resolution-markers = [
     "sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
 
+[manifest]
+overrides = [{ name = "grpcio-health-checking", specifier = "<1.82.0" }]
+
 [[package]]
 name = "aiobotocore"
 version = "3.7.0"
@@ -1054,15 +1057,15 @@ wheels = [
 
 [[package]]
 name = "grpcio-health-checking"
-version = "1.82.0"
+version = "1.81.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "grpcio" },
     { name = "protobuf" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d5/92/bd7b524a41b18668c5d59e2a1bd1940da76cfcc1f0888e681e2dcab5425a/grpcio_health_checking-1.82.0.tar.gz", hash = "sha256:0c78ede1bb324b1967a1e79d18b1a45908634896d1ca56b790fa87c25109d43b", size = 17118, upload-time = "2026-07-06T04:26:49.412Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/65/46/6b6678b5a922765ae7637205bb6d0618a4da8b35f2ce6116f8bcff262370/grpcio_health_checking-1.81.1.tar.gz", hash = "sha256:ecc61480e25058a4a04e11e4ab6900ad7439b32e60a8ce4ece7d9f219221c85d", size = 17107, upload-time = "2026-06-11T12:58:49.632Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/6c/cb/8e4a95ee66b51b1b71d80892c41d803186d4e240a09b975b594a2298d78b/grpcio_health_checking-1.82.0-py3-none-any.whl", hash = "sha256:c4daa80b6b28caad1bb1a45cb124b1f8861b00524e39276026937e1af9bc5002", size = 19118, upload-time = "2026-07-06T04:26:36.039Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/87/174bbfb5613794862c45b5cdf567fcfb478ad5a3a7b594e11d998656b2f9/grpcio_health_checking-1.81.1-py3-none-any.whl", hash = "sha256:cbc6a4171825ec64389de2f062d296ba129a5c27eefd0dd55fa837909184bdf9", size = 19120, upload-time = "2026-06-11T12:58:38.008Z" },
 ]
 
 [[package]]

--- a/dg_projects/data_loading/pyproject.toml
+++ b/dg_projects/data_loading/pyproject.toml
@@ -49,3 +49,12 @@ exclude=["data_loading_tests"]
 [tool.uv.sources]
 ol-dlt = { path = "../../src/ol_dlt", editable = true }
 ol-orchestrate-lib = { path = "../../packages/ol-orchestrate-lib", editable = true }
+
+# Pin grpcio-health-checking below 1.82.0: that release bundles health_pb2.py
+# pre-generated with protobuf 7.35.0 gencode while declaring protobuf>=6.33.5,
+# so it crashes at import time under dagster's required protobuf<7 (upstream
+# metadata/gencode mismatch in the 1.82.0 release).
+[tool.uv]
+override-dependencies = [
+    "grpcio-health-checking<1.82.0",
+]

--- a/dg_projects/data_loading/uv.lock
+++ b/dg_projects/data_loading/uv.lock
@@ -12,6 +12,9 @@ resolution-markers = [
     "python_full_version < '3.14' and platform_python_implementation == 'PyPy' and sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
 
+[manifest]
+overrides = [{ name = "grpcio-health-checking", specifier = "<1.82.0" }]
+
 [[package]]
 name = "aiobotocore"
 version = "3.7.0"
@@ -263,7 +266,7 @@ name = "cffi"
 version = "2.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pycparser", marker = "implementation_name != 'PyPy'" },
+    { name = "pycparser", marker = "(implementation_name != 'PyPy' and platform_python_implementation != 'PyPy') or (implementation_name != 'PyPy' and sys_platform == 'emscripten')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/eb/56/b1ba7935a17738ae8453301356628e8147c79dbb825bcbc73dc7401f9846/cffi-2.0.0.tar.gz", hash = "sha256:44d1b5909021139fe36001ae048dbdde8214afa20200eda0f64c068cac5d5529", size = 523588, upload-time = "2025-09-08T23:24:04.541Z" }
 wheels = [
@@ -1285,15 +1288,15 @@ wheels = [
 
 [[package]]
 name = "grpcio-health-checking"
-version = "1.82.0"
+version = "1.81.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "grpcio" },
     { name = "protobuf" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d5/92/bd7b524a41b18668c5d59e2a1bd1940da76cfcc1f0888e681e2dcab5425a/grpcio_health_checking-1.82.0.tar.gz", hash = "sha256:0c78ede1bb324b1967a1e79d18b1a45908634896d1ca56b790fa87c25109d43b", size = 17118, upload-time = "2026-07-06T04:26:49.412Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/65/46/6b6678b5a922765ae7637205bb6d0618a4da8b35f2ce6116f8bcff262370/grpcio_health_checking-1.81.1.tar.gz", hash = "sha256:ecc61480e25058a4a04e11e4ab6900ad7439b32e60a8ce4ece7d9f219221c85d", size = 17107, upload-time = "2026-06-11T12:58:49.632Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/6c/cb/8e4a95ee66b51b1b71d80892c41d803186d4e240a09b975b594a2298d78b/grpcio_health_checking-1.82.0-py3-none-any.whl", hash = "sha256:c4daa80b6b28caad1bb1a45cb124b1f8861b00524e39276026937e1af9bc5002", size = 19118, upload-time = "2026-07-06T04:26:36.039Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/87/174bbfb5613794862c45b5cdf567fcfb478ad5a3a7b594e11d998656b2f9/grpcio_health_checking-1.81.1-py3-none-any.whl", hash = "sha256:cbc6a4171825ec64389de2f062d296ba129a5c27eefd0dd55fa837909184bdf9", size = 19120, upload-time = "2026-06-11T12:58:38.008Z" },
 ]
 
 [[package]]

--- a/dg_projects/data_platform/pyproject.toml
+++ b/dg_projects/data_platform/pyproject.toml
@@ -38,3 +38,12 @@ exclude=["data_platform_tests"]
 
 [tool.uv.sources]
 ol-orchestrate-lib = { path = "../../packages/ol-orchestrate-lib", editable = true }
+
+# Pin grpcio-health-checking below 1.82.0: that release bundles health_pb2.py
+# pre-generated with protobuf 7.35.0 gencode while declaring protobuf>=6.33.5,
+# so it crashes at import time under dagster's required protobuf<7 (upstream
+# metadata/gencode mismatch in the 1.82.0 release).
+[tool.uv]
+override-dependencies = [
+    "grpcio-health-checking<1.82.0",
+]

--- a/dg_projects/data_platform/uv.lock
+++ b/dg_projects/data_platform/uv.lock
@@ -7,6 +7,9 @@ resolution-markers = [
     "sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
 
+[manifest]
+overrides = [{ name = "grpcio-health-checking", specifier = "<1.82.0" }]
+
 [[package]]
 name = "aiobotocore"
 version = "3.7.0"
@@ -1063,15 +1066,15 @@ wheels = [
 
 [[package]]
 name = "grpcio-health-checking"
-version = "1.82.0"
+version = "1.81.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "grpcio" },
     { name = "protobuf" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d5/92/bd7b524a41b18668c5d59e2a1bd1940da76cfcc1f0888e681e2dcab5425a/grpcio_health_checking-1.82.0.tar.gz", hash = "sha256:0c78ede1bb324b1967a1e79d18b1a45908634896d1ca56b790fa87c25109d43b", size = 17118, upload-time = "2026-07-06T04:26:49.412Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/65/46/6b6678b5a922765ae7637205bb6d0618a4da8b35f2ce6116f8bcff262370/grpcio_health_checking-1.81.1.tar.gz", hash = "sha256:ecc61480e25058a4a04e11e4ab6900ad7439b32e60a8ce4ece7d9f219221c85d", size = 17107, upload-time = "2026-06-11T12:58:49.632Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/6c/cb/8e4a95ee66b51b1b71d80892c41d803186d4e240a09b975b594a2298d78b/grpcio_health_checking-1.82.0-py3-none-any.whl", hash = "sha256:c4daa80b6b28caad1bb1a45cb124b1f8861b00524e39276026937e1af9bc5002", size = 19118, upload-time = "2026-07-06T04:26:36.039Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/87/174bbfb5613794862c45b5cdf567fcfb478ad5a3a7b594e11d998656b2f9/grpcio_health_checking-1.81.1-py3-none-any.whl", hash = "sha256:cbc6a4171825ec64389de2f062d296ba129a5c27eefd0dd55fa837909184bdf9", size = 19120, upload-time = "2026-06-11T12:58:38.008Z" },
 ]
 
 [[package]]

--- a/dg_projects/edxorg/pyproject.toml
+++ b/dg_projects/edxorg/pyproject.toml
@@ -46,3 +46,12 @@ exclude=["edxorg_tests"]
 
 [tool.uv.sources]
 ol-orchestrate-lib = { path = "../../packages/ol-orchestrate-lib", editable = true }
+
+# Pin grpcio-health-checking below 1.82.0: that release bundles health_pb2.py
+# pre-generated with protobuf 7.35.0 gencode while declaring protobuf>=6.33.5,
+# so it crashes at import time under dagster's required protobuf<7 (upstream
+# metadata/gencode mismatch in the 1.82.0 release).
+[tool.uv]
+override-dependencies = [
+    "grpcio-health-checking<1.82.0",
+]

--- a/dg_projects/edxorg/uv.lock
+++ b/dg_projects/edxorg/uv.lock
@@ -7,6 +7,9 @@ resolution-markers = [
     "sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
 
+[manifest]
+overrides = [{ name = "grpcio-health-checking", specifier = "<1.82.0" }]
+
 [[package]]
 name = "aiobotocore"
 version = "3.7.0"
@@ -1103,15 +1106,15 @@ wheels = [
 
 [[package]]
 name = "grpcio-health-checking"
-version = "1.82.0"
+version = "1.81.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "grpcio" },
     { name = "protobuf" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d5/92/bd7b524a41b18668c5d59e2a1bd1940da76cfcc1f0888e681e2dcab5425a/grpcio_health_checking-1.82.0.tar.gz", hash = "sha256:0c78ede1bb324b1967a1e79d18b1a45908634896d1ca56b790fa87c25109d43b", size = 17118, upload-time = "2026-07-06T04:26:49.412Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/65/46/6b6678b5a922765ae7637205bb6d0618a4da8b35f2ce6116f8bcff262370/grpcio_health_checking-1.81.1.tar.gz", hash = "sha256:ecc61480e25058a4a04e11e4ab6900ad7439b32e60a8ce4ece7d9f219221c85d", size = 17107, upload-time = "2026-06-11T12:58:49.632Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/6c/cb/8e4a95ee66b51b1b71d80892c41d803186d4e240a09b975b594a2298d78b/grpcio_health_checking-1.82.0-py3-none-any.whl", hash = "sha256:c4daa80b6b28caad1bb1a45cb124b1f8861b00524e39276026937e1af9bc5002", size = 19118, upload-time = "2026-07-06T04:26:36.039Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/87/174bbfb5613794862c45b5cdf567fcfb478ad5a3a7b594e11d998656b2f9/grpcio_health_checking-1.81.1-py3-none-any.whl", hash = "sha256:cbc6a4171825ec64389de2f062d296ba129a5c27eefd0dd55fa837909184bdf9", size = 19120, upload-time = "2026-06-11T12:58:38.008Z" },
 ]
 
 [[package]]

--- a/dg_projects/lakehouse/pyproject.toml
+++ b/dg_projects/lakehouse/pyproject.toml
@@ -44,3 +44,12 @@ exclude=["lakehouse_tests"]
 
 [tool.uv.sources]
 ol-orchestrate-lib = { path = "../../packages/ol-orchestrate-lib", editable = true }
+
+# Pin grpcio-health-checking below 1.82.0: that release bundles health_pb2.py
+# pre-generated with protobuf 7.35.0 gencode while declaring protobuf>=6.33.5,
+# so it crashes at import time under dagster's required protobuf<7 (upstream
+# metadata/gencode mismatch in the 1.82.0 release).
+[tool.uv]
+override-dependencies = [
+    "grpcio-health-checking<1.82.0",
+]

--- a/dg_projects/lakehouse/uv.lock
+++ b/dg_projects/lakehouse/uv.lock
@@ -7,6 +7,9 @@ resolution-markers = [
     "sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
 
+[manifest]
+overrides = [{ name = "grpcio-health-checking", specifier = "<1.82.0" }]
+
 [[package]]
 name = "agate"
 version = "1.9.1"
@@ -1239,15 +1242,15 @@ wheels = [
 
 [[package]]
 name = "grpcio-health-checking"
-version = "1.82.0"
+version = "1.81.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "grpcio" },
     { name = "protobuf" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d5/92/bd7b524a41b18668c5d59e2a1bd1940da76cfcc1f0888e681e2dcab5425a/grpcio_health_checking-1.82.0.tar.gz", hash = "sha256:0c78ede1bb324b1967a1e79d18b1a45908634896d1ca56b790fa87c25109d43b", size = 17118, upload-time = "2026-07-06T04:26:49.412Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/65/46/6b6678b5a922765ae7637205bb6d0618a4da8b35f2ce6116f8bcff262370/grpcio_health_checking-1.81.1.tar.gz", hash = "sha256:ecc61480e25058a4a04e11e4ab6900ad7439b32e60a8ce4ece7d9f219221c85d", size = 17107, upload-time = "2026-06-11T12:58:49.632Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/6c/cb/8e4a95ee66b51b1b71d80892c41d803186d4e240a09b975b594a2298d78b/grpcio_health_checking-1.82.0-py3-none-any.whl", hash = "sha256:c4daa80b6b28caad1bb1a45cb124b1f8861b00524e39276026937e1af9bc5002", size = 19118, upload-time = "2026-07-06T04:26:36.039Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/87/174bbfb5613794862c45b5cdf567fcfb478ad5a3a7b594e11d998656b2f9/grpcio_health_checking-1.81.1-py3-none-any.whl", hash = "sha256:cbc6a4171825ec64389de2f062d296ba129a5c27eefd0dd55fa837909184bdf9", size = 19120, upload-time = "2026-06-11T12:58:38.008Z" },
 ]
 
 [[package]]

--- a/dg_projects/learning_resources/pyproject.toml
+++ b/dg_projects/learning_resources/pyproject.toml
@@ -45,3 +45,12 @@ exclude=["learning_resources_tests"]
 
 [tool.uv.sources]
 ol-orchestrate-lib = { path = "../../packages/ol-orchestrate-lib", editable = true }
+
+# Pin grpcio-health-checking below 1.82.0: that release bundles health_pb2.py
+# pre-generated with protobuf 7.35.0 gencode while declaring protobuf>=6.33.5,
+# so it crashes at import time under dagster's required protobuf<7 (upstream
+# metadata/gencode mismatch in the 1.82.0 release).
+[tool.uv]
+override-dependencies = [
+    "grpcio-health-checking<1.82.0",
+]

--- a/dg_projects/learning_resources/uv.lock
+++ b/dg_projects/learning_resources/uv.lock
@@ -7,6 +7,9 @@ resolution-markers = [
     "sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
 
+[manifest]
+overrides = [{ name = "grpcio-health-checking", specifier = "<1.82.0" }]
+
 [[package]]
 name = "aiobotocore"
 version = "3.7.0"
@@ -1038,15 +1041,15 @@ wheels = [
 
 [[package]]
 name = "grpcio-health-checking"
-version = "1.82.0"
+version = "1.81.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "grpcio" },
     { name = "protobuf" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d5/92/bd7b524a41b18668c5d59e2a1bd1940da76cfcc1f0888e681e2dcab5425a/grpcio_health_checking-1.82.0.tar.gz", hash = "sha256:0c78ede1bb324b1967a1e79d18b1a45908634896d1ca56b790fa87c25109d43b", size = 17118, upload-time = "2026-07-06T04:26:49.412Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/65/46/6b6678b5a922765ae7637205bb6d0618a4da8b35f2ce6116f8bcff262370/grpcio_health_checking-1.81.1.tar.gz", hash = "sha256:ecc61480e25058a4a04e11e4ab6900ad7439b32e60a8ce4ece7d9f219221c85d", size = 17107, upload-time = "2026-06-11T12:58:49.632Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/6c/cb/8e4a95ee66b51b1b71d80892c41d803186d4e240a09b975b594a2298d78b/grpcio_health_checking-1.82.0-py3-none-any.whl", hash = "sha256:c4daa80b6b28caad1bb1a45cb124b1f8861b00524e39276026937e1af9bc5002", size = 19118, upload-time = "2026-07-06T04:26:36.039Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/87/174bbfb5613794862c45b5cdf567fcfb478ad5a3a7b594e11d998656b2f9/grpcio_health_checking-1.81.1-py3-none-any.whl", hash = "sha256:cbc6a4171825ec64389de2f062d296ba129a5c27eefd0dd55fa837909184bdf9", size = 19120, upload-time = "2026-06-11T12:58:38.008Z" },
 ]
 
 [[package]]

--- a/dg_projects/legacy_openedx/pyproject.toml
+++ b/dg_projects/legacy_openedx/pyproject.toml
@@ -43,3 +43,12 @@ exclude=["legacy_openedx_tests"]
 
 [tool.uv.sources]
 ol-orchestrate-lib = { path = "../../packages/ol-orchestrate-lib", editable = true }
+
+# Pin grpcio-health-checking below 1.82.0: that release bundles health_pb2.py
+# pre-generated with protobuf 7.35.0 gencode while declaring protobuf>=6.33.5,
+# so it crashes at import time under dagster's required protobuf<7 (upstream
+# metadata/gencode mismatch in the 1.82.0 release).
+[tool.uv]
+override-dependencies = [
+    "grpcio-health-checking<1.82.0",
+]

--- a/dg_projects/legacy_openedx/uv.lock
+++ b/dg_projects/legacy_openedx/uv.lock
@@ -7,6 +7,9 @@ resolution-markers = [
     "sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
 
+[manifest]
+overrides = [{ name = "grpcio-health-checking", specifier = "<1.82.0" }]
+
 [[package]]
 name = "aiobotocore"
 version = "3.7.0"
@@ -1026,15 +1029,15 @@ wheels = [
 
 [[package]]
 name = "grpcio-health-checking"
-version = "1.82.0"
+version = "1.81.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "grpcio" },
     { name = "protobuf" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d5/92/bd7b524a41b18668c5d59e2a1bd1940da76cfcc1f0888e681e2dcab5425a/grpcio_health_checking-1.82.0.tar.gz", hash = "sha256:0c78ede1bb324b1967a1e79d18b1a45908634896d1ca56b790fa87c25109d43b", size = 17118, upload-time = "2026-07-06T04:26:49.412Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/65/46/6b6678b5a922765ae7637205bb6d0618a4da8b35f2ce6116f8bcff262370/grpcio_health_checking-1.81.1.tar.gz", hash = "sha256:ecc61480e25058a4a04e11e4ab6900ad7439b32e60a8ce4ece7d9f219221c85d", size = 17107, upload-time = "2026-06-11T12:58:49.632Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/6c/cb/8e4a95ee66b51b1b71d80892c41d803186d4e240a09b975b594a2298d78b/grpcio_health_checking-1.82.0-py3-none-any.whl", hash = "sha256:c4daa80b6b28caad1bb1a45cb124b1f8861b00524e39276026937e1af9bc5002", size = 19118, upload-time = "2026-07-06T04:26:36.039Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/87/174bbfb5613794862c45b5cdf567fcfb478ad5a3a7b594e11d998656b2f9/grpcio_health_checking-1.81.1-py3-none-any.whl", hash = "sha256:cbc6a4171825ec64389de2f062d296ba129a5c27eefd0dd55fa837909184bdf9", size = 19120, upload-time = "2026-06-11T12:58:38.008Z" },
 ]
 
 [[package]]

--- a/dg_projects/openedx/pyproject.toml
+++ b/dg_projects/openedx/pyproject.toml
@@ -43,3 +43,12 @@ exclude=["openedx_tests"]
 
 [tool.uv.sources]
 ol-orchestrate-lib = { path = "../../packages/ol-orchestrate-lib", editable = true }
+
+# Pin grpcio-health-checking below 1.82.0: that release bundles health_pb2.py
+# pre-generated with protobuf 7.35.0 gencode while declaring protobuf>=6.33.5,
+# so it crashes at import time under dagster's required protobuf<7 (upstream
+# metadata/gencode mismatch in the 1.82.0 release).
+[tool.uv]
+override-dependencies = [
+    "grpcio-health-checking<1.82.0",
+]

--- a/dg_projects/openedx/uv.lock
+++ b/dg_projects/openedx/uv.lock
@@ -7,6 +7,9 @@ resolution-markers = [
     "sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
 
+[manifest]
+overrides = [{ name = "grpcio-health-checking", specifier = "<1.82.0" }]
+
 [[package]]
 name = "aiobotocore"
 version = "3.7.0"
@@ -1054,15 +1057,15 @@ wheels = [
 
 [[package]]
 name = "grpcio-health-checking"
-version = "1.82.0"
+version = "1.81.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "grpcio" },
     { name = "protobuf" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d5/92/bd7b524a41b18668c5d59e2a1bd1940da76cfcc1f0888e681e2dcab5425a/grpcio_health_checking-1.82.0.tar.gz", hash = "sha256:0c78ede1bb324b1967a1e79d18b1a45908634896d1ca56b790fa87c25109d43b", size = 17118, upload-time = "2026-07-06T04:26:49.412Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/65/46/6b6678b5a922765ae7637205bb6d0618a4da8b35f2ce6116f8bcff262370/grpcio_health_checking-1.81.1.tar.gz", hash = "sha256:ecc61480e25058a4a04e11e4ab6900ad7439b32e60a8ce4ece7d9f219221c85d", size = 17107, upload-time = "2026-06-11T12:58:49.632Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/6c/cb/8e4a95ee66b51b1b71d80892c41d803186d4e240a09b975b594a2298d78b/grpcio_health_checking-1.82.0-py3-none-any.whl", hash = "sha256:c4daa80b6b28caad1bb1a45cb124b1f8861b00524e39276026937e1af9bc5002", size = 19118, upload-time = "2026-07-06T04:26:36.039Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/87/174bbfb5613794862c45b5cdf567fcfb478ad5a3a7b594e11d998656b2f9/grpcio_health_checking-1.81.1-py3-none-any.whl", hash = "sha256:cbc6a4171825ec64389de2f062d296ba129a5c27eefd0dd55fa837909184bdf9", size = 19120, upload-time = "2026-06-11T12:58:38.008Z" },
 ]
 
 [[package]]

--- a/dg_projects/student_risk_probability/pyproject.toml
+++ b/dg_projects/student_risk_probability/pyproject.toml
@@ -46,7 +46,13 @@ ol-orchestrate-lib = { path = "../../packages/ol-orchestrate-lib", editable = tr
 
 # Override dagster-iceberg's <0.11 upper bound until upstream loosens it.
 # See https://github.com/dagster-io/community-integrations/pull/289
+#
+# Pin grpcio-health-checking below 1.82.0: that release bundles health_pb2.py
+# pre-generated with protobuf 7.35.0 gencode while declaring protobuf>=6.33.5,
+# so it crashes at import time under dagster's required protobuf<7 (upstream
+# metadata/gencode mismatch in the 1.82.0 release).
 [tool.uv]
 override-dependencies = [
     "pyiceberg>=0.11.1",
+    "grpcio-health-checking<1.82.0",
 ]

--- a/dg_projects/student_risk_probability/uv.lock
+++ b/dg_projects/student_risk_probability/uv.lock
@@ -8,7 +8,10 @@ resolution-markers = [
 ]
 
 [manifest]
-overrides = [{ name = "pyiceberg", specifier = ">=0.11.1" }]
+overrides = [
+    { name = "grpcio-health-checking", specifier = "<1.82.0" },
+    { name = "pyiceberg", specifier = ">=0.11.1" },
+]
 
 [[package]]
 name = "agate"
@@ -1260,15 +1263,15 @@ wheels = [
 
 [[package]]
 name = "grpcio-health-checking"
-version = "1.82.0"
+version = "1.81.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "grpcio" },
     { name = "protobuf" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d5/92/bd7b524a41b18668c5d59e2a1bd1940da76cfcc1f0888e681e2dcab5425a/grpcio_health_checking-1.82.0.tar.gz", hash = "sha256:0c78ede1bb324b1967a1e79d18b1a45908634896d1ca56b790fa87c25109d43b", size = 17118, upload-time = "2026-07-06T04:26:49.412Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/65/46/6b6678b5a922765ae7637205bb6d0618a4da8b35f2ce6116f8bcff262370/grpcio_health_checking-1.81.1.tar.gz", hash = "sha256:ecc61480e25058a4a04e11e4ab6900ad7439b32e60a8ce4ece7d9f219221c85d", size = 17107, upload-time = "2026-06-11T12:58:49.632Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/6c/cb/8e4a95ee66b51b1b71d80892c41d803186d4e240a09b975b594a2298d78b/grpcio_health_checking-1.82.0-py3-none-any.whl", hash = "sha256:c4daa80b6b28caad1bb1a45cb124b1f8861b00524e39276026937e1af9bc5002", size = 19118, upload-time = "2026-07-06T04:26:36.039Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/87/174bbfb5613794862c45b5cdf567fcfb478ad5a3a7b594e11d998656b2f9/grpcio_health_checking-1.81.1-py3-none-any.whl", hash = "sha256:cbc6a4171825ec64389de2f062d296ba129a5c27eefd0dd55fa837909184bdf9", size = 19120, upload-time = "2026-06-11T12:58:38.008Z" },
 ]
 
 [[package]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,13 @@ exclude = ["src/ol_dlt"]
 
 [tool.uv]
 package = false  # This is a workspace root, not a package
+# Pin grpcio-health-checking below 1.82.0: that release bundles health_pb2.py
+# pre-generated with protobuf 7.35.0 gencode while declaring protobuf>=6.33.5,
+# so it crashes at import time under dagster's required protobuf<7 (upstream
+# metadata/gencode mismatch in the 1.82.0 release).
+override-dependencies = [
+    "grpcio-health-checking<1.82.0",
+]
 
 [dependency-groups]
 dev = [

--- a/uv.lock
+++ b/uv.lock
@@ -16,6 +16,7 @@ members = [
     "ol-dbt-cli",
     "ol-orchestrate-lib",
 ]
+overrides = [{ name = "grpcio-health-checking", specifier = "<1.82.0" }]
 
 [[package]]
 name = "agate"
@@ -1490,15 +1491,15 @@ wheels = [
 
 [[package]]
 name = "grpcio-health-checking"
-version = "1.82.0"
+version = "1.81.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "grpcio" },
     { name = "protobuf" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d5/92/bd7b524a41b18668c5d59e2a1bd1940da76cfcc1f0888e681e2dcab5425a/grpcio_health_checking-1.82.0.tar.gz", hash = "sha256:0c78ede1bb324b1967a1e79d18b1a45908634896d1ca56b790fa87c25109d43b", size = 17118, upload-time = "2026-07-06T04:26:49.412Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/65/46/6b6678b5a922765ae7637205bb6d0618a4da8b35f2ce6116f8bcff262370/grpcio_health_checking-1.81.1.tar.gz", hash = "sha256:ecc61480e25058a4a04e11e4ab6900ad7439b32e60a8ce4ece7d9f219221c85d", size = 17107, upload-time = "2026-06-11T12:58:49.632Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/6c/cb/8e4a95ee66b51b1b71d80892c41d803186d4e240a09b975b594a2298d78b/grpcio_health_checking-1.82.0-py3-none-any.whl", hash = "sha256:c4daa80b6b28caad1bb1a45cb124b1f8861b00524e39276026937e1af9bc5002", size = 19118, upload-time = "2026-07-06T04:26:36.039Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/87/174bbfb5613794862c45b5cdf567fcfb478ad5a3a7b594e11d998656b2f9/grpcio_health_checking-1.81.1-py3-none-any.whl", hash = "sha256:cbc6a4171825ec64389de2f062d296ba129a5c27eefd0dd55fa837909184bdf9", size = 19120, upload-time = "2026-06-11T12:58:38.008Z" },
 ]
 
 [[package]]
@@ -3528,8 +3529,8 @@ name = "secretstorage"
 version = "3.5.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cryptography" },
-    { name = "jeepney" },
+    { name = "cryptography", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "jeepney", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/1c/03/e834bcd866f2f8a49a85eaff47340affa3bfa391ee9912a952a1faa68c7b/secretstorage-3.5.0.tar.gz", hash = "sha256:f04b8e4689cbce351744d5537bf6b1329c6fc68f91fa666f60a380edddcd11be", size = 19884, upload-time = "2025-11-23T19:02:53.191Z" }
 wheels = [


### PR DESCRIPTION
### What are the relevant tickets?
N/A

### Description (What does it do?)
All Dagster code location deployments are currently crash-looping on startup with:

```
google.protobuf.runtime_version.VersionError: Detected incompatible Protobuf Gencode/Runtime versions when loading grpc_health/v1/health.proto: gencode 7.35.0 runtime 6.33.6. Runtime version cannot be older than the linked gencode version.
```

**Root cause:** the renovate lock file maintenance commit `69b1763a` (#2372, merged 2026-07-07) bumped `grpcio-health-checking` from 1.81.1 → 1.82.0 across all 12 `uv.lock` files in this repo. That specific release bundles `grpc_health/v1/health_pb2.py` pre-generated with protobuf **7.35.0** gencode, but its PyPI metadata only declares `protobuf>=6.33.5`. Since `dagster` itself requires `protobuf<7`, uv correctly resolved `protobuf==6.33.6` everywhere — satisfying every declared constraint on paper, but incompatible with the gencode actually baked into the `grpcio-health-checking` 1.82.0 wheel. Every code location crashes at startup importing `dagster._grpc.server` → `grpc_health.v1.health_pb2`.

This is a confirmed upstream packaging bug: the grpc team has since yanked `grpcio==1.82.0` and `grpcio-status==1.82.0` for the identical protobuf mismatch ([grpc/grpc#42906](https://github.com/grpc/grpc/issues/42906)); `grpcio-health-checking==1.82.0` has the same defect but was not yanked.

**Fix:** add `[tool.uv] override-dependencies = ["grpcio-health-checking<1.82.0"]` to all 12 affected `pyproject.toml` files (root, `dg_deployments/local`, and all 10 `dg_projects/*`), following the existing override pattern already used in this repo for `pyiceberg` (see `packages/ol-orchestrate-lib/pyproject.toml` and `dg_projects/student_risk_probability/pyproject.toml`). Re-ran `uv lock --upgrade-package grpcio-health-checking` in each project, pinning it back to the known-good 1.81.1.

### Screenshots (if appropriate):
N/A

### How can this be tested?
Reproduced the crash and verified the fix locally:

1. Before the fix, `dg_projects/data_platform`'s lockfile resolved `grpcio-health-checking==1.82.0` + `protobuf==6.33.6`, and `uv run python -c "from grpc_health.v1 import health_pb2"` raised the exact `VersionError` from the crash logs.
2. After adding the override and re-locking, `grpcio-health-checing` resolves to `1.81.1` in every lockfile.
3. Re-synced the `data_platform` and `canvas` code location venvs (`uv sync --frozen`) and confirmed:
   - `from grpc_health.v1 import health, health_pb2, health_pb2_grpc` succeeds
   - `from dagster._grpc.server import DagsterApiServer, DagsterGrpcServer` succeeds
   - `uv run dagster api grpc --help` runs cleanly instead of crashing

A reviewer can validate by pulling this branch, running `uv sync --frozen` in any `dg_projects/*` directory or `dg_deployments/local`, and confirming `uv run dagster api grpc --help` no longer raises the protobuf `VersionError`. Redeploying any code location from this branch should stop the crash loop.

### Additional Context
- All 24 changed files are exactly the 12 `pyproject.toml` + 12 `uv.lock` pairs affected; no other dependency changes were bundled in.
- `grpcio` and `grpcio-status` remain at 1.82.0 in the lockfiles (untouched by `--upgrade-package`); their bundled stubs were not regenerated with the newer protoc, so they don't hit this bug — confirmed by successfully importing `dagster._grpc.server` end-to-end, which pulls in both packages.
- Once renovate/grpc ship a real fix upstream (either `grpcio-health-checking` re-released with a corrected `protobuf` floor, or protobuf 7.x support lands in `dagster`), this override can be removed.