### PR TITLE
feat(ol-dbt-cli): add `ol-dbt diff` command + agent skills (#2407)

### DIFF
--- a/agent-config.toml
+++ b/agent-config.toml
@@ -1,0 +1,29 @@
+# agent-config.toml — declarative install of this repo's agent skills via
+# agent-config-kit's `agent-kit` CLI.
+#
+# Scope is "project" (repository scope): skills install into this checkout's
+# agent config (e.g. .claude/skills), so they travel with the repo and are
+# available to anyone working in it — not into your global ~/ config.
+#
+# Usage (from the repo root):
+#   uv tool install 'agent-config-kit[cli]'
+#   agent-kit apply agent-config.toml                     # install every skill below
+#   agent-kit apply agent-config.toml --profile dbt       # just the dbt fast-QA skills
+#   agent-kit apply agent-config.toml --dry-run           # preview without writing
+#   agent-kit validate agent-config.toml                  # check for drift
+
+[options]
+scope = "project"
+
+[skills]
+ol-dbt-fast-validation = "skills/data/ol-dbt-fast-validation/SKILL.md"
+ol-dbt-local-dev       = "skills/data/ol-dbt-local-dev/SKILL.md"
+
+# The `dbt` profile is the fast, credential-light dbt-warehouse QA loop:
+# stand up the local DuckDB+Iceberg env (ol-dbt-local-dev) and validate changes
+# (ol-dbt-fast-validation) before opening or reviewing a PR.
+[profiles.dbt]
+skills = [
+    "ol-dbt-fast-validation",
+    "ol-dbt-local-dev",
+]

--- a/skills/data/ol-dbt-fast-validation/SKILL.md
+++ b/skills/data/ol-dbt-fast-validation/SKILL.md
@@ -1,0 +1,92 @@
+---
+name: ol-dbt-fast-validation
+description: >
+  Drive the ol-dbt CLI (validate, impact, diff) to QA dbt-warehouse changes fast
+  and credential-free before opening or reviewing a PR. Use this skill whenever
+  you edit models under src/ol_dbt/ (especially dimensional, mart, or reporting
+  models) and need to check SQL/YAML consistency, column-level downstream blast
+  radius, or whether a migrated model still matches its predecessor — all on the
+  local DuckDB target, no Trino/warehouse credentials required.
+license: BSD-3-Clause
+metadata:
+  category: data
+---
+
+# Fast dbt validation with `ol-dbt`
+
+The `ol-dbt` CLI (`src/ol_dbt_cli`) already emits CI-ready JSON. Reach for it
+**before** committing or when reviewing a dbt change — it catches broken
+refs, column drift, and downstream breakage without a warehouse round-trip.
+
+All commands run against the local **`dev_local`** target (DuckDB reading
+Iceberg directly) by default, so they need **no network or credentials**. Run
+them from anywhere in the repo; the CLI locates `src/ol_dbt` automatically.
+
+## The three checks (run in this order)
+
+### 1. `ol-dbt validate` — SQL/YAML consistency
+Confirms model SQL and its `.yml` schema agree (column sync, broken `ref()`s,
+`SELECT *`, doc coverage).
+
+```bash
+ol-dbt validate                      # all models
+ol-dbt validate --changed-only       # only models changed vs origin/main (-c)
+ol-dbt validate --model staging      # scope to a path/name
+ol-dbt validate --format json        # machine-readable, for CI
+```
+Exit code is non-zero when any `ERROR`-severity issue is found. Use
+`--only <check>` / `--skip <check>` to focus or suppress specific checks.
+
+### 2. `ol-dbt impact` — column-level downstream blast radius
+Diffs each changed model's output columns vs the base ref and walks forward
+lineage to flag downstream models that a removed/renamed column will break.
+
+```bash
+ol-dbt impact                        # all changed models vs origin/main
+ol-dbt impact --model dim_user       # one model
+ol-dbt impact --format json          # BREAKING/WARNING/INFO alerts for CI
+ol-dbt impact --auto-compile         # dbt compile on dev_local first for precise columns
+```
+Alert levels: 🔴 `BREAKING` (removed/renamed column is consumed downstream) ·
+⚠️ `WARNING` (impact indeterminate) · ℹ️ `INFO` (additive only). Exits non-zero
+on any `BREAKING`. For the most accurate lineage, run `dbt parse` (or
+`--auto-compile`) first so a `manifest.json` exists.
+
+### 3. `ol-dbt diff` — same-engine row/column comparison
+Compares an old model against its migrated replacement on the **same engine**
+(so dialect differences cancel). Use it to QA dimensional/mart/reporting
+migrations (epic #2072).
+
+```bash
+ol-dbt diff --old dim_user_old --new dim_user --primary-key user_pk
+ol-dbt diff --old m_old --new m_new -k id --exclude-columns _loaded_at --format json
+ol-dbt diff --old m_old --new m_new --auto-build   # build both sides first
+```
+- **Always pass `--primary-key`** for a meaningful per-column comparison, and
+  for models with known surrogate-key non-determinism (e.g. `dim_user.user_pk`
+  is email-keyed and collapses NULL emails — a naive full-row compare shows
+  spurious mismatches).
+- Use `--exclude-columns` for non-deterministic columns (load timestamps, etc.).
+- Column sets are reconciled first: a schema mismatch is reported as
+  `schema_divergence`, not a raw SQL error.
+- Exits non-zero on any divergence (`mismatch` or `schema_divergence`), so it is
+  gate-able in CI. `--limit` caps sample mismatched rows (default 20).
+
+Requires the `dbt_audit_helper` package: run `dbt deps` once if you see it
+missing.
+
+## Rules
+
+- Prefer `--format json` when a machine (CI, another agent) consumes the output;
+  the human-readable text form is the default.
+- These checks are **fast and free** — run `validate` + `impact` on every
+  dbt change before committing; run `diff` whenever you migrate or refactor a
+  mart/reporting/dimensional model.
+- Non-zero exit = blocking. Do not declare a dbt change done while `validate`
+  reports errors or `impact` reports `BREAKING` without a reviewed reason.
+- If lineage looks incomplete, you likely need a fresh manifest — run
+  `dbt parse -t dev_local` (or pass `--auto-compile`) and re-run.
+
+See `docs/specs/DBT_WAREHOUSE_CI_QA_SPEC.md` for how these commands slot into the
+phased CI/QA plan. For building models locally to diff against, see the
+`ol-dbt-local-dev` skill.

--- a/skills/data/ol-dbt-local-dev/SKILL.md
+++ b/skills/data/ol-dbt-local-dev/SKILL.md
@@ -1,0 +1,83 @@
+---
+name: ol-dbt-local-dev
+description: >
+  Stand up and drive the local DuckDB + Iceberg dbt development environment via
+  `ol-dbt local` and `ol-dbt run`. Use this skill when you need to build or
+  iterate on src/ol_dbt models locally against real production data (zero-copy,
+  no warehouse writes) — e.g. to materialize an old and a new model side-by-side
+  for `ol-dbt diff`, to iterate fast on a single changed model, or to bootstrap a
+  fresh local warehouse. Covers setup, Glue→DuckDB view registration, incremental
+  runs, and safe teardown.
+license: BSD-3-Clause
+metadata:
+  category: data
+---
+
+# Local dbt development (DuckDB + Iceberg) with `ol-dbt`
+
+`ol-dbt local` gives you a **zero-copy** local warehouse: production Glue/Iceberg
+tables are mounted as DuckDB views, and dbt's `ref()`/`source()` fall back to
+those views for models you haven't built. So you can build old + new models
+side-by-side against real prod data — without copying it or writing to the
+warehouse. The default dbt target for all of this is **`dev_local`** (DuckDB).
+
+## Workflow
+
+### 1. One-time setup
+```bash
+ol-dbt local setup          # bootstrap the local DuckDB + Iceberg env (installs deps, dbt debug)
+```
+
+### 2. Register production tables as DuckDB views
+```bash
+ol-dbt local register --all-layers      # register all standard dbt layer databases
+ol-dbt local register --database ol_warehouse_production_raw   # one layer
+ol-dbt local register --force           # re-register everything (default: only new/changed)
+ol-dbt local list-sources               # show what's currently registered
+```
+`register` reads **AWS Glue + S3**, so it needs AWS credentials (unlike the
+validation commands, which are fully offline). It is incremental by default and
+parallelized; use `--dry-run` to preview.
+
+### 3. Iterate on models
+```bash
+ol-dbt run                  # incremental: rebuild only changed/errored models (state:modified+ result:error+/fail+ --defer)
+ol-dbt run --select my_model+   # build a model and its downstream
+ol-dbt run --full-refresh   # full rebuild; also re-initialises state for the next incremental run
+```
+`ol-dbt run` saves dbt state under `<dbt_project>/.dbt-state/` (`manifest.json`,
+`run_results.json`) so subsequent runs only touch what changed — this is the same
+slim-CI mechanism used in Phase 2.
+
+### 4. Teardown
+```bash
+ol-dbt local cleanup-local          # drop locally-registered DuckDB views/tables
+ol-dbt local cleanup --dry-run      # preview cleanup of remote dev schemas (namespaced by schema_suffix)
+```
+Cleanup honors a `PROTECTED_SCHEMAS` guard — it will not drop production or
+shared schemas. Always `--dry-run` first when cleaning remote schemas.
+
+## Typical use: materialize both sides for a diff
+```bash
+ol-dbt local register --all-layers          # mount prod data
+ol-dbt run --select dim_user_old dim_user   # build both relations on dev_local
+ol-dbt diff --old dim_user_old --new dim_user --primary-key user_pk
+```
+
+## Rules
+
+- Default to the **`dev_local`** target — it needs no Trino/warehouse credentials
+  and reads Iceberg directly. Only reach for `dev_qa`/`dev_production` targets
+  when you specifically need the shared cluster.
+- `register` needs AWS creds; `setup`, `run` (on dev_local), and the validation
+  commands do not.
+- Prefer incremental `ol-dbt run` over `--full-refresh` for fast iteration;
+  reserve `--full-refresh` for when the incremental state is stale or wrong.
+- Never point `cleanup` at a shared/production schema; rely on `--dry-run` and the
+  `PROTECTED_SCHEMAS` guard.
+- StarRocks-native `b2b_analytics` models are the exception — they are not
+  representable on DuckDB and must be QA'd on StarRocks (see `ol-dbt starrocks`).
+
+Pair this with the `ol-dbt-fast-validation` skill (validate / impact / diff) to
+QA what you build. See `docs/specs/DBT_WAREHOUSE_CI_QA_SPEC.md` for the broader
+CI/QA plan and the zero-copy substrate details.

--- a/src/ol_dbt/packages.yml
+++ b/src/ol_dbt/packages.yml
@@ -8,3 +8,5 @@ packages:
   version: [">=1.3.0", "<1.4.0"]
 - package: starburstdata/trino_utils
   version: [">=0.6.0", "<1.0.0"]
+- package: dbt-labs/dbt_audit_helper
+  version: [">=0.12.0", "<0.13.0"]

--- a/src/ol_dbt_cli/ol_dbt_cli/cli.py
+++ b/src/ol_dbt_cli/ol_dbt_cli/cli.py
@@ -4,6 +4,7 @@ import sys
 
 import cyclopts
 
+from ol_dbt_cli.commands.diff import diff
 from ol_dbt_cli.commands.generate import generate_app
 from ol_dbt_cli.commands.impact import impact
 from ol_dbt_cli.commands.local_dev import local_app
@@ -40,6 +41,9 @@ app = cyclopts.App(
       7. Validate model SQL/YAML consistency:
          $ ol-dbt validate --model staging
 
+      7b. Diff an old model against its migrated replacement (same-engine):
+         $ ol-dbt diff --old dim_user_old --new dim_user --primary-key user_pk
+
       8. JSON output for CI pipelines:
          $ ol-dbt impact --format json
          $ ol-dbt validate --format json
@@ -54,6 +58,7 @@ app.command(generate_app)
 app.command(run_app)
 app.command(impact, name="impact")
 app.command(validate, name="validate")
+app.command(diff, name="diff")
 
 
 def main() -> None:

--- a/src/ol_dbt_cli/ol_dbt_cli/commands/diff.py
+++ b/src/ol_dbt_cli/ol_dbt_cli/commands/diff.py
@@ -1,0 +1,654 @@
+"""Diff command — same-engine row/column comparison of two model relations.
+
+Wraps the ``dbt_audit_helper`` package to compare a baseline model against a
+candidate model (typically an old vs a migrated mart/reporting model). Because
+both relations are built on the *same* engine (default target ``dev_local``, a
+local DuckDB reading Iceberg directly), dialect differences cancel and the diff
+reflects real data divergence rather than SQL-translation noise.
+
+Design notes (the non-obvious bits):
+
+* Column sets are reconciled BEFORE any comparison runs, so a schema mismatch
+  produces a clear structured message instead of a raw SQL error from
+  audit_helper. The diff proceeds on the intersection minus ``--exclude-columns``.
+* Known non-determinism (e.g. ``dim_user.user_pk`` is an email-keyed surrogate
+  that collapses NULL emails) is handled by passing ``--primary-key`` and/or
+  ``--exclude-columns``.
+* The comparison itself is run via ``dbt show --inline`` invoking audit_helper
+  macros with ``--output json``; results are parsed tolerantly from stdout.
+
+Driveable both by hand and by CI (Phase 2 auto-diff vs a base ref). See
+docs/specs/DBT_WAREHOUSE_CI_QA_SPEC.md §3.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from dataclasses import dataclass, field
+from enum import StrEnum
+from pathlib import Path
+from typing import Annotated, Any
+
+from cyclopts import Parameter
+from rich.console import Console
+
+from ol_dbt_cli.lib.git_utils import get_repo_root
+from ol_dbt_cli.lib.manifest import (
+    ManifestRegistry,
+    find_manifest,
+    load_manifest,
+)
+from ol_dbt_cli.lib.sql_parser import (
+    ParsedModel,
+    find_compiled_dir,
+    parse_model_file,
+)
+from ol_dbt_cli.lib.yaml_registry import YamlRegistry, build_yaml_registry
+
+console = Console()
+err_console = Console(stderr=True)
+
+# Cap on how many columns we run a per-column value comparison for, to bound the
+# number of dbt invocations. When exceeded we log it (never silently truncate).
+_MAX_PER_COLUMN_COMPARISONS = 25
+
+
+class Verdict(StrEnum):
+    MATCH = "match"
+    MISMATCH = "mismatch"
+    SCHEMA_DIVERGENCE = "schema_divergence"
+
+
+@dataclass
+class ColumnReconciliation:
+    only_in_old: list[str] = field(default_factory=list)
+    only_in_new: list[str] = field(default_factory=list)
+    compared: list[str] = field(default_factory=list)
+
+    @property
+    def diverged(self) -> bool:
+        return bool(self.only_in_old or self.only_in_new)
+
+
+@dataclass
+class ColumnMismatch:
+    column: str
+    mismatch_rate: float
+    mismatched_rows: int
+
+
+@dataclass
+class DiffResult:
+    old: str
+    new: str
+    target: str
+    primary_key: list[str]
+    excluded_columns: list[str]
+    column_reconciliation: ColumnReconciliation
+    row_counts: dict[str, int]  # {"old": .., "new": .., "delta": ..}
+    column_mismatches: list[ColumnMismatch]
+    sample_mismatches: list[dict[str, Any]]
+    verdict: Verdict
+    notes: list[str] = field(default_factory=list)
+
+
+# ---------------------------------------------------------------------------
+# Column reconciliation
+# ---------------------------------------------------------------------------
+
+
+def _resolve_columns(
+    name: str,
+    sql_models_by_name: dict[str, ParsedModel],
+    manifest: ManifestRegistry | None,
+    yaml_registry: YamlRegistry,
+) -> set[str]:
+    """Best-effort resolution of a model's output columns.
+
+    Prefers parsed (compiled) SQL output columns, then manifest column metadata,
+    then the YAML schema. Column names are lower-cased for a case-insensitive
+    comparison (dbt/DuckDB fold unquoted identifiers to lower case).
+    """
+    parsed = sql_models_by_name.get(name)
+    if parsed is not None and parsed.output_columns:
+        return {c.lower() for c in parsed.output_columns}
+    if manifest is not None:
+        model = manifest.get_model(name)
+        if model is not None and model.column_names:
+            return {c.lower() for c in model.column_names}
+    yaml_model = yaml_registry.get_model(name)
+    if yaml_model is not None and yaml_model.column_names:
+        return {c.lower() for c in yaml_model.column_names}
+    return set()
+
+
+def reconcile_columns(
+    old_cols: set[str],
+    new_cols: set[str],
+    exclude_columns: set[str],
+) -> ColumnReconciliation:
+    """Reconcile two column sets, returning the divergence and the compared set.
+
+    The compared set is the intersection minus excluded columns. Excluded
+    columns are dropped from the only_in_* lists too — an intentional exclusion
+    is not a divergence.
+    """
+    exclude = {c.lower() for c in exclude_columns}
+    old = {c.lower() for c in old_cols if c.lower() not in exclude}
+    new = {c.lower() for c in new_cols if c.lower() not in exclude}
+    return ColumnReconciliation(
+        only_in_old=sorted(old - new),
+        only_in_new=sorted(new - old),
+        compared=sorted(old & new),
+    )
+
+
+# ---------------------------------------------------------------------------
+# dbt show / audit_helper invocation
+# ---------------------------------------------------------------------------
+
+
+def _extract_show_rows(stdout: str) -> list[dict[str, Any]]:
+    """Extract the row list from ``dbt show --output json`` stdout.
+
+    dbt interleaves log lines with a JSON document on stdout. The document is an
+    object carrying a ``show`` key whose value is the list of row dicts. We parse
+    tolerantly: try the whole payload first, then fall back to scanning for the
+    JSON object on its own line(s).
+    """
+
+    def _rows_from(obj: Any) -> list[dict[str, Any]] | None:
+        if isinstance(obj, dict) and isinstance(obj.get("show"), list):
+            return obj["show"]
+        if isinstance(obj, list):
+            return obj
+        return None
+
+    stripped = stdout.strip()
+    if stripped:
+        try:
+            rows = _rows_from(json.loads(stripped))
+            if rows is not None:
+                return rows
+        except json.JSONDecodeError:
+            pass
+
+    # Fall back: scan for a JSON object spanning to the end of the payload.
+    start = stdout.find("{")
+    while start != -1:
+        candidate = stdout[start:]
+        try:
+            rows = _rows_from(json.loads(candidate))
+            if rows is not None:
+                return rows
+        except json.JSONDecodeError:
+            pass
+        start = stdout.find("{", start + 1)
+    return []
+
+
+def _run_dbt_show(
+    inline_sql: str,
+    dbt_dir: Path,
+    target: str,
+    limit: int,
+) -> list[dict[str, Any]]:
+    """Run ``dbt show --inline`` and return the parsed rows.
+
+    Raises RuntimeError on a dbt failure or a missing dbt binary so the caller
+    can surface a clean error and exit non-zero.
+    """
+    cmd = [
+        "dbt",
+        "show",
+        "--inline",
+        inline_sql,
+        "--target",
+        target,
+        "--output",
+        "json",
+        "--limit",
+        str(limit),
+    ]
+    try:
+        result = subprocess.run(  # noqa: S603, S607
+            cmd,
+            cwd=str(dbt_dir),
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+    except subprocess.CalledProcessError as exc:
+        detail = (exc.stderr or exc.stdout or str(exc)).strip()
+        msg = f"dbt show failed: {detail[-500:]}"
+        raise RuntimeError(msg) from exc
+    except FileNotFoundError as exc:
+        msg = "'dbt' command not found; install dbt and ensure it is on PATH."
+        raise RuntimeError(msg) from exc
+    return _extract_show_rows(result.stdout)
+
+
+def _jinja_list(values: list[str]) -> str:
+    """Render a Python list of identifiers as a Jinja list literal."""
+    inner = ", ".join(f"'{v}'" for v in values)
+    return f"[{inner}]"
+
+
+def _compare_relations_sql(
+    old: str,
+    new: str,
+    primary_key: list[str],
+    exclude_columns: list[str],
+    *,
+    summarize: bool,
+) -> str:
+    """Build inline SQL calling ``audit_helper.compare_relations``.
+
+    With ``summarize=True`` audit_helper returns the ``in_a``/``in_b``/``count``/
+    ``percent_of_total`` grouping; with ``summarize=False`` it returns the actual
+    differing rows (used to sample mismatches).
+    """
+    pk_arg = ""
+    if primary_key:
+        pk_repr = f"'{primary_key[0]}'" if len(primary_key) == 1 else _jinja_list(primary_key)
+        pk_arg = f", primary_key={pk_repr}"
+    exclude_arg = f", exclude_columns={_jinja_list(exclude_columns)}" if exclude_columns else ""
+    return (
+        "{{ audit_helper.compare_relations("
+        f"a_relation=ref('{old}'), b_relation=ref('{new}')"
+        f"{exclude_arg}{pk_arg}, summarize={'true' if summarize else 'false'}) }}"
+    )
+
+
+def _compare_column_sql(old: str, new: str, primary_key: list[str], column: str) -> str:
+    """Build inline SQL calling ``audit_helper.compare_column_values`` for one column."""
+    pk = f"'{primary_key[0]}'" if len(primary_key) == 1 else _jinja_list(primary_key)
+    # Model names are dbt identifiers rendered into a Jinja template compiled by
+    # dbt (not executed as a raw query here), so the S608 heuristic is a false positive.
+    return (
+        "{{ audit_helper.compare_column_values("  # noqa: S608
+        f"a_query=\"select * from {{{{ ref('{old}') }}}}\", "
+        f"b_query=\"select * from {{{{ ref('{new}') }}}}\", "
+        f"primary_key={pk}, column_to_compare='{column}') }}"
+    )
+
+
+def _int(value: Any) -> int:
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return 0
+
+
+def _summarize_relations(rows: list[dict[str, Any]]) -> tuple[dict[str, int], int]:
+    """Turn ``compare_relations(summarize=true)`` rows into row counts + mismatch count.
+
+    Each row is grouped by (in_a, in_b) with a ``count``. Rows in A = sum of
+    counts where in_a is true; likewise B. Mismatched rows = rows present in only
+    one relation.
+    """
+    old_rows = new_rows = mismatched = 0
+    for row in rows:
+        in_a = bool(row.get("in_a"))
+        in_b = bool(row.get("in_b"))
+        count = _int(row.get("count"))
+        if in_a:
+            old_rows += count
+        if in_b:
+            new_rows += count
+        if in_a != in_b:
+            mismatched += count
+    counts = {"old": old_rows, "new": new_rows, "delta": new_rows - old_rows}
+    return counts, mismatched
+
+
+# ---------------------------------------------------------------------------
+# Output rendering
+# ---------------------------------------------------------------------------
+
+
+def _result_to_dict(result: DiffResult) -> dict[str, Any]:
+    return {
+        "old": result.old,
+        "new": result.new,
+        "target": result.target,
+        "primary_key": result.primary_key,
+        "excluded_columns": result.excluded_columns,
+        "column_reconciliation": {
+            "only_in_old": result.column_reconciliation.only_in_old,
+            "only_in_new": result.column_reconciliation.only_in_new,
+            "compared": result.column_reconciliation.compared,
+        },
+        "row_counts": result.row_counts,
+        "column_mismatches": [
+            {"column": c.column, "mismatch_rate": c.mismatch_rate, "mismatched_rows": c.mismatched_rows}
+            for c in result.column_mismatches
+        ],
+        "sample_mismatches": result.sample_mismatches,
+        "verdict": result.verdict.value,
+        "notes": result.notes,
+    }
+
+
+def _print_json(result: DiffResult) -> None:
+    print(json.dumps(_result_to_dict(result), indent=2))
+
+
+def _print_text(result: DiffResult) -> None:
+    color = {
+        Verdict.MATCH: "bold green",
+        Verdict.MISMATCH: "bold red",
+        Verdict.SCHEMA_DIVERGENCE: "bold yellow",
+    }[result.verdict]
+    console.print(
+        f"\n[{color}]{result.verdict.value.upper()}[/]  "
+        f"[bold]{result.old}[/] → [bold]{result.new}[/]  ([dim]{result.target}[/])"
+    )
+
+    recon = result.column_reconciliation
+    if recon.diverged:
+        if recon.only_in_old:
+            console.print(f"   [yellow]Only in {result.old}:[/] {', '.join(recon.only_in_old)}")
+        if recon.only_in_new:
+            console.print(f"   [yellow]Only in {result.new}:[/] {', '.join(recon.only_in_new)}")
+    console.print(f"   [bold]Compared columns:[/] {len(recon.compared)}")
+
+    rc = result.row_counts
+    delta = rc.get("delta", 0)
+    delta_str = f"[green]{delta}[/]" if delta == 0 else f"[red]{delta:+d}[/]"
+    console.print(
+        f"   [bold]Row counts:[/] {result.old}={rc.get('old', 0)}  {result.new}={rc.get('new', 0)}  Δ={delta_str}"
+    )
+
+    if result.column_mismatches:
+        console.print("   [bold]Column mismatches:[/]")
+        for c in result.column_mismatches:
+            console.print(f"     • {c.column}: {c.mismatch_rate:.2%} ({c.mismatched_rows} rows)")
+
+    if result.sample_mismatches:
+        console.print(f"   [bold]Sample mismatched rows[/] (first {len(result.sample_mismatches)}):")
+        for row in result.sample_mismatches:
+            console.print(f"     {json.dumps(row, default=str)}")
+
+    for note in result.notes:
+        console.print(f"   [dim]{note}[/]")
+
+    console.print(
+        f"\n[bold]Summary:[/] {result.verdict.value} — "
+        f"row Δ {delta}, {len(result.column_mismatches)} column mismatch(es)."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Command
+# ---------------------------------------------------------------------------
+
+
+def diff(
+    old: Annotated[
+        str,
+        Parameter(name=["--old"], help="Baseline model name (the 'before' relation)."),
+    ],
+    new: Annotated[
+        str,
+        Parameter(name=["--new"], help="Candidate model name (the 'after' relation)."),
+    ],
+    dbt_dir_path: Annotated[
+        str | None,
+        Parameter(
+            name=["--dbt-dir", "-d"],
+            help="Path to dbt project root (contains dbt_project.yml). Defaults to src/ol_dbt relative to repo root.",
+        ),
+    ] = None,
+    target: Annotated[
+        str,
+        Parameter(
+            name=["--target", "-t"],
+            help=(
+                "dbt target to build/compare on (default: dev_local). dev_local uses a local "
+                "DuckDB instance reading Iceberg directly and requires no network access; both "
+                "sides build on the same engine so dialect differences cancel."
+            ),
+        ),
+    ] = "dev_local",
+    primary_key: Annotated[
+        tuple[str, ...],
+        Parameter(
+            name=["--primary-key", "-k"],
+            help=(
+                "Column(s) uniquely identifying a row, used as the comparison join key. "
+                "Repeatable. Required for per-column mismatch rates. Use this for models with "
+                "known surrogate-key non-determinism (e.g. dim_user.user_pk email-keyed collapse)."
+            ),
+        ),
+    ] = (),
+    exclude_columns: Annotated[
+        tuple[str, ...],
+        Parameter(
+            name=["--exclude-columns"],
+            help="Column(s) to exclude from the comparison (e.g. non-deterministic load timestamps). Repeatable.",
+        ),
+    ] = (),
+    output_format: Annotated[
+        str,
+        Parameter(name=["--format", "-f"], help="Output format: text (default) or json."),
+    ] = "text",
+    limit: Annotated[
+        int,
+        Parameter(name=["--limit"], help="Cap on sample mismatched rows shown (default: 20)."),
+    ] = 20,
+    auto_build: Annotated[
+        bool,
+        Parameter(
+            name=["--auto-build"],
+            help="Run 'dbt build' on both models (on --target) before comparing, so both relations exist.",
+        ),
+    ] = False,
+) -> None:
+    """Diff two dbt model relations (same-engine row/column comparison).
+
+    Reconciles column sets first (so a schema mismatch is reported clearly rather
+    than as a raw SQL error), then runs a dbt_audit_helper comparison on the
+    intersection minus --exclude-columns. Exits non-zero on any divergence, so it
+    is gate-able in CI.
+
+    Examples:
+        Compare an old mart against its migrated replacement on local DuckDB:
+            ol-dbt diff --old dim_user_old --new dim_user --primary-key user_pk
+
+        Exclude a non-deterministic column and emit JSON for CI:
+            ol-dbt diff --old m_old --new m_new -k id --exclude-columns _loaded_at --format json
+
+        Build both sides first, then compare:
+            ol-dbt diff --old m_old --new m_new --auto-build
+
+    """
+    primary_key_list = list(primary_key)
+    exclude_list = list(exclude_columns)
+    notes: list[str] = []
+
+    # Resolve dbt project directory (shared preamble with impact/validate).
+    if dbt_dir_path:
+        dbt_dir = Path(dbt_dir_path).resolve()
+    else:
+        try:
+            dbt_dir = get_repo_root() / "src" / "ol_dbt"
+        except RuntimeError:
+            dbt_dir = Path("src/ol_dbt").resolve()
+
+    if not (dbt_dir / "dbt_project.yml").exists():
+        err_console.print(f"[red]Error:[/] dbt project not found at {dbt_dir}")
+        err_console.print("  Use --dbt-dir to specify the path.")
+        sys.exit(1)
+
+    models_dir = dbt_dir / "models"
+
+    # Build the metadata sources used for column reconciliation.
+    compiled_dir = find_compiled_dir(dbt_dir)
+    manifest: ManifestRegistry | None = None
+    manifest_path = find_manifest(dbt_dir)
+    if manifest_path:
+        try:
+            manifest = load_manifest(manifest_path)
+        except Exception as exc:  # noqa: BLE001
+            notes.append(f"Could not load manifest ({exc}); reconciling columns from SQL/YAML only.")
+
+    yaml_registry = build_yaml_registry(models_dir)
+    sql_models_by_name: dict[str, ParsedModel] = {}
+    for sql_file in models_dir.rglob("*.sql"):
+        try:
+            sql_models_by_name[sql_file.stem] = parse_model_file(sql_file, compiled_dir=compiled_dir)
+        except Exception:  # noqa: BLE001, S112
+            continue
+
+    # --- Column reconciliation (before any comparison) ---
+    old_cols = _resolve_columns(old, sql_models_by_name, manifest, yaml_registry)
+    new_cols = _resolve_columns(new, sql_models_by_name, manifest, yaml_registry)
+    unresolved_note = "Column set for '{}' could not be resolved (unparsed / not in manifest); reconciliation skipped."
+    if not old_cols:
+        notes.append(unresolved_note.format(old))
+    if not new_cols:
+        notes.append(unresolved_note.format(new))
+    recon = reconcile_columns(old_cols, new_cols, set(exclude_list))
+
+    # Optionally build both relations first.
+    if auto_build:
+        build_cmd = ["dbt", "build", "--target", target, "--select", old, new]
+        if output_format == "text":
+            console.print(f"[dim]Running: {' '.join(build_cmd)} ...[/]")
+        try:
+            subprocess.run(build_cmd, cwd=str(dbt_dir), capture_output=True, text=True, check=True)  # noqa: S603, S607
+        except subprocess.CalledProcessError as exc:
+            err_console.print(f"[red]Error:[/] dbt build failed: {(exc.stderr or '')[-500:]}")
+            sys.exit(1)
+        except FileNotFoundError:
+            err_console.print("[red]Error:[/] 'dbt' command not found; install dbt and ensure it is on PATH.")
+            sys.exit(1)
+
+    # --- Comparison ---
+    row_counts: dict[str, int] = {"old": 0, "new": 0, "delta": 0}
+    column_mismatches: list[ColumnMismatch] = []
+    sample_mismatches: list[dict[str, Any]] = []
+    mismatched_rows = 0
+
+    # If the resolved column sets diverge, a value comparison would fail on
+    # mismatched columns — report the divergence clearly and skip it.
+    if recon.diverged:
+        notes.append("Column schemas diverge; skipping value comparison. Reconcile columns or use --exclude-columns.")
+        _emit_and_exit(
+            DiffResult(
+                old=old,
+                new=new,
+                target=target,
+                primary_key=primary_key_list,
+                excluded_columns=exclude_list,
+                column_reconciliation=recon,
+                row_counts=row_counts,
+                column_mismatches=column_mismatches,
+                sample_mismatches=sample_mismatches,
+                verdict=Verdict.SCHEMA_DIVERGENCE,
+                notes=notes,
+            ),
+            output_format,
+        )
+
+    try:
+        summary_rows = _run_dbt_show(
+            _compare_relations_sql(old, new, primary_key_list, exclude_list, summarize=True),
+            dbt_dir,
+            target,
+            limit=1000,
+        )
+        row_counts, mismatched_rows = _summarize_relations(summary_rows)
+
+        if mismatched_rows:
+            sample_mismatches = _run_dbt_show(
+                _compare_relations_sql(old, new, primary_key_list, exclude_list, summarize=False),
+                dbt_dir,
+                target,
+                limit=limit,
+            )
+
+        # Per-column mismatch rates require a primary key.
+        if primary_key_list and recon.compared:
+            cols = recon.compared
+            if len(cols) > _MAX_PER_COLUMN_COMPARISONS:
+                notes.append(f"Per-column comparison capped at {_MAX_PER_COLUMN_COMPARISONS} of {len(cols)} columns.")
+                cols = cols[:_MAX_PER_COLUMN_COMPARISONS]
+            for col in cols:
+                mismatch = _compare_single_column(old, new, primary_key_list, col, dbt_dir, target)
+                if mismatch is not None and mismatch.mismatched_rows > 0:
+                    column_mismatches.append(mismatch)
+        elif not primary_key_list:
+            notes.append("Per-column mismatch rates require --primary-key; skipped.")
+    except RuntimeError as exc:
+        err_console.print(f"[red]Error:[/] {exc}")
+        sys.exit(1)
+
+    # --- Verdict ---
+    if row_counts["delta"] != 0 or mismatched_rows > 0 or column_mismatches:
+        verdict = Verdict.MISMATCH
+    else:
+        verdict = Verdict.MATCH
+
+    _emit_and_exit(
+        DiffResult(
+            old=old,
+            new=new,
+            target=target,
+            primary_key=primary_key_list,
+            excluded_columns=exclude_list,
+            column_reconciliation=recon,
+            row_counts=row_counts,
+            column_mismatches=column_mismatches,
+            sample_mismatches=sample_mismatches,
+            verdict=verdict,
+            notes=notes,
+        ),
+        output_format,
+    )
+
+
+def _emit_and_exit(result: DiffResult, output_format: str) -> None:
+    """Render the result in the requested format and exit non-zero on divergence."""
+    if output_format == "json":
+        _print_json(result)
+    else:
+        _print_text(result)
+    if result.verdict != Verdict.MATCH:
+        sys.exit(1)
+
+
+def _compare_single_column(
+    old: str,
+    new: str,
+    primary_key: list[str],
+    column: str,
+    dbt_dir: Path,
+    target: str,
+) -> ColumnMismatch | None:
+    """Run a per-column value comparison, returning its mismatch rate.
+
+    audit_helper.compare_column_values returns rows tagged by ``match_status``;
+    the mismatch rate is the share of rows not in a "✅" perfect-match bucket.
+    """
+    rows = _run_dbt_show(
+        _compare_column_sql(old, new, primary_key, column),
+        dbt_dir,
+        target,
+        limit=1000,
+    )
+    total = 0
+    mismatched = 0
+    for row in rows:
+        count = _int(row.get("count_records") or row.get("count"))
+        total += count
+        # audit_helper tags the perfect-match bucket with a leading "✅"; every
+        # other bucket (value mismatch, missing from a/b) counts as a mismatch.
+        if not str(row.get("match_status", "")).startswith("✅"):
+            mismatched += count
+    if total == 0:
+        return None
+    return ColumnMismatch(column=column, mismatch_rate=mismatched / total, mismatched_rows=mismatched)

--- a/src/ol_dbt_cli/ol_dbt_cli/commands/diff.py
+++ b/src/ol_dbt_cli/ol_dbt_cli/commands/diff.py
@@ -548,7 +548,8 @@ def diff(
 
     # Optionally build both relations first.
     if auto_build:
-        build_cmd = ["dbt", "build", "--target", target, "--select", old, new]
+        # Single space-joined --select value, consistent with ol-dbt run/impact.
+        build_cmd = ["dbt", "build", "--target", target, "--select", f"{old} {new}"]
         if output_format == "text":
             console.print(f"[dim]Running: {' '.join(build_cmd)} ...[/]")
         try:

--- a/src/ol_dbt_cli/ol_dbt_cli/commands/diff.py
+++ b/src/ol_dbt_cli/ol_dbt_cli/commands/diff.py
@@ -546,6 +546,24 @@ def diff(
         notes.append(unresolved_note.format(new))
     recon = reconcile_columns(old_cols, new_cols, set(exclude_list))
 
+    # When a column set can't be resolved statically, the schema-divergence gate
+    # cannot run — an empty reconciliation is "unverified", NOT "verified equal".
+    # Surface this loudly (both output modes) so it is never mistaken for a clean
+    # schema check: audit_helper.compare_relations derives its column list from
+    # the OLD relation, so a column *added* in the new model would be ignored by
+    # the value comparison and is normally caught only by this static gate.
+    schema_gate_skipped = not (old_cols and new_cols)
+    if schema_gate_skipped:
+        notes.append(
+            "Schema-divergence gate SKIPPED (columns unresolved) — comparison alone is authoritative "
+            "and will not detect columns added in the new model. Run `dbt parse` for full schema validation."
+        )
+        err_console.print(
+            "[yellow]Warning:[/] could not resolve column sets for both models; the schema-divergence "
+            "gate was skipped. Columns added in the new model may go undetected — run `dbt parse` "
+            "(or point --dbt-dir at a compiled project) for full schema validation."
+        )
+
     # Optionally build both relations first.
     if auto_build:
         # Single space-joined --select value, consistent with ol-dbt run/impact.

--- a/src/ol_dbt_cli/ol_dbt_cli/commands/diff.py
+++ b/src/ol_dbt_cli/ol_dbt_cli/commands/diff.py
@@ -24,12 +24,13 @@ docs/specs/DBT_WAREHOUSE_CI_QA_SPEC.md §3.
 from __future__ import annotations
 
 import json
+import re
 import subprocess
 import sys
 from dataclasses import dataclass, field
 from enum import StrEnum
 from pathlib import Path
-from typing import Annotated, Any
+from typing import Annotated, Any, Literal
 
 from cyclopts import Parameter
 from rich.console import Console
@@ -53,6 +54,27 @@ err_console = Console(stderr=True)
 # Cap on how many columns we run a per-column value comparison for, to bound the
 # number of dbt invocations. When exceeded we log it (never silently truncate).
 _MAX_PER_COLUMN_COMPARISONS = 25
+
+# Model and column names are interpolated into inline Jinja SQL passed to
+# `dbt show --inline`, so they must be plain dbt identifiers — anything else
+# (quotes, braces, whitespace) could inject Jinja/SQL and is rejected up front.
+_IDENTIFIER_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+
+
+class InvalidIdentifierError(ValueError):
+    """Raised when a user-supplied name is not a safe dbt identifier."""
+
+
+def _validate_identifiers(kind: str, names: list[str]) -> None:
+    """Reject any *names* that are not plain dbt identifiers.
+
+    Guards against Jinja/SQL injection through the inline template built for
+    ``dbt show``. Raises :class:`InvalidIdentifierError` naming the offenders.
+    """
+    bad = [n for n in names if not _IDENTIFIER_RE.match(n)]
+    if bad:
+        msg = f"Invalid {kind}: {', '.join(repr(b) for b in bad)}. Expected plain identifiers ([A-Za-z_][A-Za-z0-9_]*)."
+        raise InvalidIdentifierError(msg)
 
 
 class Verdict(StrEnum):
@@ -153,10 +175,10 @@ def reconcile_columns(
 def _extract_show_rows(stdout: str) -> list[dict[str, Any]]:
     """Extract the row list from ``dbt show --output json`` stdout.
 
-    dbt interleaves log lines with a JSON document on stdout. The document is an
-    object carrying a ``show`` key whose value is the list of row dicts. We parse
-    tolerantly: try the whole payload first, then fall back to scanning for the
-    JSON object on its own line(s).
+    dbt interleaves log lines with a JSON document on stdout. The document is
+    either an object carrying a ``show`` key whose value is the list of row dicts,
+    or a bare list. We parse tolerantly: try the whole payload first, then fall
+    back to scanning for a JSON value (object or array) embedded in the output.
     """
 
     def _rows_from(obj: Any) -> list[dict[str, Any]] | None:
@@ -175,17 +197,19 @@ def _extract_show_rows(stdout: str) -> list[dict[str, Any]]:
         except json.JSONDecodeError:
             pass
 
-    # Fall back: scan for a JSON object spanning to the end of the payload.
-    start = stdout.find("{")
-    while start != -1:
-        candidate = stdout[start:]
+    # Fall back: scan for a JSON document (object OR array) embedded among log
+    # lines. raw_decode parses one value from the offset and ignores trailing text.
+    decoder = json.JSONDecoder()
+    for idx, char in enumerate(stdout):
+        if char not in "{[":
+            continue
         try:
-            rows = _rows_from(json.loads(candidate))
-            if rows is not None:
-                return rows
+            obj, _ = decoder.raw_decode(stdout[idx:])
         except json.JSONDecodeError:
-            pass
-        start = stdout.find("{", start + 1)
+            continue
+        rows = _rows_from(obj)
+        if rows is not None:
+            return rows
     return []
 
 
@@ -432,7 +456,7 @@ def diff(
         ),
     ] = (),
     output_format: Annotated[
-        str,
+        Literal["text", "json"],
         Parameter(name=["--format", "-f"], help="Output format: text (default) or json."),
     ] = "text",
     limit: Annotated[
@@ -468,6 +492,15 @@ def diff(
     primary_key_list = list(primary_key)
     exclude_list = list(exclude_columns)
     notes: list[str] = []
+
+    # Validate every value interpolated into inline Jinja SQL before use.
+    try:
+        _validate_identifiers("model name", [old, new])
+        _validate_identifiers("primary key", primary_key_list)
+        _validate_identifiers("excluded column", exclude_list)
+    except InvalidIdentifierError as exc:
+        err_console.print(f"[red]Error:[/] {exc}")
+        sys.exit(1)
 
     # Resolve dbt project directory (shared preamble with impact/validate).
     if dbt_dir_path:
@@ -521,7 +554,9 @@ def diff(
         try:
             subprocess.run(build_cmd, cwd=str(dbt_dir), capture_output=True, text=True, check=True)  # noqa: S603, S607
         except subprocess.CalledProcessError as exc:
-            err_console.print(f"[red]Error:[/] dbt build failed: {(exc.stderr or '')[-500:]}")
+            # dbt often logs useful detail to stdout, not stderr — prefer either.
+            detail = (exc.stderr or exc.stdout or str(exc)).strip()
+            err_console.print(f"[red]Error:[/] dbt build failed: {detail[-500:]}")
             sys.exit(1)
         except FileNotFoundError:
             err_console.print("[red]Error:[/] 'dbt' command not found; install dbt and ensure it is on PATH.")

--- a/src/ol_dbt_cli/ol_dbt_cli/commands/diff.py
+++ b/src/ol_dbt_cli/ol_dbt_cli/commands/diff.py
@@ -172,13 +172,20 @@ def reconcile_columns(
 # ---------------------------------------------------------------------------
 
 
-def _extract_show_rows(stdout: str) -> list[dict[str, Any]]:
+def _extract_show_rows(stdout: str) -> list[dict[str, Any]] | None:
     """Extract the row list from ``dbt show --output json`` stdout.
 
-    dbt interleaves log lines with a JSON document on stdout. The document is
-    either an object carrying a ``show`` key whose value is the list of row dicts,
-    or a bare list. We parse tolerantly: try the whole payload first, then fall
-    back to scanning for a JSON value (object or array) embedded in the output.
+    For our invocation (``dbt show --inline ... --output json``, default text
+    logging) dbt-core emits ``{"show": [ ...rows... ]}`` on stdout — see
+    ``dbt.events.types.ShowNode.message``. The non-inline form is
+    ``{"node": ..., "show": [...]}`` and a bare list is also accepted. dbt
+    interleaves log lines with that document, so we try the whole payload first,
+    then scan for an embedded JSON value.
+
+    Returns the row list (possibly empty) when a JSON document is found, or
+    ``None`` when no JSON document could be located at all. ``None`` is a *parse
+    anomaly* the caller must not treat as "no rows" — otherwise a parsing failure
+    would masquerade as a clean, difference-free comparison.
     """
 
     def _rows_from(obj: Any) -> list[dict[str, Any]] | None:
@@ -210,7 +217,7 @@ def _extract_show_rows(stdout: str) -> list[dict[str, Any]]:
         rows = _rows_from(obj)
         if rows is not None:
             return rows
-    return []
+    return None
 
 
 def _run_dbt_show(
@@ -251,7 +258,16 @@ def _run_dbt_show(
     except FileNotFoundError as exc:
         msg = "'dbt' command not found; install dbt and ensure it is on PATH."
         raise RuntimeError(msg) from exc
-    return _extract_show_rows(result.stdout)
+
+    rows = _extract_show_rows(result.stdout)
+    if rows is None:
+        # dbt exited 0 but we found no JSON document — a parse anomaly (e.g. an
+        # unexpected output format from a future dbt version). Fail loudly rather
+        # than return [] and let it masquerade as a difference-free comparison.
+        head = result.stdout.strip()[:300]
+        msg = f"could not parse rows from `dbt show` output (unexpected format). stdout starts: {head!r}"
+        raise RuntimeError(msg)
+    return rows
 
 
 def _jinja_list(values: list[str]) -> str:

--- a/src/ol_dbt_cli/tests/test_diff.py
+++ b/src/ol_dbt_cli/tests/test_diff.py
@@ -68,6 +68,16 @@ class TestExtractShowRows:
     def test_empty(self) -> None:
         assert _extract_show_rows("no json here") == []
 
+    def test_log_prefixed_bare_list(self) -> None:
+        # A bare JSON array preceded by log lines must still be extracted.
+        payload = '12:00:00  Running with dbt=1.9\n[{"in_a": true, "in_b": true, "count": 5}]\n'
+        assert _extract_show_rows(payload) == [{"in_a": True, "in_b": True, "count": 5}]
+
+    def test_json_with_trailing_log_lines(self) -> None:
+        # raw_decode must tolerate trailing text after the JSON document.
+        payload = '{"show": [{"x": 1}]}\n12:00:02  Done.\n'
+        assert _extract_show_rows(payload) == [{"x": 1}]
+
 
 class TestSummarizeRelations:
     def test_perfect_match(self) -> None:
@@ -128,10 +138,38 @@ def _make_project(tmp_path: Path, old_sql: str, new_sql: str) -> Path:
     return dbt_dir
 
 
+class TestValidateIdentifiers:
+    def test_accepts_plain_identifiers(self) -> None:
+        # Should not raise.
+        diff_mod._validate_identifiers("model name", ["dim_user", "_stg__x", "a1"])
+
+    @pytest.mark.parametrize(
+        "bad",
+        ["x{{ config }}", "a b", "a'b", "1abc", "a);drop", "ref('x')", ""],
+    )
+    def test_rejects_injection_and_non_identifiers(self, bad: str) -> None:
+        with pytest.raises(diff_mod.InvalidIdentifierError):
+            diff_mod._validate_identifiers("model name", [bad])
+
+
 class TestDiffCommand:
     def test_missing_project_exits_1(self, tmp_path: Path) -> None:
         with pytest.raises(SystemExit) as exc:
             diff(old="a", new="b", dbt_dir_path=str(tmp_path / "does_not_exist"))
+        assert exc.value.code == 1
+
+    def test_injection_identifier_exits_1_before_comparison(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        dbt_dir = _make_project(tmp_path, "select 1 as id", "select 1 as id")
+
+        def boom(*a: Any, **k: Any) -> list[dict[str, Any]]:
+            msg = "must reject the bad identifier before ever invoking dbt"
+            raise AssertionError(msg)
+
+        monkeypatch.setattr(diff_mod, "_run_dbt_show", boom)
+        with pytest.raises(SystemExit) as exc:
+            diff(old="m_old", new="m_new", primary_key=("id; drop table x",), dbt_dir_path=str(dbt_dir))
         assert exc.value.code == 1
 
     def test_match_exits_0(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:

--- a/src/ol_dbt_cli/tests/test_diff.py
+++ b/src/ol_dbt_cli/tests/test_diff.py
@@ -1,0 +1,264 @@
+"""Tests for commands/diff.py — column reconciliation, audit_helper wrapping, CLI."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from ol_dbt_cli.commands import diff as diff_mod
+from ol_dbt_cli.commands.diff import (
+    Verdict,
+    _compare_relations_sql,
+    _extract_show_rows,
+    _jinja_list,
+    _summarize_relations,
+    diff,
+    reconcile_columns,
+)
+
+
+class TestReconcileColumns:
+    def test_identical(self) -> None:
+        r = reconcile_columns({"a", "b"}, {"a", "b"}, set())
+        assert r.only_in_old == [] and r.only_in_new == []
+        assert r.compared == ["a", "b"]
+        assert not r.diverged
+
+    def test_only_in_new(self) -> None:
+        r = reconcile_columns({"a"}, {"a", "b"}, set())
+        assert r.only_in_new == ["b"]
+        assert r.only_in_old == []
+        assert r.diverged
+
+    def test_only_in_old(self) -> None:
+        r = reconcile_columns({"a", "b"}, {"a"}, set())
+        assert r.only_in_old == ["b"]
+        assert r.diverged
+
+    def test_excluded_column_is_not_a_divergence(self) -> None:
+        # 'b' only in old but excluded -> not a divergence, and not compared
+        r = reconcile_columns({"a", "b"}, {"a"}, {"b"})
+        assert not r.diverged
+        assert r.compared == ["a"]
+
+    def test_exclude_is_case_insensitive(self) -> None:
+        r = reconcile_columns({"a", "LoadedAt"}, {"a"}, {"loadedat"})
+        assert not r.diverged
+
+
+class TestExtractShowRows:
+    def test_plain_show_object(self) -> None:
+        payload = '{"node": "inline", "show": [{"x": 1}, {"x": 2}]}'
+        assert _extract_show_rows(payload) == [{"x": 1}, {"x": 2}]
+
+    def test_bare_list(self) -> None:
+        assert _extract_show_rows('[{"x": 1}]') == [{"x": 1}]
+
+    def test_log_prefixed_json(self) -> None:
+        payload = (
+            "12:00:00  Running with dbt=1.9\n"
+            "12:00:01  Previewing inline node:\n"
+            '{"node": "inline", "show": [{"in_a": true, "in_b": false, "count": 3}]}\n'
+        )
+        rows = _extract_show_rows(payload)
+        assert rows == [{"in_a": True, "in_b": False, "count": 3}]
+
+    def test_empty(self) -> None:
+        assert _extract_show_rows("no json here") == []
+
+
+class TestSummarizeRelations:
+    def test_perfect_match(self) -> None:
+        rows = [{"in_a": True, "in_b": True, "count": 100}]
+        counts, mismatched = _summarize_relations(rows)
+        assert counts == {"old": 100, "new": 100, "delta": 0}
+        assert mismatched == 0
+
+    def test_rows_missing_from_new(self) -> None:
+        rows = [
+            {"in_a": True, "in_b": True, "count": 90},
+            {"in_a": True, "in_b": False, "count": 10},
+        ]
+        counts, mismatched = _summarize_relations(rows)
+        assert counts == {"old": 100, "new": 90, "delta": -10}
+        assert mismatched == 10
+
+    def test_rows_on_both_sides(self) -> None:
+        rows = [
+            {"in_a": True, "in_b": True, "count": 80},
+            {"in_a": True, "in_b": False, "count": 5},
+            {"in_a": False, "in_b": True, "count": 7},
+        ]
+        counts, mismatched = _summarize_relations(rows)
+        assert counts == {"old": 85, "new": 87, "delta": 2}
+        assert mismatched == 12
+
+
+class TestSqlBuilders:
+    def test_jinja_list(self) -> None:
+        assert _jinja_list(["a", "b"]) == "['a', 'b']"
+
+    def test_compare_relations_single_pk_and_exclude(self) -> None:
+        sql = _compare_relations_sql("old_m", "new_m", ["id"], ["_loaded_at"], summarize=True)
+        assert "ref('old_m')" in sql
+        assert "ref('new_m')" in sql
+        assert "primary_key='id'" in sql
+        assert "exclude_columns=['_loaded_at']" in sql
+        assert "summarize=true" in sql
+
+    def test_compare_relations_composite_pk(self) -> None:
+        sql = _compare_relations_sql("a", "b", ["k1", "k2"], [], summarize=False)
+        assert "primary_key=['k1', 'k2']" in sql
+        assert "summarize=false" in sql
+
+    def test_compare_relations_no_pk(self) -> None:
+        sql = _compare_relations_sql("a", "b", [], [], summarize=True)
+        assert "primary_key" not in sql
+
+
+def _make_project(tmp_path: Path, old_sql: str, new_sql: str) -> Path:
+    """Create a minimal dbt project dir with two leaf models."""
+    dbt_dir = tmp_path / "ol_dbt"
+    (dbt_dir / "models").mkdir(parents=True)
+    (dbt_dir / "dbt_project.yml").write_text("name: test\nprofile: test\n")
+    (dbt_dir / "models" / "m_old.sql").write_text(old_sql)
+    (dbt_dir / "models" / "m_new.sql").write_text(new_sql)
+    return dbt_dir
+
+
+class TestDiffCommand:
+    def test_missing_project_exits_1(self, tmp_path: Path) -> None:
+        with pytest.raises(SystemExit) as exc:
+            diff(old="a", new="b", dbt_dir_path=str(tmp_path / "does_not_exist"))
+        assert exc.value.code == 1
+
+    def test_match_exits_0(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        dbt_dir = _make_project(
+            tmp_path,
+            "select 1 as id, 'x' as name",
+            "select 1 as id, 'x' as name",
+        )
+        monkeypatch.setattr(
+            diff_mod,
+            "_run_dbt_show",
+            lambda *a, **k: [{"in_a": True, "in_b": True, "count": 10}],
+        )
+        # A clean match returns normally (no SystemExit).
+        diff(old="m_old", new="m_new", dbt_dir_path=str(dbt_dir))
+
+    def test_row_mismatch_exits_1(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        dbt_dir = _make_project(
+            tmp_path,
+            "select 1 as id, 'x' as name",
+            "select 1 as id, 'x' as name",
+        )
+
+        def fake_show(inline_sql: str, *a: Any, **k: Any) -> list[dict[str, Any]]:
+            if "summarize=true" in inline_sql:
+                return [
+                    {"in_a": True, "in_b": True, "count": 9},
+                    {"in_a": True, "in_b": False, "count": 1},
+                ]
+            return [{"id": 42}]  # sample mismatched rows
+
+        monkeypatch.setattr(diff_mod, "_run_dbt_show", fake_show)
+        with pytest.raises(SystemExit) as exc:
+            diff(old="m_old", new="m_new", dbt_dir_path=str(dbt_dir))
+        assert exc.value.code == 1
+
+    def test_schema_divergence_exits_1_without_comparing(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        dbt_dir = _make_project(
+            tmp_path,
+            "select 1 as id, 'x' as name",
+            "select 1 as id, 'x' as name, 2 as extra",
+        )
+
+        def boom(*a: Any, **k: Any) -> list[dict[str, Any]]:
+            msg = "comparison should be skipped on schema divergence"
+            raise AssertionError(msg)
+
+        monkeypatch.setattr(diff_mod, "_run_dbt_show", boom)
+        with pytest.raises(SystemExit) as exc:
+            diff(old="m_old", new="m_new", dbt_dir_path=str(dbt_dir))
+        assert exc.value.code == 1
+
+    def test_json_output_schema(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        import json
+
+        dbt_dir = _make_project(
+            tmp_path,
+            "select 1 as id, 'x' as name",
+            "select 1 as id, 'x' as name",
+        )
+        monkeypatch.setattr(
+            diff_mod,
+            "_run_dbt_show",
+            lambda *a, **k: [{"in_a": True, "in_b": True, "count": 10}],
+        )
+        diff(old="m_old", new="m_new", dbt_dir_path=str(dbt_dir), output_format="json")
+        payload = json.loads(capsys.readouterr().out)
+        assert payload["verdict"] == Verdict.MATCH.value
+        for key in (
+            "old",
+            "new",
+            "target",
+            "primary_key",
+            "excluded_columns",
+            "column_reconciliation",
+            "row_counts",
+            "column_mismatches",
+            "sample_mismatches",
+        ):
+            assert key in payload
+        assert set(payload["column_reconciliation"]) == {"only_in_old", "only_in_new", "compared"}
+        assert payload["row_counts"] == {"old": 10, "new": 10, "delta": 0}
+
+    def test_sample_mismatches_respect_limit(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        import json
+
+        dbt_dir = _make_project(
+            tmp_path,
+            "select 1 as id, 'x' as name",
+            "select 1 as id, 'x' as name",
+        )
+        captured_limits: list[int] = []
+
+        def fake_show(inline_sql: str, dbt_dir: Path, target: str, limit: int) -> list[dict[str, Any]]:
+            captured_limits.append(limit)
+            if "summarize=true" in inline_sql:
+                return [
+                    {"in_a": True, "in_b": True, "count": 5},
+                    {"in_a": True, "in_b": False, "count": 5},
+                ]
+            # honor the limit the command passed for the sample query
+            return [{"id": i} for i in range(limit)]
+
+        monkeypatch.setattr(diff_mod, "_run_dbt_show", fake_show)
+        with pytest.raises(SystemExit):
+            diff(old="m_old", new="m_new", dbt_dir_path=str(dbt_dir), limit=3, output_format="json")
+        payload = json.loads(capsys.readouterr().out)
+        assert len(payload["sample_mismatches"]) == 3
+        # the sample query was invoked with the user's --limit
+        assert 3 in captured_limits
+
+    def test_dbt_failure_exits_1(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        dbt_dir = _make_project(
+            tmp_path,
+            "select 1 as id, 'x' as name",
+            "select 1 as id, 'x' as name",
+        )
+
+        def raise_runtime(*a: Any, **k: Any) -> list[dict[str, Any]]:
+            msg = "dbt show failed: boom"
+            raise RuntimeError(msg)
+
+        monkeypatch.setattr(diff_mod, "_run_dbt_show", raise_runtime)
+        with pytest.raises(SystemExit) as exc:
+            diff(old="m_old", new="m_new", dbt_dir_path=str(dbt_dir))
+        assert exc.value.code == 1

--- a/src/ol_dbt_cli/tests/test_diff.py
+++ b/src/ol_dbt_cli/tests/test_diff.py
@@ -65,8 +65,17 @@ class TestExtractShowRows:
         rows = _extract_show_rows(payload)
         assert rows == [{"in_a": True, "in_b": False, "count": 3}]
 
-    def test_empty(self) -> None:
-        assert _extract_show_rows("no json here") == []
+    def test_no_json_document_returns_none(self) -> None:
+        # No JSON found at all is an anomaly (None), NOT an empty result ([]).
+        assert _extract_show_rows("no json here") is None
+        assert _extract_show_rows("") is None
+        assert _extract_show_rows("12:00 [info] running") is None
+
+    def test_explicit_empty_result_is_empty_list(self) -> None:
+        # A genuinely empty result set is [] (distinct from the None anomaly).
+        assert _extract_show_rows('{"show": []}') == []
+        assert _extract_show_rows("[]") == []
+        assert _extract_show_rows('12:00:00  Preview\n{"show": []}\n') == []
 
     def test_log_prefixed_bare_list(self) -> None:
         # A bare JSON array preceded by log lines must still be extracted.
@@ -77,6 +86,27 @@ class TestExtractShowRows:
         # raw_decode must tolerate trailing text after the JSON document.
         payload = '{"show": [{"x": 1}]}\n12:00:02  Done.\n'
         assert _extract_show_rows(payload) == [{"x": 1}]
+
+
+class TestRunDbtShowParseAnomaly:
+    def test_raises_when_dbt_exits_0_but_output_unparseable(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        import subprocess
+
+        # dbt returns 0 but emits no JSON document (e.g. an unexpected future format).
+        # This must raise, not silently return [] and look like a difference-free run.
+        fake = subprocess.CompletedProcess(args=["dbt"], returncode=0, stdout="12:00 [info] weird output", stderr="")
+        monkeypatch.setattr(diff_mod.subprocess, "run", lambda *a, **k: fake)
+        with pytest.raises(RuntimeError, match="could not parse rows"):
+            diff_mod._run_dbt_show("{{ x }}", tmp_path, "dev_local", 10)
+
+    def test_returns_empty_for_explicit_empty_result(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        import subprocess
+
+        fake = subprocess.CompletedProcess(args=["dbt"], returncode=0, stdout='{"show": []}', stderr="")
+        monkeypatch.setattr(diff_mod.subprocess, "run", lambda *a, **k: fake)
+        assert diff_mod._run_dbt_show("{{ x }}", tmp_path, "dev_local", 10) == []
 
 
 class TestSummarizeRelations:

--- a/src/ol_dbt_cli/tests/test_diff.py
+++ b/src/ol_dbt_cli/tests/test_diff.py
@@ -186,6 +186,22 @@ class TestDiffCommand:
         # A clean match returns normally (no SystemExit).
         diff(old="m_old", new="m_new", dbt_dir_path=str(dbt_dir))
 
+    def test_unresolved_columns_warns_that_schema_gate_skipped(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        # Models whose columns cannot be resolved (no such files, no manifest/YAML)
+        # must not silently pass the schema gate — a stderr warning is emitted.
+        dbt_dir = _make_project(tmp_path, "select 1 as id", "select 1 as id")
+        monkeypatch.setattr(
+            diff_mod,
+            "_run_dbt_show",
+            lambda *a, **k: [{"in_a": True, "in_b": True, "count": 1}],
+        )
+        diff(old="ghost_old", new="ghost_new", dbt_dir_path=str(dbt_dir))
+        err = capsys.readouterr().err
+        assert "schema-divergence" in err
+        assert "Warning" in err
+
     def test_row_mismatch_exits_1(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         dbt_dir = _make_project(
             tmp_path,


### PR DESCRIPTION
## What

Phase 0 of the dbt-warehouse CI/QA hardening effort (project `wp-dbt-warehouse-ci-qa-hardening-data-trust-021724`, spec `docs/specs/DBT_WAREHOUSE_CI_QA_SPEC.md` §3). Closes the intent of #2407.

- **`ol-dbt diff`** — a same-engine row/column comparison of two model relations, so a migrated mart/reporting/dimensional model can be QA'd against its predecessor (epic #2072).
- **Agent skills** (`skills/data/`) + a repository-scoped **`agent-config.toml`** so humans and agents can drive the fast validation loop.

## Why a same-engine diff

Both relations build on the **same** engine (default `dev_local` DuckDB reading Iceberg directly), so dialect differences cancel and the diff reflects real data divergence rather than SQL-translation noise. Rejecting a second engine (Datafold, etc.) is deliberate.

Design choices worth a look in review:
- **Column sets are reconciled *before* comparing** — a schema mismatch is reported as `schema_divergence` (and the value comparison is skipped) instead of surfacing as a raw `audit_helper` SQL error.
- `--primary-key` / `--exclude-columns` handle known non-determinism (e.g. the email-keyed `dim_user.user_pk` NULL collapse).
- Exits non-zero on any divergence (`mismatch` / `schema_divergence`) so it is **gate-able in Phase 2 CI**. `--format json` mirrors the `impact`/`validate` convention.

## Changes

| File | What |
|------|------|
| `src/ol_dbt/packages.yml` | add `dbt-labs/dbt_audit_helper` |
| `src/ol_dbt_cli/ol_dbt_cli/commands/diff.py` | the command; wraps `audit_helper.compare_relations` / `compare_column_values` via `dbt show --inline --output json` |
| `src/ol_dbt_cli/ol_dbt_cli/cli.py` | register `diff` |
| `src/ol_dbt_cli/tests/test_diff.py` | 23 tests (dbt invocation mocked) |
| `skills/data/ol-dbt-fast-validation/` | agent skill: validate / impact / diff loop |
| `skills/data/ol-dbt-local-dev/` | agent skill: local DuckDB+Iceberg env (setup/register/run) |
| `agent-config.toml` | repository-scoped `agent-config-kit` manifest (profile: `dbt`) registering both skills |

## Verification

- `ruff`, `mypy`, and the full `src/ol_dbt_cli` suite (**239 passed**, incl. 23 new) pass; `ol-dbt diff --help` renders; `agent-kit validate agent-config.toml` recognizes both skills at project scope.
- **Remaining acceptance step:** live `dev_local` end-to-end run (needs `dbt deps` to install `dbt_audit_helper` + registered Glue views). Unit tests mock the dbt invocation, per the spec's test guidance.

Refs #2407, #2072.

🤖 Generated with [Claude Code](https://claude.com/claude-code)