### PR TITLE
fix(dimensional): coalesce nullable SCD2 change-detection keys

### DIFF
--- a/src/ol_dbt/models/dimensional/dim_course_run.sql
+++ b/src/ol_dbt/models/dimensional/dim_course_run.sql
@@ -277,7 +277,7 @@ with micromasters_courseruns as (
             existing.courserun_readable_id = courseruns_with_all_fks.courserun_readable_id
             and existing.platform = courseruns_with_all_fks.platform
             and existing.is_current = true
-            and existing.courserun_title = courseruns_with_all_fks.courserun_title
+            and coalesce(existing.courserun_title, '') = coalesce(courseruns_with_all_fks.courserun_title, '')
             and coalesce(existing.courserun_start_on, '') = coalesce(courseruns_with_all_fks.courserun_start_on, '')
             and coalesce(existing.courserun_end_on, '') = coalesce(courseruns_with_all_fks.courserun_end_on, '')
             and coalesce(existing.enrollment_start, '') = coalesce(courseruns_with_all_fks.enrollment_start, '')

--- a/src/ol_dbt/models/dimensional/dim_product.sql
+++ b/src/ol_dbt/models/dimensional/dim_product.sql
@@ -119,7 +119,7 @@ with mitxonline_products as (
             existing.source_product_id = products_with_fks.product_id
             and existing.platform = products_with_fks.platform
             and existing.is_current = true
-            and existing.product_price = products_with_fks.product_price
+            and coalesce(existing.product_price, -1) = coalesce(products_with_fks.product_price, -1)
     )
     {% endif %}
 )


### PR DESCRIPTION
## What

Fixes NULL-unsafe SCD2 change detection in `dim_course_run` and `dim_product`.

- `dim_course_run.sql` compared `existing.courserun_title = new.courserun_title` **without** `coalesce`, while every sibling attribute in the same `not exists` block was coalesced. `courserun_title` is nullable (no `not_null` test), so `NULL = NULL` evaluates to `UNKNOWN`, the `not exists` guard never matches for null-title runs, and every incremental run inserts a fresh current row and expires the prior one → unbounded SCD2 version churn.
- Same pattern on `product_price` in `dim_product.sql` (nullable, no `not_null` test).

## Fix

Coalesce both comparisons to a sentinel matching the surrounding columns (`''` for the title, `-1` for the numeric price).

Both models already carry a `dbt_utils.unique_combination_of_columns` test filtered to `is_current = true`, which asserts one current row per natural key — so the current-row invariant is already guarded; this fix stops the historical-version churn.

Closes #2380

🤖 Generated with [Claude Code](https://claude.com/claude-code)