### PR TITLE
fix(dimensional): platform-scope MicroMasters program_fk lookup in tfact_enrollment

### DIFF
--- a/src/ol_dbt/models/dimensional/_fact_tables.yml
+++ b/src/ol_dbt/models/dimensional/_fact_tables.yml
@@ -61,7 +61,12 @@ models:
       ProgramEnrollment plus one CourseRunEnrollment per course in the program, sharing
       the same source order — program_fk is recovered via that shared order and reflects
       the program the course was purchased under, not the course's curriculum membership.
-      Always populated for program enrollments (enrollment_type = 'program').
+      Also populated for edxorg/mitxonline course enrollments (enrollment_type = 'course')
+      whose course run is part of a MicroMasters curriculum, since MicroMasters has
+      no
+      explicit ProgramEnrollment record on either platform — program_fk is recovered
+      via a (courserun_readable_id, platform) lookup against MicroMasters program
+      membership. Always populated for program enrollments (enrollment_type = 'program').
     tests:
     - relationships:
         to: ref('dim_program')

--- a/src/ol_dbt/models/dimensional/tfact_enrollment.sql
+++ b/src/ol_dbt/models/dimensional/tfact_enrollment.sql
@@ -198,16 +198,36 @@ with mitxonline_enrollments as (
     from {{ ref('dim_program') }}
 )
 
--- MicroMasters program lookup: maps courserun_readable_id to micromasters program_pk.
--- Used to enrich edxorg/mitxonline enrollment rows that belong to MM programs.
+-- MicroMasters program lookup: maps (courserun_readable_id, platform) to micromasters
+-- program_pk. Used to enrich edxorg/mitxonline enrollment rows that belong to MM
+-- programs. Platform-scoped (not just courserun_readable_id) so a mitxpro/residential/
+-- bootcamps enrollment can never inherit an MM program_fk, and deduped one row per
+-- (courserun_readable_id, platform) so a course run reused across two MM programs
+-- can't fan out the enrollment it's joined against.
 , micromasters_program_lookup as (
-    select distinct
+    select
         courserun_readable_id
-        , dim_program.program_pk as micromasters_program_pk
-    from {{ ref('int__micromasters__course_enrollments') }} as mm_enroll
-    inner join dim_program
-        on cast(mm_enroll.micromasters_program_id as varchar) = cast(dim_program.source_id as varchar)
-        and dim_program.platform_code = 'micromasters'
+        , platform
+        , micromasters_program_pk
+    from (
+        select
+            mm_enroll.courserun_readable_id
+            , case
+                when mm_enroll.platform = '{{ var("edxorg") }}' then 'edxorg'
+                when mm_enroll.platform = '{{ var("mitxonline") }}' then 'mitxonline'
+            end as platform
+            , dim_program.program_pk as micromasters_program_pk
+            , row_number() over (
+                partition by mm_enroll.courserun_readable_id, mm_enroll.platform
+                order by dim_program.program_pk
+            ) as _row_num
+        from {{ ref('int__micromasters__course_enrollments') }} as mm_enroll
+        inner join dim_program
+            on cast(mm_enroll.micromasters_program_id as varchar) = cast(dim_program.source_id as varchar)
+            and dim_program.platform_code = 'micromasters'
+    ) as deduped
+    where _row_num = 1
+        and platform is not null
 )
 
 -- dim_platform not in Phase 1-2
@@ -265,6 +285,7 @@ with mitxonline_enrollments as (
         and combined_enrollments.platform_code = dim_program.platform_code
     left join micromasters_program_lookup
         on combined_enrollments.courserun_readable_id = micromasters_program_lookup.courserun_readable_id
+        and combined_enrollments.platform = micromasters_program_lookup.platform
     left join dim_platform_lookup
         on combined_enrollments.platform = dim_platform_lookup.platform_readable_id
 )


### PR DESCRIPTION
### What are the relevant tickets?
Closes https://github.com/mitodl/ol-data-platform/issues/2378

### Description (What does it do?)
`tfact_enrollment.sql`'s `micromasters_program_lookup` CTE enriched course-scope enrollments with a MicroMasters `program_fk` by joining on `courserun_readable_id` alone, with no platform constraint. That meant:

- Any platform's enrollment sharing a MM-linked `courserun_readable_id` (not just the edxorg/mitxonline enrollments that MM courses actually run on) could inherit a MicroMasters `program_fk`.
- A course run reused across two different MicroMasters programs would fan out the left join, silently masked by the model's final defensive dedup (which just picks an arbitrary winning row).
- `_fact_tables.yml` documented `program_fk` as null for course enrollments except the mitxpro program-purchase case, contradicting the MM enrichment behavior the code already relied on.

Fix:
- Platform-scope the lookup by carrying the enrollment's own `platform` value (mapped from the source `edX.org`/`MITx Online` strings to the `edxorg`/`mitxonline` codes used elsewhere in the model) and joining on `(courserun_readable_id, platform)` instead of `courserun_readable_id` alone.
- Dedupe `micromasters_program_lookup` to one row per `(courserun_readable_id, platform)` via `row_number()` (Trino has no `QUALIFY`, consistent with the existing dedup pattern later in the same model) so a course run belonging to two MM programs can't fan out the enrollment it's joined against.
- Updated the `program_fk` column description in `_fact_tables.yml` to document the MicroMasters enrichment path.

### How can this be tested?
- `dbt parse` and `dbt compile -s tfact_enrollment` both succeed against the local duckdb target; the compiled SQL confirms the Jinja `var()` calls resolve to the correct source platform strings (`edX.org`, `MITx Online`) used in the `case` mapping.
- Existing `relationships` test on `program_fk` → `dim_program.program_pk` and the `dbt_utils.unique_combination_of_columns` test on `(enrollment_id, platform, enrollment_type)` continue to guard the model's grain; a full run against the QA warehouse is recommended before merge to confirm no unexpected `program_fk` population changes for edge-case platforms.

### Additional Context
Found via the dbt warehouse semantic-accuracy audit (dimensional-layer correctness epic). Related identity-collapse issue in the same audit: MicroMasters certificates in `tfact_certificate` also dual-source from edxorg with a separate defensive-dedup gap (not addressed by this PR).