### PR TITLE
 fix(dbt): fix missing and duplicate order_id in enrollment_detail_report

### DIFF
--- a/src/ol_dbt/models/dimensional/_fact_tables.yml
+++ b/src/ol_dbt/models/dimensional/_fact_tables.yml
@@ -53,7 +53,15 @@ models:
         to: ref('dim_course_run')
         field: courserun_pk
   - name: program_fk
-    description: Foreign key to dim_program (null for course enrollments)
+    description: >
+      Foreign key to dim_program. Null for most course enrollments (courserun_fk is
+      the relevant key there), but populated for mitxpro course enrollments (enrollment_type
+      = 'course') that resulted from a program-purchase order, since xPRO creates
+      one
+      ProgramEnrollment plus one CourseRunEnrollment per course in the program, sharing
+      the same source order — program_fk is recovered via that shared order and reflects
+      the program the course was purchased under, not the course's curriculum membership.
+      Always populated for program enrollments (enrollment_type = 'program').
     tests:
     - relationships:
         to: ref('dim_program')

--- a/src/ol_dbt/models/dimensional/tfact_enrollment.sql
+++ b/src/ol_dbt/models/dimensional/tfact_enrollment.sql
@@ -34,7 +34,7 @@ with mitxonline_enrollments as (
         , program_id
         , row_number() over (
             partition by ecommerce_order_id
-            order by programenrollment_created_on desc
+            order by programenrollment_created_on desc, programenrollment_id desc
         ) as row_num
     from {{ ref('int__mitxpro__programenrollments') }}
     where ecommerce_order_id is not null

--- a/src/ol_dbt/models/dimensional/tfact_enrollment.sql
+++ b/src/ol_dbt/models/dimensional/tfact_enrollment.sql
@@ -13,6 +13,7 @@ with mitxonline_enrollments as (
         , courserun_id
         , courserun_readable_id
         , null as program_id
+        , 'course' as enrollment_scope
         , courserunenrollment_created_on as enrollment_created_on
         , courserunenrollment_updated_on as enrollment_updated_on
         , courserunenrollment_is_active as enrollment_is_active
@@ -24,22 +25,42 @@ with mitxonline_enrollments as (
     from {{ ref('int__mitxonline__courserunenrollments') }}
 )
 
+-- A program-purchase order creates one ProgramEnrollment plus one CourseRunEnrollment per
+-- course in the program, all sharing the same ecommerce_order_id. Use that shared order to
+-- recover the program_id for course-run enrollments that came from a program order.
+, mitxpro_program_enrollments_by_order as (
+    select
+        ecommerce_order_id
+        , program_id
+        , row_number() over (
+            partition by ecommerce_order_id
+            order by programenrollment_created_on desc
+        ) as row_num
+    from {{ ref('int__mitxpro__programenrollments') }}
+    where ecommerce_order_id is not null
+)
+
 , mitxpro_enrollments as (
     select
-        cast(courserunenrollment_id as varchar) as enrollment_id
-        , user_id
-        , courserun_id
-        , courserun_readable_id
-        , null as program_id
-        , courserunenrollment_created_on as enrollment_created_on
-        , courserunenrollment_updated_on as enrollment_updated_on
-        , courserunenrollment_is_active as enrollment_is_active
-        , courserunenrollment_enrollment_mode as enrollment_mode
-        , courserunenrollment_enrollment_status as enrollment_status
+        cast(enrollments.courserunenrollment_id as varchar) as enrollment_id
+        , enrollments.user_id
+        , enrollments.courserun_id
+        , enrollments.courserun_readable_id
+        , mitxpro_program_enrollments_by_order.program_id
+        , 'course' as enrollment_scope
+        , enrollments.courserunenrollment_created_on as enrollment_created_on
+        , enrollments.courserunenrollment_updated_on as enrollment_updated_on
+        , enrollments.courserunenrollment_is_active as enrollment_is_active
+        , enrollments.courserunenrollment_enrollment_mode as enrollment_mode
+        , enrollments.courserunenrollment_enrollment_status as enrollment_status
         , 'mitxpro' as platform
         , 'mitxpro' as platform_code
-        , courserunenrollment_is_edx_enrolled as enrollment_is_edx_enrolled
-    from {{ ref('int__mitxpro__courserunenrollments') }}
+        , enrollments.courserunenrollment_is_edx_enrolled as enrollment_is_edx_enrolled
+    from {{ ref('int__mitxpro__courserunenrollments') }} as enrollments
+    left join mitxpro_program_enrollments_by_order
+        on
+            enrollments.ecommerce_order_id = mitxpro_program_enrollments_by_order.ecommerce_order_id
+            and mitxpro_program_enrollments_by_order.row_num = 1
 )
 
 , edxorg_enrollments as (
@@ -50,6 +71,7 @@ with mitxonline_enrollments as (
         , null as courserun_id  -- edxorg has no integer source_id
         , courserun_readable_id
         , null as program_id
+        , 'course' as enrollment_scope
         , courserunenrollment_created_on as enrollment_created_on
         , cast(null as varchar) as enrollment_updated_on
         , courserunenrollment_is_active as enrollment_is_active
@@ -73,6 +95,7 @@ with mitxonline_enrollments as (
         , null as courserun_id
         , cast(null as varchar) as courserun_readable_id
         , program_id
+        , 'program' as enrollment_scope
         , programenrollment_created_on as enrollment_created_on
         , programenrollment_updated_on as enrollment_updated_on
         , programenrollment_is_active as enrollment_is_active
@@ -91,6 +114,7 @@ with mitxonline_enrollments as (
         , null as courserun_id
         , courserun_readable_id
         , null as program_id
+        , 'course' as enrollment_scope
         , courserunenrollment_created_on as enrollment_created_on
         , cast(null as varchar) as enrollment_updated_on
         , courserunenrollment_is_active as enrollment_is_active
@@ -109,6 +133,7 @@ with mitxonline_enrollments as (
         , courserun_id
         , courserun_readable_id
         , null as program_id
+        , 'course' as enrollment_scope
         , courserunenrollment_created_on as enrollment_created_on
         , courserunenrollment_updated_on as enrollment_updated_on
         , courserunenrollment_is_active as enrollment_is_active
@@ -254,10 +279,10 @@ with mitxonline_enrollments as (
         {{ dbt_utils.generate_surrogate_key([
             'cast(enrollment_id as varchar)',
             'platform',
-            "case when program_id is not null then 'program' else 'course' end"
+            'enrollment_scope'
         ]) }} as enrollment_key
         , enrollment_id
-        , case when program_id is not null then 'program' else 'course' end as enrollment_type
+        , enrollment_scope as enrollment_type
         , enrollment_date_key
         , user_fk
         , courserun_fk
@@ -276,7 +301,7 @@ with mitxonline_enrollments as (
     -- left join preserves enrollments from platforms/types not yet in the target table
     left join incremental_watermarks w
         on w.watermark_platform = ewf.platform
-        and w.watermark_enrollment_type = case when ewf.program_id is not null then 'program' else 'course' end
+        and w.watermark_enrollment_type = ewf.enrollment_scope
     where (
         w.max_activity_on is null  -- platform/type not yet in target, include all
         -- Use >= for updated_on watermark: updated_on can equal max on state changes within same second

--- a/src/ol_dbt/models/reporting/enrollment_detail_report.sql
+++ b/src/ol_dbt/models/reporting/enrollment_detail_report.sql
@@ -160,6 +160,10 @@ select
             case when f_order.order_id is not null then 0 else 1 end
             , case when enrollment.courserun_fk = product.courserun_fk then 1 else 2 end
             , f_order.order_updated_on desc nulls last
+            -- order_updated_on is order-level and shared by every line on a multi-line
+            -- order, so it alone can leave ties unresolved; break ties deterministically.
+            , f_order.order_id desc nulls last
+            , f_order.line_id desc nulls last
     ) as row_num
     , case enrollment.platform
         when 'bootcamps' then '{{ var("bootcamps") }}'

--- a/src/ol_dbt/models/reporting/enrollment_detail_report.sql
+++ b/src/ol_dbt/models/reporting/enrollment_detail_report.sql
@@ -33,10 +33,12 @@ with enrollment as (
 
 , product as (
     select * from {{ ref('dim_product') }}
+    where is_current = true
 )
 
 , f_order as (
     select * from {{ ref('tfact_order') }}
+    where order_state in ('fulfilled', 'refunded')
 )
 
 , discount as (
@@ -143,8 +145,23 @@ with enrollment as (
     group by user_email
 )
 
+-- An enrollment's courserun_fk/program_fk can each independently match a distinct
+-- product (e.g. the course sold standalone AND bundled into a program the learner
+-- actually purchased), fanning this join out to one row per matching order. Dedup
+-- below keeps whichever match actually has a real order, preferring the more
+-- specific course-level match and, within a priority tier, the most recent order.
+-- Note: QUALIFY is not supported by Trino; using ROW_NUMBER subquery instead.
+, report_rows as (
 select
-    case enrollment.platform
+    enrollment.enrollment_key
+    , row_number() over (
+        partition by enrollment.enrollment_key
+        order by
+            case when f_order.order_id is not null then 0 else 1 end
+            , case when enrollment.courserun_fk = product.courserun_fk then 1 else 2 end
+            , f_order.order_updated_on desc nulls last
+    ) as row_num
+    , case enrollment.platform
         when 'bootcamps' then '{{ var("bootcamps") }}'
         when 'edxorg' then '{{ var("edxorg") }}'
         when 'emeritus' then '{{ var("emeritus") }}'
@@ -298,3 +315,52 @@ left join order_emails
     and d_user.email = order_emails.user_email
 left join course_passed_counts
     on d_user.email = course_passed_counts.user_email
+)
+
+select
+    platform
+    , courserunenrollment_id
+    , course_readable_id
+    , course_title
+    , courserun_is_current
+    , courserun_readable_id
+    , courserun_start_on
+    , courserun_end_on
+    , courserun_title
+    , courserunenrollment_created_on
+    , courserunenrollment_enrollment_mode
+    , courserunenrollment_enrollment_status
+    , courserunenrollment_is_active
+    , courserunenrollment_upgraded_on
+    , courseruncertificate_created_on
+    , courseruncertificate_issued_on
+    , courseruncertificate_is_earned
+    , courseruncertificate_url
+    , courserungrade_grade
+    , courserungrade_is_passing
+    , organization_key
+    , organization_name
+    , user_country_code
+    , user_highest_education
+    , user_full_name
+    , user_username
+    , user_email
+    , num_of_course_passed
+    , coupon_code
+    , coupon_name
+    , discount
+    , order_id
+    , order_reference_number
+    , order_state
+    , order_updated_on
+    , receipt_payment_amount
+    , receipt_payment_method
+    , receipt_payment_timestamp
+    , receipt_payer_email
+    , unit_price
+    , program_name
+    , discount_type_name
+    , redeemed_email
+    , receipt_url
+from report_rows
+where row_num = 1


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
duplicate order issues in https://github.mit.edu/mitxonline/mitxonline-issues/issues/1426
missing order_id for xpro program enrollment in https://github.mit.edu/xpro/xpro-issues/issues/688 
duplicate enrollment in https://github.com/mitodl/hq/issues/12189

### Description (What does it do?)
<!--- Describe your changes in detail -->
Fixes two issues after we switched to use dimensional models for enrollment_detail_report:   

-   Missing order_id for xPRO program-order enrollments (tfact_enrollment.sql):                                   
-   Duplicate rows when an enrollment matches more than one order (enrollment_detail_report.sql), affecting any platform (confirmed on both xPRO and mitxonline)                                                                       


### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

`dbt run --select +tfact_enrollment +tfact_order enrollment_detail_report --full-refresh `

- Confirmed that this query returns order_id= 81192 instead of blank order_id for xpro.

```
select order_id, unit_price,program_name
from "ol_data_lake_production".ol_warehouse_production_rlougee_reporting.enrollment_detail_report
where courserunenrollment_id='69514' and platform='xPro'

```

- Confirmed that this query returns only 1 row instead of duplicated rows for mitxonline. This addresses the first issue in https://github.mit.edu/mitxonline/mitxonline-issues/issues/1426

```
select  *
from "ol_data_lake_production".ol_warehouse_production_reporting.enrollment_detail_report
where courserunenrollment_id='998362' and platform='MITx Online'
```

### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->


<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
