### PR TITLE
 fix(dbt): fix courserun_is_current in enrollment_detail_report  

### DIFF
--- a/src/ol_dbt/models/reporting/enrollment_detail_report.sql
+++ b/src/ol_dbt/models/reporting/enrollment_detail_report.sql
@@ -157,7 +157,8 @@ select
     , enrollment_id as courserunenrollment_id
     , course_readable_id
     , course_title
-    , course_run.is_current as courserun_is_current
+    , {{ is_courserun_current('course_run.courserun_start_on', 'course_run.courserun_end_on') }}
+        as courserun_is_current
     , course_run.courserun_readable_id
     , courserun_start_on
     , courserun_end_on


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
NA

### Description (What does it do?)
<!--- Describe your changes in detail -->
 Fixes `courserun_is_current` in `enrollment_detail_report`:
 -  it was wrongly sourced from `dim_course_run.is_current` in https://github.com/mitodl/ol-data-platform/pull/2292, which is an SCD-2 "latest version" flag , not a date-based "currently running" flag
 - this switches it to the same `is_courserun_current()` date-based macro used by every other model, matching its documented meaning. 

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

dbt build --select enrollment_detail_report

Confirmed that courserun_is_current is now populated correctly
```
 select count(*) from "ol_data_lake_production".ol_warehouse_production_rlougee_reporting.enrollment_detail_report
 where courserun_is_current =false
```

VS 

```
-- 0 on production which is wrong
 select count(*) from "ol_data_lake_production".ol_warehouse_production_reporting.enrollment_detail_report
 where courserun_is_current =false
```




### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->


<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
