### PR TITLE
fix(dbt): add tfact_enrollment_order to resolve order attribution for deferrals and program bundles in enrollment_detail_report

### DIFF
--- a/src/ol_dbt/models/dimensional/_fact_tables.yml
+++ b/src/ol_dbt/models/dimensional/_fact_tables.yml
@@ -94,6 +94,86 @@ models:
       True for edxorg (always) and residential (always). For mitxonline and mitxpro,
       sourced from the application's edx_enrolled flag. Null for program enrollments
       and bootcamps (not edX-hosted).
+  - name: order_id
+    description: >
+      Source system order ID, read directly off the enrollment record. Only xPRO
+      stores this FK on the enrollment itself (mitxonline, bootcamps, edxorg, and
+      residential have no order/purchase FK at the source, so this is null for those
+      platforms — see tfact_enrollment_order for how order attribution is resolved
+      for them instead). This value is authoritative for xPRO regardless of subsequent
+      deferral to a different course run or bundling into a program purchase, unlike
+      product-based reconstruction, which can't resolve an order for a course run
+      that was never itself purchased. Not a unique key on tfact_order (whose grain
+      is
+      order_id + line_id + platform), so no relationships test is applied here.
+
+- name: tfact_enrollment_order
+  description: >
+    Resolves which order produced each enrollment. xPRO enrollments carry a direct
+    order FK (tfact_enrollment.order_id) which is authoritative even after deferral
+    to
+    a different course run or bundling into a program purchase. Every other platform
+    has no such FK at the source, so their order is reconstructed by matching the
+    enrollment's course/program against dim_product, then to tfact_order — fragile
+    in
+    those same scenarios, but the only signal available for them. Materialized as
+    a
+    full-table rebuild (not incremental), since tfact_enrollment's own incremental
+    watermark has no visibility into order-side changes (refunds, price updates,
+    fulfillment).
+    Grain: one row per enrollment_key.
+  columns:
+  - name: enrollment_key
+    description: Foreign key to tfact_enrollment.enrollment_key
+    tests:
+    - unique
+    - not_null
+    - relationships:
+        to: ref('tfact_enrollment')
+        field: enrollment_key
+  - name: order_fk
+    description: >
+      Foreign key to tfact_order.order_key for the resolved order line. Consumers
+      needing order fields not denormalized onto this table (e.g. order_total_price_paid,
+      tax_rate_fk) should join tfact_order on this key rather than tfact_order.order_id,
+      since order_id alone is not unique there (tfact_order's grain is order_id +
+      line_id + platform) — order_fk points at the specific line this model resolved.
+      Null when no order could be resolved (e.g. free/audit enrollments with no
+      purchase).
+    tests:
+    - relationships:
+        to: ref('tfact_order')
+        field: order_key
+        where: "order_fk is not null"
+  - name: order_id
+    description: Source system order ID for the resolved order. Null when no order
+      could be resolved (e.g. free/audit enrollments with no purchase).
+  - name: order_reference_number
+    description: Order reference/confirmation number for the resolved order
+  - name: order_state
+    description: Order state (fulfilled or refunded) of the resolved order
+  - name: order_updated_on
+    description: Last-updated timestamp of the resolved order
+  - name: discount_fk
+    description: Foreign key to dim_discount for the resolved order
+    tests:
+    - relationships:
+        to: ref('dim_discount')
+        field: discount_pk
+        where: "discount_fk is not null"
+        config:
+          severity: warn
+  - name: discount_type_fk
+    description: Foreign key to dim_discount_type for the resolved order
+    tests:
+    - relationships:
+        to: ref('dim_discount_type')
+        field: discount_type_pk
+        where: "discount_type_fk is not null"
+        config:
+          severity: warn
+  - name: line_price
+    description: Price of the resolved order line, used as unit_price downstream
 
 - name: tfact_order
   description: >

--- a/src/ol_dbt/models/dimensional/tfact_enrollment.sql
+++ b/src/ol_dbt/models/dimensional/tfact_enrollment.sql
@@ -22,6 +22,9 @@ with mitxonline_enrollments as (
         , 'mitxonline' as platform
         , 'mitxonline' as platform_code
         , courserunenrollment_is_edx_enrolled as enrollment_is_edx_enrolled
+        -- mitxonline has no order FK on the enrollment record; order attribution for
+        -- this platform relies on product-matching in downstream consumers.
+        , cast(null as bigint) as order_id
     from {{ ref('int__mitxonline__courserunenrollments') }}
 )
 
@@ -56,6 +59,11 @@ with mitxonline_enrollments as (
         , 'mitxpro' as platform
         , 'mitxpro' as platform_code
         , enrollments.courserunenrollment_is_edx_enrolled as enrollment_is_edx_enrolled
+        -- xPRO is the only platform that stores an order FK directly on the enrollment
+        -- record. This is authoritative regardless of subsequent deferral to a different
+        -- course run or bundling into a program purchase — downstream consumers should
+        -- prefer this over reconstructing order attribution via product-matching.
+        , cast(enrollments.ecommerce_order_id as bigint) as order_id
     from {{ ref('int__mitxpro__courserunenrollments') }} as enrollments
     left join mitxpro_program_enrollments_by_order
         on
@@ -80,6 +88,7 @@ with mitxonline_enrollments as (
         , 'edxorg' as platform
         , 'edxorg' as platform_code
         , true as enrollment_is_edx_enrolled
+        , cast(null as bigint) as order_id
     from {{ ref('int__edxorg__mitx_courserun_enrollments') }}
 )
 
@@ -104,6 +113,7 @@ with mitxonline_enrollments as (
         , 'mitxonline' as platform
         , 'mitxonline' as platform_code
         , cast(null as boolean) as enrollment_is_edx_enrolled
+        , cast(null as bigint) as order_id
     from {{ ref('int__mitxonline__programenrollments') }}
 )
 
@@ -123,6 +133,7 @@ with mitxonline_enrollments as (
         , 'residential' as platform
         , 'residential' as platform_code
         , true as enrollment_is_edx_enrolled
+        , cast(null as bigint) as order_id
     from {{ ref('int__mitxresidential__courserun_enrollments') }}
 )
 
@@ -142,6 +153,7 @@ with mitxonline_enrollments as (
         , 'bootcamps' as platform
         , 'bootcamps' as platform_code
         , cast(null as boolean) as enrollment_is_edx_enrolled
+        , cast(null as bigint) as order_id
     from {{ ref('int__bootcamps__courserunenrollments') }}
 )
 
@@ -295,6 +307,7 @@ with mitxonline_enrollments as (
         , enrollment_created_on
         , enrollment_updated_on
         , enrollment_is_edx_enrolled
+        , order_id
     from enrollments_with_fks as ewf
 
     {% if is_incremental() %}
@@ -339,6 +352,7 @@ with mitxonline_enrollments as (
         , enrollment_created_on
         , enrollment_updated_on
         , enrollment_is_edx_enrolled
+        , order_id
         , row_number() over (
             partition by enrollment_key
             order by coalesce(enrollment_updated_on, enrollment_created_on) desc nulls last
@@ -362,5 +376,6 @@ select
     , enrollment_created_on
     , enrollment_updated_on
     , enrollment_is_edx_enrolled
+    , order_id
 from final_deduped
 where _row_num = 1

--- a/src/ol_dbt/models/dimensional/tfact_enrollment_order.sql
+++ b/src/ol_dbt/models/dimensional/tfact_enrollment_order.sql
@@ -1,0 +1,137 @@
+{{ config(
+    materialized='table'
+) }}
+
+-- Resolves which order produced each enrollment. xPRO enrollments carry a direct
+-- order FK (tfact_enrollment.order_id), authoritative even after deferral to a
+-- different course run or bundling into a program purchase; if that order hasn't
+-- resolved yet (not fulfilled/refunded, or not synced to tfact_order), we fall back to
+-- product-matching rather than dropping the enrollment. A null order_id on xPRO is
+-- treated as definitive ("no purchase") and is NOT sent through that fallback. Every
+-- other platform has no direct FK at the source at all, so their order is always
+-- reconstructed by matching the enrollment's course/program against dim_product, then
+-- to tfact_order — fragile under the same deferral/bundling scenarios, but the only
+-- signal available for them.
+-- Materialized as a full-table rebuild (not incremental): tfact_enrollment's own
+-- incremental watermark tracks enrollment activity, not order-side changes (refunds,
+-- price updates, fulfillment), so a table refresh keeps this current with tfact_order
+-- without needing its own watermark logic.
+-- Grain: one row per enrollment_key.
+with enrollment as (
+    select * from {{ ref('tfact_enrollment') }}
+)
+
+, product as (
+    select * from {{ ref('dim_product') }}
+    where is_current = true
+)
+
+, order_fact as (
+    select * from {{ ref('tfact_order') }}
+    where order_state in ('fulfilled', 'refunded')
+)
+
+, order_via_direct_fk as (
+    select
+        enrollment.enrollment_key
+        , order_fact.order_key as order_fk
+        , order_fact.order_id
+        , order_fact.order_reference_number
+        , order_fact.order_state
+        , order_fact.order_updated_on
+        , order_fact.discount_fk
+        , order_fact.discount_type_fk
+        , order_fact.line_price
+        , order_fact.line_id
+        -- the order is already known correct (direct FK); among its lines, just prefer
+        -- whichever one's product actually matches this enrollment (for an accurate
+        -- unit_price/discount), falling back to any line.
+        , case
+            when product.courserun_fk = enrollment.courserun_fk
+                or product.program_fk = enrollment.program_fk
+            then 1
+            else 2
+        end as match_priority
+    from enrollment
+    inner join order_fact
+        on
+            enrollment.order_id = order_fact.order_id
+            and enrollment.platform_fk = order_fact.platform_fk
+    left join product
+        on order_fact.product_fk = product.product_pk
+    where enrollment.order_id is not null
+)
+
+-- An enrollment's courserun_fk/program_fk can each independently match a distinct
+-- product (e.g. the course sold standalone AND bundled into a program the learner
+-- actually purchased). Used as a fallback:
+--  (a) for platforms with no direct order FK at all (order_id is always null there), or
+--  (b) for xPRO when a direct order_id exists but didn't resolve above — e.g. the order
+--      hasn't reached a fulfilled/refunded state yet, or hasn't landed in tfact_order
+--      yet — so we attempt a best-effort reconstruction rather than silently dropping
+--      the enrollment.
+-- Deliberately NOT attempted when order_id is null for a platform that has a direct FK
+-- mechanism (xPRO free/audit enrollments): a null order_id there is authoritative
+-- ("genuinely no purchase"), and reconstructing via product-matching risks attaching an
+-- unrelated real order the same user separately purchased for the same product.
+, order_via_product as (
+    select
+        enrollment.enrollment_key
+        , order_fact.order_key as order_fk
+        , order_fact.order_id
+        , order_fact.order_reference_number
+        , order_fact.order_state
+        , order_fact.order_updated_on
+        , order_fact.discount_fk
+        , order_fact.discount_type_fk
+        , order_fact.line_price
+        , order_fact.line_id
+        , case when enrollment.courserun_fk = product.courserun_fk then 1 else 2 end as match_priority
+    from enrollment
+    inner join product
+        on
+            (enrollment.courserun_fk = product.courserun_fk
+            or enrollment.program_fk = product.program_fk)
+            and enrollment.platform_fk = product.platform_fk
+    inner join order_fact
+        on
+            enrollment.user_fk = order_fact.user_fk
+            and product.product_pk = order_fact.product_fk
+            and enrollment.platform_fk = order_fact.platform_fk
+    where
+        not exists (
+            select 1 from order_via_direct_fk as d where d.enrollment_key = enrollment.enrollment_key
+        )
+        and not (enrollment.platform = 'mitxpro' and enrollment.order_id is null)
+)
+
+select
+    enrollment_key
+    , order_fk
+    , order_id
+    , order_reference_number
+    , order_state
+    , order_updated_on
+    , discount_fk
+    , discount_type_fk
+    , line_price
+from (
+    select
+        *
+        , row_number() over (
+            partition by enrollment_key
+            order by
+                match_priority
+                , order_updated_on desc nulls last
+                -- order_updated_on is order-level and shared by every line on a
+                -- multi-line order, so it alone can leave ties unresolved.
+                , order_id desc nulls last
+                , line_id desc nulls last
+        ) as row_num
+    from (
+        select * from order_via_direct_fk
+        union all
+        select * from order_via_product
+    )
+)
+where row_num = 1

--- a/src/ol_dbt/models/dimensional/tfact_enrollment_order.sql
+++ b/src/ol_dbt/models/dimensional/tfact_enrollment_order.sql
@@ -43,14 +43,13 @@ with enrollment as (
         , order_fact.discount_type_fk
         , order_fact.line_price
         , order_fact.line_id
-        -- the order is already known correct (direct FK); among its lines, just prefer
-        -- whichever one's product actually matches this enrollment (for an accurate
-        -- unit_price/discount), falling back to any line.
+        -- the order is already known correct (direct FK); among its lines, prefer
+        -- the course-run-specific match (for an accurate unit_price/discount), then a
+        -- program-level match, falling back to any other line.
         , case
-            when product.courserun_fk = enrollment.courserun_fk
-                or product.program_fk = enrollment.program_fk
-            then 1
-            else 2
+            when product.courserun_fk = enrollment.courserun_fk then 1
+            when product.program_fk = enrollment.program_fk then 2
+            else 3
         end as match_priority
     from enrollment
     inner join order_fact

--- a/src/ol_dbt/models/reporting/enrollment_detail_report.sql
+++ b/src/ol_dbt/models/reporting/enrollment_detail_report.sql
@@ -1,9 +1,22 @@
 with enrollment as (
-    select * from {{ ref('tfact_enrollment') }}
+    select
+        *
+        , case platform
+            when 'bootcamps' then '{{ var("bootcamps") }}'
+            when 'edxorg' then '{{ var("edxorg") }}'
+            when 'emeritus' then '{{ var("emeritus") }}'
+            when 'global_alumni' then '{{ var("global_alumni") }}'
+            when 'mitxonline' then '{{ var("mitxonline") }}'
+            when 'mitxpro' then '{{ var("mitxpro") }}'
+            when 'residential' then '{{ var("residential") }}'
+            else platform
+        end as platform_display
+    from {{ ref('tfact_enrollment') }}
 )
 
 , course_run as (
     select * from {{ ref('dim_course_run') }}
+    where is_current = true
 )
 
 , course as (
@@ -31,14 +44,8 @@ with enrollment as (
     select * from {{ ref('dim_user') }}
 )
 
-, product as (
-    select * from {{ ref('dim_product') }}
-    where is_current = true
-)
-
 , f_order as (
-    select * from {{ ref('tfact_order') }}
-    where order_state in ('fulfilled', 'refunded')
+    select * from {{ ref('tfact_enrollment_order') }}
 )
 
 , discount as (
@@ -145,36 +152,8 @@ with enrollment as (
     group by user_email
 )
 
--- An enrollment's courserun_fk/program_fk can each independently match a distinct
--- product (e.g. the course sold standalone AND bundled into a program the learner
--- actually purchased), fanning this join out to one row per matching order. Dedup
--- below keeps whichever match actually has a real order, preferring the more
--- specific course-level match and, within a priority tier, the most recent order.
--- Note: QUALIFY is not supported by Trino; using ROW_NUMBER subquery instead.
-, report_rows as (
 select
-    enrollment.enrollment_key
-    , row_number() over (
-        partition by enrollment.enrollment_key
-        order by
-            case when f_order.order_id is not null then 0 else 1 end
-            , case when enrollment.courserun_fk = product.courserun_fk then 1 else 2 end
-            , f_order.order_updated_on desc nulls last
-            -- order_updated_on is order-level and shared by every line on a multi-line
-            -- order, so it alone can leave ties unresolved; break ties deterministically.
-            , f_order.order_id desc nulls last
-            , f_order.line_id desc nulls last
-    ) as row_num
-    , case enrollment.platform
-        when 'bootcamps' then '{{ var("bootcamps") }}'
-        when 'edxorg' then '{{ var("edxorg") }}'
-        when 'emeritus' then '{{ var("emeritus") }}'
-        when 'global_alumni' then '{{ var("global_alumni") }}'
-        when 'mitxonline' then '{{ var("mitxonline") }}'
-        when 'mitxpro' then '{{ var("mitxpro") }}'
-        when 'residential' then '{{ var("residential") }}'
-        else enrollment.platform
-    end as platform
+    enrollment.platform_display as platform
     , enrollment_id as courserunenrollment_id
     , course_readable_id
     , course_title
@@ -263,22 +242,14 @@ left join organization
     on organization_courserun.organization_fk = organization.organization_pk
 inner join d_user
     on enrollment.user_fk = d_user.user_pk
-left join product
-    on
-        (enrollment.courserun_fk = product.courserun_fk
-        or enrollment.program_fk = product.program_fk)
-        and enrollment.platform_fk = product.platform_fk
 left join f_order
-    on
-        enrollment.user_fk = f_order.user_fk
-        and product.product_pk = f_order.product_fk
-        and enrollment.platform_fk = f_order.platform_fk
+    on enrollment.enrollment_key = f_order.enrollment_key
 left join discount
     on f_order.discount_fk = discount.discount_pk
 left join payment
     on
         f_order.order_id = payment.order_id
-        and f_order.platform_fk = payment.platform_fk
+        and enrollment.platform_fk = payment.platform_fk
 left join payment_method
     on payment.payment_method_fk = payment_method.payment_method_pk
 left join d_user_payer
@@ -291,80 +262,13 @@ left join discount_names
     on discount.discount_code = discount_names.discount_code
 left join enrollment_upgrades
     on f_order.order_id = enrollment_upgrades.order_id
-     and case enrollment.platform
-        when 'bootcamps' then '{{ var("bootcamps") }}'
-        when 'edxorg' then '{{ var("edxorg") }}'
-        when 'emeritus' then '{{ var("emeritus") }}'
-        when 'global_alumni' then '{{ var("global_alumni") }}'
-        when 'mitxonline' then '{{ var("mitxonline") }}'
-        when 'mitxpro' then '{{ var("mitxpro") }}'
-        when 'residential' then '{{ var("residential") }}'
-        else enrollment.platform
-    end = enrollment_upgrades.platform
+    and enrollment.platform_display = enrollment_upgrades.platform
     and course_run.courserun_readable_id = enrollment_upgrades.courserun_readable_id
     and d_user.email = enrollment_upgrades.user_email
 left join order_emails
     on f_order.order_id = order_emails.order_id
-    and case enrollment.platform
-        when 'bootcamps' then '{{ var("bootcamps") }}'
-        when 'edxorg' then '{{ var("edxorg") }}'
-        when 'emeritus' then '{{ var("emeritus") }}'
-        when 'global_alumni' then '{{ var("global_alumni") }}'
-        when 'mitxonline' then '{{ var("mitxonline") }}'
-        when 'mitxpro' then '{{ var("mitxpro") }}'
-        when 'residential' then '{{ var("residential") }}'
-        else enrollment.platform
-    end = order_emails.platform
+    and enrollment.platform_display = order_emails.platform
     and course_run.courserun_readable_id = order_emails.courserun_readable_id
     and d_user.email = order_emails.user_email
 left join course_passed_counts
     on d_user.email = course_passed_counts.user_email
-)
-
-select
-    platform
-    , courserunenrollment_id
-    , course_readable_id
-    , course_title
-    , courserun_is_current
-    , courserun_readable_id
-    , courserun_start_on
-    , courserun_end_on
-    , courserun_title
-    , courserunenrollment_created_on
-    , courserunenrollment_enrollment_mode
-    , courserunenrollment_enrollment_status
-    , courserunenrollment_is_active
-    , courserunenrollment_upgraded_on
-    , courseruncertificate_created_on
-    , courseruncertificate_issued_on
-    , courseruncertificate_is_earned
-    , courseruncertificate_url
-    , courserungrade_grade
-    , courserungrade_is_passing
-    , organization_key
-    , organization_name
-    , user_country_code
-    , user_highest_education
-    , user_full_name
-    , user_username
-    , user_email
-    , num_of_course_passed
-    , coupon_code
-    , coupon_name
-    , discount
-    , order_id
-    , order_reference_number
-    , order_state
-    , order_updated_on
-    , receipt_payment_amount
-    , receipt_payment_method
-    , receipt_payment_timestamp
-    , receipt_payer_email
-    , unit_price
-    , program_name
-    , discount_type_name
-    , redeemed_email
-    , receipt_url
-from report_rows
-where row_num = 1


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
addressing the missing order_id issue mentioned in Bryan's email https://github.mit.edu/xpro/xpro-issues/issues/688
part of https://github.com/mitodl/ol-data-platform/issues/2114

### Description (What does it do?)
<!--- Describe your changes in detail -->
  Fixes the missing order_id in enrollment_detail_report for xPRO program orders after we switched to use dimensional models.                                                                                                                                                                                
  - Adds `order_id` to tfact_enrollment, preserving the direct enrollment-to-order link for xPRO, which was the missing piece.                                     
  - Adds tfact_enrollment_order, a dimensional model resolving which order produced each enrollment, for both xPRO and other platforms.  
 
### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

dbt build --select +tfact_enrollment tfact_enrollment_order enrollment_detail_report --full-refresh

Confirmed that order_id is now populated correctly in this query
```

select *
from "ol_data_lake_production".ol_warehouse_production_rlougee_reporting.enrollment_detail_report
where courserunenrollment_id in ('69747','70001') and platform='xPro'
```

Confirmed that this query still produced the correct order_id 469691

```
select  *
from "ol_data_lake_production".ol_warehouse_production_reporting.enrollment_detail_report
where courserunenrollment_id='998362' and platform='MITx Online'
```

### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->


<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
