### PR TITLE
fix(combined_products): restore dropped mitxonline programs and dedupe by active product to eliminate duplicate rows

### DIFF
--- a/src/ol_dbt/models/marts/combined/_marts__combined__models.yml
+++ b/src/ol_dbt/models/marts/combined/_marts__combined__models.yml
@@ -595,7 +595,8 @@ models:
   - name: product_id
     description: int, primary key from ecommerce_product on MITx Online or xPro
   - name: product_type
-    description: str, either 'course run' or 'program run'
+    description: str, either 'course run', 'program' (MITx Online programs), or 'program
+      run' (xPro programs)
   - name: product_description
     description: str, product description
   - name: list_price

--- a/src/ol_dbt/models/marts/combined/_marts__combined__models.yml
+++ b/src/ol_dbt/models/marts/combined/_marts__combined__models.yml
@@ -600,7 +600,8 @@ models:
     description: str, product description
   - name: list_price
     description: numeric, the latest list price for the product. Null for MITx Online
-      programs and some MITx Online courses that have no normalized price.
+      programs and courses that have no ecommerce product record with a normalized
+      price.
   - name: product_is_active
     description: boolean, indicating whether the product is visible at the checkout
       page on MITx Online or xPro

--- a/src/ol_dbt/models/marts/combined/marts__combined__products.sql
+++ b/src/ol_dbt/models/marts/combined/marts__combined__products.sql
@@ -14,6 +14,23 @@ with mitxonline_product as (
     select * from {{ ref('int__mitxonline__programs') }}
 )
 
+, mitxonline_program_product as (
+    -- A program can have multiple ecommerce product rows (e.g. superseded price
+    -- changes). Keep one per program, preferring the active product.
+    select
+        product_id
+        , product_price
+        , product_is_active
+        , product_created_on
+        , program_readable_id
+        , row_number() over (
+            partition by program_readable_id
+            order by product_is_active desc, product_created_on desc
+        ) as _row_num
+    from mitxonline_product
+    where program_readable_id is not null
+)
+
 , mitxpro_product as (
     select * from {{ ref('int__mitxpro__ecommerce_product') }}
 )
@@ -80,13 +97,13 @@ with mitxonline_product as (
     union all
 
     select
-        null as product_id
+        mitxonline_program_product.product_id
         , 'program' as product_type
         , mitxonline_programs.program_readable_id as product_readable_id
-        , null as list_price
+        , mitxonline_program_product.product_price as list_price
         , mitxonline_programs.program_description as product_description
-        , mitxonline_product.product_is_active
-        , null as product_created_on
+        , mitxonline_program_product.product_is_active
+        , mitxonline_program_product.product_created_on
         , mitxonline_programs.program_title as product_name
         , null as start_on
         , null as end_on
@@ -105,9 +122,9 @@ with mitxonline_product as (
             , false
         ) as is_live
     from mitxonline_programs
-    left join mitxonline_product
-        on mitxonline_programs.program_readable_id = mitxonline_product.program_readable_id
-    where mitxonline_product.program_readable_id is null
+    left join mitxonline_program_product
+        on mitxonline_programs.program_readable_id = mitxonline_program_product.program_readable_id
+        and mitxonline_program_product._row_num = 1
 )
 
 , mitxpro_product_view as (


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
https://github.mit.edu/MIT-OL-Data-Platform/Data-Platform-Issues/issues/42

### Description (What does it do?)
<!--- Describe your changes in detail -->
Fixes `marts__combined__products` to include mitxonline programs that have an existing ecommerce product; for programs with multiple products, we keep the active one.

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

dbt build --select +marts__combined__products

Confirmed that these MM programs are populated

```
select * from  "ol_data_lake_production"."ol_warehouse_production_rlougee_mart"."marts__combined__products"
where product_readable_id in ('program-v1:MITxT+FIN','program-v1:MITxT+POM') OR product_readable_id LIKE 'program-v1:MITxT+SDS%'
```

### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->


<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
