### PR TITLE
fix(ol_dbt_cli): impact reports BREAKING for deleted models still ref()'d

### DIFF
--- a/src/ol_dbt_cli/ol_dbt_cli/commands/impact.py
+++ b/src/ol_dbt_cli/ol_dbt_cli/commands/impact.py
@@ -22,6 +22,7 @@ from ol_dbt_cli.lib.git_utils import (
     get_changed_sql_models,
     get_file_at_ref,
     get_repo_root,
+    resolve_merge_base,
 )
 from ol_dbt_cli.lib.manifest import (
     ManifestRegistry,
@@ -282,7 +283,7 @@ def _get_downstream_yaml(
 def _analyse_model(
     model_name: str,
     sql_file: Path,
-    base_ref: str,
+    merge_base: str,
     yaml_registry: YamlRegistry,
     manifest: ManifestRegistry | None,
     sql_models_by_name: dict[str, ParsedModel],
@@ -300,8 +301,10 @@ def _analyse_model(
 
     current_cols = current_parsed.output_columns
 
-    # Base (origin/main) column set
-    base_content = get_file_at_ref(sql_file, base_ref, repo_root=repo_root)
+    # Base column set, read at the merge-base commit (branch point) rather than
+    # base_ref's current tip, so commits landed on base_ref after the branch
+    # point don't leak into the "base" content (see resolve_merge_base).
+    base_content = get_file_at_ref(sql_file, merge_base, repo_root=repo_root)
     if base_content is None:
         # New model — no base to compare against
         return ImpactAlert(
@@ -565,6 +568,12 @@ def impact(
         err_console.print(f"[red]Error:[/] {exc}")
         sys.exit(1)
 
+    try:
+        merge_base = resolve_merge_base(base_ref, repo_root=repo_root)
+    except RuntimeError as exc:
+        err_console.print(f"[red]Error resolving merge-base vs {base_ref}:[/] {exc}")
+        sys.exit(1)
+
     models_dir = dbt_dir / "models"
 
     # Resolve compiled SQL directory (Jinja-free, most accurate)
@@ -675,7 +684,7 @@ def impact(
         alert = _analyse_model(
             name,
             sql_file,
-            base_ref,
+            merge_base,
             yaml_registry,
             manifest,
             sql_models_by_name,

--- a/src/ol_dbt_cli/ol_dbt_cli/commands/impact.py
+++ b/src/ol_dbt_cli/ol_dbt_cli/commands/impact.py
@@ -20,6 +20,7 @@ from rich.console import Console
 
 from ol_dbt_cli.lib.git_utils import (
     get_changed_sql_models,
+    get_deleted_sql_models,
     get_file_at_ref,
     get_repo_root,
     resolve_merge_base,
@@ -366,6 +367,59 @@ def _analyse_model(
     )
 
 
+def _analyse_deleted_model(
+    model_name: str,
+    path_at_base: Path,
+    merge_base: str,
+    manifest: ManifestRegistry | None,
+    sql_models_by_name: dict[str, ParsedModel],
+    repo_root: Path,
+) -> ImpactAlert:
+    """Return an :class:`ImpactAlert` for *model_name*, deleted since *merge_base*.
+
+    The relation no longer exists, so any surviving ``ref()`` to it is broken
+    outright — not just for specific columns. Consumers are found via textual
+    ``ref()`` scanning of every currently-parsed model (works even without a
+    manifest, and even though a *fresh* manifest can never itself contain a
+    dangling ref to a deleted model — dbt parse would already have failed on
+    it) plus, if a stale manifest still has the deleted node registered, its
+    recorded children.
+    """
+    base_content = get_file_at_ref(path_at_base, merge_base, repo_root=repo_root)
+    base_cols: set[str] = set()
+    if base_content is not None:
+        base_cols = parse_model_sql_at_content(model_name, base_content).output_columns
+
+    consumers = {name for name, parsed in sql_models_by_name.items() if model_name in parsed.refs}
+
+    manifest_available = False
+    if manifest is not None:
+        manifest_model = manifest.get_model(model_name)
+        if manifest_model is not None:
+            manifest_available = True
+            consumers |= {c.name for c in manifest.get_children(manifest_model.unique_id)}
+
+    downstream = [
+        DownstreamImpact(model_name=c, affected_columns=sorted(base_cols), depth=1) for c in sorted(consumers)
+    ]
+
+    if downstream:
+        level = AlertLevel.BREAKING
+        msg = f"Model '{model_name}' was deleted but is still ref()'d by {len(downstream)} downstream model(s)."
+    else:
+        level = AlertLevel.INFO
+        msg = f"Model '{model_name}' was deleted — no remaining ref() to it detected."
+
+    return ImpactAlert(
+        level=level,
+        changed_model=model_name,
+        column_changes=[ColumnChange(column=c, change_type="removed") for c in sorted(base_cols)],
+        downstream=downstream,
+        message=msg,
+        manifest_available=manifest_available,
+    )
+
+
 # ---------------------------------------------------------------------------
 # Output rendering
 # ---------------------------------------------------------------------------
@@ -618,8 +672,17 @@ def impact(
         except Exception as exc:  # noqa: BLE001
             parse_errors[name] = str(exc)
 
+    try:
+        deleted_models = get_deleted_sql_models(dbt_dir, base_ref=base_ref, repo_root=repo_root)
+    except RuntimeError as exc:
+        err_console.print(f"[red]Error resolving git diff:[/] {exc}")
+        sys.exit(1)
+
     # Determine which models to analyse
     if model:
+        if model not in sql_file_map and model not in deleted_models:
+            err_console.print(f"[red]Error:[/] --model value '{model}' did not match any model file.")
+            sys.exit(1)
         target_names = [model]
     else:
         try:
@@ -680,6 +743,11 @@ def impact(
     for name in target_names:
         sql_file = sql_file_map.get(name)
         if sql_file is None:
+            path_at_base = deleted_models.get(name)
+            if path_at_base is not None:
+                alerts.append(
+                    _analyse_deleted_model(name, path_at_base, merge_base, manifest, sql_models_by_name, repo_root)
+                )
             continue
         alert = _analyse_model(
             name,

--- a/src/ol_dbt_cli/ol_dbt_cli/lib/git_utils.py
+++ b/src/ol_dbt_cli/ol_dbt_cli/lib/git_utils.py
@@ -99,6 +99,33 @@ def get_changed_sql_models(
     return names
 
 
+def get_deleted_sql_models(
+    dbt_dir: Path,
+    base_ref: str = "origin/main",
+    repo_root: Path | None = None,
+) -> dict[str, Path]:
+    """Return ``{model_name: path_at_merge_base}`` for .sql files deleted since *base_ref*.
+
+    Scoped to *dbt_dir*/models/. The returned paths no longer exist on disk —
+    pass them to :func:`get_file_at_ref` with the merge-base ref (see
+    :func:`resolve_merge_base`) to read their last content.
+    """
+    root = repo_root or get_repo_root(dbt_dir)
+    models_dir = dbt_dir / "models"
+    merge_base = resolve_merge_base(base_ref, repo_root=root)
+    output = _run_git(["diff", "--name-status", "--diff-filter=D", merge_base, "HEAD"], cwd=root)
+    deleted: dict[str, Path] = {}
+    for line in output.splitlines():
+        parts = line.split("\t")
+        if len(parts) != 2:  # noqa: PLR2004
+            continue
+        _status, rel_path = parts
+        path = root / rel_path
+        if path.suffix == ".sql" and _is_under(path, models_dir):
+            deleted[path.stem] = path
+    return deleted
+
+
 def get_changed_yaml_models(
     dbt_dir: Path,
     base_ref: str = "origin/main",

--- a/src/ol_dbt_cli/ol_dbt_cli/lib/git_utils.py
+++ b/src/ol_dbt_cli/ol_dbt_cli/lib/git_utils.py
@@ -31,20 +31,42 @@ def get_repo_root(start: Path | None = None) -> Path:
         raise RuntimeError(msg) from exc
 
 
+def resolve_merge_base(base_ref: str, repo_root: Path | None = None) -> str:
+    """Return the merge-base commit SHA of *base_ref* and HEAD.
+
+    This is the fork point where the current branch diverged from *base_ref* —
+    diffing/fetching against it (rather than *base_ref* directly) gives
+    three-dot diff semantics, matching what a GitHub PR diff shows. Once
+    *base_ref* advances past the branch point (e.g. other PRs merge to main
+    while this one is open), a plain two-dot diff against *base_ref* would
+    incorrectly include those unrelated changes in the changed set.
+    """
+    root = repo_root or get_repo_root()
+    return _run_git(["merge-base", base_ref, "HEAD"], cwd=root).strip()
+
+
 def get_changed_files(
     base_ref: str = "origin/main",
     repo_root: Path | None = None,
+    *,
+    include_untracked: bool = True,
 ) -> list[Path]:
-    """Return absolute paths of tracked files changed vs *base_ref*.
+    """Return absolute paths of tracked files changed since diverging from *base_ref*.
 
-    Includes files changed relative to *base_ref* (committed), files staged for
-    commit, and unstaged modifications to tracked files.  Untracked (new) files
-    that have not yet been ``git add``-ed are **not** included.
+    Diffs against ``merge-base(base_ref, HEAD)`` rather than *base_ref* directly
+    (three-dot semantics; see :func:`resolve_merge_base`), so commits landed on
+    *base_ref* after the branch point are excluded. Includes files changed since
+    the branch point (committed), files staged for commit, and unstaged
+    modifications to tracked files. New files that have not yet been
+    ``git add``-ed are included by default (*include_untracked*) so local runs
+    see in-progress new models; set ``include_untracked=False`` to match a
+    strict porcelain diff (e.g. CI, where checkouts have no untracked files).
     """
     root = repo_root or get_repo_root()
-    # Files changed relative to base ref (committed + staged)
+    merge_base = resolve_merge_base(base_ref, repo_root=root)
+    # Files changed since the branch point (committed + staged)
     committed = _run_git(
-        ["diff", "--name-only", base_ref, "HEAD"],
+        ["diff", "--name-only", merge_base, "HEAD"],
         cwd=root,
     ).splitlines()
     # Staged but not yet committed
@@ -59,6 +81,11 @@ def get_changed_files(
     ).splitlines()
 
     all_relative = set(committed) | set(staged) | set(unstaged)
+
+    if include_untracked:
+        status = _run_git(["status", "--porcelain", "--untracked-files=all"], cwd=root).splitlines()
+        all_relative.update(line[3:].strip() for line in status if line.startswith("??"))
+
     return [root / p for p in sorted(all_relative)]
 
 

--- a/src/ol_dbt_cli/ol_dbt_cli/lib/git_utils.py
+++ b/src/ol_dbt_cli/ol_dbt_cli/lib/git_utils.py
@@ -51,40 +51,34 @@ def get_changed_files(
     *,
     include_untracked: bool = True,
 ) -> list[Path]:
-    """Return absolute paths of tracked files changed since diverging from *base_ref*.
+    """Return absolute paths of files changed since diverging from *base_ref*.
 
     Diffs against ``merge-base(base_ref, HEAD)`` rather than *base_ref* directly
     (three-dot semantics; see :func:`resolve_merge_base`), so commits landed on
-    *base_ref* after the branch point are excluded. Includes files changed since
-    the branch point (committed), files staged for commit, and unstaged
-    modifications to tracked files. New files that have not yet been
-    ``git add``-ed are included by default (*include_untracked*) so local runs
-    see in-progress new models; set ``include_untracked=False`` to match a
-    strict porcelain diff (e.g. CI, where checkouts have no untracked files).
+    *base_ref* after the branch point are excluded. Includes tracked files
+    changed since the branch point (committed), staged for commit, or with
+    unstaged modifications. New files that have not yet been ``git add``-ed are
+    also included by default (*include_untracked*) so local runs see
+    in-progress new models; set ``include_untracked=False`` to match a strict
+    porcelain diff (e.g. CI, where checkouts have no untracked files).
     """
     root = repo_root or get_repo_root()
     merge_base = resolve_merge_base(base_ref, repo_root=root)
-    # Files changed since the branch point (committed + staged)
-    committed = _run_git(
-        ["diff", "--name-only", merge_base, "HEAD"],
-        cwd=root,
-    ).splitlines()
-    # Staged but not yet committed
-    staged = _run_git(
-        ["diff", "--name-only", "--cached"],
-        cwd=root,
-    ).splitlines()
-    # Unstaged modifications (tracked files)
-    unstaged = _run_git(
-        ["diff", "--name-only"],
-        cwd=root,
-    ).splitlines()
 
-    all_relative = set(committed) | set(staged) | set(unstaged)
+    def _diff_names(*args: str) -> set[str]:
+        # -z: NUL-delimited, unquoted paths. Without it, git's default porcelain
+        # quoting (C-style escapes for whitespace/non-ASCII, e.g. "my model.sql"
+        # or "caf\303\251.sql") corrupts any such path into one that doesn't
+        # exist on disk, silently dropping it from the changed set.
+        raw = _run_git(["diff", "--name-only", "-z", *args], cwd=root)
+        return {p for p in raw.split("\0") if p}
+
+    # Files changed since the branch point (committed + staged + unstaged)
+    all_relative = _diff_names(merge_base, "HEAD") | _diff_names("--cached") | _diff_names()
 
     if include_untracked:
-        status = _run_git(["status", "--porcelain", "--untracked-files=all"], cwd=root).splitlines()
-        all_relative.update(line[3:].strip() for line in status if line.startswith("??"))
+        status = _run_git(["status", "--porcelain", "--untracked-files=all", "-z"], cwd=root)
+        all_relative.update(entry[3:] for entry in status.split("\0") if entry.startswith("??"))
 
     return [root / p for p in sorted(all_relative)]
 

--- a/src/ol_dbt_cli/tests/test_git_utils.py
+++ b/src/ol_dbt_cli/tests/test_git_utils.py
@@ -1,0 +1,137 @@
+"""Tests for lib/git_utils.py — git diff helpers for changed-model detection."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from ol_dbt_cli.lib.git_utils import (
+    get_changed_files,
+    get_changed_sql_models,
+    get_file_at_ref,
+    resolve_merge_base,
+)
+
+
+def _git(args: list[str], cwd: Path) -> str:
+    result = subprocess.run(  # noqa: S603, S607
+        ["git", *args],
+        cwd=cwd,
+        capture_output=True,
+        text=True,
+        check=True,
+        env={
+            "GIT_AUTHOR_NAME": "Test",
+            "GIT_AUTHOR_EMAIL": "test@example.com",
+            "GIT_COMMITTER_NAME": "Test",
+            "GIT_COMMITTER_EMAIL": "test@example.com",
+            "PATH": "/usr/bin:/bin:/usr/local/bin",
+        },
+    )
+    return result.stdout
+
+
+def _commit(repo: Path, message: str) -> str:
+    _git(["add", "-A"], cwd=repo)
+    _git(["commit", "-m", message], cwd=repo)
+    return _git(["rev-parse", "HEAD"], cwd=repo).strip()
+
+
+@pytest.fixture()
+def scripted_repo(tmp_path: Path) -> Path:
+    r"""Build a repo with a PR branch forked from main, plus later main-only commits.
+
+    History shape:
+        main:    C0 --- C1 (models/other.sql added; models/foo.sql gets an
+                   \        unrelated edit -- both AFTER the fork)
+        feature:    C0a (models/foo.sql: A,B -> A,C; models/bar.sql added)
+
+    C0 is the merge-base of main and feature. C1 exists only on main, after the
+    branch point:
+    - a two-dot diff (main..feature) would incorrectly show other.sql as
+      changed (it exists on main's tip but not on feature); a three-dot /
+      merge-base diff correctly excludes it.
+    - fetching foo.sql's "base" content via the raw base_ref tip (main) would
+      read C1's content (main's own later edit), not the C0 fork-point content
+      feature actually diverged from.
+    """
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git(["init", "-b", "main"], cwd=repo)
+
+    models = repo / "models"
+    models.mkdir()
+    (models / "foo.sql").write_text("select a, b\n")
+    (models / "_schema.yml").write_text("version: 2\n")
+    merge_base = _commit(repo, "C0: initial models")
+
+    _git(["checkout", "-b", "feature"], cwd=repo)
+    (models / "foo.sql").write_text("select a, c\n")
+    (models / "bar.sql").write_text("select x\n")
+    _commit(repo, "C0a: feature changes foo.sql, adds bar.sql")
+
+    _git(["checkout", "main"], cwd=repo)
+    (models / "other.sql").write_text("select y\n")
+    (models / "foo.sql").write_text("select a, b, extra\n")
+    _commit(repo, "C1: main-only changes after the fork")
+
+    _git(["checkout", "feature"], cwd=repo)
+    repo.joinpath(".merge_base_sha").write_text(merge_base)
+    return repo
+
+
+class TestResolveMergeBase:
+    def test_returns_fork_point_not_base_tip(self, scripted_repo: Path) -> None:
+        expected = scripted_repo.joinpath(".merge_base_sha").read_text()
+        assert resolve_merge_base("main", repo_root=scripted_repo) == expected
+
+    def test_differs_from_base_ref_tip(self, scripted_repo: Path) -> None:
+        base_tip = _git(["rev-parse", "main"], cwd=scripted_repo).strip()
+        merge_base = resolve_merge_base("main", repo_root=scripted_repo)
+        assert merge_base != base_tip
+
+
+class TestGetChangedFiles:
+    def test_excludes_main_only_changes_after_fork(self, scripted_repo: Path) -> None:
+        changed = get_changed_files(base_ref="main", repo_root=scripted_repo, include_untracked=False)
+        names = {p.name for p in changed}
+        assert "other.sql" not in names, "main-only commit after the fork leaked into the changed set"
+
+    def test_includes_feature_branch_changes(self, scripted_repo: Path) -> None:
+        changed = get_changed_files(base_ref="main", repo_root=scripted_repo, include_untracked=False)
+        names = {p.name for p in changed}
+        assert "foo.sql" in names
+        assert "bar.sql" in names
+
+    def test_includes_untracked_files_by_default(self, scripted_repo: Path) -> None:
+        (scripted_repo / "models" / "baz.sql").write_text("select z\n")
+        changed = get_changed_files(base_ref="main", repo_root=scripted_repo)
+        assert "baz.sql" in {p.name for p in changed}
+
+    def test_excludes_untracked_files_when_disabled(self, scripted_repo: Path) -> None:
+        (scripted_repo / "models" / "baz.sql").write_text("select z\n")
+        changed = get_changed_files(base_ref="main", repo_root=scripted_repo, include_untracked=False)
+        assert "baz.sql" not in {p.name for p in changed}
+
+
+class TestGetChangedSqlModels:
+    def test_changed_set_matches_three_dot_semantics(self, scripted_repo: Path) -> None:
+        names = get_changed_sql_models(scripted_repo, base_ref="main", repo_root=scripted_repo)
+        assert set(names) == {"foo", "bar"}
+
+
+class TestGetFileAtRef:
+    def test_merge_base_content_is_fork_point_not_base_tip(self, scripted_repo: Path) -> None:
+        merge_base = resolve_merge_base("main", repo_root=scripted_repo)
+        content = get_file_at_ref(scripted_repo / "models" / "foo.sql", merge_base, repo_root=scripted_repo)
+        assert content == "select a, b\n"
+
+    def test_base_ref_tip_content_is_polluted_by_later_main_commits(self, scripted_repo: Path) -> None:
+        # Demonstrates the bug this task fixes: fetching against the raw
+        # base_ref tip (the old behaviour) reads main's own later edit to
+        # foo.sql (C1), not the C0 fork-point content feature actually
+        # diverged from -- masking or misrepresenting the PR's real diff.
+        content = get_file_at_ref(scripted_repo / "models" / "foo.sql", "main", repo_root=scripted_repo)
+        assert content == "select a, b, extra\n"

--- a/src/ol_dbt_cli/tests/test_git_utils.py
+++ b/src/ol_dbt_cli/tests/test_git_utils.py
@@ -115,6 +115,17 @@ class TestGetChangedFiles:
         changed = get_changed_files(base_ref="main", repo_root=scripted_repo, include_untracked=False)
         assert "baz.sql" not in {p.name for p in changed}
 
+    def test_includes_untracked_files_with_special_characters_in_name(self, scripted_repo: Path) -> None:
+        # git's default porcelain quoting C-escapes paths containing whitespace or
+        # non-ASCII bytes (e.g. `?? "my model.sql"`); without -z that garbles the
+        # path into one that doesn't exist on disk and silently drops the file.
+        (scripted_repo / "models" / "my model.sql").write_text("select 1\n")
+        (scripted_repo / "models" / "café.sql").write_text("select 2\n")
+        changed = get_changed_files(base_ref="main", repo_root=scripted_repo)
+        names = {p.name for p in changed}
+        assert "my model.sql" in names
+        assert "café.sql" in names
+
 
 class TestGetChangedSqlModels:
     def test_changed_set_matches_three_dot_semantics(self, scripted_repo: Path) -> None:

--- a/src/ol_dbt_cli/tests/test_impact.py
+++ b/src/ol_dbt_cli/tests/test_impact.py
@@ -2,7 +2,10 @@
 
 from __future__ import annotations
 
+import subprocess
 from pathlib import Path
+
+import pytest
 
 from ol_dbt_cli.commands.impact import _diff_columns
 
@@ -481,3 +484,95 @@ class TestOutputColumnPassthrough:
         # SQL confirmed no consumption (output_columns doesn't include removed_col
         # and no SQL file for qualified-ref analysis) — child should NOT be flagged
         assert not any(r.model_name == "child" and r.affected_columns for r in results)
+
+
+def _git(args: list[str], cwd: Path) -> str:
+    result = subprocess.run(  # noqa: S603, S607
+        ["git", *args],
+        cwd=cwd,
+        capture_output=True,
+        text=True,
+        check=True,
+        env={
+            "GIT_AUTHOR_NAME": "Test",
+            "GIT_AUTHOR_EMAIL": "test@example.com",
+            "GIT_COMMITTER_NAME": "Test",
+            "GIT_COMMITTER_EMAIL": "test@example.com",
+            "PATH": "/usr/bin:/bin:/usr/local/bin",
+        },
+    )
+    return result.stdout
+
+
+def _commit(repo: Path, message: str) -> None:
+    _git(["add", "-A"], cwd=repo)
+    _git(["commit", "-m", message], cwd=repo)
+
+
+@pytest.fixture()
+def dbt_repo(tmp_path: Path) -> Path:
+    """Build a scripted git repo containing a two-model dbt project, ready to have one deleted."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git(["init", "-b", "main"], cwd=repo)
+
+    dbt_dir = repo / "src" / "ol_dbt"
+    models = dbt_dir / "models"
+    models.mkdir(parents=True)
+    (dbt_dir / "dbt_project.yml").write_text("name: open_learning\n")
+    (models / "int__combined__users.sql").write_text("select 1 as user_id, 'x' as email\n")
+    (models / "marts__reporting__thing.sql").write_text("select user_id from {{ ref('int__combined__users') }}\n")
+    _commit(repo, "initial models")
+    _git(["checkout", "-b", "feature"], cwd=repo)
+    return repo
+
+
+class TestImpactCommandDeletedModels:
+    """End-to-end tests for the `impact` command's handling of deleted models."""
+
+    def test_deleted_model_still_ref_d_is_breaking(self, dbt_repo: Path, capsys: pytest.CaptureFixture[str]) -> None:
+        """Deleting a model still ref()'d elsewhere must alert BREAKING and exit 1."""
+        from ol_dbt_cli.commands.impact import impact
+
+        dbt_dir = dbt_repo / "src" / "ol_dbt"
+        _git(["rm", "models/int__combined__users.sql"], cwd=dbt_dir)
+        _commit(dbt_repo, "delete int__combined__users")
+
+        with pytest.raises(SystemExit) as exc_info:
+            impact(dbt_dir_path=str(dbt_dir), base_ref="main", output_format="json")
+        assert exc_info.value.code == 1
+
+        import json
+
+        alerts = json.loads(capsys.readouterr().out)
+        deleted_alert = next(a for a in alerts if a["changed_model"] == "int__combined__users")
+        assert deleted_alert["level"] == "BREAKING"
+        assert any(d["model"] == "marts__reporting__thing" for d in deleted_alert["downstream"])
+
+    def test_deleted_model_with_no_remaining_refs_is_not_breaking(
+        self, dbt_repo: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """Deleting a model with no surviving ref() must not alert BREAKING."""
+        from ol_dbt_cli.commands.impact import impact
+
+        dbt_dir = dbt_repo / "src" / "ol_dbt"
+        # Remove the consumer too, so nothing references the deleted model anymore.
+        _git(["rm", "models/int__combined__users.sql", "models/marts__reporting__thing.sql"], cwd=dbt_dir)
+        _commit(dbt_repo, "delete both models")
+
+        impact(dbt_dir_path=str(dbt_dir), base_ref="main", output_format="json")
+
+        import json
+
+        alerts = json.loads(capsys.readouterr().out)
+        deleted_alert = next(a for a in alerts if a["changed_model"] == "int__combined__users")
+        assert deleted_alert["level"] != "BREAKING"
+
+    def test_unknown_model_flag_errors_loudly(self, dbt_repo: Path) -> None:
+        """`--model <typo>` must error and exit non-zero, not silently report success."""
+        from ol_dbt_cli.commands.impact import impact
+
+        dbt_dir = dbt_repo / "src" / "ol_dbt"
+        with pytest.raises(SystemExit) as exc_info:
+            impact(dbt_dir_path=str(dbt_dir), model="does_not_exist_typo", base_ref="main", output_format="json")
+        assert exc_info.value.code == 1


### PR DESCRIPTION
### What are the relevant tickets?
Part of https://github.com/mitodl/ol-data-platform/issues/2407

**Stacked on #2445** — this fix reuses `resolve_merge_base()` from that PR. Base branch is `fix/ol-dbt-impact-merge-base-semantics`, not `main`; the diff will shrink to just this PR's commit once #2445 merges.

### Description (What does it do?)
`impact.py`'s per-model analysis loop resolved each changed model name against `sql_file_map`, which is built from `.sql` files currently on disk:
```python
for name in target_names:
    sql_file = sql_file_map.get(name)
    if sql_file is None:
        continue   # <-- deleted model: silently skipped, no alert
```
Deleting `int__combined__users` while three marts still `ref()` it produced **"0 breaking", exit 0** — the changed-set detection correctly includes the deleted file's stem (git diff lists deletions), but the analysis step had nothing to look up on disk and just moved on. A rename hits the same skip on the old stem (the new stem separately reports as a harmless "New model"). Separately, `ol-dbt impact --model <typo>` silently produced an empty, successful report instead of erroring — `ol-dbt validate --model <typo>` already errors loudly on unknown tokens, so this was an inconsistency.

Fix:
- `git_utils.get_deleted_sql_models(dbt_dir, base_ref, repo_root)` — new helper, `git diff --name-status --diff-filter=D` against the merge-base, scoped to `models/*.sql`, mapping `{model_name: path_at_merge_base}`.
- `_analyse_deleted_model()` — new function. Reads the deleted model's column set at the merge-base via `get_file_at_ref`, then scans **every currently-parsed SQL file's `refs`** (not just manifest children) for anything still naming the deleted model, and flags each as BREAKING regardless of which specific columns it reads — the whole relation is gone, so any surviving `ref()` is broken, not just a column-level mismatch. This works without a manifest and even with a stale one; a *fresh* manifest can never itself contain a dangling ref to a deleted model (dbt parse would already have failed to compile), so textual ref-scanning is the primary signal, with a stale manifest's recorded children unioned in as a secondary check.
- The main loop now calls `_analyse_deleted_model` instead of silently `continue`-ing when a changed stem has no on-disk file and is a known deletion.
- `--model <value>` that matches neither an on-disk file nor a known deletion now exits 1 with an error, matching `validate`'s behavior.

`impact.py` had zero end-to-end tests (only unit tests of internal helpers). Added `TestImpactCommandDeletedModels` in `tests/test_impact.py` — a scripted git-repo fixture (a `feature` branch with two models, one `ref()`-ing the other) exercising:
- deleting the ref()'d model → BREAKING alert naming the surviving consumer, exit 1
- deleting both models (no surviving ref) → not BREAKING
- `--model does_not_exist_typo` → exit 1

### How can this be tested?
```
cd src/ol_dbt_cli
uv run pytest tests/test_impact.py -v -k TestImpactCommandDeletedModels   # 3 new tests
uv run pytest tests/ -q                                                    # full suite, 296 passed
```
Reverting `impact.py`/`git_utils.py` (keeping the new tests) makes all 3 new tests fail — confirmed locally by stashing the fix and re-running.

### Additional Context
Doesn't address the companion `validate.py` gap the same audit flagged (dangling `ref()` currently only surfaces as a WARNING via `upstream_refs`, not a distinct ERROR-level "ref target doesn't exist at all" check) — left as a separate follow-up per the tracked task list under this epic.