### PR TITLE
feat(ol_superset): export ignore-list so curated exclusions stick across export

### DIFF
--- a/src/ol_superset/.exportignore
+++ b/src/ol_superset/.exportignore
@@ -1,0 +1,15 @@
+# ol-superset export ignore-list
+#
+# Glob patterns (gitignore-style) for Superset assets we deliberately do NOT
+# track in this repo. `ol-superset export` prunes any exported dashboard/chart
+# whose title, name, UUID, or filename matches a pattern here, so curated
+# exclusions stick instead of reappearing on every additive export.
+#
+# Matching is dependency-consistent: removing a dashboard also removes any chart
+# that is left referenced only by removed dashboards. Datasets are never pruned
+# (physical layer, shared, validated by `ol-superset validate --dbt-dir`).
+#
+# Bypass for a one-off full export with: `ol-superset export --skip-ignore`.
+
+# MicroMasters Finance dashboards + charts — unmaintained, dropped in ce937648.
+MM_Fin_*

--- a/src/ol_superset/ol_superset/commands/export.py
+++ b/src/ol_superset/ol_superset/commands/export.py
@@ -6,6 +6,11 @@ from cyclopts import Parameter
 
 from ol_superset.commands.dedupe import dedupe
 from ol_superset.commands.normalize import normalize
+from ol_superset.lib.export_ignore import (
+    IGNORE_FILENAME,
+    load_ignore_patterns,
+    prune_ignored_assets,
+)
 from ol_superset.lib.utils import count_assets, get_assets_dir, run_sup_command
 
 
@@ -34,6 +39,13 @@ def export(
             help="Skip automatic YAML normalization after export",
         ),
     ] = False,
+    skip_ignore: Annotated[
+        bool,
+        Parameter(
+            name=["--skip-ignore"],
+            help=f"Skip pruning assets matched by {IGNORE_FILENAME}",
+        ),
+    ] = False,
 ) -> None:
     """
     Export all Superset assets from specified instance.
@@ -56,6 +68,9 @@ def export(
 
         Export without YAML normalization:
             ol-superset export --skip-normalize
+
+        Export without pruning .exportignore matches (full export):
+            ol-superset export --skip-ignore
 
         Export to custom directory:
             ol-superset export -f superset-qa -o /tmp/qa-backup
@@ -176,5 +191,34 @@ def export(
         print()
         print("ℹ️  Skipped normalization (--skip-normalize flag used)")
         print("   Run 'ol-superset normalize' to apply later.")
+
+    # Prune curated exclusions unless skipped. Runs last so it operates on the
+    # final deduped/normalized bundle.
+    if not skip_ignore:
+        patterns = load_ignore_patterns()
+        if patterns:
+            print()
+            print("=" * 50)
+            print(f"Step 6: Pruning {IGNORE_FILENAME} matches...")
+            print("=" * 50)
+            print()
+            report = prune_ignored_assets(assets_dir, patterns)
+            if report.total == 0:
+                print(
+                    f"No assets matched {IGNORE_FILENAME} ({len(patterns)} pattern(s))."
+                )
+            else:
+                print(
+                    f"Pruned {len(report.removed_dashboards)} dashboard(s) and "
+                    f"{len(report.removed_charts)} chart(s) "
+                    f"({len(report.orphaned_charts)} orphaned) "
+                    f"matching {IGNORE_FILENAME}."
+                )
+        else:
+            print()
+            print(f"ℹ️  No {IGNORE_FILENAME} patterns — nothing to prune.")
+    else:
+        print()
+        print(f"ℹ️  Skipped {IGNORE_FILENAME} pruning (--skip-ignore flag used)")
 
     print()

--- a/src/ol_superset/ol_superset/lib/export_ignore.py
+++ b/src/ol_superset/ol_superset/lib/export_ignore.py
@@ -83,9 +83,12 @@ def plan_prune(assets_dir: Path, patterns: list[str]) -> PruneReport:
     A dashboard is removed when a pattern matches its title, UUID, or filename.
     A chart is removed when a pattern matches its name, UUID, or filename
     directly, OR when it is orphaned — every dashboard that references it is
-    itself removed and at least one such dashboard exists. Charts referenced by
-    a surviving dashboard are always kept, even if orphaned charts of the same
-    name would otherwise match.
+    itself removed and at least one such dashboard exists.
+
+    A chart still referenced by a surviving (non-removed) dashboard is always
+    kept, even when it directly matches a pattern: pruning it would leave a
+    dangling Dashboard -> Chart reference that fails ``ol-superset validate``.
+    Remove the referencing dashboard too if such a chart must go.
     """
     report = PruneReport()
     if not patterns:
@@ -112,13 +115,18 @@ def plan_prune(assets_dir: Path, patterns: list[str]) -> PruneReport:
         charts_on_removed.update(index.dashboards[uuid].chart_uuids)
 
     for uuid, chart in index.charts.items():
+        # A chart still referenced by a surviving dashboard is always kept —
+        # removing it would leave a dangling Dashboard -> Chart reference that
+        # fails `ol-superset validate` and breaks bundle imports. This override
+        # wins even over a direct pattern match.
+        if surviving_refs.get(uuid, 0) > 0:
+            continue
         direct = _matches(patterns, chart.name, uuid, chart.path.name)
-        orphaned = uuid in charts_on_removed and surviving_refs.get(uuid, 0) == 0
-        if direct:
+        orphaned = uuid in charts_on_removed
+        if direct or orphaned:
             report.removed_charts.append(chart.path)
-        elif orphaned:
-            report.removed_charts.append(chart.path)
-            report.orphaned_charts.append(chart.path)
+            if orphaned and not direct:
+                report.orphaned_charts.append(chart.path)
 
     return report
 

--- a/src/ol_superset/ol_superset/lib/export_ignore.py
+++ b/src/ol_superset/ol_superset/lib/export_ignore.py
@@ -1,0 +1,139 @@
+"""Export ignore-list — keep curated exclusions across ``ol-superset export``.
+
+``ol-superset export`` pulls every asset from the live instance additively, so
+dashboards/charts we deliberately drop from the repo (e.g. the unmaintained
+``MM_Fin_*`` dashboards removed in commit ce937648) silently reappear on the
+next export. A checked-in ``.exportignore`` (gitignore-style glob patterns) lets
+those exclusions stick: after the pull the matching asset files are pruned.
+
+Matching is against the asset's *identity* fields (dashboard title, chart name,
+UUID) and its filename, so it survives dedupe's UUID-based renames. Pruning is
+dependency-consistent: removing a dashboard also removes any chart that becomes
+orphaned (referenced only by removed dashboards) — mirroring how the assets were
+removed by hand. Datasets are never auto-removed: they are the physical layer,
+are shared across charts, and are validated separately by ``ol-superset validate
+--dbt-dir``.
+"""
+
+from __future__ import annotations
+
+import fnmatch
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from ol_superset.lib.asset_index import build_asset_index
+from ol_superset.lib.utils import get_repo_root
+
+IGNORE_FILENAME = ".exportignore"
+
+
+def get_ignore_path() -> Path:
+    """Path to the checked-in ``.exportignore`` (repo root of the package)."""
+    return get_repo_root() / IGNORE_FILENAME
+
+
+def load_ignore_patterns(path: Path | None = None) -> list[str]:
+    """
+    Read glob patterns from ``.exportignore``.
+
+    Gitignore-style: one pattern per line, ``#`` comments and blank lines
+    ignored, surrounding whitespace stripped. Returns ``[]`` if the file does
+    not exist.
+    """
+    ignore_path = path if path is not None else get_ignore_path()
+    if not ignore_path.exists():
+        return []
+    patterns: list[str] = []
+    for raw in ignore_path.read_text().splitlines():
+        line = raw.strip()
+        if not line or line.startswith("#"):
+            continue
+        patterns.append(line)
+    return patterns
+
+
+def _matches(patterns: list[str], *candidates: str) -> bool:
+    """True if any pattern matches any non-empty candidate string."""
+    for pattern in patterns:
+        for candidate in candidates:
+            if candidate and fnmatch.fnmatch(candidate, pattern):
+                return True
+    return False
+
+
+@dataclass
+class PruneReport:
+    """Result of pruning ignored assets from an exported bundle."""
+
+    removed_dashboards: list[Path] = field(default_factory=list)
+    removed_charts: list[Path] = field(default_factory=list)
+    # Charts removed because every dashboard referencing them was removed
+    # (as opposed to matching a pattern by name/uuid directly).
+    orphaned_charts: list[Path] = field(default_factory=list)
+
+    @property
+    def total(self) -> int:
+        return len(self.removed_dashboards) + len(self.removed_charts)
+
+
+def plan_prune(assets_dir: Path, patterns: list[str]) -> PruneReport:
+    """
+    Compute which asset files an ``.exportignore`` would remove (no deletion).
+
+    A dashboard is removed when a pattern matches its title, UUID, or filename.
+    A chart is removed when a pattern matches its name, UUID, or filename
+    directly, OR when it is orphaned — every dashboard that references it is
+    itself removed and at least one such dashboard exists. Charts referenced by
+    a surviving dashboard are always kept, even if orphaned charts of the same
+    name would otherwise match.
+    """
+    report = PruneReport()
+    if not patterns:
+        return report
+
+    index = build_asset_index(assets_dir)
+
+    removed_dashboard_uuids: set[str] = set()
+    for uuid, dash in index.dashboards.items():
+        if _matches(patterns, dash.title, uuid, dash.path.name):
+            report.removed_dashboards.append(dash.path)
+            removed_dashboard_uuids.add(uuid)
+
+    # Which surviving dashboards still reference each chart.
+    surviving_refs: dict[str, int] = {}
+    for uuid, dash in index.dashboards.items():
+        if uuid in removed_dashboard_uuids:
+            continue
+        for chart_uuid in dash.chart_uuids:
+            surviving_refs[chart_uuid] = surviving_refs.get(chart_uuid, 0) + 1
+
+    charts_on_removed: set[str] = set()
+    for uuid in removed_dashboard_uuids:
+        charts_on_removed.update(index.dashboards[uuid].chart_uuids)
+
+    for uuid, chart in index.charts.items():
+        direct = _matches(patterns, chart.name, uuid, chart.path.name)
+        orphaned = uuid in charts_on_removed and surviving_refs.get(uuid, 0) == 0
+        if direct:
+            report.removed_charts.append(chart.path)
+        elif orphaned:
+            report.removed_charts.append(chart.path)
+            report.orphaned_charts.append(chart.path)
+
+    return report
+
+
+def prune_ignored_assets(
+    assets_dir: Path, patterns: list[str], *, dry_run: bool = False
+) -> PruneReport:
+    """
+    Delete exported asset files matching ``.exportignore`` patterns.
+
+    Returns a :class:`PruneReport` of what was (or would be, when ``dry_run``)
+    removed. Datasets are never touched.
+    """
+    report = plan_prune(assets_dir, patterns)
+    if not dry_run:
+        for path in (*report.removed_dashboards, *report.removed_charts):
+            path.unlink(missing_ok=True)
+    return report

--- a/src/ol_superset/tests/test_export_ignore.py
+++ b/src/ol_superset/tests/test_export_ignore.py
@@ -107,6 +107,30 @@ def test_orphan_only_when_all_parents_removed(tmp_path: Path) -> None:
     assert report.orphaned_charts[0].name == "Benign_benign.yaml"
 
 
+def test_surviving_reference_keeps_directly_matched_chart(tmp_path: Path) -> None:
+    # A chart whose own name matches the pattern but which is still referenced
+    # by a surviving dashboard must be KEPT — pruning it would leave a dangling
+    # Dashboard -> Chart reference and fail `ol-superset validate`.
+    base = tmp_path / "assets"
+    _write_yaml(
+        base / "dashboards" / "MM_Fin_ignored_d.yaml",
+        _dashboard("d_ignored", "MM_Fin_Board", ["c_match"]),
+    )
+    _write_yaml(
+        base / "dashboards" / "Keep_d.yaml",
+        _dashboard("d_keep", "Keep Me", ["c_match"]),
+    )
+    _write_yaml(
+        base / "charts" / "MM_Fin_Shared_c_match.yaml",
+        _chart("c_match", "MM_Fin_Shared_Chart"),
+    )
+    report = plan_prune(base, ["MM_Fin_*"])
+    removed = {p.name for p in report.removed_charts}
+    # Ignored dashboard removed, but the shared chart survives with its keeper.
+    assert {p.name for p in report.removed_dashboards} == {"MM_Fin_ignored_d.yaml"}
+    assert "MM_Fin_Shared_c_match.yaml" not in removed
+
+
 def test_match_by_uuid(tmp_path: Path) -> None:
     base = tmp_path / "assets"
     _write_yaml(

--- a/src/ol_superset/tests/test_export_ignore.py
+++ b/src/ol_superset/tests/test_export_ignore.py
@@ -1,0 +1,137 @@
+"""Tests for the export ignore-list (.exportignore) pruning."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+from ol_superset.lib.export_ignore import (
+    load_ignore_patterns,
+    plan_prune,
+    prune_ignored_assets,
+)
+
+
+def _write_yaml(path: Path, data: dict[str, object]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(yaml.dump(data))
+
+
+def _dashboard(uuid: str, title: str, chart_uuids: list[str]) -> dict[str, object]:
+    position = {
+        f"CHART-{cu}": {"type": "CHART", "meta": {"uuid": cu}} for cu in chart_uuids
+    }
+    return {"uuid": uuid, "dashboard_title": title, "position": position}
+
+
+def _chart(uuid: str, name: str, dataset_uuid: str = "ds-1") -> dict[str, object]:
+    return {
+        "uuid": uuid,
+        "slice_name": name,
+        "dataset_uuid": dataset_uuid,
+        "params": {},
+    }
+
+
+@pytest.fixture
+def assets_dir(tmp_path: Path) -> Path:
+    base = tmp_path / "assets"
+    # A tracked dashboard sharing one chart with the ignored dashboard.
+    _write_yaml(
+        base / "dashboards" / "Keep_Me_d1.yaml",
+        _dashboard("d1", "Keep Me", ["c_keep", "c_shared"]),
+    )
+    # The ignored MM_Fin dashboard, referencing an orphan chart + a shared chart.
+    _write_yaml(
+        base / "dashboards" / "MM_Fin_Main_d2.yaml",
+        _dashboard("d2", "MM_Fin_Main_Dashboard", ["c_orphan", "c_shared"]),
+    )
+    _write_yaml(base / "charts" / "Keep_c_keep.yaml", _chart("c_keep", "Keep Chart"))
+    _write_yaml(base / "charts" / "Shared_c_shared.yaml", _chart("c_shared", "Shared"))
+    _write_yaml(
+        base / "charts" / "MM_Fin_Orphan_c_orphan.yaml",
+        _chart("c_orphan", "MM_Fin_Orphan_Chart"),
+    )
+    # A dataset must never be pruned.
+    _write_yaml(
+        base / "datasets" / "Trino" / "orders_ds1.yaml",
+        {"uuid": "ds-1", "table_name": "marts__orders", "schema": "s", "catalog": "c"},
+    )
+    return base
+
+
+def test_load_ignore_patterns(tmp_path: Path) -> None:
+    ignore = tmp_path / ".exportignore"
+    ignore.write_text("# a comment\nMM_Fin_*\n\n  Foo_*  \n")
+    assert load_ignore_patterns(ignore) == ["MM_Fin_*", "Foo_*"]
+
+
+def test_load_ignore_patterns_missing(tmp_path: Path) -> None:
+    assert load_ignore_patterns(tmp_path / "nope") == []
+
+
+def test_empty_patterns_prune_nothing(assets_dir: Path) -> None:
+    report = plan_prune(assets_dir, [])
+    assert report.total == 0
+
+
+def test_prunes_matched_dashboard_and_orphan_chart(assets_dir: Path) -> None:
+    report = plan_prune(assets_dir, ["MM_Fin_*"])
+    removed = {p.name for p in (*report.removed_dashboards, *report.removed_charts)}
+    # Ignored dashboard removed.
+    assert "MM_Fin_Main_d2.yaml" in removed
+    # Its orphan chart removed (matched by name and orphaned).
+    assert "MM_Fin_Orphan_c_orphan.yaml" in removed
+    # Shared chart KEPT — still referenced by the surviving dashboard.
+    assert "Shared_c_shared.yaml" not in removed
+    # Unrelated dashboard/chart kept.
+    assert "Keep_Me_d1.yaml" not in removed
+    assert "Keep_c_keep.yaml" not in removed
+
+
+def test_orphan_only_when_all_parents_removed(tmp_path: Path) -> None:
+    # A chart named benignly, referenced only by the ignored dashboard, is
+    # removed as an orphan even though its own name does not match.
+    base = tmp_path / "assets"
+    _write_yaml(
+        base / "dashboards" / "MM_Fin_d.yaml",
+        _dashboard("d", "MM_Fin_Board", ["benign"]),
+    )
+    _write_yaml(base / "charts" / "Benign_benign.yaml", _chart("benign", "Benign"))
+    report = plan_prune(base, ["MM_Fin_*"])
+    names = {p.name for p in report.removed_charts}
+    assert "Benign_benign.yaml" in names
+    assert report.orphaned_charts
+    assert report.orphaned_charts[0].name == "Benign_benign.yaml"
+
+
+def test_match_by_uuid(tmp_path: Path) -> None:
+    base = tmp_path / "assets"
+    _write_yaml(
+        base / "charts" / "some_chart.yaml",
+        _chart("abcd-1234-uuid", "Innocent Name"),
+    )
+    report = plan_prune(base, ["abcd-1234-uuid"])
+    assert {p.name for p in report.removed_charts} == {"some_chart.yaml"}
+
+
+def test_datasets_never_pruned(assets_dir: Path) -> None:
+    # Even a pattern that would match the dataset table/uuid leaves it in place.
+    prune_ignored_assets(assets_dir, ["ds-1", "marts__orders", "*"])
+    assert (assets_dir / "datasets" / "Trino" / "orders_ds1.yaml").exists()
+
+
+def test_prune_deletes_files_and_dry_run_does_not(assets_dir: Path) -> None:
+    orphan = assets_dir / "charts" / "MM_Fin_Orphan_c_orphan.yaml"
+    dash = assets_dir / "dashboards" / "MM_Fin_Main_d2.yaml"
+
+    dry = prune_ignored_assets(assets_dir, ["MM_Fin_*"], dry_run=True)
+    assert dry.total > 0
+    assert orphan.exists() and dash.exists()  # dry-run leaves files
+
+    prune_ignored_assets(assets_dir, ["MM_Fin_*"])
+    assert not orphan.exists()
+    assert not dash.exists()
+    assert (assets_dir / "dashboards" / "Keep_Me_d1.yaml").exists()


### PR DESCRIPTION
## What & why

`ol-superset export` pulls every asset from the live instance additively, so dashboards/charts we deliberately drop from the repo silently reappear on the next export. Concretely, the unmaintained MicroMasters Finance dashboards (`MM_Fin_*`, 6 dashboards + 42 charts) were removed by hand in `ce937648`, but nothing stops a future export from pulling them back.

This adds the durable fix requested in the drift/exclusion task (`tk-ol-superset-drift-detection-...ca253c`): a checked-in `.exportignore`.

## How

- **`src/ol_superset/.exportignore`** — gitignore-style glob patterns (comments + blank lines ignored), seeded with `MM_Fin_*`.
- **`lib/export_ignore.py`** — `load_ignore_patterns()` + `plan_prune()`/`prune_ignored_assets()`. After the pull/dedupe/normalize steps, `export` prunes any **dashboard** or **chart** whose title, name, UUID, or filename matches a pattern.
  - Matching targets the asset's **identity fields** (via the existing `asset_index`), not just the filename, so it survives dedupe's UUID-based renames.
  - Pruning is **dependency-consistent**: removing a dashboard also removes charts left referenced only by removed dashboards (orphans); a chart still on a surviving dashboard is kept — mirroring the by-hand removal.
  - **Datasets are never pruned** — physical layer, shared across charts, and already covered by `ol-superset validate --dbt-dir`. (The hand-removal in `ce937648` likewise touched 0 datasets.)
- **`export`** gains `--skip-ignore` to bypass for a one-off full export, consistent with `--skip-dedupe`/`--skip-normalize`.

## Verification

- 8 new unit tests (`tests/test_export_ignore.py`); full `ol_superset` suite green (114 passed).
- End-to-end against the **real** bundle: `MM_Fin_*` matches 0 assets (already removed — no false positives).
- Reconstructed an `MM_Fin` dashboard from `ce937648~1`: dashboard + its 7 charts pruned dependency-consistently.
- `pre-commit` (ruff, mypy, detect-secrets) clean.

## Scope / follow-ups

Part of the **dbt-warehouse CI/QA hardening & data-trust** effort (#2407). This ships the credential-free exclusion slice; **owner-based export scoping** and the **credentialed `ol-superset drift` report** remain follow-ups on the same task.

🤖 Generated with [Claude Code](https://claude.com/claude-code)