### PR TITLE
feat(superset): add Year of Enrollment Created On filter to Enrollment Detail by Learner

### DIFF
--- a/src/ol_superset/assets/dashboards/Enrollment_Detail_by_Learner_da9e03d3-e1bb-45b8-981f-208deca90e7a.yaml
+++ b/src/ol_superset/assets/dashboards/Enrollment_Detail_by_Learner_da9e03d3-e1bb-45b8-981f-208deca90e7a.yaml
@@ -285,6 +285,41 @@ metadata:
         name: organization_name
       datasetUuid: 01f179b6-cb75-465f-8ceb-0525c24fa223
     type: NATIVE_FILTER
+  - cascadeParentIds: []
+    chartsInScope:
+    - 64
+    - 67
+    - 70
+    - 108
+    controlValues:
+      defaultToFirstItem: false
+      enableEmptyFilter: false
+      inverseSelection: false
+      multiSelect: true
+      searchAllOptions: true
+      sortAscending: false
+    defaultDataMask:
+      extraFormData: {}
+      filterState: {}
+      ownState: {}
+    description: ''
+    filterType: filter_select
+    id: NATIVE_FILTER-9xQ2vLmZpK4RtY7Wc3Jsd
+    name: Year Of Enrollment Created On
+    scope:
+      excluded: []
+      rootPath:
+      - ROOT_ID
+    tabsInScope:
+    - TAB-t1-4mh38qE
+    - TAB-pWPKo4rBS
+    - TAB-Eyu1xfak5
+    - TAB-tFB9eF2Ur
+    targets:
+    - column:
+        name: year_of_courserunenrollment_created_on
+      datasetUuid: 01f179b6-cb75-465f-8ceb-0525c24fa223
+    type: NATIVE_FILTER
   refresh_frequency: 86400
   shared_label_colors: []
   timed_refresh_immune_slices: []

--- a/src/ol_superset/assets/datasets/Trino/enrollment_detail_report_01f179b6-cb75-465f-8ceb-0525c24fa223.yaml
+++ b/src/ol_superset/assets/datasets/Trino/enrollment_detail_report_01f179b6-cb75-465f-8ceb-0525c24fa223.yaml
@@ -107,6 +107,18 @@ columns:
   type: VARCHAR
   verbose_name: null
 - advanced_data_type: null
+  column_name: year_of_courserunenrollment_created_on
+  description: null
+  expression: substring(courserunenrollment_created_on, 1, 4)
+  extra: {}
+  filterable: true
+  groupby: true
+  is_active: true
+  is_dttm: false
+  python_date_format: null
+  type: null
+  verbose_name: null
+- advanced_data_type: null
   column_name: receipt_payment_method
   datetime_format: null
   description: null


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
NA
Bryan requested this feature

### Description (What does it do?)
<!--- Describe your changes in detail -->
Adds a year_of_courserunenrollment_created_on calculated column to the enrollment_detail_report dataset (same substring-based approach as the Orders dashboard's year_of_order_created_date) and a matching native filter on the Enrollment Detail by Learner dashboard, scoped like the existing Platform filter. Verified on QA via ol-superset sync.


### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->
Reviewed on QA https://bi-qa.ol.mit.edu/superset/dashboard/50/

### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->


<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
