### PR TITLE
Harden lakehouse dagster-dbt integration (artifacts, catalog cadence, project wiring)

### DIFF
--- a/dg_projects/lakehouse/lakehouse/assets/lakehouse/dbt.py
+++ b/dg_projects/lakehouse/lakehouse/assets/lakehouse/dbt.py
@@ -28,10 +28,28 @@ DBT_REPO_DIR = (
     else Path("/opt/dbt")
 )
 
-dbt_project = DbtProject(
-    project_dir=DBT_REPO_DIR, target=os.environ.get("DAGSTER_DBT_TARGET", DAGSTER_ENV)
-)
+
+def _resolve_dbt_target() -> str:
+    """Resolve the dbt profile target for this environment.
+
+    Single source of truth shared by the DbtProject (which parses the manifest,
+    and therefore the Dagster asset graph) and the DbtCliResource that executes
+    it, so the graph always matches what actually runs. ``DAGSTER_DBT_TARGET``
+    overrides the mapping when set.
+    """
+    if override := os.environ.get("DAGSTER_DBT_TARGET"):
+        return override
+    # qa and production both execute against the production target.
+    return {"dev": "dev_production", "ci": "ci"}.get(DAGSTER_ENV, "production")
+
+
+DBT_TARGET = _resolve_dbt_target()
+
+dbt_project = DbtProject(project_dir=DBT_REPO_DIR, target=DBT_TARGET)
 dbt_project.prepare_if_dev()
+
+# Built once and reused rather than reconstructed for every dbt node.
+_DBT_AUTOMATION_CONDITION = upstream_or_code_changes()
 
 
 class DbtAutomationTranslator(DagsterDbtTranslator):
@@ -39,7 +57,7 @@ class DbtAutomationTranslator(DagsterDbtTranslator):
         self,
         dbt_resource_props: Mapping[str, Any],  # noqa: ARG002
     ) -> AutomationCondition | None:
-        return upstream_or_code_changes()
+        return _DBT_AUTOMATION_CONDITION
 
     def get_group_name(self, dbt_resource_props: Mapping[str, Any]) -> str | None:
         """

--- a/dg_projects/lakehouse/lakehouse/assets/lakehouse/dbt.py
+++ b/dg_projects/lakehouse/lakehouse/assets/lakehouse/dbt.py
@@ -3,7 +3,13 @@ from collections.abc import Mapping
 from pathlib import Path
 from typing import Any
 
-from dagster import AssetExecutionContext, AutomationCondition
+from dagster import (
+    AssetExecutionContext,
+    AutomationCondition,
+    OpExecutionContext,
+    job,
+    op,
+)
 from dagster_dbt import (
     DagsterDbtTranslator,
     DagsterDbtTranslatorSettings,
@@ -63,44 +69,57 @@ def full_dbt_project(
     build_invocation = dbt.cli(dbt_build_args, context=context)
     yield from (build_invocation.stream().fetch_column_metadata().fetch_row_counts())
 
+    # Upload this run's results to a per-run versioned S3 key so OpenMetadata can
+    # ingest the model/test outcomes of every incremental and full run.
+    #
+    # manifest.json and catalog.json are NOT generated here: producing the catalog
+    # recompiles the whole project and queries every relation, which is far too
+    # expensive to repeat on each incremental subset build. That work lives in the
+    # dedicated `dbt_docs_artifacts_job`, which runs on a daily schedule.
     if DAGSTER_ENV != "dev":
         if not dbt_s3_artifacts.s3_bucket:
             context.log.warning(
-                "DBT_ARTIFACTS_S3_BUCKET is not configured; dbt artifacts will not "
-                "be uploaded to S3 for OpenMetadata ingestion."
+                "DBT_ARTIFACTS_S3_BUCKET is not configured; dbt run results will "
+                "not be uploaded to S3 for OpenMetadata ingestion."
             )
         else:
-            # `dbt docs generate` recompiles the project and writes its own
-            # run_results.json to the target path. Point it at a dedicated
-            # subdirectory so it does not overwrite the build's run_results.json
-            # (which records the actual model/test outcomes we ship per run).
-            docs_target_path = build_invocation.target_path / "docs"
-            # Run docs generate without context so it covers the full project and
-            # doesn't emit redundant Dagster events.
-            docs_invocation = dbt.cli(
-                ["docs", "generate"],
-                target_path=docs_target_path,
-                raise_on_error=False,
-            )
-            docs_invocation.wait()
-
-            # run_results.json is uploaded to a per-run versioned key so results
-            # from every incremental and full run are captured; it must come from
-            # the build invocation, not docs generate.
             dbt_s3_artifacts.upload_artifacts(
                 build_invocation.target_path, ["run_results.json"], context
             )
 
-            # manifest.json and catalog.json describe the full project and are
-            # deduplicated by content hash, only uploaded when their content has
-            # changed.
-            docs_artifacts = ["manifest.json"]
-            if (docs_target_path / "catalog.json").exists():
-                docs_artifacts.append("catalog.json")
-            else:
-                context.log.warning(
-                    "dbt docs generate did not produce catalog.json; "
-                    "it will be omitted from the OpenMetadata artifact upload"
-                )
 
-            dbt_s3_artifacts.upload_artifacts(docs_target_path, docs_artifacts, context)
+@op(description="Generate dbt docs artifacts and upload them to S3 for OpenMetadata.")
+def generate_dbt_docs_artifacts(
+    context: OpExecutionContext,
+    dbt: DbtCliResource,
+    dbt_s3_artifacts: DbtS3ArtifactsResource,
+) -> None:
+    if not dbt_s3_artifacts.s3_bucket:
+        context.log.warning(
+            "DBT_ARTIFACTS_S3_BUCKET is not configured; dbt docs artifacts will "
+            "not be uploaded to S3 for OpenMetadata ingestion."
+        )
+        return
+
+    # Run without a Dagster context so it covers the full project (not just a
+    # selected subset) and doesn't emit redundant asset materialization events.
+    docs_invocation = dbt.cli(["docs", "generate"], raise_on_error=False)
+    docs_invocation.wait()
+
+    # manifest.json and catalog.json are deduplicated by content hash, so they are
+    # only re-uploaded when their content has actually changed.
+    artifacts = ["manifest.json"]
+    if (docs_invocation.target_path / "catalog.json").exists():
+        artifacts.append("catalog.json")
+    else:
+        context.log.warning(
+            "dbt docs generate did not produce catalog.json; "
+            "it will be omitted from the OpenMetadata artifact upload"
+        )
+
+    dbt_s3_artifacts.upload_artifacts(docs_invocation.target_path, artifacts, context)
+
+
+@job(description="Regenerate dbt docs artifacts for OpenMetadata on a schedule.")
+def dbt_docs_artifacts_job() -> None:
+    generate_dbt_docs_artifacts()

--- a/dg_projects/lakehouse/lakehouse/assets/lakehouse/dbt.py
+++ b/dg_projects/lakehouse/lakehouse/assets/lakehouse/dbt.py
@@ -70,29 +70,37 @@ def full_dbt_project(
                 "be uploaded to S3 for OpenMetadata ingestion."
             )
         else:
+            # `dbt docs generate` recompiles the project and writes its own
+            # run_results.json to the target path. Point it at a dedicated
+            # subdirectory so it does not overwrite the build's run_results.json
+            # (which records the actual model/test outcomes we ship per run).
+            docs_target_path = build_invocation.target_path / "docs"
             # Run docs generate without context so it covers the full project and
-            # doesn't emit redundant Dagster events. Re-use the build's target_path
-            # so all artifacts land in the same directory.
-            # run_results.json is uploaded to a per-run versioned key so results
-            # from every incremental and full run are captured. manifest.json and
-            # catalog.json are deduplicated by content hash and only uploaded when
-            # their content has changed.
+            # doesn't emit redundant Dagster events.
             docs_invocation = dbt.cli(
                 ["docs", "generate"],
-                target_path=build_invocation.target_path,
+                target_path=docs_target_path,
                 raise_on_error=False,
             )
             docs_invocation.wait()
 
-            artifacts = ["manifest.json", "run_results.json"]
-            if (build_invocation.target_path / "catalog.json").exists():
-                artifacts.append("catalog.json")
+            # run_results.json is uploaded to a per-run versioned key so results
+            # from every incremental and full run are captured; it must come from
+            # the build invocation, not docs generate.
+            dbt_s3_artifacts.upload_artifacts(
+                build_invocation.target_path, ["run_results.json"], context
+            )
+
+            # manifest.json and catalog.json describe the full project and are
+            # deduplicated by content hash, only uploaded when their content has
+            # changed.
+            docs_artifacts = ["manifest.json"]
+            if (docs_target_path / "catalog.json").exists():
+                docs_artifacts.append("catalog.json")
             else:
                 context.log.warning(
                     "dbt docs generate did not produce catalog.json; "
                     "it will be omitted from the OpenMetadata artifact upload"
                 )
 
-            dbt_s3_artifacts.upload_artifacts(
-                build_invocation.target_path, artifacts, context
-            )
+            dbt_s3_artifacts.upload_artifacts(docs_target_path, docs_artifacts, context)

--- a/dg_projects/lakehouse/lakehouse/definitions.py
+++ b/dg_projects/lakehouse/lakehouse/definitions.py
@@ -37,7 +37,11 @@ from lakehouse.assets.instructor_onboarding import (
     generate_instructor_onboarding_user_list,
     update_access_forge_repo,
 )
-from lakehouse.assets.lakehouse.dbt import DBT_REPO_DIR, full_dbt_project
+from lakehouse.assets.lakehouse.dbt import (
+    DBT_REPO_DIR,
+    dbt_docs_artifacts_job,
+    full_dbt_project,
+)
 from lakehouse.assets.superset import create_superset_asset
 from lakehouse.resources.airbyte import AirbyteOSSWorkspace
 from lakehouse.resources.dbt_s3_artifacts import DbtS3ArtifactsResource
@@ -336,6 +340,18 @@ iceberg_raw_maintenance_schedule = ScheduleDefinition(
     default_status=DefaultScheduleStatus.STOPPED,
 )
 
+# Regenerate dbt docs artifacts (manifest.json + catalog.json) for OpenMetadata
+# once daily. Decoupled from model materialization because catalog generation
+# recompiles the whole project and queries every relation. Default STOPPED; enable
+# in production via the Dagster UI or Terraform after verifying the first run.
+dbt_docs_artifacts_schedule = ScheduleDefinition(
+    name="dbt_docs_artifacts_daily",
+    job=dbt_docs_artifacts_job,
+    cron_schedule="0 4 * * *",
+    execution_timezone="UTC",
+    default_status=DefaultScheduleStatus.STOPPED,
+)
+
 # Instructor onboarding schedule
 instructor_onboarding_schedule = ScheduleDefinition(
     name="instructor_onboarding_daily_schedule",
@@ -402,11 +418,16 @@ defs = Definitions(
             | AssetSelection.groups("superset_starrocks_dataset"),
         ),
     ],
-    jobs=[*airbyte_asset_jobs, iceberg_snapshot_pointer_repair_job],
+    jobs=[
+        *airbyte_asset_jobs,
+        iceberg_snapshot_pointer_repair_job,
+        dbt_docs_artifacts_job,
+    ],
     schedules=[
         *airbyte_update_schedules,
         instructor_onboarding_schedule,
         iceberg_dbt_maintenance_schedule,
         iceberg_raw_maintenance_schedule,
+        dbt_docs_artifacts_schedule,
     ],
 )

--- a/dg_projects/lakehouse/lakehouse/definitions.py
+++ b/dg_projects/lakehouse/lakehouse/definitions.py
@@ -2,7 +2,6 @@
 
 import os
 import re
-from pathlib import Path
 
 from dagster import (
     AssetSelection,
@@ -21,7 +20,6 @@ from dagster_airbyte import (
 )
 from dagster_dbt import (
     DbtCliResource,
-    DbtProject,
 )
 from ol_orchestrate.lib.constants import DAGSTER_ENV, VAULT_ADDRESS
 from ol_orchestrate.lib.utils import authenticate_vault
@@ -39,6 +37,7 @@ from lakehouse.assets.instructor_onboarding import (
 )
 from lakehouse.assets.lakehouse.dbt import (
     DBT_REPO_DIR,
+    DBT_TARGET,
     dbt_docs_artifacts_job,
     full_dbt_project,
 )
@@ -78,20 +77,19 @@ airbyte_host = os.environ.get("DAGSTER_AIRBYTE_HOST", airbyte_host_map[DAGSTER_E
 # Set SKIP_AIRBYTE=1 to disable Airbyte connection and asset loading
 SKIP_AIRBYTE = os.environ.get("SKIP_AIRBYTE", "").lower() in ("1", "true", "yes")
 
-# Determine dagster URL and dbt target based on environment
+# Determine dagster URL based on environment. The dbt target is resolved once in
+# lakehouse.assets.lakehouse.dbt (DBT_TARGET) and shared by the DbtProject and the
+# DbtCliResource so the parsed asset graph matches what executes.
 if DAGSTER_ENV == "dev":
     dagster_url = "http://localhost:3000"
-    dbt_target = "dev_production"
 elif DAGSTER_ENV == "ci":
     dagster_url = "https://pipelines-ci.odl.mit.edu"
-    dbt_target = "ci"
 else:
     dagster_url = (
         "https://pipelines.odl.mit.edu"
         if DAGSTER_ENV == "production"
         else "https://pipelines-qa.odl.mit.edu"
     )
-    dbt_target = "production"
 
 # Initialize vault with proper auth
 try:
@@ -109,7 +107,6 @@ except Exception as e:  # noqa: BLE001 (resilient loading)
     vault = Vault(vault_addr=VAULT_ADDRESS, vault_auth_type="github")
     vault_authenticated = False
     dagster_url = "http://localhost:3000"
-    dbt_target = "dev_production"
 
 airbyte_workspace = (
     AirbyteOSSWorkspace(
@@ -131,19 +128,9 @@ airbyte_workspace = (
 dbt_config = {
     "project_dir": str(DBT_REPO_DIR),
     "profiles_dir": str(DBT_REPO_DIR),
-    "target": dbt_target,
+    "target": DBT_TARGET,
 }
 dbt_cli = DbtCliResource(**dbt_config)
-
-# Initialize dbt project - handle both local dev and Docker paths
-if Path("/app/ol_dbt").exists():
-    # In Docker container
-    DBT_PROJECT_DIR = Path("/app/ol_dbt")
-else:
-    # Local development
-    DBT_PROJECT_DIR = Path(__file__).resolve().parents[3] / "src" / "ol_dbt"
-
-dbt_project = DbtProject(project_dir=DBT_PROJECT_DIR)
 
 
 class OLAirbyteTranslator(DagsterAirbyteTranslator):

--- a/dg_projects/lakehouse/lakehouse/resources/dbt_s3_artifacts.py
+++ b/dg_projects/lakehouse/lakehouse/resources/dbt_s3_artifacts.py
@@ -3,7 +3,7 @@ from pathlib import Path
 
 import boto3
 from botocore.exceptions import ClientError
-from dagster import AssetExecutionContext, ConfigurableResource
+from dagster import AssetExecutionContext, ConfigurableResource, OpExecutionContext
 from pydantic import Field, field_validator
 
 
@@ -29,7 +29,7 @@ class DbtS3ArtifactsResource(ConfigurableResource):
         self,
         target_path: Path,
         artifacts: list[str],
-        context: AssetExecutionContext,
+        context: AssetExecutionContext | OpExecutionContext,
     ) -> None:
         """Upload artifact files from *target_path* to S3 with content-based versioning.
 


### PR DESCRIPTION
## What are the relevant tickets?

None — this came out of an audit of the dagster-dbt integration in `dg_projects/lakehouse/lakehouse/assets/lakehouse/dbt.py`.

## Description (What does this do?)

Hardens how the lakehouse code location uses the `dagster-dbt` integration. The core `@dbt_assets` wiring (`DbtProject` + `prepare_if_dev()`, `dbt.cli(["build"], context=context)` auto-subsetting, asset checks) is already the recommended shape and is unchanged. The problems were in the artifact/docs handling and in duplicated project wiring across two files. Three stacked commits, one finding each:

**1. `fix`: stop `dbt docs generate` from clobbering the build's `run_results.json`**
`dbt docs generate` recompiles the project and writes its own `run_results.json` to `DBT_TARGET_PATH`. The asset pointed it at the build invocation's `target_path`, so the catalog run's `run_results.json` overwrote the build's *before* it was uploaded to the per-run S3 key — meaning OpenMetadata ingested compile-only results instead of the actual model/test outcomes. (Verified against `dbt/task/runnable.py`, which unconditionally writes `run_results.json` in the run path.) Docs generate now uses a dedicated `docs/` subdirectory; `run_results.json` is uploaded from the build, `manifest.json`/`catalog.json` from docs.

**2. `perf`: move catalog generation off the per-build path**
`dbt docs generate` was running after *every* build, including the many incremental subset runs from sync-and-stage jobs and the automation sensor — producing full-project catalog queries (a metadata query per relation) dozens of times a day. Split the concerns: the `full_dbt_project` asset now only uploads the per-run `run_results.json`; `manifest.json`/`catalog.json` are produced by a new dedicated `dbt_docs_artifacts_job` on a daily `dbt_docs_artifacts_daily` schedule (default `STOPPED`, matching the other maintenance schedules — enable in the UI/Terraform after verifying the first run).

**3. `refactor`: single-source the dbt project/target wiring**
The `DbtProject` that parses the manifest (and therefore the Dagster asset graph) used target `DAGSTER_ENV` while the `DbtCliResource` that executes it used a different value — parsing under one target and running under another can diverge on any `{{ target.name }}`-conditional config. The target is now resolved once as `DBT_TARGET` and shared. Also removed a second, unused `DbtProject` built from a `DBT_PROJECT_DIR` (`/app/ol_dbt`) that contradicted `DBT_REPO_DIR` (`/opt/dbt`), plus its now-dead imports, and hoisted the dbt `AutomationCondition` to a module constant.

## How can this be tested?

- `pre-commit` (ruff + mypy) passes on all three commits.
- `dagster` loads the changes cleanly: the target resolver yields `dev→dev_production`, `ci→ci`, `qa→production`, `production→production` (matching the previous runtime mapping); `full_dbt_project` builds its 646 asset keys from the manifest; and `dbt_docs_artifacts_job` + `dbt_docs_artifacts_daily` wire together with exactly the `dbt` and `dbt_s3_artifacts` resources the code location already provides.
- Behavioral verification of the runtime effect (per-run `run_results.json` reflecting the build, daily catalog refresh) requires a non-dev deployment with `DBT_ARTIFACTS_S3_BUCKET` configured.

## Reviewer notes

The daily schedule ships `STOPPED`; the OpenMetadata artifact refresh cadence changes from "every build" to "once daily" once it's enabled. If you want the previous every-build catalog refresh for some reason, that's the intentional trade-off in commit 2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
