### PR TITLE
fix(ol_dbt_cli): close changed-only blind spots — macro and YAML-only changes

### DIFF
--- a/src/ol_dbt_cli/ol_dbt_cli/commands/impact.py
+++ b/src/ol_dbt_cli/ol_dbt_cli/commands/impact.py
@@ -736,9 +736,12 @@ def impact(
             for mf in macro_files:
                 if not mf.is_relative_to(dbt_dir):
                     continue
-                affected = manifest.models_for_changed_macros({str(mf.relative_to(dbt_dir))})
+                # as_posix() (not str()) so the path uses forward slashes on every
+                # platform, matching the dbt manifest's original_file_path form.
+                macro_rel_path = mf.relative_to(dbt_dir).as_posix()
+                affected = manifest.models_for_changed_macros({macro_rel_path})
                 macro_affected |= affected
-                macro_alerts.append(_analyse_macro_change(str(mf.relative_to(dbt_dir)), affected, manifest))
+                macro_alerts.append(_analyse_macro_change(macro_rel_path, affected, manifest))
         elif macro_files:
             err_console.print(
                 f"[yellow]Warning:[/] {len(macro_files)} macro file(s) changed but no manifest is "

--- a/src/ol_dbt_cli/ol_dbt_cli/commands/impact.py
+++ b/src/ol_dbt_cli/ol_dbt_cli/commands/impact.py
@@ -19,6 +19,7 @@ from cyclopts import Parameter
 from rich.console import Console
 
 from ol_dbt_cli.lib.git_utils import (
+    get_changed_macro_files,
     get_changed_sql_models,
     get_deleted_sql_models,
     get_file_at_ref,
@@ -420,6 +421,40 @@ def _analyse_deleted_model(
     )
 
 
+def _analyse_macro_change(
+    macro_rel_path: str,
+    affected_models: set[str],
+    manifest: ManifestRegistry | None,
+) -> ImpactAlert:
+    """Return an :class:`ImpactAlert` describing a changed macro's blast radius.
+
+    A macro edit touches no model ``.sql`` file, so raw column-diffing sees no
+    change. It can nonetheless alter the compiled output of every model that
+    (transitively) references it. We surface the set of dependent models so the
+    change is visible in CI rather than silently green; genuine column
+    additions/removals still require ``--auto-compile`` to detect.
+    """
+    macro_name = Path(macro_rel_path).name
+    downstream = [DownstreamImpact(model_name=name, depth=1) for name in sorted(affected_models)]
+    if downstream:
+        level = AlertLevel.WARNING
+        msg = (
+            f"Macro '{macro_name}' changed — {len(downstream)} model(s) compile with it and may "
+            "produce different output. Re-run with --auto-compile for column-level detail."
+        )
+    else:
+        level = AlertLevel.INFO
+        msg = f"Macro '{macro_name}' changed — no dependent models found in the manifest."
+    return ImpactAlert(
+        level=level,
+        changed_model=f"macro: {macro_name}",
+        column_changes=[],
+        downstream=downstream,
+        message=msg,
+        manifest_available=manifest is not None,
+    )
+
+
 # ---------------------------------------------------------------------------
 # Output rendering
 # ---------------------------------------------------------------------------
@@ -679,6 +714,7 @@ def impact(
         sys.exit(1)
 
     # Determine which models to analyse
+    macro_alerts: list[ImpactAlert] = []
     if model:
         if model not in sql_file_map and model not in deleted_models:
             err_console.print(f"[red]Error:[/] --model value '{model}' did not match any model file.")
@@ -687,10 +723,38 @@ def impact(
     else:
         try:
             target_names = get_changed_sql_models(dbt_dir, base_ref=base_ref, repo_root=repo_root)
+            macro_files = get_changed_macro_files(dbt_dir, base_ref=base_ref, repo_root=repo_root)
         except RuntimeError as exc:
             err_console.print(f"[red]Error resolving git diff:[/] {exc}")
             sys.exit(1)
-        if not target_names:
+
+        # A changed macro is invisible to SQL-file diffing but can change the
+        # output of every model that references it. Map each changed macro file
+        # to its dependent models via the manifest and surface it as an alert.
+        macro_affected: set[str] = set()
+        if macro_files and manifest is not None:
+            for mf in macro_files:
+                if not mf.is_relative_to(dbt_dir):
+                    continue
+                affected = manifest.models_for_changed_macros({str(mf.relative_to(dbt_dir))})
+                macro_affected |= affected
+                macro_alerts.append(_analyse_macro_change(str(mf.relative_to(dbt_dir)), affected, manifest))
+        elif macro_files:
+            err_console.print(
+                f"[yellow]Warning:[/] {len(macro_files)} macro file(s) changed but no manifest is "
+                "available to map them to affected models. Run with --auto-compile (or `dbt parse`) "
+                "so macro-only changes are analysed."
+            )
+
+        # With --auto-compile the compiled SQL reflects the macro edit, so run the
+        # standard column diff on affected models too — genuine added/removed
+        # columns then surface as their own (possibly BREAKING) alerts.
+        if auto_compile and macro_affected:
+            for name in sorted(macro_affected):
+                if name not in target_names:
+                    target_names.append(name)
+
+        if not target_names and not macro_alerts:
             console.print(f"[dim]No SQL model changes detected vs {base_ref}.[/]")
             return
 
@@ -767,6 +831,8 @@ def impact(
                 d_parsed = sql_models_by_name.get(d.model_name)
                 if d_parsed is not None and d_parsed.compiled_path is None:
                     models_without_compiled.append(d.model_name)
+
+    alerts.extend(macro_alerts)
 
     # Sort: BREAKING first, then WARNING, then INFO
     order = {AlertLevel.BREAKING: 0, AlertLevel.WARNING: 1, AlertLevel.INFO: 2}

--- a/src/ol_dbt_cli/ol_dbt_cli/commands/validate.py
+++ b/src/ol_dbt_cli/ol_dbt_cli/commands/validate.py
@@ -983,7 +983,16 @@ def validate(
                 target_names.append(name)
 
         if not target_names:
-            console.print(f"[dim]No changed models (SQL, macro, or YAML) detected vs {base_ref}.[/]")
+            if macro_files or yaml_files:
+                # Changes WERE detected, they just didn't resolve to any model to
+                # validate (no manifest for macro mapping, or a YAML file that
+                # declares no models). Say so rather than claiming nothing changed.
+                console.print(
+                    f"[dim]Changed macro/YAML file(s) detected vs {base_ref}, but none mapped to "
+                    "models to validate (see warnings above).[/]"
+                )
+            else:
+                console.print(f"[dim]No changed models (SQL, macro, or YAML) detected vs {base_ref}.[/]")
             return
     else:
         target_names = [f.stem for f in all_sql_files]

--- a/src/ol_dbt_cli/ol_dbt_cli/commands/validate.py
+++ b/src/ol_dbt_cli/ol_dbt_cli/commands/validate.py
@@ -32,7 +32,12 @@ from ol_dbt_cli.lib.dimensional_layering import (
     load_baseline,
     write_baseline,
 )
-from ol_dbt_cli.lib.git_utils import get_changed_sql_models, get_repo_root
+from ol_dbt_cli.lib.git_utils import (
+    get_changed_macro_files,
+    get_changed_sql_models,
+    get_changed_yaml_models,
+    get_repo_root,
+)
 from ol_dbt_cli.lib.manifest import ManifestRegistry, find_manifest, load_manifest
 from ol_dbt_cli.lib.sql_parser import ParsedModel, find_compiled_dir, get_columns_read_from_ref, parse_model_file
 from ol_dbt_cli.lib.yaml_registry import YamlRegistry, build_yaml_registry
@@ -942,11 +947,43 @@ def validate(
     elif changed_only:
         try:
             target_names = get_changed_sql_models(dbt_dir, base_ref=base_ref)
+            macro_files = get_changed_macro_files(dbt_dir, base_ref=base_ref)
+            yaml_files = get_changed_yaml_models(dbt_dir, base_ref=base_ref)
         except RuntimeError as exc:
             err_console.print(f"[red]Error resolving git diff:[/] {exc}")
             sys.exit(1)
+
+        extra: list[str] = []
+
+        # A macro edit changes no model .sql file, but can alter the compiled
+        # output of every model that (transitively) calls it. Map the changed
+        # macro files to affected models via the manifest so their checks run.
+        if macro_files:
+            if manifest is not None:
+                macro_rel = {str(p.relative_to(dbt_dir)) for p in macro_files if p.is_relative_to(dbt_dir)}
+                extra.extend(sorted(manifest.models_for_changed_macros(macro_rel)))
+            else:
+                err_console.print(
+                    f"[yellow]Warning:[/] {len(macro_files)} macro file(s) changed but no manifest is "
+                    "available to map them to affected models. Run with --auto-compile (or `dbt parse`) "
+                    "so macro-only changes are validated."
+                )
+
+        # A YAML-only change (phantom column, dropped docs) touches no .sql file
+        # either. Add models whose schema YAML changed so yaml_sql_sync runs.
+        if yaml_files:
+            resolved_file_to_models = {p.resolve(): names for p, names in yaml_registry.file_to_models.items()}
+            for yf in yaml_files:
+                extra.extend(resolved_file_to_models.get(yf.resolve(), []))
+
+        seen_targets = set(target_names)
+        for name in extra:
+            if name not in seen_targets:
+                seen_targets.add(name)
+                target_names.append(name)
+
         if not target_names:
-            console.print(f"[dim]No SQL model changes detected vs {base_ref}.[/]")
+            console.print(f"[dim]No changed models (SQL, macro, or YAML) detected vs {base_ref}.[/]")
             return
     else:
         target_names = [f.stem for f in all_sql_files]

--- a/src/ol_dbt_cli/ol_dbt_cli/commands/validate.py
+++ b/src/ol_dbt_cli/ol_dbt_cli/commands/validate.py
@@ -960,7 +960,9 @@ def validate(
         # macro files to affected models via the manifest so their checks run.
         if macro_files:
             if manifest is not None:
-                macro_rel = {str(p.relative_to(dbt_dir)) for p in macro_files if p.is_relative_to(dbt_dir)}
+                # as_posix() (not str()) so paths use forward slashes on every
+                # platform, matching the dbt manifest's original_file_path form.
+                macro_rel = {p.relative_to(dbt_dir).as_posix() for p in macro_files if p.is_relative_to(dbt_dir)}
                 extra.extend(sorted(manifest.models_for_changed_macros(macro_rel)))
             else:
                 err_console.print(

--- a/src/ol_dbt_cli/ol_dbt_cli/lib/git_utils.py
+++ b/src/ol_dbt_cli/ol_dbt_cli/lib/git_utils.py
@@ -126,6 +126,25 @@ def get_deleted_sql_models(
     return deleted
 
 
+def get_changed_macro_files(
+    dbt_dir: Path,
+    base_ref: str = "origin/main",
+    repo_root: Path | None = None,
+) -> list[Path]:
+    """Return paths of ``.sql`` macro files under *dbt_dir*/macros/ that changed.
+
+    A macro edit changes no model ``.sql`` file, so it is invisible to
+    :func:`get_changed_sql_models` — yet it can alter the compiled output of
+    every model that (transitively) calls it. Callers map these files to the
+    affected models via
+    :meth:`~ol_dbt_cli.lib.manifest.ManifestRegistry.models_for_changed_macros`.
+    """
+    root = repo_root or get_repo_root(dbt_dir)
+    macros_dir = dbt_dir / "macros"
+    changed = get_changed_files(base_ref=base_ref, repo_root=root)
+    return [path for path in changed if path.suffix == ".sql" and _is_under(path, macros_dir)]
+
+
 def get_changed_yaml_models(
     dbt_dir: Path,
     base_ref: str = "origin/main",

--- a/src/ol_dbt_cli/ol_dbt_cli/lib/manifest.py
+++ b/src/ol_dbt_cli/ol_dbt_cli/lib/manifest.py
@@ -36,6 +36,8 @@ class ManifestModel:
     columns: dict[str, ManifestColumn] = field(default_factory=dict)
     depends_on: list[str] = field(default_factory=list)
     """unique_ids of parent nodes."""
+    depends_on_macros: list[str] = field(default_factory=list)
+    """unique_ids of macros this node references (``depends_on.macros``)."""
 
     @property
     def column_names(self) -> set[str]:
@@ -44,6 +46,18 @@ class ManifestModel:
     @property
     def is_model(self) -> bool:
         return self.resource_type == "model"
+
+
+@dataclass
+class ManifestMacro:
+    """A macro node as extracted from the manifest ``macros`` section."""
+
+    unique_id: str
+    name: str
+    package_name: str
+    original_file_path: str
+    depends_on_macros: list[str] = field(default_factory=list)
+    """unique_ids of other macros this macro references."""
 
 
 @dataclass
@@ -59,6 +73,8 @@ class ManifestRegistry:
     Key is ``source_name.table_name`` (e.g. ``ol_warehouse.users``)."""
     children: dict[str, list[str]] = field(default_factory=dict)
     """unique_id -> list of child unique_ids (reverse of depends_on)."""
+    macros: dict[str, ManifestMacro] = field(default_factory=dict)
+    """macro unique_id -> ManifestMacro for every macro in the project graph."""
 
     def get_model(self, name: str) -> ManifestModel | None:
         return self.by_name.get(name)
@@ -102,6 +118,53 @@ class ManifestRegistry:
                 matches.append((child, column_name))
         return matches
 
+    def models_for_changed_macros(self, changed_macro_files: set[str]) -> set[str]:
+        """Return the names of models whose output can change when the given macros change.
+
+        *changed_macro_files* is a set of macro file paths in the manifest's
+        ``original_file_path`` form (relative to the dbt project root, e.g.
+        ``macros/extract_course_id.sql``). A single ``.sql`` file may define
+        several macros.
+
+        Node ``depends_on.macros`` records only the macros a node references
+        *directly*, not those reached transitively through other macros. So a
+        change to a low-level helper macro (called only by other macros) would
+        be invisible via a direct lookup. We therefore expand the changed
+        macros to their transitive callers over the macro→macro dependency
+        graph first, then flag every model whose direct macro dependencies
+        intersect that closure.
+        """
+        if not changed_macro_files:
+            return set()
+
+        changed_macro_ids = {
+            uid for uid, macro in self.macros.items() if macro.original_file_path in changed_macro_files
+        }
+        if not changed_macro_ids:
+            return set()
+
+        # Reverse edges: macro unique_id -> macros that reference it.
+        callers: dict[str, set[str]] = {}
+        for uid, macro in self.macros.items():
+            for dep in macro.depends_on_macros:
+                callers.setdefault(dep, set()).add(uid)
+
+        # Transitive closure: changed macros plus every macro that (transitively) calls them.
+        affected_macro_ids: set[str] = set(changed_macro_ids)
+        stack = list(changed_macro_ids)
+        while stack:
+            current = stack.pop()
+            for caller in callers.get(current, ()):
+                if caller not in affected_macro_ids:
+                    affected_macro_ids.add(caller)
+                    stack.append(caller)
+
+        return {
+            node.name
+            for node in self.nodes.values()
+            if node.is_model and affected_macro_ids.intersection(node.depends_on_macros)
+        }
+
 
 def _parse_node(node_data: dict[str, Any]) -> ManifestModel:
     """Convert a raw manifest node dict into a :class:`ManifestModel`."""
@@ -113,7 +176,7 @@ def _parse_node(node_data: dict[str, Any]) -> ManifestModel:
             data_type=col_data.get("data_type", ""),
         )
 
-    depends_on = node_data.get("depends_on", {}).get("nodes", [])
+    depends_on = node_data.get("depends_on", {})
 
     return ManifestModel(
         unique_id=node_data["unique_id"],
@@ -123,7 +186,19 @@ def _parse_node(node_data: dict[str, Any]) -> ManifestModel:
         schema=node_data.get("schema", ""),
         database=node_data.get("database", ""),
         columns=columns,
-        depends_on=depends_on,
+        depends_on=depends_on.get("nodes", []),
+        depends_on_macros=depends_on.get("macros", []),
+    )
+
+
+def _parse_macro(macro_data: dict[str, Any]) -> ManifestMacro:
+    """Convert a raw manifest macro dict into a :class:`ManifestMacro`."""
+    return ManifestMacro(
+        unique_id=macro_data["unique_id"],
+        name=macro_data.get("name", ""),
+        package_name=macro_data.get("package_name", ""),
+        original_file_path=macro_data.get("original_file_path", ""),
+        depends_on_macros=macro_data.get("depends_on", {}).get("macros", []),
     )
 
 
@@ -152,6 +227,9 @@ def load_manifest(manifest_path: Path) -> ManifestRegistry:
             table_name = node_data.get("name", "")
             if source_name and table_name:
                 registry.sources[f"{source_name}.{table_name}"] = model
+
+    for uid, macro_data in raw.get("macros", {}).items():
+        registry.macros[uid] = _parse_macro(macro_data)
 
     # Build child map (reverse of depends_on)
     for uid, model in registry.nodes.items():

--- a/src/ol_dbt_cli/ol_dbt_cli/lib/yaml_registry.py
+++ b/src/ol_dbt_cli/ol_dbt_cli/lib/yaml_registry.py
@@ -196,9 +196,19 @@ def _parse_yaml_file(path: Path) -> tuple[list[YamlModel], list[YamlSource]]:
 
 
 def build_yaml_registry(models_dir: Path) -> YamlRegistry:
-    """Walk *models_dir* recursively and build a registry from all _*.yml files."""
+    """Walk *models_dir* recursively and build a registry from every YAML schema file.
+
+    Indexes all ``.yml``/``.yaml`` files (matching how dbt itself discovers
+    schema/property files, and how :func:`git_utils.get_changed_yaml_models`
+    detects changed ones). Restricting to the ``_*.yml`` convention here would
+    silently drop any differently-named schema file: it would be detected as
+    changed but never resolve to a model, so ``validate --changed-only`` would
+    skip it. Non-schema YAML is harmless — :func:`_parse_yaml_file` only reads
+    ``models:``/``sources:`` keys and yields nothing for anything else.
+    """
     registry = YamlRegistry()
-    for yaml_path in sorted(models_dir.rglob("_*.yml")):
+    yaml_paths = sorted({*models_dir.rglob("*.yml"), *models_dir.rglob("*.yaml")})
+    for yaml_path in yaml_paths:
         models, sources = _parse_yaml_file(yaml_path)
         file_names: list[str] = []
         for model in models:

--- a/src/ol_dbt_cli/tests/test_git_utils.py
+++ b/src/ol_dbt_cli/tests/test_git_utils.py
@@ -9,7 +9,9 @@ import pytest
 
 from ol_dbt_cli.lib.git_utils import (
     get_changed_files,
+    get_changed_macro_files,
     get_changed_sql_models,
+    get_changed_yaml_models,
     get_file_at_ref,
     resolve_merge_base,
 )
@@ -131,6 +133,50 @@ class TestGetChangedSqlModels:
     def test_changed_set_matches_three_dot_semantics(self, scripted_repo: Path) -> None:
         names = get_changed_sql_models(scripted_repo, base_ref="main", repo_root=scripted_repo)
         assert set(names) == {"foo", "bar"}
+
+
+@pytest.fixture()
+def repo_with_macro_and_yaml_change(tmp_path: Path) -> Path:
+    """Build a repo whose feature branch edits a macro and a YAML file, but no model .sql."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git(["init", "-b", "main"], cwd=repo)
+
+    (repo / "models").mkdir()
+    (repo / "models" / "foo.sql").write_text("select a\n")
+    (repo / "models" / "_schema.yml").write_text("version: 2\n")
+    (repo / "macros").mkdir()
+    (repo / "macros" / "helper.sql").write_text("{% macro helper() %}1{% endmacro %}\n")
+    _commit(repo, "C0: initial")
+
+    _git(["checkout", "-b", "feature"], cwd=repo)
+    (repo / "macros" / "helper.sql").write_text("{% macro helper() %}2{% endmacro %}\n")
+    (repo / "models" / "_schema.yml").write_text("version: 2\nmodels: []\n")
+    _commit(repo, "C0a: change macro and yaml only")
+    return repo
+
+
+class TestGetChangedMacroFiles:
+    def test_detects_changed_macro(self, repo_with_macro_and_yaml_change: Path) -> None:
+        repo = repo_with_macro_and_yaml_change
+        changed = get_changed_macro_files(repo, base_ref="main", repo_root=repo)
+        assert {p.name for p in changed} == {"helper.sql"}
+
+    def test_excludes_model_sql(self, repo_with_macro_and_yaml_change: Path) -> None:
+        repo = repo_with_macro_and_yaml_change
+        changed = get_changed_macro_files(repo, base_ref="main", repo_root=repo)
+        assert all("models" not in p.parts for p in changed)
+
+
+class TestGetChangedYamlModels:
+    def test_detects_changed_yaml(self, repo_with_macro_and_yaml_change: Path) -> None:
+        repo = repo_with_macro_and_yaml_change
+        changed = get_changed_yaml_models(repo, base_ref="main", repo_root=repo)
+        assert {p.name for p in changed} == {"_schema.yml"}
+
+    def test_no_sql_models_changed(self, repo_with_macro_and_yaml_change: Path) -> None:
+        repo = repo_with_macro_and_yaml_change
+        assert get_changed_sql_models(repo, base_ref="main", repo_root=repo) == []
 
 
 class TestGetFileAtRef:

--- a/src/ol_dbt_cli/tests/test_impact.py
+++ b/src/ol_dbt_cli/tests/test_impact.py
@@ -7,7 +7,7 @@ from pathlib import Path
 
 import pytest
 
-from ol_dbt_cli.commands.impact import _diff_columns
+from ol_dbt_cli.commands.impact import AlertLevel, _analyse_macro_change, _diff_columns
 
 
 class TestDiffColumns:
@@ -34,6 +34,20 @@ class TestDiffColumns:
         changes = _diff_columns({"a", "b", "c"}, {"a"})
         removed = {c.column for c in changes if c.change_type == "removed"}
         assert removed == {"b", "c"}
+
+
+class TestAnalyseMacroChange:
+    def test_flags_affected_models_as_warning(self) -> None:
+        alert = _analyse_macro_change("macros/helper.sql", {"stg_a", "stg_b"}, manifest=None)
+        assert alert.level == AlertLevel.WARNING
+        assert alert.changed_model == "macro: helper.sql"
+        assert {d.model_name for d in alert.downstream} == {"stg_a", "stg_b"}
+        assert "helper.sql" in alert.message
+
+    def test_no_dependents_is_info(self) -> None:
+        alert = _analyse_macro_change("macros/orphan.sql", set(), manifest=None)
+        assert alert.level == AlertLevel.INFO
+        assert alert.downstream == []
 
 
 class TestGetColumnsReadFromRef:

--- a/src/ol_dbt_cli/tests/test_manifest.py
+++ b/src/ol_dbt_cli/tests/test_manifest.py
@@ -1,0 +1,105 @@
+"""Tests for lib/manifest.py — macro dependency mapping."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from ol_dbt_cli.lib.manifest import load_manifest
+
+
+def _write_manifest(tmp_path: Path, nodes: dict[str, Any], macros: dict[str, Any]) -> Path:
+    path = tmp_path / "manifest.json"
+    path.write_text(json.dumps({"nodes": nodes, "sources": {}, "macros": macros}))
+    return path
+
+
+def _model_node(name: str, macros: list[str]) -> dict[str, Any]:
+    return {
+        "unique_id": f"model.open_learning.{name}",
+        "name": name,
+        "resource_type": "model",
+        "original_file_path": f"models/{name}.sql",
+        "schema": "s",
+        "database": "d",
+        "columns": {},
+        "depends_on": {"nodes": [], "macros": macros},
+    }
+
+
+def _macro_node(name: str, file: str, macros: list[str]) -> tuple[str, dict[str, Any]]:
+    uid = f"macro.open_learning.{name}"
+    return uid, {
+        "unique_id": uid,
+        "name": name,
+        "package_name": "open_learning",
+        "original_file_path": file,
+        "depends_on": {"macros": macros},
+    }
+
+
+class TestModelsForChangedMacros:
+    def test_direct_dependency_flags_model(self, tmp_path: Path) -> None:
+        uid, macro = _macro_node("extract_course_id", "macros/extract_course_id.sql", [])
+        manifest = load_manifest(
+            _write_manifest(
+                tmp_path,
+                nodes={"model.open_learning.stg_a": _model_node("stg_a", [uid])},
+                macros={uid: macro},
+            )
+        )
+        assert manifest.models_for_changed_macros({"macros/extract_course_id.sql"}) == {"stg_a"}
+
+    def test_transitive_macro_chain_flags_model(self, tmp_path: Path) -> None:
+        # helper is called only by wrapper; model depends only on wrapper directly.
+        helper_uid, helper = _macro_node("helper", "macros/helper.sql", [])
+        wrapper_uid, wrapper = _macro_node("wrapper", "macros/wrapper.sql", [helper_uid])
+        manifest = load_manifest(
+            _write_manifest(
+                tmp_path,
+                nodes={"model.open_learning.stg_a": _model_node("stg_a", [wrapper_uid])},
+                macros={helper_uid: helper, wrapper_uid: wrapper},
+            )
+        )
+        # Changing the low-level helper must still flag stg_a via the wrapper.
+        assert manifest.models_for_changed_macros({"macros/helper.sql"}) == {"stg_a"}
+
+    def test_unrelated_macro_change_flags_nothing(self, tmp_path: Path) -> None:
+        used_uid, used = _macro_node("used", "macros/used.sql", [])
+        unused_uid, unused = _macro_node("unused", "macros/unused.sql", [])
+        manifest = load_manifest(
+            _write_manifest(
+                tmp_path,
+                nodes={"model.open_learning.stg_a": _model_node("stg_a", [used_uid])},
+                macros={used_uid: used, unused_uid: unused},
+            )
+        )
+        assert manifest.models_for_changed_macros({"macros/unused.sql"}) == set()
+
+    def test_empty_changed_set(self, tmp_path: Path) -> None:
+        uid, macro = _macro_node("m", "macros/m.sql", [])
+        manifest = load_manifest(
+            _write_manifest(
+                tmp_path,
+                nodes={"model.open_learning.stg_a": _model_node("stg_a", [uid])},
+                macros={uid: macro},
+            )
+        )
+        assert manifest.models_for_changed_macros(set()) == set()
+
+    def test_multiple_macros_one_file(self, tmp_path: Path) -> None:
+        # Two macros defined in one .sql file, each used by a different model.
+        a_uid, a = _macro_node("a", "macros/shared.sql", [])
+        b_uid, b = _macro_node("b", "macros/shared.sql", [])
+        manifest = load_manifest(
+            _write_manifest(
+                tmp_path,
+                nodes={
+                    "model.open_learning.m_a": _model_node("m_a", [a_uid]),
+                    "model.open_learning.m_b": _model_node("m_b", [b_uid]),
+                },
+                macros={a_uid: a, b_uid: b},
+            )
+        )
+        assert manifest.models_for_changed_macros({"macros/shared.sql"}) == {"m_a", "m_b"}

--- a/src/ol_dbt_cli/tests/test_yaml_registry.py
+++ b/src/ol_dbt_cli/tests/test_yaml_registry.py
@@ -105,6 +105,19 @@ class TestYamlRegistry:
         registry = build_yaml_registry(tmp_path)
         assert len(registry.models) == 0
 
+    def test_indexes_schema_files_regardless_of_name_or_extension(self, tmp_path: Path) -> None:
+        # A schema file that does not follow the _*.yml convention (no leading
+        # underscore, or a .yaml extension) must still be indexed — otherwise
+        # get_changed_yaml_models would detect it but validate --changed-only
+        # could never map it to a model.
+        staging = tmp_path / "staging"
+        staging.mkdir()
+        (staging / "schema.yml").write_text("version: 2\nmodels:\n- name: no_underscore_model\n")
+        (staging / "props.yaml").write_text("version: 2\nmodels:\n- name: yaml_ext_model\n")
+        registry = build_yaml_registry(tmp_path)
+        assert registry.get_model("no_underscore_model") is not None
+        assert registry.get_model("yaml_ext_model") is not None
+
 
 class TestYamlRegistrySources:
     def test_loads_source(self, models_dir: Path) -> None:


### PR DESCRIPTION
## What & why

`ol-dbt impact` and `ol-dbt validate --changed-only` derived the changed set **exclusively from `.sql` files under `models/`**, so on every PR the two change classes most likely to break things silently were green-lit by the Phase-1 CI gate (`dbt_pr_ci.yaml`):

- **Macro edits** — a change under `src/ol_dbt/macros/` touches no model `.sql` file, so impact reported *"No SQL model changes detected"* and exited 0, even though a macro can alter the compiled output of every model that (transitively) calls it. `cross_db_functions.sql`, for example, feeds 66 models.
- **YAML-only changes** — adding a phantom column, dropping docs, or breaking a schema entry touched no `.sql` file. `get_changed_yaml_models` already existed in `git_utils` but had **zero callers** (dead code).

## Changes

- **`manifest.py`** — parse node `depends_on.macros` and the `macros` section; add `ManifestRegistry.models_for_changed_macros()`, which maps changed macro files → affected models. It expands over the macro→macro graph first, so a change to a low-level helper macro (called only by other macros, never directly by a node) is still attributed to the models it ultimately feeds.
- **`git_utils.py`** — add `get_changed_macro_files()`.
- **`impact.py`** — surface each changed macro as a `WARNING` listing its dependent models. With `--auto-compile`, the affected models also go through the normal column diff so genuine added/removed columns escalate to `BREAKING`.
- **`validate.py`** — wire `get_changed_macro_files` + `get_changed_yaml_models` into `--changed-only` (via `YamlRegistry.file_to_models`) so `yaml_sql_sync`/`yaml_integrity` run for models whose macro or schema YAML changed.

In CI, `dbt parse` provides the manifest the macro mapping needs. Without a manifest (local runs), macro changes emit a warning pointing at `--auto-compile` rather than silently passing.

## Verification

- 308 CLI unit tests pass (11 new: macro mapping incl. transitive chains, changed-file detection, macro-change alert).
- End-to-end against the real repo manifest: a macro edit to `extract_course_id.sql` now yields `WARNING macro: extract_course_id.sql → 16 downstream` instead of exiting silently; a phantom column added to a schema YAML is caught as an ERROR by `validate --changed-only`.
- `pre-commit` (ruff format/check, mypy) clean.

Addresses the highest-value completeness gap from the 2026-07 validation audit under the dbt warehouse CI/QA hardening effort (#2407).

🤖 Generated with [Claude Code](https://claude.com/claude-code)