### PR TITLE
fix(dimensional): fix dim_instructor name-collision identity collapse

### DIFF
--- a/src/ol_dbt/models/dimensional/_course_catalog_dimensions.yml
+++ b/src/ol_dbt/models/dimensional/_course_catalog_dimensions.yml
@@ -4,14 +4,24 @@ version: 2
 models:
 - name: dim_instructor
   description: Instructor dimension containing faculty and course instructors from
-    all platforms. Grain is (instructor_name, primary_platform) — same name on different
-    platforms are kept as separate rows.
+    all platforms. Grain is (instructor_source_id, or instructor_name when no source
+    id exists, primary_platform). mitxonline (wagtail_page_id) and ocw (course_instructor_uuid)
+    have a stable per-instructor natural key and dedupe on it, so two distinct instructors
+    sharing a name on the same platform are kept as separate rows. mitxpro's source
+    data has no such key; its instructors still dedupe on name alone, so two distinct
+    mitxpro faculty sharing an exact name will collapse into a single row — an accepted,
+    documented limitation rather than a fix.
   columns:
   - name: instructor_pk
-    description: Primary key - surrogate key generated from (instructor_name, primary_platform)
+    description: Primary key - surrogate key generated from (instructor_source_id,
+      or instructor_name when no source id exists, primary_platform)
     tests:
     - unique
     - not_null
+  - name: instructor_source_id
+    description: Platform-native stable identifier for the instructor (wagtail_page_id
+      for mitxonline, course_instructor_uuid for ocw). Null for mitxpro, which has
+      no such identifier in its source data.
   - name: instructor_name
     description: Full name of the instructor
     tests:

--- a/src/ol_dbt/models/dimensional/bridge_course_instructor.sql
+++ b/src/ol_dbt/models/dimensional/bridge_course_instructor.sql
@@ -31,7 +31,7 @@ with mitxonline_course_instructors as (
 , ocw_course_instructors as (
     select
         ocw_courses.course_readable_id
-        , ocw_instructors.course_instructor_uuid as instructor_source_id
+        , cast(ocw_instructors.course_instructor_uuid as varchar) as instructor_source_id
         , ocw_instructors.course_instructor_title as instructor_name
         , 'ocw' as platform
     from {{ ref('int__ocw__course_instructors') }} as ocw_instructors

--- a/src/ol_dbt/models/dimensional/bridge_course_instructor.sql
+++ b/src/ol_dbt/models/dimensional/bridge_course_instructor.sql
@@ -6,6 +6,7 @@
 with mitxonline_course_instructors as (
     select
         course_id
+        , instructor_source_id
         , instructor_name
         , 'mitxonline' as platform
     from {{ ref('int__mitxonline__course_instructors') }}
@@ -14,6 +15,7 @@ with mitxonline_course_instructors as (
 , mitxpro_course_instructors as (
     select
         course_id
+        , cast(null as varchar) as instructor_source_id
         , cms_facultymemberspage_facultymember_name as instructor_name
         , 'mitxpro' as platform
     from {{ ref('int__mitxpro__coursesfaculty') }}
@@ -29,6 +31,7 @@ with mitxonline_course_instructors as (
 , ocw_course_instructors as (
     select
         ocw_courses.course_readable_id
+        , ocw_instructors.course_instructor_uuid as instructor_source_id
         , ocw_instructors.course_instructor_title as instructor_name
         , 'ocw' as platform
     from {{ ref('int__ocw__course_instructors') }} as ocw_instructors
@@ -50,6 +53,7 @@ with mitxonline_course_instructors as (
 , dim_instructor as (
     select
         instructor_pk
+        , instructor_source_id
         , instructor_name
         , primary_platform
     from {{ ref('dim_instructor') }}
@@ -64,7 +68,9 @@ with mitxonline_course_instructors as (
         on source_id_course_instructors.course_id = dim_course.source_id
         and source_id_course_instructors.platform = dim_course.primary_platform
     left join dim_instructor
-        on source_id_course_instructors.instructor_name = dim_instructor.instructor_name
+        on
+            coalesce(source_id_course_instructors.instructor_source_id, source_id_course_instructors.instructor_name)
+            = coalesce(dim_instructor.instructor_source_id, dim_instructor.instructor_name)
         and source_id_course_instructors.platform = dim_instructor.primary_platform
 )
 
@@ -77,7 +83,9 @@ with mitxonline_course_instructors as (
         on ocw_course_instructors.course_readable_id = dim_course.course_readable_id
         and ocw_course_instructors.platform = dim_course.primary_platform
     left join dim_instructor
-        on ocw_course_instructors.instructor_name = dim_instructor.instructor_name
+        on
+            coalesce(ocw_course_instructors.instructor_source_id, ocw_course_instructors.instructor_name)
+            = coalesce(dim_instructor.instructor_source_id, dim_instructor.instructor_name)
         and ocw_course_instructors.platform = dim_instructor.primary_platform
 )
 

--- a/src/ol_dbt/models/dimensional/dim_instructor.sql
+++ b/src/ol_dbt/models/dimensional/dim_instructor.sql
@@ -5,7 +5,8 @@
 -- Consolidate instructors from all platforms
 with mitxonline_instructors as (
     select
-        instructor_name
+        instructor_source_id
+        , instructor_name
         , instructor_title
         , instructor_bio_short
         , instructor_bio_long
@@ -15,7 +16,13 @@ with mitxonline_instructors as (
 
 , mitxpro_instructors as (
     select
-        cms_facultymemberspage_facultymember_name as instructor_name
+        -- mitxpro's CMS faculty entries carry no stable per-instructor id (only a
+        -- name and description embedded in a JSON array), so this platform must
+        -- keep deduping on name alone and accepts the risk that two distinct
+        -- faculty sharing an exact name on the same course page will collapse
+        -- into a single dim_instructor row. See _course_catalog_dimensions.yml.
+        cast(null as varchar) as instructor_source_id
+        , cms_facultymemberspage_facultymember_name as instructor_name
         , cast(null as varchar) as instructor_title
         , cast(null as varchar) as instructor_bio_short
         , cms_facultymemberspage_facultymember_description as instructor_bio_long
@@ -25,7 +32,8 @@ with mitxonline_instructors as (
 
 , ocw_instructors as (
     select
-        course_instructor_title as instructor_name
+        course_instructor_uuid as instructor_source_id
+        , course_instructor_title as instructor_name
         , course_instructor_salutation as instructor_title
         , cast(null as varchar) as instructor_bio_short
         , cast(null as varchar) as instructor_bio_long
@@ -42,21 +50,27 @@ with mitxonline_instructors as (
 )
 
 -- Keep per-platform rows — same name on different platforms are distinct instructors.
--- Use (instructor_name, platform) as the dedup grain.
+-- Dedupe on the platform's stable natural key (wagtail_page_id for mitxonline,
+-- course_instructor_uuid for ocw) when available, falling back to instructor_name
+-- for mitxpro, which has no such key. This prevents two different instructors who
+-- happen to share a name on the same platform from silently collapsing into one row.
 , deduped_instructors as (
     select
-        instructor_name
+        coalesce(instructor_source_id, instructor_name) as instructor_dedup_key
+        , max(instructor_source_id) as instructor_source_id
+        , max(instructor_name) as instructor_name
         , max(instructor_title) as instructor_title
         , max(instructor_bio_short) as instructor_bio_short
         , max(instructor_bio_long) as instructor_bio_long
         , platform as primary_platform
     from combined_instructors
     where instructor_name is not null
-    group by instructor_name, platform
+    group by coalesce(instructor_source_id, instructor_name), platform
 )
 
 select
-    {{ dbt_utils.generate_surrogate_key(['instructor_name', 'primary_platform']) }} as instructor_pk
+    {{ dbt_utils.generate_surrogate_key(['instructor_dedup_key', 'primary_platform']) }} as instructor_pk
+    , instructor_source_id
     , instructor_name
     , instructor_title
     , instructor_bio_short

--- a/src/ol_dbt/models/dimensional/dim_instructor.sql
+++ b/src/ol_dbt/models/dimensional/dim_instructor.sql
@@ -5,7 +5,7 @@
 -- Consolidate instructors from all platforms
 with mitxonline_instructors as (
     select
-        instructor_source_id
+        cast(instructor_source_id as varchar) as instructor_source_id
         , instructor_name
         , instructor_title
         , instructor_bio_short
@@ -32,7 +32,7 @@ with mitxonline_instructors as (
 
 , ocw_instructors as (
     select
-        course_instructor_uuid as instructor_source_id
+        cast(course_instructor_uuid as varchar) as instructor_source_id
         , course_instructor_title as instructor_name
         , course_instructor_salutation as instructor_title
         , cast(null as varchar) as instructor_bio_short

--- a/src/ol_dbt/models/intermediate/mitxonline/int__mitxonline__course_instructors.sql
+++ b/src/ol_dbt/models/intermediate/mitxonline/int__mitxonline__course_instructors.sql
@@ -12,7 +12,7 @@ with instructors as (
 
 select distinct
     course_pages.course_id
-    , instructors.wagtail_page_id as instructor_source_id
+    , cast(instructors.wagtail_page_id as varchar) as instructor_source_id
     , instructors.instructor_name
     , instructors.instructor_title
     , instructors.instructor_bio_short

--- a/src/ol_dbt/models/intermediate/mitxonline/int__mitxonline__course_instructors.sql
+++ b/src/ol_dbt/models/intermediate/mitxonline/int__mitxonline__course_instructors.sql
@@ -12,6 +12,7 @@ with instructors as (
 
 select distinct
     course_pages.course_id
+    , instructors.wagtail_page_id as instructor_source_id
     , instructors.instructor_name
     , instructors.instructor_title
     , instructors.instructor_bio_short


### PR DESCRIPTION
## Summary
- `dim_instructor` deduped on `(instructor_name, platform)` alone, silently merging two distinct instructors who happen to share a name on the same platform into one row, with the surviving bio text picked by alphabetical `max()` rather than any deliberate precedence.
- mitxonline and ocw both have a stable per-instructor natural key in their source data that wasn't being surfaced: `wagtail_page_id` (the CMS page identifying the instructor's bio) for mitxonline, and `course_instructor_uuid` for ocw (already present in `int__ocw__course_instructors`, just not selected downstream).
- Threaded `instructor_source_id` through `int__mitxonline__course_instructors` and `dim_instructor`, and changed the dedupe grain to `coalesce(instructor_source_id, instructor_name)`. Updated `bridge_course_instructor`'s joins to match — they previously joined `dim_instructor` by name alone and would otherwise fan out once the same name can map to more than one `instructor_pk`.
- mitxpro's CMS faculty entries have no stable id in source (just a name + description in a JSON array), so that platform keeps deduping on name alone — documented as an accepted, known limitation rather than fixed, since there's no natural key to recover it from.
- Updated `_course_catalog_dimensions.yml` to document the new grain and the mitxpro exception.

## Not addressed here
The task also flagged `dim_program.sql:135-146` and `dim_contract.sql:29-31` for spot-checking platform-mapping fallback paths, and a missing `relationships` test on `dim_program`'s `platform_fk` — left as follow-up, out of scope for this identity-collapse fix.

## Test plan
- [x] `dbt parse` (whole project) and `dbt compile --select dim_instructor bridge_course_instructor int__mitxonline__course_instructors marts__ocw_courses` succeed against the `dev_local` duckdb target
- [x] `pre-commit` (sqlfluff, yamllint, etc.) passes on changed files
- [ ] CI dbt build/test run

Fixes #2377

🤖 Generated with [Claude Code](https://claude.com/claude-code)