### PR TITLE
fix(migration): source future edxorg enrollments from mitx_user_info_combo directly

### DIFF
--- a/src/ol_dbt/models/migration/_migration__models.yml
+++ b/src/ol_dbt/models/migration/_migration__models.yml
@@ -107,7 +107,7 @@ models:
   tests:
   - dbt_expectations.expect_compound_columns_to_be_unique:
       arguments:
-        column_list: ["user_email", "courserun_readable_id"]
+        column_list: ["user_email", "courserun_readable_id", "courseruncertificate_created_on"]
 
 
 - name: edxorg_to_mitxonline_users

--- a/src/ol_dbt/models/migration/edxorg_to_mitxonline_enrollments.sql
+++ b/src/ol_dbt/models/migration/edxorg_to_mitxonline_enrollments.sql
@@ -301,16 +301,14 @@ with combined_enrollments as (
         future_run_user_info_combo_enrollments.courserunenrollment_created_on
         , future_run_user_info_combo_enrollments.courserunenrollment_enrollment_mode
         , future_run_user_info_combo_enrollments.user_id
-        , future_run_id_mapping.edxorg_courserun_readable_id as courserun_readable_id
+        , {{ format_course_id('future_run_user_info_combo_enrollments.courserun_readable_id', false) }}
+            as courserun_readable_id
         , null as course_readable_id
         , future_run_user_info_combo_enrollments.user_email
         , null as courseruncertificate_created_on
         , null as courserungrade_grade
         , null as courserungrade_is_passing
     from future_run_user_info_combo_enrollments
-    inner join future_run_id_mapping
-        on {{ format_course_id('future_run_user_info_combo_enrollments.courserun_readable_id', false) }}
-            = future_run_id_mapping.edxorg_courserun_readable_id
 )
 
 select

--- a/src/ol_dbt/models/migration/edxorg_to_mitxonline_enrollments.sql
+++ b/src/ol_dbt/models/migration/edxorg_to_mitxonline_enrollments.sql
@@ -177,6 +177,23 @@ with combined_enrollments as (
         and courserun_platform = '{{ var("mitxonline") }}'
 )
 
+, edxorg_future_enrollment as (
+    -- For future (not-yet-run) edX.org course runs, enrollment_mode/created_on are sourced
+    -- from mitx_user_info_combo instead of mitx_person_course (via edxorg_enrollment/
+    -- combined_enrollments)
+    -- Certificate data continues to source from both tables as before.
+    select
+        cast(user_id as varchar) as user_id
+        , courserunenrollment_courserun_readable_id as courserun_readable_id
+        , courserunenrollment_created_on
+        , courserunenrollment_mode as courserunenrollment_enrollment_mode
+        , user_email
+    from {{ ref('stg__edxorg__bigquery__mitx_user_info_combo') }}
+    where
+        courserun_platform = '{{ var("edxorg") }}'
+        and courserunenrollment_courserun_readable_id is not null
+)
+
 , product_versions as (
     select version_id, version_object_id
     from {{ ref('stg__mitxonline__app__postgres__reversion_version') }}
@@ -215,7 +232,28 @@ with combined_enrollments as (
     from {{ ref('stg__mitxonline__app__postgres__openedx_openedxuser') }}
 )
 
+, future_run_user_info_combo_enrollments as (
+    -- mitx_user_info_combo rows for the same future-run course list. mitx_person_course
+    -- (combined_enrollments' upstream source) may not have activity data yet for a learner who
+    -- has enrolled but not yet interacted with a not-yet-started course, so this is the only
+    -- place those enrollments exist.
+    select
+        edxorg_future_enrollment.user_id
+        , edxorg_future_enrollment.courserun_readable_id
+        , edxorg_future_enrollment.courserunenrollment_created_on
+        , edxorg_future_enrollment.courserunenrollment_enrollment_mode
+        , edxorg_future_enrollment.user_email
+    from edxorg_future_enrollment
+    inner join future_run_id_mapping
+        on {{ format_course_id('edxorg_future_enrollment.courserun_readable_id', false) }}
+            = future_run_id_mapping.edxorg_courserun_readable_id
+    -- Exclude retired users
+    where edxorg_future_enrollment.user_email not like 'retired__user%'
+)
+
 , edxorg_enrollment as (
+    -- Certificate-bearing enrollments: the course already ran, so future-run overrides never
+    -- apply here (courseruncertificate_created_on is not null below).
     select
         combined_enrollments.courserunenrollment_created_on
         , combined_enrollments.courserunenrollment_enrollment_mode
@@ -230,6 +268,7 @@ with combined_enrollments as (
     left join edxorg_runs
        on combined_enrollments.courserun_readable_id = edxorg_runs.courserun_readable_id
     where combined_enrollments.platform = '{{ var("edxorg") }}'
+    and combined_enrollments.courseruncertificate_created_on is not null
     --- exclude DEDP Micromasters program courses as those are already migrated
     and (edxorg_runs.micromasters_program_id != {{ var("dedp_micromasters_program_id") }}
     or edxorg_runs.micromasters_program_id is null)
@@ -246,6 +285,32 @@ with combined_enrollments as (
     -- Exclude retired users
     and combined_enrollments.user_email not like 'retired__user%'
     and combined_enrollments.user_username not like 'retired__user%'
+
+    union all
+
+    -- Future (not-yet-run) enrollments: sourced entirely from mitx_user_info_combo
+    -- (edxorg_future_enrollment/future_run_user_info_combo_enrollments) -- mitx_person_course
+    -- (combined_enrollments' upstream source) may lack activity data for a learner who enrolled
+    -- but hasn't interacted with a not-yet-started course yet, so this doesn't require the row to
+    -- already exist in combined_enrollments. This is independent of the certificate branch above:
+    -- a user can have both a certificate row (from combined_enrollments) and a future-enrollment
+    -- row (from mitx_user_info_combo) for the same course, e.g. once a course starts issuing
+    -- certificates while briefly still on the hardcoded future-run list -- see the
+    -- courseruncertificate_created_on-inclusive uniqueness test on this model.
+    select
+        future_run_user_info_combo_enrollments.courserunenrollment_created_on
+        , future_run_user_info_combo_enrollments.courserunenrollment_enrollment_mode
+        , future_run_user_info_combo_enrollments.user_id
+        , future_run_id_mapping.edxorg_courserun_readable_id as courserun_readable_id
+        , null as course_readable_id
+        , future_run_user_info_combo_enrollments.user_email
+        , null as courseruncertificate_created_on
+        , null as courserungrade_grade
+        , null as courserungrade_is_passing
+    from future_run_user_info_combo_enrollments
+    inner join future_run_id_mapping
+        on {{ format_course_id('future_run_user_info_combo_enrollments.courserun_readable_id', false) }}
+            = future_run_id_mapping.edxorg_courserun_readable_id
 )
 
 select
@@ -273,11 +338,13 @@ select
     , case
         when future_run_id_mapping.edxorg_courserun_readable_id is not null
             and edxorg_enrollment.courserunenrollment_enrollment_mode = 'verified'
+            and edxorg_enrollment.courseruncertificate_created_on is null
             then courserun_product_version.product_version_id
     end as product_version_id
     , case
         when future_run_id_mapping.edxorg_courserun_readable_id is not null
             and edxorg_enrollment.courserunenrollment_enrollment_mode = 'verified'
+            and edxorg_enrollment.courseruncertificate_created_on is null
             then purchased_on_edx_discount.discount_id
     end as discount_id
     , openedx_users.openedxuser_has_been_synced


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
https://github.com/mitodl/hq/issues/11545
and also https://github.com/mitodl/hq/issues/12241#issuecomment-4962301727

### Description (What does it do?)
<!--- Describe your changes in detail -->
Updates edxorg_to_mitxonline_enrollments so future enrollments are now sourced directly from mitx_user_info_combo, separate from the certificate-records branch. Because these future enrollments don't have `studentmodule` data (which `mitx_person_course` depends on), using mitx_user_info_combo  ensures they're still captured in the migration table. 

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

dbt build --select edxorg_to_mitxonline_enrollments

### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->


<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
