### PR TITLE
fix(dimensional): dedupe MicroMasters/edxorg certs and fix MM email-case join

### DIFF
--- a/src/ol_dbt/models/dimensional/_fact_tables.yml
+++ b/src/ol_dbt/models/dimensional/_fact_tables.yml
@@ -354,7 +354,10 @@ models:
 - name: tfact_certificate
   description: >
     Transaction fact table for certificate issuance events.
-    Grain: One row per certificate issued (course or program).
+    Grain: One row per certificate issued (course or program). MicroMasters course
+    certificates are earned on and issued by edX.org, so the micromasters and edxorg
+    sources both produce a row for the same (user, course run) pair; these are collapsed
+    to a single row, preferring the edxorg record as canonical.
   tests:
   - dbt_utils.unique_combination_of_columns:
       combination_of_columns:

--- a/src/ol_dbt/models/dimensional/tfact_certificate.sql
+++ b/src/ol_dbt/models/dimensional/tfact_certificate.sql
@@ -241,8 +241,10 @@ with mitxonline_certificates as (
     left join user_lookup as ul_micromasters
         on combined_certificates.platform = 'micromasters'
         -- dim_user.email is always lower()-ed; micromasters emails are not,
-        -- so a mixed-case email would otherwise silently fail to resolve user_fk
-        and lower(combined_certificates.user_email) = ul_micromasters.email
+        -- so a mixed-case email would otherwise silently fail to resolve user_fk.
+        -- lower() both sides defensively since it's unclear from this query alone
+        -- that dim_user.email is guaranteed lowercase.
+        and lower(combined_certificates.user_email) = lower(ul_micromasters.email)
     left join user_lookup as ul_bootcamps
         on combined_certificates.platform = 'bootcamps'
         and combined_certificates.user_id = ul_bootcamps.bootcamps_application_user_id

--- a/src/ol_dbt/models/dimensional/tfact_certificate.sql
+++ b/src/ol_dbt/models/dimensional/tfact_certificate.sql
@@ -240,7 +240,9 @@ with mitxonline_certificates as (
         and combined_certificates.user_id = ul_edxorg.edxorg_openedx_user_id
     left join user_lookup as ul_micromasters
         on combined_certificates.platform = 'micromasters'
-        and combined_certificates.user_email = ul_micromasters.email
+        -- dim_user.email is always lower()-ed; micromasters emails are not,
+        -- so a mixed-case email would otherwise silently fail to resolve user_fk
+        and lower(combined_certificates.user_email) = ul_micromasters.email
     left join user_lookup as ul_bootcamps
         on combined_certificates.platform = 'bootcamps'
         and combined_certificates.user_id = ul_bootcamps.bootcamps_application_user_id
@@ -257,6 +259,33 @@ with mitxonline_certificates as (
     left join dim_program
         on combined_certificates.program_id = dim_program.source_id
         and combined_certificates.platform = dim_program.platform_code
+)
+
+-- MicroMasters course certificates are earned on and issued by edX.org, and both
+-- the edxorg and micromasters sources resolve courserun_fk to the same edxorg
+-- course run (see the dim_course_run join above). Their surrogate certificate_ids
+-- differ (user_id-based vs email-based), so the same physical certificate enters
+-- as two rows and the certificate_key-based defensive dedup further below can't
+-- catch it. Collapse to one row per (user_fk, courserun_fk, certificate_scope)
+-- when both FKs resolved, preferring the canonical edxorg record.
+, cross_source_deduped as (
+    select
+        *
+        , row_number() over (
+            partition by
+                case
+                    when user_fk is not null and courserun_fk is not null
+                        then concat(cast(user_fk as varchar), '|', cast(courserun_fk as varchar), '|', certificate_scope)
+                    else concat(certificate_id, '|', platform, '|', certificate_scope)
+                end
+            order by
+                case platform
+                    when 'edxorg' then 0
+                    when 'micromasters' then 1
+                    else 0
+                end
+        ) as _cross_source_row_num
+    from certificates_with_fks
 )
 
 {% if is_incremental() %}
@@ -295,7 +324,8 @@ with mitxonline_certificates as (
         , certificate_created_on
         , certificate_updated_on
         , certificate_issued_on
-    from certificates_with_fks as cwf
+    from cross_source_deduped as cwf
+    where cwf._cross_source_row_num = 1
 
     {% if is_incremental() %}
     -- left join preserves certificates from platforms not yet in the target table

--- a/src/ol_dbt/models/dimensional/tfact_certificate.sql
+++ b/src/ol_dbt/models/dimensional/tfact_certificate.sql
@@ -325,18 +325,20 @@ with mitxonline_certificates as (
         , certificate_updated_on
         , certificate_issued_on
     from cross_source_deduped as cwf
-    where cwf._cross_source_row_num = 1
 
     {% if is_incremental() %}
     -- left join preserves certificates from platforms not yet in the target table
     left join incremental_watermarks w
         on w.watermark_platform = cwf.platform
         and w.watermark_certificate_type = cwf.certificate_scope
-    where (
+    where cwf._cross_source_row_num = 1
+    and (
         w.max_activity_on is null  -- platform/type not yet in target, include all
         or coalesce(cwf.certificate_updated_on, cwf.certificate_created_on) >= w.max_activity_on
         or cwf.certificate_created_on is null
     )
+    {% else %}
+    where cwf._cross_source_row_num = 1
     {% endif %}
 )
 


### PR DESCRIPTION
## Summary
- MicroMasters course certificates are earned on and issued by edX.org, so `int__edxorg__mitx_courserun_certificates` and `int__micromasters__course_certificates` both produce a row for the same (user, course run) pair in `tfact_certificate` — the micromasters row's `dim_course_run` join is explicitly remapped onto the `edxorg` platform. Their surrogate `certificate_id`s differ (user_id-based vs email-based), so the existing `certificate_key`-based defensive dedup couldn't catch the double-count.
- Added a `cross_source_deduped` CTE that collapses to one row per `(user_fk, courserun_fk, certificate_scope)` whenever both FKs resolved, preferring the canonical `edxorg` record — this only affects the edxorg/micromasters overlap since every other platform resolves to a distinct `courserun_fk`.
- Fixed a silent user-resolution bug: the micromasters user_email join compared raw-case email against `dim_user.email`, which is always `lower()`-ed. Mixed-case MM emails failed to resolve `user_fk` (masked by the warn-severity relationships test).
- Documented both behaviors in `_fact_tables.yml`.

## Test plan
- [x] `dbt compile --select tfact_certificate` succeeds against the `dev_local` duckdb target
- [x] `pre-commit` (sqlfluff, yamllint, etc.) passes on changed files
- [ ] CI dbt build/test run

Fixes #2381

🤖 Generated with [Claude Code](https://claude.com/claude-code)