### PR TITLE
fix(dbt): register source() dependency edge on DuckDB targets

### DIFF
--- a/.github/scripts/assert_manifest_has_source_lineage.py
+++ b/.github/scripts/assert_manifest_has_source_lineage.py
@@ -1,0 +1,28 @@
+#!/usr/bin/env python3
+"""Regression guard for override_source.sql on DuckDB targets.
+
+On DuckDB targets, source() must still register a source.* dependency edge
+(not just render the Glue view name), or manifest-based lineage/state:modified+
+selection goes blind. Run after `dbt parse -t dev` against target/manifest.json.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+manifest = json.loads(Path("target/manifest.json").read_text())
+models = [n for n in manifest["nodes"].values() if n["resource_type"] == "model"]
+with_source = [
+    m
+    for m in models
+    if any(d.startswith("source.") for d in m.get("depends_on", {}).get("nodes", []))
+]
+sys.stdout.write(
+    f"{len(with_source)}/{len(models)} models have a source.* dependency edge\n"
+)
+if not with_source:
+    sys.exit(
+        "No model has a source.* dependency edge — override_source.sql regression?"
+    )

--- a/.github/workflows/dbt_pr_ci.yaml
+++ b/.github/workflows/dbt_pr_ci.yaml
@@ -64,19 +64,7 @@ jobs:
     # name), or manifest-based lineage/state:modified+ selection goes blind.
     - name: Assert manifest has source lineage
       working-directory: src/ol_dbt
-      run: |
-        python3 -c "
-        import json, sys
-        manifest = json.load(open('target/manifest.json'))
-        models = [n for n in manifest['nodes'].values() if n['resource_type'] == 'model']
-        with_source = [
-            m for m in models
-            if any(d.startswith('source.') for d in m.get('depends_on', {}).get('nodes', []))
-        ]
-        print(f'{len(with_source)}/{len(models)} models have a source.* dependency edge')
-        if len(with_source) == 0:
-            sys.exit('No model has a source.* dependency edge — override_source.sql regression?')
-        "
+      run: python3 "${{ github.workspace }}/.github/scripts/assert_manifest_has_source_lineage.py"
 
     # Dimensional-layering gate (#2072 DoD): global, baselined — fails only on
     # NEW marts/reporting → staging/intermediate references.

--- a/.github/workflows/dbt_pr_ci.yaml
+++ b/.github/workflows/dbt_pr_ci.yaml
@@ -59,6 +59,25 @@ jobs:
         uv run --with dbt-duckdb dbt deps
         uv run --with dbt-duckdb dbt parse -t dev
 
+    # Regression guard for override_source.sql: on DuckDB targets, source() must
+    # still register a source.* dependency edge (not just render the Glue view
+    # name), or manifest-based lineage/state:modified+ selection goes blind.
+    - name: Assert manifest has source lineage
+      working-directory: src/ol_dbt
+      run: |
+        python3 -c "
+        import json, sys
+        manifest = json.load(open('target/manifest.json'))
+        models = [n for n in manifest['nodes'].values() if n['resource_type'] == 'model']
+        with_source = [
+            m for m in models
+            if any(d.startswith('source.') for d in m.get('depends_on', {}).get('nodes', []))
+        ]
+        print(f'{len(with_source)}/{len(models)} models have a source.* dependency edge')
+        if len(with_source) == 0:
+            sys.exit('No model has a source.* dependency edge — override_source.sql regression?')
+        "
+
     # Dimensional-layering gate (#2072 DoD): global, baselined — fails only on
     # NEW marts/reporting → staging/intermediate references.
     - name: Dimensional-layering lint

--- a/src/ol_dbt/macros/override_source.sql
+++ b/src/ol_dbt/macros/override_source.sql
@@ -18,6 +18,10 @@
 
     {% set glue_database = source_to_database_map.get(source_name, 'ol_warehouse_production_raw') %}
 
+    {# Register the source dependency edge in the manifest (discarding the relation) so
+       lineage/state-based selection sees this model's source.* deps on DuckDB targets too #}
+    {% do builtins.source(source_name, table_name) %}
+
     {# Return the fully qualified view name #}
     glue__{{ glue_database }}__{{ table_name }}
   {% else %}


### PR DESCRIPTION
### What are the relevant tickets?
Part of https://github.com/mitodl/ol-data-platform/issues/2407

### Description (What does it do?)
`src/ol_dbt/macros/override_source.sql`'s DuckDB branch rendered the `glue__<db>__<table>` view name as a plain string, but never called dbt's `builtins.source(source_name, table_name)`. That means dbt's parse-time dependency capture never fired for source() calls on DuckDB targets: `dbt parse -t dev` (the target used by every PR in `.github/workflows/dbt_pr_ci.yaml`) produced a manifest with **zero `source.*` dependency edges across all 652 models**, despite 373 sources being defined.

Blast radius of the bug:
- `ol-dbt validate`'s `upstream_refs` check can never resolve source columns from a dev manifest — every model that reads directly from a source warns.
- Any future `state:modified+` selection based on the dev/CI manifest is blind to source definition changes.
- Any manifest-lineage consumer (impact analysis, docs, OpenMetadata ingestion if ever run off a dev manifest) can't see source → model edges.

Fix: call `builtins.source(source_name, table_name)` (via `{% do %}`, discarding the relation) before emitting the Glue view name string, so the dependency edge is registered while the rendered SQL is unchanged.

Also added a CI assertion step (`Assert manifest has source lineage`) right after `dbt parse -t dev` in `dbt_pr_ci.yaml` that fails loudly if a parsed manifest has zero `source.*` edges, so this can't silently regress again.

### How can this be tested?
```
cd src/ol_dbt
dbt deps
dbt parse -t dev
python3 -c "
import json
m = json.load(open('target/manifest.json'))
models = [n for n in m['nodes'].values() if n['resource_type'] == 'model']
with_source = [n for n in models if any(d.startswith('source.') for d in n.get('depends_on', {}).get('nodes', []))]
print(f'{len(with_source)}/{len(models)} models have a source.* dependency edge')
"
```
Before this change: `0/652`. After: `354/652` (the remaining models genuinely have no direct source dependency — they only `ref()` other models).

Also verified compiled SQL is unaffected — `dbt compile -t dev --select irx__mitxonline__openedx__mysql__student_courseenrollment` still renders the `glue__ol_warehouse_production_raw__...` identifier exactly as before.

### Additional Context
`override_ref.sql` (the companion macro override for `ref()`) doesn't have this problem because it always calls `builtins.ref()` regardless of branch — this fix brings `override_source.sql` to parity.