### PR TITLE
populate course fk more often on dim course run table

### DIFF
--- a/src/ol_dbt/models/dimensional/dim_course_run.sql
+++ b/src/ol_dbt/models/dimensional/dim_course_run.sql
@@ -65,7 +65,7 @@ with micromasters_courseruns as (
     from {{ ref('int__mitxonline__course_runs') }} as cr
     left join micromasters_examruns as er
         on cr.courserun_readable_id = er.examrun_readable_id
-    left join {{ ref('int__mitxonline__courses') }} as cs
+    left join {{ ref('stg__mitxonline__app__postgres__courses_course') }} as cs
         on cr.course_id = cs.course_id
 )
 

--- a/src/ol_dbt/models/dimensional/dim_course_run.sql
+++ b/src/ol_dbt/models/dimensional/dim_course_run.sql
@@ -57,7 +57,7 @@ with micromasters_courseruns as (
         , cr.courserun_enrollment_end_on as enrollment_end
         , cr.courserun_is_live
         , cr.courserun_created_on
-        , cast(null as varchar) as course_readable_id
+        , cs.course_readable_id
         , er.examrun_semester as semester
         , er.examrun_passing_grade as passing_grade
         , 'mitxonline' as platform
@@ -65,6 +65,8 @@ with micromasters_courseruns as (
     from {{ ref('int__mitxonline__course_runs') }} as cr
     left join micromasters_examruns as er
         on cr.courserun_readable_id = er.examrun_readable_id
+    left join {{ ref('int__mitxonline__courses') }} as cs
+        on cr.course_id = cs.course_id
 )
 
 , mitxpro_courseruns as (


### PR DESCRIPTION
### What are the relevant tickets?
https://github.mit.edu/mitxonline/mitxonline-issues/issues/1416

I thought this wasn't an issue but it is specifically the sql below is causing the problem as the generated course id(from this piece of sql) is not always(only sometimes) the actual course id and fails a later join condition:

 , coalesce(
            course_readable_id,
            case
                when courserun_readable_id like 'course-v1:%'
                    then substring(
                        courserun_readable_id,
                        1,
                        length(courserun_readable_id)
                        - strpos(reverse(courserun_readable_id), '+')
                    )
                when regexp_like(courserun_readable_id, '^[^/]+/[^/]+/[^/]+')
                    then substring(
                        courserun_readable_id,
                        1,
                        length(courserun_readable_id)
                        - strpos(reverse(courserun_readable_id), '/')
                    )
                else courserun_readable_id
            end
        ) as course_readable_id

### Description (What does it do?)
<!--- Describe your changes in detail -->
populate course fk more often on dim course run table

### How can this be tested?
dbt build --select dim_course_run

It's not a complete fix but brings the course fk nulls down from 3853 nulls to 583 nulls so you may still get a warning. 
