### PR TITLE
fix(migration): populate certificate_page_revision_id from migrated certificate when signatory names don't match 

### DIFF
--- a/src/ol_dbt/models/migration/edxorg_to_mitxonline_enrollments.sql
+++ b/src/ol_dbt/models/migration/edxorg_to_mitxonline_enrollments.sql
@@ -111,6 +111,18 @@ with combined_enrollments as (
     from mitxonline_certificate_revision
 )
 
+, migrated_certificate_revision as (
+    -- Fallback source for certificate_page_revision_id when signatory names don't match
+    -- exactly between edX and MITx Online: use the highest wagtailcore_revision_id recorded
+    -- for any certificate on the same course run in MITx Online, one row per courserun_id.
+    select
+        courserun_id
+        , max(wagtailcore_revision_id) as wagtailcore_revision_id
+    from {{ ref('stg__mitxonline__app__postgres__courses_courseruncertificate') }}
+    where wagtailcore_revision_id is not null
+    group by courserun_id
+)
+
 , edx_to_mitxonline_certificate_revision as (
     select distinct
         edx_signatories.courserun_readable_id
@@ -331,7 +343,10 @@ select
     , edxorg_enrollment.courserungrade_is_passing
     , edxorg_enrollment.courserunenrollment_created_on
     , edxorg_enrollment.courseruncertificate_created_on
-    , edx_to_mitxonline_certificate_revision.wagtailcore_revision_id as certificate_page_revision_id
+    , coalesce(
+        edx_to_mitxonline_certificate_revision.wagtailcore_revision_id
+        , migrated_certificate_revision.wagtailcore_revision_id
+     ) as certificate_page_revision_id
     , edx_signatories.signatory_names
     , case
         when future_run_id_mapping.edxorg_courserun_readable_id is not null
@@ -376,6 +391,8 @@ left join mitxonline_enrollment as mitxonline_enrollment_by_userid
     ) = mitxonline_enrollment_by_userid.courserun_readable_id
 left join edx_to_mitxonline_certificate_revision
     on edxorg_enrollment.courserun_readable_id = edx_to_mitxonline_certificate_revision.courserun_readable_id
+left join migrated_certificate_revision
+    on mitxonline__course_runs.courserun_id = migrated_certificate_revision.courserun_id
 left join edx_signatories
     on edxorg_enrollment.courserun_readable_id = edx_signatories.courserun_readable_id
 left join retired_users


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
part of https://github.com/mitodl/hq/issues/8183

### Description (What does it do?)
<!--- Describe your changes in detail -->
populates `certificate_page_revision_id` in edxorg_to_mitxonline_enrollments
- edX signatory names don't always match MITx Online exactly, leaving certificate_page_revision_id blank on some certificate records 
- populates from the `wagtailcore_revision_id` already recorded on a migrated certificate for the same course run


### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

dbt build --select edxorg_to_mitxonline_enrollments

### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->


<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
