### PR TITLE
fix(dlt): parallelize edxorg_s3 loading and fix sensor cursor-advance-on-failure

### DIFF
--- a/dg_projects/data_loading/data_loading/defs/ingestion/assets.py
+++ b/dg_projects/data_loading/data_loading/defs/ingestion/assets.py
@@ -1,14 +1,16 @@
 """@dlt_assets wrappers that expose ol_dlt pipelines as Dagster assets.
 
 Six simple sources are wrapped uniformly via ``build_ingest_assets``. edxorg_s3
-keeps a custom asset because it adds upstream deps and materializes one table per
-``dlt.run()`` call (so STS credentials refresh between tables).
+keeps custom asset-building because it adds upstream deps and materializes each
+table as its OWN ``@dlt_assets`` op (see the edxorg_s3 section below) so tables
+of wildly different sizes can load concurrently instead of one giant table
+blocking the rest of the run behind it.
 """
 
 from collections.abc import Iterable
 from typing import Any
 
-from dagster import AssetExecutionContext, AssetKey, AssetsDefinition, Definitions
+from dagster import AssetExecutionContext, AssetsDefinition, Definitions
 from dagster_dlt import DagsterDltResource, dlt_assets
 from ol_dlt.sources import (
     edxorg_s3,
@@ -73,50 +75,53 @@ podcast_rss_assets = build_ingest_assets(
 )
 
 
-# --- edxorg_s3: custom upstream deps + per-table materialization ------------
-_EDXORG_PREFIX = "raw__edxorg__s3__tables__"
+# --- edxorg_s3: custom upstream deps + one op per table ---------------------
+
+# Bounds how many tables load concurrently. Dagster's K8sRunLauncher gives each
+# RUN its own pod (not each step); with no executor_def override, steps within
+# that pod run via the default multiprocess executor -- genuinely separate OS
+# processes (safe: dlt's non-thread-safe injectable-context dict is
+# process-local, never shared across them), but still sharing that one pod's
+# fixed CPU/memory budget. Tune the slot count in the Dagster instance UI.
+_EDXORG_S3_POOL = "edxorg_s3"
 
 
-def _edxorg_asset_key(table_name: str) -> AssetKey:
-    return AssetKey(["ol_warehouse_raw_data", f"{_EDXORG_PREFIX}{table_name}"])
+def _build_edxorg_s3_table_asset(table_name: str) -> AssetsDefinition:
+    """Wrap one edxorg_s3 table as its own ``@dlt_assets`` op.
 
-
-# The full-tables instance lets @dlt_assets discover the complete set of asset
-# specs at import time; the execution function below overrides the source
-# per-table.
-@dlt_assets(
-    dlt_source=edxorg_s3.edxorg_s3_source(tables=list(EDXORG_DB_TABLES)),
-    dlt_pipeline=edxorg_s3.edxorg_s3_pipeline,
-    name="edxorg_s3_tables",
-    # group_name is set per-asset by the translator (scoped by source system).
-    dagster_dlt_translator=EdxorgDltTranslator(),
-)
-def edxorg_s3_consolidated_tables(
-    context: AssetExecutionContext, dlt: DagsterDltResource
-) -> Iterable[Any]:
-    """Load and consolidate EdX.org database tables from S3.
-
-    Tables are processed sequentially, one per ``dlt.run()`` call, so that STS
-    tokens refresh between tables, large tables do not exhaust a single token's
-    TTL, and dlt's non-thread-safe injectable-context dict is never accessed
-    concurrently (see also [extract] workers=1 in ol_dlt/.dlt/config.toml).
+    One op per table (rather than one op looping over every table) lets
+    Dagster's step executor run tables concurrently instead of a single huge
+    table head-of-line-blocking every smaller table behind it in one
+    sequential Python loop. Each table gets its own dlt pipeline_name (see
+    ``edxorg_s3_pipeline_for``) so concurrent table loads never share a local
+    working directory.
     """
-    if context.is_subset:
-        selected_tables = [
-            t
-            for t in EDXORG_DB_TABLES
-            if _edxorg_asset_key(t) in context.selected_asset_keys
-        ]
-    else:
-        selected_tables = list(EDXORG_DB_TABLES)
+    source = edxorg_s3.edxorg_s3_source(tables=[table_name])
+    pipeline = edxorg_s3.edxorg_s3_pipeline_for(table_name)
 
-    for table_name in selected_tables:
-        table_source = edxorg_s3.edxorg_s3_source(tables=[table_name])
+    @dlt_assets(
+        dlt_source=source,
+        dlt_pipeline=pipeline,
+        name=f"edxorg_s3_{table_name}",
+        # group_name is set per-asset by the translator (scoped by source system).
+        dagster_dlt_translator=EdxorgDltTranslator(),
+        pool=_EDXORG_S3_POOL,
+    )
+    def _asset(
+        context: AssetExecutionContext, dlt: DagsterDltResource
+    ) -> Iterable[Any]:
         yield from dlt.run(
             context=context,
-            dlt_source=table_source,
+            dlt_source=source,
             loader_file_format="parquet",
         )
+
+    return _asset
+
+
+edxorg_s3_table_assets = [
+    _build_edxorg_s3_table_asset(table_name) for table_name in EDXORG_DB_TABLES
+]
 
 
 defs = Definitions(
@@ -126,6 +131,6 @@ defs = Definitions(
         mit_climate_assets,
         mit_edx_programs_assets,
         podcast_rss_assets,
-        edxorg_s3_consolidated_tables,
+        *edxorg_s3_table_assets,
     ],
 )

--- a/dg_projects/data_loading/data_loading/defs/ingestion/sensor.py
+++ b/dg_projects/data_loading/data_loading/defs/ingestion/sensor.py
@@ -20,6 +20,44 @@ edxorg_s3_ingest_job = dg.define_asset_job(
     ),
 )
 
+# Runs in these statuses haven't finished yet -- wait rather than deciding.
+_IN_FLIGHT_RUN_STATUSES = frozenset(
+    {
+        dg.DagsterRunStatus.QUEUED,
+        dg.DagsterRunStatus.NOT_STARTED,
+        dg.DagsterRunStatus.STARTING,
+        dg.DagsterRunStatus.STARTED,
+        dg.DagsterRunStatus.CANCELING,
+    }
+)
+
+# Tags every launched run with the exact set of upstream materializations it
+# was launched for. Querying runs by this tag (rather than relying on
+# context.last_run_key, which reflects the sensor DAEMON's own tick-history
+# bookkeeping) is what lets this sensor decide, from persisted run state
+# alone, whether the run gating the current unconsumed batch succeeded,
+# failed, or is still in flight -- and how many times that exact batch has
+# already been attempted.
+_BATCH_ID_TAG = "edxorg_s3/upstream_batch_id"
+
+
+def _batch_id(new_records: dict[dg.AssetKey, dg.EventLogRecord]) -> str:
+    """Return a deterministic id for a set of new upstream materializations."""
+    return "-".join(
+        f"{key.to_user_string()}:{record.storage_id}"
+        for key, record in sorted(
+            new_records.items(), key=lambda kv: kv[0].to_user_string()
+        )
+    )
+
+
+def _attempts_for_batch(
+    instance: dg.DagsterInstance, batch_id: str
+) -> list[dg.RunRecord]:
+    """Return every run previously launched for ``batch_id``, oldest first."""
+    records = instance.get_run_records(dg.RunsFilter(tags={_BATCH_ID_TAG: batch_id}))
+    return sorted(records, key=lambda r: r.create_timestamp)
+
 
 @dg.multi_asset_sensor(
     monitored_assets=_EDXORG_UPSTREAM_ASSET_KEYS,
@@ -34,15 +72,56 @@ edxorg_s3_ingest_job = dg.define_asset_job(
 def edxorg_upstream_changes_sensor(
     context: dg.MultiAssetSensorEvaluationContext,
 ) -> dg.RunRequest | dg.SkipReason:
-    """Trigger the edxorg S3 ingest job when upstream archive assets change."""
-    latest_records = context.latest_materialization_records_by_key()
+    """Trigger the edxorg S3 ingest job when upstream archive assets change.
 
-    has_new = any(record is not None for record in latest_records.values())
-    if not has_new:
+    Cursors advance only once the run they gated is confirmed to have
+    succeeded -- never at launch time -- so a failed or canceled run is
+    retried on the very next tick instead of silently waiting for the next
+    genuinely new upstream materialization (which, for a daily archive
+    process, can be a full day away).
+
+    Deliberately does not rely on ``context.last_run_key`` (the sensor
+    daemon's own tick-history bookkeeping): whether the batch of
+    materializations currently unconsumed has already been attempted, and
+    with what outcome, is instead derived entirely from real run records
+    tagged with ``_BATCH_ID_TAG``, which is both simpler to reason about and
+    directly testable without a full daemon loop.
+    """
+    latest_records = context.latest_materialization_records_by_key()
+    new_records = {key: record for key, record in latest_records.items() if record}
+    if not new_records:
         return dg.SkipReason("No new upstream edxorg materializations since last check")
 
-    context.advance_all_cursors()
-    return dg.RunRequest()
+    batch_id = _batch_id(new_records)
+    attempts = _attempts_for_batch(context.instance, batch_id)
+
+    if attempts:
+        latest_attempt = attempts[-1]
+        status = latest_attempt.dagster_run.status
+        if status in _IN_FLIGHT_RUN_STATUSES:
+            return dg.SkipReason(
+                f"edxorg_s3 ingest for this batch (run_id="
+                f"{latest_attempt.dagster_run.run_id}) is still {status.value}; "
+                "waiting for it to finish."
+            )
+        if status == dg.DagsterRunStatus.SUCCESS:
+            context.advance_all_cursors()
+            return dg.SkipReason(
+                "Most recent edxorg_s3 ingest attempt for this batch succeeded"
+            )
+        context.log.warning(
+            "edxorg_s3 ingest attempt %d for this batch (run_id=%s) finished "
+            "with status %s; retrying with a fresh run_key.",
+            len(attempts) - 1,
+            latest_attempt.dagster_run.run_id,
+            status.value,
+        )
+        # Cursor stays put: new_records remains "new" on the next tick too, so
+        # a fresh attempt is requested below instead of waiting for more
+        # upstream data.
+
+    run_key = f"edxorg_s3_ingest__{batch_id}__attempt{len(attempts)}"
+    return dg.RunRequest(run_key=run_key, tags={_BATCH_ID_TAG: batch_id})
 
 
 defs = dg.Definitions(

--- a/dg_projects/data_loading/data_loading/defs/ingestion/sensor.py
+++ b/dg_projects/data_loading/data_loading/defs/ingestion/sensor.py
@@ -1,5 +1,7 @@
 """Sensor for edxorg S3 ingest triggered by upstream asset materializations."""
 
+import hashlib
+
 import dagster as dg
 from ol_orchestrate.lib.constants import EDXORG_DB_TABLES
 
@@ -42,13 +44,27 @@ _BATCH_ID_TAG = "edxorg_s3/upstream_batch_id"
 
 
 def _batch_id(new_records: dict[dg.AssetKey, dg.EventLogRecord]) -> str:
-    """Return a deterministic id for a set of new upstream materializations."""
-    return "-".join(
+    """Return a deterministic, length-bounded id for a set of new materializations.
+
+    The raw concatenation of every unconsumed asset key + storage_id can run
+    to thousands of characters when many of the 44 monitored tables have new
+    materializations in the same tick (all monitored tables materializing
+    close together is exactly what happens on the very first successful
+    backfill, since no full run has ever completed). Postgres run storage
+    indexes ``run_tags(key, value)`` unconditionally (the dagster schema's
+    ``mysql_length`` hint on that index only applies to MySQL), and Postgres's
+    btree index has a hard ~2712-byte per-row limit -- a raw batch id that
+    long would fail run creation outright instead of just being a long tag.
+    Hashing to a fixed-length digest keeps this well under any such limit
+    while remaining just as deterministic (same batch -> same id).
+    """
+    raw = "-".join(
         f"{key.to_user_string()}:{record.storage_id}"
         for key, record in sorted(
             new_records.items(), key=lambda kv: kv[0].to_user_string()
         )
     )
+    return hashlib.sha256(raw.encode()).hexdigest()
 
 
 def _attempts_for_batch(

--- a/dg_projects/data_loading/data_loading_tests/test_sensor.py
+++ b/dg_projects/data_loading/data_loading_tests/test_sensor.py
@@ -13,6 +13,12 @@ from data_loading.defs.ingestion.sensor import (
     edxorg_s3_ingest_job,
     edxorg_upstream_changes_sensor,
 )
+from ol_orchestrate.lib.constants import EDXORG_DB_TABLES
+
+# Postgres run storage indexes run_tags(key, value) unconditionally (the
+# dagster schema's mysql_length hint on that index is MySQL-only); a btree
+# index row over ~2712 bytes fails outright on Postgres.
+_POSTGRES_BTREE_INDEX_ROW_LIMIT = 2712
 
 _TABLE_A_KEY = dg.AssetKey(["edxorg", "raw_data", "db_table", "auth_user"])
 _TABLE_B_KEY = dg.AssetKey(
@@ -164,3 +170,39 @@ def test_new_materialization_during_a_failure_retries_the_combined_batch(
     # A fresh batch (now includes table B too) -- first attempt at THIS batch.
     assert second.run_key.endswith("__attempt0")
     assert second.tags[_BATCH_ID_TAG] != first.tags[_BATCH_ID_TAG]
+
+
+def test_batch_id_and_run_key_stay_under_postgres_index_limit_at_full_scale(
+    instance: dg.DagsterInstance,
+) -> None:
+    """All 44 monitored tables materializing in one tick -- the realistic
+    worst case, since no full run has ever completed and the first backfill
+    across every table could land in the same window -- must not produce a
+    tag/run_key long enough to fail run creation on Postgres run storage.
+    """
+    assets = [
+        dg.asset(key=dg.AssetKey(["edxorg", "raw_data", "db_table", table]))(
+            lambda: None
+        )
+        for table in EDXORG_DB_TABLES
+    ]
+    definitions = dg.Definitions(
+        assets=assets,
+        jobs=[edxorg_s3_ingest_job],
+        sensors=[edxorg_upstream_changes_sensor],
+    )
+    dg.materialize(assets, instance=instance)
+
+    context = dg.build_multi_asset_sensor_context(
+        monitored_assets=_EDXORG_UPSTREAM_ASSET_KEYS,
+        instance=instance,
+        cursor=None,
+        definitions=definitions,
+    )
+    result = edxorg_upstream_changes_sensor(context)
+
+    assert isinstance(result, dg.RunRequest)
+    assert len(result.run_key) < _POSTGRES_BTREE_INDEX_ROW_LIMIT
+    assert len(result.tags[_BATCH_ID_TAG]) < _POSTGRES_BTREE_INDEX_ROW_LIMIT
+    # Fixed-length hash regardless of how many tables are in the batch.
+    assert len(result.tags[_BATCH_ID_TAG]) == 64

--- a/dg_projects/data_loading/data_loading_tests/test_sensor.py
+++ b/dg_projects/data_loading/data_loading_tests/test_sensor.py
@@ -1,0 +1,166 @@
+"""End-to-end tests for edxorg_upstream_changes_sensor against a real (ephemeral)
+Dagster instance -- not mocked -- so the retry state machine is validated
+against Dagster's own run-records/cursor semantics, not our assumptions about
+them.
+"""
+
+import dagster as dg
+import pytest
+from dagster._core.test_utils import create_run_for_test
+from data_loading.defs.ingestion.sensor import (
+    _BATCH_ID_TAG,
+    _EDXORG_UPSTREAM_ASSET_KEYS,
+    edxorg_s3_ingest_job,
+    edxorg_upstream_changes_sensor,
+)
+
+_TABLE_A_KEY = dg.AssetKey(["edxorg", "raw_data", "db_table", "auth_user"])
+_TABLE_B_KEY = dg.AssetKey(
+    ["edxorg", "raw_data", "db_table", "student_courseenrollment"]
+)
+
+
+@dg.asset(key=_TABLE_A_KEY)
+def _archive_table_a() -> None: ...
+
+
+@dg.asset(key=_TABLE_B_KEY)
+def _archive_table_b() -> None: ...
+
+
+_TEST_DEFINITIONS = dg.Definitions(
+    assets=[_archive_table_a, _archive_table_b],
+    jobs=[edxorg_s3_ingest_job],
+    sensors=[edxorg_upstream_changes_sensor],
+)
+
+
+@pytest.fixture
+def instance() -> dg.DagsterInstance:
+    return dg.DagsterInstance.ephemeral()
+
+
+def _evaluate(
+    instance: dg.DagsterInstance, cursor: str | None
+) -> tuple[dg.RunRequest | dg.SkipReason, str]:
+    """Run one sensor tick and return (result, cursor to pass to the next tick)."""
+    context = dg.build_multi_asset_sensor_context(
+        monitored_assets=_EDXORG_UPSTREAM_ASSET_KEYS,
+        instance=instance,
+        cursor=cursor,
+        definitions=_TEST_DEFINITIONS,
+    )
+    result = edxorg_upstream_changes_sensor(context)
+    context.update_cursor_after_evaluation()
+    return result, context.cursor
+
+
+def _create_attempt(
+    instance: dg.DagsterInstance,
+    run_request: dg.RunRequest,
+    status: dg.DagsterRunStatus,
+) -> None:
+    """Simulate the daemon launching run_request's run and it reaching status."""
+    create_run_for_test(
+        instance,
+        job_name=edxorg_s3_ingest_job.name,
+        tags=dict(run_request.tags),
+        status=status,
+    )
+
+
+def test_no_new_materializations_skips(instance: dg.DagsterInstance) -> None:
+    result, _ = _evaluate(instance, cursor=None)
+    assert isinstance(result, dg.SkipReason)
+
+
+def test_new_materialization_fires_run_request(instance: dg.DagsterInstance) -> None:
+    dg.materialize([_archive_table_a], instance=instance)
+    result, _ = _evaluate(instance, cursor=None)
+    assert isinstance(result, dg.RunRequest)
+    assert result.run_key is not None
+    assert result.run_key.endswith("__attempt0")
+
+
+def test_no_run_yet_launched_re_requests_the_same_key(
+    instance: dg.DagsterInstance,
+) -> None:
+    """The bug this fixes: cursors used to advance before the run was known to
+    succeed. If the daemon hasn't actually launched a run for the first
+    request yet (no run record exists), the next tick must not invent a new
+    attempt number or lose track of the batch -- it re-requests the same key.
+    """
+    dg.materialize([_archive_table_a], instance=instance)
+    first, cursor = _evaluate(instance, cursor=None)
+    assert isinstance(first, dg.RunRequest)
+
+    second, _ = _evaluate(instance, cursor=cursor)
+    assert isinstance(second, dg.RunRequest)
+    assert second.run_key == first.run_key
+
+
+def test_failed_run_is_retried_with_a_fresh_run_key(
+    instance: dg.DagsterInstance,
+) -> None:
+    dg.materialize([_archive_table_a], instance=instance)
+    first, cursor = _evaluate(instance, cursor=None)
+    assert isinstance(first, dg.RunRequest)
+    _create_attempt(instance, first, dg.DagsterRunStatus.FAILURE)
+
+    second, cursor = _evaluate(instance, cursor=cursor)
+    assert isinstance(second, dg.RunRequest)
+    assert second.run_key != first.run_key
+    assert second.run_key.endswith("__attempt1")
+    # Same batch (same upstream materialization), not a coincidentally-new one.
+    assert second.tags[_BATCH_ID_TAG] == first.tags[_BATCH_ID_TAG]
+
+    # And it keeps retrying on repeated failure.
+    _create_attempt(instance, second, dg.DagsterRunStatus.FAILURE)
+    third, _ = _evaluate(instance, cursor=cursor)
+    assert isinstance(third, dg.RunRequest)
+    assert third.run_key.endswith("__attempt2")
+
+
+def test_successful_run_advances_cursor_and_stops_retrying(
+    instance: dg.DagsterInstance,
+) -> None:
+    dg.materialize([_archive_table_a], instance=instance)
+    first, cursor = _evaluate(instance, cursor=None)
+    assert isinstance(first, dg.RunRequest)
+    _create_attempt(instance, first, dg.DagsterRunStatus.SUCCESS)
+
+    second, cursor = _evaluate(instance, cursor=cursor)
+    assert isinstance(second, dg.SkipReason)
+
+    # Cursor genuinely advanced -- a third tick with no new data also skips.
+    third, _ = _evaluate(instance, cursor=cursor)
+    assert isinstance(third, dg.SkipReason)
+
+
+def test_in_flight_run_is_not_retried(instance: dg.DagsterInstance) -> None:
+    dg.materialize([_archive_table_a], instance=instance)
+    first, cursor = _evaluate(instance, cursor=None)
+    assert isinstance(first, dg.RunRequest)
+    _create_attempt(instance, first, dg.DagsterRunStatus.STARTED)
+
+    second, _ = _evaluate(instance, cursor=cursor)
+    assert isinstance(second, dg.SkipReason)
+
+
+def test_new_materialization_during_a_failure_retries_the_combined_batch(
+    instance: dg.DagsterInstance,
+) -> None:
+    """A second table materializing while the first is being retried should
+    fold into one combined-batch retry, not race/duplicate.
+    """
+    dg.materialize([_archive_table_a], instance=instance)
+    first, cursor = _evaluate(instance, cursor=None)
+    assert isinstance(first, dg.RunRequest)
+    _create_attempt(instance, first, dg.DagsterRunStatus.FAILURE)
+
+    dg.materialize([_archive_table_b], instance=instance)
+    second, _ = _evaluate(instance, cursor=cursor)
+    assert isinstance(second, dg.RunRequest)
+    # A fresh batch (now includes table B too) -- first attempt at THIS batch.
+    assert second.run_key.endswith("__attempt0")
+    assert second.tags[_BATCH_ID_TAG] != first.tags[_BATCH_ID_TAG]

--- a/dg_projects/data_loading/data_loading_tests/test_translators.py
+++ b/dg_projects/data_loading/data_loading_tests/test_translators.py
@@ -8,6 +8,7 @@ default dev profile (filesystem storage).
 import pytest
 from dagster import AssetKey, AssetsDefinition, AssetSpec
 from data_loading.defs.ingestion import assets, translators
+from ol_orchestrate.lib.constants import EDXORG_DB_TABLES
 
 
 def _specs_by_key(assets_def: AssetsDefinition) -> dict[str, AssetSpec]:
@@ -44,8 +45,19 @@ def test_all_simple_sources_have_no_deps() -> None:
             assert list(spec.deps) == [], spec.key
 
 
+def _edxorg_table_asset(table_name: str) -> AssetsDefinition:
+    for assets_def in assets.edxorg_s3_table_assets:
+        if any(
+            spec.key.path[-1] == f"raw__edxorg__s3__tables__{table_name}"
+            for spec in assets_def.specs
+        ):
+            return assets_def
+    msg = f"no edxorg_s3 asset found for table {table_name}"
+    raise AssertionError(msg)
+
+
 def test_edxorg_spec_has_upstream_archive_dep() -> None:
-    spec = _specs_by_key(assets.edxorg_s3_consolidated_tables)[
+    spec = _specs_by_key(_edxorg_table_asset("auth_user"))[
         "ol_warehouse_raw_data/raw__edxorg__s3__tables__auth_user"
     ]
     assert spec.key == AssetKey(
@@ -56,6 +68,28 @@ def test_edxorg_spec_has_upstream_archive_dep() -> None:
     ]
     assert "dlt" in spec.kinds
     assert spec.group_name == "edxorg"  # scoped by source system
+
+
+def test_edxorg_tables_are_separate_ops() -> None:
+    """Each table is its own op (not one op looping over every table).
+
+    This is what lets Dagster's step executor run tables concurrently instead
+    of one giant table head-of-line-blocking every smaller table behind it.
+    """
+    assert len(assets.edxorg_s3_table_assets) == len(EDXORG_DB_TABLES)
+    op_names = {a.op.name for a in assets.edxorg_s3_table_assets}
+    assert len(op_names) == len(EDXORG_DB_TABLES)  # every op name is distinct
+
+
+def test_edxorg_tables_share_a_concurrency_pool() -> None:
+    """All edxorg_s3 table ops share one pool so concurrency is centrally bounded.
+
+    They all run inside the same Dagster run pod (K8sRunLauncher launches one
+    pod per run, not per step), which has a fixed CPU/memory budget -- the pool
+    lets that budget be tuned centrally via the Dagster instance UI.
+    """
+    pools = {a.op.pool for a in assets.edxorg_s3_table_assets}
+    assert pools == {"edxorg_s3"}
 
 
 def test_edxorg_programs_grouped_with_edxorg() -> None:

--- a/src/ol_dlt/ol_dlt/sources/edxorg_s3/__init__.py
+++ b/src/ol_dlt/ol_dlt/sources/edxorg_s3/__init__.py
@@ -175,3 +175,27 @@ def edxorg_s3_source(
 # Bucket prefix is "edxorg" to preserve the existing
 # s3://ol-data-lake-raw-<env>/edxorg destination path.
 edxorg_s3_pipeline = config.pipeline_for("edxorg", pipeline_name="edxorg_s3")
+
+
+def edxorg_s3_pipeline_for(table_name: str) -> dlt.Pipeline:
+    """Return a per-table pipeline for concurrent per-table materialization.
+
+    dlt pipelines keep a LOCAL working directory (extract/normalize staging,
+    schema + state cache) keyed by ``pipeline_name``. Tables loaded through
+    the shared ``edxorg_s3_pipeline`` singleton must run strictly
+    sequentially -- two pipeline instances with the same name racing in
+    separate OS processes corrupt each other's staging files (reproduced:
+    concurrent runs sharing one pipeline_name fail with
+    ``NormalizeJobFailed``/``FileNotFoundError`` on the shared staging dir).
+    A distinct, STABLE per-table pipeline_name isolates each table's local
+    state so tables can load concurrently. Still writes into the same
+    ``s3://.../edxorg`` destination bucket and dataset as ``edxorg_s3_pipeline``
+    -- only the local working-directory identity changes, not where data lands.
+
+    NOTE: this pipeline_name must stay stable across deploys -- dlt keys the
+    incremental ``modification_date`` cursor by pipeline_name + resource name,
+    so renaming it resets that table's cursor and triggers a full S3 reprocess
+    on the next run (safe -- merge + primary_key dedup makes reprocessing
+    idempotent -- but slower and more expensive for that one run).
+    """
+    return config.pipeline_for("edxorg", pipeline_name=f"edxorg_s3__{table_name}")

--- a/src/ol_dlt/tests/sources/test_edxorg_s3.py
+++ b/src/ol_dlt/tests/sources/test_edxorg_s3.py
@@ -87,8 +87,12 @@ def test_pipeline_for_gives_each_table_a_distinct_stable_name() -> None:
 def test_pipeline_for_shares_destination_with_singleton_pipeline() -> None:
     """Per-table pipelines still land in the same edxorg destination bucket."""
     per_table = edxorg_s3.edxorg_s3_pipeline_for("auth_user")
+    singleton = edxorg_s3.edxorg_s3_pipeline
+    # destination_name is just the destination TYPE (e.g. "filesystem") and
+    # would match even if the bucket/prefix diverged -- assert the actual
+    # bucket_url so this test guards the intended behavior.
     assert (
-        per_table.destination.destination_name
-        == edxorg_s3.edxorg_s3_pipeline.destination.destination_name
+        per_table.destination.config_params["bucket_url"]
+        == singleton.destination.config_params["bucket_url"]
     )
-    assert per_table.dataset_name == edxorg_s3.edxorg_s3_pipeline.dataset_name
+    assert per_table.dataset_name == singleton.dataset_name

--- a/src/ol_dlt/tests/sources/test_edxorg_s3.py
+++ b/src/ol_dlt/tests/sources/test_edxorg_s3.py
@@ -64,3 +64,31 @@ def test_source_yields_one_resource_per_table() -> None:
 def test_source_with_no_tables_yields_nothing() -> None:
     source = edxorg_s3.edxorg_s3_source(tables=[])
     assert dict(source.resources) == {}
+
+
+def test_pipeline_for_gives_each_table_a_distinct_stable_name() -> None:
+    """Each table's pipeline needs its own local working-directory identity.
+
+    Concurrent table loads sharing one pipeline_name race on dlt's local
+    extract/normalize staging files (reproduced independently: concurrent runs
+    sharing a pipeline_name fail with NormalizeJobFailed/FileNotFoundError).
+    """
+    a = edxorg_s3.edxorg_s3_pipeline_for("auth_user")
+    b = edxorg_s3.edxorg_s3_pipeline_for("student_courseenrollment")
+    assert a.pipeline_name == "edxorg_s3__auth_user"
+    assert b.pipeline_name == "edxorg_s3__student_courseenrollment"
+    # Same name every call -- required so the modification_date incremental
+    # cursor is found again on the next run instead of resetting.
+    assert edxorg_s3.edxorg_s3_pipeline_for("auth_user").pipeline_name == (
+        a.pipeline_name
+    )
+
+
+def test_pipeline_for_shares_destination_with_singleton_pipeline() -> None:
+    """Per-table pipelines still land in the same edxorg destination bucket."""
+    per_table = edxorg_s3.edxorg_s3_pipeline_for("auth_user")
+    assert (
+        per_table.destination.destination_name
+        == edxorg_s3.edxorg_s3_pipeline.destination.destination_name
+    )
+    assert per_table.dataset_name == edxorg_s3.edxorg_s3_pipeline.dataset_name


### PR DESCRIPTION
### What are the relevant tickets?
N/A -- requested directly during a follow-up session to the dlt hardening work in #2424.

### Description (What does it do?)
Two related edxorg_s3 fixes:

**1. Parallelize per-table loading (fixes head-of-line blocking).**

`edxorg_s3_consolidated_tables` was a single Dagster op looping sequentially over all 44 `EDXORG_DB_TABLES` in one process, one `dlt.run()` per table. Tables vary wildly in size, so one huge table (e.g. `courseware_studentmodule`) blocks every smaller table behind it for the full run's duration -- no full run of this asset has ever completed.

Safety check before parallelizing: the sequential design existed to avoid two past bugs (STS token exhaustion, and dlt's `ContainerInjectableContextMangled` from concurrent access to a non-thread-safe global). Confirmed via `kubectl get pods -n dagster` against `data-production-readonly` that production uses `K8sRunLauncher` (one pod per *run*, not per step) with no `executor_def` override anywhere in `ol-data-platform` or `ol-infrastructure` -- so Dagster's default `multiprocess_executor` applies: each step is a genuinely separate OS subprocess, not a thread, so parallelizing doesn't reintroduce that race. Considered `k8s_job_executor` (true per-pod isolation per step) and rejected it: 44 tables x per-pod K8s scheduling overhead would likely make the *typical* run slower for an isolation benefit not currently needed.

Found and fixed a real gotcha empirically before shipping: each table's op needs its own dlt `pipeline_name`. Reproduced directly -- 5 concurrent OS processes sharing one `pipeline_name` failed 3/5 times (`NormalizeJobFailed`/`FileNotFoundError`), racing on the same local staging directory. Added `edxorg_s3_pipeline_for(table_name)` giving each table a distinct, stable `edxorg_s3__<table>` pipeline_name. Side effect: this resets each table's `modification_date` incremental cursor on the first run under the new name -- a one-time full S3 reprocess, confirmed acceptable since no full run has ever completed.

Replaced the single multi-asset with one `@dlt_assets` op per table, each tagged `pool="edxorg_s3"` to bound concurrency (same pattern as the existing `pool="edxorg_archive"`), tunable via the Dagster instance UI.

**2. Stop the sensor from advancing cursors before a run succeeds.**

`edxorg_upstream_changes_sensor` called `context.advance_all_cursors()` before returning a `RunRequest`, so a launch or materialization failure was never retried until the next genuinely new upstream materialization arrived -- up to a full day away for this daily-polling sensor.

Investigated `context.last_run_key` (the sensor daemon's own tick-history bookkeeping) as the mechanism to check a prior run's outcome, but abandoned it after empirical testing showed it isn't populated the way a hand-rolled multi-tick test harness needs -- it's tracked by the real daemon loop, not the cursor string. Redesigned the sensor to be self-contained instead: every launched run is tagged with a deterministic `edxorg_s3/upstream_batch_id` (the sorted set of currently-unconsumed upstream materialization storage_ids), and the sensor queries `context.instance.get_run_records(...)` directly to find the latest attempt for the current batch:
- in-flight → skip, don't touch the cursor or fire again
- SUCCESS → advance cursors, skip
- FAILURE/CANCELED → cursor stays put, fire a fresh `RunRequest` with an incremented `__attemptN` run_key (Dagster refuses to relaunch an already-used run_key regardless of outcome)

If new upstream data arrives mid-retry, the batch_id naturally changes to include it, so retries and fresh triggers can't collide.

### Screenshots (if appropriate):
N/A -- no UI changes.

### How can this be tested?
- `cd src/ol_dlt && uv run pytest` -- 45 tests pass, including two new tests for `edxorg_s3_pipeline_for` (distinct stable per-table pipeline_name; shares destination/dataset with the existing singleton pipeline).
- `cd dg_projects/data_loading && uv run pytest` -- 17 tests pass:
  - `test_edxorg_tables_are_separate_ops` / `test_edxorg_tables_share_a_concurrency_pool` -- 44 distinct ops, all tagged `pool="edxorg_s3"`.
  - `test_sensor.py` (7 tests) -- runs the real decorated sensor function against a real (ephemeral, not mocked) `DagsterInstance`: cold start, first fire, re-request when no run was actually launched yet, retry-with-fresh-key on failure (including repeated failure), cursor advancement + retry-stop on success, in-flight skip, and combined-batch retry when new data arrives mid-failure.
- `ruff check` / `ruff format` / `mypy` all clean (verified via the repo's pre-commit hooks on both commits).
- The concurrent-pipeline_name race (parallelization fix) and the retry state machine (sensor fix) were both validated by direct reproduction/execution, not just read through -- details in the commit messages.

### Additional Context
Whoever tunes the `edxorg_s3` pool's slot count in the Dagster instance UI post-deploy should start conservative (e.g. 3-4 concurrent slots) given the run pod's default 3 CPU / 8Gi memory budget, and watch the first full run's memory usage (it will be a full S3 reprocess for all 44 tables, per the cursor-reset note above) before raising it.