### PR TITLE
docs(feedback): spec set for Feedback Aggregation & Clustering System

### DIFF
--- a/docs/design/README_feedback_aggregation.md
+++ b/docs/design/README_feedback_aggregation.md
@@ -19,6 +19,7 @@ signals for four audiences (support, engineering, instructors, leadership).
 | [`feedback_ml_approach.md`](./feedback_ml_approach.md) | Embedding (local, PII-safe), clustering (UMAP+HDBSCAN), category discovery (seed + LLM-label), sentiment (explicit + kNN/classifier) | `...clustering-...a1d7d6`, `...category-...550aba`, `...sentiment-...92988e` |
 | [`feedback_dagster_asset_spec.md`](./feedback_dagster_asset_spec.md) | Batch ML Dagster asset cloned from `student_risk_probability`; Vault-backed LLM resource; net-new deps; scheduling | (ML pipeline orchestration) |
 | [`feedback_consumption_ux_spec.md`](./feedback_consumption_ux_spec.md) | Audiences × altitude, Superset-first surfaces, per-persona actions, access control | `...ui-ux-...476d23` |
+| [`adr_embedding_compute_strategy.md`](./adr_embedding_compute_strategy.md) | ADR: where embedding/AI inference runs — Starburst Galaxy AI functions (Bedrock, in-SQL) vs. Fenic vs. local vs. StarRocks | (revises embedding default) |
 
 ## Key decisions (spec phase)
 
@@ -33,8 +34,12 @@ signals for four audiences (support, engineering, instructors, leadership).
    tag-seeded categories + CSAT-derived sentiment; embeddings/clustering fill `category_fk`/
    `sentiment_fk`/`embedding_id` later. Embeddings persisted **once** (the one adopted lesson
    from prototype #10793).
-4. **Local, PII-safe embeddings** by default (learner-PII posture); redaction (Presidio)
-   mandatory pre-embed; raw text stays upstream under existing Lakekeeper/Cedar authz.
+4. **Embedding compute pushed into the engine we already run** (revised 2026-07-10, ADR):
+   production is Trino on **Starburst Galaxy**, so `generate_embedding` (Bedrock, in-account,
+   public preview) generates vectors in SQL/dbt into the Iceberg sidecar — eliminating the
+   net-new torch service. Redaction (Presidio) stays mandatory pre-embed. Local self-hosted
+   embeddings and Fenic are documented fallbacks; StarRocks vector search is a Phase-3 note
+   (not deployed today).
 5. **Superset-first consumption**; support + engineering are the MVP-served audiences
    (Zendesk is not course-scoped, so instructors wait for Phase 2 sources).
 

--- a/docs/design/README_feedback_aggregation.md
+++ b/docs/design/README_feedback_aggregation.md
@@ -1,0 +1,59 @@
+# Feedback Aggregation & Clustering System — Spec Index
+
+Project: `wp-feedback-aggregation-clustering-system-2e9750` · Phase: **spec** (2026-07-10)
+RFC (team review): [mitodl/hq#12210](https://github.com/mitodl/hq/discussions/12210)
+(supersedes [#10793](https://github.com/mitodl/hq/discussions/10793)).
+
+A feedback aggregation system that ingests free-text feedback from multiple sources
+(Zendesk, edX forum, Learn AI tutor, ORA, a forthcoming edX feedback plugin) into one
+source-agnostic dimensional fact and clusters it to surface systemic issues and positive
+signals for four audiences (support, engineering, instructors, leadership).
+
+## The spec set
+
+| Doc | Scope | Resolves task |
+|---|---|---|
+| [`feedback_dimensional_model.md`](./feedback_dimensional_model.md) | Dimensional model: `tfact_feedback` grain, conformed dims, sparse FKs, PII redaction, phasing | schema design (discovery) |
+| [`feedback_event_contract_spec.md`](./feedback_event_contract_spec.md) | Common feedback event contract + migration-proof business keys; data-bus alignment as a bounded dependency | `...contract-bus-245a8e` |
+| [`feedback_zendesk_mvp_spec.md`](./feedback_zendesk_mvp_spec.md) | Build-ready Zendesk MVP: exact dbt models/columns `int__feedback__zendesk → __unioned → tfact_feedback` + 3 dims + tests | (MVP implementation) |
+| [`feedback_ml_approach.md`](./feedback_ml_approach.md) | Embedding (local, PII-safe), clustering (UMAP+HDBSCAN), category discovery (seed + LLM-label), sentiment (explicit + kNN/classifier) | `...clustering-...a1d7d6`, `...category-...550aba`, `...sentiment-...92988e` |
+| [`feedback_dagster_asset_spec.md`](./feedback_dagster_asset_spec.md) | Batch ML Dagster asset cloned from `student_risk_probability`; Vault-backed LLM resource; net-new deps; scheduling | (ML pipeline orchestration) |
+| [`feedback_consumption_ux_spec.md`](./feedback_consumption_ux_spec.md) | Audiences × altitude, Superset-first surfaces, per-persona actions, access control | `...ui-ux-...476d23` |
+
+## Key decisions (spec phase)
+
+1. **Contract-first, interim landing** (RFC Option 3): ship on the learn-ai landing now,
+   migrate to the analytics-api/StarRocks data bus later — durable artifact is the **event
+   contract + business keys**, so migration = source-swap + backfill + parity.
+2. **One common `tfact_feedback`** conforming to the Kimball layer (mirrors
+   `tfact_discussion_events`), with **sparse nullable conformed FKs** as the source-flexibility
+   mechanism. Explicit **stable `feedback_pk`** (diverges from precedent) for migration + late-arriving
+   category/sentiment updates.
+3. **ML is an additive consumer**, not a prerequisite: the fact ships useful with
+   tag-seeded categories + CSAT-derived sentiment; embeddings/clustering fill `category_fk`/
+   `sentiment_fk`/`embedding_id` later. Embeddings persisted **once** (the one adopted lesson
+   from prototype #10793).
+4. **Local, PII-safe embeddings** by default (learner-PII posture); redaction (Presidio)
+   mandatory pre-embed; raw text stays upstream under existing Lakekeeper/Cedar authz.
+5. **Superset-first consumption**; support + engineering are the MVP-served audiences
+   (Zendesk is not course-scoped, so instructors wait for Phase 2 sources).
+
+## Phasing
+
+- **MVP (Phase 1):** Zendesk-only fact + 3 dims + support/eng cluster dashboards. ~198K rows, batch.
+- **Phase 2:** add forum/tutor/ORA (additive CTEs); `afact_feedback_cluster_daily`; instructor course views.
+- **Phase 3:** migrate ingress to the data bus (gated on the write path existing + sink-topology decision).
+
+## Open questions carried to team / platform (non-blocking for MVP)
+
+- Data-bus write path (net-new platform work) + generic-sink-vs-per-topic (platform-wide, outranks feedback).
+- Final embedding model + vector store at full 1.18M scale (MVP proves it at 198K).
+- Which prototype #10793 mechanics earn their place (semantic-summary-before-embedding,
+  hierarchical truncation) — test as hypotheses, don't inherit.
+- Qualtrics/course-survey onboarding; HubSpot NPS tickets need Iceberg modeling first.
+
+## Status / next
+
+RFC #12210 is posted for team review (Draft; no comments yet as of 2026-07-10). On team
+consensus, flip RFC → Accepted and begin implementation per the build order in
+`feedback_dagster_asset_spec.md` §7 (dbt fact first, ML asset additive).

--- a/docs/design/README_feedback_aggregation.md
+++ b/docs/design/README_feedback_aggregation.md
@@ -34,15 +34,17 @@ signals for four audiences (support, engineering, instructors, leadership).
    tag-seeded categories + CSAT-derived sentiment; embeddings/clustering fill `category_fk`/
    `sentiment_fk`/`embedding_id` later. Embeddings persisted **once** (the one adopted lesson
    from prototype #10793).
-4. **Engine-portable AI compute** (revised 2026-07-10 rev. 2, ADR): because the strategic
-   direction is to **retire Trino for StarRocks**, no Galaxy-only functionality sits on the
-   critical path. Embedding stays engine-external in a Dagster asset calling **AWS Bedrock
-   `amazon.titan-embed-text-v2:0` directly via boto3** (in-account → PII-safe over redacted
-   text; no torch; indifferent to Trino vs. StarRocks). Vectors land in an open Iceberg
-   `ARRAY<float>` sidecar; **StarRocks HNSW is the intended vector-serving tier**, reached by
-   loading those vectors (no re-embed). Redaction (Presidio) mandatory pre-embed. Fenic and
-   local `sentence-transformers` are fallbacks; Starburst `generate_embedding` is **rejected**
-   for engine lock-in.
+4. **Engine-portable AI compute via Fenic** (revised 2026-07-10 rev. 3, ADR): because the
+   strategic direction is to **retire Trino for StarRocks**, no Galaxy-only functionality sits
+   on the critical path (Starburst `generate_embedding` **rejected**). AI compute stays
+   engine-external using **Fenic (Apache-2.0)** in a Dagster asset — batching/caching/lineage for
+   free, indifferent to Trino vs. StarRocks. **Embedding provider is a PII-policy choice:**
+   in-account **AWS Bedrock** `amazon.titan-embed-text-v2:0` (best posture — via boto3 today, as
+   native Fenic Bedrock embeddings are roadmap-not-shipped) or a Fenic-native managed provider
+   (Cohere/OpenAI/Google) over redacted text. Vectors → open Iceberg `ARRAY<float>` sidecar;
+   **StarRocks HNSW is the intended vector-serving tier**, reached by loading those vectors (no
+   re-embed). Clustering stays our own HDBSCAN (Fenic has K-means only). Presidio redaction
+   mandatory pre-embed.
 5. **Superset-first consumption**; support + engineering are the MVP-served audiences
    (Zendesk is not course-scoped, so instructors wait for Phase 2 sources).
 

--- a/docs/design/README_feedback_aggregation.md
+++ b/docs/design/README_feedback_aggregation.md
@@ -34,12 +34,15 @@ signals for four audiences (support, engineering, instructors, leadership).
    tag-seeded categories + CSAT-derived sentiment; embeddings/clustering fill `category_fk`/
    `sentiment_fk`/`embedding_id` later. Embeddings persisted **once** (the one adopted lesson
    from prototype #10793).
-4. **Embedding compute pushed into the engine we already run** (revised 2026-07-10, ADR):
-   production is Trino on **Starburst Galaxy**, so `generate_embedding` (Bedrock, in-account,
-   public preview) generates vectors in SQL/dbt into the Iceberg sidecar — eliminating the
-   net-new torch service. Redaction (Presidio) stays mandatory pre-embed. Local self-hosted
-   embeddings and Fenic are documented fallbacks; StarRocks vector search is a Phase-3 note
-   (not deployed today).
+4. **Engine-portable AI compute** (revised 2026-07-10 rev. 2, ADR): because the strategic
+   direction is to **retire Trino for StarRocks**, no Galaxy-only functionality sits on the
+   critical path. Embedding stays engine-external in a Dagster asset calling **AWS Bedrock
+   `amazon.titan-embed-text-v2:0` directly via boto3** (in-account → PII-safe over redacted
+   text; no torch; indifferent to Trino vs. StarRocks). Vectors land in an open Iceberg
+   `ARRAY<float>` sidecar; **StarRocks HNSW is the intended vector-serving tier**, reached by
+   loading those vectors (no re-embed). Redaction (Presidio) mandatory pre-embed. Fenic and
+   local `sentence-transformers` are fallbacks; Starburst `generate_embedding` is **rejected**
+   for engine lock-in.
 5. **Superset-first consumption**; support + engineering are the MVP-served audiences
    (Zendesk is not course-scoped, so instructors wait for Phase 2 sources).
 

--- a/docs/design/README_feedback_aggregation.md
+++ b/docs/design/README_feedback_aggregation.md
@@ -18,7 +18,7 @@ signals for four audiences (support, engineering, instructors, leadership).
 | [`feedback_zendesk_mvp_spec.md`](./feedback_zendesk_mvp_spec.md) | Build-ready Zendesk MVP: exact dbt models/columns `int__feedback__zendesk → __unioned → tfact_feedback` + 3 dims + tests | (MVP implementation) |
 | [`feedback_ml_approach.md`](./feedback_ml_approach.md) | Embedding (local, PII-safe), clustering (UMAP+HDBSCAN), category discovery (seed + LLM-label), sentiment (explicit + kNN/classifier) | `...clustering-...a1d7d6`, `...category-...550aba`, `...sentiment-...92988e` |
 | [`feedback_dagster_asset_spec.md`](./feedback_dagster_asset_spec.md) | Batch ML Dagster asset cloned from `student_risk_probability`; Vault-backed LLM resource; net-new deps; scheduling | (ML pipeline orchestration) |
-| [`feedback_consumption_ux_spec.md`](./feedback_consumption_ux_spec.md) | Audiences × altitude, Superset-first surfaces, per-persona actions, access control | `...ui-ux-...476d23` |
+| [`feedback_consumption_ux_spec.md`](./feedback_consumption_ux_spec.md) | Audiences × altitude, surface options (Superset / Marimo notebook-as-webapp / net-new app), per-persona actions, access control | `...ui-ux-...476d23` |
 | [`adr_embedding_compute_strategy.md`](./adr_embedding_compute_strategy.md) | ADR: where embedding/AI inference runs — Starburst Galaxy AI functions (Bedrock, in-SQL) vs. Fenic vs. local vs. StarRocks | (revises embedding default) |
 
 ## Key decisions (spec phase)
@@ -48,8 +48,14 @@ signals for four audiences (support, engineering, instructors, leadership).
    is K-means only); LLM semantic-normalization-before-embedding is a first-class eval arm (2026
    evidence: biggest lever for short-ticket cluster quality). Presidio redaction mandatory
    pre-embed (data-minimization, independent of egress).
-5. **Superset-first consumption**; support + engineering are the MVP-served audiences
-   (Zendesk is not course-scoped, so instructors wait for Phase 2 sources).
+5. **Consumption surface is an open, per-audience choice** — Superset dashboard, deployed
+   **Marimo notebook-as-webapp**, or a net-new app; all read the same modeled tables, so the
+   choice is reversible. Recommended phasing: Superset for MVP trend/cluster dashboards (RLS
+   already solved in `src/ol_superset/`), a Marimo notebook-as-webapp (existing image +
+   Keycloak/Trino/IRSA) for interactive exploration + the category-curation loop and to
+   prototype the UX, and a net-new app only when write-back/product-embedding justifies it.
+   Support + engineering are the MVP-served audiences (Zendesk is not course-scoped, so
+   instructors wait for Phase 2 sources).
 
 ## Phasing
 

--- a/docs/design/README_feedback_aggregation.md
+++ b/docs/design/README_feedback_aggregation.md
@@ -34,17 +34,20 @@ signals for four audiences (support, engineering, instructors, leadership).
    tag-seeded categories + CSAT-derived sentiment; embeddings/clustering fill `category_fk`/
    `sentiment_fk`/`embedding_id` later. Embeddings persisted **once** (the one adopted lesson
    from prototype #10793).
-4. **Engine-portable AI compute via Fenic** (revised 2026-07-10 rev. 3, ADR): because the
-   strategic direction is to **retire Trino for StarRocks**, no Galaxy-only functionality sits
-   on the critical path (Starburst `generate_embedding` **rejected**). AI compute stays
-   engine-external using **Fenic (Apache-2.0)** in a Dagster asset — batching/caching/lineage for
-   free, indifferent to Trino vs. StarRocks. **Embedding provider is a PII-policy choice:**
-   in-account **AWS Bedrock** `amazon.titan-embed-text-v2:0` (best posture — via boto3 today, as
-   native Fenic Bedrock embeddings are roadmap-not-shipped) or a Fenic-native managed provider
-   (Cohere/OpenAI/Google) over redacted text. Vectors → open Iceberg `ARRAY<float>` sidecar;
-   **StarRocks HNSW is the intended vector-serving tier**, reached by loading those vectors (no
-   re-embed). Clustering stays our own HDBSCAN (Fenic has K-means only). Presidio redaction
-   mandatory pre-embed.
+4. **Engine-portable AI compute via Fenic; embedding model chosen by effectiveness** (revised
+   2026-07-10 rev. 4, ADR): because the strategic direction is to **retire Trino for StarRocks**,
+   no Galaxy-only functionality sits on the critical path (Starburst `generate_embedding`
+   **rejected**). AI compute stays engine-external using **Fenic (Apache-2.0)** in a Dagster asset
+   — batching/caching/lineage for free, portable across Trino→StarRocks. **Bedrock is not
+   required; the embedding model is selected by task effectiveness** — MTEB to narrow, then
+   benchmark the shortlist (Fenic-native `gemini-embedding-001`/Cohere `embed-v4`/OpenAI
+   `text-embedding-3-large`; or self-hosted Qwen3/BGE-M3) on a labeled Zendesk sample by
+   clustering agreement/coherence + cost, sweeping Matryoshka dims (`feedback_ml_approach.md`
+   §B.1). Choice is reversible via `model_version`. Vectors → open Iceberg `ARRAY<float>` sidecar;
+   **StarRocks HNSW is the intended vector-serving tier**. Clustering stays our own HDBSCAN (Fenic
+   is K-means only); LLM semantic-normalization-before-embedding is a first-class eval arm (2026
+   evidence: biggest lever for short-ticket cluster quality). Presidio redaction mandatory
+   pre-embed (data-minimization, independent of egress).
 5. **Superset-first consumption**; support + engineering are the MVP-served audiences
    (Zendesk is not course-scoped, so instructors wait for Phase 2 sources).
 

--- a/docs/design/README_feedback_aggregation.md
+++ b/docs/design/README_feedback_aggregation.md
@@ -13,8 +13,8 @@ signals for four audiences (support, engineering, instructors, leadership).
 
 | Doc | Scope | Resolves task |
 |---|---|---|
-| [`feedback_erd.md`](./feedback_erd.md) | **Start here for the shape:** Mermaid ERDs for the star schema, the event contract, the ML sidecar and the Phase-1 subset; records the schema deltas from #2422 review feedback | (visual index) |
-| [`feedback_dimensional_model.md`](./feedback_dimensional_model.md) | Dimensional model: `tfact_feedback` grain, conformed dims, sparse FKs, subject reference, PII redaction, phasing | schema design (discovery) |
+| [`feedback_erd.md`](./feedback_erd.md) | **Start here for the shape:** the conformance rule, Mermaid ERDs for the star schema, the event contract, the conversation fact, the ML sidecar and the Phase-1 subset; carries the change log | (visual index) |
+| [`feedback_dimensional_model.md`](./feedback_dimensional_model.md) | Dimensional model: `tfact_feedback` turn grain, conformed dims, sparse FKs, subject reference, the `source_metadata` variant, conversation fact, PII redaction, phasing | schema design (discovery) |
 | [`feedback_event_contract_spec.md`](./feedback_event_contract_spec.md) | Common feedback event contract + migration-proof business keys; data-bus alignment as a bounded dependency | `...contract-bus-245a8e` |
 | [`feedback_zendesk_mvp_spec.md`](./feedback_zendesk_mvp_spec.md) | Build-ready Zendesk MVP: exact dbt models/columns `int__feedback__zendesk → __unioned → tfact_feedback` + 3 dims + tests | (MVP implementation) |
 | [`feedback_ml_approach.md`](./feedback_ml_approach.md) | Embedding (local, PII-safe), clustering (UMAP+HDBSCAN), category discovery (seed + LLM-label), sentiment (explicit + kNN/classifier) | `...clustering-...a1d7d6`, `...category-...550aba`, `...sentiment-...92988e` |
@@ -31,6 +31,18 @@ signals for four audiences (support, engineering, instructors, leadership).
    `tfact_discussion_events`), with **sparse nullable conformed FKs** as the source-flexibility
    mechanism. Explicit **stable `feedback_pk`** (diverges from precedent) for migration + late-arriving
    category/sentiment updates.
+2b. **Grain is one row per conversation *turn*** (revised 2026-08-07): Zendesk is modelled at
+   comment grain like every other source, not ticket grain. First-comment-only survives as the
+   `is_conversation_opening` filter. Zendesk's `source_record_ref` is therefore `comment_id`, which is why
+   this had to land before the fact ships. Conversation-level lifecycle lives in a sibling
+   `afact_feedback_conversation`.
+2c. **Conformance rule — ≥2 sources or it's a variant** (revised 2026-08-07): an attribute earns a column
+   on the fact or a conformed dimension only if two or more sources can populate it; everything else lives
+   in the `source_metadata` variant (a varchar-held JSON string, since Iceberg v2 has no native JSON type)
+   and is promoted when a second source needs it. This is what stops Zendesk's shape from becoming the
+   model's shape. It added `dim_feedback_channel` (the one genuinely conformed facet) and
+   `dim_feedback_tag`/`bridge_feedback_tag`, and it withdrew the `dim_feedback_context` junk dimension and
+   the `source_brand`/`source_group` facet columns proposed a week earlier.
 3. **ML is an additive consumer**, not a prerequisite: the fact ships useful with
    tag-seeded categories + CSAT-derived sentiment; embeddings/clustering fill `category_fk`/
    `sentiment_fk` later and otherwise live entirely in the sidecar (three tables — vectors,
@@ -55,8 +67,9 @@ signals for four audiences (support, engineering, instructors, leadership).
    a polymorphic `subject_type`/`subject_ref`/`subject_url` triple on the contract and the fact, resolved to
    a conformed FK where one exists — `courserun_fk` for runs, the new **`content_block_fk →
    dim_course_content`** for edX courseware blocks. No new subject dimension: the subject is polymorphic
-   across dims that already exist. Zendesk `brand_name`/`group_name` land as `source_brand`/`source_group`
-   facets ([hq#12607](https://github.com/mitodl/hq/issues/12607)).
+   across dims that already exist. Zendesk `brand_name`/`group_name`
+   ([hq#12607](https://github.com/mitodl/hq/issues/12607)) are carried and filterable —
+   **superseded by 2c**: they ride in `source_metadata` rather than in dedicated facet columns.
 6. **Consumption surface is an open, per-audience choice** — Superset dashboard, deployed
    **Marimo notebook-as-webapp**, or a net-new app; all read the same modeled tables, so the
    choice is reversible. Recommended phasing: Superset for MVP trend/cluster dashboards (RLS
@@ -68,9 +81,20 @@ signals for four audiences (support, engineering, instructors, leadership).
 
 ## Phasing
 
-- **MVP (Phase 1):** Zendesk-only fact + 3 dims + support/eng cluster dashboards. ~198K rows, batch.
-- **Phase 2:** add forum/tutor/ORA (additive CTEs); `afact_feedback_cluster_daily`; instructor course views.
+- **MVP (Phase 1):** Zendesk-only fact at turn grain + 4 dims + `bridge_feedback_tag` +
+  `afact_feedback_conversation` (available-today columns) + support/eng cluster dashboards. Batch.
+  **Row count is unmeasured** — it is public requester comments, not the previous ~198K tickets.
+- **Phase 2:** add forum/tutor/ORA (additive CTEs); `afact_feedback_cluster_daily`; instructor course views;
+  conversation duration measures once `ticket_metrics` is synced.
 - **Phase 3:** migrate ingress to the data bus (gated on the write path existing + sink-topology decision).
+
+## Prerequisites (from the 2026-08-07 revision)
+
+- Carry `comment_author_user_id` through `int__zendesk__ticket_comment` — **blocking** for the turn grain
+  (classifies requester-vs-agent turns and resolves `user_fk`).
+- Measure public, requester-authored comments per ticket — sizes the fact and the embedding budget.
+- Add the `ticket_metrics` Airbyte stream — non-blocking; unblocks conversation duration measures.
+- Confirm the conformed `channel_slug` value set against each source's actual channel values.
 
 ## Open questions carried to team / platform (non-blocking for MVP)
 
@@ -82,11 +106,20 @@ signals for four audiences (support, engineering, instructors, leadership).
 
 ## Status / next
 
-RFC #12210 is posted for team review (Draft). Review feedback on this PR from @pdpinch (2026-08-03) has
-been folded in as of 2026-08-07: the subject reference (`feedback_dimensional_model.md` §2a), Zendesk
-brand/group facets ([hq#12607](https://github.com/mitodl/hq/issues/12607)), and the ERDs in
-[`feedback_erd.md`](./feedback_erd.md) — also
-[posted as an RFC addendum](https://github.com/mitodl/hq/discussions/12210#discussioncomment-17935060).
+RFC #12210 is posted for team review (Draft). Two rounds of review feedback have been folded in as of
+2026-08-07:
 
-On team consensus, flip RFC → Accepted and begin implementation per the build order in
-`feedback_dagster_asset_spec.md` §7 (dbt fact first, ML asset additive).
+- **@pdpinch** ([#2422](https://github.com/mitodl/ol-data-platform/pull/2422#issuecomment-5169778966)) — the
+  subject reference (`feedback_dimensional_model.md` §2a) and Zendesk brand/group
+  ([hq#12607](https://github.com/mitodl/hq/issues/12607)); ERDs added in
+  [`feedback_erd.md`](./feedback_erd.md), also
+  [posted as an RFC addendum](https://github.com/mitodl/hq/discussions/12210#discussioncomment-17935060).
+- **@KatelynGit** ([RFC #12210](https://github.com/mitodl/hq/discussions/12210#discussioncomment-17937328)) —
+  date/time FK naming, lifecycle timestamps, and moving descriptive fields off the fact. This round produced
+  the turn-grain change and the conformance rule (key decisions 2b/2c) and superseded parts of the first
+  round.
+
+Before flipping RFC → Accepted, the prerequisites above should be closed — particularly the volume
+measurement and the `comment_author_user_id` change, both of which gate the turn grain. Then begin
+implementation per the build order in `feedback_dagster_asset_spec.md` §7 (dbt fact first, ML asset
+additive).

--- a/docs/design/README_feedback_aggregation.md
+++ b/docs/design/README_feedback_aggregation.md
@@ -16,7 +16,7 @@ signals for four audiences (support, engineering, instructors, leadership).
 | [`feedback_erd.md`](./feedback_erd.md) | **Start here for the shape:** the conformance rule, Mermaid ERDs for the star schema, the event contract, the conversation analysis fact, run provenance and the Phase-1 subset; carries the change log | (visual index) |
 | [`feedback_dimensional_model.md`](./feedback_dimensional_model.md) | Dimensional model: the fact pair — `tfact_feedback` at turn grain and `afact_feedback_conversation` at conversation grain — conformed dims, sparse FKs, subject reference, the `source_metadata` variant, the summary, PII redaction, phasing | schema design (discovery) |
 | [`feedback_event_contract_spec.md`](./feedback_event_contract_spec.md) | Common feedback event contract + migration-proof business keys; data-bus alignment as a bounded dependency | `...contract-bus-245a8e` |
-| [`feedback_zendesk_mvp_spec.md`](./feedback_zendesk_mvp_spec.md) | Build-ready Zendesk MVP: exact dbt models/columns `int__feedback__zendesk → __unioned → tfact_feedback` + 3 dims + tests | (MVP implementation) |
+| [`feedback_zendesk_mvp_spec.md`](./feedback_zendesk_mvp_spec.md) | Build-ready Zendesk MVP: exact dbt models/columns `int__feedback__zendesk → __unioned → feedback_redacted → tfact_feedback` + 3 dims + tests | (MVP implementation) |
 | [`feedback_ml_approach.md`](./feedback_ml_approach.md) | Embedding (local, PII-safe), clustering (UMAP+HDBSCAN), category discovery (seed + LLM-label), sentiment (explicit + kNN/classifier) | `...clustering-...a1d7d6`, `...category-...550aba`, `...sentiment-...92988e` |
 | [`feedback_dagster_asset_spec.md`](./feedback_dagster_asset_spec.md) | Batch ML Dagster asset cloned from `student_risk_probability`; Vault-backed LLM resource; net-new deps; scheduling | (ML pipeline orchestration) |
 | [`feedback_consumption_ux_spec.md`](./feedback_consumption_ux_spec.md) | Audiences × altitude, surface options (Superset / Marimo notebook-as-webapp / net-new app), per-persona actions, access control | `...ui-ux-...476d23` |
@@ -110,6 +110,9 @@ signals for four audiences (support, engineering, instructors, leadership).
 - Carry `comment_author_user_id` through `int__zendesk__ticket_comment` — **blocking** for the turn grain
   (classifies requester-vs-agent turns and resolves `user_fk`). Verified against the repo: the column exists
   in `stg__zendesk__ticket_comment` and the int model joins it away, exposing only `comment_author` as a name.
+- Carry `ticket_requester_user_id` through `int__zendesk__ticket` (added 2026-08-13) — **blocking**, same
+  reason: the requester-vs-agent filter compares ids, and the int model exposes only `ticket_requester`
+  (a name), even though the join it needs already exists in the model.
 - Measure public, requester-authored comments per ticket **and the multi-turn share** — sizes the turn fact,
   and the multi-turn share drives the summarization budget (2d).
 - Add the `ticket_metrics` Airbyte stream — non-blocking; unblocks conversation duration measures.
@@ -143,8 +146,19 @@ analysis fact (2d) and cut to a ~1,500-word read. Three rounds of feedback have 
 - **Owner direction (2026-08-10)** — cluster the turn records into a coherent conversation and make that
   aggregate fact the home for the generated summary, embeddings and sentiment. This produced key decision
   2d and rev. 3 across the spec set.
+- **@copilot + @rachellougee** ([#2422](https://github.com/mitodl/ol-data-platform/pull/2422), 2026-08-13) —
+  a round of implementation-blocking fixes with no grain/key/shape changes: a second missing prerequisite
+  column (`ticket_requester_user_id`, same class as `comment_author_user_id`); redaction split into its own
+  Phase-1 asset (`feedback_redacted`) to remove a dependency cycle in rev. 3's placement; `conversation_ref`
+  and `source_url` added/required on the event contract; `(feedback_source_fk, conversation_id)` replacing
+  bare `conversation_id` everywhere the turn fact joins the conversation fact; a stale `category_slug`
+  hash-of-hash, a non-existent `unknown` sentiment member, a `participant_count` that was always 1, and an
+  `avg_explicit_rating` on a non-numeric column, all corrected; `feedback_clusters` split into a
+  `@multi_asset`; `dim_user.user_pk`'s formula corrected to match current `main`; and `subject_user_ref`
+  retained on `tfact_feedback` so identity can be re-matched later without a rebuild. Detail and rationale
+  are in each doc's own rev. 4/5 changelog entry.
 
 Before flipping RFC → Accepted, the prerequisites above should be closed — particularly the volume
-measurement and the `comment_author_user_id` change, both of which gate the turn grain. Then begin
-implementation per the build order in `feedback_dagster_asset_spec.md` §7 (dbt facts first, ML asset
-additive).
+measurement and the `comment_author_user_id`/`ticket_requester_user_id` changes, both of which gate the turn
+grain. Then begin implementation per the build order in `feedback_dagster_asset_spec.md` §7 (dbt facts
+first, ML asset additive).

--- a/docs/design/README_feedback_aggregation.md
+++ b/docs/design/README_feedback_aggregation.md
@@ -13,8 +13,8 @@ signals for four audiences (support, engineering, instructors, leadership).
 
 | Doc | Scope | Resolves task |
 |---|---|---|
-| [`feedback_erd.md`](./feedback_erd.md) | **Start here for the shape:** the conformance rule, Mermaid ERDs for the star schema, the event contract, the conversation fact, the ML sidecar and the Phase-1 subset; carries the change log | (visual index) |
-| [`feedback_dimensional_model.md`](./feedback_dimensional_model.md) | Dimensional model: `tfact_feedback` turn grain, conformed dims, sparse FKs, subject reference, the `source_metadata` variant, conversation fact, PII redaction, phasing | schema design (discovery) |
+| [`feedback_erd.md`](./feedback_erd.md) | **Start here for the shape:** the conformance rule, Mermaid ERDs for the star schema, the event contract, the conversation analysis fact, run provenance and the Phase-1 subset; carries the change log | (visual index) |
+| [`feedback_dimensional_model.md`](./feedback_dimensional_model.md) | Dimensional model: the fact pair — `tfact_feedback` at turn grain and `afact_feedback_conversation` at conversation grain — conformed dims, sparse FKs, subject reference, the `source_metadata` variant, the summary, PII redaction, phasing | schema design (discovery) |
 | [`feedback_event_contract_spec.md`](./feedback_event_contract_spec.md) | Common feedback event contract + migration-proof business keys; data-bus alignment as a bounded dependency | `...contract-bus-245a8e` |
 | [`feedback_zendesk_mvp_spec.md`](./feedback_zendesk_mvp_spec.md) | Build-ready Zendesk MVP: exact dbt models/columns `int__feedback__zendesk → __unioned → tfact_feedback` + 3 dims + tests | (MVP implementation) |
 | [`feedback_ml_approach.md`](./feedback_ml_approach.md) | Embedding (local, PII-safe), clustering (UMAP+HDBSCAN), category discovery (seed + LLM-label), sentiment (explicit + kNN/classifier) | `...clustering-...a1d7d6`, `...category-...550aba`, `...sentiment-...92988e` |
@@ -29,13 +29,27 @@ signals for four audiences (support, engineering, instructors, leadership).
    contract + business keys**, so migration = source-swap + backfill + parity.
 2. **One common `tfact_feedback`** conforming to the Kimball layer (mirrors
    `tfact_discussion_events`), with **sparse nullable conformed FKs** as the source-flexibility
-   mechanism. Explicit **stable `feedback_pk`** (diverges from precedent) for migration + late-arriving
-   category/sentiment updates.
+   mechanism. Explicit **stable `feedback_pk`** (diverges from precedent) so the interim→data-bus source
+   swap regenerates the same key. (Rev. 2's second reason — anchoring late-arriving category/sentiment
+   updates — lapsed with 2d; the migration reason still holds on its own.)
 2b. **Grain is one row per conversation *turn*** (revised 2026-08-07): Zendesk is modelled at
-   comment grain like every other source, not ticket grain. First-comment-only survives as the
-   `is_conversation_opening` filter. Zendesk's `source_record_ref` is therefore `comment_id`, which is why
-   this had to land before the fact ships. Conversation-level lifecycle lives in a sibling
-   `afact_feedback_conversation`.
+   comment grain like every other source, not ticket grain, sourced from `int__zendesk__ticket_comment`.
+   First-comment-only survives as the `is_conversation_opening` filter. Zendesk's `source_record_ref` is
+   therefore `comment_id`, which is why this had to land before the fact ships.
+
+2d. **The analysis unit is the conversation, and `afact_feedback_conversation` holds everything generated**
+   (revised 2026-08-10): the aggregate fact carries the LLM summary, the embedding vector, `category_fk`,
+   `sentiment_fk` and cluster membership alongside the conversation lifecycle columns. `category_fk` and
+   `sentiment_fk` are **removed from `tfact_feedback`**, which makes that fact **insert-only** — there is no
+   post-insert write path to it at all. The per-turn ML sidecar (`feedback_embeddings`,
+   `feedback_cluster_assignment`) is withdrawn; `feedback_cluster_run` survives and a small
+   `feedback_cluster_candidate` covers run-vs-run comparison.
+   Rationale: a complaint usually emerges across several turns, so embedding turns independently splits one
+   issue into several weak cluster members and scores sentiment off a fragment. This is *not* a return to
+   ticket grain — the fact still records every turn, and the assembled conversation is built from all of
+   them. Cost consequence: the summary is the one per-record LLM call in the design (low hundreds of dollars
+   one-time for Zendesk, skipped entirely for single-turn conversations) — measure it on a sample before the
+   backfill.
 2c. **Conformance rule — ≥2 sources or it's a variant** (revised 2026-08-07): an attribute earns a column
    on the fact or a conformed dimension only if two or more sources can populate it; everything else lives
    in the `source_metadata` variant (a varchar-held JSON string, since Iceberg v2 has no native JSON type)
@@ -43,11 +57,12 @@ signals for four audiences (support, engineering, instructors, leadership).
    model's shape. It added `dim_feedback_channel` (the one genuinely conformed facet) and
    `dim_feedback_tag`/`bridge_feedback_tag`, and it withdrew the `dim_feedback_context` junk dimension and
    the `source_brand`/`source_group` facet columns proposed a week earlier.
-3. **ML is an additive consumer**, not a prerequisite: the fact ships useful with
-   tag-seeded categories + CSAT-derived sentiment; embeddings/clustering fill `category_fk`/
-   `sentiment_fk` later and otherwise live entirely in the sidecar (three tables — vectors,
-   cluster runs, cluster assignments — split by grain so re-clustering never rewrites vectors).
-   Embeddings persisted **once** (the one adopted lesson from prototype #10793).
+3. **ML is an additive consumer**, not a prerequisite: the warehouse layer ships useful with
+   tag-seeded categories + CSAT-derived sentiment; summaries, embeddings and clustering fill nullable
+   columns on `afact_feedback_conversation` later and touch nothing else (**superseded in part by 2d**:
+   the three-table per-turn sidecar is withdrawn; only `feedback_cluster_run` and a candidate table remain
+   alongside the aggregate fact). Embeddings persisted **once** (the one adopted lesson from prototype
+   #10793).
 4. **Engine-portable AI compute via Fenic; embedding model chosen by effectiveness** (revised
    2026-07-10 rev. 4, ADR): because the strategic direction is to **retire Trino for StarRocks**,
    no Galaxy-only functionality sits on the critical path (Starburst `generate_embedding`
@@ -57,7 +72,8 @@ signals for four audiences (support, engineering, instructors, leadership).
    benchmark the shortlist (Fenic-native `gemini-embedding-001`/Cohere `embed-v4`/OpenAI
    `text-embedding-3-large`; or self-hosted Qwen3/BGE-M3) on a labeled Zendesk sample by
    clustering agreement/coherence + cost, sweeping Matryoshka dims (`feedback_ml_approach.md`
-   §B.1). Choice is reversible via `model_version`. Vectors → open Iceberg `ARRAY<float>` sidecar;
+   §B.1). Choice is reversible via `embedding_model_version`. Vectors → an open Iceberg `ARRAY<float>` column
+   on `afact_feedback_conversation` (per 2d, no longer a separate sidecar table);
    **StarRocks HNSW is the intended vector-serving tier**. Clustering stays our own HDBSCAN (Fenic
    is K-means only); LLM semantic-normalization-before-embedding is a first-class eval arm (2026
    evidence: biggest lever for short-ticket cluster quality). Presidio redaction mandatory
@@ -82,8 +98,9 @@ signals for four audiences (support, engineering, instructors, leadership).
 ## Phasing
 
 - **MVP (Phase 1):** Zendesk-only fact at turn grain + 4 dims + `bridge_feedback_tag` +
-  `afact_feedback_conversation` (available-today columns) + support/eng cluster dashboards. Batch.
-  **Row count is unmeasured** — it is public requester comments, not the previous ~198K tickets.
+  `int__feedback__conversation` + `afact_feedback_conversation` (lifecycle columns first, generated columns
+  as the ML asset lands) + support/eng cluster dashboards. Batch. The conversation fact is ~198K rows (one
+  per ticket, a known figure); the **turn fact's row count is unmeasured** — it is public requester comments.
 - **Phase 2:** add forum/tutor/ORA (additive CTEs); `afact_feedback_cluster_daily`; instructor course views;
   conversation duration measures once `ticket_metrics` is synced.
 - **Phase 3:** migrate ingress to the data bus (gated on the write path existing + sink-topology decision).
@@ -91,23 +108,28 @@ signals for four audiences (support, engineering, instructors, leadership).
 ## Prerequisites (from the 2026-08-07 revision)
 
 - Carry `comment_author_user_id` through `int__zendesk__ticket_comment` — **blocking** for the turn grain
-  (classifies requester-vs-agent turns and resolves `user_fk`).
-- Measure public, requester-authored comments per ticket — sizes the fact and the embedding budget.
+  (classifies requester-vs-agent turns and resolves `user_fk`). Verified against the repo: the column exists
+  in `stg__zendesk__ticket_comment` and the int model joins it away, exposing only `comment_author` as a name.
+- Measure public, requester-authored comments per ticket **and the multi-turn share** — sizes the turn fact,
+  and the multi-turn share drives the summarization budget (2d).
 - Add the `ticket_metrics` Airbyte stream — non-blocking; unblocks conversation duration measures.
 - Confirm the conformed `channel_slug` value set against each source's actual channel values.
+- Decide `embedding_input` (summary vs. concatenated turns) via the bake-off — non-blocking for the schema.
 
 ## Open questions carried to team / platform (non-blocking for MVP)
 
 - Data-bus write path (net-new platform work) + generic-sink-vs-per-topic (platform-wide, outranks feedback).
-- Final embedding model + vector store at full 1.18M scale (MVP proves it at 198K).
-- Which prototype #10793 mechanics earn their place (semantic-summary-before-embedding,
-  hierarchical truncation) — test as hypotheses, don't inherit.
+- Final embedding model + vector store at the full ~600K-conversation scale (MVP proves it at ~198K).
+- What gets embedded — the summary or the concatenated turns — and whether the summary's per-conversation
+  LLM cost is justified by measured cluster-quality lift. (This subsumes prototype #10793's
+  semantic-summary-before-embedding question, now a scored eval arm rather than a rejected default.
+  Hierarchical truncation remains a hypothesis to test, not inherit.)
 - Qualtrics/course-survey onboarding; HubSpot NPS tickets need Iceberg modeling first.
 
 ## Status / next
 
-RFC #12210 is posted for team review (Draft). Two rounds of review feedback have been folded in as of
-2026-08-07:
+RFC #12210 is posted for team review (Draft). It was rewritten on 2026-08-10 to carry the conversation-grain
+analysis fact (2d) and cut to a ~1,500-word read. Three rounds of feedback have been folded in:
 
 - **@pdpinch** ([#2422](https://github.com/mitodl/ol-data-platform/pull/2422#issuecomment-5169778966)) — the
   subject reference (`feedback_dimensional_model.md` §2a) and Zendesk brand/group
@@ -118,8 +140,11 @@ RFC #12210 is posted for team review (Draft). Two rounds of review feedback have
   date/time FK naming, lifecycle timestamps, and moving descriptive fields off the fact. This round produced
   the turn-grain change and the conformance rule (key decisions 2b/2c) and superseded parts of the first
   round.
+- **Owner direction (2026-08-10)** — cluster the turn records into a coherent conversation and make that
+  aggregate fact the home for the generated summary, embeddings and sentiment. This produced key decision
+  2d and rev. 3 across the spec set.
 
 Before flipping RFC → Accepted, the prerequisites above should be closed — particularly the volume
 measurement and the `comment_author_user_id` change, both of which gate the turn grain. Then begin
-implementation per the build order in `feedback_dagster_asset_spec.md` §7 (dbt fact first, ML asset
+implementation per the build order in `feedback_dagster_asset_spec.md` §7 (dbt facts first, ML asset
 additive).

--- a/docs/design/README_feedback_aggregation.md
+++ b/docs/design/README_feedback_aggregation.md
@@ -13,7 +13,8 @@ signals for four audiences (support, engineering, instructors, leadership).
 
 | Doc | Scope | Resolves task |
 |---|---|---|
-| [`feedback_dimensional_model.md`](./feedback_dimensional_model.md) | Dimensional model: `tfact_feedback` grain, conformed dims, sparse FKs, PII redaction, phasing | schema design (discovery) |
+| [`feedback_erd.md`](./feedback_erd.md) | **Start here for the shape:** Mermaid ERDs for the star schema, the event contract, the ML sidecar and the Phase-1 subset; records the schema deltas from #2422 review feedback | (visual index) |
+| [`feedback_dimensional_model.md`](./feedback_dimensional_model.md) | Dimensional model: `tfact_feedback` grain, conformed dims, sparse FKs, subject reference, PII redaction, phasing | schema design (discovery) |
 | [`feedback_event_contract_spec.md`](./feedback_event_contract_spec.md) | Common feedback event contract + migration-proof business keys; data-bus alignment as a bounded dependency | `...contract-bus-245a8e` |
 | [`feedback_zendesk_mvp_spec.md`](./feedback_zendesk_mvp_spec.md) | Build-ready Zendesk MVP: exact dbt models/columns `int__feedback__zendesk → __unioned → tfact_feedback` + 3 dims + tests | (MVP implementation) |
 | [`feedback_ml_approach.md`](./feedback_ml_approach.md) | Embedding (local, PII-safe), clustering (UMAP+HDBSCAN), category discovery (seed + LLM-label), sentiment (explicit + kNN/classifier) | `...clustering-...a1d7d6`, `...category-...550aba`, `...sentiment-...92988e` |
@@ -32,8 +33,9 @@ signals for four audiences (support, engineering, instructors, leadership).
    category/sentiment updates.
 3. **ML is an additive consumer**, not a prerequisite: the fact ships useful with
    tag-seeded categories + CSAT-derived sentiment; embeddings/clustering fill `category_fk`/
-   `sentiment_fk`/`embedding_id` later. Embeddings persisted **once** (the one adopted lesson
-   from prototype #10793).
+   `sentiment_fk` later and otherwise live entirely in the sidecar (three tables — vectors,
+   cluster runs, cluster assignments — split by grain so re-clustering never rewrites vectors).
+   Embeddings persisted **once** (the one adopted lesson from prototype #10793).
 4. **Engine-portable AI compute via Fenic; embedding model chosen by effectiveness** (revised
    2026-07-10 rev. 4, ADR): because the strategic direction is to **retire Trino for StarRocks**,
    no Galaxy-only functionality sits on the critical path (Starburst `generate_embedding`
@@ -48,7 +50,14 @@ signals for four audiences (support, engineering, instructors, leadership).
    is K-means only); LLM semantic-normalization-before-embedding is a first-class eval arm (2026
    evidence: biggest lever for short-ticket cluster quality). Presidio redaction mandatory
    pre-embed (data-minimization, independent of egress).
-5. **Consumption surface is an open, per-audience choice** — Superset dashboard, deployed
+5. **The fact records what feedback is *about*, not just who/when** (added 2026-08-07 from
+   [#2422 review feedback](https://github.com/mitodl/ol-data-platform/pull/2422#issuecomment-3157271372)):
+   a polymorphic `subject_type`/`subject_ref`/`subject_url` triple on the contract and the fact, resolved to
+   a conformed FK where one exists — `courserun_fk` for runs, the new **`content_block_fk →
+   dim_course_content`** for edX courseware blocks. No new subject dimension: the subject is polymorphic
+   across dims that already exist. Zendesk `brand_name`/`group_name` land as `source_brand`/`source_group`
+   facets ([hq#12607](https://github.com/mitodl/hq/issues/12607)).
+6. **Consumption surface is an open, per-audience choice** — Superset dashboard, deployed
    **Marimo notebook-as-webapp**, or a net-new app; all read the same modeled tables, so the
    choice is reversible. Recommended phasing: Superset for MVP trend/cluster dashboards (RLS
    already solved in `src/ol_superset/`), a Marimo notebook-as-webapp (existing image +
@@ -73,6 +82,11 @@ signals for four audiences (support, engineering, instructors, leadership).
 
 ## Status / next
 
-RFC #12210 is posted for team review (Draft; no comments yet as of 2026-07-10). On team
-consensus, flip RFC → Accepted and begin implementation per the build order in
+RFC #12210 is posted for team review (Draft). Review feedback on this PR from @pdpinch (2026-08-03) has
+been folded in as of 2026-08-07: the subject reference (`feedback_dimensional_model.md` §2a), Zendesk
+brand/group facets ([hq#12607](https://github.com/mitodl/hq/issues/12607)), and the ERDs in
+[`feedback_erd.md`](./feedback_erd.md) — also
+[posted as an RFC addendum](https://github.com/mitodl/hq/discussions/12210#discussioncomment-17935060).
+
+On team consensus, flip RFC → Accepted and begin implementation per the build order in
 `feedback_dagster_asset_spec.md` §7 (dbt fact first, ML asset additive).

--- a/docs/design/adr_embedding_compute_strategy.md
+++ b/docs/design/adr_embedding_compute_strategy.md
@@ -1,134 +1,140 @@
 # ADR: Where feedback embedding / AI inference runs
 
 Status: **proposed** · Project: `wp-feedback-aggregation-clustering-system-2e9750`
-Date: 2026-07-10 · Amends [`feedback_ml_approach.md`](./feedback_ml_approach.md) §B/§E and
+Date: 2026-07-10 (rev. 2 — engine-portability constraint) · Amends
+[`feedback_ml_approach.md`](./feedback_ml_approach.md) §B/§E and
 [`feedback_dagster_asset_spec.md`](./feedback_dagster_asset_spec.md).
 
 ## Context
 
-The original ML spec (`feedback_ml_approach.md` §B) proposed a **net-new Dagster code
-location** running `sentence-transformers`/`torch` to embed feedback locally, chosen for the
-learner-PII posture (avoid shipping ~1.18M utterances to a third-party API). The Dagster
-explore flagged this as the heaviest part of the whole system: a large image (torch + spaCy),
-a first-of-its-kind ML service in the repo, and all-net-new deps.
+The original ML spec (`feedback_ml_approach.md` §B) proposed a net-new Dagster code location
+running `sentence-transformers`/`torch` to embed feedback locally, for the learner-PII posture.
+The Dagster explore flagged this as the heaviest part of the system (large image, first ML
+service, all-new deps).
 
-A prompt to evaluate **in-engine AI functions** (Trino/Starburst, StarRocks) and a
-**DataFrame-based AI framework** (Fenic) against that approach surfaced a decisive fact from
-the repo:
+Two facts then reshaped the decision:
 
-- **Production runs Trino on Starburst Galaxy** (`*.trino.galaxy.starburst.io`;
-  `src/ol_dbt/profiles.yml` production/qa targets `type: trino`). Local dev is DuckDB.
-- **StarRocks is NOT deployed** — it exists only as `starrocks__` dispatch branches in
-  `macros/cross_db_functions.sql` and "future" language in `DBT_DIALECT_COMPATIBILITY.md`.
-- There is **zero existing use** of engine-native AI/embedding/vector SQL functions.
+1. **Production runs Trino on Starburst Galaxy** (`src/ol_dbt/profiles.yml`); local dev is
+   DuckDB; **StarRocks is not deployed** (only `starrocks__` dispatch branches in
+   `macros/cross_db_functions.sql`).
+2. **Strategic direction (owner, 2026-07-10): retire Trino in favour of StarRocks** as the
+   single engine for warehouse/Iceberg transformations, the "data bus", and OLAP serving.
+   **Therefore: no Galaxy-only (Starburst-proprietary) functionality may sit on the critical
+   path** — anything we build on the SQL engine must survive the Trino→StarRocks migration.
 
-This means the engine we already run has AI functions available, and the vector-DB engine we
-don't run is the only one the "StarRocks vector index" idea depended on.
+Rev. 1 of this ADR recommended pushing embedding into SQL via Starburst Galaxy's
+`generate_embedding`. **Fact 2 vetoes that**: it is a Galaxy-proprietary SQL function living in
+exactly the layer being migrated to StarRocks, and StarRocks has **no** embedding-generation
+function to migrate it to (StarRocks vector support is *store + ANN search* only —
+`cosine_similarity`, HNSW/IVFPQ indexes — not generation). Adopting it would guarantee a
+rewrite. This revision removes it from the critical path.
 
 ## The three candidates, disambiguated
 
-They are **not** the same kind of thing — the original prompt ("use a dataframe for the AI
-functions in Trino/Starburst or StarRocks") blends them; they separate cleanly:
-
-| Candidate | What it is | Runs where | Generates embeddings? | Vector search? |
+| Candidate | What it is | Runs where | Generates embeddings? | Engine-portable (Trino→StarRocks)? |
 |---|---|---|---|---|
-| **Starburst Galaxy AI functions** | In-SQL `starburst.ai.generate_embedding(text, model)` → `ARRAY(DOUBLE)`, plus `analyze_sentiment`, `classify`, `mask`, `prompt` | **inside our production Trino engine** | **yes** (Bedrock/OpenAI) | via generated vectors + similarity |
-| **Fenic** (typedef.ai) | PySpark-style **client-side** DataFrame lib with semantic operators (`embed`, `with_cluster_labels` K-means, `analyze_sentiment`, `classify`, `semantic.join`) | a Python process (a Dagster asset) | **yes** (OpenAI/Google/Cohere APIs — cloud only) | K-means clustering built in |
-| **StarRocks vector index** | HNSW/IVFPQ index + `approx_cosine_similarity` | inside StarRocks — **not deployed** | **no** (store/search only) | yes (ANN) |
+| **Starburst Galaxy AI functions** | in-SQL `starburst.ai.generate_embedding` etc. (Galaxy preview) | inside the SQL engine | yes (Bedrock/OpenAI **wrapper**) | **no — Galaxy-only; StarRocks has no equivalent** |
+| **Direct AWS Bedrock client** (boto3) | `bedrock-runtime.invoke_model('amazon.titan-embed-text-v2:0', …)` | an **engine-external** Dagster asset | yes (Bedrock, **in our AWS account**) | **yes — indifferent to the SQL engine** |
+| **Fenic** (typedef.ai) | client-side DataFrame lib w/ semantic ops + K-means | an engine-external Dagster asset | yes (OpenAI/Google/Cohere APIs — cloud only) | yes (engine-external) but **cloud-egress**, K-means only |
+| **local `sentence-transformers`** | self-hosted model in a Dagster asset | engine-external | yes (local, $0 egress) | yes, but heaviest image |
+| **StarRocks vector index** | HNSW/IVFPQ + `approx_cosine_similarity` | inside StarRocks (future) | **no** (store/search only) | it *is* the target — for serving, not generation |
 
-Key correction to the original framing: **Fenic does not "use" Trino/StarRocks AI functions.**
-It has its *own* embedding/semantic operators and runs client-side; it is an alternative to a
-hand-rolled Python pipeline, not a way to invoke engine AI functions. StarRocks *stores &
-searches* vectors but does **not** generate them. Only Starburst pushes embedding generation
-into the engine we already run.
+Two corrections to the earlier framing that matter here:
+- **Starburst's `generate_embedding` is only a SQL wrapper over Bedrock models.** We can call the
+  *same* Bedrock model directly with boto3 from the Dagster layer — keeping the in-account /
+  PII-safe benefit while dropping the Galaxy dependency. The wrapper buys nothing we can't get
+  portably.
+- **StarRocks does not generate embeddings.** So "do it in the future engine's SQL" is not an
+  option either. Embedding generation is inherently engine-external; the only question is which
+  external tool.
 
 ## Decision
 
-**Primary: push embedding + model-based sentiment into SQL/dbt via Starburst Galaxy AI
-functions, on AWS Bedrock models, over Presidio-redacted text. Keep only clustering +
-LLM cluster-labeling as a (now lightweight) Python Dagster asset.**
+**Keep all AI/embedding compute in the engine-external orchestration (Dagster/Python) layer,
+reading and writing open Iceberg tables — so it is indifferent to whether the SQL engine is
+Trino today or StarRocks tomorrow. Generate embeddings by calling AWS Bedrock
+(`amazon.titan-embed-text-v2:0`) directly via boto3, not through any engine's SQL AI function.**
 
-Revised pipeline (replaces `feedback_ml_approach.md` §A for the embed/sentiment stages):
+Revised pipeline:
 
 ```
-int__feedback__unioned (redacted text, feedback_pk)                       [dbt/SQL]
-  → feedback_embeddings   : generate_embedding() → ARRAY(DOUBLE) in Iceberg [dbt, trino_only]
-  → sentiment_fk          : analyze_sentiment() (+ explicit CSAT seed §E)   [dbt, trino_only]
-  → feedback_clusters     : read vectors from Iceberg → UMAP+HDBSCAN         [Dagster py asset]
-  → dim_feedback_category : LLM-label clusters (Bedrock via prompt())        [Dagster py asset]
+int__feedback__unioned (redacted text, feedback_pk)                         [dbt/SQL — portable, no AI funcs]
+  → feedback_embeddings  : Dagster asset, boto3 Bedrock invoke_model         [engine-external]
+                           → vectors into Iceberg ARRAY<float> sidecar
+  → feedback_clusters    : Dagster asset, read vectors → UMAP+HDBSCAN         [engine-external]
+  → dim_feedback_category: Dagster asset, LLM-label clusters (Bedrock)        [engine-external]
+  → sentiment_fk         : explicit CSAT seed + embedding-kNN (reuse vectors) [portable dbt/py, NO analyze_sentiment]
 ```
 
 Rationale:
-1. **Eliminates the heaviest infra.** No torch/sentence-transformers, no embedding model in a
-   Docker image. Embedding + sentiment become `trino_only`-tagged dbt models. The Python
-   surface shrinks to *just* clustering + labeling — which read pre-computed vectors, so the
-   asset stays tiny (sklearn/UMAP, CPU) and still clones `student_risk_probability`.
-2. **Vectors land where dbt already lives.** `generate_embeddings` procedure (or
-   `generate_embedding()` in an INSERT) writes straight into the `feedback_embeddings` Iceberg
-   `ARRAY(DOUBLE)` column — no new store, no data movement.
-3. **PII posture improves, doesn't regress.** Starburst AI runs against **AWS Bedrock**, which
-   can be in our own AWS account/region (we already run on AWS: Glue/S3/EKS). Bedrock-in-account
-   over Presidio-redacted text removes the "third-party egress" objection that drove the
-   original local-only recommendation. (Presidio stays the deterministic redaction guarantee;
-   `ai.mask` is an LLM-based masker to *evaluate as an add-on*, not to trust for compliance.)
-4. **Already on the engine.** No new service to run or operate — it's a feature of the Trino
-   cluster we already pay for.
+1. **Zero engine lock-in.** Nothing AI-specific touches Trino or StarRocks SQL. The dbt models
+   stay pure, portable, and continue to compile through the existing Trino/DuckDB/`starrocks__`
+   dispatch. When transforms move to StarRocks, the embedding path doesn't change at all.
+2. **Keeps the PII win without the wrapper.** Bedrock Titan runs in **our own AWS account**
+   (we're already on AWS: Glue/S3/EKS) over Presidio-redacted text — same posture Rev. 1 gained
+   from Starburst AI, obtained instead by a direct boto3 call. Auth via the Dagster pod's IAM
+   role (IRSA) with `bedrock:InvokeModel` — likely **no Vault secret** needed (unlike a
+   third-party API key).
+3. **Light, not heavy.** A boto3 Bedrock client is a thin dependency — **no torch, no
+   sentence-transformers, no model in the image**. It removes the original spec's heaviest
+   infra *and* avoids the Galaxy dependency. Batching/retries are a modest amount of code around
+   `invoke_model` (or use Bedrock batch inference for the 1.18M backfill).
+4. **Open landing = free StarRocks path.** Vectors persist in an Iceberg `ARRAY<float>` sidecar
+   (open format). When StarRocks becomes the serving/OLAP + data-bus engine, it **reads those
+   Iceberg vectors and builds an HNSW index over them** — a load, not a re-embed. So the
+   target-state vector-serving tier (StarRocks ANN) is reached without rework, and it is now
+   **on the intended path**, not a Phase-3 afterthought.
+5. **Sentiment stays engine-agnostic.** Use the cheaper explicit-CSAT-seed + embedding-kNN path
+   (`feedback_ml_approach.md` §E) — which reuses the vectors and needs no per-row LLM call and
+   no engine AI function. Explicitly **do not** adopt Starburst `analyze_sentiment` (Galaxy-only).
+6. **Clustering stays Python** (sklearn/UMAP/**HDBSCAN** for the noise class — one-off vs.
+   systemic; Fenic's K-means can't do this) — already engine-external and portable.
 
-**Clustering stays Python** because neither Trino nor DuckDB does density clustering, and we
-specifically want **HDBSCAN's noise class** to separate one-off complaints from systemic
-signal (`feedback_ml_approach.md` §C) — Fenic's `with_cluster_labels` is **K-means only** (no
-noise class), so it does not satisfy that requirement.
+## Consequences / caveats
 
-## Consequences / caveats (must be resolved before committing)
-
-1. **Gating question — is the AI-workflows feature enabled on our Galaxy plan?**
-   `generate_embedding` is **public preview** in Starburst Galaxy. Confirm it's available on
-   our subscription and that we accept depending on a preview feature for a production pipeline
-   (API-stability risk). This is the single decision that makes-or-breaks the primary option.
-2. **Bedrock model access + config.** Requires configuring an embedding model (e.g.
-   `bedrock_titan`) and a language model in Galaxy AI Model Access Management, and enabling
-   Bedrock in our AWS account. New platform setup, but far lighter than a torch service.
-3. **DuckDB local-dev / CI incompatibility.** AI functions are Trino-only; the embedding and
-   `analyze_sentiment` models must carry `tags: ['trino_only']` (existing repo pattern) and
-   will **not** run under the DuckDB `dev_local` target or the DuckDB-based docs CI. Embedding
-   is not something we'd want running on every local build anyway (cost), so gating it is
-   acceptable — but you lose full local reproducibility of those two models.
-4. **Cost shifts from one-time-local to per-invocation-provider.** Original: ~$2–16 one-time
-   local compute. Now: Bedrock embedding cost per record (Titan text embeddings are cheap —
-   order low-tens-of-dollars for 1.18M short redacted utterances — but it's a provider line
-   item, and re-embedding must still be avoided via persist-once + `model_version`). Do a
-   quick Bedrock-pricing sanity check at spec-approval time.
-5. **`analyze_sentiment`/`classify` are LLM calls per row.** Fine at MVP volume (198K, batch),
-   but confirm the batch cost and that per-row LLM sentiment beats the cheaper
-   explicit-CSAT-seed + embedding-kNN option (`feedback_ml_approach.md` §E) — it may not, in
-   which case keep sentiment on the kNN path and use Starburst AI only for embedding.
+1. **Slightly more code than a SQL one-liner.** We write a small Bedrock-client Dagster asset
+   instead of a `generate_embedding` dbt model. That is the price of portability, and it is
+   small (thin boto3 wrapper cloned from `student_risk_probability`'s asset shape).
+2. **Bedrock model access + IAM.** Enable `amazon.titan-embed-text-v2:0` (and a text model for
+   cluster labels) in our AWS account/region and grant the Dagster role `bedrock:InvokeModel`.
+   No Galaxy AI feature, no preview dependency.
+3. **Cost is per-invocation Bedrock**, but cheap: Titan V2 text embeddings at ~$0.02 / 1M tokens
+   → low tens of dollars for ~1.18M short redacted utterances, one-time (persist-once +
+   `model_version`; never re-embed). Use Bedrock **batch inference** for the backfill to cut
+   cost/throughput pressure. Sanity-check at approval time.
+4. **Dimensions choice:** Titan V2 supports 256/512/1024 — pick 256 or 512 for a smaller sidecar
+   and faster HDBSCAN/HNSW unless retrieval quality needs 1024. Tune on the Zendesk sample.
+5. **No StarRocks work now.** StarRocks HNSW is the documented *target* serving tier but is not
+   built until StarRocks is deployed; MVP uses Iceberg-ARRAY brute-force (fine at ≤1.18M for
+   batch clustering; the "similar feedback"/RAG serving need is what later justifies the HNSW
+   index).
 
 ## Alternatives (kept, in preference order)
 
-- **Fenic (fallback if the Galaxy AI preview is unavailable/undesired).** Gives
-  batching/caching/cost-accounting/row-level lineage for the Python path and does embed +
-  sentiment + K-means in one DataFrame pipeline reading Parquet/S3. Downsides vs. the primary:
-  still client-side (no engine push-down), **cloud-API egress only** (no self-hosted / no
-  in-account Bedrock embedding path documented), K-means clustering (no HDBSCAN noise class),
-  and a new framework dependency. Reasonable middle ground; less aligned than SQL push-down
-  given we're already on Galaxy. (License: OSS public repo — confirm Apache-2.0 before adopting.)
-- **Local `sentence-transformers` in Dagster (original §B).** Now the *last* resort: only if
-  both the Starburst AI feature and cloud/Bedrock egress are ruled out. Zero per-record
-  provider cost and no egress, but the heaviest image/infra and the most net-new code.
-- **StarRocks vector index — deferred to Phase 3.** Not applicable now (not deployed). When/if
-  the data bus lands on StarRocks, migrate the `feedback_embeddings` sidecar from Iceberg
-  `ARRAY(DOUBLE)` brute-force to a StarRocks HNSW index for ANN serving (similar-feedback / RAG
-  at query time). StarRocks still won't *generate* embeddings — those keep coming from Starburst
-  AI (or a UDF). Fold into the `afact`/serving work, not the MVP.
+- **Fenic** — optional ergonomics wrapper for the Python embedding/label path (batching, caching,
+  cost-accounting, row-level lineage, K-means + `analyze_sentiment` operators). Still
+  engine-external and portable, **but** its embedding providers are cloud APIs
+  (OpenAI/Google/Cohere) with **no in-account Bedrock path documented**, so it reintroduces
+  third-party egress and is less aligned than a direct Bedrock client on the PII axis; its
+  clustering is K-means (no noise class). Adopt only if the ergonomics outweigh the egress and
+  we keep clustering on our own HDBSCAN. (Confirm OSS license before use.)
+- **Local `sentence-transformers`** — the zero-egress fallback if in-account Bedrock is somehow
+  ruled out. Heaviest image/infra; no provider cost. Still engine-external/portable.
+- **Starburst Galaxy `generate_embedding` — REJECTED for the critical path.** Galaxy-proprietary,
+  sits in the SQL layer being migrated off, no StarRocks equivalent. Only reconsider as a throwaway
+  spike if we needed embeddings before any Dagster/Bedrock wiring existed — not worth the eventual
+  rewrite.
 
 ## Net change to the spec
 
-- `feedback_ml_approach.md` §B default flips: **Starburst Galaxy AI `generate_embedding`
-  (Bedrock, in-account, on redacted text)** becomes the recommended embedding path;
-  local self-hosted drops to fallback.
-- `feedback_dagster_asset_spec.md`: the `feedback_embeddings` and `feedback_sentiment` stages
-  move from Python assets to `trino_only` dbt models; the Dagster asset shrinks to
-  `feedback_clusters` + `feedback_category_proposals` (read vectors, UMAP+HDBSCAN, LLM-label).
-- No change to the fact, the dims, the contract, or the business keys — this ADR only changes
-  *where the vector/sentiment compute runs*, which the schema was deliberately built to be
-  agnostic about (embeddings live in a sidecar; category/sentiment are late-arriving FKs).
+- `feedback_ml_approach.md` §B default: **engine-external Dagster asset calling Bedrock
+  `amazon.titan-embed-text-v2:0` via boto3**, vectors in an Iceberg `ARRAY<float>` sidecar. (Rev. 1's
+  "Starburst AI `trino_only` dbt model" is withdrawn for engine lock-in.)
+- `feedback_dagster_asset_spec.md`: the embedding stage stays a Dagster asset but is a thin
+  Bedrock-client call (no torch); sentiment stays the CSAT-seed + kNN path; clustering + labeling
+  unchanged. No `trino_only` AI dbt models.
+- StarRocks HNSW vector index is elevated from a Phase-3 afterthought to the **intended
+  target vector-serving tier**, reached by loading the open Iceberg vectors (no re-embed).
+- Schema, contract, and business keys unchanged — compute location was always meant to be
+  swappable (vectors in a sidecar; category/sentiment late-arriving FKs), which is exactly what
+  makes this a compute-only, engine-portable revision.

--- a/docs/design/adr_embedding_compute_strategy.md
+++ b/docs/design/adr_embedding_compute_strategy.md
@@ -1,140 +1,134 @@
 # ADR: Where feedback embedding / AI inference runs
 
 Status: **proposed** · Project: `wp-feedback-aggregation-clustering-system-2e9750`
-Date: 2026-07-10 (rev. 2 — engine-portability constraint) · Amends
+Date: 2026-07-10 (rev. 3 — Fenic as the engine-external framework) · Amends
 [`feedback_ml_approach.md`](./feedback_ml_approach.md) §B/§E and
 [`feedback_dagster_asset_spec.md`](./feedback_dagster_asset_spec.md).
 
 ## Context
 
-The original ML spec (`feedback_ml_approach.md` §B) proposed a net-new Dagster code location
-running `sentence-transformers`/`torch` to embed feedback locally, for the learner-PII posture.
-The Dagster explore flagged this as the heaviest part of the system (large image, first ML
-service, all-new deps).
+Original spec (`feedback_ml_approach.md` §B) proposed a net-new Dagster location running
+`sentence-transformers`/`torch` to embed locally — the heaviest infra in the system. Two
+constraints then reshaped the decision:
 
-Two facts then reshaped the decision:
+1. **Production runs Trino on Starburst Galaxy**; local dev is DuckDB; **StarRocks is not yet
+   deployed**. And the **strategic direction is to retire Trino for StarRocks** (warehouse
+   transforms + data bus + OLAP serving). ⇒ **No Galaxy-only functionality on the critical
+   path.** This vetoes pushing embedding into SQL via Starburst's `generate_embedding`
+   (Galaxy-proprietary; StarRocks has no embedding-generation equivalent — its vector support
+   is *store + ANN search* only). Embedding generation is inherently **engine-external**.
+2. **Fenic** ([typedef-ai/fenic](https://github.com/typedef-ai/fenic)) is a viable
+   engine-external framework for this layer — this revision evaluates it as a first-class option
+   rather than a footnote.
 
-1. **Production runs Trino on Starburst Galaxy** (`src/ol_dbt/profiles.yml`); local dev is
-   DuckDB; **StarRocks is not deployed** (only `starrocks__` dispatch branches in
-   `macros/cross_db_functions.sql`).
-2. **Strategic direction (owner, 2026-07-10): retire Trino in favour of StarRocks** as the
-   single engine for warehouse/Iceberg transformations, the "data bus", and OLAP serving.
-   **Therefore: no Galaxy-only (Starburst-proprietary) functionality may sit on the critical
-   path** — anything we build on the SQL engine must survive the Trino→StarRocks migration.
+### What Fenic actually is (verified against the source, 2026-07-10)
 
-Rev. 1 of this ADR recommended pushing embedding into SQL via Starburst Galaxy's
-`generate_embedding`. **Fact 2 vetoes that**: it is a Galaxy-proprietary SQL function living in
-exactly the layer being migrated to StarRocks, and StarRocks has **no** embedding-generation
-function to migrate it to (StarRocks vector support is *store + ANN search* only —
-`cosine_similarity`, HNSW/IVFPQ indexes — not generation). Adopting it would guarantee a
-rewrite. This revision removes it from the critical path.
-
-## The three candidates, disambiguated
-
-| Candidate | What it is | Runs where | Generates embeddings? | Engine-portable (Trino→StarRocks)? |
-|---|---|---|---|---|
-| **Starburst Galaxy AI functions** | in-SQL `starburst.ai.generate_embedding` etc. (Galaxy preview) | inside the SQL engine | yes (Bedrock/OpenAI **wrapper**) | **no — Galaxy-only; StarRocks has no equivalent** |
-| **Direct AWS Bedrock client** (boto3) | `bedrock-runtime.invoke_model('amazon.titan-embed-text-v2:0', …)` | an **engine-external** Dagster asset | yes (Bedrock, **in our AWS account**) | **yes — indifferent to the SQL engine** |
-| **Fenic** (typedef.ai) | client-side DataFrame lib w/ semantic ops + K-means | an engine-external Dagster asset | yes (OpenAI/Google/Cohere APIs — cloud only) | yes (engine-external) but **cloud-egress**, K-means only |
-| **local `sentence-transformers`** | self-hosted model in a Dagster asset | engine-external | yes (local, $0 egress) | yes, but heaviest image |
-| **StarRocks vector index** | HNSW/IVFPQ + `approx_cosine_similarity` | inside StarRocks (future) | **no** (store/search only) | it *is* the target — for serving, not generation |
-
-Two corrections to the earlier framing that matter here:
-- **Starburst's `generate_embedding` is only a SQL wrapper over Bedrock models.** We can call the
-  *same* Bedrock model directly with boto3 from the Dagster layer — keeping the in-account /
-  PII-safe benefit while dropping the Galaxy dependency. The wrapper buys nothing we can't get
-  portably.
-- **StarRocks does not generate embeddings.** So "do it in the future engine's SQL" is not an
-  option either. Embedding generation is inherently engine-external; the only question is which
-  external tool.
+- **License: Apache-2.0** (`LICENSE` on `main`). Genuinely open source — no Galaxy-style
+  lock-in.
+- **Engine-external**, PySpark-style DataFrame framework with a query engine built for LLM
+  inference: semantic operators (`embed`, `semantic.classify`, `semantic.analyze_sentiment`,
+  `semantic.extract`, `semantic.join`, `semantic.reduce`), a native `EmbeddingType`, plus
+  `with_cluster_labels(by, num_clusters)` (**K-means**), and built-in batching, rate-limiting,
+  retries, token/cost accounting, and row-level lineage. Reads CSV/Parquet/S3/HF datasets.
+- **Embedding providers in the shipped `SessionConfig`:** `OpenAIEmbeddingModel`,
+  `CohereEmbeddingModel`, `GoogleDeveloperEmbeddingModel`, `GoogleVertexEmbeddingModel`
+  (language models: OpenAI, Anthropic, Google Developer/Vertex, OpenRouter). So it is
+  **embedding-provider-agnostic** across those vendors.
+- **AWS Bedrock status — important nuance:** there is **no `BedrockEmbeddingModel` config class
+  today.** In `config.py`, "Bedrock" appears only as an *OpenRouter routing target for language
+  models* (a third-party hop through openrouter.ai, and for LLMs, not embeddings), and
+  `ROADMAP.md` lists Bedrock as planned. So **native, in-account Bedrock *embeddings* through
+  Fenic are not yet available** — but because Fenic is Apache-2.0, a Bedrock embedding provider
+  can be contributed/added if we require it. (If a Fenic+Bedrock embedding path has landed in a
+  newer release than what `main` showed here, confirm the exact `SessionConfig` class before
+  relying on it.)
 
 ## Decision
 
-**Keep all AI/embedding compute in the engine-external orchestration (Dagster/Python) layer,
-reading and writing open Iceberg tables — so it is indifferent to whether the SQL engine is
-Trino today or StarRocks tomorrow. Generate embeddings by calling AWS Bedrock
-(`amazon.titan-embed-text-v2:0`) directly via boto3, not through any engine's SQL AI function.**
-
-Revised pipeline:
+**Keep all AI/embedding compute engine-external so it is indifferent to Trino-today vs.
+StarRocks-tomorrow, and use Fenic (Apache-2.0) as that engine-external framework** for the
+embed → (classify/sentiment) → label pipeline, running in a Dagster asset that reads the dbt
+outputs and writes vectors/labels back to open Iceberg. **Clustering stays our own
+sklearn/UMAP + HDBSCAN** (Fenic offers only K-means; we need HDBSCAN's noise class to separate
+one-off complaints from systemic signal — `feedback_ml_approach.md` §C).
 
 ```
-int__feedback__unioned (redacted text, feedback_pk)                         [dbt/SQL — portable, no AI funcs]
-  → feedback_embeddings  : Dagster asset, boto3 Bedrock invoke_model         [engine-external]
-                           → vectors into Iceberg ARRAY<float> sidecar
-  → feedback_clusters    : Dagster asset, read vectors → UMAP+HDBSCAN         [engine-external]
-  → dim_feedback_category: Dagster asset, LLM-label clusters (Bedrock)        [engine-external]
-  → sentiment_fk         : explicit CSAT seed + embedding-kNN (reuse vectors) [portable dbt/py, NO analyze_sentiment]
+int__feedback__unioned (redacted text, feedback_pk)                    [dbt/SQL — portable, no AI funcs]
+  → Fenic pipeline in a Dagster asset:                                  [engine-external, Apache-2.0]
+       .semantic.embed        → EmbeddingType column → Iceberg ARRAY<float> sidecar
+       .semantic.analyze_sentiment / .classify (optional; see §E note)
+  → feedback_clusters : our sklearn UMAP+HDBSCAN over the vectors       [engine-external]
+  → dim_feedback_category : LLM-label clusters (Fenic semantic op or a client call)
+  → sentiment_fk : explicit-CSAT seed + embedding-kNN (default) or Fenic analyze_sentiment
 ```
 
-Rationale:
-1. **Zero engine lock-in.** Nothing AI-specific touches Trino or StarRocks SQL. The dbt models
-   stay pure, portable, and continue to compile through the existing Trino/DuckDB/`starrocks__`
-   dispatch. When transforms move to StarRocks, the embedding path doesn't change at all.
-2. **Keeps the PII win without the wrapper.** Bedrock Titan runs in **our own AWS account**
-   (we're already on AWS: Glue/S3/EKS) over Presidio-redacted text — same posture Rev. 1 gained
-   from Starburst AI, obtained instead by a direct boto3 call. Auth via the Dagster pod's IAM
-   role (IRSA) with `bedrock:InvokeModel` — likely **no Vault secret** needed (unlike a
-   third-party API key).
-3. **Light, not heavy.** A boto3 Bedrock client is a thin dependency — **no torch, no
-   sentence-transformers, no model in the image**. It removes the original spec's heaviest
-   infra *and* avoids the Galaxy dependency. Batching/retries are a modest amount of code around
-   `invoke_model` (or use Bedrock batch inference for the 1.18M backfill).
-4. **Open landing = free StarRocks path.** Vectors persist in an Iceberg `ARRAY<float>` sidecar
-   (open format). When StarRocks becomes the serving/OLAP + data-bus engine, it **reads those
-   Iceberg vectors and builds an HNSW index over them** — a load, not a re-embed. So the
-   target-state vector-serving tier (StarRocks ANN) is reached without rework, and it is now
-   **on the intended path**, not a Phase-3 afterthought.
-5. **Sentiment stays engine-agnostic.** Use the cheaper explicit-CSAT-seed + embedding-kNN path
-   (`feedback_ml_approach.md` §E) — which reuses the vectors and needs no per-row LLM call and
-   no engine AI function. Explicitly **do not** adopt Starburst `analyze_sentiment` (Galaxy-only).
-6. **Clustering stays Python** (sklearn/UMAP/**HDBSCAN** for the noise class — one-off vs.
-   systemic; Fenic's K-means can't do this) — already engine-external and portable.
+**Embedding provider is a PII-policy choice, decoupled from the framework:**
+- **If in-account AWS Bedrock is a hard requirement** (best PII posture — vectors never leave
+  our AWS account, over Presidio-redacted text): today that means either (a) **contribute/point a
+  Bedrock embedding provider into Fenic** (Apache-2.0 allows it; aligns with their roadmap), or
+  (b) compute the embedding with a thin **boto3 `bedrock-runtime.invoke_model`
+  (`amazon.titan-embed-text-v2:0`)** step and use Fenic for the *rest* of the semantic pipeline.
+  Both keep the compute engine-external and portable.
+- **If a supported managed provider on redacted text is acceptable** (Cohere / OpenAI / Google
+  via Fenic's shipped config): simplest path, at the cost of provider egress of
+  *already-redacted* text. Decide against the learner-PII policy.
+
+Either way the **vectors land in an open Iceberg `ARRAY<float>` sidecar**, so when StarRocks
+becomes the serving/OLAP + data-bus engine it **reads those vectors and builds an HNSW index**
+over them (a load, not a re-embed) — **StarRocks ANN is the intended vector-serving tier**,
+reached with no rework. dbt models stay pure and portable (existing
+`default__`/`duckdb__`/`starrocks__` dispatch); **no engine-native AI SQL functions, no
+`trino_only` AI models.**
+
+## Why Fenic over a hand-rolled boto3 pipeline
+
+Both are engine-external and portable; Fenic adds, for free, what we'd otherwise hand-build:
+automatic batching, rate-limiting, retries, token/cost accounting, response caching, row-level
+lineage, and typed semantic operators (`classify`/`analyze_sentiment`/`extract`) we can reuse
+for category assignment and sentiment. Apache-2.0 means no lock-in and the option to extend it
+(e.g. the Bedrock embedding provider). The one thing it does **not** replace is HDBSCAN — keep
+that ours.
 
 ## Consequences / caveats
 
-1. **Slightly more code than a SQL one-liner.** We write a small Bedrock-client Dagster asset
-   instead of a `generate_embedding` dbt model. That is the price of portability, and it is
-   small (thin boto3 wrapper cloned from `student_risk_probability`'s asset shape).
-2. **Bedrock model access + IAM.** Enable `amazon.titan-embed-text-v2:0` (and a text model for
-   cluster labels) in our AWS account/region and grant the Dagster role `bedrock:InvokeModel`.
-   No Galaxy AI feature, no preview dependency.
-3. **Cost is per-invocation Bedrock**, but cheap: Titan V2 text embeddings at ~$0.02 / 1M tokens
-   → low tens of dollars for ~1.18M short redacted utterances, one-time (persist-once +
-   `model_version`; never re-embed). Use Bedrock **batch inference** for the backfill to cut
-   cost/throughput pressure. Sanity-check at approval time.
-4. **Dimensions choice:** Titan V2 supports 256/512/1024 — pick 256 or 512 for a smaller sidecar
-   and faster HDBSCAN/HNSW unless retrieval quality needs 1024. Tune on the Zendesk sample.
-5. **No StarRocks work now.** StarRocks HNSW is the documented *target* serving tier but is not
-   built until StarRocks is deployed; MVP uses Iceberg-ARRAY brute-force (fine at ≤1.18M for
-   batch clustering; the "similar feedback"/RAG serving need is what later justifies the HNSW
-   index).
+1. **New dependency (Fenic) + provider setup.** Add `fenic` to the new Dagster project's
+   `pyproject.toml`. Configure the chosen embedding provider (Bedrock-via-boto3/contrib, or a
+   Fenic-native provider) and credentials (Bedrock → Dagster pod IAM role `bedrock:InvokeModel`,
+   likely no Vault secret; a managed provider → a Vault-stored API key via the existing
+   `ConfigurableResource` pattern).
+2. **Bedrock-embedding gap (see Context).** If in-account Bedrock embeddings are required *now*
+   and not yet native to Fenic, use the boto3-embed + Fenic-for-the-rest split, or add the
+   provider. Don't assume a `BedrockEmbeddingModel` exists without checking the installed version.
+3. **Iceberg I/O is not native to Fenic.** Fenic reads CSV/Parquet/S3/HF, not Iceberg directly.
+   Integration: load the dbt table to a DataFrame (existing `get_dbt_model_as_dataframe` →
+   Polars) and stage to Parquet/S3 for `session.read.parquet(...)`, or hand Fenic the frame if
+   in-memory ingestion is supported in the installed version; write vectors out as Parquet and
+   load to the Iceberg sidecar. Confirm the exact read/write surface at implementation.
+4. **Clustering is not Fenic's.** UMAP+HDBSCAN stays a small sklearn step reading the vectors.
+5. **Cost/PII depend on the provider, not Fenic.** Titan V2 embeddings ~$0.02/1M tokens → low
+   tens of $ one-time for ~1.18M redacted utterances; persist-once + `model_version`, never
+   re-embed; use batch inference for the backfill. A managed provider has similar cost but
+   egresses redacted text — a policy call.
 
-## Alternatives (kept, in preference order)
+## Alternatives (kept)
 
-- **Fenic** — optional ergonomics wrapper for the Python embedding/label path (batching, caching,
-  cost-accounting, row-level lineage, K-means + `analyze_sentiment` operators). Still
-  engine-external and portable, **but** its embedding providers are cloud APIs
-  (OpenAI/Google/Cohere) with **no in-account Bedrock path documented**, so it reintroduces
-  third-party egress and is less aligned than a direct Bedrock client on the PII axis; its
-  clustering is K-means (no noise class). Adopt only if the ergonomics outweigh the egress and
-  we keep clustering on our own HDBSCAN. (Confirm OSS license before use.)
-- **Local `sentence-transformers`** — the zero-egress fallback if in-account Bedrock is somehow
-  ruled out. Heaviest image/infra; no provider cost. Still engine-external/portable.
-- **Starburst Galaxy `generate_embedding` — REJECTED for the critical path.** Galaxy-proprietary,
-  sits in the SQL layer being migrated off, no StarRocks equivalent. Only reconsider as a throwaway
-  spike if we needed embeddings before any Dagster/Bedrock wiring existed — not worth the eventual
-  rewrite.
+- **Direct boto3 Bedrock client, no Fenic** — the minimal engine-external path; use if we don't
+  want the Fenic dependency. Loses the batching/caching/lineage ergonomics (hand-build them).
+- **Local `sentence-transformers`** — zero-egress, no provider cost, but the heaviest image;
+  fallback only if all managed/Bedrock options are ruled out. Still engine-external/portable;
+  could even be wired behind Fenic if/when it supports local models.
+- **Starburst Galaxy `generate_embedding` — REJECTED for the critical path** (Galaxy-proprietary,
+  in the layer being migrated off, no StarRocks equivalent).
+- **StarRocks vector index** — the *target serving tier*, not a generation option; built once
+  StarRocks is deployed, by loading the open Iceberg vectors.
 
 ## Net change to the spec
 
-- `feedback_ml_approach.md` §B default: **engine-external Dagster asset calling Bedrock
-  `amazon.titan-embed-text-v2:0` via boto3**, vectors in an Iceberg `ARRAY<float>` sidecar. (Rev. 1's
-  "Starburst AI `trino_only` dbt model" is withdrawn for engine lock-in.)
-- `feedback_dagster_asset_spec.md`: the embedding stage stays a Dagster asset but is a thin
-  Bedrock-client call (no torch); sentiment stays the CSAT-seed + kNN path; clustering + labeling
-  unchanged. No `trino_only` AI dbt models.
-- StarRocks HNSW vector index is elevated from a Phase-3 afterthought to the **intended
-  target vector-serving tier**, reached by loading the open Iceberg vectors (no re-embed).
+- `feedback_ml_approach.md` §B default: **engine-external Fenic pipeline (Apache-2.0), embedding
+  provider chosen by PII policy** (in-account Bedrock via boto3/contrib preferred; managed
+  provider on redacted text acceptable if policy allows). Vectors → Iceberg `ARRAY<float>` sidecar.
+- `feedback_dagster_asset_spec.md`: embedding/sentiment run via Fenic in the Dagster asset (not
+  torch, not a Starburst SQL function); clustering stays sklearn HDBSCAN; no `trino_only` AI models.
+- StarRocks HNSW is the **intended** vector-serving tier, reached by loading Iceberg vectors.
 - Schema, contract, and business keys unchanged — compute location was always meant to be
-  swappable (vectors in a sidecar; category/sentiment late-arriving FKs), which is exactly what
-  makes this a compute-only, engine-portable revision.
+  swappable (vectors in a sidecar; category/sentiment late-arriving FKs).

--- a/docs/design/adr_embedding_compute_strategy.md
+++ b/docs/design/adr_embedding_compute_strategy.md
@@ -62,16 +62,17 @@ int__feedback__unioned (redacted text, feedback_pk)                    [dbt/SQL 
   → sentiment_fk : explicit-CSAT seed + embedding-kNN (default) or Fenic analyze_sentiment
 ```
 
-**Embedding provider is a PII-policy choice, decoupled from the framework:**
-- **If in-account AWS Bedrock is a hard requirement** (best PII posture — vectors never leave
-  our AWS account, over Presidio-redacted text): today that means either (a) **contribute/point a
-  Bedrock embedding provider into Fenic** (Apache-2.0 allows it; aligns with their roadmap), or
-  (b) compute the embedding with a thin **boto3 `bedrock-runtime.invoke_model`
-  (`amazon.titan-embed-text-v2:0`)** step and use Fenic for the *rest* of the semantic pipeline.
-  Both keep the compute engine-external and portable.
-- **If a supported managed provider on redacted text is acceptable** (Cohere / OpenAI / Google
-  via Fenic's shipped config): simplest path, at the cost of provider egress of
-  *already-redacted* text. Decide against the learner-PII policy.
+**Embedding model is chosen by TASK EFFECTIVENESS, not by provider/PII** (owner direction,
+2026-07-10: Bedrock/in-account is **not** a requirement; select the model on how well it clusters
+and retrieves *our* feedback). Egress of Presidio-redacted text to a managed provider is
+acceptable. See `feedback_ml_approach.md` §B.1 for the selection harness (MTEB to narrow →
+benchmark the shortlist on a labeled Zendesk sample → pick by clustering agreement/coherence and
+cost; sweep Matryoshka dims). Candidate providers: Fenic-native managed
+(`gemini-embedding-001` / Cohere `embed-v4` / OpenAI `text-embedding-3-large`) and self-hosted
+open (Qwen3-Embedding / BGE-M3 via `sentence-transformers`) if we host for effectiveness. Because
+vectors persist with `model_version`, the choice is reversible (re-embed later without touching
+the fact). Bedrock (`amazon.titan-embed-text-v2:0` via boto3) remains *a* candidate — no longer
+the default, just one option in the bake-off.
 
 Either way the **vectors land in an open Iceberg `ARRAY<float>` sidecar**, so when StarRocks
 becomes the serving/OLAP + data-bus engine it **reads those vectors and builds an HNSW index**

--- a/docs/design/adr_embedding_compute_strategy.md
+++ b/docs/design/adr_embedding_compute_strategy.md
@@ -1,0 +1,134 @@
+# ADR: Where feedback embedding / AI inference runs
+
+Status: **proposed** · Project: `wp-feedback-aggregation-clustering-system-2e9750`
+Date: 2026-07-10 · Amends [`feedback_ml_approach.md`](./feedback_ml_approach.md) §B/§E and
+[`feedback_dagster_asset_spec.md`](./feedback_dagster_asset_spec.md).
+
+## Context
+
+The original ML spec (`feedback_ml_approach.md` §B) proposed a **net-new Dagster code
+location** running `sentence-transformers`/`torch` to embed feedback locally, chosen for the
+learner-PII posture (avoid shipping ~1.18M utterances to a third-party API). The Dagster
+explore flagged this as the heaviest part of the whole system: a large image (torch + spaCy),
+a first-of-its-kind ML service in the repo, and all-net-new deps.
+
+A prompt to evaluate **in-engine AI functions** (Trino/Starburst, StarRocks) and a
+**DataFrame-based AI framework** (Fenic) against that approach surfaced a decisive fact from
+the repo:
+
+- **Production runs Trino on Starburst Galaxy** (`*.trino.galaxy.starburst.io`;
+  `src/ol_dbt/profiles.yml` production/qa targets `type: trino`). Local dev is DuckDB.
+- **StarRocks is NOT deployed** — it exists only as `starrocks__` dispatch branches in
+  `macros/cross_db_functions.sql` and "future" language in `DBT_DIALECT_COMPATIBILITY.md`.
+- There is **zero existing use** of engine-native AI/embedding/vector SQL functions.
+
+This means the engine we already run has AI functions available, and the vector-DB engine we
+don't run is the only one the "StarRocks vector index" idea depended on.
+
+## The three candidates, disambiguated
+
+They are **not** the same kind of thing — the original prompt ("use a dataframe for the AI
+functions in Trino/Starburst or StarRocks") blends them; they separate cleanly:
+
+| Candidate | What it is | Runs where | Generates embeddings? | Vector search? |
+|---|---|---|---|---|
+| **Starburst Galaxy AI functions** | In-SQL `starburst.ai.generate_embedding(text, model)` → `ARRAY(DOUBLE)`, plus `analyze_sentiment`, `classify`, `mask`, `prompt` | **inside our production Trino engine** | **yes** (Bedrock/OpenAI) | via generated vectors + similarity |
+| **Fenic** (typedef.ai) | PySpark-style **client-side** DataFrame lib with semantic operators (`embed`, `with_cluster_labels` K-means, `analyze_sentiment`, `classify`, `semantic.join`) | a Python process (a Dagster asset) | **yes** (OpenAI/Google/Cohere APIs — cloud only) | K-means clustering built in |
+| **StarRocks vector index** | HNSW/IVFPQ index + `approx_cosine_similarity` | inside StarRocks — **not deployed** | **no** (store/search only) | yes (ANN) |
+
+Key correction to the original framing: **Fenic does not "use" Trino/StarRocks AI functions.**
+It has its *own* embedding/semantic operators and runs client-side; it is an alternative to a
+hand-rolled Python pipeline, not a way to invoke engine AI functions. StarRocks *stores &
+searches* vectors but does **not** generate them. Only Starburst pushes embedding generation
+into the engine we already run.
+
+## Decision
+
+**Primary: push embedding + model-based sentiment into SQL/dbt via Starburst Galaxy AI
+functions, on AWS Bedrock models, over Presidio-redacted text. Keep only clustering +
+LLM cluster-labeling as a (now lightweight) Python Dagster asset.**
+
+Revised pipeline (replaces `feedback_ml_approach.md` §A for the embed/sentiment stages):
+
+```
+int__feedback__unioned (redacted text, feedback_pk)                       [dbt/SQL]
+  → feedback_embeddings   : generate_embedding() → ARRAY(DOUBLE) in Iceberg [dbt, trino_only]
+  → sentiment_fk          : analyze_sentiment() (+ explicit CSAT seed §E)   [dbt, trino_only]
+  → feedback_clusters     : read vectors from Iceberg → UMAP+HDBSCAN         [Dagster py asset]
+  → dim_feedback_category : LLM-label clusters (Bedrock via prompt())        [Dagster py asset]
+```
+
+Rationale:
+1. **Eliminates the heaviest infra.** No torch/sentence-transformers, no embedding model in a
+   Docker image. Embedding + sentiment become `trino_only`-tagged dbt models. The Python
+   surface shrinks to *just* clustering + labeling — which read pre-computed vectors, so the
+   asset stays tiny (sklearn/UMAP, CPU) and still clones `student_risk_probability`.
+2. **Vectors land where dbt already lives.** `generate_embeddings` procedure (or
+   `generate_embedding()` in an INSERT) writes straight into the `feedback_embeddings` Iceberg
+   `ARRAY(DOUBLE)` column — no new store, no data movement.
+3. **PII posture improves, doesn't regress.** Starburst AI runs against **AWS Bedrock**, which
+   can be in our own AWS account/region (we already run on AWS: Glue/S3/EKS). Bedrock-in-account
+   over Presidio-redacted text removes the "third-party egress" objection that drove the
+   original local-only recommendation. (Presidio stays the deterministic redaction guarantee;
+   `ai.mask` is an LLM-based masker to *evaluate as an add-on*, not to trust for compliance.)
+4. **Already on the engine.** No new service to run or operate — it's a feature of the Trino
+   cluster we already pay for.
+
+**Clustering stays Python** because neither Trino nor DuckDB does density clustering, and we
+specifically want **HDBSCAN's noise class** to separate one-off complaints from systemic
+signal (`feedback_ml_approach.md` §C) — Fenic's `with_cluster_labels` is **K-means only** (no
+noise class), so it does not satisfy that requirement.
+
+## Consequences / caveats (must be resolved before committing)
+
+1. **Gating question — is the AI-workflows feature enabled on our Galaxy plan?**
+   `generate_embedding` is **public preview** in Starburst Galaxy. Confirm it's available on
+   our subscription and that we accept depending on a preview feature for a production pipeline
+   (API-stability risk). This is the single decision that makes-or-breaks the primary option.
+2. **Bedrock model access + config.** Requires configuring an embedding model (e.g.
+   `bedrock_titan`) and a language model in Galaxy AI Model Access Management, and enabling
+   Bedrock in our AWS account. New platform setup, but far lighter than a torch service.
+3. **DuckDB local-dev / CI incompatibility.** AI functions are Trino-only; the embedding and
+   `analyze_sentiment` models must carry `tags: ['trino_only']` (existing repo pattern) and
+   will **not** run under the DuckDB `dev_local` target or the DuckDB-based docs CI. Embedding
+   is not something we'd want running on every local build anyway (cost), so gating it is
+   acceptable — but you lose full local reproducibility of those two models.
+4. **Cost shifts from one-time-local to per-invocation-provider.** Original: ~$2–16 one-time
+   local compute. Now: Bedrock embedding cost per record (Titan text embeddings are cheap —
+   order low-tens-of-dollars for 1.18M short redacted utterances — but it's a provider line
+   item, and re-embedding must still be avoided via persist-once + `model_version`). Do a
+   quick Bedrock-pricing sanity check at spec-approval time.
+5. **`analyze_sentiment`/`classify` are LLM calls per row.** Fine at MVP volume (198K, batch),
+   but confirm the batch cost and that per-row LLM sentiment beats the cheaper
+   explicit-CSAT-seed + embedding-kNN option (`feedback_ml_approach.md` §E) — it may not, in
+   which case keep sentiment on the kNN path and use Starburst AI only for embedding.
+
+## Alternatives (kept, in preference order)
+
+- **Fenic (fallback if the Galaxy AI preview is unavailable/undesired).** Gives
+  batching/caching/cost-accounting/row-level lineage for the Python path and does embed +
+  sentiment + K-means in one DataFrame pipeline reading Parquet/S3. Downsides vs. the primary:
+  still client-side (no engine push-down), **cloud-API egress only** (no self-hosted / no
+  in-account Bedrock embedding path documented), K-means clustering (no HDBSCAN noise class),
+  and a new framework dependency. Reasonable middle ground; less aligned than SQL push-down
+  given we're already on Galaxy. (License: OSS public repo — confirm Apache-2.0 before adopting.)
+- **Local `sentence-transformers` in Dagster (original §B).** Now the *last* resort: only if
+  both the Starburst AI feature and cloud/Bedrock egress are ruled out. Zero per-record
+  provider cost and no egress, but the heaviest image/infra and the most net-new code.
+- **StarRocks vector index — deferred to Phase 3.** Not applicable now (not deployed). When/if
+  the data bus lands on StarRocks, migrate the `feedback_embeddings` sidecar from Iceberg
+  `ARRAY(DOUBLE)` brute-force to a StarRocks HNSW index for ANN serving (similar-feedback / RAG
+  at query time). StarRocks still won't *generate* embeddings — those keep coming from Starburst
+  AI (or a UDF). Fold into the `afact`/serving work, not the MVP.
+
+## Net change to the spec
+
+- `feedback_ml_approach.md` §B default flips: **Starburst Galaxy AI `generate_embedding`
+  (Bedrock, in-account, on redacted text)** becomes the recommended embedding path;
+  local self-hosted drops to fallback.
+- `feedback_dagster_asset_spec.md`: the `feedback_embeddings` and `feedback_sentiment` stages
+  move from Python assets to `trino_only` dbt models; the Dagster asset shrinks to
+  `feedback_clusters` + `feedback_category_proposals` (read vectors, UMAP+HDBSCAN, LLM-label).
+- No change to the fact, the dims, the contract, or the business keys — this ADR only changes
+  *where the vector/sentiment compute runs*, which the schema was deliberately built to be
+  agnostic about (embeddings live in a sidecar; category/sentiment are late-arriving FKs).

--- a/docs/design/adr_embedding_compute_strategy.md
+++ b/docs/design/adr_embedding_compute_strategy.md
@@ -53,14 +53,21 @@ sklearn/UMAP + HDBSCAN** (Fenic offers only K-means; we need HDBSCAN's noise cla
 one-off complaints from systemic signal — `feedback_ml_approach.md` §C).
 
 ```
-int__feedback__unioned (redacted text, feedback_pk)                    [dbt/SQL — portable, no AI funcs]
+int__feedback__conversation (redacted turns assembled)                 [dbt/SQL — portable, no AI funcs]
   → Fenic pipeline in a Dagster asset:                                  [engine-external, Apache-2.0]
-       .semantic.embed        → EmbeddingType column → Iceberg ARRAY<float> sidecar
+       summarize              → conversation_summary (multi-turn only)
+       .semantic.embed        → EmbeddingType column → Iceberg ARRAY<float> on the conversation fact
        .semantic.analyze_sentiment / .classify (optional; see §E note)
   → feedback_clusters : our sklearn UMAP+HDBSCAN over the vectors       [engine-external]
   → dim_feedback_category : LLM-label clusters (Fenic semantic op or a client call)
   → sentiment_fk : explicit-CSAT seed + embedding-kNN (default) or Fenic analyze_sentiment
+  → all of it written to afact_feedback_conversation, one row per conversation
 ```
+
+> **Rev. 3 (2026-08-10):** the grain of everything above is the **conversation**, and the target is
+> `afact_feedback_conversation` rather than a per-turn embeddings sidecar
+> (`feedback_dimensional_model.md` §5a). The engine-externality argument — the actual subject of this ADR —
+> is unaffected: it is about *where compute runs*, not what it is keyed by.
 
 **Embedding model is chosen by TASK EFFECTIVENESS, not by provider/PII** (owner direction,
 2026-07-10: Bedrock/in-account is **not** a requirement; select the model on how well it clusters

--- a/docs/design/feedback_consumption_ux_spec.md
+++ b/docs/design/feedback_consumption_ux_spec.md
@@ -1,0 +1,101 @@
+# Feedback Aggregation — Consumption / UX Spec
+
+Status: **spec** · Project: `wp-feedback-aggregation-clustering-system-2e9750`
+Date: 2026-07-10 · Resolves `tk-...-ui-ux-audience-actions-and-where-the-expe-476d23`
+Companion to [`feedback_dimensional_model.md`](./feedback_dimensional_model.md).
+
+Defines **who consumes the feedback fact, at what altitude, what actions they take, and
+where the experience lives.** The fact + dims are the substrate; this spec is the demand
+side that validates the model actually serves its audiences.
+
+---
+
+## 1. Audiences × altitude (from the RFC)
+
+Four audiences at three altitudes. Each maps to a specific slice of `tfact_feedback` +
+`dim_feedback_category`/`dim_sentiment` and a specific row-level access rule.
+
+| Audience | Altitude | Core question | Grain they work at | Row-level access |
+|---|---|---|---|---|
+| **Customer support** | operational | "What recurring issues are coming in this week?" | cluster → individual ticket drill-down | all feedback |
+| **Engineering** | operational | "Which systemic platform defects does feedback point to?" | cluster (systemic-only, filter noise) → ticket | all feedback |
+| **Instructors / instructional designers** | course-scoped | "What are my learners saying about *my* course?" | feedback filtered to their `courserun_fk` | only their courserun(s) |
+| **Department leadership** | strategic | "How are category/sentiment trends moving; where are new-offering opportunities?" | `afact_feedback_cluster_daily` rollups | aggregates only (no raw text) |
+
+Three altitudes = the same fact read three ways: **operational drill-down** (row-level,
+support/eng), **course-scoped** (filtered fact, instructors), **strategic rollup**
+(aggregate fact, leadership). This is why `dim_feedback_source.source_audience_scope`
+(`operational | course | strategic`) exists on the source dim.
+
+---
+
+## 2. Surface — where the experience lives
+
+**Recommendation: start in Superset (BI), not a custom app.** Rationale:
+- The warehouse already exposes facts to Superset; zero new app infrastructure (matches the
+  RFC's "effectively zero new infrastructure" MVP posture).
+- Support/eng/leadership are already BI consumers; instructors are the only audience that
+  might warrant an embedded surface later.
+- Row-level security in Superset covers the instructor courserun-scoping and the
+  leadership aggregates-only rule.
+
+**MVP surfaces (Superset dashboards):**
+1. **Support triage** — cluster list ranked by size/recency, filterable by
+   `source_status`/`source_priority`/`source_channel`/`source_tags`, each cluster
+   drill-through to constituent (redacted) tickets with `source_url` deep-links back to
+   Zendesk. Sentiment facet from `dim_sentiment`.
+2. **Engineering systemic view** — same cluster list but filtered to systemic clusters
+   (HDBSCAN non-noise, above a `min_cluster_size` threshold; noise/one-offs hidden), sorted
+   by cluster cohesion/size, with category labels from `dim_feedback_category`.
+3. **Leadership trends** — `afact_feedback_cluster_daily` time-series of category × sentiment
+   volume; no raw text. (Phase 2, needs the aggregate fact + cross-source data.)
+4. **Instructor course view** — feedback filtered to a courserun; **Phase 2** (needs
+   course-scoped sources: forum/tutor/ORA — Zendesk MVP is not course-scoped, so instructors
+   get nothing from the MVP slice. Documented gap.)
+
+**When to graduate to an embedded/custom app:** only if write-back actions (§3) outgrow
+Superset — e.g. support wants in-context triage/routing, or eng wants one-click issue
+filing. Treat that as a deliberate later decision, not MVP.
+
+---
+
+## 3. Actions per persona (write-back)
+
+MVP is **read-only insight**; write-back is explicitly deferred but the design should not
+preclude it. Documented target actions (open question, RFC):
+
+| Persona | Read (MVP) | Write-back (later) |
+|---|---|---|
+| Support | view clusters, drill to tickets, filter | mark cluster as triaged / route to team |
+| Engineering | view systemic clusters, category labels | file a linked eng issue from a cluster |
+| Instructor | (Phase 2) view own-course feedback | acknowledge / respond |
+| Leadership | view trends | none (consumption only) |
+| Curator (any) | — | approve/merge/deprecate `dim_feedback_category` labels (the curation loop) |
+
+The **category curation loop** (approve LLM-proposed labels) is the one write-back that IS
+needed early — it can live as a lightweight admin surface or even a manual dbt-seed edit at
+MVP, upgrading to a UI when volume warrants (`feedback_ml_approach.md` §D).
+
+---
+
+## 4. Access control (ties to design §7 + Lakekeeper/Cedar)
+
+- **Redacted text only** is exposed in any consumption surface (raw text stays in
+  `raw`/`stg` under existing PII classification + Lakekeeper/Cedar authz — design §7).
+- **Instructor** dashboards are row-filtered to their `courserun_fk` (Superset RLS or a
+  Cedar policy on the fact).
+- **Leadership** sees the aggregate fact only (no row-level text) — enforced by pointing
+  their dashboards at `afact_feedback_cluster_daily`, not `tfact_feedback`.
+- Re-applying PII classification + Lakekeeper/Cedar authz at the new fact/dims is tracked by
+  `tk-re-apply-pii-classification-lakekeeper-cedar-aut-1b3516` (p3).
+
+---
+
+## 5. What the MVP consumption slice actually delivers
+
+Given the MVP is Zendesk-only and not course-scoped: **support + engineering get working
+cluster-triage dashboards; leadership gets Zendesk-only category/sentiment trends;
+instructors get nothing until Phase 2 course-scoped sources land.** That is the honest
+scope — the model supports all four, but only two-and-a-half audiences are served by the
+first data slice. This is acceptable because support/eng recurring-issue triage is the
+primary stated motivation.

--- a/docs/design/feedback_consumption_ux_spec.md
+++ b/docs/design/feedback_consumption_ux_spec.md
@@ -31,15 +31,37 @@ support/eng), **course-scoped** (filtered fact, instructors), **strategic rollup
 
 ## 2. Surface — where the experience lives
 
-**Recommendation: start in Superset (BI), not a custom app.** Rationale:
-- The warehouse already exposes facts to Superset; zero new app infrastructure (matches the
-  RFC's "effectively zero new infrastructure" MVP posture).
-- Support/eng/leadership are already BI consumers; instructors are the only audience that
-  might warrant an embedded surface later.
-- Row-level security in Superset covers the instructor courserun-scoping and the
-  leadership aggregates-only rule.
+**The surface is an open choice, and it need not be one surface for all audiences.** Because the
+fact + dims are the substrate and every surface just *reads the modeled tables*, the surface is a
+swappable, reversible consumer — pick per audience by interactivity and write-back need, and you
+can run more than one against the same tables. Three viable options, all grounded in tooling the
+platform **already operates**:
 
-**MVP surfaces (Superset dashboards):**
+| Option | What it is | Already in-repo? | Best for | Auth / row-level access | Interactivity & write-back | Effort |
+|---|---|---|---|---|---|---|
+| **Superset dashboard** | Managed BI; dashboards/charts/datasets as code | **Yes** — `src/ol_superset/` (`ol-superset` CLI export/validate/sync/promote) + `dg_projects/lakehouse/.../assets/superset.py`; **programmatic RLS** via `apply_rls.py` | Leadership trend dashboards; support/eng cluster tables with drill-through; anything chart-shaped and read-mostly | **RLS already solved** (per-role row filters) — covers instructor courserun-scoping + leadership aggregates-only | Rich filtering/drill; **little/no write-back**; bespoke interactions are hard | **Lowest** — a new dataset + dashboards on the fact |
+| **Marimo notebook-as-webapp** | A reactive Python notebook served as an app (`marimo run`) | **Partly** — `images/marimo-jupyterlab/` image exists (marimo + Keycloak OIDC + per-user Trino token + IRSA to S3/Glue), currently in JupyterHub *notebook* mode; serving one as an app is a small new deploy reusing that image/auth | Analyst/eng **interactive cluster exploration**, semantic-search over clusters, the **category-curation loop**, and **prototyping the UX** before committing to an app | Runs queries **as the user** (Keycloak OIDC → Trino/StarRocks token) → can push **row-level authz to the engine** (Lakekeeper/Cedar) rather than reimplement it | High interactivity; **Python** so it can call the embedding/cluster/LLM code directly; light write-back via widgets (e.g. approve labels) | **Medium** — write a notebook; add an app-serve deploy behind APISIX |
+| **Net-new application** | A purpose-built web app | No | **Instructor-embedded** views (in MIT Learn), **support triage/route** workflows at scale, product integration | Full control via the org's **APISIX/Keycloak**; bespoke per-persona policies | Full custom UX + rich **write-back** workflows | **Highest** — a service to build, deploy, own |
+
+**Recommendation — phased and audience-matched, not one surface:**
+1. **MVP (fastest value): Superset** for leadership trends and the support/eng cluster tables —
+   it's already operated, RLS is already solved as code, and it matches the RFC's
+   "near-zero new infrastructure" posture. Datasets point at `tfact_feedback` /
+   `afact_feedback_cluster_daily` / the dims.
+2. **Interactive + curation surface: a deployed Marimo notebook-as-webapp** — the right home for
+   cluster exploration, semantic search, and the **category-curation loop** (approve/merge
+   LLM-proposed labels), and the **cheapest way to prototype the real UX** before deciding whether
+   a net-new app is warranted. It reuses the existing marimo image + Keycloak/Trino/IRSA plumbing,
+   and being Python it can call the same embedding/clustering/label code the pipeline uses.
+3. **Net-new app: only when write-back or product-embedding justifies it** — e.g. instructor-facing
+   views inside MIT Learn, or support triage-and-routing at scale. Defer until the Marimo prototype
+   has shown what the workflow actually needs; the app then formalizes a proven UX rather than
+   guessing.
+
+This ordering keeps commitment low (all three read the same tables) and treats Marimo as the
+discovery vehicle between "a dashboard is enough" and "we need a real app."
+
+**MVP surface content (Superset unless noted):**
 1. **Support triage** — cluster list ranked by size/recency, filterable by
    `source_status`/`source_priority`/`source_channel`/`source_tags`, each cluster
    drill-through to constituent (redacted) tickets with `source_url` deep-links back to
@@ -52,10 +74,8 @@ support/eng), **course-scoped** (filtered fact, instructors), **strategic rollup
 4. **Instructor course view** — feedback filtered to a courserun; **Phase 2** (needs
    course-scoped sources: forum/tutor/ORA — Zendesk MVP is not course-scoped, so instructors
    get nothing from the MVP slice. Documented gap.)
-
-**When to graduate to an embedded/custom app:** only if write-back actions (§3) outgrow
-Superset — e.g. support wants in-context triage/routing, or eng wants one-click issue
-filing. Treat that as a deliberate later decision, not MVP.
+5. **Cluster exploration + curation** (Marimo) — interactive nearest-neighbour/semantic browse of
+   clusters and the label-approval loop; the one surface where MVP write-back genuinely lives.
 
 ---
 
@@ -73,17 +93,21 @@ preclude it. Documented target actions (open question, RFC):
 | Curator (any) | — | approve/merge/deprecate `dim_feedback_category` labels (the curation loop) |
 
 The **category curation loop** (approve LLM-proposed labels) is the one write-back that IS
-needed early — it can live as a lightweight admin surface or even a manual dbt-seed edit at
-MVP, upgrading to a UI when volume warrants (`feedback_ml_approach.md` §D).
+needed early. Its natural MVP home is the **Marimo notebook-as-webapp** (§2) — Python widgets over
+`dim_feedback_category`, reusing the same code path as the labeling pipeline — with a manual
+dbt-seed edit as the zero-UI fallback. It upgrades into a net-new app only if/when the other
+write-back workflows (§3) do.
 
 ---
 
 ## 4. Access control (ties to design §7 + Lakekeeper/Cedar)
 
+Row-level access can be enforced at **two layers**, and the surface choice (§2) decides which:
+- **Surface-layer (Superset):** per-role **RLS is already solved as code** (`src/ol_superset/.../apply_rls.py`) — instructor rows filtered to their `courserun_fk`, leadership pointed at the aggregate fact only.
+- **Engine-layer (Marimo / net-new app):** these run queries **as the user** via the Keycloak OIDC → Trino/StarRocks token (the marimo image already does this), so authz can be **pushed to the engine (Lakekeeper/Cedar)** instead of reimplemented in the app — one policy set governs every surface. This aligns with the platform's authz direction and is the preferred model for non-Superset surfaces.
+
 - **Redacted text only** is exposed in any consumption surface (raw text stays in
   `raw`/`stg` under existing PII classification + Lakekeeper/Cedar authz — design §7).
-- **Instructor** dashboards are row-filtered to their `courserun_fk` (Superset RLS or a
-  Cedar policy on the fact).
 - **Leadership** sees the aggregate fact only (no row-level text) — enforced by pointing
   their dashboards at `afact_feedback_cluster_daily`, not `tfact_feedback`.
 - Re-applying PII classification + Lakekeeper/Cedar authz at the new fact/dims is tracked by
@@ -94,8 +118,10 @@ MVP, upgrading to a UI when volume warrants (`feedback_ml_approach.md` §D).
 ## 5. What the MVP consumption slice actually delivers
 
 Given the MVP is Zendesk-only and not course-scoped: **support + engineering get working
-cluster-triage dashboards; leadership gets Zendesk-only category/sentiment trends;
-instructors get nothing until Phase 2 course-scoped sources land.** That is the honest
-scope — the model supports all four, but only two-and-a-half audiences are served by the
-first data slice. This is acceptable because support/eng recurring-issue triage is the
-primary stated motivation.
+cluster-triage dashboards (Superset); a curator gets the label-approval loop (Marimo);
+leadership gets Zendesk-only category/sentiment trends; instructors get nothing until Phase 2
+course-scoped sources land.** That is the honest scope — the model supports all four audiences and
+all three surfaces, but only two-and-a-half audiences are served by the first data slice. This is
+acceptable because support/eng recurring-issue triage is the primary stated motivation. The
+surface decision stays reversible: start with Superset + a Marimo curation/exploration notebook,
+and only build a net-new app once the Marimo prototype proves the workflow warrants it.

--- a/docs/design/feedback_consumption_ux_spec.md
+++ b/docs/design/feedback_consumption_ux_spec.md
@@ -62,10 +62,17 @@ This ordering keeps commitment low (all three read the same tables) and treats M
 discovery vehicle between "a dashboard is enough" and "we need a real app."
 
 **MVP surface content (Superset unless noted):**
-1. **Support triage** — cluster list ranked by size/recency, filterable by
-   `source_status`/`source_priority`/`source_channel`/`source_tags`, each cluster
-   drill-through to constituent (redacted) tickets with `source_url` deep-links back to
-   Zendesk. Sentiment facet from `dim_sentiment`.
+1. **Support triage** — cluster list ranked by **distinct conversation count** (not row count — at turn
+   grain one verbose ticket contributes many turns) and recency, filterable by
+   `dim_feedback_channel`, tags via `bridge_feedback_tag`, and status/priority extracted from
+   `source_metadata` with `json_query_string`. Each cluster drills through to constituent (redacted) turns,
+   grouped by `conversation_id`, with `source_url` deep-links back to Zendesk. Sentiment facet from
+   `dim_sentiment`. Conversation-level context (age, resolution state) joins from
+   `afact_feedback_conversation`.
+
+   *Superset note:* the variant column means status/priority are a computed dataset column
+   (`json_query_string(source_metadata, '$.ticket_status')`) rather than a physical one — define them once
+   on the Superset dataset so every chart filters on a named column, not an expression.
 2. **Engineering systemic view** — same cluster list but filtered to systemic clusters
    (HDBSCAN non-noise, above a `min_cluster_size` threshold; noise/one-offs hidden), sorted
    by cluster cohesion/size, with category labels from `dim_feedback_category`.

--- a/docs/design/feedback_consumption_ux_spec.md
+++ b/docs/design/feedback_consumption_ux_spec.md
@@ -12,8 +12,14 @@ side that validates the model actually serves its audiences.
 
 ## 1. Audiences × altitude (from the RFC)
 
-Four audiences at three altitudes. Each maps to a specific slice of `tfact_feedback` +
-`dim_feedback_category`/`dim_sentiment` and a specific row-level access rule.
+Four audiences at three altitudes. Each maps to a specific slice of the fact pair —
+`afact_feedback_conversation` (the analysis unit: summary, cluster, category, sentiment) drilling through to
+`tfact_feedback` (the turns) — plus a specific row-level access rule.
+
+> **Rev. 3 note.** Cluster listings, category and sentiment now read from
+> `afact_feedback_conversation`; `tfact_feedback` is the drill-down target, not the primary query surface.
+> The practical gain for consumers is that a cluster row carries an LLM summary of the conversation, so a
+> triage list is readable without expanding threads.
 
 | Audience | Altitude | Core question | Grain they work at | Row-level access |
 |---|---|---|---|---|
@@ -46,8 +52,8 @@ platform **already operates**:
 **Recommendation — phased and audience-matched, not one surface:**
 1. **MVP (fastest value): Superset** for leadership trends and the support/eng cluster tables —
    it's already operated, RLS is already solved as code, and it matches the RFC's
-   "near-zero new infrastructure" posture. Datasets point at `tfact_feedback` /
-   `afact_feedback_cluster_daily` / the dims.
+   "near-zero new infrastructure" posture. Datasets point at `afact_feedback_conversation` /
+   `afact_feedback_cluster_daily` / the dims, with `tfact_feedback` as the drill-through detail.
 2. **Interactive + curation surface: a deployed Marimo notebook-as-webapp** — the right home for
    cluster exploration, semantic search, and the **category-curation loop** (approve/merge
    LLM-proposed labels), and the **cheapest way to prototype the real UX** before deciding whether
@@ -62,13 +68,13 @@ This ordering keeps commitment low (all three read the same tables) and treats M
 discovery vehicle between "a dashboard is enough" and "we need a real app."
 
 **MVP surface content (Superset unless noted):**
-1. **Support triage** — cluster list ranked by **distinct conversation count** (not row count — at turn
-   grain one verbose ticket contributes many turns) and recency, filterable by
-   `dim_feedback_channel`, tags via `bridge_feedback_tag`, and status/priority extracted from
-   `source_metadata` with `json_query_string`. Each cluster drills through to constituent (redacted) turns,
-   grouped by `conversation_id`, with `source_url` deep-links back to Zendesk. Sentiment facet from
-   `dim_sentiment`. Conversation-level context (age, resolution state) joins from
-   `afact_feedback_conversation`.
+1. **Support triage** — cluster list over `afact_feedback_conversation`, ranked by conversation count and
+   recency (at conversation grain the cluster's member count *is* its conversation count, so rev. 2's
+   distinct-count workaround is gone), filterable by `dim_feedback_channel`, tags via `bridge_feedback_tag`,
+   and status/priority extracted from `source_metadata` with `json_query_string`. Each cluster lists its
+   conversations **by `conversation_summary`** — readable without expanding anything — and each conversation
+   drills through to its constituent (redacted) turns in `tfact_feedback`, with `source_url` deep-links back
+   to Zendesk. Sentiment facet from `dim_sentiment`; age and resolution state are columns on the same row.
 
    *Superset note:* the variant column means status/priority are a computed dataset column
    (`json_query_string(source_metadata, '$.ticket_status')`) rather than a physical one — define them once
@@ -115,9 +121,14 @@ Row-level access can be enforced at **two layers**, and the surface choice (§2)
 
 - **Redacted text only** is exposed in any consumption surface (raw text stays in
   `raw`/`stg` under existing PII classification + Lakekeeper/Cedar authz — design §7).
-- **Leadership** sees the aggregate fact only (no row-level text) — enforced by pointing
-  their dashboards at `afact_feedback_cluster_daily`, not `tfact_feedback`.
-- Re-applying PII classification + Lakekeeper/Cedar authz at the new fact/dims is tracked by
+  **`conversation_summary` counts as text for this purpose** — it is generated from redacted input and
+  inherits that classification, so it is governed exactly like `feedback_text`, not treated as an
+  aggregate.
+- **Leadership** sees the aggregate rollup only (no row-level text) — enforced by pointing
+  their dashboards at `afact_feedback_cluster_daily`, **not** `afact_feedback_conversation`. Note the
+  rev. 3 sharpening: the conversation fact is an `afact_` but it is *not* text-free, so "leadership sees
+  aggregates" can no longer be read as "leadership sees anything prefixed `afact_`".
+- Re-applying PII classification + Lakekeeper/Cedar authz at the new facts/dims is tracked by
   `tk-re-apply-pii-classification-lakekeeper-cedar-aut-1b3516` (p3).
 
 ---

--- a/docs/design/feedback_dagster_asset_spec.md
+++ b/docs/design/feedback_dagster_asset_spec.md
@@ -9,17 +9,23 @@ LLM-proposed categories, and sentiment. Grounded in the existing repo orchestrat
 patterns. **The fact ships without this asset**; this is purely additive (fills
 `embedding_id`, `category_fk`, `sentiment_fk`, and the `feedback_embeddings` sidecar).
 
-> **REVISED 2026-07-10 (rev. 2) — see [`adr_embedding_compute_strategy.md`](./adr_embedding_compute_strategy.md).**
+> **REVISED 2026-07-10 (rev. 3) — see [`adr_embedding_compute_strategy.md`](./adr_embedding_compute_strategy.md).**
 > Because the strategic direction is to **retire Trino for StarRocks**, all AI compute stays
 > **engine-external and portable** — no engine-native AI SQL functions (Starburst's are
-> Galaxy-only; StarRocks has none). So the embedding stage stays a Dagster asset, but it is a
-> **thin boto3 AWS Bedrock call** (`amazon.titan-embed-text-v2:0`), **not** torch/sentence-transformers
-> and **not** a Starburst `trino_only` dbt model. Auth via the Dagster pod IAM role
-> (`bedrock:InvokeModel`), likely no Vault secret. Vectors land in an open Iceberg `ARRAY<float>`
-> sidecar (StarRocks reads it later to build an HNSW index — a load, not a re-embed). Sentiment
-> stays the explicit-CSAT + embedding-kNN path (no `analyze_sentiment`). §2–§6 below describe the
-> asset shape; substitute the boto3-Bedrock client for the local embedding model where §4 lists
-> `sentence-transformers` (that is now the fallback, not the default).
+> Galaxy-only; StarRocks has none). The embedding/sentiment/labeling stages run via **Fenic
+> (Apache-2.0)** inside a Dagster asset — not torch, not a Starburst `trino_only` dbt model.
+> **Embedding provider is a PII-policy choice:** in-account AWS Bedrock
+> `amazon.titan-embed-text-v2:0` (via boto3 today — native Fenic Bedrock *embeddings* are
+> roadmap-not-shipped — or contribute the provider), or a Fenic-native managed provider
+> (Cohere/OpenAI/Google) over redacted text if policy allows. Bedrock auth via the Dagster pod
+> IAM role (`bedrock:InvokeModel`), likely no Vault secret; a managed provider uses a
+> Vault-stored key via the existing `ConfigurableResource` pattern. Vectors land in an open
+> Iceberg `ARRAY<float>` sidecar (StarRocks reads it later to build an HNSW index — a load, not a
+> re-embed). **Clustering stays our own sklearn UMAP+HDBSCAN** (Fenic has K-means only, no noise
+> class). Sentiment defaults to the explicit-CSAT + embedding-kNN path. Fenic does not read
+> Iceberg natively — stage via Parquet/S3 or hand it the in-memory frame (confirm at
+> implementation). §2–§6 below describe the asset shape; substitute Fenic (or a boto3 Bedrock
+> client) for the local `sentence-transformers` model where §4 lists it (now a fallback).
 
 ---
 

--- a/docs/design/feedback_dagster_asset_spec.md
+++ b/docs/design/feedback_dagster_asset_spec.md
@@ -9,16 +9,17 @@ LLM-proposed categories, and sentiment. Grounded in the existing repo orchestrat
 patterns. **The fact ships without this asset**; this is purely additive (fills
 `embedding_id`, `category_fk`, `sentiment_fk`, and the `feedback_embeddings` sidecar).
 
-> **REVISED 2026-07-10 — see [`adr_embedding_compute_strategy.md`](./adr_embedding_compute_strategy.md).**
-> Because production runs **Starburst Galaxy** (Trino), the **embedding** and **model-based
-> sentiment** stages move OUT of this Python asset and INTO `trino_only` dbt models using
-> Starburst AI functions (`generate_embedding` → Iceberg `ARRAY(DOUBLE)`; `analyze_sentiment`).
-> This asset then shrinks to **only what SQL cannot do: clustering + LLM cluster-labeling** —
-> read pre-computed vectors from the Iceberg sidecar → UMAP+HDBSCAN → LLM-label clusters. No
-> embedding model in the image (no torch/sentence-transformers), so it stays a small
-> sklearn/UMAP CPU asset still cloned from `student_risk_probability`. §2–§6 below describe the
-> full-fat Python version; treat the embed/sentiment assets there as the fallback used only if
-> the Starburst AI preview is not adopted (ADR "Alternatives").
+> **REVISED 2026-07-10 (rev. 2) — see [`adr_embedding_compute_strategy.md`](./adr_embedding_compute_strategy.md).**
+> Because the strategic direction is to **retire Trino for StarRocks**, all AI compute stays
+> **engine-external and portable** — no engine-native AI SQL functions (Starburst's are
+> Galaxy-only; StarRocks has none). So the embedding stage stays a Dagster asset, but it is a
+> **thin boto3 AWS Bedrock call** (`amazon.titan-embed-text-v2:0`), **not** torch/sentence-transformers
+> and **not** a Starburst `trino_only` dbt model. Auth via the Dagster pod IAM role
+> (`bedrock:InvokeModel`), likely no Vault secret. Vectors land in an open Iceberg `ARRAY<float>`
+> sidecar (StarRocks reads it later to build an HNSW index — a load, not a re-embed). Sentiment
+> stays the explicit-CSAT + embedding-kNN path (no `analyze_sentiment`). §2–§6 below describe the
+> asset shape; substitute the boto3-Bedrock client for the local embedding model where §4 lists
+> `sentence-transformers` (that is now the fallback, not the default).
 
 ---
 

--- a/docs/design/feedback_dagster_asset_spec.md
+++ b/docs/design/feedback_dagster_asset_spec.md
@@ -14,12 +14,12 @@ patterns. **The fact ships without this asset**; this is purely additive (fills
 > **engine-external and portable** — no engine-native AI SQL functions (Starburst's are
 > Galaxy-only; StarRocks has none). The embedding/sentiment/labeling stages run via **Fenic
 > (Apache-2.0)** inside a Dagster asset — not torch, not a Starburst `trino_only` dbt model.
-> **Embedding provider is a PII-policy choice:** in-account AWS Bedrock
-> `amazon.titan-embed-text-v2:0` (via boto3 today — native Fenic Bedrock *embeddings* are
-> roadmap-not-shipped — or contribute the provider), or a Fenic-native managed provider
-> (Cohere/OpenAI/Google) over redacted text if policy allows. Bedrock auth via the Dagster pod
-> IAM role (`bedrock:InvokeModel`), likely no Vault secret; a managed provider uses a
-> Vault-stored key via the existing `ConfigurableResource` pattern. Vectors land in an open
+> **Embedding model is chosen by task effectiveness** (Bedrock not required) — MTEB-narrowed
+> shortlist benchmarked on a labeled Zendesk sample (`feedback_ml_approach.md` §B.1): Fenic-native
+> managed (`gemini-embedding-001`/Cohere `embed-v4`/OpenAI `text-embedding-3-large`) or
+> self-hosted open (Qwen3/BGE-M3). Egress of Presidio-redacted text is acceptable. A managed
+> provider uses a Vault-stored key via the existing `ConfigurableResource` pattern; a self-hosted
+> model needs no secret but a heavier image. Choice is reversible via `model_version`. Vectors land in an open
 > Iceberg `ARRAY<float>` sidecar (StarRocks reads it later to build an HNSW index — a load, not a
 > re-embed). **Clustering stays our own sklearn UMAP+HDBSCAN** (Fenic has K-means only, no noise
 > class). Sentiment defaults to the explicit-CSAT + embedding-kNN path. Fenic does not read

--- a/docs/design/feedback_dagster_asset_spec.md
+++ b/docs/design/feedback_dagster_asset_spec.md
@@ -147,7 +147,7 @@ class LLMClientFactory(ConfigurableResource):
     vault_mount_point: str = Field(default="secret-data")
     vault_secret_path: str = Field(default="pipelines/feedback-llm")  # NEW Vault path to provision
     vault_secret_key: str = Field(default="api_key")
-    _client = PrivateAttr(default=None)
+    _client: Anthropic | None = PrivateAttr(default=None)
 
     def get_client(self):
         if self._client is None:

--- a/docs/design/feedback_dagster_asset_spec.md
+++ b/docs/design/feedback_dagster_asset_spec.md
@@ -1,0 +1,182 @@
+# Feedback Aggregation — Dagster ML Asset Spec (MVP)
+
+Status: **spec** · Project: `wp-feedback-aggregation-clustering-system-2e9750`
+Date: 2026-07-10 · Companion to [`feedback_zendesk_mvp_spec.md`](./feedback_zendesk_mvp_spec.md)
+and [`feedback_ml_approach.md`](./feedback_ml_approach.md)
+
+The scheduled batch job that turns the redacted feedback fact into embeddings, clusters,
+LLM-proposed categories, and sentiment. Grounded in the existing repo orchestration
+patterns. **The fact ships without this asset**; this is purely additive (fills
+`embedding_id`, `category_fk`, `sentiment_fk`, and the `feedback_embeddings` sidecar).
+
+---
+
+## 1. Template: clone `student_risk_probability`
+
+There is a near-exact precedent code location: `dg_projects/student_risk_probability/` — a
+standalone `dg`-managed Dagster project whose single Python `@asset` reads a dbt-modeled
+Iceberg table into a Polars frame, runs scikit-learn ML, and writes results back via the
+Iceberg IO manager. **Clone its structure** for a new
+`dg_projects/feedback_clustering/` code location:
+
+```
+dg_projects/feedback_clustering/
+  pyproject.toml            # + NEW deps: embeddings + clustering + LLM + presidio (§4)
+  uv.lock
+  Dockerfile
+  build.yaml
+  feedback_clustering/
+    definitions.py          # Definitions(assets, resources={io_manager, vault, llm}, jobs, schedules)
+    assets/feedback_clustering.py   # thin @asset(s)
+    resources/llm.py        # NEW Vault-backed LLM/embeddings client factory
+    lib/embed.py            # embedding + redaction helpers
+    lib/cluster.py          # UMAP+HDBSCAN helpers
+    lib/label.py            # LLM cluster-labeling + sentiment helpers
+    schedules/              # cron ScheduleDefinition (optional; declarative default)
+```
+
+Scaffold via the `dagster-code-location-structure` skill (`dg`), copying
+`student_risk_probability`'s `definitions.py` (Iceberg `PolarsIcebergIOManager`, Vault
+auth, `define_asset_job`) verbatim as the skeleton. Replicate its Python pin
+(`>=3.14,<3.15`) and its `pyiceberg`/`grpcio` overrides.
+
+---
+
+## 2. Asset graph (MVP)
+
+Model each stage as its own `@asset` so re-runs are granular and cached independently. All
+read/write Iceberg via `get_dbt_model_as_dataframe(...)`
+(`ol_orchestrate.lib.glue_helper`) and the `io_manager` (`PolarsIcebergIOManager`).
+
+```
+[dbt] int__feedback__unioned   (redacted text + feedback_pk)      ← upstream AssetKey dep
+   │
+   ▼
+feedback_embeddings            @asset  → writes feedback_embeddings (feedback_pk, vector,
+   │                                     model_version)  [embedding computed ONCE per model_version]
+   ▼
+feedback_clusters              @asset  → adds cluster_id, cluster_probability, cluster_run_id
+   │                                     to feedback_embeddings (UMAP→HDBSCAN)
+   ├─────────────► feedback_category_proposals  @asset → LLM-labels clusters → dim_feedback_category
+   │                                                     (category_source='llm_discovered', status='proposed')
+   └─────────────► feedback_sentiment           @asset → sentiment per feedback_pk (explicit + kNN/classifier)
+                                                          → writes sentiment_fk assignments
+   ▼
+tfact_feedback late-arriving update  ← category_fk / sentiment_fk / embedding_id upsert by feedback_pk
+```
+
+- **Redaction placement (design §7 / MVP spec §3):** the `feedback_embeddings` asset does
+  the Presidio redaction on its input (or reads an already-redacted `int__feedback__unioned`
+  column). Recommend redaction lives here in Python since Presidio is Python — the fact then
+  reads redacted text produced by this asset. **Decision for implementation:** either (a)
+  the asset writes `text_redacted` back to a table the fact reads, or (b) `int__feedback__unioned`
+  is itself a Python-materialized step. Pick (a) to keep dbt pure-SQL; documented as the one
+  interleave point.
+- **`code_version`** on each asset (as `student_risk_probability` does) so a helper/model
+  change re-triggers via declarative automation.
+- **`pool=`** set per asset (concurrency governed by the production instance pool config —
+  slot limits live in the Dagster UI, not repo config).
+
+---
+
+## 3. Reading & writing data (exact repo helpers)
+
+- **Read** the dbt fact/union: `get_dbt_model_as_dataframe(database_name="ol_warehouse_production_<schema>",
+  table_name="int__feedback__unioned")` → Polars. (Same call `student_risk_probability`
+  uses against `reporting.cheating_detection_report`.)
+- **Write** results: return a `pl.DataFrame` from the asset; the `io_manager` key
+  (`PolarsIcebergIOManager`, configured in `definitions.py`) persists it to the target
+  Iceberg table. `feedback_embeddings` is a new Iceberg table with the schema in
+  `feedback_ml_approach.md` §B/§C.
+- **Late-arriving `category_fk`/`sentiment_fk` back onto `tfact_feedback`:** because dbt owns
+  `tfact_feedback`, the cleanest MVP path is an incremental dbt model / `merge` keyed by
+  `feedback_pk` that reads the assignment table this asset writes — not a direct Python
+  mutation of the fact. So the asset writes `feedback_category_assignments` /
+  `feedback_sentiment_assignments` Iceberg tables, and a dbt step joins them onto the fact.
+  This keeps the fact dbt-owned and the ML output append-only.
+
+---
+
+## 4. New dependencies (net-new to the repo)
+
+Confirmed absent repo-wide today (no openai/anthropic/sentence-transformers/transformers/
+torch/hdbscan/umap/faiss/qdrant/pgvector anywhere). Add to the **new project's**
+`pyproject.toml` only (keep them out of the shared lib and other locations):
+
+| Purpose | Dep | Notes |
+|---|---|---|
+| Embeddings (local, PII-safe) | `sentence-transformers` (pulls `torch`) | default; CPU ok at MVP. Heavy image — consider a CPU-only torch wheel. |
+| Dim-reduction + clustering | `umap-learn`, `hdbscan` | or use in-stack `scikit-learn` `HDBSCAN`≥1.3 to avoid `hdbscan` compiled dep — decide on image build constraints. `scikit-learn` already proven in-stack. |
+| LLM cluster labeling + (fallback) sentiment | Anthropic client (Claude Haiku/Sonnet class) | one call per *cluster*, not per record — cheap batch. |
+| PII redaction | `presidio-analyzer`, `presidio-anonymizer` (+ spaCy model) | precedent: OM profiler already runs Presidio recognizers. |
+
+**Image-size caveat:** `torch` + spaCy make a large image. If that is a problem, the
+fallback is a hosted embedding API behind the same resource interface (accepting the
+PII-egress tradeoff called out in `feedback_ml_approach.md` §B) — but default to local.
+
+---
+
+## 5. Secrets — Vault `ConfigurableResource` (repo pattern)
+
+API keys come from **HashiCorp Vault via a `ConfigurableResource`**, not `EnvVar`
+(repo convention; `EnvVar` is not used for secrets here). Build an
+`LLMClientFactory(ConfigurableResource)` holding `vault: Vault`, modeled exactly on
+`packages/ol-orchestrate-lib/src/ol_orchestrate/resources/github.py`:
+
+```python
+class LLMClientFactory(ConfigurableResource):
+    vault: Vault = Field(...)
+    vault_mount_point: str = Field(default="secret-data")
+    vault_secret_path: str = Field(default="pipelines/feedback-llm")  # NEW Vault path to provision
+    vault_secret_key: str = Field(default="api_key")
+    _client = PrivateAttr(default=None)
+
+    def get_client(self):
+        if self._client is None:
+            data = self.vault.client.secrets.kv.v1.read_secret(
+                mount_point=self.vault_mount_point, path=self.vault_secret_path)
+            self._client = Anthropic(api_key=data["data"][self.vault_secret_key])
+        return self._client
+```
+
+Register in `Definitions.resources` alongside the `vault` resource
+(`authenticate_vault(DAGSTER_ENV, VAULT_ADDRESS)` with the resilient-load fallback, as in
+`student_risk_probability/definitions.py`). **Action item:** provision a Vault secret path
+(e.g. `pipelines/feedback-llm`) for the LLM key. A local embedding model needs no secret.
+
+---
+
+## 6. Scheduling
+
+Two options, both in use in the repo:
+- **(recommend) Declarative automation:** put `automation_condition=upstream_or_code_changes()`
+  (`ol_orchestrate.lib.automation_policies`) on the `feedback_embeddings` asset so it re-runs
+  when `int__feedback__unioned` refreshes or the code version changes. Downstream cluster/
+  label/sentiment assets chain off it. This is what `student_risk_probability` and the dbt
+  assets use — no cron to maintain.
+- **Cron alternative:** wrap the assets in `define_asset_job(...)` + a
+  `dg.ScheduleDefinition(cron_schedule="0 4 * * *", execution_timezone="Etc/UTC")` (pattern:
+  `dg_projects/data_loading/.../schedules.py`) if a fixed cadence is preferred over
+  data-driven triggering. MVP volume (~198K) runs comfortably in one nightly batch.
+
+---
+
+## 7. Build order (so the fact ships first)
+
+1. dbt models (`feedback_zendesk_mvp_spec.md`) — `tfact_feedback` + dims. **Ships and is
+   useful with tag-seeded categories + CSAT-derived sentiment, no ML.**
+2. Scaffold `dg_projects/feedback_clustering/`; add deps; provision Vault path.
+3. `feedback_embeddings` asset (embed + redact) → sidecar table.
+4. `feedback_clusters` asset (UMAP+HDBSCAN).
+5. `feedback_category_proposals` + `feedback_sentiment` assets → assignment tables.
+6. dbt late-arriving join of assignment tables onto `tfact_feedback` (`category_fk`/`sentiment_fk`).
+7. Human curation loop on `dim_feedback_category` (approve/merge proposed labels).
+
+---
+
+## 8. Explicit non-goals (MVP)
+
+- No online/real-time embedding or serving (batch only).
+- No dedicated vector DB (Iceberg `ARRAY<float>` sidecar; revisit at Phase 2/serving need).
+- No GPU requirement (CPU batch at MVP scale; revisit at full 1.18M-row scale).
+- No cross-source clustering until forum/tutor/ORA sources land (Phase 2).

--- a/docs/design/feedback_dagster_asset_spec.md
+++ b/docs/design/feedback_dagster_asset_spec.md
@@ -9,6 +9,17 @@ LLM-proposed categories, and sentiment. Grounded in the existing repo orchestrat
 patterns. **The fact ships without this asset**; this is purely additive (fills
 `embedding_id`, `category_fk`, `sentiment_fk`, and the `feedback_embeddings` sidecar).
 
+> **REVISED 2026-07-10 — see [`adr_embedding_compute_strategy.md`](./adr_embedding_compute_strategy.md).**
+> Because production runs **Starburst Galaxy** (Trino), the **embedding** and **model-based
+> sentiment** stages move OUT of this Python asset and INTO `trino_only` dbt models using
+> Starburst AI functions (`generate_embedding` → Iceberg `ARRAY(DOUBLE)`; `analyze_sentiment`).
+> This asset then shrinks to **only what SQL cannot do: clustering + LLM cluster-labeling** —
+> read pre-computed vectors from the Iceberg sidecar → UMAP+HDBSCAN → LLM-label clusters. No
+> embedding model in the image (no torch/sentence-transformers), so it stays a small
+> sklearn/UMAP CPU asset still cloned from `student_risk_probability`. §2–§6 below describe the
+> full-fat Python version; treat the embed/sentiment assets there as the fallback used only if
+> the Starburst AI preview is not adopted (ADR "Alternatives").
+
 ---
 
 ## 1. Template: clone `student_risk_probability`

--- a/docs/design/feedback_dagster_asset_spec.md
+++ b/docs/design/feedback_dagster_asset_spec.md
@@ -1,8 +1,9 @@
 # Feedback Aggregation — Dagster ML Asset Spec (MVP)
 
 Status: **spec** · Project: `wp-feedback-aggregation-clustering-system-2e9750`
-Date: 2026-08-10 (rev. 4 — conversation grain) · Companion to
-[`feedback_zendesk_mvp_spec.md`](./feedback_zendesk_mvp_spec.md)
+Date: 2026-08-13 (rev. 5 — `feedback_clusters` is a `@multi_asset`; see
+[#2422 review](https://github.com/mitodl/ol-data-platform/pull/2422)) · rev. 4 (2026-08-10, conversation
+grain) · Companion to [`feedback_zendesk_mvp_spec.md`](./feedback_zendesk_mvp_spec.md)
 and [`feedback_ml_approach.md`](./feedback_ml_approach.md)
 
 The scheduled batch job that turns assembled, redacted conversations into summaries, embeddings, clusters,
@@ -10,6 +11,11 @@ LLM-proposed categories, and sentiment. Grounded in the existing repo orchestrat
 ships without this asset**; this is purely additive — it fills the generated columns on
 `afact_feedback_conversation` and writes `feedback_cluster_run` (see
 [`feedback_erd.md`](./feedback_erd.md) §4/§5).
+
+> **REVISED 2026-08-13 (rev. 5) — `feedback_clusters` is a `@multi_asset`.** §2 specified one stage
+> producing two target tables (`feedback_cluster_run`, `feedback_cluster_candidate`) through a single
+> `@asset`; a plain `@asset` has one materialized output, so that could not actually run as written. Split
+> into two named `AssetOut`s on one `@multi_asset` — same stage, same UMAP+HDBSCAN call, two writes.
 
 > **REVISED 2026-08-10 (rev. 4) — the analysis unit is the conversation** (design §5a). The asset reads
 > `int__feedback__conversation` (one row per conversation, turns assembled and ordered) instead of
@@ -85,9 +91,13 @@ feedback_summaries             @asset  → conversation_summary + summary_model_
 feedback_embeddings            @asset  → embedding_vector, embedding_dim, embedding_input,
    │                                     embedding_model_version   [computed ONCE per version]
    ▼
-feedback_clusters              @asset  → writes feedback_cluster_run (one row: algorithm, params,
-   │                                     cluster_count, noise_count, silhouette) + cluster_id /
-   │                                     cluster_probability per conversation  (UMAP→HDBSCAN)
+feedback_clusters              @multi_asset (two AssetOuts — fixed rev. 4, @copilot: a plain @asset has one
+   │                                     materialized output and cannot populate two target tables from one
+   │                                     DataFrame through PolarsIcebergIOManager)
+   │           ├─ out: feedback_cluster_run       → one row: algorithm, params, cluster_count, noise_count,
+   │           │                                     silhouette   (UMAP→HDBSCAN, run-level)
+   │           └─ out: feedback_cluster_candidate → cluster_id / cluster_probability per conversation
+   │                                                 (per-conversation, this run only — §4f/design §4f)
    ├─────────────► feedback_category_proposals  @asset → LLM-labels clusters → dim_feedback_category
    │                                                     (category_source='llm_discovered', status='proposed',
    │                                                      cluster_run_id = provenance)
@@ -127,7 +137,8 @@ Promotion copies the assignment onto `afact_feedback_conversation` and drops the
   uses against `reporting.cheating_detection_report`.)
 - **Write** results: return a `pl.DataFrame` from the asset; the `io_manager` key
   (`PolarsIcebergIOManager`, configured in `definitions.py`) persists it to the target
-  Iceberg table. `feedback_cluster_run` and `feedback_cluster_candidate` are new Iceberg tables with the
+  Iceberg table. `feedback_clusters` (§2) returns **two** DataFrames, one per `AssetOut`, since it is a
+  `@multi_asset`. `feedback_cluster_run` and `feedback_cluster_candidate` are new Iceberg tables with the
   schemas in `feedback_ml_approach.md` §A (ERD: [`feedback_erd.md`](./feedback_erd.md) §5).
 - **Getting the generated columns onto `afact_feedback_conversation`:** dbt owns that table, so the assets
   write per-stage Iceberg output tables (`feedback_summaries`, `feedback_embeddings`,

--- a/docs/design/feedback_dagster_asset_spec.md
+++ b/docs/design/feedback_dagster_asset_spec.md
@@ -1,15 +1,21 @@
 # Feedback Aggregation — Dagster ML Asset Spec (MVP)
 
 Status: **spec** · Project: `wp-feedback-aggregation-clustering-system-2e9750`
-Date: 2026-07-10 · Companion to [`feedback_zendesk_mvp_spec.md`](./feedback_zendesk_mvp_spec.md)
+Date: 2026-08-10 (rev. 4 — conversation grain) · Companion to
+[`feedback_zendesk_mvp_spec.md`](./feedback_zendesk_mvp_spec.md)
 and [`feedback_ml_approach.md`](./feedback_ml_approach.md)
 
-The scheduled batch job that turns the redacted feedback fact into embeddings, clusters,
-LLM-proposed categories, and sentiment. Grounded in the existing repo orchestration
-patterns. **The fact ships without this asset**; this is purely additive (fills `category_fk` /
-`sentiment_fk` on the fact and populates the sidecar tables `feedback_embeddings`,
-`feedback_cluster_run`, `feedback_cluster_assignment` — see
-[`feedback_erd.md`](./feedback_erd.md) §3).
+The scheduled batch job that turns assembled, redacted conversations into summaries, embeddings, clusters,
+LLM-proposed categories, and sentiment. Grounded in the existing repo orchestration patterns. **The fact
+ships without this asset**; this is purely additive — it fills the generated columns on
+`afact_feedback_conversation` and writes `feedback_cluster_run` (see
+[`feedback_erd.md`](./feedback_erd.md) §4/§5).
+
+> **REVISED 2026-08-10 (rev. 4) — the analysis unit is the conversation** (design §5a). The asset reads
+> `int__feedback__conversation` (one row per conversation, turns assembled and ordered) instead of
+> `int__feedback__unioned`, gains a **summarization stage** (§2), and writes **one target table** instead of
+> a three-table per-turn sidecar. **It never writes to `tfact_feedback`** — that fact is now insert-only, so
+> the rev. 3 "late-arriving `category_fk`/`sentiment_fk` upsert onto the fact" is gone entirely.
 
 > **REVISED 2026-07-10 (rev. 3) — see [`adr_embedding_compute_strategy.md`](./adr_embedding_compute_strategy.md).**
 > Because the strategic direction is to **retire Trino for StarRocks**, all AI compute stays
@@ -49,6 +55,7 @@ dg_projects/feedback_clustering/
     definitions.py          # Definitions(assets, resources={io_manager, vault, llm}, jobs, schedules)
     assets/feedback_clustering.py   # thin @asset(s)
     resources/llm.py        # NEW Vault-backed LLM/embeddings client factory
+    lib/summarize.py        # conversation summarization + the skip rule (ml §A.1)
     lib/embed.py            # embedding + redaction helpers
     lib/cluster.py          # UMAP+HDBSCAN helpers
     lib/label.py            # LLM cluster-labeling + sentiment helpers
@@ -69,39 +76,42 @@ read/write Iceberg via `get_dbt_model_as_dataframe(...)`
 (`ol_orchestrate.lib.glue_helper`) and the `io_manager` (`PolarsIcebergIOManager`).
 
 ```
-[dbt] int__feedback__unioned   (redacted text + feedback_pk)      ← upstream AssetKey dep
+[dbt] int__feedback__conversation  (redacted turns assembled per conversation)  ← upstream AssetKey dep
    │
    ▼
-feedback_embeddings            @asset  → writes feedback_embeddings
-   │                                     grain (feedback_pk, model_version); vector, vector_dim,
-   │                                     text_variant  [embedding computed ONCE per model_version]
+feedback_summaries             @asset  → conversation_summary + summary_model_version
+   │                                     SKIPS turn_count = 1 and short conversations (ml §A.1)
+   ▼
+feedback_embeddings            @asset  → embedding_vector, embedding_dim, embedding_input,
+   │                                     embedding_model_version   [computed ONCE per version]
    ▼
 feedback_clusters              @asset  → writes feedback_cluster_run (one row: algorithm, params,
-   │                                     cluster_count, noise_count, silhouette) AND
-   │                                     feedback_cluster_assignment, grain
-   │                                     (feedback_pk, cluster_run_id)  (UMAP→HDBSCAN)
-   │                                     — it NEVER writes back to feedback_embeddings
+   │                                     cluster_count, noise_count, silhouette) + cluster_id /
+   │                                     cluster_probability per conversation  (UMAP→HDBSCAN)
    ├─────────────► feedback_category_proposals  @asset → LLM-labels clusters → dim_feedback_category
    │                                                     (category_source='llm_discovered', status='proposed',
    │                                                      cluster_run_id = provenance)
-   └─────────────► feedback_sentiment           @asset → sentiment per feedback_pk (explicit + kNN/classifier)
-                                                          → writes sentiment_fk assignments
+   └─────────────► feedback_sentiment           @asset → sentiment per conversation
+                                                          (explicit rating + kNN/classifier)
    ▼
-tfact_feedback late-arriving update  ← category_fk / sentiment_fk upsert by feedback_pk
+afact_feedback_conversation  ← the generated columns, one row per conversation
 ```
 
-The clustering asset writing its own tables rather than mutating `feedback_embeddings` is the
-grain split from `feedback_ml_approach.md` §A: vectors are per `(feedback_pk, model_version)`,
-assignments are per `(feedback_pk, cluster_run_id)`. Re-clustering is then append-only and can
-never disturb the vectors it read.
+Asset names are retained from rev. 3 where the stage is the same; what changed is the grain (conversation,
+not turn) and the target (one fact table, not three sidecars). Each stage stamps its own version column, so
+re-running one stage does not invalidate the others: re-clustering reuses the stored vectors, and re-embedding
+reuses the stored summaries.
 
-- **Redaction placement (design §7 / MVP spec §3):** the `feedback_embeddings` asset does
-  the Presidio redaction on its input (or reads an already-redacted `int__feedback__unioned`
-  column). Recommend redaction lives here in Python since Presidio is Python — the fact then
-  reads redacted text produced by this asset. **Decision for implementation:** either (a)
-  the asset writes `text_redacted` back to a table the fact reads, or (b) `int__feedback__unioned`
-  is itself a Python-materialized step. Pick (a) to keep dbt pure-SQL; documented as the one
-  interleave point.
+**Unpromoted runs** go to `feedback_cluster_candidate`, not straight onto the fact — that is what lets a
+proposed run be compared against the live one during the embedding bake-off (`feedback_ml_approach.md` §B.1).
+Promotion copies the assignment onto `afact_feedback_conversation` and drops the candidate rows.
+
+- **Redaction placement (design §7 / MVP spec §3):** unchanged in substance — Presidio is Python, so
+  redaction happens in a Python asset upstream of both the fact and this pipeline. **Decision for
+  implementation:** either (a) an asset writes `text_redacted` back to a table the fact reads, or (b)
+  `int__feedback__unioned` is itself a Python-materialized step. Pick (a) to keep dbt pure-SQL; documented as
+  the one interleave point. Note the assembly step (`int__feedback__conversation`) is plain SQL over
+  already-redacted turns, so it adds no new interleave.
 - **`code_version`** on each asset (as `student_risk_probability` does) so a helper/model
   change re-triggers via declarative automation.
 - **`pool=`** set per asset (concurrency governed by the production instance pool config —
@@ -111,20 +121,21 @@ never disturb the vectors it read.
 
 ## 3. Reading & writing data (exact repo helpers)
 
-- **Read** the dbt fact/union: `get_dbt_model_as_dataframe(database_name="ol_warehouse_production_<schema>",
-  table_name="int__feedback__unioned")` → Polars. (Same call `student_risk_probability`
+- **Read** the assembled conversations:
+  `get_dbt_model_as_dataframe(database_name="ol_warehouse_production_<schema>",
+  table_name="int__feedback__conversation")` → Polars. (Same call `student_risk_probability`
   uses against `reporting.cheating_detection_report`.)
 - **Write** results: return a `pl.DataFrame` from the asset; the `io_manager` key
   (`PolarsIcebergIOManager`, configured in `definitions.py`) persists it to the target
-  Iceberg table. `feedback_embeddings`, `feedback_cluster_run` and `feedback_cluster_assignment`
-  are new Iceberg tables with the schemas in `feedback_ml_approach.md` §A/§B/§C
-  (ERD: [`feedback_erd.md`](./feedback_erd.md) §3).
-- **Late-arriving `category_fk`/`sentiment_fk` back onto `tfact_feedback`:** because dbt owns
-  `tfact_feedback`, the cleanest MVP path is an incremental dbt model / `merge` keyed by
-  `feedback_pk` that reads the assignment table this asset writes — not a direct Python
-  mutation of the fact. So the asset writes `feedback_category_assignments` /
-  `feedback_sentiment_assignments` Iceberg tables, and a dbt step joins them onto the fact.
-  This keeps the fact dbt-owned and the ML output append-only.
+  Iceberg table. `feedback_cluster_run` and `feedback_cluster_candidate` are new Iceberg tables with the
+  schemas in `feedback_ml_approach.md` §A (ERD: [`feedback_erd.md`](./feedback_erd.md) §5).
+- **Getting the generated columns onto `afact_feedback_conversation`:** dbt owns that table, so the assets
+  write per-stage Iceberg output tables (`feedback_summaries`, `feedback_embeddings`,
+  `feedback_cluster_assignments`, `feedback_sentiment_assignments`) keyed by `feedback_conversation_pk`, and
+  the dbt model left-joins them onto the conversation aggregate. Same pattern as rev. 3, one grain up — and
+  because the target is a derived aggregate rather than a transactional fact, this join is a plain rebuild
+  rather than an incremental `merge` into a fact with consumers.
+- **Nothing writes to `tfact_feedback`.** There is no ML-owned column on it any more.
 
 ---
 
@@ -138,7 +149,7 @@ torch/hdbscan/umap/faiss/qdrant/pgvector anywhere). Add to the **new project's**
 |---|---|---|
 | Embeddings (local, PII-safe) | `sentence-transformers` (pulls `torch`) | default; CPU ok at MVP. Heavy image — consider a CPU-only torch wheel. |
 | Dim-reduction + clustering | `umap-learn`, `hdbscan` | or use in-stack `scikit-learn` `HDBSCAN`≥1.3 to avoid `hdbscan` compiled dep — decide on image build constraints. `scikit-learn` already proven in-stack. |
-| LLM cluster labeling + (fallback) sentiment | Anthropic client (Claude Haiku/Sonnet class) | one call per *cluster*, not per record — cheap batch. |
+| Conversation summarization + LLM cluster labeling + (fallback) sentiment | Anthropic client (Claude Haiku/Sonnet class) | **Two different cost profiles:** labeling is one call per *cluster* (hundreds — trivial); summarization is one call per *multi-turn conversation* (`feedback_ml_approach.md` §A.1 — the one per-record LLM cost, low hundreds of dollars one-time for Zendesk, to be sample-measured). Batch both; cap and checkpoint the summarizer so a failed run does not re-pay for work already done. |
 | PII redaction | `presidio-analyzer`, `presidio-anonymizer` (+ spaCy model) | precedent: OM profiler already runs Presidio recognizers. |
 
 **Image-size caveat:** `torch` + spaCy make a large image. If that is a problem, the
@@ -181,35 +192,43 @@ Register in `Definitions.resources` alongside the `vault` resource
 
 Two options, both in use in the repo:
 - **(recommend) Declarative automation:** put `automation_condition=upstream_or_code_changes()`
-  (`ol_orchestrate.lib.automation_policies`) on the `feedback_embeddings` asset so it re-runs
-  when `int__feedback__unioned` refreshes or the code version changes. Downstream cluster/
+  (`ol_orchestrate.lib.automation_policies`) on the `feedback_summaries` asset so it re-runs
+  when `int__feedback__conversation` refreshes or the code version changes. Downstream embed/cluster/
   label/sentiment assets chain off it. This is what `student_risk_probability` and the dbt
-  assets use — no cron to maintain.
+  assets use — no cron to maintain. **Caveat now that summarization costs money per conversation:** make the
+  summarizer incremental on `feedback_conversation_pk` (only unsummarized or changed conversations), or an
+  upstream refresh re-pays for the whole corpus.
 - **Cron alternative:** wrap the assets in `define_asset_job(...)` + a
   `dg.ScheduleDefinition(cron_schedule="0 4 * * *", execution_timezone="Etc/UTC")` (pattern:
   `dg_projects/data_loading/.../schedules.py`) if a fixed cadence is preferred over
-  data-driven triggering. MVP volume is the Zendesk turn count (`feedback_ml_approach.md` §B.2 — the old
-  ~198K ticket figure no longer applies); still expected to run comfortably in one nightly batch, but
-  confirm against the measurement before fixing the schedule.
+  data-driven triggering. MVP volume is ~198K Zendesk **conversations** (`feedback_ml_approach.md` §B.2),
+  which runs comfortably in one nightly batch; only the first backfill is large, and it is bounded by the
+  summarizer's throughput rather than the embedder's.
 
 ---
 
 ## 7. Build order (so the fact ships first)
 
-1. dbt models (`feedback_zendesk_mvp_spec.md`) — `tfact_feedback` + dims. **Ships and is
-   useful with tag-seeded categories + CSAT-derived sentiment, no ML.**
+1. dbt models (`feedback_zendesk_mvp_spec.md`) — `tfact_feedback` + dims +
+   `int__feedback__conversation` + `afact_feedback_conversation` with its **lifecycle columns only**.
+   **Ships and is useful with tag-seeded categories + CSAT-derived sentiment, no ML.**
 2. Scaffold `dg_projects/feedback_clustering/`; add deps; provision Vault path.
-3. `feedback_embeddings` asset (embed + redact) → vector sidecar.
-4. `feedback_clusters` asset (UMAP+HDBSCAN) → `feedback_cluster_run` + `feedback_cluster_assignment`.
-5. `feedback_category_proposals` + `feedback_sentiment` assets → assignment tables.
-6. dbt late-arriving join of assignment tables onto `tfact_feedback` (`category_fk`/`sentiment_fk`).
-7. Human curation loop on `dim_feedback_category` (approve/merge proposed labels).
+3. `feedback_summaries` asset (multi-turn conversations only) — **sample-measure the cost first** (§4).
+4. `feedback_embeddings` asset → vectors keyed by `feedback_conversation_pk`.
+5. `feedback_clusters` asset (UMAP+HDBSCAN) → `feedback_cluster_run` + assignments.
+6. `feedback_category_proposals` + `feedback_sentiment` assets → assignment tables.
+7. dbt join of the stage outputs onto `afact_feedback_conversation`'s generated columns.
+8. Human curation loop on `dim_feedback_category` (approve/merge proposed labels), and run promotion
+   (candidate → live cluster assignment).
 
 ---
 
 ## 8. Explicit non-goals (MVP)
 
 - No online/real-time embedding or serving (batch only).
-- No dedicated vector DB (Iceberg `ARRAY<float>` sidecar; revisit at Phase 2/serving need).
-- No GPU requirement (CPU batch at MVP scale; revisit at full 1.18M-row scale).
+- No dedicated vector DB (Iceberg `ARRAY<float>` column on the conversation fact; revisit at Phase 2/serving
+  need).
+- No GPU requirement (CPU batch at MVP scale; revisit at the full ~600K-conversation scale).
 - No cross-source clustering until forum/tutor/ORA sources land (Phase 2).
+- **No turn-level embeddings.** Conversations only; the turn grain in `tfact_feedback` keeps the option open
+  if a retrieval use case ever needs it.

--- a/docs/design/feedback_dagster_asset_spec.md
+++ b/docs/design/feedback_dagster_asset_spec.md
@@ -188,7 +188,9 @@ Two options, both in use in the repo:
 - **Cron alternative:** wrap the assets in `define_asset_job(...)` + a
   `dg.ScheduleDefinition(cron_schedule="0 4 * * *", execution_timezone="Etc/UTC")` (pattern:
   `dg_projects/data_loading/.../schedules.py`) if a fixed cadence is preferred over
-  data-driven triggering. MVP volume (~198K) runs comfortably in one nightly batch.
+  data-driven triggering. MVP volume is the Zendesk turn count (`feedback_ml_approach.md` §B.2 — the old
+  ~198K ticket figure no longer applies); still expected to run comfortably in one nightly batch, but
+  confirm against the measurement before fixing the schedule.
 
 ---
 

--- a/docs/design/feedback_dagster_asset_spec.md
+++ b/docs/design/feedback_dagster_asset_spec.md
@@ -6,8 +6,10 @@ and [`feedback_ml_approach.md`](./feedback_ml_approach.md)
 
 The scheduled batch job that turns the redacted feedback fact into embeddings, clusters,
 LLM-proposed categories, and sentiment. Grounded in the existing repo orchestration
-patterns. **The fact ships without this asset**; this is purely additive (fills
-`embedding_id`, `category_fk`, `sentiment_fk`, and the `feedback_embeddings` sidecar).
+patterns. **The fact ships without this asset**; this is purely additive (fills `category_fk` /
+`sentiment_fk` on the fact and populates the sidecar tables `feedback_embeddings`,
+`feedback_cluster_run`, `feedback_cluster_assignment` — see
+[`feedback_erd.md`](./feedback_erd.md) §3).
 
 > **REVISED 2026-07-10 (rev. 3) — see [`adr_embedding_compute_strategy.md`](./adr_embedding_compute_strategy.md).**
 > Because the strategic direction is to **retire Trino for StarRocks**, all AI compute stays
@@ -70,18 +72,28 @@ read/write Iceberg via `get_dbt_model_as_dataframe(...)`
 [dbt] int__feedback__unioned   (redacted text + feedback_pk)      ← upstream AssetKey dep
    │
    ▼
-feedback_embeddings            @asset  → writes feedback_embeddings (feedback_pk, vector,
-   │                                     model_version)  [embedding computed ONCE per model_version]
+feedback_embeddings            @asset  → writes feedback_embeddings
+   │                                     grain (feedback_pk, model_version); vector, vector_dim,
+   │                                     text_variant  [embedding computed ONCE per model_version]
    ▼
-feedback_clusters              @asset  → adds cluster_id, cluster_probability, cluster_run_id
-   │                                     to feedback_embeddings (UMAP→HDBSCAN)
+feedback_clusters              @asset  → writes feedback_cluster_run (one row: algorithm, params,
+   │                                     cluster_count, noise_count, silhouette) AND
+   │                                     feedback_cluster_assignment, grain
+   │                                     (feedback_pk, cluster_run_id)  (UMAP→HDBSCAN)
+   │                                     — it NEVER writes back to feedback_embeddings
    ├─────────────► feedback_category_proposals  @asset → LLM-labels clusters → dim_feedback_category
-   │                                                     (category_source='llm_discovered', status='proposed')
+   │                                                     (category_source='llm_discovered', status='proposed',
+   │                                                      cluster_run_id = provenance)
    └─────────────► feedback_sentiment           @asset → sentiment per feedback_pk (explicit + kNN/classifier)
                                                           → writes sentiment_fk assignments
    ▼
-tfact_feedback late-arriving update  ← category_fk / sentiment_fk / embedding_id upsert by feedback_pk
+tfact_feedback late-arriving update  ← category_fk / sentiment_fk upsert by feedback_pk
 ```
+
+The clustering asset writing its own tables rather than mutating `feedback_embeddings` is the
+grain split from `feedback_ml_approach.md` §A: vectors are per `(feedback_pk, model_version)`,
+assignments are per `(feedback_pk, cluster_run_id)`. Re-clustering is then append-only and can
+never disturb the vectors it read.
 
 - **Redaction placement (design §7 / MVP spec §3):** the `feedback_embeddings` asset does
   the Presidio redaction on its input (or reads an already-redacted `int__feedback__unioned`
@@ -104,8 +116,9 @@ tfact_feedback late-arriving update  ← category_fk / sentiment_fk / embedding_
   uses against `reporting.cheating_detection_report`.)
 - **Write** results: return a `pl.DataFrame` from the asset; the `io_manager` key
   (`PolarsIcebergIOManager`, configured in `definitions.py`) persists it to the target
-  Iceberg table. `feedback_embeddings` is a new Iceberg table with the schema in
-  `feedback_ml_approach.md` §B/§C.
+  Iceberg table. `feedback_embeddings`, `feedback_cluster_run` and `feedback_cluster_assignment`
+  are new Iceberg tables with the schemas in `feedback_ml_approach.md` §A/§B/§C
+  (ERD: [`feedback_erd.md`](./feedback_erd.md) §3).
 - **Late-arriving `category_fk`/`sentiment_fk` back onto `tfact_feedback`:** because dbt owns
   `tfact_feedback`, the cleanest MVP path is an incremental dbt model / `merge` keyed by
   `feedback_pk` that reads the assignment table this asset writes — not a direct Python
@@ -184,8 +197,8 @@ Two options, both in use in the repo:
 1. dbt models (`feedback_zendesk_mvp_spec.md`) — `tfact_feedback` + dims. **Ships and is
    useful with tag-seeded categories + CSAT-derived sentiment, no ML.**
 2. Scaffold `dg_projects/feedback_clustering/`; add deps; provision Vault path.
-3. `feedback_embeddings` asset (embed + redact) → sidecar table.
-4. `feedback_clusters` asset (UMAP+HDBSCAN).
+3. `feedback_embeddings` asset (embed + redact) → vector sidecar.
+4. `feedback_clusters` asset (UMAP+HDBSCAN) → `feedback_cluster_run` + `feedback_cluster_assignment`.
 5. `feedback_category_proposals` + `feedback_sentiment` assets → assignment tables.
 6. dbt late-arriving join of assignment tables onto `tfact_feedback` (`category_fk`/`sentiment_fk`).
 7. Human curation loop on `dim_feedback_category` (approve/merge proposed labels).

--- a/docs/design/feedback_dimensional_model.md
+++ b/docs/design/feedback_dimensional_model.md
@@ -35,7 +35,7 @@ excluded (filter to `*.created`).
 
 ```
 -- surrogate + conformed FKs
-feedback_pk           -- generate_surrogate_key([feedback_source, source_natural_key])  (see §6)
+feedback_pk           -- generate_surrogate_key([source_slug, source_record_ref])  (see §6)
 feedback_source_fk    -> dim_feedback_source.feedback_source_pk
 user_fk               -> dim_user.user_pk            (nullable; anonymous/aggregate sources)
 platform_fk           -> dim_platform.platform_pk    (nullable; non-course sources e.g. Zendesk)
@@ -161,11 +161,12 @@ tracking logs share ingress semantics.
 
 ## 6. Business-key strategy (migration-proof)
 
-`feedback_pk = generate_surrogate_key([feedback_source, source_natural_key])` where `source_natural_key` is a
-**stable business identifier from the source system**, never a warehouse/Airbyte/Postgres row PK:
+`feedback_pk = generate_surrogate_key([source_slug, source_record_ref])` where `source_record_ref` is a
+**stable business identifier from the source system**, never a warehouse/Airbyte/Postgres row PK
+(terminology matches the event contract + Zendesk MVP spec):
 
-| Source | source_natural_key |
-|--------|--------------------|
+| Source | source_record_ref |
+|--------|-------------------|
 | Zendesk | `ticket_id` |
 | edX forum | `post_id` |
 | Learn AI tutor | `thread_id` + `checkpoint_pk` (or message index) |
@@ -197,8 +198,9 @@ raw__<source>__…                         (existing per source; new: raw__learn
       → tfact_feedback                    (resolve conformed FKs, generate feedback_pk §6)
         → afact_feedback_cluster_daily    (aggregate fact: cluster × category × sentiment × date × source — strategic rollup)
 ```
-Clustering/labeling jobs (Dagster asset) read `int__feedback__unioned` (redacted) → write `feedback_embeddings`
-+ `dim_feedback_category` + `category_fk`/`sentiment_fk` back onto the fact (late-arriving update).
+Clustering/labeling jobs (Dagster asset) read `int__feedback__unioned` (redacted) and write
+`feedback_embeddings`, `dim_feedback_category`, and `category_fk`/`sentiment_fk` back onto the fact
+(late-arriving update).
 
 ---
 

--- a/docs/design/feedback_dimensional_model.md
+++ b/docs/design/feedback_dimensional_model.md
@@ -1,0 +1,222 @@
+# Feedback Aggregation — Dimensional Model Design
+
+Status: **spec** · Project: `wp-feedback-aggregation-clustering-system-2e9750`
+Date: 2026-07-06 (schema) · See [`README_feedback_aggregation.md`](./README_feedback_aggregation.md) for the full spec set.
+
+Conforms to the existing Kimball layer in `src/ol_dbt/models/dimensional` (`tfact_*` transactional facts,
+`afact_*` aggregate facts, `dim_*` conformed dimensions, surrogate `*_pk` via
+`dbt_utils.generate_surrogate_key`, `*_fk` in facts, `time_fk`/`date_fk`). Precedents: `tfact_discussion_events`,
+`tfact_chatbot_events`.
+
+---
+
+## 1. Grain
+
+**`tfact_feedback` — one row per atomic free-text feedback utterance.**
+
+"Utterance" = the smallest independently-clusterable unit of a source:
+
+| Source | One row = | Text column source |
+|--------|-----------|--------------------|
+| Zendesk | one ticket (first comment) | `ticket_description` (+ `ticket_subject`) |
+| edX forum | one `*.created` post/response/comment | `post_content` (+ `post_title`) |
+| Learn AI tutor | one human turn | `human_message` |
+| ORA peer feedback | one feedback submission | `feedback_text` |
+| edX feedback plugin (new) | one feedback event | `feedback_text` (contract §5) |
+
+Rationale: the ML tasks (embed → cluster → label) operate per-utterance. Ticket *threads* and full tutor
+*conversations* are deliberately **not** the grain — a `conversation_fk` / `thread_id` degenerate key preserves
+the ability to roll up. Agent/bot messages are excluded (not feedback); forum view/vote/follow events are
+excluded (filter to `*.created`).
+
+---
+
+## 2. The fact: `tfact_feedback`
+
+```
+-- surrogate + conformed FKs
+feedback_pk           -- generate_surrogate_key([feedback_source, source_natural_key])  (see §6)
+feedback_source_fk    -> dim_feedback_source.feedback_source_pk
+user_fk               -> dim_user.user_pk            (nullable; anonymous/aggregate sources)
+platform_fk           -> dim_platform.platform_pk    (nullable; non-course sources e.g. Zendesk)
+courserun_fk          -> dim_course_run.courserun_pk  (nullable; only course-scoped sources)
+organization_fk       -> dim_organization.organization_pk (nullable; Zendesk group/org)
+category_fk           -> dim_feedback_category.feedback_category_pk (late-arriving, §4a)
+sentiment_fk          -> dim_sentiment.sentiment_pk           (late-arriving, §4b)
+time_fk               -> dim_time
+date_fk               -> dim_date
+
+-- degenerate / conversational keys
+conversation_id       -- thread/ticket id, source-native (roll up utterances → conversation)
+source_record_id      -- source PK (zendesk ticket_id, forum post_id, checkpoint id, ora id)
+source_url            -- deep link back to origin (ticket api url, forum page_url)
+
+-- text (REDACTED — see §7; raw text never lands in the fact)
+feedback_title        -- subject / post_title (redacted)
+feedback_text         -- description / post_content / human_message / feedback_text (redacted)
+feedback_text_chars   -- length metric (pre-redaction), for sizing/analytics
+embedding_id          -- FK/handle into the embedding + cluster store (§4c); nullable until scored
+
+-- source-native descriptive attributes (kept for facet filters; NOT conformed)
+source_status         -- zendesk ticket_status / null
+source_priority       -- zendesk ticket_priority / null
+source_tags           -- array<varchar>: zendesk ticket_tags, forum roles, etc. (category SEEDS, §4a)
+source_channel        -- zendesk source_channel / tutor agent / forum component
+csat_score            -- zendesk satisfaction_rating_score / tutor rating / null (explicit sentiment)
+
+-- audit
+feedback_occurred_at  -- source event time (created_at / event_timestamp / checkpoint_created_on)
+feedback_ingested_at
+```
+
+Materialized `table`. Nullable FKs are expected and correct: Zendesk has no courserun; forum/tutor have no
+org; anonymous feedback has no user. The fact tolerates sparse conformance — that is what makes it
+*source-flexible*.
+
+---
+
+## 3. Conformed dimensions — REUSED (no new work)
+
+| Dim | Key | Populated for |
+|-----|-----|---------------|
+| `dim_user` | `user_pk` | forum, tutor, ORA, Zendesk (where requester resolves) |
+| `dim_platform` | `platform_pk` | course-scoped sources |
+| `dim_course_run` | `courserun_pk` | forum, tutor, ORA (via `courserun_readable_id`) |
+| `dim_organization` | `organization_pk` | Zendesk (`group_name`/`organization_name`) |
+| `dim_date` / `dim_time` | `date_fk`/`time_fk` | all |
+
+**Identity is the highest-risk join** (cf. open p0 bug `tk-fix-dim-user-null-email-identity-collapse`).
+Resolve `user_fk` via the same paths the existing facts use — `openedx_user_id` → `dim_user.mitlearn_openedx_user_id`
+(forum/tutor), `user_global_id` (tutor `int__learn_ai__chatbot`), email (Zendesk requester, last resort).
+Never key the fact off a source's local PK (§6).
+
+---
+
+## 4. New dimensions
+
+### 4a. `dim_feedback_category` (LLM/embedding-discovered, curated)
+```
+feedback_category_pk   -- generate_surrogate_key([category_slug])
+category_slug          -- stable machine key (survives relabeling)
+category_label         -- human label (LLM-proposed, human-approved)
+category_parent_slug   -- optional hierarchy (cluster → category → theme)
+category_status        -- proposed | approved | merged | deprecated
+category_source        -- 'llm_discovered' | 'seed' | 'manual'
+first_seen_at / updated_at
+```
+Bootstrapped, **not cold-start**: seed from Zendesk `ticket_tags` (2,354 distinct) + `group_name`, then LLM-label
+embedding clusters (task `tk-define-llm-driven-category-discovery`). SCD-lite: relabeling changes `category_label`,
+never `category_slug`. Assignment (`category_fk` on the fact) is late-arriving — a ticket can be categorized after
+insert.
+
+### 4b. `dim_sentiment`
+```
+sentiment_pk           -- generate_surrogate_key([sentiment_slug])
+sentiment_slug         -- 'positive' | 'neutral' | 'negative' | (aspect-based later)
+polarity_score_bucket  -- optional coarse bucket for trend rollups
+```
+Small conformed dim. `sentiment_fk` derived by the sentiment task (`tk-define-sentiment-mapping`) —
+semantic/embedding or LLM. Explicit signals (`csat_score`, tutor `rating`) seed/validate it.
+
+### 4c. `dim_feedback_source`
+```
+feedback_source_pk     -- generate_surrogate_key([source_slug])
+source_slug            -- 'zendesk' | 'edx_forum' | 'learn_ai_tutor' | 'ora' | 'edx_feedback_plugin'
+source_name            -- display
+source_medium          -- 'support_ticket' | 'forum_post' | 'chat' | 'assessment' | 'in_product'
+source_audience_scope  -- 'operational' | 'course' | 'strategic' (see audience memory)
+is_course_scoped       -- bool (whether courserun_fk applies)
+```
+
+### 4d. Embedding + cluster store (NOT in the dimensional schema)
+Vectors and cluster assignments live in a **sidecar** table (`feedback_embeddings`) keyed by `embedding_id`,
+not in `tfact_feedback` (facts stay narrow, embeddings churn on re-clustering). It holds: `embedding_id`,
+`feedback_pk`, `vector`, `cluster_id`, `cluster_run_id`, `model_version`. `dim_feedback_category` is the
+*curated* projection of stable clusters; the sidecar is the *mutable* ML working set. This keeps re-clustering
+from rewriting the fact.
+
+---
+
+## 5. Common feedback event contract (interim↔target bridge)
+
+Both the interim learn-ai landing (`raw__learn_ai__…__feedback`) and the eventual analytics-api/StarRocks
+data-bus MUST emit this shape so `stg__…__feedback` → `tfact_feedback` is source-path-agnostic
+(task `tk-define-stable-common-feedback-event-contract-bus-245a8e`):
+
+```
+source_slug            -- maps to dim_feedback_source
+occurred_at            -- ISO8601
+subject_user_ref       -- global/openedx user id (NOT a source-local PK)
+courserun_readable_id  -- nullable
+platform               -- nullable
+conversation_ref       -- thread/ticket id
+source_record_ref      -- source-native id (idempotency key)
+title / text           -- raw free text (redaction happens in-warehouse, §7)
+source_metadata        -- json: tags, status, priority, channel, csat, etc.
+```
+Align this to the **general data-bus ingestion contract**, not a feedback-specific one, so future openedx
+tracking logs share ingress semantics.
+
+---
+
+## 6. Business-key strategy (migration-proof)
+
+`feedback_pk = generate_surrogate_key([feedback_source, source_natural_key])` where `source_natural_key` is a
+**stable business identifier from the source system**, never a warehouse/Airbyte/Postgres row PK:
+
+| Source | source_natural_key |
+|--------|--------------------|
+| Zendesk | `ticket_id` |
+| edX forum | `post_id` |
+| Learn AI tutor | `thread_id` + `checkpoint_pk` (or message index) |
+| ORA | `submission_uuid` |
+| edX plugin | contract `source_record_ref` |
+
+This is what lets the interim→analytics-api migration be "swap source + backfill + parity" rather than a
+rebuild: the same `feedback_pk` regenerates identically regardless of pipe.
+
+---
+
+## 7. PII handling (mandatory pre-embed)
+
+`ticket_description` and `int__learn_ai__chatbot.human_message` carry emails/phones/names (profiler-flagged
+`PII.Sensitive`). A **redaction step in the `int__` layer** (Presidio — precedent: the OM profiler already runs
+Presidio recognizers) masks entities before text lands in `tfact_feedback` or the embedding store. Raw text
+stays in `raw`/`stg` under existing PII classification + Lakekeeper/Cedar authz; the fact carries redacted text
+only. Access to the fact is still governed per §audience (course instructors see their courserun; support/eng
+see tickets; leadership sees aggregates).
+
+---
+
+## 8. Layering & build path
+
+```
+raw__<source>__…                         (existing per source; new: raw__learn_ai__…__feedback)
+  → stg__<source>__…__feedback           (conform to §5 contract, light typing)
+    → int__feedback__unioned             (UNION all sources into the common shape + redact PII §7)
+      → tfact_feedback                    (resolve conformed FKs, generate feedback_pk §6)
+        → afact_feedback_cluster_daily    (aggregate fact: cluster × category × sentiment × date × source — strategic rollup)
+```
+Clustering/labeling jobs (Dagster asset) read `int__feedback__unioned` (redacted) → write `feedback_embeddings`
++ `dim_feedback_category` + `category_fk`/`sentiment_fk` back onto the fact (late-arriving update).
+
+---
+
+## 9. MVP vs. full
+
+- **MVP (support/eng):** `dim_feedback_source` + `tfact_feedback` restricted to `source_slug='zendesk'`, category
+  seeded from `ticket_tags`, sentiment from `csat_score` + model. ~198K rows, batch. No new dims beyond the three.
+- **Phase 2:** add forum/tutor/ORA sources (fact already tolerates them), enable cross-source
+  `afact_feedback_cluster_daily` for leadership, course-scoped views for instructors.
+- **Phase 3:** analytics-api/data-bus ingress (contract §5 already lets the fact ignore the switch).
+
+---
+
+## 10. Open items handed to downstream tasks
+
+- Category discovery & seeding → `tk-define-llm-driven-category-discovery-to-seed-pop-550aba`
+- Sentiment method & `dim_sentiment` grain → `tk-define-sentiment-mapping-via-semantic-embedding--92988e`
+- Clustering method + `feedback_embeddings` store + roll-up hierarchy → `tk-define-clustering-approach-for-systemic-issue-de-a1d7d6`
+- Per-persona actions, surface, row-level access → `tk-define-ui-ux-audience-actions-and-where-the-expe-476d23`
+- Contract finalization + business keys → `tk-define-stable-common-feedback-event-contract-bus-245a8e`
+```

--- a/docs/design/feedback_dimensional_model.md
+++ b/docs/design/feedback_dimensional_model.md
@@ -8,6 +8,9 @@ Conforms to the existing Kimball layer in `src/ol_dbt/models/dimensional` (`tfac
 `dbt_utils.generate_surrogate_key`, `*_fk` in facts, `time_fk`/`date_fk`). Precedents: `tfact_discussion_events`,
 `tfact_chatbot_events`.
 
+> **Diagrams:** [`feedback_erd.md`](./feedback_erd.md) renders this model (plus the contract, the ML sidecar
+> and the Phase-1 subset) as Mermaid ERDs, and records the schema deltas applied below in §5.
+
 ---
 
 ## 1. Grain
@@ -40,7 +43,8 @@ feedback_source_fk    -> dim_feedback_source.feedback_source_pk
 user_fk               -> dim_user.user_pk            (nullable; anonymous/aggregate sources)
 platform_fk           -> dim_platform.platform_pk    (nullable; non-course sources e.g. Zendesk)
 courserun_fk          -> dim_course_run.courserun_pk  (nullable; only course-scoped sources)
-organization_fk       -> dim_organization.organization_pk (nullable; Zendesk group/org)
+content_block_fk      -> dim_course_content.content_block_pk (nullable; resolves subject_ref, §2a)
+organization_fk       -> dim_organization.organization_pk (nullable; Zendesk group/org — see §2b)
 category_fk           -> dim_feedback_category.feedback_category_pk (late-arriving, §4a)
 sentiment_fk          -> dim_sentiment.sentiment_pk           (late-arriving, §4b)
 time_fk               -> dim_time
@@ -51,17 +55,23 @@ conversation_id       -- thread/ticket id, source-native (roll up utterances →
 source_record_id      -- source PK (zendesk ticket_id, forum post_id, checkpoint id, ora id)
 source_url            -- deep link back to origin (ticket api url, forum page_url)
 
+-- subject: WHAT the feedback is about (§2a) — polymorphic, degenerate
+subject_type          -- courseware_block | course_run | course | program | page_url | resource | unspecified
+subject_ref           -- source-native id of that thing (edX usage key, courserun readable id, decoded URL)
+subject_url           -- canonical/decoded deep link to the subject (nullable)
+
 -- text (REDACTED — see §7; raw text never lands in the fact)
 feedback_title        -- subject / post_title (redacted)
 feedback_text         -- description / post_content / human_message / feedback_text (redacted)
 feedback_text_chars   -- length metric (pre-redaction), for sizing/analytics
-embedding_id          -- FK/handle into the embedding + cluster store (§4c); nullable until scored
 
 -- source-native descriptive attributes (kept for facet filters; NOT conformed)
 source_status         -- zendesk ticket_status / null
 source_priority       -- zendesk ticket_priority / null
 source_tags           -- array<varchar>: zendesk ticket_tags, forum roles, etc. (category SEEDS, §4a)
 source_channel        -- zendesk source_channel / tutor agent / forum component
+source_brand          -- zendesk brand_name (hq#12607) / null
+source_group          -- zendesk group_name (hq#12607) / null
 csat_score            -- zendesk satisfaction_rating_score / tutor rating / null (explicit sentiment)
 
 -- audit
@@ -72,6 +82,36 @@ feedback_ingested_at
 Materialized `table`. Nullable FKs are expected and correct: Zendesk has no courserun; forum/tutor have no
 org; anonymous feedback has no user. The fact tolerates sparse conformance — that is what makes it
 *source-flexible*.
+
+### 2a. Subject — what the feedback is *about*
+
+Added after review feedback on [#2422](https://github.com/mitodl/ol-data-platform/pull/2422#issuecomment-3157271372):
+the model captured *who* said it, *when*, and *in what conversation*, but had no unambiguous slot for what it
+concerns — which is exactly the axis you aggregate on. Known cases: the edX feedback plugin captures the
+courseware block id; some Zendesk tickets carry course metadata; Appzi-originated tickets capture the
+(encoded) URL the user was viewing.
+
+Modelled as a **polymorphic degenerate triple plus one conformed FK**, deliberately *not* a new
+`dim_feedback_subject` — the subject is polymorphic across dimensions that already exist (a block is
+`dim_course_content`, a run is `dim_course_run`, a program is `dim_program`), and a new dim would shadow them.
+
+- `subject_type` / `subject_ref` / `subject_url` — the universal fallback, always populated where known,
+  including for URLs and references that resolve to nothing in the warehouse.
+- Resolve to a conformed FK where one exists. `courserun_fk` already covers the course-run case; the only new
+  conformed join is **`content_block_fk → dim_course_content.content_block_pk`** — the existing SCD for Open
+  edX blocks (courses, chapters, subsections, problems, videos) used by `tfact_problem_events` and
+  `tfact_course_navigation_events`. edX-plugin and ORA feedback therefore joins the courseware star with no
+  new dimensional work.
+- **Appzi URL decoding is the source adapter's job** (`int__feedback__zendesk`), populating
+  `subject_url`/`subject_ref` — not every consumer's query.
+
+### 2b. `organization_fk` is unresolvable for Zendesk under the current key
+
+`dim_organization.organization_pk = generate_surrogate_key(['platform', 'source_id'])`
+(`src/ol_dbt/models/dimensional/dim_organization.sql:38`). Zendesk supplies neither, so `organization_fk`
+stays **null** for Zendesk and the Zendesk organisation/group is carried as the `source_group` facet instead.
+Either that is acceptable, or `dim_organization` needs a Zendesk-aware alternate key — recorded here so it is
+an explicit decision rather than a surprise at build time.
 
 ---
 
@@ -102,6 +142,7 @@ category_label         -- human label (LLM-proposed, human-approved)
 category_parent_slug   -- optional hierarchy (cluster → category → theme)
 category_status        -- proposed | approved | merged | deprecated
 category_source        -- 'llm_discovered' | 'seed' | 'manual'
+cluster_run_id         -- provenance: which cluster run proposed this category (§4d)
 first_seen_at / updated_at
 ```
 Bootstrapped, **not cold-start**: seed from Zendesk `ticket_tags` (2,354 distinct) + `group_name`, then LLM-label
@@ -129,11 +170,28 @@ is_course_scoped       -- bool (whether courserun_fk applies)
 ```
 
 ### 4d. Embedding + cluster store (NOT in the dimensional schema)
-Vectors and cluster assignments live in a **sidecar** table (`feedback_embeddings`) keyed by `embedding_id`,
-not in `tfact_feedback` (facts stay narrow, embeddings churn on re-clustering). It holds: `embedding_id`,
-`feedback_pk`, `vector`, `cluster_id`, `cluster_run_id`, `model_version`. `dim_feedback_category` is the
-*curated* projection of stable clusters; the sidecar is the *mutable* ML working set. This keeps re-clustering
-from rewriting the fact.
+Vectors and cluster assignments live in **sidecar** tables keyed by `feedback_pk`, not in `tfact_feedback`
+(facts stay narrow, embeddings churn on re-clustering). `dim_feedback_category` is the *curated* projection of
+stable clusters; the sidecar is the *mutable* ML working set. This keeps re-clustering from rewriting the fact.
+
+**Three tables, not one** — vectors and cluster assignments have different grains, and collapsing them means
+re-clustering against an unchanged model rewrites or duplicates vector rows, losing the very property this
+sidecar exists to buy:
+
+```
+feedback_embeddings          -- grain (feedback_pk, model_version)
+    vector (Iceberg ARRAY<float>), vector_dim, text_variant, embedded_at
+
+feedback_cluster_run         -- grain (cluster_run_id) — one row per clustering run
+    model_version, algorithm, run_params, cluster_count, noise_count, silhouette,
+    run_status ('candidate'|'approved'), run_at
+
+feedback_cluster_assignment  -- grain (feedback_pk, cluster_run_id)
+    cluster_id (-1 = noise = one-off), cluster_probability
+```
+
+Consequence: the fact carries **no `embedding_id`**. The sidecar joins on `feedback_pk`, so an
+`embedding_id` column would add no reachability while forcing a write to the fact when embeddings land.
 
 ---
 

--- a/docs/design/feedback_dimensional_model.md
+++ b/docs/design/feedback_dimensional_model.md
@@ -1,36 +1,71 @@
 # Feedback Aggregation — Dimensional Model Design
 
 Status: **spec** · Project: `wp-feedback-aggregation-clustering-system-2e9750`
-Date: 2026-07-06 (schema) · See [`README_feedback_aggregation.md`](./README_feedback_aggregation.md) for the full spec set.
+Date: 2026-08-07 (rev. 2 — turn grain + conformance rule; original schema 2026-07-06) ·
+See [`README_feedback_aggregation.md`](./README_feedback_aggregation.md) for the full spec set.
 
 Conforms to the existing Kimball layer in `src/ol_dbt/models/dimensional` (`tfact_*` transactional facts,
 `afact_*` aggregate facts, `dim_*` conformed dimensions, surrogate `*_pk` via
 `dbt_utils.generate_surrogate_key`, `*_fk` in facts, `time_fk`/`date_fk`). Precedents: `tfact_discussion_events`,
 `tfact_chatbot_events`.
 
-> **Diagrams:** [`feedback_erd.md`](./feedback_erd.md) renders this model (plus the contract, the ML sidecar
-> and the Phase-1 subset) as Mermaid ERDs, and records the schema deltas applied below in §5.
+> **Diagrams:** [`feedback_erd.md`](./feedback_erd.md) renders this model (plus the contract, the conversation
+> fact, the ML sidecar and the Phase-1 subset) as Mermaid ERDs, and carries the change log.
+
+---
+
+## 0. The conformance rule
+
+> **An attribute earns a column on the fact, or a conformed dimension, only if two or more sources can
+> populate it.** Everything else lives in the `source_metadata` variant column (§2c), and is promoted to a
+> real column if and when a second source starts supplying it.
+
+Adopted 2026-08-07 after RFC review. `tfact_feedback` exists to aggregate Zendesk *plus* edX forum, Learn AI
+tutor, ORA and the edX feedback plugin; shaping the core tables around what Zendesk happens to expose makes
+every later source pay for it. The full per-attribute audit against all five sources is in
+[`feedback_erd.md`](./feedback_erd.md) §1.
+
+**Promotion path** (so the variant is a staging area, not a dumping ground): when a second source begins
+populating a key inside `source_metadata`, promote it to a real column or a conformed dimension **in the same
+change that onboards that source** — not later, and not speculatively in advance.
 
 ---
 
 ## 1. Grain
 
-**`tfact_feedback` — one row per atomic free-text feedback utterance.**
+**`tfact_feedback` — one row per atomic free-text feedback utterance, where an utterance is one *turn* of a
+conversation.**
 
-"Utterance" = the smallest independently-clusterable unit of a source:
+| Source | One row = | Text column source | `source_record_ref` | `conversation_ref` |
+|---|---|---|---|---|
+| Zendesk | one **public, requester-authored comment** | `comment_plain_body` (+ `ticket_subject`) | `comment_id` | `ticket_id` |
+| edX forum | one `*.created` post/response/comment | `post_content` (+ `post_title`) | `post_id` | thread id |
+| Learn AI tutor | one human turn | `human_message` | `checkpoint_id` | `chatsession_thread_id` |
+| ORA peer feedback | one feedback submission | `feedback_text` | `submission_uuid` | n/a |
+| edX feedback plugin (new) | one feedback event | `feedback_text` | plugin event id | n/a |
 
-| Source | One row = | Text column source |
-|--------|-----------|--------------------|
-| Zendesk | one ticket (first comment) | `ticket_description` (+ `ticket_subject`) |
-| edX forum | one `*.created` post/response/comment | `post_content` (+ `post_title`) |
-| Learn AI tutor | one human turn | `human_message` |
-| ORA peer feedback | one feedback submission | `feedback_text` |
-| edX feedback plugin (new) | one feedback event | `feedback_text` (contract §5) |
+Rationale: the ML tasks (embed → cluster → label) operate per-utterance, and turn grain is what the other
+sources already do — `int__learn_ai__chatbot` is one row per `djangocheckpoint` (ordered by
+`checkpoint_step`), and the forum sources are one row per tracking-log event.
 
-Rationale: the ML tasks (embed → cluster → label) operate per-utterance. Ticket *threads* and full tutor
-*conversations* are deliberately **not** the grain — a `conversation_fk` / `thread_id` degenerate key preserves
-the ability to roll up. Agent/bot messages are excluded (not feedback); forum view/vote/follow events are
-excluded (filter to `*.created`).
+**Changed in rev. 2:** Zendesk was previously modelled at *ticket* grain (text = `ticket_description`, the
+first comment only), which made it the only source where "utterance" silently meant "whole conversation" —
+a Zendesk-shaped exception of exactly the kind §0 exists to prevent. `int__zendesk__ticket_comment` already
+exists at comment grain. First-comment-only is preserved as a **filter, not a grain**, via
+`is_conversation_opening`.
+
+**Exclusions, stated once as a single rule across sources — the author must be the person giving feedback,
+not the platform answering:**
+
+| Source | Keep | Drop |
+|---|---|---|
+| Zendesk | `comment_is_public = true` **and** author = ticket requester | internal notes, agent replies |
+| Learn AI tutor | `human_message` | `agent_message` (bot turns) |
+| edX forum | `*.created` events | view / vote / follow events |
+
+Conversation-level attributes (status, priority, due date, resolution time) are **not** denormalized onto
+this fact — at turn grain they would repeat across every row of a conversation. They live in
+`afact_feedback_conversation` (§5a).
 
 ---
 
@@ -40,6 +75,7 @@ excluded (filter to `*.created`).
 -- surrogate + conformed FKs
 feedback_pk           -- generate_surrogate_key([source_slug, source_record_ref])  (see §6)
 feedback_source_fk    -> dim_feedback_source.feedback_source_pk
+feedback_channel_fk   -> dim_feedback_channel.feedback_channel_pk  (conformed; every source has one)
 user_fk               -> dim_user.user_pk            (nullable; anonymous/aggregate sources)
 platform_fk           -> dim_platform.platform_pk    (nullable; non-course sources e.g. Zendesk)
 courserun_fk          -> dim_course_run.courserun_pk  (nullable; only course-scoped sources)
@@ -47,12 +83,20 @@ content_block_fk      -> dim_course_content.content_block_pk (nullable; resolves
 organization_fk       -> dim_organization.organization_pk (nullable; Zendesk group/org — see §2b)
 category_fk           -> dim_feedback_category.feedback_category_pk (late-arriving, §4a)
 sentiment_fk          -> dim_sentiment.sentiment_pk           (late-arriving, §4b)
-time_fk               -> dim_time
-date_fk               -> dim_date
+
+-- role-playing date/time FKs (§2d)
+occurred_date_fk      -> dim_date    -- the utterance itself; the grain's timestamp
+occurred_time_fk      -> dim_time
+created_date_fk       -> dim_date    -- source lifecycle
+created_time_fk       -> dim_time
+updated_date_fk       -> dim_date
+updated_time_fk       -> dim_time
 
 -- degenerate / conversational keys
-conversation_id       -- thread/ticket id, source-native (roll up utterances → conversation)
-source_record_id      -- source PK (zendesk ticket_id, forum post_id, checkpoint id, ora id)
+conversation_id       -- thread/ticket id, source-native (roll up turns → conversation)
+turn_index            -- ordinal of this turn within the conversation
+is_conversation_opening -- boolean; recovers the first-turn-only view as a filter
+source_record_id      -- the TURN business key (zendesk comment_id, forum post_id, tutor checkpoint_id)
 source_url            -- deep link back to origin (ticket api url, forum page_url)
 
 -- subject: WHAT the feedback is about (§2a) — polymorphic, degenerate
@@ -62,26 +106,30 @@ subject_url           -- canonical/decoded deep link to the subject (nullable)
 
 -- text (REDACTED — see §7; raw text never lands in the fact)
 feedback_title        -- subject / post_title (redacted)
-feedback_text         -- description / post_content / human_message / feedback_text (redacted)
+feedback_text         -- comment body / post_content / human_message / feedback_text (redacted)
 feedback_text_chars   -- length metric (pre-redaction), for sizing/analytics
 
--- source-native descriptive attributes (kept for facet filters; NOT conformed)
-source_status         -- zendesk ticket_status / null
-source_priority       -- zendesk ticket_priority / null
-source_tags           -- array<varchar>: zendesk ticket_tags, forum roles, etc. (category SEEDS, §4a)
-source_channel        -- zendesk source_channel / tutor agent / forum component
-source_brand          -- zendesk brand_name (hq#12607) / null
-source_group          -- zendesk group_name (hq#12607) / null
-csat_score            -- zendesk satisfaction_rating_score / tutor rating / null (explicit sentiment)
+-- conformed measure
+explicit_rating       -- zendesk satisfaction_rating_score / tutor rating / ORA score (§4b seed)
+
+-- everything not yet conformed (§2c)
+source_metadata       -- VARIANT (varchar holding JSON): status, priority, brand, group, due,
+                      --   custom fields, and whatever the next source brings
 
 -- audit
-feedback_occurred_at  -- source event time (created_at / event_timestamp / checkpoint_created_on)
+feedback_occurred_at  -- source event time (comment_created_at / event_timestamp / checkpoint_created_on)
+feedback_created_at   -- source lifecycle timestamp
+feedback_updated_at   -- source lifecycle timestamp
 feedback_ingested_at
 ```
 
 Materialized `table`. Nullable FKs are expected and correct: Zendesk has no courserun; forum/tutor have no
 org; anonymous feedback has no user. The fact tolerates sparse conformance — that is what makes it
 *source-flexible*.
+
+Multi-valued `source_tags` is **not** a column on the fact — it is `bridge_feedback_tag` + `dim_feedback_tag`
+(§4e). An `array<varchar>` on a fact is a modelling smell, and the tag set is also the category seed, so it
+earns a real dimension.
 
 ### 2a. Subject — what the feedback is *about*
 
@@ -109,9 +157,42 @@ Modelled as a **polymorphic degenerate triple plus one conformed FK**, deliberat
 
 `dim_organization.organization_pk = generate_surrogate_key(['platform', 'source_id'])`
 (`src/ol_dbt/models/dimensional/dim_organization.sql:38`). Zendesk supplies neither, so `organization_fk`
-stays **null** for Zendesk and the Zendesk organisation/group is carried as the `source_group` facet instead.
+stays **null** for Zendesk and the Zendesk organisation/group rides in `source_metadata` instead.
 Either that is acceptable, or `dim_organization` needs a Zendesk-aware alternate key — recorded here so it is
 an explicit decision rather than a surprise at build time.
+
+### 2c. `source_metadata` — the variant column
+
+Everything that fails the §0 rule lives here rather than becoming a Zendesk-shaped facet column on the fact.
+At MVP that is `ticket_status`, `ticket_priority`, `brand_name`, `group_name`, `ticket_due_at`,
+`organization_name` and Zendesk custom fields.
+
+**Storage.** Iceberg v2 has **no native JSON type**, so the repo's established pattern is a **varchar holding
+a JSON string** — written with `json_format(...)`, read with the cross-db `json_query_string` /
+`json_extract_value` macros in `src/ol_dbt/macros/cross_db_functions.sql`, which already dispatch across
+Trino / DuckDB / StarRocks. In-repo precedent: `dim_course_content.block_metadata` ("a JSON string
+representing the metadata field… different block types may have different member fields"). StarRocks has a
+native JSON type and the read macros already target it, so the eventual migration is a column-type change,
+not a redesign.
+
+**This is the mechanism that makes a new source additive.** A source arriving with attributes nobody has
+seen before does not require a schema change — its extras land in the variant, and only graduate to a column
+when a second source needs them (§0 promotion path).
+
+### 2d. Role-playing date/time FKs
+
+Every existing `tfact_*` in the repo uses bare `date_fk`/`time_fk`, with no qualified variant anywhere. That
+convention holds only because every existing fact is single-dated. This fact carries three timestamps, so
+the bare name would be genuinely ambiguous: `date_fk`/`time_fk` are renamed to
+`occurred_date_fk`/`occurred_time_fk`, and `created_*`/`updated_*` join the same `dim_date`/`dim_time` in
+role-playing positions.
+
+`occurred_at` and `created_at` are the same value for a Zendesk comment today, and are kept separate
+deliberately: `occurred_at` is the **contract** field every producer must supply, `created_at` is the
+source's own lifecycle timestamp. They diverge wherever the utterance and its container are not created
+together — which at turn grain is the common case, not the exception.
+
+`due_at` is **not** a role-playing FK: it is Zendesk-only, so per §0 it lives in `source_metadata`.
 
 ---
 
@@ -122,13 +203,20 @@ an explicit decision rather than a surprise at build time.
 | `dim_user` | `user_pk` | forum, tutor, ORA, Zendesk (where requester resolves) |
 | `dim_platform` | `platform_pk` | course-scoped sources |
 | `dim_course_run` | `courserun_pk` | forum, tutor, ORA (via `courserun_readable_id`) |
-| `dim_organization` | `organization_pk` | Zendesk (`group_name`/`organization_name`) |
-| `dim_date` / `dim_time` | `date_fk`/`time_fk` | all |
+| `dim_organization` | `organization_pk` | none at MVP — see §2b |
+| `dim_course_content` | `content_block_pk` | edX plugin, ORA, forum (via `subject_ref`, §2a) |
+| `dim_date` / `dim_time` | role-playing, §2d | all |
 
 **Identity is the highest-risk join** (cf. open p0 bug `tk-fix-dim-user-null-email-identity-collapse`).
 Resolve `user_fk` via the same paths the existing facts use — `openedx_user_id` → `dim_user.mitlearn_openedx_user_id`
-(forum/tutor), `user_global_id` (tutor `int__learn_ai__chatbot`), email (Zendesk requester, last resort).
+(forum/tutor), `user_global_id` (tutor `int__learn_ai__chatbot`), email (Zendesk comment author, last resort).
 Never key the fact off a source's local PK (§6).
+
+At turn grain the Zendesk identity path resolves against the **comment author**, not the ticket requester —
+which needs `comment_author_user_id` carried through `int__zendesk__ticket_comment` (it exists in
+`stg__zendesk__ticket_comment` but is not in the int model, which exposes only `comment_author` as a *name*).
+That same column is what distinguishes requester turns from agent turns, so it is a prerequisite for the
+grain change, not an optimisation.
 
 ---
 
@@ -157,7 +245,8 @@ sentiment_slug         -- 'positive' | 'neutral' | 'negative' | (aspect-based la
 polarity_score_bucket  -- optional coarse bucket for trend rollups
 ```
 Small conformed dim. `sentiment_fk` derived by the sentiment task (`tk-define-sentiment-mapping`) —
-semantic/embedding or LLM. Explicit signals (`csat_score`, tutor `rating`) seed/validate it.
+semantic/embedding or LLM. The conformed `explicit_rating` measure (Zendesk `satisfaction_rating_score`,
+tutor `rating`, ORA score) seeds and validates it.
 
 ### 4c. `dim_feedback_source`
 ```
@@ -167,9 +256,49 @@ source_name            -- display
 source_medium          -- 'support_ticket' | 'forum_post' | 'chat' | 'assessment' | 'in_product'
 source_audience_scope  -- 'operational' | 'course' | 'strategic' (see audience memory)
 is_course_scoped       -- bool (whether courserun_fk applies)
+is_conversational      -- bool (whether conversation_id/turn_index are meaningful, §1)
 ```
 
-### 4d. Embedding + cluster store (NOT in the dimensional schema)
+### 4d. `dim_feedback_channel` (conformed)
+```
+feedback_channel_pk    -- generate_surrogate_key([channel_slug])
+channel_slug           -- 'email' | 'web_form' | 'in_product_widget' | 'chat' | 'forum_post'
+                       --   | 'assessment' | 'api'
+channel_name           -- display
+is_solicited           -- bool: did we ask for this feedback, or did the user volunteer it
+```
+
+*How* the feedback arrived, normalized across sources — Zendesk `ticket_source_channel` /
+`comment_source_channel`, the tutor's agent, the forum component, the plugin's widget all map into one value
+set. This is the **only** attribute from the withdrawn `dim_feedback_context` junk dimension that survives
+the §0 rule; status/priority/brand/group are Zendesk-only and live in `source_metadata`.
+
+`is_solicited` is the analytically interesting split the conformed view unlocks: volunteered feedback (a
+support ticket, a forum complaint) and solicited feedback (a survey widget, a CSAT prompt) have different
+selection biases and should rarely be pooled without saying so.
+
+Open item: confirm the value set against each source's actual channel values before seeding.
+
+### 4e. `dim_feedback_tag` + `bridge_feedback_tag`
+```
+dim_feedback_tag
+    feedback_tag_pk    -- generate_surrogate_key([source_slug, tag_slug])
+    tag_slug           -- slugified source tag
+    tag_label          -- as it appears in the source
+    source_slug        -- tags are SOURCE-SCOPED, not global
+
+bridge_feedback_tag    -- grain (feedback_pk, feedback_tag_pk)
+```
+
+Replaces the multi-valued `source_tags` array column. Repo precedent: `bridge_course_topic`,
+`bridge_user_organization`. Tags are keyed with `source_slug` because a Zendesk tag and a forum role that
+happen to share a string are not the same thing — deliberately *not* conformed, which is the honest modelling
+of a source-scoped vocabulary.
+
+This also makes the ~2,354-tag category seed (§4a) a real dimension to select from rather than an array to
+unnest.
+
+### 4f. Embedding + cluster store (NOT in the dimensional schema)
 Vectors and cluster assignments live in **sidecar** tables keyed by `feedback_pk`, not in `tfact_feedback`
 (facts stay narrow, embeddings churn on re-clustering). `dim_feedback_category` is the *curated* projection of
 stable clusters; the sidecar is the *mutable* ML working set. This keeps re-clustering from rewriting the fact.
@@ -204,16 +333,60 @@ data-bus MUST emit this shape so `stg__…__feedback` → `tfact_feedback` is so
 ```
 source_slug            -- maps to dim_feedback_source
 occurred_at            -- ISO8601
+source_record_ref      -- source-native TURN id (idempotency + business key)
+text                   -- raw free text (redaction happens in-warehouse, §7)
+channel_slug           -- maps to dim_feedback_channel
+title                  -- nullable
+conversation_ref       -- thread/ticket id
+turn_index             -- ordinal within the conversation
 subject_user_ref       -- global/openedx user id (NOT a source-local PK)
 courserun_readable_id  -- nullable
 platform               -- nullable
-conversation_ref       -- thread/ticket id
-source_record_ref      -- source-native id (idempotency key)
-title / text           -- raw free text (redaction happens in-warehouse, §7)
-source_metadata        -- json: tags, status, priority, channel, csat, etc.
+subject_type / subject_ref / subject_url  -- what the feedback is about (§2a)
+explicit_rating        -- CSAT / tutor rating / ORA score (conformed)
+created_at / updated_at
+source_metadata        -- json: everything NOT conformed — status, priority, brand, group, due,
+                       --   custom fields. Survives into the fact as a variant (§2c).
 ```
 Align this to the **general data-bus ingestion contract**, not a feedback-specific one, so future openedx
 tracking logs share ingress semantics.
+
+Full field table, types and required-ness: [`feedback_event_contract_spec.md`](./feedback_event_contract_spec.md) §1.
+
+---
+
+## 5a. `afact_feedback_conversation` (conversation grain)
+
+Turn grain (§1) means conversation-level attributes would repeat across every row of a conversation. They
+belong to a different grain, so they get an **accumulating-snapshot fact** — following the repo's `afact_`
+prefix for non-transactional facts.
+
+```
+feedback_conversation_pk    -- generate_surrogate_key([source_slug, conversation_ref])
+feedback_source_fk          -> dim_feedback_source
+opened_by_user_fk           -> dim_user (nullable)
+opened_date_fk              -> dim_date          [available today]
+first_response_date_fk      -> dim_date          [BLOCKED — needs ticket_metrics]
+resolved_date_fk            -> dim_date          [BLOCKED]
+closed_date_fk              -> dim_date          [BLOCKED]
+turn_count                  -- integer           [available today]
+participant_count           -- integer           [available today]
+resolution_duration_seconds -- the "how long was it open" measure  [BLOCKED]
+final_status                -- current-state snapshot              [available today]
+explicit_rating             -- conversation-level rating           [available today]
+```
+
+**Partially blocked on ingestion.** The Zendesk streams landed in the lake
+(`src/ol_dbt/models/staging/zendesk/_zendesk__sources.yml`) are exactly seven — `tickets`,
+`ticket_comments`, `ticket_fields`, `brands`, `groups`, `organizations`, `users`. `solved_at`, `closed_at`,
+`initially_assigned_at`, `first_resolution_time` and `full_resolution_time` live in Zendesk's
+**`ticket_metrics`** endpoint; full state history lives in **`ticket_audits`**. Neither is synced. In the
+`tickets` stream, "solved"/"closed" appear only as *values of `ticket_status`* — a snapshot with no history.
+
+So this table ships with the available-today columns and the duration measures land once `ticket_metrics` is
+added to the connector (a separate ingestion ticket). The grain does not move when they arrive.
+
+It conforms beyond Zendesk: a tutor thread and a forum thread also open, run, and go quiet.
 
 ---
 
@@ -223,27 +396,39 @@ tracking logs share ingress semantics.
 **stable business identifier from the source system**, never a warehouse/Airbyte/Postgres row PK
 (terminology matches the event contract + Zendesk MVP spec):
 
-| Source | source_record_ref |
-|--------|-------------------|
-| Zendesk | `ticket_id` |
-| edX forum | `post_id` |
-| Learn AI tutor | `thread_id` + `checkpoint_pk` (or message index) |
-| ORA | `submission_uuid` |
-| edX plugin | contract `source_record_ref` |
+| Source | `source_record_ref` (the **turn** id) | `conversation_ref` |
+|--------|-------------------|---|
+| Zendesk | `comment_id` | `ticket_id` |
+| edX forum | `post_id` | thread id |
+| Learn AI tutor | `checkpoint_id` | `chatsession_thread_id` |
+| ORA | `submission_uuid` | n/a |
+| edX plugin | plugin-native event id | n/a |
 
 This is what lets the interim→analytics-api migration be "swap source + backfill + parity" rather than a
 rebuild: the same `feedback_pk` regenerates identically regardless of pipe.
+
+> **Changed in rev. 2, and this is the reason the grain decision (§1) had to land before the fact ships.**
+> Zendesk's `source_record_ref` moved from `ticket_id` to `comment_id`. The *formula* is unchanged, but the
+> *value* is not — so the key would have had to be regenerated after the fact had consumers, which is exactly
+> the rebuild this strategy exists to avoid.
 
 ---
 
 ## 7. PII handling (mandatory pre-embed)
 
-`ticket_description` and `int__learn_ai__chatbot.human_message` carry emails/phones/names (profiler-flagged
-`PII.Sensitive`). A **redaction step in the `int__` layer** (Presidio — precedent: the OM profiler already runs
-Presidio recognizers) masks entities before text lands in `tfact_feedback` or the embedding store. Raw text
-stays in `raw`/`stg` under existing PII classification + Lakekeeper/Cedar authz; the fact carries redacted text
-only. Access to the fact is still governed per §audience (course instructors see their courserun; support/eng
-see tickets; leadership sees aggregates).
+Zendesk ticket text and `int__learn_ai__chatbot.human_message` carry emails/phones/names —
+`ticket_description` is profiler-flagged `PII.Sensitive`. A **redaction step in the `int__` layer**
+(Presidio — precedent: the OM profiler already runs Presidio recognizers) masks entities before text lands
+in `tfact_feedback` or the embedding store. Raw text stays in `raw`/`stg` under existing PII classification
++ Lakekeeper/Cedar authz; the fact carries redacted text only. Access to the fact is still governed per
+§audience (course instructors see their courserun; support/eng see tickets; leadership sees aggregates).
+
+**Turn grain widens the exposure surface, so this gets *more* important, not less.** The redaction target is
+now `comment_plain_body` across every kept turn, not just `ticket_description`. Follow-up turns are where
+users paste order numbers, screenshots-as-text, alternate email addresses and phone numbers in response to
+an agent asking for them — plausibly a *higher* PII density than the opening comment. The profiler has only
+classified `ticket_description`; **run it over `comment_plain_body` before the first embed run** rather than
+assuming the classification carries over.
 
 ---
 
@@ -252,9 +437,12 @@ see tickets; leadership sees aggregates).
 ```
 raw__<source>__…                         (existing per source; new: raw__learn_ai__…__feedback)
   → stg__<source>__…__feedback           (conform to §5 contract, light typing)
-    → int__feedback__unioned             (UNION all sources into the common shape + redact PII §7)
-      → tfact_feedback                    (resolve conformed FKs, generate feedback_pk §6)
-        → afact_feedback_cluster_daily    (aggregate fact: cluster × category × sentiment × date × source — strategic rollup)
+    → int__feedback__<source>            (per-source adapter; TURN grain + source filters §1)
+      → int__feedback__unioned           (UNION all sources into the common shape + redact PII §7)
+        → tfact_feedback                  (resolve conformed FKs, generate feedback_pk §6)
+          → bridge_feedback_tag           (explode source tags → dim_feedback_tag §4e)
+          → afact_feedback_cluster_daily  (cluster × category × sentiment × date × source — strategic rollup)
+        → afact_feedback_conversation     (conversation grain §5a; also reads the source's conversation model)
 ```
 Clustering/labeling jobs (Dagster asset) read `int__feedback__unioned` (redacted) and write
 `feedback_embeddings`, `dim_feedback_category`, and `category_fk`/`sentiment_fk` back onto the fact
@@ -264,19 +452,67 @@ Clustering/labeling jobs (Dagster asset) read `int__feedback__unioned` (redacted
 
 ## 9. MVP vs. full
 
-- **MVP (support/eng):** `dim_feedback_source` + `tfact_feedback` restricted to `source_slug='zendesk'`, category
-  seeded from `ticket_tags`, sentiment from `csat_score` + model. ~198K rows, batch. No new dims beyond the three.
+- **MVP (support/eng):** `tfact_feedback` restricted to `source_slug='zendesk'` at **turn grain**, plus
+  `dim_feedback_source`, `dim_feedback_channel`, `dim_feedback_category` (seeded from `ticket_tags`),
+  `dim_sentiment`, `dim_feedback_tag` + `bridge_feedback_tag`, and `afact_feedback_conversation`
+  (available-today columns only). Batch. Row count is public-requester **comments**, not the previous ~198K
+  tickets — **to be measured before committing** (§10).
 - **Phase 2:** add forum/tutor/ORA sources (fact already tolerates them), enable cross-source
-  `afact_feedback_cluster_daily` for leadership, course-scoped views for instructors.
+  `afact_feedback_cluster_daily` for leadership, course-scoped views for instructors, and the
+  `ticket_metrics`-gated duration measures on `afact_feedback_conversation`.
 - **Phase 3:** analytics-api/data-bus ingress (contract §5 already lets the fact ignore the switch).
+
+**Cost note.** Rev. 2 moves MVP from 3 new dimensions to 4 dimensions + 1 bridge + 1 conversation fact. The
+additions are `select distinct` cheap (`dim_feedback_channel`, `dim_feedback_tag`) or a straight aggregation
+(`afact_feedback_conversation`), so the build cost is small — but it is a real increase and worth confirming
+deliberately. The argument for paying it now: reshaping a fact after it has consumers is the expensive
+version, and the §1 grain change has to land pre-ship regardless because it moves the business key (§6).
 
 ---
 
 ## 10. Open items handed to downstream tasks
+
+**Prerequisites for the rev. 2 grain change:**
+
+| Item | Kind | Blocks |
+|---|---|---|
+| Carry `comment_author_user_id` through `int__zendesk__ticket_comment` (present in `stg__zendesk__ticket_comment`; the int model exposes only `comment_author` as a name) | small dbt change | requester-vs-agent turn classification; `user_fk` resolution |
+| Measure public, requester-authored comments per ticket | measurement | sizing the fact and the embedding budget (§9) |
+| Add the `ticket_metrics` stream to the Zendesk Airbyte connector | ingestion, separate ticket | duration measures on `afact_feedback_conversation` (§5a) |
+| Confirm the conformed `channel_slug` value set against each source's actual channel values | modeling | `dim_feedback_channel` seed (§4d) |
+| Run the PII profiler over `comment_plain_body` (only `ticket_description` is classified today) | classification | the first embed run at turn grain (§7) |
+
+**Handed to existing tasks:**
 
 - Category discovery & seeding → `tk-define-llm-driven-category-discovery-to-seed-pop-550aba`
 - Sentiment method & `dim_sentiment` grain → `tk-define-sentiment-mapping-via-semantic-embedding--92988e`
 - Clustering method + `feedback_embeddings` store + roll-up hierarchy → `tk-define-clustering-approach-for-systemic-issue-de-a1d7d6`
 - Per-persona actions, surface, row-level access → `tk-define-ui-ux-audience-actions-and-where-the-expe-476d23`
 - Contract finalization + business keys → `tk-define-stable-common-feedback-event-contract-bus-245a8e`
+
+---
+
+## 11. Change log
+
+**rev. 2 (2026-08-07)** — from [@KatelynGit's RFC
+review](https://github.com/mitodl/hq/discussions/12210#discussioncomment-17937328):
+
+- **Grain moved from ticket to turn** (§1) — Zendesk `source_record_ref` is now `comment_id`. Added
+  `turn_index`, `is_conversation_opening`.
+- **Adopted the ≥2-sources conformance rule** (§0) and re-audited every attribute against it.
+- **Added** `dim_feedback_channel` (§4d), `dim_feedback_tag` + `bridge_feedback_tag` (§4e),
+  `afact_feedback_conversation` (§5a), `is_conversational` on `dim_feedback_source`.
+- **Renamed** `date_fk`/`time_fk` → `occurred_date_fk`/`occurred_time_fk`; **added** created/updated
+  role-playing FKs and timestamps (§2d).
+- **`source_metadata` is persisted as a variant on the fact** (§2c) instead of being flattened into
+  Zendesk-shaped facet columns. **Removed** `source_status`, `source_priority`, `source_channel`,
+  `source_brand`, `source_group`, `source_tags` from the fact; renamed `csat_score` → `explicit_rating`.
+- **Withdrawn** from the rev. 1 ERD addendum: the `dim_feedback_context` junk dimension (Zendesk-shaped,
+  fails §0), the `source_brand`/`source_group` facet columns added for
+  [hq#12607](https://github.com/mitodl/hq/issues/12607) (still filterable from the variant), and
+  `due_date_fk` (Zendesk-only).
+
+**rev. 1 (2026-08-07)** — subject reference `subject_type`/`subject_ref`/`subject_url` + `content_block_fk`
+(§2a) from [@pdpinch's review](https://github.com/mitodl/ol-data-platform/pull/2422#issuecomment-5169778966);
+ML sidecar grain split (§4f), dropping `embedding_id` from the fact.
 ```

--- a/docs/design/feedback_dimensional_model.md
+++ b/docs/design/feedback_dimensional_model.md
@@ -1,8 +1,8 @@
 # Feedback Aggregation — Dimensional Model Design
 
 Status: **spec** · Project: `wp-feedback-aggregation-clustering-system-2e9750`
-Date: 2026-08-10 (rev. 3 — conversation-grain analysis fact; rev. 2 turn grain + conformance rule;
-original schema 2026-07-06) ·
+Date: 2026-08-13 (rev. 4 — fixes from [#2422 review](https://github.com/mitodl/ol-data-platform/pull/2422);
+rev. 3 conversation-grain analysis fact; rev. 2 turn grain + conformance rule; original schema 2026-07-06) ·
 See [`README_feedback_aggregation.md`](./README_feedback_aggregation.md) for the full spec set.
 
 Conforms to the existing Kimball layer in `src/ol_dbt/models/dimensional` (`tfact_*` transactional facts,
@@ -91,6 +91,9 @@ feedback_pk           -- generate_surrogate_key([source_slug, source_record_ref]
 feedback_source_fk    -> dim_feedback_source.feedback_source_pk
 feedback_channel_fk   -> dim_feedback_channel.feedback_channel_pk  (conformed; every source has one)
 user_fk               -> dim_user.user_pk            (nullable; anonymous/aggregate sources)
+subject_user_ref       -- WHO said it, kept RAW alongside user_fk, not just consumed by the join and
+                       --   dropped (nullable; rev. 4, §3 below) — lets user_fk be re-resolved later
+                       --   against a future dim_user without rebuilding this insert-only fact
 platform_fk           -> dim_platform.platform_pk    (nullable; non-course sources e.g. Zendesk)
 courserun_fk          -> dim_course_run.courserun_pk  (nullable; only course-scoped sources)
 content_block_fk      -> dim_course_content.content_block_pk (nullable; resolves subject_ref, §2a)
@@ -171,6 +174,20 @@ Modelled as a **polymorphic degenerate triple plus one conformed FK**, deliberat
   edX blocks (courses, chapters, subsections, problems, videos) used by `tfact_problem_events` and
   `tfact_course_navigation_events`. edX-plugin and ORA feedback therefore joins the courseware star with no
   new dimensional work.
+- **The `content_block_fk` join must specify a version (fixed rev. 4, @copilot).** `dim_course_content` is
+  versioned: `content_block_pk = generate_surrogate_key(['block_id', 'retrieved_at'])`
+  (`dim_course_content.sql:141`), and the same `block_id` legitimately has multiple rows across course
+  structure snapshots, distinguished by the dimension's own `is_latest` flag. Resolving `subject_ref` on
+  `block_id` alone, without also constraining `platform`/`courserun_readable_id` and picking a version, can
+  fan out one feedback row into several (a join hit per retained snapshot) or land on an arbitrary one. The
+  rule: join on `block_id` **and** `platform` **and** `courserun_readable_id`, filtered to
+  `is_latest = true` — i.e. resolve against the block's *current* structure, not an as-of-`occurred_at`
+  lookup. That is deliberately the simpler of the two options: feedback about a courseware block is about
+  the block as a concept, not about a specific structural snapshot of the course, and courseware structure
+  changes within a run are rare enough that the drift this trades away is not worth the added join
+  complexity at MVP. `content_block_fk` is null for the Zendesk-only MVP regardless (§2a is not exercised
+  until Phase 2's edX-plugin/ORA sources land), so this is a rule for the Phase 2 adapter to implement, not
+  something MVP builds against today.
 - **Appzi URL decoding is the source adapter's job** (`int__feedback__zendesk`), populating
   `subject_url`/`subject_ref` — not every consumer's query.
 
@@ -231,11 +248,25 @@ together — which at turn grain is the common case, not the exception.
 **Identity is the highest-risk join.** The p0 `dim_user` NULL-email collapse bug that motivated this warning
 is **fixed and merged** ([#2400](https://github.com/mitodl/ol-data-platform/pull/2400), 2026-07-15 — all six
 union branches now filter `email is not null`, plus a `not_null` regression test). The risk that remains is
-structural, not that specific bug: `dim_user.user_pk = generate_surrogate_key([lower(email)])`, and Zendesk
-can only resolve identity by email, so every unmatched or shared address is still a miss or a merge.
+structural, not that specific bug — and the structure changed since rev. 3 (fixed rev. 4, @rachellougee):
+`dim_user.user_pk` is **not** `generate_surrogate_key([lower(email)])`; on current `main` it is
+`generate_surrogate_key(['user_identity_source', 'user_identity_id'])`, where
+`user_identity_id = coalesce(user_global_id, id_source_user_id, email)` — email is the *last-resort*
+component of the key, not the whole of it. Zendesk still resolves identity by email only, so the join in
+`feedback_zendesk_mvp_spec.md` §4 targets `dim_user.email` (a plain column, present regardless of which
+identifier won the key) rather than reconstructing the PK formula — every unmatched or shared address is
+still a miss or a merge, that part is unchanged.
 Resolve `user_fk` via the same paths the existing facts use — `openedx_user_id` → `dim_user.mitlearn_openedx_user_id`
 (forum/tutor), `user_global_id` (tutor `int__learn_ai__chatbot`), email (Zendesk comment author, last resort).
 Never key the fact off a source's local PK (§6).
+
+**Re-matching after the fact loads (rev. 4).** `tfact_feedback` is insert-only (§2) and loads incrementally,
+so `user_fk` is resolved once, at load time — an author who does not match today (typo'd email, no account
+yet, a `dim_user` coverage gap) has no automatic path to being matched later. `subject_user_ref` (the raw
+identity ref) is therefore kept as a column on the fact specifically so `user_fk` can be recomputed against
+a later `dim_user` without a rebuild — `feedback_zendesk_mvp_spec.md` §4 has the detail. `tk-...-b7ca16`
+covers identity re-derivation as part of the data-bus migration specifically; it is not what makes MVP
+re-matching possible, `subject_user_ref`'s retention is.
 
 At turn grain the Zendesk identity path resolves against the **comment author**, not the ticket requester —
 which needs `comment_author_user_id` carried through `int__zendesk__ticket_comment` (it exists in
@@ -410,7 +441,13 @@ is the decision to put them in the same table:
 ```
 -- identity
 feedback_conversation_pk    -- generate_surrogate_key([source_slug, conversation_ref])
-conversation_id             -- degenerate; the source-native thread/ticket id (joins tfact_feedback)
+conversation_id             -- degenerate; the source-native thread/ticket id. Joins tfact_feedback on
+                             --   (feedback_source_fk, conversation_id) TOGETHER, never conversation_id
+                             --   alone — it is source-native and unqualified ids can collide across
+                             --   Zendesk/forum/tutor (fixed rev. 4, @copilot). feedback_conversation_pk
+                             --   already hashes both source_slug and conversation_ref for exactly this
+                             --   reason; this note makes the same requirement explicit for hand-written
+                             --   joins and tests against the degenerate column.
 feedback_source_fk          -> dim_feedback_source
 opened_by_user_fk           -> dim_user (nullable)
 
@@ -527,11 +564,13 @@ rebuild: the same `feedback_pk` regenerates identically regardless of pipe.
 ## 7. PII handling (mandatory pre-embed)
 
 Zendesk ticket text and `int__learn_ai__chatbot.human_message` carry emails/phones/names —
-`ticket_description` is profiler-flagged `PII.Sensitive`. A **redaction step in the `int__` layer**
-(Presidio — precedent: the OM profiler already runs Presidio recognizers) masks entities before text lands
-in `tfact_feedback` or the embedding store. Raw text stays in `raw`/`stg` under existing PII classification
-+ Lakekeeper/Cedar authz; the fact carries redacted text only. Access to the fact is still governed per
-§audience (course instructors see their courserun; support/eng see tickets; leadership sees aggregates).
+`ticket_description` is profiler-flagged `PII.Sensitive`. A **redaction step between `int__feedback__unioned`
+and `tfact_feedback`** — `feedback_redacted`, a Python Dagster asset since Presidio is Python, not SQL (§8
+layering; fixed rev. 4 to be its own Phase-1 asset rather than sharing one with embedding — see
+`feedback_zendesk_mvp_spec.md` §3) — masks entities before text lands in `tfact_feedback` or the embedding
+store. Raw text stays in `raw`/`stg` under existing PII classification + Lakekeeper/Cedar authz; the fact
+carries redacted text only. Access to the fact is still governed per §audience (course instructors see their
+courserun; support/eng see tickets; leadership sees aggregates).
 
 **Turn grain widens the exposure surface, so this gets *more* important, not less.** The redaction target is
 now `comment_plain_body` across every kept turn, not just `ticket_description`. Follow-up turns are where
@@ -548,12 +587,15 @@ assuming the classification carries over.
 raw__<source>__…                         (existing per source; new: raw__learn_ai__…__feedback)
   → stg__<source>__…__feedback           (conform to §5 contract, light typing)
     → int__feedback__<source>            (per-source adapter; TURN grain + source filters §1)
-      → int__feedback__unioned           (UNION all sources into the common shape + redact PII §7)
-        → tfact_feedback                  (resolve conformed FKs, generate feedback_pk §6 — INSERT-ONLY)
-          → bridge_feedback_tag           (explode source tags → dim_feedback_tag §4e)
-          → int__feedback__conversation   (assemble kept turns per conversation_id, ordered by turn_index)
-            → afact_feedback_conversation (§5a — lifecycle + summary + vector + sentiment/category/cluster)
-              → afact_feedback_cluster_daily  (cluster × category × sentiment × date × source rollup)
+      → int__feedback__unioned           (UNION all sources into the common shape)
+        → feedback_redacted               (Dagster Python asset — Presidio masking §7; a Phase-1
+                                           prerequisite for the fact, NOT part of the ML asset in §8 below —
+                                           fixed rev. 4, see feedback_zendesk_mvp_spec.md §3)
+          → tfact_feedback                  (resolve conformed FKs, generate feedback_pk §6 — INSERT-ONLY)
+            → bridge_feedback_tag           (explode source tags → dim_feedback_tag §4e)
+            → int__feedback__conversation   (assemble kept turns per conversation_id, ordered by turn_index)
+              → afact_feedback_conversation (§5a — lifecycle + summary + vector + sentiment/category/cluster)
+                → afact_feedback_cluster_daily  (cluster × category × sentiment × date × source rollup)
 ```
 The ML batch (Dagster asset) reads `int__feedback__conversation` (redacted, assembled) and writes
 `afact_feedback_conversation` plus proposed rows on `dim_feedback_category`. **It never writes to
@@ -615,6 +657,28 @@ moves the business key (§6).
 ---
 
 ## 11. Change log
+
+**rev. 4 (2026-08-13)** — implementation-blocking fixes from
+[#2422 review](https://github.com/mitodl/ol-data-platform/pull/2422), no grain/key/shape changes:
+
+- **`content_block_fk` needs a version rule** (§2a) — `dim_course_content` is versioned
+  (`generate_surrogate_key(['block_id', 'retrieved_at'])`), so resolving `subject_ref` on `block_id` alone
+  can fan out or pick an arbitrary snapshot. Rule: join on `block_id` + `platform` + `courserun_readable_id`,
+  filtered to `is_latest = true`. Applies to Phase 2 (edX plugin/ORA); `content_block_fk` is null for
+  Zendesk-only MVP.
+- **`conversation_id` joins must be qualified by source** (§5a) — it is source-native and can collide across
+  Zendesk/forum/tutor, so joins and tests against it use `(feedback_source_fk, conversation_id)`, matching
+  what `feedback_conversation_pk` already hashes.
+- **`dim_user.user_pk`'s formula corrected** (§3) — it is no longer `generate_surrogate_key([lower(email)])`;
+  current `main` uses `generate_surrogate_key(['user_identity_source', 'user_identity_id'])` with
+  `user_identity_id = coalesce(user_global_id, id_source_user_id, email)`. The Zendesk join is unaffected (it
+  targets the `email` column, not the PK formula) but the doc's claim about the formula was stale.
+- **`subject_user_ref` is retained on `tfact_feedback`** (§2), not just consumed by the `user_fk` join and
+  dropped — answers "how do we re-match identity later" for an insert-only fact that never revisits a loaded
+  row (@rachellougee).
+- **Redaction is its own Phase-1 asset** (§7/§8) — `feedback_redacted`, upstream of `tfact_feedback` and
+  distinct from the ML/clustering asset, fixing a dependency cycle in rev. 3's placement (detail in
+  `feedback_zendesk_mvp_spec.md` §3).
 
 **rev. 3 (2026-08-10)** — the analysis unit moves from the turn to the conversation
 ([RFC #12210](https://github.com/mitodl/hq/discussions/12210)):

--- a/docs/design/feedback_dimensional_model.md
+++ b/docs/design/feedback_dimensional_model.md
@@ -228,7 +228,11 @@ together — which at turn grain is the common case, not the exception.
 | `dim_course_content` | `content_block_pk` | edX plugin, ORA, forum (via `subject_ref`, §2a) |
 | `dim_date` / `dim_time` | role-playing, §2d | all |
 
-**Identity is the highest-risk join** (cf. open p0 bug `tk-fix-dim-user-null-email-identity-collapse`).
+**Identity is the highest-risk join.** The p0 `dim_user` NULL-email collapse bug that motivated this warning
+is **fixed and merged** ([#2400](https://github.com/mitodl/ol-data-platform/pull/2400), 2026-07-15 — all six
+union branches now filter `email is not null`, plus a `not_null` regression test). The risk that remains is
+structural, not that specific bug: `dim_user.user_pk = generate_surrogate_key([lower(email)])`, and Zendesk
+can only resolve identity by email, so every unmatched or shared address is still a miss or a merge.
 Resolve `user_fk` via the same paths the existing facts use — `openedx_user_id` → `dim_user.mitlearn_openedx_user_id`
 (forum/tutor), `user_global_id` (tutor `int__learn_ai__chatbot`), email (Zendesk comment author, last resort).
 Never key the fact off a source's local PK (§6).

--- a/docs/design/feedback_dimensional_model.md
+++ b/docs/design/feedback_dimensional_model.md
@@ -1,7 +1,8 @@
 # Feedback Aggregation — Dimensional Model Design
 
 Status: **spec** · Project: `wp-feedback-aggregation-clustering-system-2e9750`
-Date: 2026-08-07 (rev. 2 — turn grain + conformance rule; original schema 2026-07-06) ·
+Date: 2026-08-10 (rev. 3 — conversation-grain analysis fact; rev. 2 turn grain + conformance rule;
+original schema 2026-07-06) ·
 See [`README_feedback_aggregation.md`](./README_feedback_aggregation.md) for the full spec set.
 
 Conforms to the existing Kimball layer in `src/ol_dbt/models/dimensional` (`tfact_*` transactional facts,
@@ -10,7 +11,13 @@ Conforms to the existing Kimball layer in `src/ol_dbt/models/dimensional` (`tfac
 `tfact_chatbot_events`.
 
 > **Diagrams:** [`feedback_erd.md`](./feedback_erd.md) renders this model (plus the contract, the conversation
-> fact, the ML sidecar and the Phase-1 subset) as Mermaid ERDs, and carries the change log.
+> fact and the Phase-1 subset) as Mermaid ERDs, and carries the change log.
+
+> **Two facts, one pair.** `tfact_feedback` (§2) records what was said, one row per turn, and is never
+> rewritten. `afact_feedback_conversation` (§5a) is the **analysis unit** — one row per conversation, carrying
+> everything a model generated: the summary, the embedding, the sentiment, the category and the cluster. The
+> line between them is *ingested* vs. *inferred*, and it is what lets the whole inferred layer be rebuilt
+> without touching the record of what people actually wrote.
 
 ---
 
@@ -44,9 +51,11 @@ conversation.**
 | ORA peer feedback | one feedback submission | `feedback_text` | `submission_uuid` | n/a |
 | edX feedback plugin (new) | one feedback event | `feedback_text` | plugin event id | n/a |
 
-Rationale: the ML tasks (embed → cluster → label) operate per-utterance, and turn grain is what the other
-sources already do — `int__learn_ai__chatbot` is one row per `djangocheckpoint` (ordered by
-`checkpoint_step`), and the forum sources are one row per tracking-log event.
+Rationale: turn grain is what the other sources already do — `int__learn_ai__chatbot` is one row per
+`djangocheckpoint` (ordered by `checkpoint_step`), and the forum sources are one row per tracking-log event —
+and it is the only grain from which a *complete* conversation can be assembled. Recording the turns is what
+makes the conversation-grain analysis in §5a possible; the ML tasks themselves operate on the assembled
+conversation, not on isolated turns (**changed in rev. 3**).
 
 **Changed in rev. 2:** Zendesk was previously modelled at *ticket* grain (text = `ticket_description`, the
 first comment only), which made it the only source where "utterance" silently meant "whole conversation" —
@@ -65,7 +74,12 @@ not the platform answering:**
 
 Conversation-level attributes (status, priority, due date, resolution time) are **not** denormalized onto
 this fact — at turn grain they would repeat across every row of a conversation. They live in
-`afact_feedback_conversation` (§5a).
+`afact_feedback_conversation` (§5a), which is also where every model-derived attribute lives (rev. 3).
+
+**Sources with no thread** — ORA submissions and edX-plugin events — have `conversation_ref =
+source_record_ref`, so they degenerate to a one-turn conversation and still get exactly one
+`afact_feedback_conversation` row. `dim_feedback_source.is_conversational` marks the distinction; nothing
+downstream has to special-case them.
 
 ---
 
@@ -81,8 +95,10 @@ platform_fk           -> dim_platform.platform_pk    (nullable; non-course sourc
 courserun_fk          -> dim_course_run.courserun_pk  (nullable; only course-scoped sources)
 content_block_fk      -> dim_course_content.content_block_pk (nullable; resolves subject_ref, §2a)
 organization_fk       -> dim_organization.organization_pk (nullable; Zendesk group/org — see §2b)
-category_fk           -> dim_feedback_category.feedback_category_pk (late-arriving, §4a)
-sentiment_fk          -> dim_sentiment.sentiment_pk           (late-arriving, §4b)
+
+-- NOTE (rev. 3): category_fk / sentiment_fk are NOT on this fact. They are model-derived, they are
+--   assigned at conversation grain, and they used to be the only reason anything ever wrote to
+--   tfact_feedback after insert. They live on afact_feedback_conversation (§5a).
 
 -- role-playing date/time FKs (§2d)
 occurred_date_fk      -> dim_date    -- the utterance itself; the grain's timestamp
@@ -126,6 +142,11 @@ feedback_ingested_at
 Materialized `table`. Nullable FKs are expected and correct: Zendesk has no courserun; forum/tutor have no
 org; anonymous feedback has no user. The fact tolerates sparse conformance — that is what makes it
 *source-flexible*.
+
+**Insert-only as of rev. 3.** With `category_fk`/`sentiment_fk` gone, no process updates a row of this fact
+after it lands. That is a stronger property than "the sidecar keeps re-clustering off the fact": there is now
+no late-arriving write path to `tfact_feedback` at all, so re-summarizing, re-embedding, re-scoring and
+re-clustering are all confined to a table that can be dropped and rebuilt.
 
 Multi-valued `source_tags` is **not** a column on the fact — it is `bridge_feedback_tag` + `dim_feedback_tag`
 (§4e). An `array<varchar>` on a fact is a modelling smell, and the tag set is also the category seed, so it
@@ -235,8 +256,9 @@ first_seen_at / updated_at
 ```
 Bootstrapped, **not cold-start**: seed from Zendesk `ticket_tags` (2,354 distinct) + `group_name`, then LLM-label
 embedding clusters (task `tk-define-llm-driven-category-discovery`). SCD-lite: relabeling changes `category_label`,
-never `category_slug`. Assignment (`category_fk` on the fact) is late-arriving — a ticket can be categorized after
-insert.
+never `category_slug`. **Assignment (`category_fk`) is made on `afact_feedback_conversation`, not on the fact**
+(rev. 3) — a conversation is categorized whenever the ML batch next runs, and the dimension itself is unaffected
+by where the FK sits.
 
 ### 4b. `dim_sentiment`
 ```
@@ -245,8 +267,12 @@ sentiment_slug         -- 'positive' | 'neutral' | 'negative' | (aspect-based la
 polarity_score_bucket  -- optional coarse bucket for trend rollups
 ```
 Small conformed dim. `sentiment_fk` derived by the sentiment task (`tk-define-sentiment-mapping`) —
-semantic/embedding or LLM. The conformed `explicit_rating` measure (Zendesk `satisfaction_rating_score`,
-tutor `rating`, ORA score) seeds and validates it.
+semantic/embedding or LLM — and assigned on `afact_feedback_conversation` (rev. 3).
+
+**Rev. 3 fixes a grain mismatch here.** Zendesk's `satisfaction_rating_score` is a *ticket*-level signal. At
+turn grain it had to be propagated to every turn of a rated ticket, which rev. 2 had to flag as a weak,
+potentially misleading label. At conversation grain the explicit rating and the derived sentiment are the same
+grain, so `explicit_rating` seeds and validates `sentiment_fk` exactly rather than approximately.
 
 ### 4c. `dim_feedback_source`
 ```
@@ -298,29 +324,41 @@ of a source-scoped vocabulary.
 This also makes the ~2,354-tag category seed (§4a) a real dimension to select from rather than an array to
 unnest.
 
-### 4f. Embedding + cluster store (NOT in the dimensional schema)
-Vectors and cluster assignments live in **sidecar** tables keyed by `feedback_pk`, not in `tfact_feedback`
-(facts stay narrow, embeddings churn on re-clustering). `dim_feedback_category` is the *curated* projection of
-stable clusters; the sidecar is the *mutable* ML working set. This keeps re-clustering from rewriting the fact.
+### 4f. Where ML output lives (rev. 3: on the aggregate fact, not a per-turn sidecar)
 
-**Three tables, not one** — vectors and cluster assignments have different grains, and collapsing them means
-re-clustering against an unchanged model rewrites or duplicates vector rows, losing the very property this
-sidecar exists to buy:
+**Summaries, vectors, sentiment, categories and cluster membership all live on
+`afact_feedback_conversation` (§5a)** — one row per conversation, one generation at a time. The per-turn
+`feedback_embeddings` / `feedback_cluster_assignment` sidecar tables from rev. 2 are **withdrawn**; the
+aggregate fact *is* the sidecar, promoted to a first-class dimensional table under the existing `afact_`
+convention (precedent: `afact_discussion_engagement`).
+
+Two tables survive alongside it, because they are genuinely different grains:
 
 ```
-feedback_embeddings          -- grain (feedback_pk, model_version)
-    vector (Iceberg ARRAY<float>), vector_dim, text_variant, embedded_at
-
-feedback_cluster_run         -- grain (cluster_run_id) — one row per clustering run
-    model_version, algorithm, run_params, cluster_count, noise_count, silhouette,
+feedback_cluster_run       -- grain (cluster_run_id) — one row per clustering run
+    embedding_model_version, algorithm, run_params, cluster_count, noise_count, silhouette,
     run_status ('candidate'|'approved'), run_at
 
-feedback_cluster_assignment  -- grain (feedback_pk, cluster_run_id)
-    cluster_id (-1 = noise = one-off), cluster_probability
+feedback_cluster_candidate -- grain (feedback_conversation_pk, cluster_run_id)
+    cluster_id, cluster_probability
+    -- ONLY for runs still in 'candidate' status. Promoting a run copies its assignment onto
+    -- afact_feedback_conversation and the candidate rows are dropped.
 ```
 
-Consequence: the fact carries **no `embedding_id`**. The sidecar joins on `feedback_pk`, so an
-`embedding_id` column would add no reachability while forcing a write to the fact when embeddings land.
+`feedback_cluster_candidate` exists for one reason: comparing a proposed run against the live one, which is
+what the embedding-model bake-off (`feedback_ml_approach.md` §B.1) and every subsequent re-tune need. It is
+not a consumption table and nothing outside the ML pipeline should read it.
+
+**What this trades away, stated plainly.** Rev. 2 split the sidecar so that re-clustering could never rewrite
+vector rows. Collapsing onto one row per conversation gives that up: a promoted run rewrites the afact row,
+vector column included. The cost is real but small — the *vector value* is carried forward, not recomputed, so
+nothing is re-embedded; what is lost is the ability to hold several model generations live in production at
+once, which is a bake-off need, and the candidate table covers it off the critical path. What is bought is
+that a consumer reads one table instead of joining four, and that `tfact_feedback` becomes insert-only (§2).
+
+`dim_feedback_category` remains the *curated, stable* projection of clusters that a human approved; the
+aggregate fact is the *churny* generated layer. That decoupling is unchanged and is what still lets clustering
+re-run freely.
 
 ---
 
@@ -355,26 +393,93 @@ Full field table, types and required-ness: [`feedback_event_contract_spec.md`](.
 
 ---
 
-## 5a. `afact_feedback_conversation` (conversation grain)
+## 5a. `afact_feedback_conversation` — the analysis fact (conversation grain)
 
-Turn grain (§1) means conversation-level attributes would repeat across every row of a conversation. They
-belong to a different grain, so they get an **accumulating-snapshot fact** — following the repo's `afact_`
-prefix for non-transactional facts.
+**One row per conversation**, keyed on the source's own thread identifier. Two things live here, and rev. 3
+is the decision to put them in the same table:
+
+1. **Conversation lifecycle** — attributes that would repeat across every turn at §1's grain (status,
+   rating, counts, durations).
+2. **Everything a model generated** — the summary, the embedding, the sentiment, the category and the
+   cluster.
 
 ```
+-- identity
 feedback_conversation_pk    -- generate_surrogate_key([source_slug, conversation_ref])
+conversation_id             -- degenerate; the source-native thread/ticket id (joins tfact_feedback)
 feedback_source_fk          -> dim_feedback_source
 opened_by_user_fk           -> dim_user (nullable)
+
+-- lifecycle
 opened_date_fk              -> dim_date          [available today]
+last_turn_date_fk           -> dim_date          [available today]
 first_response_date_fk      -> dim_date          [BLOCKED — needs ticket_metrics]
 resolved_date_fk            -> dim_date          [BLOCKED]
 closed_date_fk              -> dim_date          [BLOCKED]
 turn_count                  -- integer           [available today]
 participant_count           -- integer           [available today]
+conversation_text_chars     -- summed pre-redaction length of the kept turns  [available today]
 resolution_duration_seconds -- the "how long was it open" measure  [BLOCKED]
 final_status                -- current-state snapshot              [available today]
 explicit_rating             -- conversation-level rating           [available today]
+
+-- generated: summary (§5b)
+conversation_summary        -- LLM-generated abstract of the whole exchange (REDACTED-derived)
+summary_model_version       -- which model/prompt produced it; null = not summarized
+summarized_at
+
+-- generated: embedding
+embedding_vector            -- Iceberg ARRAY<float>
+embedding_dim               -- Matryoshka sweep: 256 | 512 | 1024
+embedding_model_version     -- makes the model choice reversible without touching tfact_feedback
+embedding_input             -- 'summary' | 'concatenated_turns' — what was actually embedded
+embedded_at
+
+-- generated: assignments
+category_fk                 -> dim_feedback_category (nullable; §4a)
+sentiment_fk                -> dim_sentiment         (nullable; §4b)
+sentiment_source            -- 'explicit_rating' | 'model' — which tier produced it (§4b)
+cluster_run_id              -> feedback_cluster_run  (which run produced the assignment below)
+cluster_id                  -- -1 = noise = one-off, not systemic
+cluster_probability         -- cohesion signal for ranking systemic issues
+
+-- audit
+conversation_ingested_at
 ```
+
+**Why the conversation is the analysis unit.** A support ticket's actual complaint frequently emerges over
+several exchanges. Embedding turns independently splits one issue into several weak cluster members, scores
+sentiment off a fragment ("still not working"), and makes cluster size a function of how talkative the
+reporter was. At conversation grain a cluster's size *is* its distinct-conversation count, which is the
+number the systemic-vs-one-off judgement actually wants.
+
+**This is not a return to rev. 1's ticket grain.** Rev. 2's argument was that a problem first articulated in
+turn 4 must reach the warehouse at all — it fixed *what gets recorded*. Rev. 3 fixes *what gets analyzed*:
+turn 4's text is now part of the same analysis unit as turn 1 rather than a separate one. Both depend on the
+turn grain in §1; the fact still records every turn, and the assembled conversation is built from all of
+them, not from `is_conversation_opening`.
+
+### 5b. The summary, and what it costs
+
+`conversation_summary` is an LLM abstract of the assembled (redacted) turns. It is the thing a human reads in
+a cluster listing instead of scrolling a thread, and — per `feedback_ml_approach.md` §B.1 — it is also a
+candidate for *what gets embedded*, which the 2026 support-ticket-clustering evidence identifies as the
+largest single lever on cluster quality for short, noisy text.
+
+It is also the one genuinely per-record LLM cost in this design, so it is stated rather than buried:
+
+- **Summarize only where it can add something.** Skip single-turn conversations and conversations under a
+  length threshold — the raw text already *is* the summary. ORA (~140 chars) and the plugin are single-turn
+  by construction and are never summarized; short one-and-done Zendesk tickets are skipped by the same rule.
+  `summary_model_version` is null for those rows and `embedding_input` is `concatenated_turns`.
+- **Order of magnitude, to be validated on a sample before the backfill:** the multi-turn share of ~198K
+  Zendesk tickets at roughly 1–2K input tokens and ~100 output tokens each puts the one-time backfill in the
+  low hundreds of dollars at Haiku-class pricing, with steady state (~24K tickets/yr, a fraction multi-turn)
+  in the tens of dollars a year. That is one to two orders of magnitude above the $2–16 embedding backfill
+  and still small in absolute terms — but it is a real change to the "trivial batch cost" posture the
+  project has carried since discovery, and it should be confirmed with a measured sample rather than assumed.
+- **PII:** the summary is generated *from redacted text only* and inherits that classification. It is never
+  generated from `stg`/`raw`.
 
 **Partially blocked on ingestion.** The Zendesk streams landed in the lake
 (`src/ol_dbt/models/staging/zendesk/_zendesk__sources.yml`) are exactly seven — `tickets`,
@@ -386,7 +491,8 @@ explicit_rating             -- conversation-level rating           [available to
 So this table ships with the available-today columns and the duration measures land once `ticket_metrics` is
 added to the connector (a separate ingestion ticket). The grain does not move when they arrive.
 
-It conforms beyond Zendesk: a tutor thread and a forum thread also open, run, and go quiet.
+It conforms beyond Zendesk: a tutor thread and a forum thread also open, run, and go quiet — and a
+single-utterance ORA submission is a conversation of length one (§1).
 
 ---
 
@@ -439,14 +545,19 @@ raw__<source>__…                         (existing per source; new: raw__learn
   → stg__<source>__…__feedback           (conform to §5 contract, light typing)
     → int__feedback__<source>            (per-source adapter; TURN grain + source filters §1)
       → int__feedback__unioned           (UNION all sources into the common shape + redact PII §7)
-        → tfact_feedback                  (resolve conformed FKs, generate feedback_pk §6)
+        → tfact_feedback                  (resolve conformed FKs, generate feedback_pk §6 — INSERT-ONLY)
           → bridge_feedback_tag           (explode source tags → dim_feedback_tag §4e)
-          → afact_feedback_cluster_daily  (cluster × category × sentiment × date × source — strategic rollup)
-        → afact_feedback_conversation     (conversation grain §5a; also reads the source's conversation model)
+          → int__feedback__conversation   (assemble kept turns per conversation_id, ordered by turn_index)
+            → afact_feedback_conversation (§5a — lifecycle + summary + vector + sentiment/category/cluster)
+              → afact_feedback_cluster_daily  (cluster × category × sentiment × date × source rollup)
 ```
-Clustering/labeling jobs (Dagster asset) read `int__feedback__unioned` (redacted) and write
-`feedback_embeddings`, `dim_feedback_category`, and `category_fk`/`sentiment_fk` back onto the fact
-(late-arriving update).
+The ML batch (Dagster asset) reads `int__feedback__conversation` (redacted, assembled) and writes
+`afact_feedback_conversation` plus proposed rows on `dim_feedback_category`. **It never writes to
+`tfact_feedback`** — the late-arriving update path that existed through rev. 2 is gone (§2).
+
+`afact_feedback_cluster_daily` now aggregates the conversation fact rather than the turn fact, which
+collapses rev. 2's awkward `feedback_count` vs. `distinct_conversation_count` distinction: at this grain
+they are the same number.
 
 ---
 
@@ -454,19 +565,24 @@ Clustering/labeling jobs (Dagster asset) read `int__feedback__unioned` (redacted
 
 - **MVP (support/eng):** `tfact_feedback` restricted to `source_slug='zendesk'` at **turn grain**, plus
   `dim_feedback_source`, `dim_feedback_channel`, `dim_feedback_category` (seeded from `ticket_tags`),
-  `dim_sentiment`, `dim_feedback_tag` + `bridge_feedback_tag`, and `afact_feedback_conversation`
-  (available-today columns only). Batch. Row count is public-requester **comments**, not the previous ~198K
-  tickets — **to be measured before committing** (§10).
+  `dim_sentiment`, `dim_feedback_tag` + `bridge_feedback_tag`, and `afact_feedback_conversation` — its
+  lifecycle columns first (one row per ticket, ~198K, a number that *is* known), then the generated columns
+  as the ML asset lands. Batch. The turn-fact row count is public-requester **comments**, not tickets —
+  **to be measured before committing** (§10).
 - **Phase 2:** add forum/tutor/ORA sources (fact already tolerates them), enable cross-source
   `afact_feedback_cluster_daily` for leadership, course-scoped views for instructors, and the
   `ticket_metrics`-gated duration measures on `afact_feedback_conversation`.
 - **Phase 3:** analytics-api/data-bus ingress (contract §5 already lets the fact ignore the switch).
 
-**Cost note.** Rev. 2 moves MVP from 3 new dimensions to 4 dimensions + 1 bridge + 1 conversation fact. The
-additions are `select distinct` cheap (`dim_feedback_channel`, `dim_feedback_tag`) or a straight aggregation
-(`afact_feedback_conversation`), so the build cost is small — but it is a real increase and worth confirming
-deliberately. The argument for paying it now: reshaping a fact after it has consumers is the expensive
-version, and the §1 grain change has to land pre-ship regardless because it moves the business key (§6).
+**Cost note.** Rev. 2 moved MVP from 3 new dimensions to 4 dimensions + 1 bridge + 1 conversation fact — all
+`select distinct` cheap or a straight aggregation, so the dbt build cost is small. Rev. 3 adds **no** new
+tables: it withdraws two (`feedback_embeddings`, `feedback_cluster_assignment`) and widens
+`afact_feedback_conversation`. The cost it *does* add is the per-conversation LLM summary (§5b), which is a
+step up from the embedding-only budget and is the number to confirm on a sample before the backfill.
+
+The argument for paying the rev. 2/3 reshaping now rather than later is unchanged: reshaping a fact after it
+has consumers is the expensive version, and the §1 grain change has to land pre-ship regardless because it
+moves the business key (§6).
 
 ---
 
@@ -481,18 +597,41 @@ version, and the §1 grain change has to land pre-ship regardless because it mov
 | Add the `ticket_metrics` stream to the Zendesk Airbyte connector | ingestion, separate ticket | duration measures on `afact_feedback_conversation` (§5a) |
 | Confirm the conformed `channel_slug` value set against each source's actual channel values | modeling | `dim_feedback_channel` seed (§4d) |
 | Run the PII profiler over `comment_plain_body` (only `ticket_description` is classified today) | classification | the first embed run at turn grain (§7) |
+| Measure the multi-turn share of Zendesk tickets and sample-price the summary step | measurement | the §5b summarization budget, and the skip-threshold that keeps single-turn conversations free |
+| Decide `embedding_input` — summary, concatenated turns, or both as an eval arm | modeling | the bake-off in `feedback_ml_approach.md` §B.1 |
 
 **Handed to existing tasks:**
 
 - Category discovery & seeding → `tk-define-llm-driven-category-discovery-to-seed-pop-550aba`
 - Sentiment method & `dim_sentiment` grain → `tk-define-sentiment-mapping-via-semantic-embedding--92988e`
-- Clustering method + `feedback_embeddings` store + roll-up hierarchy → `tk-define-clustering-approach-for-systemic-issue-de-a1d7d6`
+- Clustering method + embedding storage on the conversation fact + roll-up hierarchy → `tk-define-clustering-approach-for-systemic-issue-de-a1d7d6`
 - Per-persona actions, surface, row-level access → `tk-define-ui-ux-audience-actions-and-where-the-expe-476d23`
 - Contract finalization + business keys → `tk-define-stable-common-feedback-event-contract-bus-245a8e`
 
 ---
 
 ## 11. Change log
+
+**rev. 3 (2026-08-10)** — the analysis unit moves from the turn to the conversation
+([RFC #12210](https://github.com/mitodl/hq/discussions/12210)):
+
+- **`afact_feedback_conversation` becomes the analysis fact** (§5a) — it now carries the LLM summary, the
+  embedding vector, `category_fk`, `sentiment_fk` and cluster membership alongside the lifecycle columns it
+  had in rev. 2, with `summary_model_version` / `embedding_model_version` / `cluster_run_id` recording which
+  generation produced each.
+- **`category_fk` and `sentiment_fk` are removed from `tfact_feedback`** (§2). With them gone there is no
+  late-arriving write path to the fact at all: **`tfact_feedback` is insert-only**.
+- **The per-turn ML sidecar is withdrawn** (§4f) — `feedback_embeddings` and `feedback_cluster_assignment`
+  are gone. `feedback_cluster_run` survives (a genuinely different grain) and a small
+  `feedback_cluster_candidate` covers run-vs-run comparison for the model bake-off.
+- **Added `conversation_summary`** (§5b), with an explicit skip rule for single-turn/short conversations and
+  a stated cost, because it is the one per-record LLM call in the design.
+- **Sentiment's grain mismatch is fixed** (§4b) — Zendesk's ticket-level CSAT is now the same grain as the
+  sentiment it seeds, instead of a label propagated across turns.
+- `afact_feedback_cluster_daily` aggregates the conversation fact, so `feedback_count` and
+  `distinct_conversation_count` collapse into one measure (§8).
+- **Unchanged:** the turn grain of `tfact_feedback` (§1), the Zendesk comment sourcing, the business-key
+  strategy (§6), the conformance rule (§0) and the event contract (§5).
 
 **rev. 2 (2026-08-07)** — from [@KatelynGit's RFC
 review](https://github.com/mitodl/hq/discussions/12210#discussioncomment-17937328):

--- a/docs/design/feedback_erd.md
+++ b/docs/design/feedback_erd.md
@@ -1,7 +1,8 @@
 # Feedback Aggregation — Entity-Relationship Diagrams
 
 Status: **spec** · Project: `wp-feedback-aggregation-clustering-system-2e9750`
-Date: 2026-08-07 · Companion to [`feedback_dimensional_model.md`](./feedback_dimensional_model.md),
+Date: 2026-08-07 (rev. 2 — turn grain + conformance rule) · Companion to
+[`feedback_dimensional_model.md`](./feedback_dimensional_model.md),
 [`feedback_event_contract_spec.md`](./feedback_event_contract_spec.md) and
 [`feedback_ml_approach.md`](./feedback_ml_approach.md).
 
@@ -9,13 +10,28 @@ Visual counterpart to the column lists in the specs above, so the schema is revi
 than as prose. Also posted as an addendum on
 [RFC mitodl/hq#12210](https://github.com/mitodl/hq/discussions/12210#discussioncomment-17935060).
 
-Drawing the model surfaced three schema changes — two from review feedback on
-[#2422](https://github.com/mitodl/ol-data-platform/pull/2422), one from the diagram itself. They are applied
-in the diagrams below and in the companion specs; §5 records what changed and why.
-
 **Reading the diagrams:** `||--o{` = required FK (never null). `|o--o{` = **nullable** FK — sparse
-conformance is the flexibility mechanism (`feedback_dimensional_model.md` §2), so most of the star is
-deliberately optional.
+conformance is the flexibility mechanism, so most of the star is deliberately optional.
+
+---
+
+## 0. The conformance rule
+
+Everything below follows from one rule, adopted after review feedback on
+[#2422](https://github.com/mitodl/ol-data-platform/pull/2422) and
+[RFC #12210](https://github.com/mitodl/hq/discussions/12210#discussioncomment-17937328):
+
+> **An attribute earns a column on the fact, or a conformed dimension, only if two or more sources can
+> populate it.** Everything else lives in the `source_metadata` variant column, and is promoted to a real
+> column if and when a second source starts supplying it.
+
+`tfact_feedback` exists to aggregate Zendesk *plus* edX forum, Learn AI tutor, ORA and the edX feedback
+plugin. Shaping the core tables around what Zendesk happens to expose makes every later source pay for it.
+Applying the rule is what produced the attribute placement in §1 and the withdrawals in §6.
+
+**Promotion path** (so the variant does not become a dumping ground): when a second source begins populating
+a key inside `source_metadata`, promote it to a real column or a conformed dimension **in the same change
+that onboards that source** — not later, and not speculatively in advance.
 
 ---
 
@@ -24,46 +40,53 @@ deliberately optional.
 ```mermaid
 erDiagram
     dim_feedback_source   ||--o{ tfact_feedback : "feedback_source_fk"
-    dim_date              ||--o{ tfact_feedback : "date_fk"
-    dim_time              ||--o{ tfact_feedback : "time_fk"
+    dim_feedback_channel  ||--o{ tfact_feedback : "feedback_channel_fk"
+    dim_date              ||--o{ tfact_feedback : "occurred / created / updated (role-playing)"
+    dim_time              ||--o{ tfact_feedback : "occurred / created / updated (role-playing)"
     dim_feedback_category |o--o{ tfact_feedback : "category_fk (late-arriving)"
     dim_sentiment         |o--o{ tfact_feedback : "sentiment_fk (late-arriving)"
     dim_user              |o--o{ tfact_feedback : "user_fk (identity: highest-risk join)"
     dim_platform          |o--o{ tfact_feedback : "platform_fk"
     dim_course_run        |o--o{ tfact_feedback : "courserun_fk (course-scoped sources)"
-    dim_course_content    |o--o{ tfact_feedback : "content_block_fk (NEW - what it is about)"
+    dim_course_content    |o--o{ tfact_feedback : "content_block_fk (what it is about)"
     dim_organization      |o--o{ tfact_feedback : "organization_fk"
-    tfact_feedback        ||--o{ feedback_embeddings : "feedback_pk"
+    tfact_feedback        ||--o{ bridge_feedback_tag : "feedback_pk"
+    dim_feedback_tag      ||--o{ bridge_feedback_tag : "feedback_tag_pk"
+    afact_feedback_conversation ||--o{ tfact_feedback : "conversation_id (turns roll up)"
 
     tfact_feedback {
-        varchar feedback_pk PK "surrogate_key(source_slug, source_record_ref) - stable across the data-bus migration"
+        varchar feedback_pk PK "surrogate_key(source_slug, source_record_ref) - ref is the TURN id"
         varchar feedback_source_fk FK "required"
-        varchar user_fk FK "nullable - anonymous or unresolved requester"
+        varchar feedback_channel_fk FK "required - conformed; every source has a channel"
+        varchar user_fk FK "nullable - anonymous or unresolved author"
         varchar platform_fk FK "nullable"
         varchar courserun_fk FK "nullable - Zendesk is not course-scoped"
-        varchar content_block_fk FK "nullable - NEW, resolves subject_ref for edX blocks"
+        varchar content_block_fk FK "nullable - resolves subject_ref for edX blocks"
         varchar organization_fk FK "nullable"
         varchar category_fk FK "nullable at insert - ML or seed fills later"
-        varchar sentiment_fk FK "nullable at insert - CSAT or model fills later"
-        varchar date_fk FK "required"
-        varchar time_fk FK "required"
-        varchar conversation_id "degenerate - roll utterances up to a ticket or thread"
-        varchar source_record_id "degenerate - source-native business key, idempotency key"
-        varchar source_url "deep link back to origin"
-        varchar subject_type "NEW - courseware_block, course_run, course, program, page_url, resource, unspecified"
-        varchar subject_ref "NEW - source-native id of the thing the feedback is about"
-        varchar subject_url "NEW - canonical or decoded deep link to that thing"
+        varchar sentiment_fk FK "nullable at insert - rating or model fills later"
+        integer occurred_date_fk FK "required - role-playing on the utterance timestamp"
+        integer occurred_time_fk FK "required"
+        integer created_date_fk FK "role-playing"
+        integer created_time_fk FK "role-playing"
+        integer updated_date_fk FK "role-playing"
+        integer updated_time_fk FK "role-playing"
+        varchar conversation_id "degenerate - ticket_id, chatsession_thread_id, forum thread"
+        integer turn_index "ordinal of this turn within the conversation"
+        boolean is_conversation_opening "first-turn-only becomes a filter, not a grain"
+        varchar source_record_id "degenerate - the TURN business key (comment_id, checkpoint_id)"
+        varchar source_url "degenerate - unique per row, deep link back to origin"
+        varchar subject_type "courseware_block, course_run, course, program, page_url, resource, unspecified"
+        varchar subject_ref "source-native id of the thing the feedback is about"
+        varchar subject_url "canonical or decoded deep link to that thing"
         varchar feedback_title "REDACTED"
         varchar feedback_text "REDACTED - raw text never lands in the fact"
         integer feedback_text_chars "pre-redaction length metric"
-        varchar source_status "facet - Zendesk ticket_status"
-        varchar source_priority "facet - Zendesk ticket_priority"
-        varchar source_channel "facet - Zendesk source_channel, tutor agent, forum component"
-        varchar source_brand "NEW facet - Zendesk brand_name (hq#12607)"
-        varchar source_group "NEW facet - Zendesk group_name (hq#12607)"
-        array source_tags "array of varchar - category seeds"
-        varchar csat_score "explicit sentiment signal"
-        timestamp feedback_occurred_at "source event time"
+        varchar explicit_rating "conformed - Zendesk CSAT, tutor rating, ORA score"
+        varchar source_metadata "VARIANT - JSON string; status, priority, brand, group, due, custom fields"
+        timestamp feedback_occurred_at "the utterance itself"
+        timestamp feedback_created_at
+        timestamp feedback_updated_at
         timestamp feedback_ingested_at
     }
 
@@ -74,6 +97,14 @@ erDiagram
         varchar source_medium "support_ticket, forum_post, chat, assessment, in_product"
         varchar source_audience_scope "operational, course, strategic"
         boolean is_course_scoped
+        boolean is_conversational "does this source have multi-turn conversations"
+    }
+
+    dim_feedback_channel {
+        varchar feedback_channel_pk PK "surrogate_key(channel_slug)"
+        varchar channel_slug UK "email, web_form, in_product_widget, chat, forum_post, assessment, api"
+        varchar channel_name
+        boolean is_solicited "did we ask for it, or did they volunteer it"
     }
 
     dim_feedback_category {
@@ -83,7 +114,7 @@ erDiagram
         varchar category_parent_slug "optional hierarchy: cluster to category to theme"
         varchar category_status "proposed, approved, merged, deprecated"
         varchar category_source "seed, llm_discovered, manual"
-        varchar cluster_run_id "NEW - provenance: which run proposed this category"
+        varchar cluster_run_id "provenance: which run proposed this category"
         timestamp first_seen_at
         timestamp updated_at
     }
@@ -93,18 +124,86 @@ erDiagram
         varchar sentiment_slug UK "positive, neutral, negative"
         varchar polarity_score_bucket "coarse bucket for trend rollups"
     }
+
+    dim_feedback_tag {
+        varchar feedback_tag_pk PK "surrogate_key(source_slug, tag_slug)"
+        varchar tag_slug "tags are source-scoped, not global"
+        varchar tag_label
+        varchar source_slug FK "which source system uses this tag"
+    }
+
+    bridge_feedback_tag {
+        varchar feedback_pk PK "part of compound key"
+        varchar feedback_tag_pk PK "part of compound key"
+    }
 ```
 
-The three new dimensions are the only new dimensional work. `dim_user`, `dim_platform`, `dim_course_run`,
-`dim_organization`, `dim_course_content` and `dim_date`/`dim_time` are reused as-is.
+Two dimensions are conformed-by-construction (`dim_feedback_source`, `dim_feedback_channel`), two are
+derived and source-agnostic (`dim_feedback_category`, `dim_sentiment`), one is explicitly source-scoped
+(`dim_feedback_tag`). `dim_user`, `dim_platform`, `dim_course_run`, `dim_organization`,
+`dim_course_content` and `dim_date`/`dim_time` are reused as-is.
+
+### Why these attributes and not others
+
+Every attribute was audited against all five sources before being given a home:
+
+| Attribute | Zendesk | forum | tutor | ORA | plugin | Home |
+|---|:-:|:-:|:-:|:-:|:-:|---|
+| channel / medium | ✓ | ✓ | ✓ | ✓ | ✓ | **`dim_feedback_channel`** |
+| explicit rating | ✓ | ✗ | ✓ | ✓ | ✓ | **`explicit_rating`** measure on the fact |
+| turn index | ✓ | ✓ | ✓ | ✗ | ✗ | **`turn_index`** degenerate |
+| conversation ref | ✓ | ✓ | ✓ | ✗ | ✗ | **`conversation_id`** degenerate |
+| subject (what it is about) | ~ | ✓ | ✓ | ✓ | ✓ | **`subject_*`** + `content_block_fk` |
+| created / updated | ✓ | ✓ | ✓ | ✓ | ✓ | **role-playing date/time FKs** |
+| tags | ✓ | ~ | ✗ | ✗ | ? | **`bridge_feedback_tag`** (source-scoped) |
+| status | ✓ | ✗ | ✗ | ✗ | ✗ | `source_metadata` |
+| priority | ✓ | ✗ | ✗ | ✗ | ✗ | `source_metadata` |
+| brand | ✓ | ✗ | ✗ | ✗ | ✗ | `source_metadata` |
+| group | ✓ | ✗ | ✗ | ✗ | ✗ | `source_metadata` |
+| due date | ✓ | ✗ | ✗ | ✗ | ✗ | `source_metadata` |
+
+### `source_metadata` — how the variant is actually stored
+
+Iceberg v2 has **no native JSON type**, so the repo's established pattern is to persist JSON as a
+**varchar containing a JSON string** — written with `json_format(...)`, read with the cross-db
+`json_query_string` / `json_extract_value` macros in `src/ol_dbt/macros/cross_db_functions.sql`, which
+already dispatch across Trino / DuckDB / StarRocks. In-repo precedent: `dim_course_content.block_metadata`
+("a JSON string representing the metadata field… different block types may have different member fields").
+
+StarRocks has a native JSON type and the read macros already target it, so the eventual migration is a
+column-type change, not a redesign.
 
 ---
 
-## 2. Common event contract → the fact
+## 2. Grain — one row per turn
 
-The contract is the durable artifact (RFC Option 3): every producer presents this shape at the
-`stg__…__feedback` / `int__feedback__<source>` boundary, so the fact is indifferent to which pipe delivered
-the row.
+**`tfact_feedback` = one row per atomic free-text utterance, where an utterance is one *turn* of a
+conversation** — not one conversation.
+
+| Source | One row = | Text column | `source_record_ref` | `conversation_ref` |
+|---|---|---|---|---|
+| Zendesk | one **public, requester-authored comment** | `comment_plain_body` | `comment_id` | `ticket_id` |
+| edX forum | one `*.created` post / response / comment | `post_content` | `post_id` | thread id |
+| Learn AI tutor | one human turn | `human_message` | `checkpoint_id` | `chatsession_thread_id` |
+| ORA | one feedback submission | `feedback_text` | `submission_uuid` | n/a |
+| edX plugin | one feedback event | `feedback_text` | plugin event id | n/a |
+
+Turn grain is what the other sources already do: `int__learn_ai__chatbot` is one row per
+`djangocheckpoint` (ordered by `checkpoint_step`), and the forum sources are one row per tracking-log
+event. Zendesk at ticket grain was the only outlier, and it was an outlier in the Zendesk-shaped direction
+the §0 rule exists to prevent.
+
+**Exclusions are stated per source as one consistent rule — the author must be the person giving feedback,
+not the platform answering:** Zendesk keeps `comment_is_public = true` and author = requester (drops
+internal notes and agent replies); tutor keeps `human_message` and drops `agent_message`; forum keeps
+`*.created` and drops view/vote/follow events.
+
+`is_conversation_opening` recovers the previous first-comment-only view as a `WHERE` clause, so nothing is
+lost by widening the grain.
+
+---
+
+## 3. Common event contract → the fact
 
 ```mermaid
 erDiagram
@@ -114,34 +213,79 @@ erDiagram
     feedback_event_contract {
         varchar source_slug "REQUIRED - maps to dim_feedback_source"
         timestamp occurred_at "REQUIRED - ISO8601 source event time"
-        varchar source_record_ref "REQUIRED - stable source-native id, idempotency and business key"
+        varchar source_record_ref "REQUIRED - stable source-native TURN id, idempotency + business key"
         varchar text "REQUIRED - raw free text, redacted in-warehouse"
+        varchar channel_slug "REQUIRED - maps to dim_feedback_channel"
         varchar title "subject or heading"
         varchar conversation_ref "thread or ticket id"
+        integer turn_index "ordinal within the conversation"
         varchar subject_user_ref "global or openedx user id - NEVER a source row PK"
         varchar courserun_readable_id "course scope"
         varchar platform "platform readable id"
-        varchar subject_type "NEW - what the feedback is ABOUT"
-        varchar subject_ref "NEW - source-native id of that thing"
-        varchar subject_url "NEW - canonical or decoded deep link"
-        json source_metadata "extension point - tags, status, priority, channel, csat, brand, group"
+        varchar subject_type "what the feedback is ABOUT"
+        varchar subject_ref "source-native id of that thing"
+        varchar subject_url "canonical or decoded deep link"
+        varchar explicit_rating "CSAT, tutor rating, ORA score - conformed"
+        varchar created_at "source lifecycle timestamp"
+        varchar updated_at "source lifecycle timestamp"
+        json source_metadata "everything not yet conformed - survives into the fact as a variant"
     }
 ```
 
-Per source:
-
-| Source | `source_record_ref` | `subject_type` / `subject_ref` |
-|---|---|---|
-| Zendesk (agent/web) | `ticket_id` | `course_run` / course readable id from ticket metadata, where present |
-| Zendesk (Appzi) | `ticket_id` | `page_url` / **decoded** Appzi URL (decoding is the adapter's job, §5a) |
-| edX forum | `post_id` | `courseware_block` / usage key of the discussion block |
-| Learn AI tutor | `thread_id` + `checkpoint_pk` | `course_run` / `courserun_readable_id` |
-| ORA | `submission_uuid` | `courseware_block` / ORA block usage key |
-| edX feedback plugin | plugin-native event id | `courseware_block` / block usage key |
+`source_metadata` is no longer flattened into Zendesk-shaped facet columns at the fact boundary — it is
+carried through **as a variant**, which is what makes a new source additive rather than a schema change.
 
 ---
 
-## 3. ML sidecar — embeddings, cluster runs, categories
+## 4. Conversation lifecycle — `afact_feedback_conversation`
+
+At turn grain, conversation-level attributes (status, priority, due date, CSAT, resolution time) repeat
+across every row of a conversation. They belong to a different grain, so they get their own table: an
+**accumulating-snapshot fact at conversation grain**, following the repo's `afact_` prefix for
+non-transactional facts.
+
+```mermaid
+erDiagram
+    afact_feedback_conversation ||--o{ tfact_feedback : "conversation_id"
+    dim_feedback_source ||--o{ afact_feedback_conversation : "feedback_source_fk"
+    dim_date            ||--o{ afact_feedback_conversation : "opened / resolved / closed (role-playing)"
+    dim_user            |o--o{ afact_feedback_conversation : "opened_by_user_fk"
+
+    afact_feedback_conversation {
+        varchar feedback_conversation_pk PK "surrogate_key(source_slug, conversation_ref)"
+        varchar feedback_source_fk FK
+        varchar opened_by_user_fk FK "nullable"
+        integer opened_date_fk FK "available today"
+        integer first_response_date_fk FK "BLOCKED - needs ticket_metrics"
+        integer resolved_date_fk FK "BLOCKED - needs ticket_metrics"
+        integer closed_date_fk FK "BLOCKED - needs ticket_metrics"
+        integer turn_count "available today"
+        integer participant_count "available today"
+        integer resolution_duration_seconds "BLOCKED - the how-long-was-it-open measure"
+        varchar final_status "available today - current-state snapshot"
+        varchar explicit_rating "available today"
+    }
+```
+
+**Partially blocked on ingestion.** The Zendesk streams landed in the lake
+(`src/ol_dbt/models/staging/zendesk/_zendesk__sources.yml`) are exactly seven:
+
+```
+tickets · ticket_comments · ticket_fields · brands · groups · organizations · users
+```
+
+`solved_at`, `closed_at`, `initially_assigned_at`, `first_resolution_time` and `full_resolution_time` live
+in Zendesk's **`ticket_metrics`** endpoint; full state history lives in **`ticket_audits`**. Neither is
+synced. In the `tickets` stream, "solved"/"closed" appear only as *values of `ticket_status`* — a snapshot
+with no history.
+
+So this table ships with `turn_count`, `participant_count`, `opened_date_fk`, `final_status` and
+`explicit_rating` now, and the duration measures land once `ticket_metrics` is added to the connector —
+an ingestion ticket, tracked separately. The grain does not move when they arrive.
+
+---
+
+## 5. ML sidecar — embeddings, cluster runs, categories
 
 ```mermaid
 erDiagram
@@ -183,121 +327,117 @@ erDiagram
     afact_feedback_cluster_daily {
         varchar date_fk FK
         varchar feedback_source_fk FK
+        varchar feedback_channel_fk FK
         varchar category_fk FK
         varchar sentiment_fk FK
         integer cluster_id
         integer feedback_count
         integer distinct_user_count
-        float avg_csat_score
+        integer distinct_conversation_count "turn grain means turns per conversation varies"
+        float avg_explicit_rating
     }
 ```
 
 `dim_feedback_category` is the *curated, stable* projection; `feedback_cluster_*` is the *churny* ML working
 set. Only an approved run advances the dimension — that decoupling is what lets clustering re-run freely.
 
+**Turn grain changes the ML volumes.** The record count is now public-requester *comments*, not tickets.
+Embedding cost scales linearly and stays small at these magnitudes, but the multiplier must be measured
+before committing (see §7). Turn grain also *helps* clustering: a follow-up complaint in turn 4 of a ticket
+is currently invisible, because only the first comment is embedded.
+
 ---
 
-## 4. What Phase 1 (Zendesk MVP) actually builds
+## 6. What Phase 1 (Zendesk MVP) builds
 
 ```mermaid
 erDiagram
     dim_feedback_source   ||--o{ tfact_feedback : "feedback_source_fk = zendesk"
-    dim_date              ||--o{ tfact_feedback : "date_fk"
-    dim_time              ||--o{ tfact_feedback : "time_fk"
+    dim_feedback_channel  ||--o{ tfact_feedback : "feedback_channel_fk - from comment_source_channel"
+    dim_date              ||--o{ tfact_feedback : "occurred / created / updated"
+    dim_time              ||--o{ tfact_feedback : "occurred / created / updated"
     dim_feedback_category |o--o{ tfact_feedback : "category_fk - seeded from ticket_tags"
     dim_sentiment         |o--o{ tfact_feedback : "sentiment_fk - from satisfaction_rating_score"
-    dim_user              |o--o{ tfact_feedback : "user_fk - requester email, last-resort path"
+    dim_user              |o--o{ tfact_feedback : "user_fk - comment author, email path"
+    tfact_feedback        ||--o{ bridge_feedback_tag : "feedback_pk"
+    dim_feedback_tag      ||--o{ bridge_feedback_tag : "feedback_tag_pk"
 
     tfact_feedback {
-        varchar feedback_pk PK "surrogate_key(zendesk, ticket_id)"
+        varchar feedback_pk PK "surrogate_key(zendesk, comment_id)"
+        varchar conversation_id "ticket_id"
         varchar courserun_fk "NULL at MVP - Zendesk is not course-scoped"
-        varchar platform_fk "NULL at MVP - but see the brand note in section 5b"
-        varchar organization_fk "NULL at MVP - see the dim_organization key note in section 5d"
+        varchar platform_fk "NULL at MVP - re-evaluate once brand is landed"
+        varchar organization_fk "NULL at MVP - see the dim_organization key note below"
         varchar content_block_fk "NULL at MVP - arrives with the edX plugin source"
+        varchar source_metadata "status, priority, brand, group, due, custom fields"
     }
 ```
-
-~198K rows, one batch. No ML required for the fact to be useful.
 
 Build path:
 
 ```mermaid
 flowchart TD
-    A["raw__thirdparty__zendesk_support__tickets<br/>(existing Airbyte)"] --> B["stg__zendesk__ticket<br/>(existing)"]
-    B --> C["int__zendesk__ticket<br/>(existing - grain source, already carries brand_name + group_name)"]
-    C --> D["int__feedback__zendesk<br/>(NEW - conform to the event contract)"]
+    A["raw__thirdparty__zendesk_support__tickets<br/>raw__thirdparty__zendesk_support__ticket_comments"] --> B["stg__zendesk__ticket<br/>stg__zendesk__ticket_comment<br/>(existing)"]
+    B --> C["int__zendesk__ticket_comment<br/>(existing - GRAIN SOURCE; needs comment_author_user_id added)"]
+    B --> C2["int__zendesk__ticket<br/>(existing - conversation attributes)"]
+    C --> D["int__feedback__zendesk<br/>(NEW - conform to the event contract, filter to public requester turns)"]
+    C2 --> D
     D --> E["int__feedback__unioned<br/>(NEW - union all sources + Presidio redaction)"]
     E --> F["tfact_feedback<br/>(NEW - resolve FKs, mint feedback_pk)"]
-    F --> G["afact_feedback_cluster_daily<br/>(Phase 2)"]
-    E -.->|Fenic, engine-external| H["feedback_embeddings<br/>feedback_cluster_run<br/>feedback_cluster_assignment"]
-    H -.->|LLM label, human approve| I["dim_feedback_category"]
-    I -.->|late-arriving update| F
-    F2["forum / tutor / ORA / edX plugin<br/>(Phase 2 - additive CTEs)"] --> E
+    F --> G["bridge_feedback_tag"]
+    C2 --> H["afact_feedback_conversation<br/>(NEW - conversation grain; durations blocked on ticket_metrics)"]
+    F --> H
+    F --> I["afact_feedback_cluster_daily<br/>(Phase 2)"]
+    E -.->|Fenic, engine-external| J["feedback_embeddings<br/>feedback_cluster_run<br/>feedback_cluster_assignment"]
+    J -.->|LLM label, human approve| K["dim_feedback_category"]
+    K -.->|late-arriving update| F
+    L["forum / tutor / ORA / edX plugin<br/>(Phase 2 - additive CTEs)"] --> E
 ```
 
----
-
-## 5. Schema deltas introduced with these diagrams
-
-### 5a. "What is the feedback *about*?" — `subject_type` / `subject_ref` / `subject_url` + `content_block_fk`
-
-Raised by @pdpinch on [#2422](https://github.com/mitodl/ol-data-platform/pull/2422#issuecomment-3157271372).
-The contract had *who* said it, *when*, and *in what conversation*, but no unambiguous slot for what it
-concerns — which is precisely the axis you aggregate on. Named cases: the edX feedback plugin captures the
-courseware block id; some Zendesk tickets carry course metadata; Appzi-originated tickets capture the URL the
-user was viewing (encoded).
-
-Deliberately **not** a new `dim_feedback_subject`: the subject is polymorphic across dimensions that already
-exist — a block is `dim_course_content`, a run is `dim_course_run`, a program is `dim_program`. A new dim
-would shadow them. Instead:
-
-- `subject_type` / `subject_ref` / `subject_url` are a degenerate triple on the contract and the fact — the
-  universal fallback that always works, including for URLs and unresolvable references.
-- Resolve to a conformed FK where one exists. `courserun_fk` already covers the course-run case; the only
-  new conformed join needed is **`content_block_fk → dim_course_content.content_block_pk`**, the existing
-  SCD for Open edX blocks (courses, chapters, subsections, problems, videos) that `tfact_problem_events` and
-  `tfact_course_navigation_events` already use. edX-plugin and ORA feedback therefore lands in the courseware
-  star with zero new dimensional work.
-- **Appzi URL decoding belongs in `int__feedback__zendesk`**, populating `subject_url`/`subject_ref` — not in
-  every consumer's query.
-
-### 5b. Zendesk brand and group as first-class facets
-
-Raised by @pdpinch citing [hq#12607](https://github.com/mitodl/hq/issues/12607). Cheap:
-`int__zendesk__ticket` already carries `brand_name` and `group_name` (joined from `stg__zendesk__brand` /
-`stg__zendesk__group`). Carry both in `source_metadata` at the contract boundary and project them to
-`source_brand` / `source_group` facet columns on the fact, so Superset filters on a plain varchar rather than
-a JSON extract.
-
-Worth evaluating during implementation: Zendesk **brand** is effectively "which help centre / product the
-ticket came in through", the closest thing Zendesk has to a platform. If brands map cleanly onto
-`dim_platform`, `platform_fk` need not be null for Zendesk after all.
-
-### 5c. Sidecar grain split
-
-`feedback_ml_approach.md` §A put vectors and cluster assignments in one `feedback_embeddings` table, but they
-have **different grains**: a vector is one per `(feedback_pk, model_version)`; a cluster assignment is one per
-`(feedback_pk, cluster_run_id)`. Re-clustering against an unchanged model would rewrite or duplicate vector
-rows — losing the "re-clustering never touches the durable artifact" property the design is buying. Split
-into `feedback_embeddings` / `feedback_cluster_run` / `feedback_cluster_assignment` as drawn in §3.
-
-Two consequences:
-
-- `dim_feedback_category` gains a `cluster_run_id` provenance column — trace a category back to the run that
-  proposed it.
-- The fact's `embedding_id` column is **dropped**. The sidecar is keyed by `feedback_pk`, so `embedding_id`
-  adds no reachability and would mean writing to the fact when embeddings land.
-
-### 5d. Known-null FK, flagged rather than discovered later
-
-`dim_organization.organization_pk = generate_surrogate_key(['platform', 'source_id'])`
-(`src/ol_dbt/models/dimensional/dim_organization.sql:38`). Zendesk has neither, so `organization_fk` cannot
-resolve for Zendesk tickets under the current key. It stays null at MVP and the Zendesk organisation/group is
-carried as a facet instead. Either that is acceptable, or `dim_organization` needs a Zendesk-aware alternate
-key — a decision worth making explicitly rather than by omission.
+**MVP cost check.** This moves Phase 1 from 3 new dimensions to **4 dimensions + 1 bridge + 1 conversation
+fact**. All of the additions are `select distinct` cheap (`dim_feedback_channel`, `dim_feedback_tag`) or a
+straight aggregation (`afact_feedback_conversation`), so the build cost is small — but it is a real increase
+and worth confirming deliberately. The argument for paying it now: reshaping a fact after it has consumers
+is the expensive version, and the grain change in §2 has to land before the fact ships regardless, because
+it moves the business key.
 
 ---
 
-Unchanged by all of the above: the business-key strategy
-(`feedback_pk = generate_surrogate_key([source_slug, source_record_ref])`), so the interim → data-bus
-migration is still "swap source + backfill + parity".
+## 7. Prerequisites and open items
+
+| Item | Kind | Blocks |
+|---|---|---|
+| Carry `comment_author_user_id` through `int__zendesk__ticket_comment` (it is in `stg__zendesk__ticket_comment`, not in the int model) | small dbt change | classifying requester-vs-agent turns; `user_fk` resolution |
+| Measure public-requester comment volume per ticket | measurement | sizing the fact and the embedding budget |
+| Add the `ticket_metrics` stream to the Zendesk Airbyte connector | ingestion, separate ticket | resolution/closure durations in `afact_feedback_conversation` |
+| Confirm the conformed `channel_slug` value set against each source's actual channel values | modeling | `dim_feedback_channel` seed |
+| `dim_organization.organization_pk = generate_surrogate_key(['platform','source_id'])` (`dim_organization.sql:38`) — Zendesk supplies neither | known-null, explicit decision | `organization_fk` for Zendesk stays null; org rides in `source_metadata` |
+
+---
+
+## 8. Change log
+
+**rev. 2 (2026-08-07)** — from [@KatelynGit's RFC
+review](https://github.com/mitodl/hq/discussions/12210#discussioncomment-17937328) and the conformance rule
+in §0:
+
+- **Grain moved from ticket to turn.** Zendesk `source_record_ref` is now `comment_id`, `conversation_ref`
+  is `ticket_id`. Added `turn_index` and `is_conversation_opening`.
+- **Adopted the ≥2-sources conformance rule** (§0) and re-audited every attribute against it.
+- **Added `dim_feedback_channel`** — the one attribute in the withdrawn junk dimension that is genuinely
+  conformed.
+- **Added `afact_feedback_conversation`** — conversation-grain lifecycle, partially blocked on ingestion.
+- **Added `dim_feedback_tag` + `bridge_feedback_tag`** — replaces the multi-valued `source_tags` array.
+- **Renamed** `date_fk`/`time_fk` → `occurred_date_fk`/`occurred_time_fk`; **added** created/updated
+  role-playing FKs and timestamps.
+- **`source_metadata` is now persisted as a variant on the fact** rather than flattened into facet columns.
+- **Withdrawn:** the `dim_feedback_context` junk dimension proposed in rev. 1 — it was Zendesk-shaped and
+  fails the §0 rule. **Withdrawn:** the `source_brand` / `source_group` facet columns added for
+  [hq#12607](https://github.com/mitodl/hq/issues/12607) — same reason; both fields remain available and
+  filterable from `source_metadata`. **Withdrawn:** `due_date_fk` — Zendesk-only, so it lives in the variant.
+
+**rev. 1 (2026-08-07)** — initial ERDs; subject reference (`subject_type`/`subject_ref`/`subject_url` +
+`content_block_fk`) from [@pdpinch's
+review](https://github.com/mitodl/ol-data-platform/pull/2422#issuecomment-5169778966); ML sidecar grain
+split into `feedback_embeddings` / `feedback_cluster_run` / `feedback_cluster_assignment`, dropping
+`embedding_id` from the fact.

--- a/docs/design/feedback_erd.md
+++ b/docs/design/feedback_erd.md
@@ -1,7 +1,8 @@
 # Feedback Aggregation — Entity-Relationship Diagrams
 
 Status: **spec** · Project: `wp-feedback-aggregation-clustering-system-2e9750`
-Date: 2026-08-10 (rev. 3 — conversation-grain analysis fact) · Companion to
+Date: 2026-08-13 (rev. 4 — fixes from [#2422 review](https://github.com/mitodl/ol-data-platform/pull/2422);
+rev. 3 conversation-grain analysis fact) · Companion to
 [`feedback_dimensional_model.md`](./feedback_dimensional_model.md),
 [`feedback_event_contract_spec.md`](./feedback_event_contract_spec.md) and
 [`feedback_ml_approach.md`](./feedback_ml_approach.md).
@@ -55,7 +56,7 @@ erDiagram
     dim_organization      |o--o{ tfact_feedback : "organization_fk"
     tfact_feedback        ||--o{ bridge_feedback_tag : "feedback_pk"
     dim_feedback_tag      ||--o{ bridge_feedback_tag : "feedback_tag_pk"
-    afact_feedback_conversation ||--o{ tfact_feedback : "conversation_id (turns roll up)"
+    afact_feedback_conversation ||--o{ tfact_feedback : "(feedback_source_fk, conversation_id) - turns roll up"
 
     tfact_feedback {
         varchar feedback_pk PK "surrogate_key(source_slug, source_record_ref) - ref is the TURN id"
@@ -212,8 +213,9 @@ lost by widening the grain.
 
 ```mermaid
 erDiagram
-    feedback_event_contract ||--|| int__feedback__unioned : "union all + Presidio redaction"
-    int__feedback__unioned  ||--|| tfact_feedback : "resolve conformed FKs, mint feedback_pk"
+    feedback_event_contract ||--|| int__feedback__unioned : "union all"
+    int__feedback__unioned  ||--|| feedback_redacted : "Presidio redaction (own Phase-1 asset, rev. 4)"
+    feedback_redacted       ||--|| tfact_feedback : "resolve conformed FKs, mint feedback_pk"
 
     feedback_event_contract {
         varchar source_slug "REQUIRED - maps to dim_feedback_source"
@@ -222,14 +224,15 @@ erDiagram
         varchar text "REQUIRED - raw free text, redacted in-warehouse"
         varchar channel_slug "REQUIRED - maps to dim_feedback_channel"
         varchar title "subject or heading"
-        varchar conversation_ref "thread or ticket id"
+        varchar conversation_ref "REQUIRED (rev. 4) - thread/ticket id; non-conversational sources set this to source_record_ref"
         integer turn_index "ordinal within the conversation"
         varchar subject_user_ref "global or openedx user id - NEVER a source row PK"
         varchar courserun_readable_id "course scope"
         varchar platform "platform readable id"
         varchar subject_type "what the feedback is ABOUT"
         varchar subject_ref "source-native id of that thing"
-        varchar subject_url "canonical or decoded deep link"
+        varchar subject_url "canonical or decoded deep link to the SUBJECT"
+        varchar source_url "NEW (rev. 4) - deep link to the record ITSELF, e.g. ticket API URL"
         varchar explicit_rating "CSAT, tutor rating, ORA score - conformed"
         varchar created_at "source lifecycle timestamp"
         varchar updated_at "source lifecycle timestamp"
@@ -255,7 +258,7 @@ conversation is built from all of them.
 
 ```mermaid
 erDiagram
-    afact_feedback_conversation ||--o{ tfact_feedback : "conversation_id (turns roll up)"
+    afact_feedback_conversation ||--o{ tfact_feedback : "(feedback_source_fk, conversation_id) - turns roll up"
     dim_feedback_source   ||--o{ afact_feedback_conversation : "feedback_source_fk"
     dim_date              ||--o{ afact_feedback_conversation : "opened / last_turn / resolved / closed"
     dim_user              |o--o{ afact_feedback_conversation : "opened_by_user_fk"
@@ -265,7 +268,7 @@ erDiagram
 
     afact_feedback_conversation {
         varchar feedback_conversation_pk PK "surrogate_key(source_slug, conversation_ref)"
-        varchar conversation_id "degenerate - joins tfact_feedback.conversation_id"
+        varchar conversation_id "degenerate - joins tfact_feedback on (feedback_source_fk, conversation_id) TOGETHER, never alone (rev. 4)"
         varchar feedback_source_fk FK
         varchar opened_by_user_fk FK "nullable"
         integer opened_date_fk FK "available today"
@@ -362,7 +365,7 @@ erDiagram
         integer cluster_id
         integer conversation_count "at conversation grain this IS the cluster size"
         integer distinct_user_count
-        float avg_explicit_rating
+        integer rated_conversation_count "coverage only - count with a non-null explicit_rating; replaces avg_explicit_rating (rev. 4, see note below)"
     }
 ```
 
@@ -379,6 +382,15 @@ what still lets clustering re-run freely.
 one talkative reporter could manufacture a systemic issue. At conversation grain a cluster's size *is* its
 conversation count, and that whole caveat disappears.
 
+**`rated_conversation_count` replaces `avg_explicit_rating` (fixed rev. 4, @copilot).**
+`explicit_rating` is a heterogeneous *string* across sources — Zendesk `'good'`/`'bad'`, tutor and ORA
+numeric-looking scores that are not on a shared scale — so averaging it as a float requires a conformed
+numeric mapping this design does not define. `sentiment_fk` is already the conformed signal on this rollup
+(derived from `explicit_rating` at MVP, per `feedback_zendesk_mvp_spec.md` §6), so a positive/neutral/
+negative breakdown is available via `sentiment_fk` without inventing a second normalization. The rollup
+keeps only `rated_conversation_count` — coverage, not an average — rather than defining a rating-to-number
+mapping speculatively ahead of a second source needing one.
+
 ---
 
 ## 6. What Phase 1 (Zendesk MVP) builds
@@ -392,7 +404,7 @@ erDiagram
     dim_user              |o--o{ tfact_feedback : "user_fk - comment author, email path"
     tfact_feedback        ||--o{ bridge_feedback_tag : "feedback_pk"
     dim_feedback_tag      ||--o{ bridge_feedback_tag : "feedback_tag_pk"
-    afact_feedback_conversation ||--o{ tfact_feedback : "conversation_id = ticket_id"
+    afact_feedback_conversation ||--o{ tfact_feedback : "(feedback_source_fk, conversation_id) = (zendesk, ticket_id)"
     dim_feedback_category |o--o{ afact_feedback_conversation : "category_fk - seeded from ticket_tags"
     dim_sentiment         |o--o{ afact_feedback_conversation : "sentiment_fk - from satisfaction_rating_score"
 
@@ -413,11 +425,12 @@ Build path:
 flowchart TD
     A["raw__thirdparty__zendesk_support__tickets<br/>raw__thirdparty__zendesk_support__ticket_comments"] --> B["stg__zendesk__ticket<br/>stg__zendesk__ticket_comment<br/>(existing)"]
     B --> C["int__zendesk__ticket_comment<br/>(existing - GRAIN SOURCE; needs comment_author_user_id added)"]
-    B --> C2["int__zendesk__ticket<br/>(existing - conversation attributes)"]
+    B --> C2["int__zendesk__ticket<br/>(existing - conversation attributes; needs ticket_requester_user_id added, rev. 4)"]
     C --> D["int__feedback__zendesk<br/>(NEW - conform to the event contract, filter to public requester turns)"]
     C2 --> D
-    D --> E["int__feedback__unioned<br/>(NEW - union all sources + Presidio redaction)"]
-    E --> F["tfact_feedback<br/>(NEW - resolve FKs, mint feedback_pk; INSERT-ONLY)"]
+    D --> E["int__feedback__unioned<br/>(NEW - union all sources)"]
+    E --> R["feedback_redacted<br/>(NEW, rev. 4 - Dagster Python asset, Presidio masking; Phase-1, upstream of the fact, NOT the ML asset)"]
+    R --> F["tfact_feedback<br/>(NEW - resolve FKs, mint feedback_pk; INSERT-ONLY)"]
     F --> G["bridge_feedback_tag"]
     F --> M["int__feedback__conversation<br/>(NEW - assemble kept turns per conversation, ordered)"]
     C2 --> H["afact_feedback_conversation<br/>(NEW - lifecycle + generated columns)"]
@@ -446,6 +459,7 @@ regardless, because it moves the business key.
 | Item | Kind | Blocks |
 |---|---|---|
 | Carry `comment_author_user_id` through `int__zendesk__ticket_comment` (it is in `stg__zendesk__ticket_comment`, not in the int model) | small dbt change | classifying requester-vs-agent turns; `user_fk` resolution |
+| Carry `ticket_requester_user_id` through `int__zendesk__ticket` (NEW, rev. 4 — the join to `stg__zendesk__user` already exists at `int__zendesk__ticket.sql:117-118`, only `requester.user_name` is selected today) | small dbt change | the §2 filter compares ids, not names — it cannot compile without this |
 | Measure public-requester comment volume per ticket | measurement | sizing the fact and the embedding budget |
 | Add the `ticket_metrics` stream to the Zendesk Airbyte connector | ingestion, separate ticket | resolution/closure durations in `afact_feedback_conversation` |
 | Confirm the conformed `channel_slug` value set against each source's actual channel values | modeling | `dim_feedback_channel` seed |
@@ -456,6 +470,23 @@ regardless, because it moves the business key.
 ---
 
 ## 8. Change log
+
+**rev. 4 (2026-08-13)** — implementation-blocking fixes from
+[#2422 review](https://github.com/mitodl/ol-data-platform/pull/2422), no grain/key/shape changes:
+
+- **`feedback_redacted` is its own node** (§3/§6) — redaction sits between `int__feedback__unioned` and
+  `tfact_feedback` as a distinct Phase-1 Dagster asset, not folded into the same union step or the ML
+  pipeline (detail: `feedback_zendesk_mvp_spec.md` §3).
+- **`conversation_ref` is required** in the contract (§3), with non-conversational sources setting it to
+  `source_record_ref`; **`source_url` added** to the contract (§3) — both were fact/adapter requirements
+  with no contract field to source them from.
+- **`(feedback_source_fk, conversation_id)` replaces bare `conversation_id`** everywhere the turn fact joins
+  the conversation fact (§1/§4/§6) — `conversation_id` is source-native and can collide across sources.
+- **`rated_conversation_count` replaces `avg_explicit_rating`** (§5) — `explicit_rating` is a heterogeneous
+  string, not a number, so it cannot be averaged without a normalization this design doesn't define.
+- **`ticket_requester_user_id` added to the prerequisites** (§7) — the same class of gap as
+  `comment_author_user_id`: the §2 filter needs the id, and `int__zendesk__ticket` today exposes only the
+  requester's name.
 
 **rev. 3 (2026-08-10)** — the analysis unit moves from the turn to the conversation
 ([RFC #12210](https://github.com/mitodl/hq/discussions/12210)):

--- a/docs/design/feedback_erd.md
+++ b/docs/design/feedback_erd.md
@@ -1,0 +1,303 @@
+# Feedback Aggregation — Entity-Relationship Diagrams
+
+Status: **spec** · Project: `wp-feedback-aggregation-clustering-system-2e9750`
+Date: 2026-08-07 · Companion to [`feedback_dimensional_model.md`](./feedback_dimensional_model.md),
+[`feedback_event_contract_spec.md`](./feedback_event_contract_spec.md) and
+[`feedback_ml_approach.md`](./feedback_ml_approach.md).
+
+Visual counterpart to the column lists in the specs above, so the schema is reviewable as a shape rather
+than as prose. Also posted as an addendum on
+[RFC mitodl/hq#12210](https://github.com/mitodl/hq/discussions/12210#discussioncomment-17935060).
+
+Drawing the model surfaced three schema changes — two from review feedback on
+[#2422](https://github.com/mitodl/ol-data-platform/pull/2422), one from the diagram itself. They are applied
+in the diagrams below and in the companion specs; §5 records what changed and why.
+
+**Reading the diagrams:** `||--o{` = required FK (never null). `|o--o{` = **nullable** FK — sparse
+conformance is the flexibility mechanism (`feedback_dimensional_model.md` §2), so most of the star is
+deliberately optional.
+
+---
+
+## 1. Target star schema — `tfact_feedback` and its dimensions
+
+```mermaid
+erDiagram
+    dim_feedback_source   ||--o{ tfact_feedback : "feedback_source_fk"
+    dim_date              ||--o{ tfact_feedback : "date_fk"
+    dim_time              ||--o{ tfact_feedback : "time_fk"
+    dim_feedback_category |o--o{ tfact_feedback : "category_fk (late-arriving)"
+    dim_sentiment         |o--o{ tfact_feedback : "sentiment_fk (late-arriving)"
+    dim_user              |o--o{ tfact_feedback : "user_fk (identity: highest-risk join)"
+    dim_platform          |o--o{ tfact_feedback : "platform_fk"
+    dim_course_run        |o--o{ tfact_feedback : "courserun_fk (course-scoped sources)"
+    dim_course_content    |o--o{ tfact_feedback : "content_block_fk (NEW - what it is about)"
+    dim_organization      |o--o{ tfact_feedback : "organization_fk"
+    tfact_feedback        ||--o{ feedback_embeddings : "feedback_pk"
+
+    tfact_feedback {
+        varchar feedback_pk PK "surrogate_key(source_slug, source_record_ref) - stable across the data-bus migration"
+        varchar feedback_source_fk FK "required"
+        varchar user_fk FK "nullable - anonymous or unresolved requester"
+        varchar platform_fk FK "nullable"
+        varchar courserun_fk FK "nullable - Zendesk is not course-scoped"
+        varchar content_block_fk FK "nullable - NEW, resolves subject_ref for edX blocks"
+        varchar organization_fk FK "nullable"
+        varchar category_fk FK "nullable at insert - ML or seed fills later"
+        varchar sentiment_fk FK "nullable at insert - CSAT or model fills later"
+        varchar date_fk FK "required"
+        varchar time_fk FK "required"
+        varchar conversation_id "degenerate - roll utterances up to a ticket or thread"
+        varchar source_record_id "degenerate - source-native business key, idempotency key"
+        varchar source_url "deep link back to origin"
+        varchar subject_type "NEW - courseware_block, course_run, course, program, page_url, resource, unspecified"
+        varchar subject_ref "NEW - source-native id of the thing the feedback is about"
+        varchar subject_url "NEW - canonical or decoded deep link to that thing"
+        varchar feedback_title "REDACTED"
+        varchar feedback_text "REDACTED - raw text never lands in the fact"
+        integer feedback_text_chars "pre-redaction length metric"
+        varchar source_status "facet - Zendesk ticket_status"
+        varchar source_priority "facet - Zendesk ticket_priority"
+        varchar source_channel "facet - Zendesk source_channel, tutor agent, forum component"
+        varchar source_brand "NEW facet - Zendesk brand_name (hq#12607)"
+        varchar source_group "NEW facet - Zendesk group_name (hq#12607)"
+        array source_tags "array of varchar - category seeds"
+        varchar csat_score "explicit sentiment signal"
+        timestamp feedback_occurred_at "source event time"
+        timestamp feedback_ingested_at
+    }
+
+    dim_feedback_source {
+        varchar feedback_source_pk PK "surrogate_key(source_slug)"
+        varchar source_slug UK "zendesk, edx_forum, learn_ai_tutor, ora, edx_feedback_plugin"
+        varchar source_name
+        varchar source_medium "support_ticket, forum_post, chat, assessment, in_product"
+        varchar source_audience_scope "operational, course, strategic"
+        boolean is_course_scoped
+    }
+
+    dim_feedback_category {
+        varchar feedback_category_pk PK "surrogate_key(category_slug)"
+        varchar category_slug UK "stable machine key - survives relabelling"
+        varchar category_label "LLM-proposed, human-approved"
+        varchar category_parent_slug "optional hierarchy: cluster to category to theme"
+        varchar category_status "proposed, approved, merged, deprecated"
+        varchar category_source "seed, llm_discovered, manual"
+        varchar cluster_run_id "NEW - provenance: which run proposed this category"
+        timestamp first_seen_at
+        timestamp updated_at
+    }
+
+    dim_sentiment {
+        varchar sentiment_pk PK "surrogate_key(sentiment_slug)"
+        varchar sentiment_slug UK "positive, neutral, negative"
+        varchar polarity_score_bucket "coarse bucket for trend rollups"
+    }
+```
+
+The three new dimensions are the only new dimensional work. `dim_user`, `dim_platform`, `dim_course_run`,
+`dim_organization`, `dim_course_content` and `dim_date`/`dim_time` are reused as-is.
+
+---
+
+## 2. Common event contract → the fact
+
+The contract is the durable artifact (RFC Option 3): every producer presents this shape at the
+`stg__…__feedback` / `int__feedback__<source>` boundary, so the fact is indifferent to which pipe delivered
+the row.
+
+```mermaid
+erDiagram
+    feedback_event_contract ||--|| int__feedback__unioned : "union all + Presidio redaction"
+    int__feedback__unioned  ||--|| tfact_feedback : "resolve conformed FKs, mint feedback_pk"
+
+    feedback_event_contract {
+        varchar source_slug "REQUIRED - maps to dim_feedback_source"
+        timestamp occurred_at "REQUIRED - ISO8601 source event time"
+        varchar source_record_ref "REQUIRED - stable source-native id, idempotency and business key"
+        varchar text "REQUIRED - raw free text, redacted in-warehouse"
+        varchar title "subject or heading"
+        varchar conversation_ref "thread or ticket id"
+        varchar subject_user_ref "global or openedx user id - NEVER a source row PK"
+        varchar courserun_readable_id "course scope"
+        varchar platform "platform readable id"
+        varchar subject_type "NEW - what the feedback is ABOUT"
+        varchar subject_ref "NEW - source-native id of that thing"
+        varchar subject_url "NEW - canonical or decoded deep link"
+        json source_metadata "extension point - tags, status, priority, channel, csat, brand, group"
+    }
+```
+
+Per source:
+
+| Source | `source_record_ref` | `subject_type` / `subject_ref` |
+|---|---|---|
+| Zendesk (agent/web) | `ticket_id` | `course_run` / course readable id from ticket metadata, where present |
+| Zendesk (Appzi) | `ticket_id` | `page_url` / **decoded** Appzi URL (decoding is the adapter's job, §5a) |
+| edX forum | `post_id` | `courseware_block` / usage key of the discussion block |
+| Learn AI tutor | `thread_id` + `checkpoint_pk` | `course_run` / `courserun_readable_id` |
+| ORA | `submission_uuid` | `courseware_block` / ORA block usage key |
+| edX feedback plugin | plugin-native event id | `courseware_block` / block usage key |
+
+---
+
+## 3. ML sidecar — embeddings, cluster runs, categories
+
+```mermaid
+erDiagram
+    tfact_feedback              ||--o{ feedback_embeddings : "feedback_pk"
+    tfact_feedback              ||--o{ feedback_cluster_assignment : "feedback_pk"
+    feedback_cluster_run        ||--o{ feedback_cluster_assignment : "cluster_run_id"
+    feedback_cluster_run        |o--o{ dim_feedback_category : "cluster_run_id (provenance)"
+    dim_feedback_category       |o--o{ tfact_feedback : "category_fk (late-arriving)"
+    tfact_feedback              ||--o{ afact_feedback_cluster_daily : "aggregated"
+
+    feedback_embeddings {
+        varchar feedback_pk PK "part of compound key"
+        varchar model_version PK "part of compound key - makes the model choice reversible"
+        array vector "Iceberg ARRAY of float - StarRocks HNSW indexes this later, a load not a re-embed"
+        integer vector_dim "Matryoshka sweep: 256, 512, 1024"
+        varchar text_variant "raw or llm_normalized - the semantic-normalisation eval arm"
+        timestamp embedded_at
+    }
+
+    feedback_cluster_run {
+        varchar cluster_run_id PK
+        varchar model_version FK "which embeddings this run consumed"
+        varchar algorithm "umap+hdbscan"
+        json run_params "min_cluster_size, n_neighbors - config not hardcoded"
+        integer cluster_count
+        integer noise_count "the one-off bucket"
+        float silhouette "only if the algorithm produces it"
+        varchar run_status "candidate, approved"
+        timestamp run_at
+    }
+
+    feedback_cluster_assignment {
+        varchar feedback_pk PK "part of compound key"
+        varchar cluster_run_id PK "part of compound key"
+        integer cluster_id "-1 = noise = one-off complaint"
+        float cluster_probability "cohesion signal for ranking systemic issues"
+    }
+
+    afact_feedback_cluster_daily {
+        varchar date_fk FK
+        varchar feedback_source_fk FK
+        varchar category_fk FK
+        varchar sentiment_fk FK
+        integer cluster_id
+        integer feedback_count
+        integer distinct_user_count
+        float avg_csat_score
+    }
+```
+
+`dim_feedback_category` is the *curated, stable* projection; `feedback_cluster_*` is the *churny* ML working
+set. Only an approved run advances the dimension — that decoupling is what lets clustering re-run freely.
+
+---
+
+## 4. What Phase 1 (Zendesk MVP) actually builds
+
+```mermaid
+erDiagram
+    dim_feedback_source   ||--o{ tfact_feedback : "feedback_source_fk = zendesk"
+    dim_date              ||--o{ tfact_feedback : "date_fk"
+    dim_time              ||--o{ tfact_feedback : "time_fk"
+    dim_feedback_category |o--o{ tfact_feedback : "category_fk - seeded from ticket_tags"
+    dim_sentiment         |o--o{ tfact_feedback : "sentiment_fk - from satisfaction_rating_score"
+    dim_user              |o--o{ tfact_feedback : "user_fk - requester email, last-resort path"
+
+    tfact_feedback {
+        varchar feedback_pk PK "surrogate_key(zendesk, ticket_id)"
+        varchar courserun_fk "NULL at MVP - Zendesk is not course-scoped"
+        varchar platform_fk "NULL at MVP - but see the brand note in section 5b"
+        varchar organization_fk "NULL at MVP - see the dim_organization key note in section 5d"
+        varchar content_block_fk "NULL at MVP - arrives with the edX plugin source"
+    }
+```
+
+~198K rows, one batch. No ML required for the fact to be useful.
+
+Build path:
+
+```mermaid
+flowchart TD
+    A["raw__thirdparty__zendesk_support__tickets<br/>(existing Airbyte)"] --> B["stg__zendesk__ticket<br/>(existing)"]
+    B --> C["int__zendesk__ticket<br/>(existing - grain source, already carries brand_name + group_name)"]
+    C --> D["int__feedback__zendesk<br/>(NEW - conform to the event contract)"]
+    D --> E["int__feedback__unioned<br/>(NEW - union all sources + Presidio redaction)"]
+    E --> F["tfact_feedback<br/>(NEW - resolve FKs, mint feedback_pk)"]
+    F --> G["afact_feedback_cluster_daily<br/>(Phase 2)"]
+    E -.->|Fenic, engine-external| H["feedback_embeddings<br/>feedback_cluster_run<br/>feedback_cluster_assignment"]
+    H -.->|LLM label, human approve| I["dim_feedback_category"]
+    I -.->|late-arriving update| F
+    F2["forum / tutor / ORA / edX plugin<br/>(Phase 2 - additive CTEs)"] --> E
+```
+
+---
+
+## 5. Schema deltas introduced with these diagrams
+
+### 5a. "What is the feedback *about*?" — `subject_type` / `subject_ref` / `subject_url` + `content_block_fk`
+
+Raised by @pdpinch on [#2422](https://github.com/mitodl/ol-data-platform/pull/2422#issuecomment-3157271372).
+The contract had *who* said it, *when*, and *in what conversation*, but no unambiguous slot for what it
+concerns — which is precisely the axis you aggregate on. Named cases: the edX feedback plugin captures the
+courseware block id; some Zendesk tickets carry course metadata; Appzi-originated tickets capture the URL the
+user was viewing (encoded).
+
+Deliberately **not** a new `dim_feedback_subject`: the subject is polymorphic across dimensions that already
+exist — a block is `dim_course_content`, a run is `dim_course_run`, a program is `dim_program`. A new dim
+would shadow them. Instead:
+
+- `subject_type` / `subject_ref` / `subject_url` are a degenerate triple on the contract and the fact — the
+  universal fallback that always works, including for URLs and unresolvable references.
+- Resolve to a conformed FK where one exists. `courserun_fk` already covers the course-run case; the only
+  new conformed join needed is **`content_block_fk → dim_course_content.content_block_pk`**, the existing
+  SCD for Open edX blocks (courses, chapters, subsections, problems, videos) that `tfact_problem_events` and
+  `tfact_course_navigation_events` already use. edX-plugin and ORA feedback therefore lands in the courseware
+  star with zero new dimensional work.
+- **Appzi URL decoding belongs in `int__feedback__zendesk`**, populating `subject_url`/`subject_ref` — not in
+  every consumer's query.
+
+### 5b. Zendesk brand and group as first-class facets
+
+Raised by @pdpinch citing [hq#12607](https://github.com/mitodl/hq/issues/12607). Cheap:
+`int__zendesk__ticket` already carries `brand_name` and `group_name` (joined from `stg__zendesk__brand` /
+`stg__zendesk__group`). Carry both in `source_metadata` at the contract boundary and project them to
+`source_brand` / `source_group` facet columns on the fact, so Superset filters on a plain varchar rather than
+a JSON extract.
+
+Worth evaluating during implementation: Zendesk **brand** is effectively "which help centre / product the
+ticket came in through", the closest thing Zendesk has to a platform. If brands map cleanly onto
+`dim_platform`, `platform_fk` need not be null for Zendesk after all.
+
+### 5c. Sidecar grain split
+
+`feedback_ml_approach.md` §A put vectors and cluster assignments in one `feedback_embeddings` table, but they
+have **different grains**: a vector is one per `(feedback_pk, model_version)`; a cluster assignment is one per
+`(feedback_pk, cluster_run_id)`. Re-clustering against an unchanged model would rewrite or duplicate vector
+rows — losing the "re-clustering never touches the durable artifact" property the design is buying. Split
+into `feedback_embeddings` / `feedback_cluster_run` / `feedback_cluster_assignment` as drawn in §3.
+
+Two consequences:
+
+- `dim_feedback_category` gains a `cluster_run_id` provenance column — trace a category back to the run that
+  proposed it.
+- The fact's `embedding_id` column is **dropped**. The sidecar is keyed by `feedback_pk`, so `embedding_id`
+  adds no reachability and would mean writing to the fact when embeddings land.
+
+### 5d. Known-null FK, flagged rather than discovered later
+
+`dim_organization.organization_pk = generate_surrogate_key(['platform', 'source_id'])`
+(`src/ol_dbt/models/dimensional/dim_organization.sql:38`). Zendesk has neither, so `organization_fk` cannot
+resolve for Zendesk tickets under the current key. It stays null at MVP and the Zendesk organisation/group is
+carried as a facet instead. Either that is acceptable, or `dim_organization` needs a Zendesk-aware alternate
+key — a decision worth making explicitly rather than by omission.
+
+---
+
+Unchanged by all of the above: the business-key strategy
+(`feedback_pk = generate_surrogate_key([source_slug, source_record_ref])`), so the interim → data-bus
+migration is still "swap source + backfill + parity".

--- a/docs/design/feedback_erd.md
+++ b/docs/design/feedback_erd.md
@@ -1,7 +1,7 @@
 # Feedback Aggregation — Entity-Relationship Diagrams
 
 Status: **spec** · Project: `wp-feedback-aggregation-clustering-system-2e9750`
-Date: 2026-08-07 (rev. 2 — turn grain + conformance rule) · Companion to
+Date: 2026-08-10 (rev. 3 — conversation-grain analysis fact) · Companion to
 [`feedback_dimensional_model.md`](./feedback_dimensional_model.md),
 [`feedback_event_contract_spec.md`](./feedback_event_contract_spec.md) and
 [`feedback_ml_approach.md`](./feedback_ml_approach.md).
@@ -12,6 +12,11 @@ than as prose. Also posted as an addendum on
 
 **Reading the diagrams:** `||--o{` = required FK (never null). `|o--o{` = **nullable** FK — sparse
 conformance is the flexibility mechanism, so most of the star is deliberately optional.
+
+**Two facts.** `tfact_feedback` (§1) is the *ingested* record — one row per turn, insert-only.
+`afact_feedback_conversation` (§4) is the *inferred* layer — one row per conversation, carrying the summary,
+the embedding, the sentiment, the category and the cluster. Read §4 to see where the models write; nothing
+writes to §1 after insert.
 
 ---
 
@@ -43,8 +48,6 @@ erDiagram
     dim_feedback_channel  ||--o{ tfact_feedback : "feedback_channel_fk"
     dim_date              ||--o{ tfact_feedback : "occurred / created / updated (role-playing)"
     dim_time              ||--o{ tfact_feedback : "occurred / created / updated (role-playing)"
-    dim_feedback_category |o--o{ tfact_feedback : "category_fk (late-arriving)"
-    dim_sentiment         |o--o{ tfact_feedback : "sentiment_fk (late-arriving)"
     dim_user              |o--o{ tfact_feedback : "user_fk (identity: highest-risk join)"
     dim_platform          |o--o{ tfact_feedback : "platform_fk"
     dim_course_run        |o--o{ tfact_feedback : "courserun_fk (course-scoped sources)"
@@ -63,8 +66,6 @@ erDiagram
         varchar courserun_fk FK "nullable - Zendesk is not course-scoped"
         varchar content_block_fk FK "nullable - resolves subject_ref for edX blocks"
         varchar organization_fk FK "nullable"
-        varchar category_fk FK "nullable at insert - ML or seed fills later"
-        varchar sentiment_fk FK "nullable at insert - rating or model fills later"
         integer occurred_date_fk FK "required - role-playing on the utterance timestamp"
         integer occurred_time_fk FK "required"
         integer created_date_fk FK "role-playing"
@@ -139,9 +140,13 @@ erDiagram
 ```
 
 Two dimensions are conformed-by-construction (`dim_feedback_source`, `dim_feedback_channel`), two are
-derived and source-agnostic (`dim_feedback_category`, `dim_sentiment`), one is explicitly source-scoped
-(`dim_feedback_tag`). `dim_user`, `dim_platform`, `dim_course_run`, `dim_organization`,
-`dim_course_content` and `dim_date`/`dim_time` are reused as-is.
+derived and source-agnostic (`dim_feedback_category`, `dim_sentiment` — which attach to the **conversation**
+fact in §4, not here), one is explicitly source-scoped (`dim_feedback_tag`). `dim_user`, `dim_platform`,
+`dim_course_run`, `dim_organization`, `dim_course_content` and `dim_date`/`dim_time` are reused as-is.
+
+**`tfact_feedback` is insert-only (rev. 3).** `category_fk` and `sentiment_fk` used to hang off this fact as
+late-arriving updates; they moved to `afact_feedback_conversation` (§4) along with the rest of the generated
+layer, so nothing writes to a row of this fact after it lands.
 
 ### Why these attributes and not others
 
@@ -237,35 +242,65 @@ carried through **as a variant**, which is what makes a new source additive rath
 
 ---
 
-## 4. Conversation lifecycle — `afact_feedback_conversation`
+## 4. The analysis fact — `afact_feedback_conversation`
 
-At turn grain, conversation-level attributes (status, priority, due date, CSAT, resolution time) repeat
-across every row of a conversation. They belong to a different grain, so they get their own table: an
-**accumulating-snapshot fact at conversation grain**, following the repo's `afact_` prefix for
-non-transactional facts.
+**One row per conversation**, keyed on the source's own thread id. It holds two things: the conversation
+lifecycle attributes that would otherwise repeat across every turn, **and everything a model generated** —
+the summary, the embedding, the sentiment, the category and the cluster (rev. 3).
+
+The conversation is the analysis unit because a complaint usually emerges across several turns. Embedding
+turns independently splits one issue into several weak cluster members and scores sentiment off a fragment.
+This is *not* a return to ticket grain: `tfact_feedback` still records every turn (§2), and the assembled
+conversation is built from all of them.
 
 ```mermaid
 erDiagram
-    afact_feedback_conversation ||--o{ tfact_feedback : "conversation_id"
-    dim_feedback_source ||--o{ afact_feedback_conversation : "feedback_source_fk"
-    dim_date            ||--o{ afact_feedback_conversation : "opened / resolved / closed (role-playing)"
-    dim_user            |o--o{ afact_feedback_conversation : "opened_by_user_fk"
+    afact_feedback_conversation ||--o{ tfact_feedback : "conversation_id (turns roll up)"
+    dim_feedback_source   ||--o{ afact_feedback_conversation : "feedback_source_fk"
+    dim_date              ||--o{ afact_feedback_conversation : "opened / last_turn / resolved / closed"
+    dim_user              |o--o{ afact_feedback_conversation : "opened_by_user_fk"
+    dim_feedback_category |o--o{ afact_feedback_conversation : "category_fk (generated)"
+    dim_sentiment         |o--o{ afact_feedback_conversation : "sentiment_fk (generated)"
+    feedback_cluster_run  |o--o{ afact_feedback_conversation : "cluster_run_id (which run assigned it)"
 
     afact_feedback_conversation {
         varchar feedback_conversation_pk PK "surrogate_key(source_slug, conversation_ref)"
+        varchar conversation_id "degenerate - joins tfact_feedback.conversation_id"
         varchar feedback_source_fk FK
         varchar opened_by_user_fk FK "nullable"
         integer opened_date_fk FK "available today"
+        integer last_turn_date_fk FK "available today"
         integer first_response_date_fk FK "BLOCKED - needs ticket_metrics"
         integer resolved_date_fk FK "BLOCKED - needs ticket_metrics"
         integer closed_date_fk FK "BLOCKED - needs ticket_metrics"
         integer turn_count "available today"
         integer participant_count "available today"
+        integer conversation_text_chars "summed pre-redaction length of kept turns"
         integer resolution_duration_seconds "BLOCKED - the how-long-was-it-open measure"
         varchar final_status "available today - current-state snapshot"
-        varchar explicit_rating "available today"
+        varchar explicit_rating "available today - and now grain-matched to sentiment_fk"
+        varchar conversation_summary "GENERATED - LLM abstract of the exchange, from redacted text only"
+        varchar summary_model_version "null = not summarized (single-turn or under the length threshold)"
+        timestamp summarized_at
+        array embedding_vector "GENERATED - Iceberg ARRAY of float; StarRocks HNSW indexes it later"
+        integer embedding_dim "Matryoshka sweep: 256, 512, 1024"
+        varchar embedding_model_version "makes the model choice reversible without touching tfact_feedback"
+        varchar embedding_input "summary or concatenated_turns - what was actually embedded"
+        timestamp embedded_at
+        varchar category_fk FK "GENERATED - nullable, a valid queryable state"
+        varchar sentiment_fk FK "GENERATED - nullable"
+        varchar sentiment_source "explicit_rating or model - which tier produced it"
+        varchar cluster_run_id FK "GENERATED - the approved run"
+        integer cluster_id "-1 = noise = one-off complaint, not systemic"
+        float cluster_probability "cohesion signal for ranking systemic issues"
+        timestamp conversation_ingested_at
     }
 ```
+
+**The summary is the one per-record LLM cost in the design.** It is skipped for single-turn conversations and
+conversations under a length threshold — where the raw text already *is* the summary — which makes ORA and
+the edX plugin free by construction. Cost is sized in `feedback_dimensional_model.md` §5b and must be
+sample-measured before the backfill.
 
 **Partially blocked on ingestion.** The Zendesk streams landed in the lake
 (`src/ol_dbt/models/staging/zendesk/_zendesk__sources.yml`) are exactly seven:
@@ -280,34 +315,28 @@ synced. In the `tickets` stream, "solved"/"closed" appear only as *values of `ti
 with no history.
 
 So this table ships with `turn_count`, `participant_count`, `opened_date_fk`, `final_status` and
-`explicit_rating` now, and the duration measures land once `ticket_metrics` is added to the connector —
-an ingestion ticket, tracked separately. The grain does not move when they arrive.
+`explicit_rating` now, the generated columns fill in as the ML asset lands, and the duration measures arrive
+once `ticket_metrics` is added to the connector — an ingestion ticket, tracked separately. The grain does not
+move when any of them arrive.
 
 ---
 
-## 5. ML sidecar — embeddings, cluster runs, categories
+## 5. Run provenance and the strategic rollup
+
+The per-turn ML sidecar from rev. 2 (`feedback_embeddings`, `feedback_cluster_assignment`) is **withdrawn** —
+its contents live on `afact_feedback_conversation` (§4). Two tables remain, both genuinely different grains
+from the conversation fact:
 
 ```mermaid
 erDiagram
-    tfact_feedback              ||--o{ feedback_embeddings : "feedback_pk"
-    tfact_feedback              ||--o{ feedback_cluster_assignment : "feedback_pk"
-    feedback_cluster_run        ||--o{ feedback_cluster_assignment : "cluster_run_id"
+    feedback_cluster_run        ||--o{ feedback_cluster_candidate : "cluster_run_id"
     feedback_cluster_run        |o--o{ dim_feedback_category : "cluster_run_id (provenance)"
-    dim_feedback_category       |o--o{ tfact_feedback : "category_fk (late-arriving)"
-    tfact_feedback              ||--o{ afact_feedback_cluster_daily : "aggregated"
-
-    feedback_embeddings {
-        varchar feedback_pk PK "part of compound key"
-        varchar model_version PK "part of compound key - makes the model choice reversible"
-        array vector "Iceberg ARRAY of float - StarRocks HNSW indexes this later, a load not a re-embed"
-        integer vector_dim "Matryoshka sweep: 256, 512, 1024"
-        varchar text_variant "raw or llm_normalized - the semantic-normalisation eval arm"
-        timestamp embedded_at
-    }
+    afact_feedback_conversation ||--o{ feedback_cluster_candidate : "feedback_conversation_pk"
+    afact_feedback_conversation ||--o{ afact_feedback_cluster_daily : "aggregated"
 
     feedback_cluster_run {
         varchar cluster_run_id PK
-        varchar model_version FK "which embeddings this run consumed"
+        varchar embedding_model_version "which generation of vectors this run consumed"
         varchar algorithm "umap+hdbscan"
         json run_params "min_cluster_size, n_neighbors - config not hardcoded"
         integer cluster_count
@@ -317,11 +346,11 @@ erDiagram
         timestamp run_at
     }
 
-    feedback_cluster_assignment {
-        varchar feedback_pk PK "part of compound key"
+    feedback_cluster_candidate {
+        varchar feedback_conversation_pk PK "part of compound key"
         varchar cluster_run_id PK "part of compound key"
-        integer cluster_id "-1 = noise = one-off complaint"
-        float cluster_probability "cohesion signal for ranking systemic issues"
+        integer cluster_id
+        float cluster_probability
     }
 
     afact_feedback_cluster_daily {
@@ -331,20 +360,24 @@ erDiagram
         varchar category_fk FK
         varchar sentiment_fk FK
         integer cluster_id
-        integer feedback_count
+        integer conversation_count "at conversation grain this IS the cluster size"
         integer distinct_user_count
-        integer distinct_conversation_count "turn grain means turns per conversation varies"
         float avg_explicit_rating
     }
 ```
 
-`dim_feedback_category` is the *curated, stable* projection; `feedback_cluster_*` is the *churny* ML working
-set. Only an approved run advances the dimension — that decoupling is what lets clustering re-run freely.
+`feedback_cluster_candidate` holds **only runs that have not been promoted**. Promoting a run copies its
+assignment onto `afact_feedback_conversation` and drops the candidate rows; it exists so a proposed run can
+be compared against the live one during the embedding-model bake-off, and nothing outside the ML pipeline
+should read it.
 
-**Turn grain changes the ML volumes.** The record count is now public-requester *comments*, not tickets.
-Embedding cost scales linearly and stays small at these magnitudes, but the multiplier must be measured
-before committing (see §7). Turn grain also *helps* clustering: a follow-up complaint in turn 4 of a ticket
-is currently invisible, because only the first comment is embedded.
+`dim_feedback_category` remains the *curated, stable* projection — only an approved run advances it, which is
+what still lets clustering re-run freely.
+
+**Conversation grain simplifies the rollup.** Rev. 2 had to carry both `feedback_count` and
+`distinct_conversation_count`, and had to warn that `min_cluster_size` counted turns rather than tickets so
+one talkative reporter could manufacture a systemic issue. At conversation grain a cluster's size *is* its
+conversation count, and that whole caveat disappears.
 
 ---
 
@@ -356,11 +389,12 @@ erDiagram
     dim_feedback_channel  ||--o{ tfact_feedback : "feedback_channel_fk - from comment_source_channel"
     dim_date              ||--o{ tfact_feedback : "occurred / created / updated"
     dim_time              ||--o{ tfact_feedback : "occurred / created / updated"
-    dim_feedback_category |o--o{ tfact_feedback : "category_fk - seeded from ticket_tags"
-    dim_sentiment         |o--o{ tfact_feedback : "sentiment_fk - from satisfaction_rating_score"
     dim_user              |o--o{ tfact_feedback : "user_fk - comment author, email path"
     tfact_feedback        ||--o{ bridge_feedback_tag : "feedback_pk"
     dim_feedback_tag      ||--o{ bridge_feedback_tag : "feedback_tag_pk"
+    afact_feedback_conversation ||--o{ tfact_feedback : "conversation_id = ticket_id"
+    dim_feedback_category |o--o{ afact_feedback_conversation : "category_fk - seeded from ticket_tags"
+    dim_sentiment         |o--o{ afact_feedback_conversation : "sentiment_fk - from satisfaction_rating_score"
 
     tfact_feedback {
         varchar feedback_pk PK "surrogate_key(zendesk, comment_id)"
@@ -383,23 +417,27 @@ flowchart TD
     C --> D["int__feedback__zendesk<br/>(NEW - conform to the event contract, filter to public requester turns)"]
     C2 --> D
     D --> E["int__feedback__unioned<br/>(NEW - union all sources + Presidio redaction)"]
-    E --> F["tfact_feedback<br/>(NEW - resolve FKs, mint feedback_pk)"]
+    E --> F["tfact_feedback<br/>(NEW - resolve FKs, mint feedback_pk; INSERT-ONLY)"]
     F --> G["bridge_feedback_tag"]
-    C2 --> H["afact_feedback_conversation<br/>(NEW - conversation grain; durations blocked on ticket_metrics)"]
-    F --> H
-    F --> I["afact_feedback_cluster_daily<br/>(Phase 2)"]
-    E -.->|Fenic, engine-external| J["feedback_embeddings<br/>feedback_cluster_run<br/>feedback_cluster_assignment"]
-    J -.->|LLM label, human approve| K["dim_feedback_category"]
-    K -.->|late-arriving update| F
+    F --> M["int__feedback__conversation<br/>(NEW - assemble kept turns per conversation, ordered)"]
+    C2 --> H["afact_feedback_conversation<br/>(NEW - lifecycle + generated columns)"]
+    M --> H
+    M -.->|Fenic / sklearn, engine-external| N["summarize -> embed -> cluster -> sentiment"]
+    N -.->|writes generated columns| H
+    N -.-> J["feedback_cluster_run<br/>feedback_cluster_candidate"]
+    N -.->|LLM label, human approve| K["dim_feedback_category"]
+    K -.->|category_fk| H
+    H --> I["afact_feedback_cluster_daily<br/>(Phase 2)"]
     L["forum / tutor / ORA / edX plugin<br/>(Phase 2 - additive CTEs)"] --> E
 ```
 
-**MVP cost check.** This moves Phase 1 from 3 new dimensions to **4 dimensions + 1 bridge + 1 conversation
-fact**. All of the additions are `select distinct` cheap (`dim_feedback_channel`, `dim_feedback_tag`) or a
-straight aggregation (`afact_feedback_conversation`), so the build cost is small — but it is a real increase
-and worth confirming deliberately. The argument for paying it now: reshaping a fact after it has consumers
-is the expensive version, and the grain change in §2 has to land before the fact ships regardless, because
-it moves the business key.
+**MVP cost check.** Phase 1 is **4 dimensions + 1 bridge + 2 facts**. The dimension additions are `select
+distinct` cheap and the conversation fact is a straight aggregation, so the dbt build cost is small. Rev. 3
+adds no tables — it withdraws the two per-turn sidecar tables and widens the conversation fact — but it does
+add the per-conversation LLM summary, which is the one cost worth confirming on a sample before the backfill
+(`feedback_dimensional_model.md` §5b). The argument for paying the reshaping now: reshaping a fact after it
+has consumers is the expensive version, and the grain change in §2 has to land before the fact ships
+regardless, because it moves the business key.
 
 ---
 
@@ -412,10 +450,25 @@ it moves the business key.
 | Add the `ticket_metrics` stream to the Zendesk Airbyte connector | ingestion, separate ticket | resolution/closure durations in `afact_feedback_conversation` |
 | Confirm the conformed `channel_slug` value set against each source's actual channel values | modeling | `dim_feedback_channel` seed |
 | `dim_organization.organization_pk = generate_surrogate_key(['platform','source_id'])` (`dim_organization.sql:38`) — Zendesk supplies neither | known-null, explicit decision | `organization_fk` for Zendesk stays null; org rides in `source_metadata` |
+| Measure the multi-turn share of tickets and sample-price the summary step | measurement | the summarization budget and the skip threshold (§4) |
+| Decide `embedding_input`: summary vs. concatenated turns vs. both as eval arms | modeling | the bake-off in `feedback_ml_approach.md` §B.1 |
 
 ---
 
 ## 8. Change log
+
+**rev. 3 (2026-08-10)** — the analysis unit moves from the turn to the conversation
+([RFC #12210](https://github.com/mitodl/hq/discussions/12210)):
+
+- **`afact_feedback_conversation` is now the analysis fact** (§4) — summary, embedding vector, `category_fk`,
+  `sentiment_fk` and cluster membership join the lifecycle columns it already had.
+- **`category_fk`/`sentiment_fk` removed from `tfact_feedback`** (§1), which makes that fact **insert-only**.
+- **Withdrawn:** `feedback_embeddings` and `feedback_cluster_assignment` (§5). `feedback_cluster_run` stays;
+  a small `feedback_cluster_candidate` replaces the assignment table for unpromoted runs only.
+- **Added `conversation_summary`** with an explicit skip rule and a stated per-record LLM cost.
+- `afact_feedback_cluster_daily` aggregates the conversation fact, so `feedback_count` /
+  `distinct_conversation_count` collapse to one measure and the `min_cluster_size` caveat disappears.
+- **Unchanged:** turn grain, the Zendesk comment sourcing, business keys, the conformance rule, the contract.
 
 **rev. 2 (2026-08-07)** — from [@KatelynGit's RFC
 review](https://github.com/mitodl/hq/discussions/12210#discussioncomment-17937328) and the conformance rule

--- a/docs/design/feedback_event_contract_spec.md
+++ b/docs/design/feedback_event_contract_spec.md
@@ -1,0 +1,105 @@
+# Feedback Aggregation — Common Event Contract & Business-Key Strategy
+
+Status: **spec** · Project: `wp-feedback-aggregation-clustering-system-2e9750`
+Date: 2026-07-10 · Resolves `tk-...-common-feedback-event-contract-bus-245a8e`
+Consolidates design §5–6; companion to [`feedback_dimensional_model.md`](./feedback_dimensional_model.md).
+
+This is the **highest-leverage migration de-risker** (do at spec time regardless of interim
+path). If the interim learn-ai landing AND the eventual analytics-api/StarRocks data-bus
+both emit this shape, the migration collapses to *source-swap + backfill + parity*; if they
+diverge, it's a rebuild.
+
+---
+
+## 1. The contract (source-agnostic feedback event)
+
+Every producer — the interim learn-ai feedback table, the edX feedback plugin, and each dbt
+staging model that adapts an existing source (Zendesk, forum, tutor, ORA) — MUST present
+this shape at the `stg__…__feedback` boundary:
+
+| Field | Type | Meaning | Required |
+|---|---|---|---|
+| `source_slug` | string | maps to `dim_feedback_source.source_slug` | yes |
+| `occurred_at` | ISO8601 timestamp | source event time | yes |
+| `source_record_ref` | string | **stable source-native id** — idempotency key + business key (§2) | yes |
+| `text` | string | raw free text (redaction happens in-warehouse, design §7) | yes |
+| `title` | string | subject/heading; nullable | no |
+| `conversation_ref` | string | thread/ticket id — roll utterances → conversation | no |
+| `subject_user_ref` | string | **global/openedx user id** (NOT a source-local PK); email only as last resort | no |
+| `courserun_readable_id` | string | course scope; null for non-course sources | no |
+| `platform` | string | platform readable id; nullable | no |
+| `source_metadata` | JSON | tags, status, priority, channel, csat, etc. | no |
+
+**Design rules:**
+- `subject_user_ref` is a **global identity ref, never a source row PK** — this is what lets
+  `user_fk` resolve against `dim_user` consistently across sources and survive the migration.
+  (Zendesk, lacking an openedx id, uses requester email as the documented last-resort ref —
+  which shares the `dim_user` NULL-email identity-collapse failure class; see design §3.)
+- `text`/`title` carry **raw** text across the contract; redaction is a warehouse step
+  (design §7), not a producer responsibility — so producers never need Presidio.
+- `source_metadata` is the extension point: anything source-specific rides in the JSON and is
+  projected into the fact's non-conformed facet columns (`source_status`, `source_priority`,
+  `source_tags`, `source_channel`, `csat_score`) without changing the contract.
+
+---
+
+## 2. Business-key strategy (migration-proof)
+
+```
+feedback_pk = generate_surrogate_key([source_slug, source_record_ref])
+```
+
+`source_record_ref` is a **stable business identifier from the source system**, never a
+warehouse/Airbyte/Postgres row PK:
+
+| Source | `source_record_ref` |
+|---|---|
+| Zendesk | `ticket_id` |
+| edX forum | `post_id` |
+| Learn AI tutor | `thread_id` + `checkpoint_pk` (or message index) |
+| ORA | `submission_uuid` |
+| edX feedback plugin | plugin-native event/record id |
+
+Because `feedback_pk` regenerates **identically** regardless of which pipe delivered the
+event, the interim→data-bus swap re-lands the same rows with the same keys — enabling
+backfill + parity validation instead of a rebuild. This is the linchpin of the whole
+contract-first strategy (RFC Option 3).
+
+---
+
+## 3. Alignment to the general data-bus ingestion contract (dependency, not a decision here)
+
+Per the 2026-07-06 correction: this contract should align to the **general StarRocks
+data-bus ingestion contract** (shared write/dedup/flush semantics), *not* a feedback-specific
+shape — so feedback and the future openedx tracking-logs workload share ingress semantics.
+
+**But** the data-bus write path does not exist yet, and its sink topology (**one generic
+sink vs. sink-per-topic**) is an unsettled platform-wide question that outranks feedback
+(`pf-starrocks-data-bus-write-path-not-built-yet-gene-bf78da`; RFC Open Questions). So:
+
+- This spec defines the **feedback event contract now** (the durable artifact) and keys the
+  fact off stable business ids (§2) — both fully within feedback's control and sufficient to
+  de-risk the migration.
+- It does **not** unilaterally define the general bus contract. When the platform settles
+  generic-vs-per-topic and builds the write path, this contract's field set is the proposed
+  feedback *topic* payload; reconcile field names/envelope with the bus's shared envelope at
+  that time. The business-key rule (§2) is invariant under that reconciliation.
+- **Landing namespace** on eventual flush: a dedicated `feedback`/ingested schema (or a
+  per-topic schema, depending on the sink decision), **not** `raw`. Decided before migration
+  step 9, not now.
+
+**Net:** feedback ships on the contract + business keys defined here (non-blocking for the
+MVP); the general-bus alignment is a documented, bounded reconciliation gated on platform
+decisions that feedback must conform to rather than set.
+
+---
+
+## 4. Conformance requirements (what each producer/adapter must do)
+
+- **Interim learn-ai feedback table:** shape its columns to §1 so `stg__learn_ai__…__feedback`
+  is a near pass-through (RFC Implementation step 2).
+- **Zendesk adapter (MVP):** `int__feedback__zendesk` maps ticket columns → §1
+  (`feedback_zendesk_mvp_spec.md` §2). `source_record_ref = ticket_id`.
+- **Future producers (edX plugin, etc.):** emit §1 directly or via a thin staging adapter.
+- **The fact never reads a source's raw shape** — only `int__feedback__unioned` in the §1
+  contract shape. This is the isolation that makes new sources additive.

--- a/docs/design/feedback_event_contract_spec.md
+++ b/docs/design/feedback_event_contract_spec.md
@@ -1,7 +1,9 @@
 # Feedback Aggregation — Common Event Contract & Business-Key Strategy
 
 Status: **spec** · Project: `wp-feedback-aggregation-clustering-system-2e9750`
-Date: 2026-07-10 · Resolves `tk-...-common-feedback-event-contract-bus-245a8e`
+Date: 2026-08-13 (rev. 4 — `conversation_ref` required, `source_url` added, stale ticket-grain reference
+fixed; see [#2422 review](https://github.com/mitodl/ol-data-platform/pull/2422)) · original 2026-07-10 ·
+Resolves `tk-...-common-feedback-event-contract-bus-245a8e`
 Consolidates design §5–6; companion to [`feedback_dimensional_model.md`](./feedback_dimensional_model.md).
 
 This is the **highest-leverage migration de-risker** (do at spec time regardless of interim
@@ -25,7 +27,7 @@ this shape at the `stg__…__feedback` boundary:
 | `text` | string | raw free text (redaction happens in-warehouse, design §7) | yes |
 | `channel_slug` | string | maps to `dim_feedback_channel.channel_slug` — how the feedback arrived | yes |
 | `title` | string | subject/heading; nullable | no |
-| `conversation_ref` | string | thread/ticket id — roll turns → conversation | no |
+| `conversation_ref` | string | thread/ticket id — roll turns → conversation. **Non-conversational sources set this to `source_record_ref`** (their own turn id) rather than omitting it — see the design rule below | **yes** |
 | `turn_index` | integer | ordinal of this turn within the conversation | no |
 | `subject_user_ref` | string | **global/openedx user id** (NOT a source-local PK); email only as last resort | no |
 | `courserun_readable_id` | string | course scope; null for non-course sources | no |
@@ -33,6 +35,7 @@ this shape at the `stg__…__feedback` boundary:
 | `subject_type` | string | **what the feedback is about**: `courseware_block` \| `course_run` \| `course` \| `program` \| `page_url` \| `resource` \| `unspecified` | no |
 | `subject_ref` | string | source-native id of that thing (edX usage key, courserun readable id, decoded URL) | no |
 | `subject_url` | string | canonical/decoded deep link to the subject | no |
+| `source_url` | string | deep link back to the source record itself (ticket API URL, forum page URL) — distinct from `subject_url`, which links to what the feedback is *about* | no |
 | `explicit_rating` | string | conformed explicit signal — Zendesk CSAT, tutor rating, ORA score | no |
 | `created_at` | ISO8601 timestamp | source lifecycle timestamp | no |
 | `updated_at` | ISO8601 timestamp | source lifecycle timestamp | no |
@@ -63,6 +66,19 @@ or most sources have them) while status, priority, brand, group and due date are
 - **`source_record_ref` identifies a turn, not a conversation.** For Zendesk that is `comment_id`, with
   `ticket_id` in `conversation_ref` (design §1). Adapters that emit one row per conversation are not
   conformant — the grain is one atomic utterance, and every source's own model already works that way.
+- **`conversation_ref` is required, not optional (fixed rev. 4, @copilot).** It is a component of
+  `feedback_conversation_pk = generate_surrogate_key([source_slug, conversation_ref])`
+  (`feedback_dimensional_model.md` §5a), and every event — conversational or not — must resolve to exactly
+  one `afact_feedback_conversation` row. **Non-conversational sources (ORA, the edX plugin) set
+  `conversation_ref = source_record_ref`** — the event degenerates to a one-turn conversation of itself,
+  which is what `dim_feedback_source.is_conversational = false` marks and is why those sources need no
+  special-case handling downstream (design §1). An adapter that leaves `conversation_ref` null produces an
+  event with no valid conversation row to land on.
+- **`source_url` is a required *field on the fact*, but sourced from every adapter, not the contract's
+  `subject_*` triple.** `tfact_feedback` and the Zendesk adapter (`feedback_zendesk_mvp_spec.md` §2, §4) both
+  carry a `source_url` — the deep link back to the record itself (e.g. `ticket_api_url`), distinct from
+  `subject_url` (a link to what the feedback is *about*). Added to the contract table above (rev. 4,
+  @copilot) so future adapters have a defined source for it instead of inventing one ad hoc.
 - **`subject_*` answers "what is this feedback about?"** — the axis you aggregate on, and the one
   the contract originally lacked (raised on [#2422](https://github.com/mitodl/ol-data-platform/pull/2422#issuecomment-3157271372)).
   It is a *polymorphic degenerate triple*: always carryable, whatever the subject is. The fact resolves
@@ -133,8 +149,11 @@ decisions that feedback must conform to rather than set.
 
 - **Interim learn-ai feedback table:** shape its columns to §1 so `stg__learn_ai__…__feedback`
   is a near pass-through (RFC Implementation step 2).
-- **Zendesk adapter (MVP):** `int__feedback__zendesk` maps ticket columns → §1
-  (`feedback_zendesk_mvp_spec.md` §2). `source_record_ref = ticket_id`.
+- **Zendesk adapter (MVP):** `int__feedback__zendesk` maps comment columns → §1
+  (`feedback_zendesk_mvp_spec.md` §2). `source_record_ref = comment_id` (the **turn**, not the ticket —
+  fixed rev. 4, @copilot/@rachellougee: this line still said `ticket_id`, which is the rev. 1 grain and
+  conflicts with §2's own table below; implementing it as written would collapse every comment in a ticket
+  onto one `feedback_pk`). `conversation_ref = ticket_id`.
 - **Future producers (edX plugin, etc.):** emit §1 directly or via a thin staging adapter.
 - **The fact never reads a source's raw shape** — only `int__feedback__unioned` in the §1
   contract shape. This is the isolation that makes new sources additive.

--- a/docs/design/feedback_event_contract_spec.md
+++ b/docs/design/feedback_event_contract_spec.md
@@ -21,17 +21,32 @@ this shape at the `stg__…__feedback` boundary:
 |---|---|---|---|
 | `source_slug` | string | maps to `dim_feedback_source.source_slug` | yes |
 | `occurred_at` | ISO8601 timestamp | source event time | yes |
-| `source_record_ref` | string | **stable source-native id** — idempotency key + business key (§2) | yes |
+| `source_record_ref` | string | **stable source-native id of the TURN** — idempotency key + business key (§2) | yes |
 | `text` | string | raw free text (redaction happens in-warehouse, design §7) | yes |
+| `channel_slug` | string | maps to `dim_feedback_channel.channel_slug` — how the feedback arrived | yes |
 | `title` | string | subject/heading; nullable | no |
-| `conversation_ref` | string | thread/ticket id — roll utterances → conversation | no |
+| `conversation_ref` | string | thread/ticket id — roll turns → conversation | no |
+| `turn_index` | integer | ordinal of this turn within the conversation | no |
 | `subject_user_ref` | string | **global/openedx user id** (NOT a source-local PK); email only as last resort | no |
 | `courserun_readable_id` | string | course scope; null for non-course sources | no |
 | `platform` | string | platform readable id; nullable | no |
 | `subject_type` | string | **what the feedback is about**: `courseware_block` \| `course_run` \| `course` \| `program` \| `page_url` \| `resource` \| `unspecified` | no |
 | `subject_ref` | string | source-native id of that thing (edX usage key, courserun readable id, decoded URL) | no |
 | `subject_url` | string | canonical/decoded deep link to the subject | no |
-| `source_metadata` | JSON | tags, status, priority, channel, csat, brand, group, etc. | no |
+| `explicit_rating` | string | conformed explicit signal — Zendesk CSAT, tutor rating, ORA score | no |
+| `created_at` | ISO8601 timestamp | source lifecycle timestamp | no |
+| `updated_at` | ISO8601 timestamp | source lifecycle timestamp | no |
+| `source_metadata` | JSON | **everything not yet conformed** — status, priority, brand, group, due date, custom fields | no |
+
+**The conformance rule that decides what is a field vs. what is `source_metadata`:**
+
+> An attribute earns a contract field only if **two or more sources can populate it**. Everything else rides
+> in `source_metadata`, and is promoted to a field if and when a second source starts supplying it — in the
+> same change that onboards that source.
+
+This is why `channel_slug`, `explicit_rating`, `created_at`/`updated_at` and `turn_index` are fields (every
+or most sources have them) while status, priority, brand, group and due date are not (Zendesk-only). Adopted
+2026-08-07 after RFC review; the full per-attribute audit is in [`feedback_erd.md`](./feedback_erd.md) §1.
 
 **Design rules:**
 - `subject_user_ref` is a **global identity ref, never a source row PK** — this is what lets
@@ -40,10 +55,14 @@ this shape at the `stg__…__feedback` boundary:
   which shares the `dim_user` NULL-email identity-collapse failure class; see design §3.)
 - `text`/`title` carry **raw** text across the contract; redaction is a warehouse step
   (design §7), not a producer responsibility — so producers never need Presidio.
-- `source_metadata` is the extension point: anything source-specific rides in the JSON and is
-  projected into the fact's non-conformed facet columns (`source_status`, `source_priority`,
-  `source_tags`, `source_channel`, `source_brand`, `source_group`, `csat_score`) without changing
-  the contract.
+- `source_metadata` is the extension point, and it **survives into the fact as a variant column** rather
+  than being flattened into facet columns (design §2c). Iceberg v2 has no native JSON type, so it persists
+  as a varchar holding a JSON string, read back with the cross-db `json_query_string` /
+  `json_extract_value` macros. This is the mechanism that makes a new source additive: a producer arriving
+  with attributes nobody has seen before needs no schema change.
+- **`source_record_ref` identifies a turn, not a conversation.** For Zendesk that is `comment_id`, with
+  `ticket_id` in `conversation_ref` (design §1). Adapters that emit one row per conversation are not
+  conformant — the grain is one atomic utterance, and every source's own model already works that way.
 - **`subject_*` answers "what is this feedback about?"** — the axis you aggregate on, and the one
   the contract originally lacked (raised on [#2422](https://github.com/mitodl/ol-data-platform/pull/2422#issuecomment-3157271372)).
   It is a *polymorphic degenerate triple*: always carryable, whatever the subject is. The fact resolves
@@ -63,13 +82,18 @@ feedback_pk = generate_surrogate_key([source_slug, source_record_ref])
 `source_record_ref` is a **stable business identifier from the source system**, never a
 warehouse/Airbyte/Postgres row PK:
 
-| Source | `source_record_ref` |
-|---|---|
-| Zendesk | `ticket_id` |
-| edX forum | `post_id` |
-| Learn AI tutor | `thread_id` + `checkpoint_pk` (or message index) |
-| ORA | `submission_uuid` |
-| edX feedback plugin | plugin-native event/record id |
+| Source | `source_record_ref` (the **turn**) | `conversation_ref` |
+|---|---|---|
+| Zendesk | `comment_id` | `ticket_id` |
+| edX forum | `post_id` | thread id |
+| Learn AI tutor | `checkpoint_id` | `chatsession_thread_id` |
+| ORA | `submission_uuid` | n/a |
+| edX feedback plugin | plugin-native event/record id | n/a |
+
+> **Changed 2026-08-07 (rev. 2).** Zendesk's `source_record_ref` moved from `ticket_id` to `comment_id` when
+> the grain moved from ticket to turn (design §1). The formula is unchanged; the *value* is not — which is
+> exactly why the grain decision had to land before the fact ships. Regenerating this key after the fact has
+> consumers is the rebuild this strategy exists to avoid.
 
 Because `feedback_pk` regenerates **identically** regardless of which pipe delivered the
 event, the interim→data-bus swap re-lands the same rows with the same keys — enabling

--- a/docs/design/feedback_event_contract_spec.md
+++ b/docs/design/feedback_event_contract_spec.md
@@ -51,8 +51,8 @@ or most sources have them) while status, priority, brand, group and due date are
 **Design rules:**
 - `subject_user_ref` is a **global identity ref, never a source row PK** — this is what lets
   `user_fk` resolve against `dim_user` consistently across sources and survive the migration.
-  (Zendesk, lacking an openedx id, uses requester email as the documented last-resort ref —
-  which shares the `dim_user` NULL-email identity-collapse failure class; see design §3.)
+  (Zendesk, lacking an openedx id, uses the comment author's email as the documented last-resort ref;
+  see design §3 for the residual identity risk — the specific NULL-email collapse bug is fixed.)
 - `text`/`title` carry **raw** text across the contract; redaction is a warehouse step
   (design §7), not a producer responsibility — so producers never need Presidio.
 - `source_metadata` is the extension point, and it **survives into the fact as a variant column** rather

--- a/docs/design/feedback_event_contract_spec.md
+++ b/docs/design/feedback_event_contract_spec.md
@@ -28,7 +28,10 @@ this shape at the `stg__…__feedback` boundary:
 | `subject_user_ref` | string | **global/openedx user id** (NOT a source-local PK); email only as last resort | no |
 | `courserun_readable_id` | string | course scope; null for non-course sources | no |
 | `platform` | string | platform readable id; nullable | no |
-| `source_metadata` | JSON | tags, status, priority, channel, csat, etc. | no |
+| `subject_type` | string | **what the feedback is about**: `courseware_block` \| `course_run` \| `course` \| `program` \| `page_url` \| `resource` \| `unspecified` | no |
+| `subject_ref` | string | source-native id of that thing (edX usage key, courserun readable id, decoded URL) | no |
+| `subject_url` | string | canonical/decoded deep link to the subject | no |
+| `source_metadata` | JSON | tags, status, priority, channel, csat, brand, group, etc. | no |
 
 **Design rules:**
 - `subject_user_ref` is a **global identity ref, never a source row PK** — this is what lets
@@ -39,7 +42,15 @@ this shape at the `stg__…__feedback` boundary:
   (design §7), not a producer responsibility — so producers never need Presidio.
 - `source_metadata` is the extension point: anything source-specific rides in the JSON and is
   projected into the fact's non-conformed facet columns (`source_status`, `source_priority`,
-  `source_tags`, `source_channel`, `csat_score`) without changing the contract.
+  `source_tags`, `source_channel`, `source_brand`, `source_group`, `csat_score`) without changing
+  the contract.
+- **`subject_*` answers "what is this feedback about?"** — the axis you aggregate on, and the one
+  the contract originally lacked (raised on [#2422](https://github.com/mitodl/ol-data-platform/pull/2422#issuecomment-3157271372)).
+  It is a *polymorphic degenerate triple*: always carryable, whatever the subject is. The fact resolves
+  it to a conformed FK where one exists — `courserun_fk` for course runs, the new
+  `content_block_fk → dim_course_content` for edX blocks (design §2a). Producers emit the raw ref;
+  **normalising it is the adapter's job**, e.g. decoding the encoded Appzi URL in
+  `int__feedback__zendesk`.
 
 ---
 

--- a/docs/design/feedback_ml_approach.md
+++ b/docs/design/feedback_ml_approach.md
@@ -38,13 +38,25 @@ so a re-run never duplicates and never mutates the fact grain. Embedding is comp
 **Decision: one shared embedding, computed once, stored in the `feedback_embeddings`
 sidecar.** Both clustering and (semantic) sentiment consume it — do not embed twice.
 
-- **Model choice — recommend an open/self-hostable model** (e.g. `BAAI/bge-small-en-v1.5`
-  or `sentence-transformers/all-MiniLM-L6-v2`, 384-dim) over a hosted API, for the
-  **learner-PII posture**: even post-redaction, sending ~1.18M feedback utterances to a
-  third-party embedding API is an avoidable data-egress and cost exposure. A local
+> **REVISED 2026-07-10 — see [`adr_embedding_compute_strategy.md`](./adr_embedding_compute_strategy.md).**
+> Production runs Trino on **Starburst Galaxy**, whose in-SQL AI functions
+> (`starburst.ai.generate_embedding` → `ARRAY(DOUBLE)`, public preview) can generate
+> embeddings **inside the engine we already run**, on **AWS Bedrock in our own AWS account**,
+> writing vectors straight into the Iceberg sidecar. That both eliminates the net-new
+> torch/sentence-transformers service *and* removes the third-party-egress objection below
+> (Bedrock-in-account over Presidio-redacted text). **New default: Starburst AI
+> `generate_embedding` as a `trino_only` dbt model.** The local option below drops to a
+> last-resort fallback. StarRocks vector functions are irrelevant for now (not deployed) — see
+> the ADR for the Phase-3 note. The rest of §B (persist-once, `model_version`, Iceberg ARRAY
+> storage, redaction-upstream) is unchanged and applies regardless of who computes the vector.
+
+- **Model choice (fallback path, if the Starburst AI preview is unavailable/undesired) —
+  an open/self-hostable model** (e.g. `BAAI/bge-small-en-v1.5` or
+  `sentence-transformers/all-MiniLM-L6-v2`, 384-dim): even post-redaction, sending ~1.18M
+  feedback utterances to a *third-party* embedding API is avoidable egress — but note this
+  concern does **not** apply to Bedrock-in-account via Starburst AI (the new default). A local
   sentence-transformers model runs the full corpus in a single batch job on CPU/GPU for
-  effectively $0 marginal cost. Keep an OpenAI `text-embedding-3-small` adapter behind the
-  same resource interface as a fallback/benchmark, but default to local.
+  effectively $0 marginal provider cost, at the price of the heaviest image/infra.
   - Open question deferred to implementation: GPU vs CPU throughput at 1.18M rows. At
     MVP scale (198K) CPU is fine (single-digit minutes to low hours).
 - **Redaction is upstream and mandatory** (design §7): embeddings are computed on the

--- a/docs/design/feedback_ml_approach.md
+++ b/docs/design/feedback_ml_approach.md
@@ -38,28 +38,35 @@ so a re-run never duplicates and never mutates the fact grain. Embedding is comp
 **Decision: one shared embedding, computed once, stored in the `feedback_embeddings`
 sidecar.** Both clustering and (semantic) sentiment consume it — do not embed twice.
 
-> **REVISED 2026-07-10 (rev. 2) — see [`adr_embedding_compute_strategy.md`](./adr_embedding_compute_strategy.md).**
+> **REVISED 2026-07-10 (rev. 3) — see [`adr_embedding_compute_strategy.md`](./adr_embedding_compute_strategy.md).**
 > Strategic direction is to **retire Trino for StarRocks** (transforms + data bus + OLAP
 > serving), so **no Galaxy-only functionality may sit on the critical path** — this rules out
 > Starburst's `generate_embedding` (Galaxy-proprietary; StarRocks has no embedding-generation
-> equivalent). **New default: keep embedding compute engine-external in a Dagster asset that
-> calls AWS Bedrock `amazon.titan-embed-text-v2:0` directly via boto3** — in our own AWS account
-> (PII-safe over redacted text), a thin dependency (no torch), and indifferent to whether the
-> SQL engine is Trino or StarRocks. Vectors land in an open Iceberg `ARRAY<float>` sidecar, which
-> StarRocks later reads to build an HNSW index (a load, not a re-embed) — making StarRocks ANN
-> the intended serving tier. The rest of §B (persist-once, `model_version`, Iceberg storage,
-> redaction-upstream) is unchanged and applies regardless of who computes the vector.
+> equivalent). **New default: keep embedding compute engine-external, using Fenic (Apache-2.0)
+> as the framework** in a Dagster asset reading the dbt outputs and writing vectors to an open
+> Iceberg `ARRAY<float>` sidecar — indifferent to whether the SQL engine is Trino or StarRocks,
+> and giving batching/caching/cost-accounting/lineage for free. **Embedding provider is a
+> PII-policy choice, decoupled from the framework:** in-account **AWS Bedrock**
+> `amazon.titan-embed-text-v2:0` (best posture — via boto3 today, since a native Fenic Bedrock
+> *embedding* provider is roadmap-not-shipped; or contribute it, Apache-2.0), OR a Fenic-native
+> managed provider (Cohere/OpenAI/Google) over Presidio-redacted text if policy allows. Vectors
+> in Iceberg → StarRocks later builds an HNSW index over them (a load, not a re-embed) = intended
+> serving tier. The rest of §B (persist-once, `model_version`, Iceberg storage, redaction-upstream)
+> is unchanged regardless of who computes the vector.
 
-- **Model choice — default is Bedrock `amazon.titan-embed-text-v2:0`** (dims 256/512/1024 — pick
-  256/512 for a smaller sidecar + faster HDBSCAN/HNSW unless retrieval needs 1024), called via
-  boto3 from the Dagster layer. In-account Bedrock over Presidio-redacted text has no
-  third-party-egress concern. Use Bedrock **batch inference** for the 1.18M backfill.
-  - **Fallbacks (ADR):** local `sentence-transformers` (`BAAI/bge-small-en-v1.5` /
-    `all-MiniLM-L6-v2`, 384-dim) as the $0-egress-but-heaviest option; Fenic as an ergonomics
-    wrapper (but cloud-egress only). Both stay engine-external/portable.
-  - Open question deferred to implementation: GPU vs CPU throughput at 1.18M rows (moot for the
-    Bedrock path — it's an API call; relevant only for the local fallback). MVP scale (198K) is
-    trivial batch either way.
+- **Model choice — recommend Bedrock `amazon.titan-embed-text-v2:0`** (dims 256/512/1024 — pick
+  256/512 for a smaller sidecar + faster HDBSCAN/HNSW unless retrieval needs 1024) for the
+  in-account PII posture over Presidio-redacted text; use Bedrock **batch inference** for the
+  1.18M backfill. A Fenic-native managed provider (Cohere/OpenAI/Google) is the simpler
+  alternative if egress of *redacted* text is acceptable by policy.
+  - **Fallbacks (ADR):** direct boto3 Bedrock client without Fenic (minimal, hand-build the
+    batching); local `sentence-transformers` (`BAAI/bge-small-en-v1.5` / `all-MiniLM-L6-v2`,
+    384-dim) as the $0-egress-but-heaviest option. All stay engine-external/portable.
+  - Note: **HDBSCAN clustering stays our own sklearn step** — Fenic offers only K-means
+    (`with_cluster_labels`), which lacks the noise class we need (§C). Fenic covers embed +
+    classify/sentiment + labeling; not clustering.
+  - Open question deferred to implementation: throughput at 1.18M rows (moot for the Bedrock/API
+    path). MVP scale (198K) is trivial batch either way.
 - **Redaction is upstream and mandatory** (design §7): embeddings are computed on the
   Presidio-redacted text only. Raw text never reaches the embedding step.
 - **`model_version` is a first-class column** on `feedback_embeddings`. Changing the model

--- a/docs/design/feedback_ml_approach.md
+++ b/docs/design/feedback_ml_approach.md
@@ -38,51 +38,70 @@ so a re-run never duplicates and never mutates the fact grain. Embedding is comp
 **Decision: one shared embedding, computed once, stored in the `feedback_embeddings`
 sidecar.** Both clustering and (semantic) sentiment consume it — do not embed twice.
 
-> **REVISED 2026-07-10 (rev. 3) — see [`adr_embedding_compute_strategy.md`](./adr_embedding_compute_strategy.md).**
-> Strategic direction is to **retire Trino for StarRocks** (transforms + data bus + OLAP
-> serving), so **no Galaxy-only functionality may sit on the critical path** — this rules out
-> Starburst's `generate_embedding` (Galaxy-proprietary; StarRocks has no embedding-generation
-> equivalent). **New default: keep embedding compute engine-external, using Fenic (Apache-2.0)
-> as the framework** in a Dagster asset reading the dbt outputs and writing vectors to an open
-> Iceberg `ARRAY<float>` sidecar — indifferent to whether the SQL engine is Trino or StarRocks,
-> and giving batching/caching/cost-accounting/lineage for free. **Embedding provider is a
-> PII-policy choice, decoupled from the framework:** in-account **AWS Bedrock**
-> `amazon.titan-embed-text-v2:0` (best posture — via boto3 today, since a native Fenic Bedrock
-> *embedding* provider is roadmap-not-shipped; or contribute it, Apache-2.0), OR a Fenic-native
-> managed provider (Cohere/OpenAI/Google) over Presidio-redacted text if policy allows. Vectors
-> in Iceberg → StarRocks later builds an HNSW index over them (a load, not a re-embed) = intended
-> serving tier. The rest of §B (persist-once, `model_version`, Iceberg storage, redaction-upstream)
-> is unchanged regardless of who computes the vector.
+> **REVISED 2026-07-10 (rev. 4) — see [`adr_embedding_compute_strategy.md`](./adr_embedding_compute_strategy.md).**
+> Compute stays engine-external via **Fenic (Apache-2.0)** in a Dagster asset, writing vectors to
+> an open Iceberg `ARRAY<float>` sidecar (portable across Trino→StarRocks; StarRocks later indexes
+> those vectors with HNSW). **Bedrock/in-account is NOT a requirement** — the **embedding model is
+> chosen by task effectiveness** (clustering + retrieval on OUR feedback corpus), with egress of
+> Presidio-redacted text to a managed provider acceptable. Model selection is specified as an
+> evaluation below, not a fixed pick. Persist-once, `model_version`, Iceberg storage, and
+> mandatory upstream redaction are unchanged.
 
-- **Model choice — recommend Bedrock `amazon.titan-embed-text-v2:0`** (dims 256/512/1024 — pick
-  256/512 for a smaller sidecar + faster HDBSCAN/HNSW unless retrieval needs 1024) for the
-  in-account PII posture over Presidio-redacted text; use Bedrock **batch inference** for the
-  1.18M backfill. A Fenic-native managed provider (Cohere/OpenAI/Google) is the simpler
-  alternative if egress of *redacted* text is acceptable by policy.
-  - **Fallbacks (ADR):** direct boto3 Bedrock client without Fenic (minimal, hand-build the
-    batching); local `sentence-transformers` (`BAAI/bge-small-en-v1.5` / `all-MiniLM-L6-v2`,
-    384-dim) as the $0-egress-but-heaviest option. All stay engine-external/portable.
-  - Note: **HDBSCAN clustering stays our own sklearn step** — Fenic offers only K-means
-    (`with_cluster_labels`), which lacks the noise class we need (§C). Fenic covers embed +
-    classify/sentiment + labeling; not clustering.
-  - Open question deferred to implementation: throughput at 1.18M rows (moot for the Bedrock/API
-    path). MVP scale (198K) is trivial batch either way.
+### B.1 Embedding-model selection — by effectiveness, on our own labeled corpus
+
+Selection principle (industry consensus): **use the MTEB leaderboard to *narrow*, then benchmark
+the shortlist on our own labeled Zendesk sample — the decisive metric is performance on our
+corpus, not the public average.** Because embeddings are persisted with `model_version` (below),
+the choice is **reversible**: re-embed with a better model later without touching the fact.
+
+**Candidate shortlist (narrow with current MTEB *clustering + retrieval* standings at eval time;
+these move monthly).** Two tiers:
+
+| Tier | Candidates (2026) | Via | Notes |
+|---|---|---|---|
+| Managed (Fenic-native) | Google `gemini-embedding-001`; Cohere `embed-v4`; OpenAI `text-embedding-3-large` | Fenic `GoogleVertex/GoogleDeveloper/Cohere/OpenAI EmbeddingModel` | gemini + Cohere v4 currently edge OpenAI on MTEB; all support **Matryoshka dim truncation** (test 256/512/1024 — smaller = faster HDBSCAN/HNSW + smaller sidecar, usually minimal quality loss). Egress of redacted text. |
+| Self-hosted open (top of MTEB) | Qwen3-Embedding; BGE-M3; NV-Embed-v2 | `sentence-transformers` (outside Fenic's provider set) | Currently top the MTEB average / best open quality-cost (BGE-M3); $0 marginal cost, no egress, full control — at the price of hosting a model (heavier Dagster image / a GPU batch). Include if we're willing to self-host for effectiveness. |
+
+**Evaluation harness (run once on a labeled sample, ~2–5k tickets):**
+1. **Label set:** reuse the existing structure as ground truth — Zendesk `ticket_tags` /
+   `group_name` give a free (noisy) cluster/label reference; optionally hand-label a few hundred
+   for a cleaner set.
+2. **Task-aligned metrics, not MTEB average:**
+   - *Clustering* (our primary task): run the §C pipeline (UMAP+HDBSCAN) on each candidate's
+     vectors; score **silhouette** + **agreement with the tag reference** (adjusted Rand /
+     normalized mutual information) + a small **human-coherence** rating of the top clusters.
+   - *Retrieval* (future "similar feedback"/RAG serving): nearest-neighbour precision@k on
+     tag-matched pairs.
+3. **Also sweep dimension** (Matryoshka 256/512/1024) and **cost/latency per 1M** as tie-breakers.
+4. **Pick** the model×dim that maximizes clustering agreement/coherence at acceptable cost.
+
+**Starting default for the eval** (so implementation isn't blocked on the bake-off): a strong
+current all-rounder available via Fenic — `gemini-embedding-001` or Cohere `embed-v4` at 512-dim
+— with `text-embedding-3-large` as the "safe baseline" comparison and BGE-M3 as the self-hosted
+comparison. Let the harness decide; do not hardcode a winner in the spec.
+
+- **HDBSCAN clustering stays our own sklearn step** — Fenic offers only K-means
+  (`with_cluster_labels`), which lacks the noise class we need (§C). Fenic covers embed +
+  classify/sentiment + labeling; not clustering.
 - **Redaction is upstream and mandatory** (design §7): embeddings are computed on the
-  Presidio-redacted text only. Raw text never reaches the embedding step.
-- **`model_version` is a first-class column** on `feedback_embeddings`. Changing the model
-  = new `model_version` rows, old ones retained until re-cluster completes (no in-place
-  overwrite → no torn state).
-- **Vector storage:** at ~1.18M × 384 float32 ≈ 1.8 GB. Store as an Iceberg `ARRAY<float>`
-  column in `feedback_embeddings` for the MVP (no new operational service; aligns with the
-  lake). Revisit a dedicated vector index (StarRocks vector column, S3 Vectors, Qdrant)
-  only when an online nearest-neighbour/serving need appears — the batch clustering job
-  reads the whole set into memory, which is fine at this scale. This defers the RFC's
-  "embedding model & vector store" open question to a reversible, low-cost default.
+  Presidio-redacted text only. Raw text never reaches the embedding step. (Redaction remains
+  required even though provider egress is now acceptable — it is a data-minimization guarantee,
+  not just an egress control.)
+- **`model_version` is a first-class column** on `feedback_embeddings`. Changing the model (or the
+  dimension) = new `model_version` rows, old retained until re-cluster completes (no torn state).
+  This is what makes the model choice reversible and the eval low-risk.
+- **Vector storage:** ~1.18M × (256–1024) float32 ≈ 1.2–4.8 GB. Store as an Iceberg `ARRAY<float>`
+  column for the MVP (no new service; the batch clustering job reads the set into memory — fine at
+  this scale). StarRocks HNSW becomes the serving-tier index once deployed (ADR).
 
-**Rejected:** re-embedding on every run (the prototype #10793 flaw the RFC explicitly
-fixes); semantic-summary-before-embedding as a default (see §C, treated as a hypothesis
-to test, not a baseline — an LLM call per record turns a ~$2–16 job into a per-record LLM
-cost across 1M+ records and can distort short-text sources).
+**Rejected:** re-embedding on every run (the prototype #10793 flaw the RFC fixes).
+**Upgraded from "rejected" to "evaluate seriously" (new evidence, 2026-07):** LLM
+**semantic-normalization before embedding**. Recent support-ticket-clustering literature reports it
+is *the single largest contributor to cluster quality* on short/noisy ticket text (improved
+silhouette + human-rated coherence over baselines) — stronger than the RFC's earlier skeptical
+stance. Treat it as a **first-class arm of the §C evaluation**, not a default: it adds an LLM call
+per record (cost), so gate by measured lift vs. cost, and expect it to help most on the long noisy
+Zendesk descriptions (avg ~1,000 chars) and least on already-short sources (tutor ~58, ORA ~140).
 
 ---
 
@@ -107,6 +126,12 @@ cohesion signal that lets a human say "this is recurring."
   raw high-dim space). `n_neighbors`/`min_cluster_size` are the two knobs to tune on a
   Zendesk sample; `min_cluster_size` is effectively the "how many tickets before we call
   it systemic" threshold and should be a config, not hardcoded.
+- **Pre-embedding LLM semantic-normalization is a first-class eval arm here** (see §B.1): recent
+  support-ticket-clustering evidence (2026) reports it is the single largest lever on cluster
+  quality for short/noisy ticket text. Evaluate `normalize→embed→cluster` against `embed→cluster`
+  on the labeled sample (silhouette + tag-agreement + human coherence); adopt only where the
+  measured lift justifies the per-record LLM cost — likely worth it for the long Zendesk
+  descriptions, likely not for already-short sources.
 - **Re-clustering is cheap and expected:** each run writes a new `cluster_run_id`; the
   sidecar keeps prior runs. `dim_feedback_category` (curated) only advances when a human
   approves labels from a run (design §4a), decoupling churny clustering from the stable

--- a/docs/design/feedback_ml_approach.md
+++ b/docs/design/feedback_ml_approach.md
@@ -38,27 +38,28 @@ so a re-run never duplicates and never mutates the fact grain. Embedding is comp
 **Decision: one shared embedding, computed once, stored in the `feedback_embeddings`
 sidecar.** Both clustering and (semantic) sentiment consume it — do not embed twice.
 
-> **REVISED 2026-07-10 — see [`adr_embedding_compute_strategy.md`](./adr_embedding_compute_strategy.md).**
-> Production runs Trino on **Starburst Galaxy**, whose in-SQL AI functions
-> (`starburst.ai.generate_embedding` → `ARRAY(DOUBLE)`, public preview) can generate
-> embeddings **inside the engine we already run**, on **AWS Bedrock in our own AWS account**,
-> writing vectors straight into the Iceberg sidecar. That both eliminates the net-new
-> torch/sentence-transformers service *and* removes the third-party-egress objection below
-> (Bedrock-in-account over Presidio-redacted text). **New default: Starburst AI
-> `generate_embedding` as a `trino_only` dbt model.** The local option below drops to a
-> last-resort fallback. StarRocks vector functions are irrelevant for now (not deployed) — see
-> the ADR for the Phase-3 note. The rest of §B (persist-once, `model_version`, Iceberg ARRAY
-> storage, redaction-upstream) is unchanged and applies regardless of who computes the vector.
+> **REVISED 2026-07-10 (rev. 2) — see [`adr_embedding_compute_strategy.md`](./adr_embedding_compute_strategy.md).**
+> Strategic direction is to **retire Trino for StarRocks** (transforms + data bus + OLAP
+> serving), so **no Galaxy-only functionality may sit on the critical path** — this rules out
+> Starburst's `generate_embedding` (Galaxy-proprietary; StarRocks has no embedding-generation
+> equivalent). **New default: keep embedding compute engine-external in a Dagster asset that
+> calls AWS Bedrock `amazon.titan-embed-text-v2:0` directly via boto3** — in our own AWS account
+> (PII-safe over redacted text), a thin dependency (no torch), and indifferent to whether the
+> SQL engine is Trino or StarRocks. Vectors land in an open Iceberg `ARRAY<float>` sidecar, which
+> StarRocks later reads to build an HNSW index (a load, not a re-embed) — making StarRocks ANN
+> the intended serving tier. The rest of §B (persist-once, `model_version`, Iceberg storage,
+> redaction-upstream) is unchanged and applies regardless of who computes the vector.
 
-- **Model choice (fallback path, if the Starburst AI preview is unavailable/undesired) —
-  an open/self-hostable model** (e.g. `BAAI/bge-small-en-v1.5` or
-  `sentence-transformers/all-MiniLM-L6-v2`, 384-dim): even post-redaction, sending ~1.18M
-  feedback utterances to a *third-party* embedding API is avoidable egress — but note this
-  concern does **not** apply to Bedrock-in-account via Starburst AI (the new default). A local
-  sentence-transformers model runs the full corpus in a single batch job on CPU/GPU for
-  effectively $0 marginal provider cost, at the price of the heaviest image/infra.
-  - Open question deferred to implementation: GPU vs CPU throughput at 1.18M rows. At
-    MVP scale (198K) CPU is fine (single-digit minutes to low hours).
+- **Model choice — default is Bedrock `amazon.titan-embed-text-v2:0`** (dims 256/512/1024 — pick
+  256/512 for a smaller sidecar + faster HDBSCAN/HNSW unless retrieval needs 1024), called via
+  boto3 from the Dagster layer. In-account Bedrock over Presidio-redacted text has no
+  third-party-egress concern. Use Bedrock **batch inference** for the 1.18M backfill.
+  - **Fallbacks (ADR):** local `sentence-transformers` (`BAAI/bge-small-en-v1.5` /
+    `all-MiniLM-L6-v2`, 384-dim) as the $0-egress-but-heaviest option; Fenic as an ergonomics
+    wrapper (but cloud-egress only). Both stay engine-external/portable.
+  - Open question deferred to implementation: GPU vs CPU throughput at 1.18M rows (moot for the
+    Bedrock path — it's an API call; relevant only for the local fallback). MVP scale (198K) is
+    trivial batch either way.
 - **Redaction is upstream and mandatory** (design §7): embeddings are computed on the
   Presidio-redacted text only. Raw text never reaches the embedding step.
 - **`model_version` is a first-class column** on `feedback_embeddings`. Changing the model

--- a/docs/design/feedback_ml_approach.md
+++ b/docs/design/feedback_ml_approach.md
@@ -1,0 +1,181 @@
+# Feedback Aggregation — ML/LLM Approach Spec
+
+Status: **spec** · Project: `wp-feedback-aggregation-clustering-system-2e9750`
+Date: 2026-07-10 · Companion to [`feedback_dimensional_model.md`](./feedback_dimensional_model.md)
+
+Resolves the open items the dimensional-model design handed to downstream tasks:
+clustering (`tk-...-clustering-approach-...a1d7d6`), category discovery
+(`tk-...-llm-driven-category-discovery-...550aba`), and sentiment
+(`tk-...-sentiment-mapping-...92988e`). Grounded in the discovery cost model
+(~1.18M text records; one-time embed ≈ $2–16; MVP = ~198K Zendesk tickets, batch).
+
+The guiding principle from the RFC: **the durable artifact is the feedback fact +
+persisted embeddings; clustering/category/sentiment are re-runnable consumers of it.**
+Nothing here rewrites `tfact_feedback`; all ML output lands in the `feedback_embeddings`
+sidecar or the late-arriving `category_fk`/`sentiment_fk` update.
+
+---
+
+## A. Pipeline shape (single batch Dagster asset graph, MVP)
+
+```
+int__feedback__unioned (redacted text, feedback_pk)          [dbt]
+  → embed        : text → vector, persisted once             [py asset: feedback_embeddings]
+  → cluster      : vectors → cluster_id per cluster_run       [py asset: feedback_embeddings.cluster_id]
+  → label        : cluster centroid/samples → category label  [py asset: dim_feedback_category (proposed)]
+  → sentiment    : text/vector → sentiment_slug               [py asset: sentiment_fk]
+  → assign       : write category_fk/sentiment_fk back        [dbt incremental or py upsert]
+```
+
+Each stage is idempotent and keyed by `feedback_pk` + `model_version`/`cluster_run_id`,
+so a re-run never duplicates and never mutates the fact grain. Embedding is computed
+**once per (feedback_pk, model_version)**; only cluster/label/sentiment re-run cheaply.
+
+---
+
+## B. Embedding (foundation for clustering AND sentiment)
+
+**Decision: one shared embedding, computed once, stored in the `feedback_embeddings`
+sidecar.** Both clustering and (semantic) sentiment consume it — do not embed twice.
+
+- **Model choice — recommend an open/self-hostable model** (e.g. `BAAI/bge-small-en-v1.5`
+  or `sentence-transformers/all-MiniLM-L6-v2`, 384-dim) over a hosted API, for the
+  **learner-PII posture**: even post-redaction, sending ~1.18M feedback utterances to a
+  third-party embedding API is an avoidable data-egress and cost exposure. A local
+  sentence-transformers model runs the full corpus in a single batch job on CPU/GPU for
+  effectively $0 marginal cost. Keep an OpenAI `text-embedding-3-small` adapter behind the
+  same resource interface as a fallback/benchmark, but default to local.
+  - Open question deferred to implementation: GPU vs CPU throughput at 1.18M rows. At
+    MVP scale (198K) CPU is fine (single-digit minutes to low hours).
+- **Redaction is upstream and mandatory** (design §7): embeddings are computed on the
+  Presidio-redacted text only. Raw text never reaches the embedding step.
+- **`model_version` is a first-class column** on `feedback_embeddings`. Changing the model
+  = new `model_version` rows, old ones retained until re-cluster completes (no in-place
+  overwrite → no torn state).
+- **Vector storage:** at ~1.18M × 384 float32 ≈ 1.8 GB. Store as an Iceberg `ARRAY<float>`
+  column in `feedback_embeddings` for the MVP (no new operational service; aligns with the
+  lake). Revisit a dedicated vector index (StarRocks vector column, S3 Vectors, Qdrant)
+  only when an online nearest-neighbour/serving need appears — the batch clustering job
+  reads the whole set into memory, which is fine at this scale. This defers the RFC's
+  "embedding model & vector store" open question to a reversible, low-cost default.
+
+**Rejected:** re-embedding on every run (the prototype #10793 flaw the RFC explicitly
+fixes); semantic-summary-before-embedding as a default (see §C, treated as a hypothesis
+to test, not a baseline — an LLM call per record turns a ~$2–16 job into a per-record LLM
+cost across 1M+ records and can distort short-text sources).
+
+---
+
+## C. Clustering (systemic-issue detection) — `tk-...-a1d7d6`
+
+**Goal:** turn per-utterance embeddings into clusters that distinguish a *systemic issue*
+(many tickets, one root theme) from a *one-off*. Output = `cluster_id` + a cluster-size /
+cohesion signal that lets a human say "this is recurring."
+
+- **Algorithm: HDBSCAN** (density-based) as the default, over UMAP-reduced embeddings.
+  Rationale vs. k-means:
+  - No pre-set `k` — the number of systemic themes is unknown and grows; k-means forces a
+    guess and splits/merges arbitrarily.
+  - **Native noise class** — HDBSCAN labels sparse points as noise (`cluster_id = -1`),
+    which *is* the "one-off complaint" bucket we explicitly want to separate from systemic
+    signal. This maps directly to the motivation ("not just one-off complaints").
+  - Produces a `probability`/`persistence` per point → a cohesion signal for ranking
+    clusters by how tight/recurring they are.
+  - Precedent alignment: the #10793 prototype's hierarchical intent is served by
+    HDBSCAN's condensed tree without baking in its manual truncation.
+- **Dimensionality reduction: UMAP** to ~5–15 dims before HDBSCAN (HDBSCAN degrades in
+  raw high-dim space). `n_neighbors`/`min_cluster_size` are the two knobs to tune on a
+  Zendesk sample; `min_cluster_size` is effectively the "how many tickets before we call
+  it systemic" threshold and should be a config, not hardcoded.
+- **Re-clustering is cheap and expected:** each run writes a new `cluster_run_id`; the
+  sidecar keeps prior runs. `dim_feedback_category` (curated) only advances when a human
+  approves labels from a run (design §4a), decoupling churny clustering from the stable
+  category dimension.
+- **Cross-source clustering (Phase 2):** because all sources share one embedding space in
+  `int__feedback__unioned`, a cluster can span Zendesk + forum + tutor — this is the
+  mechanism behind `afact_feedback_cluster_daily` (cluster × category × sentiment × date ×
+  source). No algorithm change needed; just don't filter `source_slug` at cluster time.
+- **Deps:** `umap-learn`, `hdbscan` (or `scikit-learn`'s `HDBSCAN` ≥1.3 to avoid the
+  separate compiled dep — decide at implementation based on the Dagster image's build
+  constraints). All CPU, no service.
+
+**Cluster-quality columns** on `feedback_embeddings` are added *only if the chosen
+algorithm produces them* (RFC step 6): `cluster_id`, `cluster_probability`,
+`cluster_run_id`, `model_version` — silhouette/persistence optional.
+
+---
+
+## D. Category discovery & seeding — `tk-...-550aba`
+
+**Bootstrapped, not cold-start** (design §4a). Two inputs seed `dim_feedback_category`:
+
+1. **Seed from existing structure (no LLM):** Zendesk `ticket_tags` (~2,354 distinct) +
+   support `group_name` give an immediate, human-meaningful starter taxonomy. These become
+   `category_source='seed'` rows with `category_status='proposed'`. This alone makes the
+   MVP useful before any clustering runs.
+2. **LLM-label the clusters (§C output):** for each HDBSCAN cluster, sample N
+   representative (redacted) utterances near the centroid + the cluster's dominant seed
+   tags, and prompt an LLM to propose a short `category_label` + a stable `category_slug`
+   + a one-line description. `category_source='llm_discovered'`, `category_status='proposed'`
+   until a human approves (`approved`), merges (`merged`), or deprecates.
+
+**Key design invariants (from §4a):**
+- **SCD-lite on `category_slug`:** relabeling changes `category_label`, never the slug —
+  so `category_fk` on the fact is stable across renames.
+- **Assignment is late-arriving:** a ticket gets `category_fk` after insert, by mapping its
+  `cluster_id` → the approved category for that cluster. Uncategorized = `category_fk` null
+  (a valid, queryable state).
+- **LLM cost is bounded:** one LLM call *per cluster*, not per record (there are hundreds
+  of clusters, not millions of tickets). This is the critical cost distinction from the
+  rejected per-record semantic-summary approach.
+- **Model:** any capable instruction model (Claude Haiku/Sonnet class) — labeling a few
+  hundred clusters is a trivial, cheap batch. Keep the labeler behind a resource interface.
+
+**Human-in-the-loop is required, not optional:** LLM proposes, a human curates the
+category dimension. The dimension is a *curated projection* of clusters (design §4d), which
+is why it is a dbt/warehouse dimension and not raw model output.
+
+---
+
+## E. Sentiment mapping — `tk-...-92988e`
+
+**Grain:** `sentiment_fk` on `tfact_feedback`, one sentiment per utterance.
+`dim_sentiment` starts coarse: `positive | neutral | negative` (design §4b), with a
+`polarity_score_bucket` for trend rollups. Aspect-based sentiment is a later refinement,
+not MVP.
+
+**Two-tier derivation, cheapest-signal-first:**
+1. **Explicit signals seed & validate (free, high-precision):** where the source carries
+   an explicit rating — Zendesk `satisfaction_rating_score`, tutor `rating`, ORA scores —
+   map it directly to a sentiment bucket. This gives a labeled validation set for free and
+   covers a real fraction of rows at zero model cost.
+2. **Model the rest:** for utterances with no explicit signal, derive sentiment from the
+   text. Two options, in preference order:
+   - **(recommend MVP) A lightweight local classifier / lexicon** over the redacted text —
+     e.g. a fine-tuned or off-the-shelf sentiment model (`distilbert-sst2`-class) run in the
+     same batch job as embedding. CPU-cheap, no per-record API cost, keeps PII local.
+     Validate its output against the tier-1 explicit signals to pick a threshold.
+   - **(fallback) LLM classification** only if the local classifier's accuracy against the
+     explicit-signal validation set is inadequate. Even then, batch it and cap it — do not
+     make it a per-record online cost.
+   - **Semantic/embedding mapping** (the task title's phrasing): the embeddings already
+     computed (§B) can be nearest-neighbour-mapped to the explicit-signal-labeled examples
+     as a zero-extra-model-cost sentiment estimate. This is the most economical option and
+     reuses the one embedding — evaluate it against the local-classifier option on a sample.
+
+**Decision handed to implementation with a concrete evaluation:** run all three (explicit
++ embedding-kNN, explicit + local classifier, explicit + LLM) on a labeled Zendesk sample,
+pick by accuracy-vs-cost. Default assumption: **explicit signals + embedding-kNN** wins on
+cost and is "good enough" for trend-level sentiment; upgrade only if the accuracy gap is
+material. `dim_sentiment` and the fact column are unaffected by which wins.
+
+---
+
+## F. What is explicitly deferred (non-blocking for spec/MVP)
+
+- Embedding model final pick + GPU/CPU throughput at full 1.18M scale (MVP proves it at 198K).
+- Dedicated vector store / online serving (Iceberg ARRAY suffices for batch).
+- Aspect-based sentiment; multi-lingual handling.
+- Semantic-summary-before-embedding and hierarchical truncation from prototype #10793 —
+  test as hypotheses on a sample, do not inherit (RFC Open Questions).
+- Cross-source `afact_feedback_cluster_daily` tuning (Phase 2).

--- a/docs/design/feedback_ml_approach.md
+++ b/docs/design/feedback_ml_approach.md
@@ -7,12 +7,19 @@ Resolves the open items the dimensional-model design handed to downstream tasks:
 clustering (`tk-...-clustering-approach-...a1d7d6`), category discovery
 (`tk-...-llm-driven-category-discovery-...550aba`), and sentiment
 (`tk-...-sentiment-mapping-...92988e`). Grounded in the discovery cost model
-(~1.18M text records; one-time embed ≈ $2–16; MVP = ~198K Zendesk tickets, batch).
+(~1.18M text records; one-time embed ≈ $2–16). **The MVP figure of ~198K is stale** — it was the Zendesk
+*ticket* count, and rev. 2 moves the grain to turns; see §B.2.
 
 The guiding principle from the RFC: **the durable artifact is the feedback fact +
 persisted embeddings; clustering/category/sentiment are re-runnable consumers of it.**
 Nothing here rewrites `tfact_feedback`; all ML output lands in the `feedback_embeddings`
 sidecar or the late-arriving `category_fk`/`sentiment_fk` update.
+
+> **REVISED 2026-08-07 (rev. 2) — grain moved from ticket to turn** (design §1). Two consequences for this
+> spec, both worked through below: the **record count is now public requester *comments*, not tickets**
+> (§B.2), and the **text profile changes** — a mid-conversation turn is shorter and more context-dependent
+> than a ticket description, which is exactly the regime where the semantic-normalization eval arm (§B.1)
+> matters most.
 
 ---
 
@@ -111,6 +118,30 @@ comparison. Let the harness decide; do not hardcode a winner in the spec.
   column for the MVP (no new service; the batch clustering job reads the set into memory — fine at
   this scale). StarRocks HNSW becomes the serving-tier index once deployed (ADR).
 
+### B.2 Volume and text profile at turn grain (rev. 2)
+
+The discovery cost model (~1.18M records, one-time embed ≈ $2–16, MVP ≈ 198K Zendesk *tickets*) assumed
+ticket grain. At turn grain the MVP input is public, requester-authored **comments**, and that multiplier is
+**unmeasured** — it is a prerequisite in `feedback_zendesk_mvp_spec.md` §0 and must be run before the
+embedding budget is treated as known. Embedding cost scales linearly, so even a 3–5× multiplier keeps the
+one-time backfill in low tens of dollars; the reason to measure is sizing and runtime, not affordability.
+
+Three substantive effects, not just a bigger number:
+
+- **Turn grain helps clustering.** Under ticket grain only the opening comment is embedded, so a problem
+  first articulated in turn 4 ("actually the real issue is the certificate never generated") is invisible to
+  the systemic-issue detector. That is a recall gap, and it is the kind of thing this system exists to find.
+- **Turn text is shorter and more context-dependent.** The ~1,000-char average for `ticket_description` does
+  not hold for follow-up turns, which skew short and often refer back ("still not working", "same as
+  before"). This is precisely the short/noisy regime where the 2026 support-ticket-clustering evidence
+  reports **semantic-normalization before embedding** to be the largest lever (§B.1) — so the eval arm gets
+  *more* important, not less, and should be scored separately on opening vs. follow-up turns.
+- **Cluster sizes stop being ticket counts.** A single verbose ticket can contribute many turns to one
+  cluster. `min_cluster_size` therefore no longer reads as "how many tickets before we call it systemic" —
+  rank clusters by **distinct `conversation_id`**, not row count, or one talkative user manufactures a
+  systemic issue. This is a real change to §C's tuning story and to `afact_feedback_cluster_daily`, which
+  carries `distinct_conversation_count` for the same reason.
+
 **Rejected:** re-embedding on every run (the prototype #10793 flaw the RFC fixes).
 **Upgraded from "rejected" to "evaluate seriously" (new evidence, 2026-07):** LLM
 **semantic-normalization before embedding**. Recent support-ticket-clustering literature reports it
@@ -141,8 +172,10 @@ cohesion signal that lets a human say "this is recurring."
     HDBSCAN's condensed tree without baking in its manual truncation.
 - **Dimensionality reduction: UMAP** to ~5–15 dims before HDBSCAN (HDBSCAN degrades in
   raw high-dim space). `n_neighbors`/`min_cluster_size` are the two knobs to tune on a
-  Zendesk sample; `min_cluster_size` is effectively the "how many tickets before we call
-  it systemic" threshold and should be a config, not hardcoded.
+  Zendesk sample and should be config, not hardcoded.
+  **rev. 2:** at turn grain `min_cluster_size` counts *turns*, not tickets, so it no longer reads directly
+  as "how many tickets before we call it systemic". Rank and threshold clusters by **distinct
+  `conversation_id`** (§B.2) so one verbose conversation cannot manufacture a systemic issue.
 - **Pre-embedding LLM semantic-normalization is a first-class eval arm here** (see §B.1): recent
   support-ticket-clustering evidence (2026) reports it is the single largest lever on cluster
   quality for short/noisy ticket text. Evaluate `normalize→embed→cluster` against `embed→cluster`
@@ -235,7 +268,8 @@ material. `dim_sentiment` and the fact column are unaffected by which wins.
 
 ## F. What is explicitly deferred (non-blocking for spec/MVP)
 
-- Embedding model final pick + GPU/CPU throughput at full 1.18M scale (MVP proves it at 198K).
+- Embedding model final pick + GPU/CPU throughput at full scale (MVP proves it on the Zendesk turn corpus,
+  whose size is the §B.2 measurement).
 - Dedicated vector store / online serving (Iceberg ARRAY suffices for batch).
 - Aspect-based sentiment; multi-lingual handling.
 - Semantic-summary-before-embedding and hierarchical truncation from prototype #10793 —

--- a/docs/design/feedback_ml_approach.md
+++ b/docs/design/feedback_ml_approach.md
@@ -1,71 +1,104 @@
 # Feedback Aggregation — ML/LLM Approach Spec
 
 Status: **spec** · Project: `wp-feedback-aggregation-clustering-system-2e9750`
-Date: 2026-07-10 · Companion to [`feedback_dimensional_model.md`](./feedback_dimensional_model.md)
+Date: 2026-08-10 (rev. 3 — conversation-grain analysis) · Companion to
+[`feedback_dimensional_model.md`](./feedback_dimensional_model.md)
 
 Resolves the open items the dimensional-model design handed to downstream tasks:
 clustering (`tk-...-clustering-approach-...a1d7d6`), category discovery
 (`tk-...-llm-driven-category-discovery-...550aba`), and sentiment
-(`tk-...-sentiment-mapping-...92988e`). Grounded in the discovery cost model
-(~1.18M text records; one-time embed ≈ $2–16). **The MVP figure of ~198K is stale** — it was the Zendesk
-*ticket* count, and rev. 2 moves the grain to turns; see §B.2.
+(`tk-...-sentiment-mapping-...92988e`). Grounded in the discovery cost model (~1.18M text records; one-time
+embed ≈ $2–16). At rev. 3's conversation grain the embedding input is **~198K Zendesk conversations**
+(~600K across all sources) rather than the turn corpus — see §B.2.
 
-The guiding principle from the RFC: **the durable artifact is the feedback fact +
-persisted embeddings; clustering/category/sentiment are re-runnable consumers of it.**
-Nothing here rewrites `tfact_feedback`; all ML output lands in the `feedback_embeddings`
-sidecar or the late-arriving `category_fk`/`sentiment_fk` update.
+The guiding principle from the RFC: **the durable artifact is the feedback fact; everything a model produces
+is a re-runnable derived layer.** Nothing here writes to `tfact_feedback` — as of rev. 3 that fact is
+insert-only and has no late-arriving update path at all. All ML output lands on
+`afact_feedback_conversation`.
 
-> **REVISED 2026-08-07 (rev. 2) — grain moved from ticket to turn** (design §1). Two consequences for this
-> spec, both worked through below: the **record count is now public requester *comments*, not tickets**
-> (§B.2), and the **text profile changes** — a mid-conversation turn is shorter and more context-dependent
-> than a ticket description, which is exactly the regime where the semantic-normalization eval arm (§B.1)
-> matters most.
+> **REVISED 2026-08-10 (rev. 3) — the analysis unit is the conversation, not the turn** (design §5a).
+> `tfact_feedback` keeps its turn grain, but summarization, embedding, sentiment and clustering all operate
+> on the **assembled conversation** and write one row per conversation. Consequences worked through below:
+> the record count is conversations (~198K for Zendesk, a *known* number) rather than an unmeasured comment
+> multiplier (§B.2); a new **summarization stage** is the one per-record LLM cost (§A.1); `min_cluster_size`
+> once again reads as "how many conversations before we call it systemic" (§C); and the Zendesk CSAT signal
+> becomes grain-matched to the sentiment it seeds (§E).
+
+> **REVISED 2026-08-07 (rev. 2) — `tfact_feedback` grain moved from ticket to turn** (design §1). Still in
+> force: the fact records every requester turn, sourced from `int__zendesk__ticket_comment`. Rev. 3 changes
+> what the *models* consume, not what the fact records — and the turn grain is precisely what makes a
+> complete conversation assemblable.
 
 ---
 
 ## A. Pipeline shape (single batch Dagster asset graph, MVP)
 
 ```
-int__feedback__unioned (redacted text, feedback_pk)          [dbt]
-  → embed        : text → vector, persisted once             [py asset: feedback_embeddings]
-  → cluster      : vectors → cluster_id per cluster_run       [py asset: feedback_cluster_run
-                                                               + feedback_cluster_assignment]
-  → label        : cluster centroid/samples → category label  [py asset: dim_feedback_category (proposed)]
-  → sentiment    : text/vector → sentiment_slug               [py asset: sentiment_fk]
-  → assign       : write category_fk/sentiment_fk back        [dbt incremental or py upsert]
+int__feedback__conversation (redacted turns assembled per conversation) [dbt]
+  → summarize    : turns → conversation_summary               [py; SKIPPED for single-turn/short — §A.1]
+  → embed        : summary or turns → vector                  [py]
+  → cluster      : vectors → cluster_id per cluster_run       [py; + feedback_cluster_run]
+  → label        : cluster centroid/samples → category label  [py: dim_feedback_category (proposed)]
+  → sentiment    : rating or text/vector → sentiment_slug     [py]
+  → write        : one row per conversation                   [afact_feedback_conversation]
 ```
 
-Each stage is idempotent and keyed by `feedback_pk` + `model_version`/`cluster_run_id`,
-so a re-run never duplicates and never mutates the fact grain. Embedding is computed
-**once per (feedback_pk, model_version)**; only cluster/label/sentiment re-run cheaply.
+Every stage is keyed by `feedback_conversation_pk` and stamps the version that produced it
+(`summary_model_version`, `embedding_model_version`, `cluster_run_id`), so a re-run is an idempotent
+overwrite of a derived row. **No stage writes to `tfact_feedback`.**
 
-**The sidecar is three tables, not one** (design §4d; ERD in [`feedback_erd.md`](./feedback_erd.md) §3).
-Vectors are one row per `(feedback_pk, model_version)`; cluster assignments are one row per
-`(feedback_pk, cluster_run_id)`. Collapsing them into a single `feedback_embeddings` table means
-re-clustering against an unchanged model rewrites or duplicates vector rows — which is exactly the
-"re-clustering never touches the durable artifact" property this design exists to buy:
+**One target table, not a sidecar** (design §4f/§5a; ERD in [`feedback_erd.md`](./feedback_erd.md) §4). The
+rev. 2 sidecar split — `feedback_embeddings` at `(feedback_pk, model_version)` and
+`feedback_cluster_assignment` at `(feedback_pk, cluster_run_id)` — is withdrawn. All of it collapses onto one
+row per conversation, and two tables survive at genuinely different grains:
 
 | Table | Grain | Holds |
 |---|---|---|
-| `feedback_embeddings` | `(feedback_pk, model_version)` | `vector` (Iceberg `ARRAY<float>`), `vector_dim`, `text_variant`, `embedded_at` |
-| `feedback_cluster_run` | `(cluster_run_id)` | `model_version`, `algorithm`, `run_params`, `cluster_count`, `noise_count`, `silhouette`, `run_status`, `run_at` |
-| `feedback_cluster_assignment` | `(feedback_pk, cluster_run_id)` | `cluster_id` (`-1` = noise = one-off), `cluster_probability` |
+| `afact_feedback_conversation` | `(feedback_conversation_pk)` | summary, `embedding_vector`, `embedding_dim`, `embedding_input`, `category_fk`, `sentiment_fk`, `cluster_id`, `cluster_probability` + version stamps |
+| `feedback_cluster_run` | `(cluster_run_id)` | `embedding_model_version`, `algorithm`, `run_params`, `cluster_count`, `noise_count`, `silhouette`, `run_status`, `run_at` |
+| `feedback_cluster_candidate` | `(feedback_conversation_pk, cluster_run_id)` | `cluster_id`, `cluster_probability` — **unpromoted runs only**, for run-vs-run comparison |
 
-`text_variant` (`raw` \| `llm_normalized`) makes the semantic-normalisation eval arm (§B.1) a *row*
-distinction rather than a separate pipeline — both arms coexist under one `model_version` sweep.
-`dim_feedback_category.cluster_run_id` records which run proposed a category.
+**What the collapse costs, honestly.** Re-clustering now rewrites the afact row, vector column included — the
+property rev. 2's split was bought to preserve. The vector *value* is carried forward rather than recomputed,
+so nothing is re-embedded; what is lost is holding several generations live in production simultaneously.
+That is a bake-off need, and `feedback_cluster_candidate` (plus scratch tables during the §B.1 evaluation)
+covers it off the critical path. What is bought is a single table for consumers and an insert-only fact.
+
+`embedding_input` (`summary` \| `concatenated_turns`) is what makes the summarize-before-embed question
+(§B.1) a *column* on the eval rather than a separate pipeline. `dim_feedback_category.cluster_run_id` still
+records which run proposed a category.
+
+### A.1 Summarization — the one per-record LLM call
+
+New in rev. 3. `conversation_summary` is an LLM abstract of the assembled redacted turns. It serves two
+purposes: it is what a human reads in a cluster listing instead of scrolling a thread, and it is a candidate
+for `embedding_input` — which is the same lever §B.1 already identified as the largest single contributor to
+cluster quality on short, noisy ticket text. Rev. 3 promotes it from an eval arm to a first-class artifact,
+so its cost has to be stated rather than assumed away:
+
+- **Skip rule:** conversations with `turn_count = 1` or under a length threshold are **not** summarized —
+  the raw text already is the summary. `summary_model_version` stays null and `embedding_input` is
+  `concatenated_turns`. ORA and the edX plugin are single-turn by construction and are free.
+- **Order of magnitude (validate on a sample first):** the multi-turn share of ~198K Zendesk conversations at
+  ~1–2K input and ~100 output tokens each lands the one-time backfill in the low hundreds of dollars at
+  Haiku-class pricing; steady state (~24K conversations/yr, a fraction multi-turn) is tens of dollars a year.
+  One to two orders of magnitude above the $2–16 embedding backfill, still small absolutely — but it is a
+  real departure from the "trivial batch cost" posture this project has carried since discovery, and it is
+  the number to measure before committing.
+- **PII:** summaries are generated from Presidio-redacted text only and inherit that classification.
 
 ---
 
 ## B. Embedding (foundation for clustering AND sentiment)
 
-**Decision: one shared embedding, computed once, stored in the `feedback_embeddings`
-sidecar.** Both clustering and (semantic) sentiment consume it — do not embed twice.
+**Decision: one shared embedding per conversation, computed once, stored on
+`afact_feedback_conversation`.** Both clustering and (semantic) sentiment consume it — do not embed twice.
 
 > **REVISED 2026-07-10 (rev. 4) — see [`adr_embedding_compute_strategy.md`](./adr_embedding_compute_strategy.md).**
 > Compute stays engine-external via **Fenic (Apache-2.0)** in a Dagster asset, writing vectors to
-> an open Iceberg `ARRAY<float>` sidecar (portable across Trino→StarRocks; StarRocks later indexes
-> those vectors with HNSW). **Bedrock/in-account is NOT a requirement** — the **embedding model is
+> an open Iceberg `ARRAY<float>` column (rev. 3: on `afact_feedback_conversation`; portable across
+> Trino→StarRocks, and StarRocks later indexes those vectors with HNSW — a load, not a re-embed).
+> **Bedrock/in-account is NOT a requirement** — the **embedding model is
 > chosen by task effectiveness** (clustering + retrieval on OUR feedback corpus), with egress of
 > Presidio-redacted text to a managed provider acceptable. Model selection is specified as an
 > evaluation below, not a fixed pick. Persist-once, `model_version`, Iceberg storage, and
@@ -111,36 +144,45 @@ comparison. Let the harness decide; do not hardcode a winner in the spec.
   Presidio-redacted text only. Raw text never reaches the embedding step. (Redaction remains
   required even though provider egress is now acceptable — it is a data-minimization guarantee,
   not just an egress control.)
-- **`model_version` is a first-class column** on `feedback_embeddings`. Changing the model (or the
-  dimension) = new `model_version` rows, old retained until re-cluster completes (no torn state).
-  This is what makes the model choice reversible and the eval low-risk.
-- **Vector storage:** ~1.18M × (256–1024) float32 ≈ 1.2–4.8 GB. Store as an Iceberg `ARRAY<float>`
-  column for the MVP (no new service; the batch clustering job reads the set into memory — fine at
-  this scale). StarRocks HNSW becomes the serving-tier index once deployed (ADR).
+- **`embedding_model_version` is a first-class column** on `afact_feedback_conversation`. Changing the model
+  (or the dimension) = a rebuild of the derived table under a new version stamp, with the bake-off run
+  against scratch/candidate tables so production is never in a torn state. This is what makes the model
+  choice reversible and the eval low-risk — and it costs nothing on `tfact_feedback`, which is untouched.
+- **Vector storage:** at conversation grain the vector count is *conversations*, not turns — ~198K for the
+  Zendesk MVP and roughly 600K across all sources (Zendesk tickets + forum threads + tutor threads + ORA
+  submissions), against the ~1.18M *turn* figure the earlier estimate used. At (256–1024) float32 that is
+  ~0.2–2.5 GB. Store as an Iceberg `ARRAY<float>` column for the MVP (no new service; the batch clustering
+  job reads the set into memory — comfortable at this scale). StarRocks HNSW becomes the serving-tier index
+  once deployed (ADR).
 
-### B.2 Volume and text profile at turn grain (rev. 2)
+### B.2 Volume and text profile at conversation grain (rev. 3)
 
-The discovery cost model (~1.18M records, one-time embed ≈ $2–16, MVP ≈ 198K Zendesk *tickets*) assumed
-ticket grain. At turn grain the MVP input is public, requester-authored **comments**, and that multiplier is
-**unmeasured** — it is a prerequisite in `feedback_zendesk_mvp_spec.md` §0 and must be run before the
-embedding budget is treated as known. Embedding cost scales linearly, so even a 3–5× multiplier keeps the
-one-time backfill in low tens of dollars; the reason to measure is sizing and runtime, not affordability.
+**The embedding input count is now a known number, not an unmeasured multiplier.** Rev. 2 put the ML input at
+public, requester-authored *comments*, whose ratio to tickets nobody had measured. Rev. 3 embeds
+conversations, so the MVP input is **~198K Zendesk tickets** — the figure discovery actually measured — and
+roughly ~600K across all sources once forum threads, tutor threads and ORA submissions are onboarded, versus
+the ~1.18M turn-level corpus. Embedding cost returns to the original $2–16 order of magnitude.
 
-Three substantive effects, not just a bigger number:
+The turn-count measurement in `feedback_zendesk_mvp_spec.md` §0 is **still required**, but for different
+reasons now: it sizes `tfact_feedback` itself, and it determines the multi-turn share that drives the
+summarization budget (§A.1).
 
-- **Turn grain helps clustering.** Under ticket grain only the opening comment is embedded, so a problem
-  first articulated in turn 4 ("actually the real issue is the certificate never generated") is invisible to
-  the systemic-issue detector. That is a recall gap, and it is the kind of thing this system exists to find.
-- **Turn text is shorter and more context-dependent.** The ~1,000-char average for `ticket_description` does
-  not hold for follow-up turns, which skew short and often refer back ("still not working", "same as
-  before"). This is precisely the short/noisy regime where the 2026 support-ticket-clustering evidence
-  reports **semantic-normalization before embedding** to be the largest lever (§B.1) — so the eval arm gets
-  *more* important, not less, and should be scored separately on opening vs. follow-up turns.
-- **Cluster sizes stop being ticket counts.** A single verbose ticket can contribute many turns to one
-  cluster. `min_cluster_size` therefore no longer reads as "how many tickets before we call it systemic" —
-  rank clusters by **distinct `conversation_id`**, not row count, or one talkative user manufactures a
-  systemic issue. This is a real change to §C's tuning story and to `afact_feedback_cluster_daily`, which
-  carries `distinct_conversation_count` for the same reason.
+Three substantive effects, not just a different number:
+
+- **Conversation grain fixes the recall gap without reintroducing the old one.** Rev. 1's ticket grain
+  embedded only the opening comment, so a problem first articulated in turn 4 ("actually the real issue is
+  the certificate never generated") was invisible to the systemic-issue detector. Embedding the *assembled*
+  conversation includes turn 4 — while also keeping it attached to the turn-1 context that makes it
+  interpretable, which per-turn embedding threw away.
+- **The text profile improves in the direction §B.1 cares about.** Isolated follow-up turns skew short and
+  referential ("still not working", "same as before") — the worst case for an embedding model. An assembled
+  conversation, and more so its summary, is self-contained. This does not retire the summarize-before-embed
+  eval arm; it makes it a comparison between two coherent inputs (`embedding_input = summary` vs.
+  `concatenated_turns`) rather than a rescue operation on fragments.
+- **Cluster size means what it should again.** A cluster's member count *is* its distinct-conversation count,
+  so `min_cluster_size` reads directly as "how many conversations before we call this systemic" and one
+  talkative reporter can no longer manufacture a systemic issue. Rev. 2's rank-by-`distinct conversation_id`
+  workaround and `afact_feedback_cluster_daily`'s twin count columns both go away.
 
 **Rejected:** re-embedding on every run (the prototype #10793 flaw the RFC fixes).
 **Upgraded from "rejected" to "evaluate seriously" (new evidence, 2026-07):** LLM
@@ -155,8 +197,8 @@ Zendesk descriptions (avg ~1,000 chars) and least on already-short sources (tuto
 
 ## C. Clustering (systemic-issue detection) — `tk-...-a1d7d6`
 
-**Goal:** turn per-utterance embeddings into clusters that distinguish a *systemic issue*
-(many tickets, one root theme) from a *one-off*. Output = `cluster_id` + a cluster-size /
+**Goal:** turn per-conversation embeddings into clusters that distinguish a *systemic issue*
+(many conversations, one root theme) from a *one-off*. Output = `cluster_id` + a cluster-size /
 cohesion signal that lets a human say "this is recurring."
 
 - **Algorithm: HDBSCAN** (density-based) as the default, over UMAP-reduced embeddings.
@@ -173,29 +215,30 @@ cohesion signal that lets a human say "this is recurring."
 - **Dimensionality reduction: UMAP** to ~5–15 dims before HDBSCAN (HDBSCAN degrades in
   raw high-dim space). `n_neighbors`/`min_cluster_size` are the two knobs to tune on a
   Zendesk sample and should be config, not hardcoded.
-  **rev. 2:** at turn grain `min_cluster_size` counts *turns*, not tickets, so it no longer reads directly
-  as "how many tickets before we call it systemic". Rank and threshold clusters by **distinct
-  `conversation_id`** (§B.2) so one verbose conversation cannot manufacture a systemic issue.
-- **Pre-embedding LLM semantic-normalization is a first-class eval arm here** (see §B.1): recent
-  support-ticket-clustering evidence (2026) reports it is the single largest lever on cluster
-  quality for short/noisy ticket text. Evaluate `normalize→embed→cluster` against `embed→cluster`
-  on the labeled sample (silhouette + tag-agreement + human coherence); adopt only where the
-  measured lift justifies the per-record LLM cost — likely worth it for the long Zendesk
-  descriptions, likely not for already-short sources.
-- **Re-clustering is cheap and expected:** each run writes a new `cluster_run_id`; the
-  sidecar keeps prior runs. `dim_feedback_category` (curated) only advances when a human
-  approves labels from a run (design §4a), decoupling churny clustering from the stable
-  category dimension.
+  **rev. 3:** at conversation grain `min_cluster_size` counts conversations, so it reads directly as "how
+  many conversations before we call it systemic" and needs no correction. (Rev. 2's rank-by-distinct-
+  `conversation_id` workaround, required when clustering turns, is retired.)
+- **Summary-vs-raw is the eval arm** (see §B.1/§A.1): recent support-ticket-clustering evidence (2026)
+  reports LLM normalization before embedding is the single largest lever on cluster quality for short/noisy
+  ticket text. Rev. 3 makes the summary a first-class artifact, so this becomes a comparison between
+  `embedding_input = 'summary'` and `embedding_input = 'concatenated_turns'` on the labeled sample
+  (silhouette + tag-agreement + human coherence). Adopt the summary as the embedding input only where the
+  measured lift justifies its per-conversation LLM cost — expected to help most on long multi-turn Zendesk
+  tickets and not at all on single-turn sources, which the §A.1 skip rule never summarizes anyway.
+- **Re-clustering is cheap and expected:** each run writes a new `cluster_run_id` to `feedback_cluster_run`;
+  an unpromoted run's assignments sit in `feedback_cluster_candidate` until approved, at which point they are
+  copied onto `afact_feedback_conversation`. `dim_feedback_category` (curated) only advances when a human
+  approves labels from a run (design §4a), decoupling churny clustering from the stable category dimension.
 - **Cross-source clustering (Phase 2):** because all sources share one embedding space in
-  `int__feedback__unioned`, a cluster can span Zendesk + forum + tutor — this is the
+  `int__feedback__conversation`, a cluster can span Zendesk + forum + tutor — this is the
   mechanism behind `afact_feedback_cluster_daily` (cluster × category × sentiment × date ×
   source). No algorithm change needed; just don't filter `source_slug` at cluster time.
 - **Deps:** `umap-learn`, `hdbscan` (or `scikit-learn`'s `HDBSCAN` ≥1.3 to avoid the
   separate compiled dep — decide at implementation based on the Dagster image's build
   constraints). All CPU, no service.
 
-**Cluster-quality columns** are added *only if the chosen algorithm produces them* (RFC step 6):
-`cluster_id` + `cluster_probability` on `feedback_cluster_assignment`; run-level `silhouette`,
+**Cluster-quality columns** are added *only if the chosen algorithm produces them*:
+`cluster_id` + `cluster_probability` on `afact_feedback_conversation`; run-level `silhouette`,
 `cluster_count`, `noise_count` on `feedback_cluster_run` (§A) — persistence optional.
 
 ---
@@ -216,10 +259,11 @@ cohesion signal that lets a human say "this is recurring."
 
 **Key design invariants (from §4a):**
 - **SCD-lite on `category_slug`:** relabeling changes `category_label`, never the slug —
-  so `category_fk` on the fact is stable across renames.
-- **Assignment is late-arriving:** a ticket gets `category_fk` after insert, by mapping its
-  `cluster_id` → the approved category for that cluster. Uncategorized = `category_fk` null
-  (a valid, queryable state).
+  so `category_fk` is stable across renames.
+- **Assignment lands on `afact_feedback_conversation`** (rev. 3), by mapping a conversation's `cluster_id` →
+  the approved category for that cluster. Uncategorized = `category_fk` null (a valid, queryable state).
+  This is no longer a "late-arriving update to the fact" — the fact has no update path; it is a rebuild of a
+  derived column.
 - **LLM cost is bounded:** one LLM call *per cluster*, not per record (there are hundreds
   of clusters, not millions of tickets). This is the critical cost distinction from the
   rejected per-record semantic-summary approach.
@@ -234,10 +278,16 @@ is why it is a dbt/warehouse dimension and not raw model output.
 
 ## E. Sentiment mapping — `tk-...-92988e`
 
-**Grain:** `sentiment_fk` on `tfact_feedback`, one sentiment per utterance.
+**Grain:** `sentiment_fk` on `afact_feedback_conversation`, one sentiment per **conversation** (rev. 3).
 `dim_sentiment` starts coarse: `positive | neutral | negative` (design §4b), with a
 `polarity_score_bucket` for trend rollups. Aspect-based sentiment is a later refinement,
 not MVP.
+
+> **Rev. 3 fixes a grain mismatch.** Zendesk's `satisfaction_rating_score` is a *ticket*-level signal. At
+> turn grain it had to be propagated to every turn of a rated ticket, which rev. 2 had to flag as a weak and
+> potentially misleading label. It is now the same grain as the sentiment it seeds, so tier 1 below is an
+> exact label rather than an approximation — which also makes the tier-2 validation set trustworthy.
+> `sentiment_source` (`explicit_rating` | `model`) records which tier produced each row.
 
 **Two-tier derivation, cheapest-signal-first:**
 1. **Explicit signals seed & validate (free, high-precision):** where the source carries
@@ -262,16 +312,20 @@ not MVP.
 + embedding-kNN, explicit + local classifier, explicit + LLM) on a labeled Zendesk sample,
 pick by accuracy-vs-cost. Default assumption: **explicit signals + embedding-kNN** wins on
 cost and is "good enough" for trend-level sentiment; upgrade only if the accuracy gap is
-material. `dim_sentiment` and the fact column are unaffected by which wins.
+material. `dim_sentiment` and the conversation-fact column are unaffected by which wins.
 
 ---
 
 ## F. What is explicitly deferred (non-blocking for spec/MVP)
 
-- Embedding model final pick + GPU/CPU throughput at full scale (MVP proves it on the Zendesk turn corpus,
-  whose size is the §B.2 measurement).
+- Embedding model final pick + GPU/CPU throughput at full scale (MVP proves it on ~198K Zendesk
+  conversations).
 - Dedicated vector store / online serving (Iceberg ARRAY suffices for batch).
 - Aspect-based sentiment; multi-lingual handling.
-- Semantic-summary-before-embedding and hierarchical truncation from prototype #10793 —
-  test as hypotheses on a sample, do not inherit (RFC Open Questions).
+- **Turn-level embeddings.** Rev. 3 embeds conversations only. If a later retrieval use case needs
+  "find me the exact turn where this was said", turn-level vectors can be added as a genuine sidecar then —
+  the turn grain in `tfact_feedback` preserves the option. Nothing in the MVP needs it.
+- Hierarchical truncation from prototype #10793 — test as a hypothesis on a sample, do not inherit
+  (RFC Open Questions). Semantic-summary-before-embedding is no longer deferred: rev. 3 makes the summary a
+  first-class artifact and its use as `embedding_input` a scored eval arm (§A.1, §C).
 - Cross-source `afact_feedback_cluster_daily` tuning (Phase 2).

--- a/docs/design/feedback_ml_approach.md
+++ b/docs/design/feedback_ml_approach.md
@@ -21,7 +21,8 @@ sidecar or the late-arriving `category_fk`/`sentiment_fk` update.
 ```
 int__feedback__unioned (redacted text, feedback_pk)          [dbt]
   → embed        : text → vector, persisted once             [py asset: feedback_embeddings]
-  → cluster      : vectors → cluster_id per cluster_run       [py asset: feedback_embeddings.cluster_id]
+  → cluster      : vectors → cluster_id per cluster_run       [py asset: feedback_cluster_run
+                                                               + feedback_cluster_assignment]
   → label        : cluster centroid/samples → category label  [py asset: dim_feedback_category (proposed)]
   → sentiment    : text/vector → sentiment_slug               [py asset: sentiment_fk]
   → assign       : write category_fk/sentiment_fk back        [dbt incremental or py upsert]
@@ -30,6 +31,22 @@ int__feedback__unioned (redacted text, feedback_pk)          [dbt]
 Each stage is idempotent and keyed by `feedback_pk` + `model_version`/`cluster_run_id`,
 so a re-run never duplicates and never mutates the fact grain. Embedding is computed
 **once per (feedback_pk, model_version)**; only cluster/label/sentiment re-run cheaply.
+
+**The sidecar is three tables, not one** (design §4d; ERD in [`feedback_erd.md`](./feedback_erd.md) §3).
+Vectors are one row per `(feedback_pk, model_version)`; cluster assignments are one row per
+`(feedback_pk, cluster_run_id)`. Collapsing them into a single `feedback_embeddings` table means
+re-clustering against an unchanged model rewrites or duplicates vector rows — which is exactly the
+"re-clustering never touches the durable artifact" property this design exists to buy:
+
+| Table | Grain | Holds |
+|---|---|---|
+| `feedback_embeddings` | `(feedback_pk, model_version)` | `vector` (Iceberg `ARRAY<float>`), `vector_dim`, `text_variant`, `embedded_at` |
+| `feedback_cluster_run` | `(cluster_run_id)` | `model_version`, `algorithm`, `run_params`, `cluster_count`, `noise_count`, `silhouette`, `run_status`, `run_at` |
+| `feedback_cluster_assignment` | `(feedback_pk, cluster_run_id)` | `cluster_id` (`-1` = noise = one-off), `cluster_probability` |
+
+`text_variant` (`raw` \| `llm_normalized`) makes the semantic-normalisation eval arm (§B.1) a *row*
+distinction rather than a separate pipeline — both arms coexist under one `model_version` sweep.
+`dim_feedback_category.cluster_run_id` records which run proposed a category.
 
 ---
 
@@ -144,9 +161,9 @@ cohesion signal that lets a human say "this is recurring."
   separate compiled dep — decide at implementation based on the Dagster image's build
   constraints). All CPU, no service.
 
-**Cluster-quality columns** on `feedback_embeddings` are added *only if the chosen
-algorithm produces them* (RFC step 6): `cluster_id`, `cluster_probability`,
-`cluster_run_id`, `model_version` — silhouette/persistence optional.
+**Cluster-quality columns** are added *only if the chosen algorithm produces them* (RFC step 6):
+`cluster_id` + `cluster_probability` on `feedback_cluster_assignment`; run-level `silhouette`,
+`cluster_count`, `noise_count` on `feedback_cluster_run` (§A) — persistence optional.
 
 ---
 

--- a/docs/design/feedback_zendesk_mvp_spec.md
+++ b/docs/design/feedback_zendesk_mvp_spec.md
@@ -1,0 +1,243 @@
+# Feedback Aggregation — Zendesk MVP Implementation Spec
+
+Status: **spec** · Project: `wp-feedback-aggregation-clustering-system-2e9750`
+Date: 2026-07-10 · Companion to [`feedback_dimensional_model.md`](./feedback_dimensional_model.md)
+and [`feedback_ml_approach.md`](./feedback_ml_approach.md)
+
+Concrete, build-ready spec for the first slice: **Zendesk tickets → `tfact_feedback`**,
+serving support + engineering. Grounded in the actual repo models/columns. Everything here
+is Phase-1 MVP scope (design §9); forum/tutor/ORA and the data-bus migration are later.
+
+Convention baseline: mirrors `tfact_discussion_events` (the existing multi-source fact) —
+same timestamp macros, same FK-by-lookup-join pattern, same `_dim__models.yml` contract
+style. Divergence from precedent is called out explicitly where intentional.
+
+---
+
+## 1. dbt model DAG (MVP)
+
+```
+raw__thirdparty__zendesk_support__tickets        (existing Airbyte raw, in _zendesk__sources.yml)
+  → stg__zendesk__ticket        (existing)
+  → int__zendesk__ticket        (existing, one row per ticket — grain source)
+      │
+      ├─ stg__zendesk__user     (existing — for requester email → dim_user)
+      │
+      ▼
+  int__feedback__zendesk        (NEW — conform ticket to the common event contract §5 of design doc)
+      ▼
+  int__feedback__unioned        (NEW — UNION of all sources; MVP = zendesk only; + PII redaction §7)
+      ▼
+  tfact_feedback                (NEW — resolve conformed FKs, generate feedback_pk)
+
+  dim_feedback_source           (NEW — seed rows, static/near-static)
+  dim_feedback_category         (NEW — seeded from ticket_tags + group_name; LLM-labeled later)
+  dim_sentiment                 (NEW — seeded static buckets)
+```
+
+The two-hop `int__feedback__zendesk → int__feedback__unioned` looks redundant at MVP (one
+source) but is deliberate: `__unioned` is where new sources plug in without touching the
+fact, and where redaction happens once for all sources. Keeping it from day one makes
+Phase 2 a pure additive change.
+
+---
+
+## 2. `int__feedback__zendesk` (NEW) — conform Zendesk to the common contract
+
+Reads `int__zendesk__ticket` (grain: one row per ticket, `ticket_id` unique+not_null),
+left-joined to `stg__zendesk__ticket` (for `ticket_requester_user_id`) → `stg__zendesk__user`
+(for `user_email`, needed because `int__zendesk__ticket` only carries `ticket_requester`
+as a *name*, not an id/email — confirmed in source inventory).
+
+Output columns = the common feedback event contract (design §5), source-typed:
+
+| Contract field | Zendesk expression |
+|---|---|
+| `source_slug` | literal `'zendesk'` |
+| `occurred_at` | `ticket_created_at` (ISO8601) |
+| `subject_user_ref` | `user_email` from `stg__zendesk__user` via `ticket_requester_user_id` (last-resort identity path, see §4) |
+| `courserun_readable_id` | `null` (Zendesk is not course-scoped) |
+| `platform` | `null` |
+| `conversation_ref` | `ticket_id` (thread/ticket id) |
+| `source_record_ref` | `ticket_id` (**idempotency + business key**, §6 of design) |
+| `title` | `ticket_subject` |
+| `text` | `ticket_description` (= first comment body) |
+| `source_metadata` | struct/JSON: `ticket_tags`, `ticket_status`, `ticket_priority`, `ticket_source_channel`, `ticket_satisfaction_rating_score`, `ticket_satisfaction_rating_comment`, `group_name`, `organization_name`, `ticket_api_url` |
+
+Notes:
+- **`ticket_description` = first comment only** (confirmed). That is the correct MVP grain
+  per design §1 (Zendesk row = first comment). Full-thread text via
+  `int__zendesk__ticket_comment` is a Phase-2 option, not MVP.
+- Carry `ticket_api_url` through as the `source_url` deep-link.
+- Do **not** redact here — redaction is centralized in `int__feedback__unioned` (§3).
+
+---
+
+## 3. `int__feedback__unioned` (NEW) — union + redact
+
+- **Union** all per-source `int__feedback__<source>` models into the single common shape.
+  MVP: just `int__feedback__zendesk`. The model is written as an explicit `union all` of
+  CTEs (mirrors `tfact_discussion_events`' per-source CTE style) so adding forum/tutor is a
+  new CTE + one `union all` line.
+- **PII redaction (design §7, mandatory pre-embed):** apply the Presidio-based masking to
+  `title` and `text` here, producing `title_redacted` / `text_redacted`. Raw `title`/`text`
+  do **not** propagate past this model — only redacted text flows to `tfact_feedback` and
+  the embedding store. Raw text remains available upstream in `stg`/`int__zendesk` under
+  existing PII classification + Lakekeeper/Cedar authz.
+  - Implementation note: Presidio is Python, not SQL. Two viable placements — (a) a Python
+    Dagster asset that materializes the redacted column between `int__feedback__unioned`
+    and the fact, or (b) a dbt Python model if the warehouse adapter supports it. **Recommend
+    (a)** for MVP: the same batch asset that embeds also redacts, single Python surface,
+    and it keeps the dbt layer pure-SQL (repo convention). Revisit if a SQL-native masking
+    macro is preferred. This is the one place the spec's dbt DAG and the Dagster asset graph
+    interleave — see §7.
+- Carry `feedback_text_chars = length(text)` (pre-redaction length metric, design §2) for
+  sizing/analytics; computing length before masking is fine (no PII in an integer).
+
+---
+
+## 4. `tfact_feedback` (NEW) — the fact
+
+Mirrors `tfact_discussion_events` conventions. Reads `int__feedback__unioned`.
+
+**Grain:** one row per atomic feedback utterance. `feedback_pk` unique.
+
+**Surrogate + FK resolution:**
+```sql
+-- surrogate business key (DIVERGES from precedent — see note)
+{{ dbt_utils.generate_surrogate_key(['source_slug', 'source_record_ref']) }} as feedback_pk
+
+-- conformed FK: source
+{{ dbt_utils.generate_surrogate_key(['source_slug']) }} as feedback_source_fk
+
+-- conformed FK: user (nullable). Zendesk = last-resort email path.
+users.user_pk as user_fk
+...
+left join dim_user as users
+    on lower(unioned.subject_user_ref) = users.email   -- dim_user.user_pk = surrogate_key(lower(email))
+
+-- conformed FKs not populated for Zendesk (nullable, correct):
+-- courserun_fk, platform_fk  -> null at MVP
+-- organization_fk -> resolve from source_metadata.organization_name if/when a
+--    dim_organization join key exists; null-tolerant otherwise
+
+-- late-arriving, null at insert, updated by ML asset (design §4a/§4b):
+cast(null as varchar) as category_fk
+cast(null as varchar) as sentiment_fk
+
+-- time
+{{ iso8601_to_time_key('occurred_at') }} as time_fk
+{{ iso8601_to_date_key('occurred_at') }} as date_fk
+```
+
+**Identity resolution — the highest-risk join (design §3, RFC Consequences).** Zendesk has
+no openedx user id, so `user_fk` resolves via **email → `dim_user.email`** (which is how
+`dim_user.user_pk` itself is generated: `generate_surrogate_key(['lower(email)'])`). This is
+the last-resort path and shares the failure class of the open p0 `dim_user` NULL-email
+identity-collapse bug (`tk-re-derive-identity-conformed-dimension-joins-pos-b7ca16`). Guard:
+- Never key `feedback_pk` off the resolved `user_fk` (it keys off `source_record_ref`), so a
+  bad identity join can never collapse or duplicate the fact grain.
+- `user_fk` stays **nullable**; an unresolved requester email = null `user_fk`, not a wrong
+  join. Do not coalesce to a sentinel.
+- Re-run `tk-...-b7ca16` before enabling any cross-source identity rollups on this fact.
+
+**Divergence from precedent (intentional):** `tfact_chatbot_events`/`tfact_discussion_events`
+mint no `*_pk` and rely on a model-level `expect_compound_columns_to_be_unique` test. This
+fact mints an explicit `feedback_pk` from the stable source business key because (1) the
+migration strategy (design §6) requires the same PK to regenerate identically across the
+interim→data-bus source swap, and (2) `category_fk`/`sentiment_fk` are late-arriving updates
+that need a stable row key to target. We keep the compound-uniqueness test *as well* (§8).
+
+**Output columns** (fact): `feedback_pk`, `feedback_source_fk`, `user_fk`, `courserun_fk`,
+`platform_fk`, `organization_fk`, `category_fk`, `sentiment_fk`, `time_fk`, `date_fk`,
+`conversation_id` (=`conversation_ref`), `source_record_id` (=`source_record_ref`),
+`source_url`, `feedback_title` (redacted), `feedback_text` (redacted), `feedback_text_chars`,
+`embedding_id` (nullable), `source_status`, `source_priority`, `source_tags`,
+`source_channel`, `csat_score`, `feedback_occurred_at`, `feedback_ingested_at`.
+
+---
+
+## 5. New dimensions (MVP)
+
+### `dim_feedback_source` — static seed
+Rows for MVP: one, `zendesk`. Columns per design §4c
+(`feedback_source_pk = generate_surrogate_key(['source_slug'])`, `source_slug`, `source_name`,
+`source_medium='support_ticket'`, `source_audience_scope='operational'`, `is_course_scoped=false`).
+Implement as a dbt seed (`seeds/`) or a small `select ... union all` model — recommend a
+seed CSV since the set is tiny and hand-curated.
+
+### `dim_sentiment` — static seed
+Rows: `positive`, `neutral`, `negative` (design §4b), `sentiment_pk = generate_surrogate_key(['sentiment_slug'])`,
+`polarity_score_bucket`. dbt seed CSV.
+
+### `dim_feedback_category` — seeded, then ML-curated
+- **MVP seed (no ML):** distinct `ticket_tags` (~2,354) + `group_name` from
+  `int__zendesk__ticket`, materialized as `category_source='seed'`,
+  `category_status='proposed'`, `category_slug = generate_surrogate_key([slugified tag])`.
+  A dbt model that unnests `ticket_tags` and selects distinct, plus group names.
+- **ML curation (later, per `feedback_ml_approach.md` §D):** LLM-labeled clusters upsert
+  `category_source='llm_discovered'` rows; humans flip `category_status` to `approved`.
+- SCD-lite: relabel changes `category_label`, never `category_slug`.
+
+---
+
+## 6. Sentiment & category assignment at MVP
+
+- **Sentiment (`sentiment_fk`):** MVP can populate a *coarse* sentiment immediately from the
+  explicit signal with **no model**: map `ticket_satisfaction_rating_score`
+  (`'good'`→positive, `'bad'`→negative, `'offered'`/null→neutral/unknown) → `dim_sentiment`.
+  The model-based sentiment (`feedback_ml_approach.md` §E) upgrades the null/`offered` rows
+  later. This gives a working sentiment facet on day one for the rated subset.
+- **Category (`category_fk`):** MVP can assign the tag-seed category by mapping a ticket's
+  dominant `ticket_tag` → its seed `category_slug`. Cluster-based reassignment comes with the
+  ML asset. Unassigned = null (queryable).
+
+Both are late-arriving updates, so the fact builds and is useful before the ML asset exists.
+
+---
+
+## 7. Dagster asset (MVP) — SEE `feedback_dagster_asset_spec.md`
+
+The scheduled batch asset (pull → redact → embed → cluster → LLM-label → write
+category/sentiment back) is specified separately once the orchestration layout is confirmed.
+The dbt models above are independently buildable and testable *without* the ML asset — the
+ML asset only fills `embedding_id`, `category_fk`, `sentiment_fk`, and the `feedback_embeddings`
+sidecar. This ordering lets the fact ship first.
+
+---
+
+## 8. Tests / contract (`_dim__models.yml` entries)
+
+Mirror the `tfact_discussion_events` yml style:
+- Per-column `not_null` on: `feedback_pk`, `feedback_source_fk`, `source_slug` equivalent,
+  `source_record_id`, `feedback_occurred_at`, `time_fk`, `date_fk`.
+- `unique` on `feedback_pk`.
+- Nullable (description-only, no not_null): `user_fk`, `courserun_fk`, `platform_fk`,
+  `organization_fk`, `category_fk`, `sentiment_fk`, `embedding_id`.
+- Model-level `dbt_expectations.expect_compound_columns_to_be_unique` on
+  `['source_slug', 'source_record_id']` (belt-and-suspenders alongside the `feedback_pk`
+  unique test — matches the precedent's compound-uniqueness convention).
+- `relationships` tests from each `*_fk` to its dim PK (richer-contract style, as
+  `dim_course_run` does).
+- New dims get their own entries; `dim_feedback_category` gets a `unique` on `category_slug`.
+
+---
+
+## 9. Build & verify path (local)
+
+Per repo convention (`ol-dbt` CLI, DuckDB-over-Iceberg local): after writing models, run
+`local register` + a targeted `dbt build --select +tfact_feedback` to validate the fact and
+its upstreams compile and pass tests against live Iceberg data. Expected MVP volume ~198K
+rows, single batch (design §9). Validate: `feedback_pk` uniqueness, null-`user_fk` rate
+(sanity-check identity resolution isn't silently collapsing), and row count vs.
+`int__zendesk__ticket`.
+
+---
+
+## 10. Scope boundary (what this MVP does NOT do)
+
+- No forum/tutor/ORA sources (Phase 2 — additive CTEs in `int__feedback__unioned`).
+- No `afact_feedback_cluster_daily` aggregate (Phase 2).
+- No data-bus/analytics-api ingress (Phase 3, gated on the write path — RFC Open Questions).
+- No embedding/clustering *required* for the fact to be useful (ML asset is additive).
+- No cross-source identity rollups until `tk-...-b7ca16` is re-derived.

--- a/docs/design/feedback_zendesk_mvp_spec.md
+++ b/docs/design/feedback_zendesk_mvp_spec.md
@@ -209,14 +209,16 @@ sidecar. This ordering lets the fact ship first.
 ## 8. Tests / contract (`_dim__models.yml` entries)
 
 Mirror the `tfact_discussion_events` yml style:
-- Per-column `not_null` on: `feedback_pk`, `feedback_source_fk`, `source_slug` equivalent,
-  `source_record_id`, `feedback_occurred_at`, `time_fk`, `date_fk`.
+- Per-column `not_null` on: `feedback_pk`, `feedback_source_fk`, `source_record_id`,
+  `feedback_occurred_at`, `time_fk`, `date_fk`.
 - `unique` on `feedback_pk`.
 - Nullable (description-only, no not_null): `user_fk`, `courserun_fk`, `platform_fk`,
   `organization_fk`, `category_fk`, `sentiment_fk`, `embedding_id`.
 - Model-level `dbt_expectations.expect_compound_columns_to_be_unique` on
-  `['source_slug', 'source_record_id']` (belt-and-suspenders alongside the `feedback_pk`
-  unique test — matches the precedent's compound-uniqueness convention).
+  `['feedback_source_fk', 'source_record_id']` (belt-and-suspenders alongside the `feedback_pk`
+  unique test — matches the precedent's compound-uniqueness convention; both columns exist on the
+  fact, and `feedback_source_fk = generate_surrogate_key([source_slug])` so this is the same
+  business grain as `[source_slug, source_record_ref]`).
 - `relationships` tests from each `*_fk` to its dim PK (richer-contract style, as
   `dim_course_run` does).
 - New dims get their own entries; `dim_feedback_category` gets a `unique` on `category_slug`.

--- a/docs/design/feedback_zendesk_mvp_spec.md
+++ b/docs/design/feedback_zendesk_mvp_spec.md
@@ -1,7 +1,7 @@
 # Feedback Aggregation — Zendesk MVP Implementation Spec
 
 Status: **spec** · Project: `wp-feedback-aggregation-clustering-system-2e9750`
-Date: 2026-08-07 (rev. 2 — turn grain) · Companion to
+Date: 2026-08-10 (rev. 3 — conversation-grain analysis fact) · Companion to
 [`feedback_dimensional_model.md`](./feedback_dimensional_model.md),
 [`feedback_erd.md`](./feedback_erd.md) and [`feedback_ml_approach.md`](./feedback_ml_approach.md)
 
@@ -13,10 +13,17 @@ Convention baseline: mirrors `tfact_discussion_events` (the existing multi-sourc
 same timestamp macros, same FK-by-lookup-join pattern, same `_dim__models.yml` contract
 style. Divergence from precedent is called out explicitly where intentional.
 
-> **rev. 2 changes the grain source.** Zendesk is modelled at **comment (turn) grain**, not ticket grain
-> (design §1). The adapter reads `int__zendesk__ticket_comment`, filters to public requester-authored
-> comments, and joins `int__zendesk__ticket` for conversation-level attributes. `source_record_ref` is
-> `comment_id`; `conversation_ref` is `ticket_id`.
+> **rev. 2 changes the grain source, and it stands.** Zendesk is modelled at **comment (turn) grain**, not
+> ticket grain (design §1). The adapter reads `int__zendesk__ticket_comment` — verified to exist at one row
+> per comment, carrying `ticket_id` and `comment_plain_body` — filters to public requester-authored comments,
+> and joins `int__zendesk__ticket` for conversation-level attributes. `source_record_ref` is `comment_id`;
+> `conversation_ref` is `ticket_id`.
+
+> **rev. 3 changes where the models write, not where the turns come from.** `category_fk`/`sentiment_fk`
+> leave `tfact_feedback` (§4) and join the summary, embedding and cluster columns on
+> `afact_feedback_conversation` (§5), which becomes the analysis fact. A new
+> `int__feedback__conversation` assembles each ticket's kept turns for the ML batch. The Zendesk sourcing,
+> the filter, the business key and the turn grain are all unchanged.
 
 ---
 
@@ -25,7 +32,7 @@ style. Divergence from precedent is called out explicitly where intentional.
 | Item | What | Why |
 |---|---|---|
 | `comment_author_user_id` on `int__zendesk__ticket_comment` | it exists in `stg__zendesk__ticket_comment` but the int model exposes only `comment_author` (a *name*) | needed to classify requester-vs-agent turns **and** to resolve `user_fk`. Blocking. |
-| Volume measurement | count public, requester-authored comments per ticket | sizes the fact and the embedding budget; the previous ~198K ticket estimate no longer applies |
+| Volume measurement | count public, requester-authored comments per ticket, and the **multi-turn share** | sizes `tfact_feedback`, and the multi-turn share drives the summarization budget (`feedback_ml_approach.md` §A.1). The embedding budget is back to the ~198K *conversation* count under rev. 3 |
 | `ticket_metrics` Airbyte stream | not currently synced (see §5a of the design doc) | duration measures on `afact_feedback_conversation`. **Non-blocking** — that table ships without them |
 
 ---
@@ -47,11 +54,14 @@ raw__thirdparty__zendesk_support__ticket_comments  (existing Airbyte raw)
       ▼
   int__feedback__unioned        (NEW — UNION of all sources; MVP = zendesk only; + PII redaction §7)
       ▼
-  tfact_feedback                (NEW — resolve conformed FKs, generate feedback_pk)
+  tfact_feedback                (NEW — resolve conformed FKs, generate feedback_pk; INSERT-ONLY)
       ▼
   bridge_feedback_tag           (NEW — explode ticket tags → dim_feedback_tag)
 
-  afact_feedback_conversation   (NEW — conversation grain, from int__zendesk__ticket + turn aggregates)
+  int__feedback__conversation   (NEW — assemble a ticket's kept turns, ordered by turn_index; ML input)
+      ▼
+  afact_feedback_conversation   (NEW — the analysis fact: lifecycle from int__zendesk__ticket + turn
+                                 aggregates, plus the generated summary/embedding/sentiment/category/cluster)
 
   dim_feedback_source           (NEW — seed rows, static/near-static)
   dim_feedback_channel          (NEW — seed rows, conformed channel value set)
@@ -196,9 +206,8 @@ left join dim_user as users
 --    (dim_organization.sql:38). The Zendesk org/group rides in source_metadata instead.
 --    Design §2b records this as an explicit decision, not an oversight.
 
--- late-arriving, null at insert, updated by ML asset (design §4a/§4b):
-cast(null as varchar) as category_fk
-cast(null as varchar) as sentiment_fk
+-- rev. 3: NO category_fk / sentiment_fk here. They are model-derived and live on
+-- afact_feedback_conversation (§5). With them gone this fact has no post-insert write path.
 
 -- role-playing date/time (design §2d) — bare date_fk/time_fk are renamed because the
 -- fact now carries three timestamps and the unqualified name would be ambiguous
@@ -227,13 +236,15 @@ identity-collapse bug (`tk-re-derive-identity-conformed-dimension-joins-pos-b7ca
 
 **Divergence from precedent (intentional):** `tfact_chatbot_events`/`tfact_discussion_events`
 mint no `*_pk` and rely on a model-level `expect_compound_columns_to_be_unique` test. This
-fact mints an explicit `feedback_pk` from the stable source business key because (1) the
+fact mints an explicit `feedback_pk` from the stable source business key because the
 migration strategy (design §6) requires the same PK to regenerate identically across the
-interim→data-bus source swap, and (2) `category_fk`/`sentiment_fk` are late-arriving updates
-that need a stable row key to target. We keep the compound-uniqueness test *as well* (§8).
+interim→data-bus source swap. (Rev. 2's second reason — giving late-arriving
+`category_fk`/`sentiment_fk` a stable row to target — no longer applies, since rev. 3 moved both off this
+fact. The migration reason alone still justifies the divergence.) We keep the compound-uniqueness test
+*as well* (§8).
 
 **Output columns** (fact): `feedback_pk`, `feedback_source_fk`, `feedback_channel_fk`, `user_fk`,
-`courserun_fk`, `content_block_fk`, `platform_fk`, `organization_fk`, `category_fk`, `sentiment_fk`,
+`courserun_fk`, `content_block_fk`, `platform_fk`, `organization_fk`,
 `occurred_date_fk`, `occurred_time_fk`, `created_date_fk`, `created_time_fk`, `updated_date_fk`,
 `updated_time_fk`, `conversation_id` (=`conversation_ref`), `turn_index`, `is_conversation_opening`,
 `source_record_id` (=`source_record_ref`), `source_url`, `subject_type`, `subject_ref`, `subject_url`,
@@ -244,9 +255,10 @@ that need a stable row key to target. We keep the compound-uniqueness test *as w
 **Removed in rev. 2** (design §0 conformance rule): `source_status`, `source_priority`, `source_channel`,
 `source_brand`, `source_group` → `source_metadata`; `source_tags` → `bridge_feedback_tag`; `csat_score`
 renamed `explicit_rating`.
+**Removed in rev. 3:** `category_fk`, `sentiment_fk` → `afact_feedback_conversation` (design §5a).
 
-No `embedding_id`: the ML sidecar joins on `feedback_pk` (design §4f), so the column would add no
-reachability while forcing a write to the fact when embeddings land.
+No embedding column and no `embedding_id`: vectors live on the conversation fact (design §4f), which joins to
+this one on `conversation_id`.
 
 ---
 
@@ -293,45 +305,66 @@ Rows: `positive`, `neutral`, `negative` (design §4b), `sentiment_pk = generate_
   `category_source='llm_discovered'` rows; humans flip `category_status` to `approved`.
 - SCD-lite: relabel changes `category_label`, never `category_slug`.
 
-### `afact_feedback_conversation` — conversation grain (NEW in rev. 2)
-Per design §5a. Reads `int__zendesk__ticket` for conversation attributes and aggregates
-`tfact_feedback` for `turn_count` / `participant_count`.
-`feedback_conversation_pk = generate_surrogate_key(['source_slug', 'conversation_ref'])`.
+### `int__feedback__conversation` — the ML input (NEW in rev. 3)
+One row per `(source_slug, conversation_ref)`, assembling that conversation's kept turns from
+`int__feedback__unioned` in `turn_index` order — the redacted text concatenated with a turn delimiter, plus
+`turn_count`, `participant_count` and `conversation_text_chars`. This is what the summarizer and embedder
+read; it exists so the ML batch never has to re-derive conversation assembly in Python, and so the assembly
+logic is testable in dbt.
 
-MVP ships the available-today columns (`opened_date_fk`, `turn_count`, `participant_count`,
-`final_status`, `explicit_rating`). The duration measures (`first_response_date_fk`, `resolved_date_fk`,
-`closed_date_fk`, `resolution_duration_seconds`) are **blocked on the `ticket_metrics` Airbyte stream**
-(§0) and land additively — the grain does not move when they arrive.
+For non-conversational sources (`is_conversational = false`) this is a pass-through of a single turn —
+`conversation_ref = source_record_ref` — so ORA and the edX plugin need no special case.
+
+### `afact_feedback_conversation` — the analysis fact (NEW in rev. 2, widened in rev. 3)
+Per design §5a. `feedback_conversation_pk = generate_surrogate_key(['source_slug', 'conversation_ref'])`.
+Two column groups:
+
+- **Lifecycle** — reads `int__zendesk__ticket` for conversation attributes and aggregates `tfact_feedback`
+  for `turn_count` / `participant_count` / `last_turn_date_fk` / `conversation_text_chars`.
+- **Generated (rev. 3)** — `conversation_summary`, `embedding_vector`, `category_fk`, `sentiment_fk`,
+  `cluster_id` and their version stamps, left-joined from the ML asset's per-stage output tables
+  (`feedback_dagster_asset_spec.md` §3). All nullable; the table is queryable and useful before any of them
+  are populated.
+
+MVP ships the available-today lifecycle columns (`opened_date_fk`, `last_turn_date_fk`, `turn_count`,
+`participant_count`, `final_status`, `explicit_rating`) first. The duration measures
+(`first_response_date_fk`, `resolved_date_fk`, `closed_date_fk`, `resolution_duration_seconds`) are
+**blocked on the `ticket_metrics` Airbyte stream** (§0); the generated columns arrive with the ML asset.
+Both land additively — the grain does not move when they arrive.
+
+**Row count is known:** one row per Zendesk ticket, ~198K. Unlike the turn fact, this table needs no volume
+measurement before it can be sized.
 
 ---
 
 ## 6. Sentiment & category assignment at MVP
 
+Both now land on `afact_feedback_conversation`, not on `tfact_feedback` (rev. 3).
+
 - **Sentiment (`sentiment_fk`):** MVP can populate a *coarse* sentiment immediately from the
   explicit signal with **no model**: map `explicit_rating`
-  (`'good'`→positive, `'bad'`→negative, `'offered'`/null→neutral/unknown) → `dim_sentiment`.
-  The model-based sentiment (`feedback_ml_approach.md` §E) upgrades the null/`offered` rows
-  later. This gives a working sentiment facet on day one for the rated subset.
-  **Turn-grain caveat:** the Zendesk rating is a *ticket*-level signal, so at turn grain it applies the same
-  sentiment to every turn of a rated ticket. That is a weak label — fine for seeding and validating the
-  model, misleading if read as per-turn sentiment. The model-derived value should take precedence over the
-  propagated rating for non-opening turns.
+  (`'good'`→positive, `'bad'`→negative, `'offered'`/null→neutral/unknown) → `dim_sentiment`, with
+  `sentiment_source = 'explicit_rating'`. The model-based sentiment (`feedback_ml_approach.md` §E) upgrades
+  the null/`offered` rows later with `sentiment_source = 'model'`.
+  **Rev. 3 removes rev. 2's caveat here:** the Zendesk rating is a ticket-level signal and the target row is
+  now a ticket, so this is a grain-matched label rather than a value propagated across turns. It is a real
+  label for the rated ~6% of tickets, which is exactly what the model tier needs for validation.
 - **Category (`category_fk`):** MVP can assign the tag-seed category by mapping a ticket's
-  dominant tag (via `bridge_feedback_tag`) → its seed `category_slug`. Cluster-based reassignment comes with
-  the ML asset. Unassigned = null (queryable).
+  dominant tag (via `bridge_feedback_tag`, aggregated to the ticket) → its seed `category_slug`.
+  Cluster-based reassignment comes with the ML asset. Unassigned = null (queryable).
 
-Both are late-arriving updates, so the fact builds and is useful before the ML asset exists.
+Both are nullable columns on a derived aggregate, so the whole warehouse layer builds and is useful before
+the ML asset exists.
 
 ---
 
 ## 7. Dagster asset (MVP) — SEE `feedback_dagster_asset_spec.md`
 
-The scheduled batch asset (pull → redact → embed → cluster → LLM-label → write
-category/sentiment back) is specified separately once the orchestration layout is confirmed.
-The dbt models above are independently buildable and testable *without* the ML asset — the
-ML asset only fills `category_fk` / `sentiment_fk` on the fact and populates the sidecar tables
-(`feedback_embeddings`, `feedback_cluster_run`, `feedback_cluster_assignment`). This ordering lets
-the fact ship first.
+The scheduled batch asset (assemble → summarize → embed → cluster → LLM-label → sentiment) is specified
+separately. The dbt models above are independently buildable and testable *without* the ML asset — it only
+fills the generated columns on `afact_feedback_conversation` and writes `feedback_cluster_run`. This ordering
+lets both facts ship first, and rev. 3 strengthens it: the ML asset no longer touches `tfact_feedback` at
+all, so there is no dbt↔Dagster write ordering to coordinate on the transactional fact.
 
 ---
 
@@ -342,7 +375,7 @@ Mirror the `tfact_discussion_events` yml style:
   `feedback_occurred_at`, `occurred_date_fk`, `occurred_time_fk`.
 - `unique` on `feedback_pk`.
 - Nullable (description-only, no not_null): `user_fk`, `courserun_fk`, `content_block_fk`,
-  `platform_fk`, `organization_fk`, `category_fk`, `sentiment_fk`, `subject_ref`, `subject_url`,
+  `platform_fk`, `organization_fk`, `subject_ref`, `subject_url`,
   `explicit_rating`, `source_metadata`.
 - `accepted_values` on `subject_type` (`courseware_block`, `course_run`, `course`, `program`,
   `page_url`, `resource`, `unspecified`) — it is the discriminator for the polymorphic subject ref,
@@ -366,7 +399,17 @@ Mirror the `tfact_discussion_events` yml style:
   `dim_feedback_tag` a compound-unique on `['source_slug', 'tag_slug']`.
 - `bridge_feedback_tag`: `not_null` on both columns, compound-unique on the pair, `relationships` to
   `tfact_feedback.feedback_pk` and `dim_feedback_tag.feedback_tag_pk`.
-- `afact_feedback_conversation`: `unique` + `not_null` on `feedback_conversation_pk`; `turn_count >= 1`.
+- `afact_feedback_conversation`: `unique` + `not_null` on `feedback_conversation_pk`; `not_null` on
+  `conversation_id` and `feedback_source_fk`; `turn_count >= 1`; `relationships` from `conversation_id` to
+  `tfact_feedback.conversation_id` **and the reverse** — every turn's `conversation_id` must resolve here, so
+  a conversation cannot go missing from the analysis fact and quietly drop its turns out of every cluster.
+  Generated columns are all nullable (description-only): `conversation_summary`, `embedding_vector`,
+  `category_fk`, `sentiment_fk`, `cluster_id`. Two consistency tests worth having once the ML asset lands:
+  `embedding_model_version` is not null wherever `embedding_vector` is, and `summary_model_version` is null
+  exactly where the §A.1 skip rule applies (`turn_count = 1` or under the length threshold) — that second one
+  is the guard that a silent summarizer failure doesn't read as "short conversation".
+- `int__feedback__conversation`: compound-unique on `['source_slug', 'conversation_ref']`; `turn_count`
+  matches the turn count in `tfact_feedback` for the same conversation.
 
 ---
 
@@ -376,15 +419,18 @@ Per repo convention (`ol-dbt` CLI, DuckDB-over-Iceberg local): after writing mod
 `local register` + a targeted `dbt build --select +tfact_feedback` to validate the fact and
 its upstreams compile and pass tests against live Iceberg data.
 
-**Volume is no longer ~198K.** That figure was the ticket count; at turn grain the row count is public,
-requester-authored *comments*. Measuring that multiplier is a §0 prerequisite — run it first, because it
-sizes both the fact and the embedding budget.
+**Two different volumes now.** `afact_feedback_conversation` is ~198K rows (one per ticket — a known figure).
+`tfact_feedback` is public, requester-authored *comments*, whose multiplier over tickets is still unmeasured;
+that measurement is a §0 prerequisite. Rev. 3 lowers its stakes — the embedding budget is now driven by the
+conversation count, not the turn count — but it still sizes the turn fact and, via the multi-turn share, the
+summarization budget.
 
 Validate: `feedback_pk` uniqueness; the three turn-grain tests (§8); null-`user_fk` rate (sanity-check
 identity resolution isn't silently collapsing); distinct `conversation_id` count vs. `int__zendesk__ticket`
 row count (these *should* match — a mismatch means the filter dropped whole tickets, e.g. tickets whose only
-public comment is from an agent, which is worth knowing rather than discovering later); and the
-`is_conversation_opening` count vs. the same.
+public comment is from an agent, which is worth knowing rather than discovering later); the
+`is_conversation_opening` count vs. the same; and that `afact_feedback_conversation` has exactly one row per
+distinct `conversation_id` in the turn fact.
 
 ---
 
@@ -397,5 +443,6 @@ public comment is from an agent, which is worth knowing rather than discovering 
 - No full-thread agent replies — the §2 filter keeps requester turns only. Agent responses are a
   support-quality dataset, not feedback, and would need their own justification to include.
 - No data-bus/analytics-api ingress (Phase 3, gated on the write path — RFC Open Questions).
-- No embedding/clustering *required* for the fact to be useful (ML asset is additive).
+- No embedding/clustering *required* for either fact to be useful (ML asset is additive).
+- No turn-level embeddings or summaries — the analysis unit is the conversation (design §5a).
 - No cross-source identity rollups until `tk-...-b7ca16` is re-derived.

--- a/docs/design/feedback_zendesk_mvp_spec.md
+++ b/docs/design/feedback_zendesk_mvp_spec.md
@@ -25,6 +25,16 @@ style. Divergence from precedent is called out explicitly where intentional.
 > `int__feedback__conversation` assembles each ticket's kept turns for the ML batch. The Zendesk sourcing,
 > the filter, the business key and the turn grain are all unchanged.
 
+> **rev. 4 fixes seven implementation-blocking gaps from [#2422 review](https://github.com/mitodl/ol-data-platform/pull/2422)**,
+> none of which change grain, business keys or the fact/asset shapes: `ticket_requester_user_id` is added to
+> the §0/§1 prerequisites (the §2 filter cannot compile without it); redaction becomes its own Phase-1 asset
+> (`feedback_redacted`, §1/§3) so it no longer shares an asset with embedding, which would have created a
+> dependency cycle; `category_slug` in the tag seed (§5) is the slug itself, not a hash of it; the sentiment
+> seed (§6) leaves `offered`/null ratings null rather than mapping them to a nonexistent `unknown` member;
+> `participant_count` (§5) is sourced from the ticket's full comment history, not the filtered turns (which
+> are single-author by construction); and `subject_user_ref` is retained as a column on `tfact_feedback` (§4)
+> so identity can be re-resolved later without a rebuild.
+
 ---
 
 ## 0. Prerequisites (must land before or with the adapter)
@@ -32,6 +42,7 @@ style. Divergence from precedent is called out explicitly where intentional.
 | Item | What | Why |
 |---|---|---|
 | `comment_author_user_id` on `int__zendesk__ticket_comment` | it exists in `stg__zendesk__ticket_comment` but the int model exposes only `comment_author` (a *name*) | needed to classify requester-vs-agent turns **and** to resolve `user_fk`. Blocking. |
+| `ticket_requester_user_id` on `int__zendesk__ticket` (NEW in rev. 4) | `int__zendesk__ticket.sql` already joins `stg__zendesk__user as requester on ticket.ticket_requester_user_id = requester.user_id` (line 117-118) but only selects `requester.user_name`; add the bare `ticket.ticket_requester_user_id` to the select list | the §2 filter compares `comment.comment_author_user_id = ticket.ticket_requester_user_id` — the id, not the name. Blocking, same change class as the row above. |
 | Volume measurement | count public, requester-authored comments per ticket, and the **multi-turn share** | sizes `tfact_feedback`, and the multi-turn share drives the summarization budget (`feedback_ml_approach.md` §A.1). The embedding budget is back to the ~198K *conversation* count under rev. 3 |
 | `ticket_metrics` Airbyte stream | not currently synced (see §5a of the design doc) | duration measures on `afact_feedback_conversation`. **Non-blocking** — that table ships without them |
 
@@ -52,7 +63,11 @@ raw__thirdparty__zendesk_support__ticket_comments  (existing Airbyte raw)
       ▼
   int__feedback__zendesk        (NEW — conform comments to the common event contract; filter §2)
       ▼
-  int__feedback__unioned        (NEW — UNION of all sources; MVP = zendesk only; + PII redaction §7)
+  int__feedback__unioned        (NEW — UNION of all sources; MVP = zendesk only)
+      ▼
+  feedback_redacted             (NEW — Dagster Python asset, Presidio masking §3/§7; emits title_redacted /
+                                 text_redacted. Phase-1, upstream of the fact — NOT part of the ML pipeline
+                                 in §7; nothing here waits on summarization/embedding/clustering)
       ▼
   tfact_feedback                (NEW — resolve conformed FKs, generate feedback_pk; INSERT-ONLY)
       ▼
@@ -72,8 +87,8 @@ raw__thirdparty__zendesk_support__ticket_comments  (existing Airbyte raw)
 
 The two-hop `int__feedback__zendesk → int__feedback__unioned` looks redundant at MVP (one
 source) but is deliberate: `__unioned` is where new sources plug in without touching the
-fact, and where redaction happens once for all sources. Keeping it from day one makes
-Phase 2 a pure additive change.
+fact or the redaction asset downstream of it. Keeping it from day one makes Phase 2 a pure
+additive change.
 
 ---
 
@@ -117,7 +132,7 @@ Output columns = the common feedback event contract (design §5), source-typed:
 | `explicit_rating` | `ticket_satisfaction_rating_score` | ticket |
 | `created_at` | `comment_created_at` | comment |
 | `updated_at` | `ticket_updated_at` | ticket |
-| `source_metadata` | JSON string via `json_format(...)`: `ticket_status`, `ticket_priority`, `ticket_due_at`, `brand_name`, `group_name`, `organization_name`, `ticket_satisfaction_rating_comment`, `custom_fields` | ticket |
+| `source_metadata` | JSON string via `json_format(...)`: `ticket_status`, `ticket_priority`, `ticket_due_at`, `brand_name`, `group_name`, `organization_name` — **not** `ticket_satisfaction_rating_comment` or `custom_fields` (rev. 4; see the redaction note below) | ticket |
 
 Tags are **not** in `source_metadata` — `ticket_tags` feeds `bridge_feedback_tag` / `dim_feedback_tag`
 (design §4e), so they are carried alongside for the bridge model to explode.
@@ -127,7 +142,16 @@ Notes:
   `ticket_description` (first comment only) view is recoverable as `where is_conversation_opening`.
 - Carry `ticket_api_url` through as the `source_url` deep-link. (Per-comment deep links are not exposed by
   the connector; the ticket URL is the best available and is stable per conversation.)
-- Do **not** redact here — redaction is centralized in `int__feedback__unioned` (§3).
+- Do **not** redact here — redaction is centralized in the `feedback_redacted` asset, downstream of
+  `int__feedback__unioned` (§3).
+- **Excluded from `source_metadata` at MVP, fixed in rev. 4 (@copilot):** `ticket_satisfaction_rating_comment`
+  (free text) and `custom_fields` (arbitrary, org-defined shape) can carry the same emails, names or case
+  details Presidio exists to strip from `title`/`text` — putting them into the fact unredacted would violate
+  the "redacted text only" access guarantee (design §7) for a broadly-consumed table. Unlike `title`/`text`,
+  neither is profiler-classified today and `custom_fields`' shape is not even known in advance, so they are
+  left out entirely rather than redacted-and-included. Each can be added back to `source_metadata` — through
+  `feedback_redacted`, same as `title`/`text` — once it is PII-profiled and, if needed, a redaction pass is
+  defined for it; this follows the same promotion-path discipline as design §0.
 - **Ticket-level fields repeat across a ticket's turns** (`ticket_subject`, status, priority, rating). That is
   expected at turn grain and is why the conversation-level view lives in `afact_feedback_conversation`
   (design §5a) rather than being the only place these are queryable.
@@ -155,20 +179,31 @@ Notes:
   MVP: just `int__feedback__zendesk`. The model is written as an explicit `union all` of
   CTEs (mirrors `tfact_discussion_events`' per-source CTE style) so adding forum/tutor is a
   new CTE + one `union all` line.
-- **PII redaction (design §7, mandatory pre-embed):** apply the Presidio-based masking to
-  `title` and `text` here, producing `title_redacted` / `text_redacted`. Raw `title`/`text`
-  do **not** propagate past this model — only redacted text flows to `tfact_feedback` and
-  the embedding store. Raw text remains available upstream in `stg`/`int__zendesk` under
-  existing PII classification + Lakekeeper/Cedar authz.
-  - Implementation note: Presidio is Python, not SQL. Two viable placements — (a) a Python
-    Dagster asset that materializes the redacted column between `int__feedback__unioned`
-    and the fact, or (b) a dbt Python model if the warehouse adapter supports it. **Recommend
-    (a)** for MVP: the same batch asset that embeds also redacts, single Python surface,
-    and it keeps the dbt layer pure-SQL (repo convention). Revisit if a SQL-native masking
-    macro is preferred. This is the one place the spec's dbt DAG and the Dagster asset graph
-    interleave — see §7.
 - Carry `feedback_text_chars = length(text)` (pre-redaction length metric, design §2) for
   sizing/analytics; computing length before masking is fine (no PII in an integer).
+- Redaction is **not** done in this model — see `feedback_redacted` below.
+
+**`feedback_redacted` (NEW, rev. 4) — its own Phase-1 Dagster asset, upstream of the fact:**
+
+- **PII redaction (design §7, mandatory pre-embed):** apply the Presidio-based masking to
+  `title` and `text`, producing `title_redacted` / `text_redacted`. Raw `title`/`text`
+  do **not** propagate past this step — only redacted text flows to `tfact_feedback` and
+  the embedding store. Raw text remains available upstream in `stg`/`int__zendesk` under
+  existing PII classification + Lakekeeper/Cedar authz.
+- **Why this is its own asset, not bundled into the ML pipeline (fixes a rev. 3 dependency
+  cycle):** the ML asset in `feedback_dagster_asset_spec.md` §2 reads `int__feedback__conversation`,
+  which is *downstream* of `tfact_feedback` — but `tfact_feedback` cannot build until redaction has
+  run. Rev. 3's recommendation ("the same batch asset that embeds also redacts") would have made the
+  fact depend on the ML asset to get its redacted text while the ML asset's input depends on the fact
+  existing — a cycle, and also a direct contradiction of §7 below, which says the dbt layer builds
+  independently of the ML asset. Making `feedback_redacted` its own asset, upstream of both, resolves
+  both problems: it is a Phase-1 prerequisite for the fact, not a stage of clustering/summarization/
+  embedding, and it never reads anything downstream of `tfact_feedback`.
+- Implementation: Presidio is Python, not SQL. A Python Dagster asset materializes
+  `title_redacted`/`text_redacted` into a table keyed on `feedback_pk`'s components
+  (`source_slug`, `source_record_ref`) that `tfact_feedback` left-joins in — keeping the dbt layer
+  pure-SQL (repo convention) rather than reaching for a dbt Python model. This is the one place the
+  spec's dbt DAG and the Dagster asset graph interleave.
 
 ---
 
@@ -193,9 +228,12 @@ Mirrors `tfact_discussion_events` conventions. Reads `int__feedback__unioned`.
 -- conformed FK: user (nullable). Zendesk = last-resort email path, resolved from the
 -- COMMENT author (not the ticket requester) now that the grain is per turn.
 users.user_pk as user_fk
+
+-- rev. 4: kept raw, NOT just used-and-dropped — see the identity note below
+unioned.subject_user_ref as subject_user_ref
 ...
 left join dim_user as users
-    on lower(unioned.subject_user_ref) = users.email   -- dim_user.user_pk = surrogate_key(lower(email))
+    on lower(unioned.subject_user_ref) = users.email   -- joins dim_user's email COLUMN, not its PK formula
 
 -- conformed FKs not populated for Zendesk (nullable, correct):
 -- courserun_fk    -> null at MVP unless subject_type='course_run' resolves a readable id
@@ -220,12 +258,10 @@ left join dim_user as users
 ```
 
 **Identity resolution — the highest-risk join (design §3, RFC Consequences).** Zendesk has
-no openedx user id, so `user_fk` resolves via **email → `dim_user.email`** (which is how
-`dim_user.user_pk` itself is generated: `generate_surrogate_key(['lower(email)'])`). This is
+no openedx user id, so `user_fk` resolves via **email → `dim_user.email`**. This is
 the last-resort path. The p0 `dim_user` NULL-email identity-collapse bug it used to share a failure class
 with is **fixed and merged** ([#2400](https://github.com/mitodl/ol-data-platform/pull/2400), 2026-07-15), so
-the residual risk is the structural one — email is the only identifier Zendesk offers, and
-`dim_user.user_pk` is keyed on it. Guard:
+the residual risk is the structural one — email is the only identifier Zendesk offers. Guard:
 - Never key `feedback_pk` off the resolved `user_fk` (it keys off `source_record_ref`), so a
   bad identity join can never collapse or duplicate the fact grain.
 - `user_fk` stays **nullable**; an unresolved author email = null `user_fk`, not a wrong
@@ -237,6 +273,24 @@ the residual risk is the structural one — email is the only identifier Zendesk
   the author of a given turn is the correct identity, and the §2 filter already restricts to requester turns
   — so the two agree today, but keying off the comment author is the honest expression and stays correct if
   the filter is ever widened (e.g. to include CC'd participants).
+- **rev. 4 corrects the PK claim above and answers @rachellougee's re-match question.**
+  `dim_user.user_pk` is **not** `generate_surrogate_key(['lower(email)'])` any more — it is
+  `generate_surrogate_key(['user_identity_source', 'user_identity_id'])` where
+  `user_identity_id = coalesce(user_global_id, id_source_user_id, email)` (`dim_user.sql`, current main).
+  The join above still works — it matches against `dim_user.email`, a plain column on the dim, not the PK
+  formula — but a Zendesk requester who *also* has an openedx account now lands on a `user_pk` keyed by
+  their global/platform id, not by email, which is the correct outcome (one identity, not a second
+  email-keyed row for the same person).
+  **The re-match question:** `tfact_feedback` is insert-only and loads incrementally (§ above), so
+  `user_fk` is resolved once, at load time, and never revisited — an author unmatched today (email typo,
+  account created after the ticket, `dim_user` coverage gap) stays unmatched forever unless something
+  re-derives it. `tk-...-b7ca16` is the *data-bus migration's* identity task, not an MVP one, and nothing
+  currently re-runs identity resolution against the interim source. So: **`subject_user_ref` (the raw
+  email) is kept as a column on `tfact_feedback`**, not just consumed and dropped by the join — it costs
+  nothing (already computed) and is what makes a future re-match a join against the existing rows rather
+  than a rebuild, consistent with the insert-only property this fact otherwise buys for everything else.
+  It is not used by any downstream consumer; it exists solely so `user_fk` can be recomputed later without
+  re-reading `int__feedback__unioned`, which retains no history once the interim source is replaced.
 
 **Divergence from precedent (intentional):** `tfact_chatbot_events`/`tfact_discussion_events`
 mint no `*_pk` and rely on a model-level `expect_compound_columns_to_be_unique` test. This
@@ -252,6 +306,7 @@ fact. The migration reason alone still justifies the divergence.) We keep the co
 `occurred_date_fk`, `occurred_time_fk`, `created_date_fk`, `created_time_fk`, `updated_date_fk`,
 `updated_time_fk`, `conversation_id` (=`conversation_ref`), `turn_index`, `is_conversation_opening`,
 `source_record_id` (=`source_record_ref`), `source_url`, `subject_type`, `subject_ref`, `subject_url`,
+`subject_user_ref` (raw identity ref, kept for future re-match — see the identity note above, rev. 4),
 `feedback_title` (redacted), `feedback_text` (redacted), `feedback_text_chars`, `explicit_rating`,
 `source_metadata`, `feedback_occurred_at`, `feedback_created_at`, `feedback_updated_at`,
 `feedback_ingested_at`.
@@ -303,7 +358,10 @@ Rows: `positive`, `neutral`, `negative` (design §4b), `sentiment_pk = generate_
 ### `dim_feedback_category` — seeded, then ML-curated
 - **MVP seed (no ML):** distinct tags from `dim_feedback_tag` + `group_name` from
   `int__zendesk__ticket`, materialized as `category_source='seed'`,
-  `category_status='proposed'`, `category_slug = generate_surrogate_key([slugified tag])`.
+  `category_status='proposed'`, `category_slug = <slugified tag>` (the slug itself — it is the
+  **stable machine key** per design §4a, not a hash of one; `feedback_category_pk =
+  generate_surrogate_key([category_slug])` is what hashes it, exactly once, same as every other
+  conformed dimension in this spec).
   With `dim_feedback_tag` in place this is a `select` from a dimension rather than an array unnest.
 - **ML curation (later, per `feedback_ml_approach.md` §D):** LLM-labeled clusters upsert
   `category_source='llm_discovered'` rows; humans flip `category_status` to `approved`.
@@ -312,9 +370,16 @@ Rows: `positive`, `neutral`, `negative` (design §4b), `sentiment_pk = generate_
 ### `int__feedback__conversation` — the ML input (NEW in rev. 3)
 One row per `(source_slug, conversation_ref)`, assembling that conversation's kept turns from
 `int__feedback__unioned` in `turn_index` order — the redacted text concatenated with a turn delimiter, plus
-`turn_count`, `participant_count` and `conversation_text_chars`. This is what the summarizer and embedder
+`turn_count` and `conversation_text_chars`. This is what the summarizer and embedder
 read; it exists so the ML batch never has to re-derive conversation assembly in Python, and so the assembly
 logic is testable in dbt.
+
+**`participant_count` is sourced separately (fixed in rev. 4).** The §2 filter keeps only public,
+requester-authored turns, so a count derived from the *kept* turns is always one author (or zero/null when
+identity is unresolved) — not the number of people in the conversation. `participant_count` is instead
+`count(distinct comment_author_user_id)` over the ticket's **full, unfiltered** comment history in
+`int__zendesk__ticket_comment` (requester + agents + CC'd), joined in by `conversation_ref`/`ticket_id`
+alongside the kept-turn aggregates, not derived from them.
 
 For non-conversational sources (`is_conversational = false`) this is a pass-through of a single turn —
 `conversation_ref = source_record_ref` — so ORA and the edX plugin need no special case.
@@ -324,7 +389,9 @@ Per design §5a. `feedback_conversation_pk = generate_surrogate_key(['source_slu
 Two column groups:
 
 - **Lifecycle** — reads `int__zendesk__ticket` for conversation attributes and aggregates `tfact_feedback`
-  for `turn_count` / `participant_count` / `last_turn_date_fk` / `conversation_text_chars`.
+  for `turn_count` / `last_turn_date_fk` / `conversation_text_chars`. `participant_count` is the one
+  exception — sourced from the ticket's unfiltered comment history, not from `tfact_feedback`'s
+  requester-only turns (§5 note above), since aggregating the kept turns alone would always yield one.
 - **Generated (rev. 3)** — `conversation_summary`, `embedding_vector`, `category_fk`, `sentiment_fk`,
   `cluster_id` and their version stamps, left-joined from the ML asset's per-stage output tables
   (`feedback_dagster_asset_spec.md` §3). All nullable; the table is queryable and useful before any of them
@@ -347,9 +414,13 @@ Both now land on `afact_feedback_conversation`, not on `tfact_feedback` (rev. 3)
 
 - **Sentiment (`sentiment_fk`):** MVP can populate a *coarse* sentiment immediately from the
   explicit signal with **no model**: map `explicit_rating`
-  (`'good'`→positive, `'bad'`→negative, `'offered'`/null→neutral/unknown) → `dim_sentiment`, with
-  `sentiment_source = 'explicit_rating'`. The model-based sentiment (`feedback_ml_approach.md` §E) upgrades
-  the null/`offered` rows later with `sentiment_source = 'model'`.
+  (`'good'`→positive, `'bad'`→negative) → `dim_sentiment`, with `sentiment_source = 'explicit_rating'`.
+  **Fixed in rev. 4:** `dim_sentiment` (design §4b) has no `unknown` member, and an `offered`/null rating is
+  an absence of signal, not a neutral one — mapping it to `'neutral'` would manufacture a false label for
+  every unrated ticket (~94% of them). `'offered'`/null ratings leave **both** `sentiment_fk` and
+  `sentiment_source` **null**, which is exactly the queryable "not yet assigned" state the model-based tier
+  needs to find and fill. The model-based sentiment (`feedback_ml_approach.md` §E) upgrades those null rows
+  later with `sentiment_source = 'model'`.
   **Rev. 3 removes rev. 2's caveat here:** the Zendesk rating is a ticket-level signal and the target row is
   now a ticket, so this is a grain-matched label rather than a value propagated across turns. It is a real
   label for the rated ~6% of tickets, which is exactly what the model tier needs for validation.
@@ -365,10 +436,15 @@ the ML asset exists.
 ## 7. Dagster asset (MVP) — SEE `feedback_dagster_asset_spec.md`
 
 The scheduled batch asset (assemble → summarize → embed → cluster → LLM-label → sentiment) is specified
-separately. The dbt models above are independently buildable and testable *without* the ML asset — it only
+separately. The dbt models above are independently buildable and testable *without the ML asset* — it only
 fills the generated columns on `afact_feedback_conversation` and writes `feedback_cluster_run`. This ordering
 lets both facts ship first, and rev. 3 strengthens it: the ML asset no longer touches `tfact_feedback` at
 all, so there is no dbt↔Dagster write ordering to coordinate on the transactional fact.
+
+**`feedback_redacted` (§3) is a separate, Phase-1 asset, not part of the ML asset above.** It is a genuine
+prerequisite for `tfact_feedback` — the fact cannot build without it — but it does no summarization,
+embedding, clustering or labeling, so "the dbt models are independently buildable without the ML asset"
+still holds: what the fact actually needs pre-ship is redaction, and nothing about the ML pipeline itself.
 
 ---
 
@@ -379,7 +455,7 @@ Mirror the `tfact_discussion_events` yml style:
   `feedback_occurred_at`, `occurred_date_fk`, `occurred_time_fk`.
 - `unique` on `feedback_pk`.
 - Nullable (description-only, no not_null): `user_fk`, `courserun_fk`, `content_block_fk`,
-  `platform_fk`, `organization_fk`, `subject_ref`, `subject_url`,
+  `platform_fk`, `organization_fk`, `subject_ref`, `subject_url`, `subject_user_ref`,
   `explicit_rating`, `source_metadata`.
 - `accepted_values` on `subject_type` (`courseware_block`, `course_run`, `course`, `program`,
   `page_url`, `resource`, `unspecified`) — it is the discriminator for the polymorphic subject ref,
@@ -404,9 +480,14 @@ Mirror the `tfact_discussion_events` yml style:
 - `bridge_feedback_tag`: `not_null` on both columns, compound-unique on the pair, `relationships` to
   `tfact_feedback.feedback_pk` and `dim_feedback_tag.feedback_tag_pk`.
 - `afact_feedback_conversation`: `unique` + `not_null` on `feedback_conversation_pk`; `not_null` on
-  `conversation_id` and `feedback_source_fk`; `turn_count >= 1`; `relationships` from `conversation_id` to
-  `tfact_feedback.conversation_id` **and the reverse** — every turn's `conversation_id` must resolve here, so
-  a conversation cannot go missing from the analysis fact and quietly drop its turns out of every cluster.
+  `conversation_id` and `feedback_source_fk`; `turn_count >= 1`. The turn↔conversation link is a **compound**
+  key test, not a plain `relationships` on `conversation_id` alone — `conversation_id` is source-native and
+  can collide across sources (design §2a fix, rev. 4) — so use
+  `dbt_expectations.expect_column_pair_values_A_to_exist_in_relation_B` on
+  `[feedback_source_fk, conversation_id]` from `tfact_feedback` into `afact_feedback_conversation`, **and the
+  reverse**: every turn's `(feedback_source_fk, conversation_id)` must resolve here, and every conversation
+  row must have at least one turn, so a conversation cannot go missing from the analysis fact and quietly
+  drop its turns out of every cluster.
   Generated columns are all nullable (description-only): `conversation_summary`, `embedding_vector`,
   `category_fk`, `sentiment_fk`, `cluster_id`. Two consistency tests worth having once the ML asset lands:
   `embedding_model_version` is not null wherever `embedding_vector` is, and `summary_model_version` is null

--- a/docs/design/feedback_zendesk_mvp_spec.md
+++ b/docs/design/feedback_zendesk_mvp_spec.md
@@ -62,7 +62,10 @@ Output columns = the common feedback event contract (design §5), source-typed:
 | `source_record_ref` | `ticket_id` (**idempotency + business key**, §6 of design) |
 | `title` | `ticket_subject` |
 | `text` | `ticket_description` (= first comment body) |
-| `source_metadata` | struct/JSON: `ticket_tags`, `ticket_status`, `ticket_priority`, `ticket_source_channel`, `ticket_satisfaction_rating_score`, `ticket_satisfaction_rating_comment`, `group_name`, `organization_name`, `ticket_api_url` |
+| `subject_type` | `'page_url'` for Appzi-originated tickets; `'course_run'` where ticket metadata names a course; else `'unspecified'` |
+| `subject_ref` | decoded Appzi URL / course readable id / null (see notes) |
+| `subject_url` | decoded Appzi URL, else null |
+| `source_metadata` | struct/JSON: `ticket_tags`, `ticket_status`, `ticket_priority`, `ticket_source_channel`, `ticket_satisfaction_rating_score`, `ticket_satisfaction_rating_comment`, `brand_name`, `group_name`, `organization_name`, `ticket_api_url` |
 
 Notes:
 - **`ticket_description` = first comment only** (confirmed). That is the correct MVP grain
@@ -70,6 +73,17 @@ Notes:
   `int__zendesk__ticket_comment` is a Phase-2 option, not MVP.
 - Carry `ticket_api_url` through as the `source_url` deep-link.
 - Do **not** redact here — redaction is centralized in `int__feedback__unioned` (§3).
+- **Brand & group** (@pdpinch, [hq#12607](https://github.com/mitodl/hq/issues/12607)): `int__zendesk__ticket`
+  already carries `brand_name` and `group_name` (joined from `stg__zendesk__brand` / `stg__zendesk__group`),
+  so this is a pass-through. They ride in `source_metadata` and are projected to the `source_brand` /
+  `source_group` facet columns on the fact, so Superset filters a plain varchar rather than a JSON extract.
+  **Evaluate during implementation:** Zendesk *brand* is effectively "which help centre/product the ticket
+  came in through" — the closest thing Zendesk has to a platform. If brands map cleanly onto `dim_platform`,
+  `platform_fk` need not be null for Zendesk after all.
+- **Subject** (design §2a): the Appzi URL is **encoded in the source** — decode it *here*, in the adapter, not
+  in consumers. Where a ticket's metadata names a course, emit `subject_type='course_run'` and let the fact
+  resolve `courserun_fk`. `content_block_fk` is not populated by Zendesk; it arrives with the edX plugin
+  source in Phase 2.
 
 ---
 
@@ -117,9 +131,13 @@ left join dim_user as users
     on lower(unioned.subject_user_ref) = users.email   -- dim_user.user_pk = surrogate_key(lower(email))
 
 -- conformed FKs not populated for Zendesk (nullable, correct):
--- courserun_fk, platform_fk  -> null at MVP
--- organization_fk -> resolve from source_metadata.organization_name if/when a
---    dim_organization join key exists; null-tolerant otherwise
+-- courserun_fk    -> null at MVP unless subject_type='course_run' resolves a readable id
+-- content_block_fk -> null at MVP (arrives with the edX plugin source, design §2a)
+-- platform_fk     -> null at MVP; re-evaluate once brand_name is landed (see §2 notes)
+-- organization_fk -> NULL at MVP, and structurally so: dim_organization.organization_pk =
+--    generate_surrogate_key(['platform','source_id']) and Zendesk supplies neither
+--    (dim_organization.sql:38). The Zendesk org/group is carried as the source_group facet
+--    instead. Design §2b records this as an explicit decision, not an oversight.
 
 -- late-arriving, null at insert, updated by ML asset (design §4a/§4b):
 cast(null as varchar) as category_fk
@@ -149,11 +167,15 @@ interim→data-bus source swap, and (2) `category_fk`/`sentiment_fk` are late-ar
 that need a stable row key to target. We keep the compound-uniqueness test *as well* (§8).
 
 **Output columns** (fact): `feedback_pk`, `feedback_source_fk`, `user_fk`, `courserun_fk`,
-`platform_fk`, `organization_fk`, `category_fk`, `sentiment_fk`, `time_fk`, `date_fk`,
+`content_block_fk`, `platform_fk`, `organization_fk`, `category_fk`, `sentiment_fk`, `time_fk`, `date_fk`,
 `conversation_id` (=`conversation_ref`), `source_record_id` (=`source_record_ref`),
-`source_url`, `feedback_title` (redacted), `feedback_text` (redacted), `feedback_text_chars`,
-`embedding_id` (nullable), `source_status`, `source_priority`, `source_tags`,
-`source_channel`, `csat_score`, `feedback_occurred_at`, `feedback_ingested_at`.
+`source_url`, `subject_type`, `subject_ref`, `subject_url`, `feedback_title` (redacted),
+`feedback_text` (redacted), `feedback_text_chars`, `source_status`, `source_priority`, `source_tags`,
+`source_channel`, `source_brand`, `source_group`, `csat_score`, `feedback_occurred_at`,
+`feedback_ingested_at`.
+
+No `embedding_id`: the ML sidecar joins on `feedback_pk` (design §4d), so the column would add no
+reachability while forcing a write to the fact when embeddings land.
 
 ---
 
@@ -201,8 +223,9 @@ Both are late-arriving updates, so the fact builds and is useful before the ML a
 The scheduled batch asset (pull → redact → embed → cluster → LLM-label → write
 category/sentiment back) is specified separately once the orchestration layout is confirmed.
 The dbt models above are independently buildable and testable *without* the ML asset — the
-ML asset only fills `embedding_id`, `category_fk`, `sentiment_fk`, and the `feedback_embeddings`
-sidecar. This ordering lets the fact ship first.
+ML asset only fills `category_fk` / `sentiment_fk` on the fact and populates the sidecar tables
+(`feedback_embeddings`, `feedback_cluster_run`, `feedback_cluster_assignment`). This ordering lets
+the fact ship first.
 
 ---
 
@@ -212,8 +235,12 @@ Mirror the `tfact_discussion_events` yml style:
 - Per-column `not_null` on: `feedback_pk`, `feedback_source_fk`, `source_record_id`,
   `feedback_occurred_at`, `time_fk`, `date_fk`.
 - `unique` on `feedback_pk`.
-- Nullable (description-only, no not_null): `user_fk`, `courserun_fk`, `platform_fk`,
-  `organization_fk`, `category_fk`, `sentiment_fk`, `embedding_id`.
+- Nullable (description-only, no not_null): `user_fk`, `courserun_fk`, `content_block_fk`,
+  `platform_fk`, `organization_fk`, `category_fk`, `sentiment_fk`, `subject_ref`, `subject_url`,
+  `source_brand`, `source_group`.
+- `accepted_values` on `subject_type` (`courseware_block`, `course_run`, `course`, `program`,
+  `page_url`, `resource`, `unspecified`) — it is the discriminator for the polymorphic subject ref,
+  so an unconstrained value silently breaks every consumer that switches on it.
 - Model-level `dbt_expectations.expect_compound_columns_to_be_unique` on
   `['feedback_source_fk', 'source_record_id']` (belt-and-suspenders alongside the `feedback_pk`
   unique test — matches the precedent's compound-uniqueness convention; both columns exist on the

--- a/docs/design/feedback_zendesk_mvp_spec.md
+++ b/docs/design/feedback_zendesk_mvp_spec.md
@@ -222,13 +222,17 @@ left join dim_user as users
 **Identity resolution — the highest-risk join (design §3, RFC Consequences).** Zendesk has
 no openedx user id, so `user_fk` resolves via **email → `dim_user.email`** (which is how
 `dim_user.user_pk` itself is generated: `generate_surrogate_key(['lower(email)'])`). This is
-the last-resort path and shares the failure class of the open p0 `dim_user` NULL-email
-identity-collapse bug (`tk-re-derive-identity-conformed-dimension-joins-pos-b7ca16`). Guard:
+the last-resort path. The p0 `dim_user` NULL-email identity-collapse bug it used to share a failure class
+with is **fixed and merged** ([#2400](https://github.com/mitodl/ol-data-platform/pull/2400), 2026-07-15), so
+the residual risk is the structural one — email is the only identifier Zendesk offers, and
+`dim_user.user_pk` is keyed on it. Guard:
 - Never key `feedback_pk` off the resolved `user_fk` (it keys off `source_record_ref`), so a
   bad identity join can never collapse or duplicate the fact grain.
 - `user_fk` stays **nullable**; an unresolved author email = null `user_fk`, not a wrong
   join. Do not coalesce to a sentinel.
-- Re-run `tk-...-b7ca16` before enabling any cross-source identity rollups on this fact.
+- Measure the null-`user_fk` rate on first build and treat a high rate as a finding, not noise —
+  `tk-...-b7ca16` (post-swap identity re-derivation) is the task that revisits this after the data-bus
+  migration, but the MVP number is worth knowing on day one.
 - **rev. 2:** the email resolves from `comment_author_user_id`, not `ticket_requester_user_id`. At turn grain
   the author of a given turn is the correct identity, and the §2 filter already restricts to requester turns
   — so the two agree today, but keying off the comment author is the honest expression and stays correct if
@@ -445,4 +449,5 @@ distinct `conversation_id` in the turn fact.
 - No data-bus/analytics-api ingress (Phase 3, gated on the write path — RFC Open Questions).
 - No embedding/clustering *required* for either fact to be useful (ML asset is additive).
 - No turn-level embeddings or summaries — the analysis unit is the conversation (design §5a).
-- No cross-source identity rollups until `tk-...-b7ca16` is re-derived.
+- No cross-source identity rollups — Zendesk resolves `user_fk` by email only, so joining its users to
+  course-scoped sources' users waits for the Phase 2 sources that carry an openedx id.

--- a/docs/design/feedback_zendesk_mvp_spec.md
+++ b/docs/design/feedback_zendesk_mvp_spec.md
@@ -1,10 +1,11 @@
 # Feedback Aggregation — Zendesk MVP Implementation Spec
 
 Status: **spec** · Project: `wp-feedback-aggregation-clustering-system-2e9750`
-Date: 2026-07-10 · Companion to [`feedback_dimensional_model.md`](./feedback_dimensional_model.md)
-and [`feedback_ml_approach.md`](./feedback_ml_approach.md)
+Date: 2026-08-07 (rev. 2 — turn grain) · Companion to
+[`feedback_dimensional_model.md`](./feedback_dimensional_model.md),
+[`feedback_erd.md`](./feedback_erd.md) and [`feedback_ml_approach.md`](./feedback_ml_approach.md)
 
-Concrete, build-ready spec for the first slice: **Zendesk tickets → `tfact_feedback`**,
+Concrete, build-ready spec for the first slice: **Zendesk → `tfact_feedback`**,
 serving support + engineering. Grounded in the actual repo models/columns. Everything here
 is Phase-1 MVP scope (design §9); forum/tutor/ORA and the data-bus migration are later.
 
@@ -12,27 +13,51 @@ Convention baseline: mirrors `tfact_discussion_events` (the existing multi-sourc
 same timestamp macros, same FK-by-lookup-join pattern, same `_dim__models.yml` contract
 style. Divergence from precedent is called out explicitly where intentional.
 
+> **rev. 2 changes the grain source.** Zendesk is modelled at **comment (turn) grain**, not ticket grain
+> (design §1). The adapter reads `int__zendesk__ticket_comment`, filters to public requester-authored
+> comments, and joins `int__zendesk__ticket` for conversation-level attributes. `source_record_ref` is
+> `comment_id`; `conversation_ref` is `ticket_id`.
+
+---
+
+## 0. Prerequisites (must land before or with the adapter)
+
+| Item | What | Why |
+|---|---|---|
+| `comment_author_user_id` on `int__zendesk__ticket_comment` | it exists in `stg__zendesk__ticket_comment` but the int model exposes only `comment_author` (a *name*) | needed to classify requester-vs-agent turns **and** to resolve `user_fk`. Blocking. |
+| Volume measurement | count public, requester-authored comments per ticket | sizes the fact and the embedding budget; the previous ~198K ticket estimate no longer applies |
+| `ticket_metrics` Airbyte stream | not currently synced (see §5a of the design doc) | duration measures on `afact_feedback_conversation`. **Non-blocking** — that table ships without them |
+
 ---
 
 ## 1. dbt model DAG (MVP)
 
 ```
-raw__thirdparty__zendesk_support__tickets        (existing Airbyte raw, in _zendesk__sources.yml)
-  → stg__zendesk__ticket        (existing)
-  → int__zendesk__ticket        (existing, one row per ticket — grain source)
+raw__thirdparty__zendesk_support__tickets          (existing Airbyte raw, in _zendesk__sources.yml)
+raw__thirdparty__zendesk_support__ticket_comments  (existing Airbyte raw)
+  → stg__zendesk__ticket          (existing)
+  → stg__zendesk__ticket_comment  (existing — carries comment_author_user_id)
       │
-      ├─ stg__zendesk__user     (existing — for requester email → dim_user)
+      ├─ int__zendesk__ticket_comment  (existing, one row per comment — GRAIN SOURCE; needs §0 change)
+      ├─ int__zendesk__ticket          (existing, one row per ticket — conversation attributes)
+      ├─ stg__zendesk__user            (existing — for author email → dim_user)
       │
       ▼
-  int__feedback__zendesk        (NEW — conform ticket to the common event contract §5 of design doc)
+  int__feedback__zendesk        (NEW — conform comments to the common event contract; filter §2)
       ▼
   int__feedback__unioned        (NEW — UNION of all sources; MVP = zendesk only; + PII redaction §7)
       ▼
   tfact_feedback                (NEW — resolve conformed FKs, generate feedback_pk)
+      ▼
+  bridge_feedback_tag           (NEW — explode ticket tags → dim_feedback_tag)
+
+  afact_feedback_conversation   (NEW — conversation grain, from int__zendesk__ticket + turn aggregates)
 
   dim_feedback_source           (NEW — seed rows, static/near-static)
+  dim_feedback_channel          (NEW — seed rows, conformed channel value set)
   dim_feedback_category         (NEW — seeded from ticket_tags + group_name; LLM-labeled later)
   dim_sentiment                 (NEW — seeded static buckets)
+  dim_feedback_tag              (NEW — distinct source-scoped tags)
 ```
 
 The two-hop `int__feedback__zendesk → int__feedback__unioned` looks redundant at MVP (one
@@ -42,44 +67,71 @@ Phase 2 a pure additive change.
 
 ---
 
-## 2. `int__feedback__zendesk` (NEW) — conform Zendesk to the common contract
+## 2. `int__feedback__zendesk` (NEW) — conform Zendesk comments to the common contract
 
-Reads `int__zendesk__ticket` (grain: one row per ticket, `ticket_id` unique+not_null),
-left-joined to `stg__zendesk__ticket` (for `ticket_requester_user_id`) → `stg__zendesk__user`
-(for `user_email`, needed because `int__zendesk__ticket` only carries `ticket_requester`
-as a *name*, not an id/email — confirmed in source inventory).
+Reads `int__zendesk__ticket_comment` (grain: one row per comment), joined to
+`int__zendesk__ticket` (for ticket-level attributes and the requester id) and
+`stg__zendesk__user` (for the author's `user_email`).
+
+**Filter — keep only turns where the author is the person giving feedback:**
+
+```sql
+where comment.comment_is_public = true          -- drop internal agent notes
+  and comment.comment_author_user_id = ticket.ticket_requester_user_id   -- drop agent replies
+```
+
+This is the same rule the other sources follow (tutor keeps `human_message` and drops `agent_message`;
+forum keeps `*.created`), stated per source rather than as a Zendesk quirk — design §1.
+
+`turn_index` = `row_number() over (partition by ticket_id order by comment_created_at)` over the *kept*
+comments; `is_conversation_opening` = `turn_index = 1`.
 
 Output columns = the common feedback event contract (design §5), source-typed:
 
-| Contract field | Zendesk expression |
-|---|---|
-| `source_slug` | literal `'zendesk'` |
-| `occurred_at` | `ticket_created_at` (ISO8601) |
-| `subject_user_ref` | `user_email` from `stg__zendesk__user` via `ticket_requester_user_id` (last-resort identity path, see §4) |
-| `courserun_readable_id` | `null` (Zendesk is not course-scoped) |
-| `platform` | `null` |
-| `conversation_ref` | `ticket_id` (thread/ticket id) |
-| `source_record_ref` | `ticket_id` (**idempotency + business key**, §6 of design) |
-| `title` | `ticket_subject` |
-| `text` | `ticket_description` (= first comment body) |
-| `subject_type` | `'page_url'` for Appzi-originated tickets; `'course_run'` where ticket metadata names a course; else `'unspecified'` |
-| `subject_ref` | decoded Appzi URL / course readable id / null (see notes) |
-| `subject_url` | decoded Appzi URL, else null |
-| `source_metadata` | struct/JSON: `ticket_tags`, `ticket_status`, `ticket_priority`, `ticket_source_channel`, `ticket_satisfaction_rating_score`, `ticket_satisfaction_rating_comment`, `brand_name`, `group_name`, `organization_name`, `ticket_api_url` |
+| Contract field | Zendesk expression | From |
+|---|---|---|
+| `source_slug` | literal `'zendesk'` | — |
+| `occurred_at` | `comment_created_at` (ISO8601) | comment |
+| `source_record_ref` | `comment_id` (**idempotency + business key**, design §6) | comment |
+| `text` | `comment_plain_body` | comment |
+| `channel_slug` | `comment_source_channel` mapped to the conformed value set (design §4d) | comment |
+| `title` | `ticket_subject` (constant across a ticket's turns) | ticket |
+| `conversation_ref` | `ticket_id` | comment |
+| `turn_index` | `row_number()` over kept comments, partitioned by `ticket_id`, ordered by `comment_created_at` | derived |
+| `subject_user_ref` | `user_email` from `stg__zendesk__user` via `comment_author_user_id` (last-resort identity path, §4) | comment |
+| `courserun_readable_id` | `null` (Zendesk is not course-scoped) | — |
+| `platform` | `null` (but see the brand note below) | — |
+| `subject_type` | `'page_url'` for Appzi-originated tickets; `'course_run'` where ticket metadata names a course; else `'unspecified'` | ticket |
+| `subject_ref` | decoded Appzi URL / course readable id / null | ticket |
+| `subject_url` | decoded Appzi URL, else null | ticket |
+| `explicit_rating` | `ticket_satisfaction_rating_score` | ticket |
+| `created_at` | `comment_created_at` | comment |
+| `updated_at` | `ticket_updated_at` | ticket |
+| `source_metadata` | JSON string via `json_format(...)`: `ticket_status`, `ticket_priority`, `ticket_due_at`, `brand_name`, `group_name`, `organization_name`, `ticket_satisfaction_rating_comment`, `custom_fields` | ticket |
+
+Tags are **not** in `source_metadata` — `ticket_tags` feeds `bridge_feedback_tag` / `dim_feedback_tag`
+(design §4e), so they are carried alongside for the bridge model to explode.
 
 Notes:
-- **`ticket_description` = first comment only** (confirmed). That is the correct MVP grain
-  per design §1 (Zendesk row = first comment). Full-thread text via
-  `int__zendesk__ticket_comment` is a Phase-2 option, not MVP.
-- Carry `ticket_api_url` through as the `source_url` deep-link.
+- **Grain (rev. 2):** one row per **public, requester-authored comment**, not per ticket. The previous
+  `ticket_description` (first comment only) view is recoverable as `where is_conversation_opening`.
+- Carry `ticket_api_url` through as the `source_url` deep-link. (Per-comment deep links are not exposed by
+  the connector; the ticket URL is the best available and is stable per conversation.)
 - Do **not** redact here — redaction is centralized in `int__feedback__unioned` (§3).
+- **Ticket-level fields repeat across a ticket's turns** (`ticket_subject`, status, priority, rating). That is
+  expected at turn grain and is why the conversation-level view lives in `afact_feedback_conversation`
+  (design §5a) rather than being the only place these are queryable.
 - **Brand & group** (@pdpinch, [hq#12607](https://github.com/mitodl/hq/issues/12607)): `int__zendesk__ticket`
   already carries `brand_name` and `group_name` (joined from `stg__zendesk__brand` / `stg__zendesk__group`),
-  so this is a pass-through. They ride in `source_metadata` and are projected to the `source_brand` /
-  `source_group` facet columns on the fact, so Superset filters a plain varchar rather than a JSON extract.
-  **Evaluate during implementation:** Zendesk *brand* is effectively "which help centre/product the ticket
-  came in through" — the closest thing Zendesk has to a platform. If brands map cleanly onto `dim_platform`,
-  `platform_fk` need not be null for Zendesk after all.
+  so this is a pass-through. **rev. 2:** they ride in `source_metadata` and are read back with
+  `json_query_string` — the dedicated `source_brand`/`source_group` facet columns proposed in rev. 1 are
+  withdrawn, because they are Zendesk-only and fail the design §0 conformance rule. Both fields remain
+  present and filterable. **Evaluate during implementation:** Zendesk *brand* is effectively "which help
+  centre/product the ticket came in through" — the closest thing Zendesk has to a platform. If brands map
+  cleanly onto `dim_platform`, `platform_fk` need not be null for Zendesk after all.
+- **Channel** is the one Zendesk facet that *is* conformed (design §4d): `ticket_source_channel` /
+  `comment_source_channel` map onto the shared `channel_slug` value set. Confirm the actual Zendesk channel
+  values against that set when seeding.
 - **Subject** (design §2a): the Appzi URL is **encoded in the source** — decode it *here*, in the adapter, not
   in consumers. Where a ticket's metadata names a course, emit `subject_type='course_run'` and let the fact
   resolve `courserun_fk`. `content_block_fk` is not populated by Zendesk; it arrives with the edX plugin
@@ -114,17 +166,22 @@ Notes:
 
 Mirrors `tfact_discussion_events` conventions. Reads `int__feedback__unioned`.
 
-**Grain:** one row per atomic feedback utterance. `feedback_pk` unique.
+**Grain:** one row per atomic feedback utterance = one **turn**. `feedback_pk` unique.
 
 **Surrogate + FK resolution:**
 ```sql
 -- surrogate business key (DIVERGES from precedent — see note)
+-- rev. 2: source_record_ref is the TURN id (comment_id), not ticket_id
 {{ dbt_utils.generate_surrogate_key(['source_slug', 'source_record_ref']) }} as feedback_pk
 
 -- conformed FK: source
 {{ dbt_utils.generate_surrogate_key(['source_slug']) }} as feedback_source_fk
 
--- conformed FK: user (nullable). Zendesk = last-resort email path.
+-- conformed FK: channel (design §4d) — required, every source has one
+{{ dbt_utils.generate_surrogate_key(['channel_slug']) }} as feedback_channel_fk
+
+-- conformed FK: user (nullable). Zendesk = last-resort email path, resolved from the
+-- COMMENT author (not the ticket requester) now that the grain is per turn.
 users.user_pk as user_fk
 ...
 left join dim_user as users
@@ -136,16 +193,21 @@ left join dim_user as users
 -- platform_fk     -> null at MVP; re-evaluate once brand_name is landed (see §2 notes)
 -- organization_fk -> NULL at MVP, and structurally so: dim_organization.organization_pk =
 --    generate_surrogate_key(['platform','source_id']) and Zendesk supplies neither
---    (dim_organization.sql:38). The Zendesk org/group is carried as the source_group facet
---    instead. Design §2b records this as an explicit decision, not an oversight.
+--    (dim_organization.sql:38). The Zendesk org/group rides in source_metadata instead.
+--    Design §2b records this as an explicit decision, not an oversight.
 
 -- late-arriving, null at insert, updated by ML asset (design §4a/§4b):
 cast(null as varchar) as category_fk
 cast(null as varchar) as sentiment_fk
 
--- time
-{{ iso8601_to_time_key('occurred_at') }} as time_fk
-{{ iso8601_to_date_key('occurred_at') }} as date_fk
+-- role-playing date/time (design §2d) — bare date_fk/time_fk are renamed because the
+-- fact now carries three timestamps and the unqualified name would be ambiguous
+{{ iso8601_to_time_key('occurred_at') }} as occurred_time_fk
+{{ iso8601_to_date_key('occurred_at') }} as occurred_date_fk
+{{ iso8601_to_time_key('created_at') }}  as created_time_fk
+{{ iso8601_to_date_key('created_at') }}  as created_date_fk
+{{ iso8601_to_time_key('updated_at') }}  as updated_time_fk
+{{ iso8601_to_date_key('updated_at') }}  as updated_date_fk
 ```
 
 **Identity resolution — the highest-risk join (design §3, RFC Consequences).** Zendesk has
@@ -155,9 +217,13 @@ the last-resort path and shares the failure class of the open p0 `dim_user` NULL
 identity-collapse bug (`tk-re-derive-identity-conformed-dimension-joins-pos-b7ca16`). Guard:
 - Never key `feedback_pk` off the resolved `user_fk` (it keys off `source_record_ref`), so a
   bad identity join can never collapse or duplicate the fact grain.
-- `user_fk` stays **nullable**; an unresolved requester email = null `user_fk`, not a wrong
+- `user_fk` stays **nullable**; an unresolved author email = null `user_fk`, not a wrong
   join. Do not coalesce to a sentinel.
 - Re-run `tk-...-b7ca16` before enabling any cross-source identity rollups on this fact.
+- **rev. 2:** the email resolves from `comment_author_user_id`, not `ticket_requester_user_id`. At turn grain
+  the author of a given turn is the correct identity, and the §2 filter already restricts to requester turns
+  — so the two agree today, but keying off the comment author is the honest expression and stays correct if
+  the filter is ever widened (e.g. to include CC'd participants).
 
 **Divergence from precedent (intentional):** `tfact_chatbot_events`/`tfact_discussion_events`
 mint no `*_pk` and rely on a model-level `expect_compound_columns_to_be_unique` test. This
@@ -166,15 +232,20 @@ migration strategy (design §6) requires the same PK to regenerate identically a
 interim→data-bus source swap, and (2) `category_fk`/`sentiment_fk` are late-arriving updates
 that need a stable row key to target. We keep the compound-uniqueness test *as well* (§8).
 
-**Output columns** (fact): `feedback_pk`, `feedback_source_fk`, `user_fk`, `courserun_fk`,
-`content_block_fk`, `platform_fk`, `organization_fk`, `category_fk`, `sentiment_fk`, `time_fk`, `date_fk`,
-`conversation_id` (=`conversation_ref`), `source_record_id` (=`source_record_ref`),
-`source_url`, `subject_type`, `subject_ref`, `subject_url`, `feedback_title` (redacted),
-`feedback_text` (redacted), `feedback_text_chars`, `source_status`, `source_priority`, `source_tags`,
-`source_channel`, `source_brand`, `source_group`, `csat_score`, `feedback_occurred_at`,
+**Output columns** (fact): `feedback_pk`, `feedback_source_fk`, `feedback_channel_fk`, `user_fk`,
+`courserun_fk`, `content_block_fk`, `platform_fk`, `organization_fk`, `category_fk`, `sentiment_fk`,
+`occurred_date_fk`, `occurred_time_fk`, `created_date_fk`, `created_time_fk`, `updated_date_fk`,
+`updated_time_fk`, `conversation_id` (=`conversation_ref`), `turn_index`, `is_conversation_opening`,
+`source_record_id` (=`source_record_ref`), `source_url`, `subject_type`, `subject_ref`, `subject_url`,
+`feedback_title` (redacted), `feedback_text` (redacted), `feedback_text_chars`, `explicit_rating`,
+`source_metadata`, `feedback_occurred_at`, `feedback_created_at`, `feedback_updated_at`,
 `feedback_ingested_at`.
 
-No `embedding_id`: the ML sidecar joins on `feedback_pk` (design §4d), so the column would add no
+**Removed in rev. 2** (design §0 conformance rule): `source_status`, `source_priority`, `source_channel`,
+`source_brand`, `source_group` → `source_metadata`; `source_tags` → `bridge_feedback_tag`; `csat_score`
+renamed `explicit_rating`.
+
+No `embedding_id`: the ML sidecar joins on `feedback_pk` (design §4f), so the column would add no
 reachability while forcing a write to the fact when embeddings land.
 
 ---
@@ -184,35 +255,70 @@ reachability while forcing a write to the fact when embeddings land.
 ### `dim_feedback_source` — static seed
 Rows for MVP: one, `zendesk`. Columns per design §4c
 (`feedback_source_pk = generate_surrogate_key(['source_slug'])`, `source_slug`, `source_name`,
-`source_medium='support_ticket'`, `source_audience_scope='operational'`, `is_course_scoped=false`).
+`source_medium='support_ticket'`, `source_audience_scope='operational'`, `is_course_scoped=false`,
+`is_conversational=true`).
 Implement as a dbt seed (`seeds/`) or a small `select ... union all` model — recommend a
 seed CSV since the set is tiny and hand-curated.
+
+### `dim_feedback_channel` — static seed (NEW in rev. 2)
+The conformed channel value set (design §4d): `email`, `web_form`, `in_product_widget`, `chat`,
+`forum_post`, `assessment`, `api`. `feedback_channel_pk = generate_surrogate_key(['channel_slug'])`,
+plus `channel_name` and `is_solicited`. dbt seed CSV.
+
+**Open item before seeding:** confirm the value set against Zendesk's actual `ticket_source_channel` /
+`comment_source_channel` values, and map them onto it in `int__feedback__zendesk`. An unmapped source value
+must fail loudly rather than silently bucketing to a catch-all — an unnoticed mapping gap makes the one
+genuinely conformed facet useless for cross-source comparison.
 
 ### `dim_sentiment` — static seed
 Rows: `positive`, `neutral`, `negative` (design §4b), `sentiment_pk = generate_surrogate_key(['sentiment_slug'])`,
 `polarity_score_bucket`. dbt seed CSV.
 
+### `dim_feedback_tag` + `bridge_feedback_tag` — derived (NEW in rev. 2)
+- `dim_feedback_tag`: `select distinct` over `ticket_tags` from `int__zendesk__ticket`, slugified.
+  `feedback_tag_pk = generate_surrogate_key(['source_slug', 'tag_slug'])` — tags are **source-scoped**
+  (design §4e), so a Zendesk tag and a forum role that share a string stay distinct.
+- `bridge_feedback_tag`: unnest `ticket_tags` per turn and join to `dim_feedback_tag`. Grain
+  `(feedback_pk, feedback_tag_pk)`, both `not_null`, compound-unique.
+- Note the tags are a *ticket* attribute applied to every turn of that ticket. That is correct — a tag
+  describes the conversation, and a per-turn bridge lets you filter turns by their conversation's tags
+  without a join back to the conversation fact.
+
 ### `dim_feedback_category` — seeded, then ML-curated
-- **MVP seed (no ML):** distinct `ticket_tags` (~2,354) + `group_name` from
+- **MVP seed (no ML):** distinct tags from `dim_feedback_tag` + `group_name` from
   `int__zendesk__ticket`, materialized as `category_source='seed'`,
   `category_status='proposed'`, `category_slug = generate_surrogate_key([slugified tag])`.
-  A dbt model that unnests `ticket_tags` and selects distinct, plus group names.
+  With `dim_feedback_tag` in place this is a `select` from a dimension rather than an array unnest.
 - **ML curation (later, per `feedback_ml_approach.md` §D):** LLM-labeled clusters upsert
   `category_source='llm_discovered'` rows; humans flip `category_status` to `approved`.
 - SCD-lite: relabel changes `category_label`, never `category_slug`.
+
+### `afact_feedback_conversation` — conversation grain (NEW in rev. 2)
+Per design §5a. Reads `int__zendesk__ticket` for conversation attributes and aggregates
+`tfact_feedback` for `turn_count` / `participant_count`.
+`feedback_conversation_pk = generate_surrogate_key(['source_slug', 'conversation_ref'])`.
+
+MVP ships the available-today columns (`opened_date_fk`, `turn_count`, `participant_count`,
+`final_status`, `explicit_rating`). The duration measures (`first_response_date_fk`, `resolved_date_fk`,
+`closed_date_fk`, `resolution_duration_seconds`) are **blocked on the `ticket_metrics` Airbyte stream**
+(§0) and land additively — the grain does not move when they arrive.
 
 ---
 
 ## 6. Sentiment & category assignment at MVP
 
 - **Sentiment (`sentiment_fk`):** MVP can populate a *coarse* sentiment immediately from the
-  explicit signal with **no model**: map `ticket_satisfaction_rating_score`
+  explicit signal with **no model**: map `explicit_rating`
   (`'good'`→positive, `'bad'`→negative, `'offered'`/null→neutral/unknown) → `dim_sentiment`.
   The model-based sentiment (`feedback_ml_approach.md` §E) upgrades the null/`offered` rows
   later. This gives a working sentiment facet on day one for the rated subset.
+  **Turn-grain caveat:** the Zendesk rating is a *ticket*-level signal, so at turn grain it applies the same
+  sentiment to every turn of a rated ticket. That is a weak label — fine for seeding and validating the
+  model, misleading if read as per-turn sentiment. The model-derived value should take precedence over the
+  propagated rating for non-opening turns.
 - **Category (`category_fk`):** MVP can assign the tag-seed category by mapping a ticket's
-  dominant `ticket_tag` → its seed `category_slug`. Cluster-based reassignment comes with the
-  ML asset. Unassigned = null (queryable).
+  dominant tag (via `bridge_feedback_tag`) → its seed `category_slug`. Cluster-based reassignment comes with
+  the ML asset. Unassigned = null (queryable).
 
 Both are late-arriving updates, so the fact builds and is useful before the ML asset exists.
 
@@ -232,12 +338,12 @@ the fact ship first.
 ## 8. Tests / contract (`_dim__models.yml` entries)
 
 Mirror the `tfact_discussion_events` yml style:
-- Per-column `not_null` on: `feedback_pk`, `feedback_source_fk`, `source_record_id`,
-  `feedback_occurred_at`, `time_fk`, `date_fk`.
+- Per-column `not_null` on: `feedback_pk`, `feedback_source_fk`, `feedback_channel_fk`, `source_record_id`,
+  `feedback_occurred_at`, `occurred_date_fk`, `occurred_time_fk`.
 - `unique` on `feedback_pk`.
 - Nullable (description-only, no not_null): `user_fk`, `courserun_fk`, `content_block_fk`,
   `platform_fk`, `organization_fk`, `category_fk`, `sentiment_fk`, `subject_ref`, `subject_url`,
-  `source_brand`, `source_group`.
+  `explicit_rating`, `source_metadata`.
 - `accepted_values` on `subject_type` (`courseware_block`, `course_run`, `course`, `program`,
   `page_url`, `resource`, `unspecified`) — it is the discriminator for the polymorphic subject ref,
   so an unconstrained value silently breaks every consumer that switches on it.
@@ -246,9 +352,21 @@ Mirror the `tfact_discussion_events` yml style:
   unique test — matches the precedent's compound-uniqueness convention; both columns exist on the
   fact, and `feedback_source_fk = generate_surrogate_key([source_slug])` so this is the same
   business grain as `[source_slug, source_record_ref]`).
+- **Turn-grain tests (new in rev. 2):**
+  - `expect_compound_columns_to_be_unique` on `['feedback_source_fk', 'conversation_id', 'turn_index']` —
+    catches a broken window function or a duplicated comment, which the `feedback_pk` test alone would not.
+  - `not_null` on `turn_index` and `is_conversation_opening` for conversational sources
+    (`dim_feedback_source.is_conversational = true`); both are legitimately null otherwise.
+  - Exactly one `is_conversation_opening = true` per `(feedback_source_fk, conversation_id)` — a singular
+    test. This is the guard that the previous first-comment-only view is faithfully recoverable.
 - `relationships` tests from each `*_fk` to its dim PK (richer-contract style, as
   `dim_course_run` does).
-- New dims get their own entries; `dim_feedback_category` gets a `unique` on `category_slug`.
+- New dims get their own entries; `dim_feedback_category` gets a `unique` on `category_slug`,
+  `dim_feedback_channel` a `unique` on `channel_slug` plus `accepted_values` matching the conformed set, and
+  `dim_feedback_tag` a compound-unique on `['source_slug', 'tag_slug']`.
+- `bridge_feedback_tag`: `not_null` on both columns, compound-unique on the pair, `relationships` to
+  `tfact_feedback.feedback_pk` and `dim_feedback_tag.feedback_tag_pk`.
+- `afact_feedback_conversation`: `unique` + `not_null` on `feedback_conversation_pk`; `turn_count >= 1`.
 
 ---
 
@@ -256,10 +374,17 @@ Mirror the `tfact_discussion_events` yml style:
 
 Per repo convention (`ol-dbt` CLI, DuckDB-over-Iceberg local): after writing models, run
 `local register` + a targeted `dbt build --select +tfact_feedback` to validate the fact and
-its upstreams compile and pass tests against live Iceberg data. Expected MVP volume ~198K
-rows, single batch (design §9). Validate: `feedback_pk` uniqueness, null-`user_fk` rate
-(sanity-check identity resolution isn't silently collapsing), and row count vs.
-`int__zendesk__ticket`.
+its upstreams compile and pass tests against live Iceberg data.
+
+**Volume is no longer ~198K.** That figure was the ticket count; at turn grain the row count is public,
+requester-authored *comments*. Measuring that multiplier is a §0 prerequisite — run it first, because it
+sizes both the fact and the embedding budget.
+
+Validate: `feedback_pk` uniqueness; the three turn-grain tests (§8); null-`user_fk` rate (sanity-check
+identity resolution isn't silently collapsing); distinct `conversation_id` count vs. `int__zendesk__ticket`
+row count (these *should* match — a mismatch means the filter dropped whole tickets, e.g. tickets whose only
+public comment is from an agent, which is worth knowing rather than discovering later); and the
+`is_conversation_opening` count vs. the same.
 
 ---
 
@@ -267,6 +392,10 @@ rows, single batch (design §9). Validate: `feedback_pk` uniqueness, null-`user_
 
 - No forum/tutor/ORA sources (Phase 2 — additive CTEs in `int__feedback__unioned`).
 - No `afact_feedback_cluster_daily` aggregate (Phase 2).
+- No conversation **duration** measures — blocked on the `ticket_metrics` stream (§0); the rest of
+  `afact_feedback_conversation` ships.
+- No full-thread agent replies — the §2 filter keeps requester turns only. Agent responses are a
+  support-quality dataset, not feedback, and would need their own justification to include.
 - No data-bus/analytics-api ingress (Phase 3, gated on the write path — RFC Open Questions).
 - No embedding/clustering *required* for the fact to be useful (ML asset is additive).
 - No cross-source identity rollups until `tk-...-b7ca16` is re-derived.


### PR DESCRIPTION
## What & why

Advances the **Feedback Aggregation & Clustering System** through its **spec** phase. The architecture RFC ([mitodl/hq#12210](https://github.com/mitodl/hq/discussions/12210), supersedes #10793) settled the two decisions — *contract-first interim landing* and *one common `tfact_feedback`*. This PR turns that direction into build-ready, repo-grounded specs so implementation can start without re-deriving source columns, dbt conventions, or the ML/orchestration shape.

The dimensional-model design existed only as an uncommitted draft in an unrelated worktree; it is recovered here and joined by five new specs.

## Contents (`docs/design/`)

| Doc | Scope |
|---|---|
| `README_feedback_aggregation.md` | Spec index, key decisions, phasing |
| `feedback_dimensional_model.md` | `tfact_feedback` schema (recovered) |
| `feedback_event_contract_spec.md` | Common event contract + migration-proof business keys |
| `feedback_zendesk_mvp_spec.md` | Build-ready Zendesk MVP dbt models w/ **exact repo columns** |
| `feedback_ml_approach.md` | Embedding / UMAP+HDBSCAN clustering / category discovery / sentiment |
| `feedback_dagster_asset_spec.md` | Batch ML asset cloning `student_risk_probability`; Vault LLM resource |
| `feedback_consumption_ux_spec.md` | Audiences × altitude, Superset surfaces, access control |

## Key decisions

1. **Contract-first, interim learn-ai landing** → migrate to the analytics-api/StarRocks data bus later; durable artifact is the **event contract + stable business keys**, so migration = source-swap + backfill + parity.
2. **One common `tfact_feedback`** mirroring `tfact_discussion_events`, with sparse nullable conformed FKs; explicit stable `feedback_pk` (diverges from precedent) for migration + late-arriving category/sentiment.
3. **ML is additive, not a prerequisite** — the fact ships useful with tag-seeded categories + CSAT-derived sentiment; embeddings persisted once.
4. **Local, PII-safe embeddings** by default; Presidio redaction mandatory pre-embed.
5. **Superset-first** consumption; support + engineering are the MVP-served audiences.

## Scope

Design/tracking only — **no pipeline code**. MVP ships the fact first; the ML Dagster asset is a separate, additive follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)