### PR TITLE
fix(dimensional): fix dim_discount grain mismatch causing tfact_order fan-out

### DIFF
--- a/src/ol_dbt/models/dimensional/_dim__models.yml
+++ b/src/ol_dbt/models/dimensional/_dim__models.yml
@@ -1057,7 +1057,9 @@ models:
   - name: source_discount_id
     description: integer, original discount or coupon ID from the source platform
   - name: discount_code
-    description: string, the discount or coupon code used at checkout
+    description: string, the discount or coupon code used at checkout. If a discount's
+      code was changed over its lifetime, this reflects the most recently updated
+      code on file, not necessarily the code used on every order that redeemed it
   - name: discount_type
     description: string, type of discount. e.g. percent-off, dollars-off, fixed-price
   - name: discount_amount

--- a/src/ol_dbt/models/dimensional/_dim__models.yml
+++ b/src/ol_dbt/models/dimensional/_dim__models.yml
@@ -1043,6 +1043,11 @@ models:
   description: Dimension table combining discount/coupon records across MITxOnline
     and MITxPro platforms. Each row represents a unique discount or coupon identified
     by a surrogate key derived from the source platform and source discount ID.
+  tests:
+  - dbt_utils.unique_combination_of_columns:
+      combination_of_columns:
+      - source_discount_id
+      - platform_code
   columns:
   - name: discount_pk
     description: string, surrogate primary key for this table, generated from source_discount_id

--- a/src/ol_dbt/models/dimensional/_dim__models.yml
+++ b/src/ol_dbt/models/dimensional/_dim__models.yml
@@ -1060,7 +1060,9 @@ models:
     tests:
     - not_null
   - name: source_discount_id
-    description: integer, original discount or coupon ID from the source platform
+    description: integer, original discount or coupon ID from the source platform.
+      For mitxpro b2b bulk-purchase coupons (which have no coupon_id), this is the
+      negated b2bcoupon_id instead, to keep it distinct from regular coupon IDs.
   - name: discount_code
     description: string, the discount or coupon code used at checkout. If a discount's
       code was changed over its lifetime, this reflects the most recently updated

--- a/src/ol_dbt/models/dimensional/_fact_tables.yml
+++ b/src/ol_dbt/models/dimensional/_fact_tables.yml
@@ -242,8 +242,12 @@ models:
         config:
           severity: warn
   - name: discount_fk
-    description: Foreign key to dim_discount (null when no discount applied on this
-      line)
+    description: >
+      Foreign key to dim_discount (null when no discount applied on this line).
+      dim_discount is full-refresh and this table is incremental — a
+      dim_discount.discount_pk hashing change requires a `dbt run --select
+      tfact_order --full-refresh` immediately after to avoid orphaning
+      discount_fk on historical order lines.
     tests:
     - relationships:
         to: ref('dim_discount')

--- a/src/ol_dbt/models/dimensional/dim_discount.sql
+++ b/src/ol_dbt/models/dimensional/dim_discount.sql
@@ -71,8 +71,22 @@ with mitxonline_discounts as (
     from micromasters_discounts
 )
 
+-- A discount can be re-saved under a new discount_code over its lifetime, so
+-- dedupe to one row per (source_discount_id, platform_code), keeping the most
+-- recently updated code, to match the documented grain and prevent downstream
+-- fact joins keyed on (source_discount_id, platform_code) from fanning out.
+, deduped_discounts as (
+    select
+        *
+        , row_number() over (
+            partition by platform_code, source_discount_id
+            order by updated_on desc nulls last, created_on desc nulls last
+        ) as _row_num
+    from combined_discounts
+)
+
 select
-    {{ dbt_utils.generate_surrogate_key(['cast(source_discount_id as varchar)', 'discount_code', 'platform_code']) }} as discount_pk
+    {{ dbt_utils.generate_surrogate_key(['cast(source_discount_id as varchar)', 'platform_code']) }} as discount_pk
     , platform_code
     , source_discount_id
     , discount_code
@@ -85,4 +99,5 @@ select
     , expires_on
     , created_on
     , updated_on
-from combined_discounts
+from deduped_discounts
+where _row_num = 1

--- a/src/ol_dbt/models/dimensional/dim_discount.sql
+++ b/src/ol_dbt/models/dimensional/dim_discount.sql
@@ -80,7 +80,9 @@ with mitxonline_discounts as (
         *
         , row_number() over (
             partition by platform_code, source_discount_id
-            order by updated_on desc nulls last, created_on desc nulls last
+            -- discount_code as a final tie-breaker keeps the pick deterministic when
+            -- updated_on/created_on are identical (or both null) across duplicate rows
+            order by updated_on desc nulls last, created_on desc nulls last, discount_code desc nulls last
         ) as _row_num
     from combined_discounts
 )

--- a/src/ol_dbt/models/dimensional/dim_discount.sql
+++ b/src/ol_dbt/models/dimensional/dim_discount.sql
@@ -87,6 +87,10 @@ with mitxonline_discounts as (
     from combined_discounts
 )
 
+-- This table is full-refresh (materialized='table' above), so every run regenerates
+-- discount_pk for all rows. Changing this hash's inputs requires a full-refresh of
+-- incremental consumers (e.g. tfact_order.discount_fk) in the same deploy, or their
+-- historical rows are left pointing at pks that no longer exist.
 select
     {{ dbt_utils.generate_surrogate_key(['cast(source_discount_id as varchar)', 'platform_code']) }} as discount_pk
     , platform_code

--- a/src/ol_dbt/models/dimensional/dim_discount.sql
+++ b/src/ol_dbt/models/dimensional/dim_discount.sql
@@ -36,7 +36,11 @@ with mitxonline_discounts as (
 
     select
         'mitxpro' as platform_code
-        , coupon_id as source_discount_id
+        -- b2b bulk-purchase coupons have no coupon_id (see int__mitxpro__ecommerce_allcoupons,
+        -- where it's explicitly nulled for b2b rows); their real identifier is b2bcoupon_id.
+        -- Negate it so it can't collide with a coupon_id from the unrelated ecommerce_coupon
+        -- table sharing the same numeric range, while keeping source_discount_id an integer.
+        , coalesce(coupon_id, -b2bcoupon_id) as source_discount_id
         , coupon_code as discount_code
         , discount_type
         , case


### PR DESCRIPTION
## Summary
- `dim_discount.discount_pk` was hashed from `(source_discount_id, discount_code, platform_code)`, but the model docs and `tfact_order`'s join both assume `(source_discount_id, platform_code)` is the unique grain.
- When a discount's `discount_code` is updated over its lifetime, `dim_discount` emitted multiple rows per `(source_discount_id, platform_code)`, so `tfact_order`'s dimension join on those two columns fanned out — and the final dedup in `tfact_order` picked an arbitrary `discount_fk` because `order_updated_on` was identical across the fanned rows.
- Dedupe `dim_discount` to one row per `(source_discount_id, platform_code)`, keeping the most recently updated `discount_code`, and hash the surrogate key from just those two columns to match the documented and consumed grain.
- Added `discount_code` as a deterministic tie-breaker in the dedup `ROW_NUMBER()` and an explicit `dbt_utils.unique_combination_of_columns` test on `(source_discount_id, platform_code)` per review feedback.
- Documented (in `dim_discount.sql` and `tfact_order`'s `discount_fk` column) that this surrogate-key change requires a `--full-refresh` of `tfact_order` in the same deploy, since `dim_discount` is full-refresh but `tfact_order` is incremental and won't otherwise recompute `discount_fk` for historical rows.

## Test plan
- [x] `dbt parse` and `dbt compile --select dim_discount tfact_order` succeed against the `dev_local` duckdb target
- [x] `pre-commit` (sqlfluff, yamllint, etc.) passes on changed files
- [ ] CI dbt build/test run

## Deployment notes
- After this merges, run `dbt run --select tfact_order --full-refresh` (or the equivalent full pipeline full-refresh) to avoid orphaned `discount_fk` values on historical order lines — see inline comments in `dim_discount.sql` / `_fact_tables.yml`.

Fixes #2379

🤖 Generated with [Claude Code](https://claude.com/claude-code)
