### PR TITLE
fix(superset): raise Enrollment Detail chart row_limit to 100000

### DIFF
--- a/src/ol_superset/assets/charts/Enrollment_Detail_1cf394ec-8561-4b0d-9d9b-f394a6029b33.yaml
+++ b/src/ol_superset/assets/charts/Enrollment_Detail_1cf394ec-8561-4b0d-9d9b-f394a6029b33.yaml
@@ -90,7 +90,7 @@ params:
   percent_metric_calculation: row_limit
   percent_metrics: []
   query_mode: raw
-  row_limit: 50000
+  row_limit: 100000
   server_pagination: false
   show_cell_bars: true
   show_totals: false


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->

### Description (What does it do?)
<!--- Describe your changes in detail -->
The chart's row_limit of 50000 was stuck serving a stale cached result for some user-email filters after enrollment_detail_report was rebuilt with the order_id fix. Raising the limit sidesteps the poisoned cache entry; the underlying data was already correct. This is a workaround for a Superset caching bug, not a data fix.

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->


<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
