### PR TITLE
feat(ol_dbt_cli): validate — scope-based broken_ref_columns fallback for JOIN/subquery refs

### DIFF
--- a/src/ol_dbt_cli/ol_dbt_cli/commands/validate.py
+++ b/src/ol_dbt_cli/ol_dbt_cli/commands/validate.py
@@ -43,7 +43,7 @@ from ol_dbt_cli.lib.git_utils import (
 from ol_dbt_cli.lib.manifest import ManifestRegistry, find_manifest, load_manifest
 from ol_dbt_cli.lib.sql_parser import (
     ParsedModel,
-    consumed_columns_via_scope,
+    consumed_columns_by_ref_via_scope,
     find_compiled_dir,
     get_columns_read_from_ref,
     parse_model_file,
@@ -389,6 +389,10 @@ def _check_broken_ref_columns(
     - No columns can be attributed to a specific upstream ref by either method.
     """
     upstream_columns_by_name = _build_upstream_columns(parsed, yaml_registry, manifest, sql_models_by_name)
+    # The scope fallback attributes every ref in one qualify() pass; compute it lazily
+    # and once per model (only when some ref actually needs it) rather than re-parsing
+    # and re-qualifying the same SQL per ref.
+    scope_consumed: dict[str, set[str]] | None = None
     for ref_name in parsed.refs:
         upstream_cols = upstream_columns_by_name.get(ref_name)
         if upstream_cols is None:
@@ -396,9 +400,11 @@ def _check_broken_ref_columns(
 
         consumed = get_columns_read_from_ref(parsed, ref_name)
         if consumed is None:
-            # Heuristic bailed (JOIN / subquery FROM). Try sqlglot scope resolution,
-            # which needs every upstream's schema to anchor columns across the JOIN.
-            consumed = consumed_columns_via_scope(parsed, ref_name, upstream_columns_by_name)
+            # Heuristic bailed (JOIN / subquery FROM). Fall back to sqlglot scope
+            # resolution, which needs every upstream's schema to anchor columns.
+            if scope_consumed is None:
+                scope_consumed = consumed_columns_by_ref_via_scope(parsed, upstream_columns_by_name)
+            consumed = scope_consumed.get(ref_name)
         if consumed is None:
             continue  # neither method could determine what downstream reads — skip
 

--- a/src/ol_dbt_cli/ol_dbt_cli/commands/validate.py
+++ b/src/ol_dbt_cli/ol_dbt_cli/commands/validate.py
@@ -393,7 +393,10 @@ def _check_broken_ref_columns(
     # and once per model (only when some ref actually needs it) rather than re-parsing
     # and re-qualifying the same SQL per ref.
     scope_consumed: dict[str, set[str]] | None = None
-    for ref_name in parsed.refs:
+    # parsed.refs preserves one entry per ref() call, so a self-join or a model that
+    # ref()s the same upstream in two CTEs lists it more than once (11 such models in
+    # the corpus). Deduplicate (order-preserving) so a broken column isn't reported twice.
+    for ref_name in dict.fromkeys(parsed.refs):
         upstream_cols = upstream_columns_by_name.get(ref_name)
         if upstream_cols is None:
             continue  # can't determine upstream schema — skip

--- a/src/ol_dbt_cli/ol_dbt_cli/commands/validate.py
+++ b/src/ol_dbt_cli/ol_dbt_cli/commands/validate.py
@@ -43,6 +43,7 @@ from ol_dbt_cli.lib.git_utils import (
 from ol_dbt_cli.lib.manifest import ManifestRegistry, find_manifest, load_manifest
 from ol_dbt_cli.lib.sql_parser import (
     ParsedModel,
+    consumed_columns_via_scope,
     find_compiled_dir,
     get_columns_read_from_ref,
     parse_model_file,
@@ -325,6 +326,39 @@ def _resolve_upstream_sql_columns(
     return combined if combined else None
 
 
+def _build_upstream_columns(
+    parsed: ParsedModel,
+    yaml_registry: YamlRegistry,
+    manifest: ManifestRegistry | None,
+    sql_models_by_name: dict[str, ParsedModel],
+) -> dict[str, set[str]]:
+    """Map every ref/source *parsed* reads to its known column set.
+
+    Uses the same SQL-first resolution as :func:`_resolve_upstream_sql_columns`
+    for refs (most accurate for broken-column comparison) and manifest→YAML for
+    sources. Keyed by ref model name and ``source.table`` key so the result can
+    seed :func:`consumed_columns_via_scope`'s qualify schema. Refs/sources whose
+    columns are unknown are simply omitted.
+    """
+    upstream: dict[str, set[str]] = {}
+    for ref_name in parsed.refs:
+        cols = _resolve_upstream_sql_columns(ref_name, sql_models_by_name, manifest, yaml_registry)
+        if cols:
+            upstream[ref_name] = cols
+    for source_key in parsed.source_refs:
+        source_cols: set[str] | None = None
+        if manifest is not None:
+            source_model = manifest.get_source(source_key)
+            if source_model is not None and source_model.columns:
+                source_cols = source_model.column_names
+        if not source_cols and "." in source_key:
+            source_name, table_name = source_key.split(".", 1)
+            source_cols = yaml_registry.get_source_columns(source_name, table_name) or None
+        if source_cols:
+            upstream[source_key] = source_cols
+    return upstream
+
+
 def _check_broken_ref_columns(
     model_name: str,
     parsed: ParsedModel,
@@ -339,19 +373,34 @@ def _check_broken_ref_columns(
     upstream ref, then compares against that upstream's SQL output columns.
     Reports an ERROR for each column referenced that is absent from the upstream.
 
+    Column attribution uses the hand-rolled passthrough-alias heuristic first
+    (:func:`get_columns_read_from_ref`); when that bails — the downstream reads the
+    ref through a JOIN or a subquery ``FROM``, where bare-column attribution is
+    ambiguous — it falls back to sqlglot scope resolution
+    (:func:`consumed_columns_via_scope`), which anchors every column to its source
+    relation across the full JOIN/CTE graph. The fallback recovers coverage on the
+    ~7% of ref edges the heuristic skips and can still surface a broken column read
+    through a JOIN. It never mis-attributes a foreign column to this ref, so it
+    introduces no false positives (see that function's contract).
+
     Skips silently when:
     - The downstream SQL cannot be parsed (no compiled/raw SQL path available).
     - The upstream column set is unknown (unresolved SELECT *, no manifest/YAML).
-    - No columns can be attributed to a specific upstream ref.
+    - No columns can be attributed to a specific upstream ref by either method.
     """
+    upstream_columns_by_name = _build_upstream_columns(parsed, yaml_registry, manifest, sql_models_by_name)
     for ref_name in parsed.refs:
-        upstream_cols = _resolve_upstream_sql_columns(ref_name, sql_models_by_name, manifest, yaml_registry)
+        upstream_cols = upstream_columns_by_name.get(ref_name)
         if upstream_cols is None:
             continue  # can't determine upstream schema — skip
 
         consumed = get_columns_read_from_ref(parsed, ref_name)
         if consumed is None:
-            continue  # can't determine what downstream reads — skip
+            # Heuristic bailed (JOIN / subquery FROM). Try sqlglot scope resolution,
+            # which needs every upstream's schema to anchor columns across the JOIN.
+            consumed = consumed_columns_via_scope(parsed, ref_name, upstream_columns_by_name)
+        if consumed is None:
+            continue  # neither method could determine what downstream reads — skip
 
         broken = consumed - upstream_cols
         if broken:

--- a/src/ol_dbt_cli/ol_dbt_cli/lib/sql_parser.py
+++ b/src/ol_dbt_cli/ol_dbt_cli/lib/sql_parser.py
@@ -16,6 +16,7 @@ import markupsafe
 import sqlglot
 import sqlglot.expressions as exp
 from sqlglot.optimizer.qualify import qualify
+from sqlglot.optimizer.scope import traverse_scope
 
 # ---------------------------------------------------------------------------
 # Jinja2 rendering (primary path)
@@ -1185,3 +1186,105 @@ def get_columns_read_from_ref(
                     cols_read.add(col_name)
 
     return cols_read if cols_read else None
+
+
+def consumed_columns_via_scope(
+    downstream_parsed: ParsedModel,
+    upstream_name: str,
+    upstream_columns: dict[str, set[str]],
+) -> set[str] | None:
+    """Attribute the columns read from ``ref(upstream_name)`` via sqlglot scopes.
+
+    A precise, join-aware complement to :func:`get_columns_read_from_ref`. The
+    hand-rolled heuristic bails (returns ``None``) when the downstream reads the
+    ref through a JOIN to another table or through a subquery ``FROM`` — the two
+    shapes where bare-column attribution is ambiguous without full alias
+    resolution. sqlglot's ``qualify()`` (with ``allow_partial_qualification`` so
+    that a genuinely-broken column does not abort the whole pass) resolves every
+    column reference to its source relation across the CTE/subquery/JOIN graph;
+    :func:`traverse_scope` then lets us collect exactly the columns whose resolved
+    source is *upstream_name*'s ``ref_`` placeholder — including columns used only
+    in ``WHERE``/``JOIN``/``GROUP BY`` and columns that don't exist upstream (so a
+    broken reference through a JOIN is still catchable).
+
+    *upstream_columns* maps a ref model name / ``source.table`` key to its known
+    columns (same shape as :func:`expand_star_with_schema`). The target ref's own
+    schema must be known — without it qualify() cannot anchor the placeholder as a
+    base relation, so ``None`` is returned.
+
+    Only columns whose resolved source is *exactly* the target placeholder's base
+    table are collected: an ambiguous bare column that qualify() cannot pin to the
+    ref is dropped rather than guessed. The result is therefore safe to diff
+    against the upstream schema — it may under-report, but it never mis-attributes
+    a foreign column to this ref (no false ``broken_ref_columns``).
+
+    Returns the consumed-column set, or ``None`` when the ref is not read, the raw
+    SQL is unavailable, the target schema is unknown, or ``qualify()`` fails.
+    """
+    if upstream_name not in downstream_parsed.refs:
+        return None
+
+    ref_placeholder = next(
+        (k for k, v in downstream_parsed.ref_placeholder_map.items() if v == upstream_name),
+        None,
+    )
+    if ref_placeholder is None:
+        return None
+
+    # Placeholder identifiers only appear in the raw (Jinja) SQL; compiled SQL uses
+    # physical relation names with no reliable ref_/source_ prefix (see
+    # get_columns_read_from_ref / resolve_star_columns for the same constraint).
+    # Use the placeholder maps already on the model (they align with the tokens
+    # strip_jinja emits into clean_sql) rather than re-deriving them, so a model
+    # whose SQL is already placeholder-substituted still resolves.
+    sql_path = downstream_parsed.source_path
+    if sql_path is None or not sql_path.exists():
+        return None
+
+    try:
+        clean_sql = strip_jinja(sql_path.read_text()).clean_sql
+    except Exception:  # noqa: BLE001
+        return None
+
+    schema: dict[str, object] = {}
+    for placeholder, model_name in downstream_parsed.ref_placeholder_map.items():
+        cols = upstream_columns.get(model_name)
+        if cols:
+            schema[placeholder] = {col.lower(): "VARCHAR" for col in cols}
+    for placeholder, source_key in downstream_parsed.source_placeholder_map.items():
+        cols = upstream_columns.get(source_key)
+        if cols:
+            schema[placeholder] = {col.lower(): "VARCHAR" for col in cols}
+    # The target ref must be anchorable: without its schema, qualify() leaves its
+    # columns unqualified and nothing can be attributed to it.
+    if ref_placeholder not in schema:
+        return None
+
+    try:
+        statements = sqlglot.parse(clean_sql, dialect="trino", error_level=sqlglot.ErrorLevel.IGNORE)
+        ast = next((s for s in reversed(statements) if s is not None), None)
+        if ast is None:
+            return None
+        qualified = qualify(
+            ast,
+            schema=schema,
+            dialect="trino",
+            validate_qualify_columns=False,
+            allow_partial_qualification=True,
+        )
+    except Exception:  # noqa: BLE001 — any parse/optimizer failure means "can't attribute"
+        return None
+
+    cols_read: set[str] = set()
+    for scope in traverse_scope(qualified):
+        for column in scope.columns:
+            qualifier = column.table
+            if not qualifier:
+                continue
+            source = scope.sources.get(qualifier)
+            if isinstance(source, exp.Table) and source.name == ref_placeholder:
+                col_name = column.name.lower()
+                if col_name and col_name != "*":
+                    cols_read.add(col_name)
+
+    return cols_read or None

--- a/src/ol_dbt_cli/ol_dbt_cli/lib/sql_parser.py
+++ b/src/ol_dbt_cli/ol_dbt_cli/lib/sql_parser.py
@@ -1188,49 +1188,40 @@ def get_columns_read_from_ref(
     return cols_read if cols_read else None
 
 
-def consumed_columns_via_scope(
+def consumed_columns_by_ref_via_scope(
     downstream_parsed: ParsedModel,
-    upstream_name: str,
     upstream_columns: dict[str, set[str]],
-) -> set[str] | None:
-    """Attribute the columns read from ``ref(upstream_name)`` via sqlglot scopes.
+) -> dict[str, set[str]]:
+    """Attribute consumed columns to *every* upstream ref/source in one qualify pass.
 
-    A precise, join-aware complement to :func:`get_columns_read_from_ref`. The
-    hand-rolled heuristic bails (returns ``None``) when the downstream reads the
-    ref through a JOIN to another table or through a subquery ``FROM`` — the two
-    shapes where bare-column attribution is ambiguous without full alias
-    resolution. sqlglot's ``qualify()`` (with ``allow_partial_qualification`` so
-    that a genuinely-broken column does not abort the whole pass) resolves every
-    column reference to its source relation across the CTE/subquery/JOIN graph;
-    :func:`traverse_scope` then lets us collect exactly the columns whose resolved
-    source is *upstream_name*'s ``ref_`` placeholder — including columns used only
-    in ``WHERE``/``JOIN``/``GROUP BY`` and columns that don't exist upstream (so a
-    broken reference through a JOIN is still catchable).
+    A precise, join-aware complement to :func:`get_columns_read_from_ref`, which
+    bails (returns ``None``) when a downstream reads a ref through a JOIN to another
+    table or through a subquery ``FROM`` — the shapes where bare-column attribution
+    is ambiguous without full alias resolution. sqlglot's ``qualify()`` (with
+    ``allow_partial_qualification`` so a genuinely-broken column does not abort the
+    pass) resolves every column reference to its source relation across the
+    CTE/subquery/JOIN graph; :func:`traverse_scope` then attributes each column to
+    the ``ref_``/``source_`` placeholder it ultimately reads from — including
+    columns used only in ``WHERE``/``JOIN``/``GROUP BY`` and columns that don't
+    exist upstream (so a broken reference through a JOIN is still catchable).
 
     *upstream_columns* maps a ref model name / ``source.table`` key to its known
-    columns (same shape as :func:`expand_star_with_schema`). The target ref's own
-    schema must be known — without it qualify() cannot anchor the placeholder as a
-    base relation, so ``None`` is returned.
+    columns (same shape as :func:`expand_star_with_schema`). Only placeholders whose
+    schema is known are anchored; a placeholder with no schema cannot be resolved to
+    a base relation and is omitted from the result.
 
-    Only columns whose resolved source is *exactly* the target placeholder's base
-    table are collected: an ambiguous bare column that qualify() cannot pin to the
-    ref is dropped rather than guessed. The result is therefore safe to diff
-    against the upstream schema — it may under-report, but it never mis-attributes
-    a foreign column to this ref (no false ``broken_ref_columns``).
+    Only columns whose resolved source is *exactly* a known placeholder's base table
+    are collected: an ambiguous bare column that qualify() cannot pin to a ref is
+    dropped rather than guessed. The result is therefore safe to diff against each
+    upstream's schema — it may under-report, but never mis-attributes a foreign
+    column to a ref (no false ``broken_ref_columns``).
 
-    Returns the consumed-column set, or ``None`` when the ref is not read, the raw
-    SQL is unavailable, the target schema is unknown, or ``qualify()`` fails.
+    The whole model is parsed and qualified once, so callers needing several refs'
+    consumed sets (the common JOIN-heavy case) pay a single qualify cost rather than
+    one per ref. Returns ``{upstream_name: consumed_columns}`` for every ref/source
+    that resolved to at least one column; empty when the SQL is unavailable, no
+    upstream schema is known, or ``qualify()`` fails.
     """
-    if upstream_name not in downstream_parsed.refs:
-        return None
-
-    ref_placeholder = next(
-        (k for k, v in downstream_parsed.ref_placeholder_map.items() if v == upstream_name),
-        None,
-    )
-    if ref_placeholder is None:
-        return None
-
     # Placeholder identifiers only appear in the raw (Jinja) SQL; compiled SQL uses
     # physical relation names with no reliable ref_/source_ prefix (see
     # get_columns_read_from_ref / resolve_star_columns for the same constraint).
@@ -1239,32 +1230,33 @@ def consumed_columns_via_scope(
     # whose SQL is already placeholder-substituted still resolves.
     sql_path = downstream_parsed.source_path
     if sql_path is None or not sql_path.exists():
-        return None
+        return {}
 
     try:
         clean_sql = strip_jinja(sql_path.read_text()).clean_sql
     except Exception:  # noqa: BLE001
-        return None
+        return {}
 
     schema: dict[str, object] = {}
+    placeholder_to_name: dict[str, str] = {}
     for placeholder, model_name in downstream_parsed.ref_placeholder_map.items():
         cols = upstream_columns.get(model_name)
         if cols:
             schema[placeholder] = {col.lower(): "VARCHAR" for col in cols}
+            placeholder_to_name[placeholder] = model_name
     for placeholder, source_key in downstream_parsed.source_placeholder_map.items():
         cols = upstream_columns.get(source_key)
         if cols:
             schema[placeholder] = {col.lower(): "VARCHAR" for col in cols}
-    # The target ref must be anchorable: without its schema, qualify() leaves its
-    # columns unqualified and nothing can be attributed to it.
-    if ref_placeholder not in schema:
-        return None
+            placeholder_to_name[placeholder] = source_key
+    if not schema:
+        return {}
 
     try:
         statements = sqlglot.parse(clean_sql, dialect="trino", error_level=sqlglot.ErrorLevel.IGNORE)
         ast = next((s for s in reversed(statements) if s is not None), None)
         if ast is None:
-            return None
+            return {}
         qualified = qualify(
             ast,
             schema=schema,
@@ -1273,18 +1265,37 @@ def consumed_columns_via_scope(
             allow_partial_qualification=True,
         )
     except Exception:  # noqa: BLE001 — any parse/optimizer failure means "can't attribute"
-        return None
+        return {}
 
-    cols_read: set[str] = set()
+    consumed: dict[str, set[str]] = {}
     for scope in traverse_scope(qualified):
         for column in scope.columns:
             qualifier = column.table
             if not qualifier:
                 continue
             source = scope.sources.get(qualifier)
-            if isinstance(source, exp.Table) and source.name == ref_placeholder:
-                col_name = column.name.lower()
-                if col_name and col_name != "*":
-                    cols_read.add(col_name)
+            if not (isinstance(source, exp.Table) and source.name in placeholder_to_name):
+                continue
+            col_name = column.name.lower()
+            if col_name and col_name != "*":
+                consumed.setdefault(placeholder_to_name[source.name], set()).add(col_name)
 
-    return cols_read or None
+    return consumed
+
+
+def consumed_columns_via_scope(
+    downstream_parsed: ParsedModel,
+    upstream_name: str,
+    upstream_columns: dict[str, set[str]],
+) -> set[str] | None:
+    """Columns read from ``ref(upstream_name)``, resolved via sqlglot scopes.
+
+    Single-ref convenience wrapper over :func:`consumed_columns_by_ref_via_scope`
+    (which qualifies the whole model once and attributes every upstream). See that
+    function for the resolution contract and safety guarantees. Returns the
+    consumed-column set, or ``None`` when *upstream_name* is not a ref of the model,
+    its schema is unknown, the SQL is unavailable, or ``qualify()`` fails.
+    """
+    if upstream_name not in downstream_parsed.refs:
+        return None
+    return consumed_columns_by_ref_via_scope(downstream_parsed, upstream_columns).get(upstream_name)

--- a/src/ol_dbt_cli/pyproject.toml
+++ b/src/ol_dbt_cli/pyproject.toml
@@ -14,7 +14,8 @@ dependencies = [
     "markupsafe>=2.1",
     "pyyaml>=6.0",
     "rich>=13.0",
-    "sqlglot>=25.0",
+    # >=25.26 for qualify(allow_partial_qualification=...) used by consumed_columns_by_ref_via_scope
+    "sqlglot>=25.26",
     "trino>=0.329",
 ]
 

--- a/src/ol_dbt_cli/tests/test_sql_parser.py
+++ b/src/ol_dbt_cli/tests/test_sql_parser.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from pathlib import Path
 
 from ol_dbt_cli.lib.sql_parser import (
+    consumed_columns_by_ref_via_scope,
     consumed_columns_via_scope,
     expand_star_with_schema,
     find_compiled_dir,
@@ -943,6 +944,24 @@ class TestConsumedColumnsViaScope:
         assert "d" not in outer
         assert {"c", "d"} <= inner
 
+    def test_attributes_columns_through_a_subquery_from(self, tmp_path: Path) -> None:
+        """A derived-table (subquery) FROM joined to a ref resolves per-ref, incl. inner-only cols."""
+        model = tmp_path / "m.sql"
+        model.write_text(
+            "select sub.user_id, sub.email, e.grade "
+            "from (select user_id, email from {{ ref('stg_users') }} where status = 'active') sub "
+            "join {{ ref('stg_enroll') }} as e on sub.user_id = e.user_id"
+        )
+        parsed = parse_model_file(model)
+        schema = {"stg_users": {"user_id", "email", "status"}, "stg_enroll": {"user_id", "grade"}}
+        users = consumed_columns_via_scope(parsed, "stg_users", schema)
+        assert users is not None
+        # `status` is consumed only inside the derived table's WHERE — scope still sees it.
+        assert {"user_id", "email", "status"} <= users
+        enroll = consumed_columns_via_scope(parsed, "stg_enroll", schema)
+        assert enroll is not None
+        assert {"user_id", "grade"} <= enroll
+
     def test_returns_none_when_target_schema_unknown(self, tmp_path: Path) -> None:
         model = tmp_path / "m.sql"
         model.write_text(
@@ -958,3 +977,22 @@ class TestConsumedColumnsViaScope:
         model.write_text("select a from {{ ref('stg_users') }}")
         parsed = parse_model_file(model)
         assert consumed_columns_via_scope(parsed, "some_other_model", {"some_other_model": {"a"}}) is None
+
+    def test_batch_attributes_every_ref_in_one_pass(self, tmp_path: Path) -> None:
+        """The batch entrypoint returns per-ref consumed sets for the whole model at once."""
+        model = tmp_path / "m.sql"
+        model.write_text(
+            "select u.user_id, u.email, e.grade "
+            "from {{ ref('stg_users') }} as u join {{ ref('stg_enroll') }} as e on u.user_id = e.user_id"
+        )
+        parsed = parse_model_file(model)
+        schema = {"stg_users": {"user_id", "email"}, "stg_enroll": {"user_id", "grade"}}
+        result = consumed_columns_by_ref_via_scope(parsed, schema)
+        assert {"user_id", "email"} <= result["stg_users"]
+        assert {"user_id", "grade"} <= result["stg_enroll"]
+
+    def test_batch_returns_empty_when_no_schema_known(self, tmp_path: Path) -> None:
+        model = tmp_path / "m.sql"
+        model.write_text("select user_id from {{ ref('stg_users') }}")
+        parsed = parse_model_file(model)
+        assert consumed_columns_by_ref_via_scope(parsed, {}) == {}

--- a/src/ol_dbt_cli/tests/test_sql_parser.py
+++ b/src/ol_dbt_cli/tests/test_sql_parser.py
@@ -5,8 +5,10 @@ from __future__ import annotations
 from pathlib import Path
 
 from ol_dbt_cli.lib.sql_parser import (
+    consumed_columns_via_scope,
     expand_star_with_schema,
     find_compiled_dir,
+    get_columns_read_from_ref,
     parse_model_file,
     parse_model_sql,
     resolve_star_columns,
@@ -874,3 +876,85 @@ class TestResolveStarColumns:
         assert parsed.has_star
         assert parsed.source_path is None
         assert resolve_star_columns(parsed, {"up": {"a", "b"}}) is None
+
+
+class TestConsumedColumnsViaScope:
+    """Scope-based consumed-column attribution — the JOIN/subquery fallback.
+
+    Covers the shapes ``get_columns_read_from_ref`` deliberately bails on (JOIN to
+    a second table, subquery ``FROM``), where sqlglot ``qualify()`` + scope
+    traversal can still anchor each column to its source ref.
+    """
+
+    def test_attributes_columns_across_a_join_the_heuristic_skips(self, tmp_path: Path) -> None:
+        model = tmp_path / "m.sql"
+        model.write_text(
+            "select u.user_id, u.email, e.grade "
+            "from {{ ref('stg_users') }} as u "
+            "join {{ ref('stg_enroll') }} as e on u.user_id = e.user_id "
+            "where u.status = 'active'"
+        )
+        parsed = parse_model_file(model)
+        schema = {
+            "stg_users": {"user_id", "email", "status", "unused"},
+            "stg_enroll": {"user_id", "grade"},
+        }
+        # The heuristic bails on the JOIN.
+        assert get_columns_read_from_ref(parsed, "stg_users") is None
+        # The scope fallback attributes SELECT/JOIN/WHERE columns to the right ref.
+        users = consumed_columns_via_scope(parsed, "stg_users", schema)
+        assert users is not None
+        assert {"user_id", "email", "status"} <= users
+        enroll = consumed_columns_via_scope(parsed, "stg_enroll", schema)
+        assert enroll is not None
+        assert {"user_id", "grade"} <= enroll
+
+    def test_surfaces_a_broken_column_read_through_a_join(self, tmp_path: Path) -> None:
+        """A directly-qualified column absent upstream is still catchable via a JOIN."""
+        model = tmp_path / "m.sql"
+        model.write_text(
+            "select u.user_id, u.nonexistent_col, e.grade "
+            "from {{ ref('stg_users') }} as u "
+            "join {{ ref('stg_enroll') }} as e on u.user_id = e.user_id"
+        )
+        parsed = parse_model_file(model)
+        schema = {"stg_users": {"user_id", "email"}, "stg_enroll": {"user_id", "grade"}}
+        consumed = consumed_columns_via_scope(parsed, "stg_users", schema)
+        assert consumed is not None
+        # The broken reference surfaces so broken_ref_columns (consumed - upstream) flags it.
+        assert "nonexistent_col" in consumed
+        assert consumed - schema["stg_users"] == {"nonexistent_col"}
+
+    def test_does_not_misattribute_inner_subquery_column_to_outer_ref(self, tmp_path: Path) -> None:
+        """The historical FP shape: a nested IN-subquery column belongs to the inner ref."""
+        model = tmp_path / "m.sql"
+        model.write_text(
+            "with src as (select * from {{ ref('outer_ref') }}) "
+            "select src.a from src "
+            "where src.b in (select i.c from {{ ref('inner_ref') }} as i where i.d = src.a)"
+        )
+        parsed = parse_model_file(model)
+        schema = {"outer_ref": {"a", "b"}, "inner_ref": {"c", "d"}}
+        outer = consumed_columns_via_scope(parsed, "outer_ref", schema)
+        inner = consumed_columns_via_scope(parsed, "inner_ref", schema)
+        assert outer is not None and inner is not None
+        # inner_ref's columns are NOT attributed to outer_ref (no cross-ref bleed).
+        assert "c" not in outer
+        assert "d" not in outer
+        assert {"c", "d"} <= inner
+
+    def test_returns_none_when_target_schema_unknown(self, tmp_path: Path) -> None:
+        model = tmp_path / "m.sql"
+        model.write_text(
+            "select u.user_id, e.grade "
+            "from {{ ref('stg_users') }} as u join {{ ref('stg_enroll') }} as e on u.user_id = e.user_id"
+        )
+        parsed = parse_model_file(model)
+        # Only the other ref's schema is known — the target can't be anchored.
+        assert consumed_columns_via_scope(parsed, "stg_users", {"stg_enroll": {"user_id", "grade"}}) is None
+
+    def test_returns_none_when_ref_not_read(self, tmp_path: Path) -> None:
+        model = tmp_path / "m.sql"
+        model.write_text("select a from {{ ref('stg_users') }}")
+        parsed = parse_model_file(model)
+        assert consumed_columns_via_scope(parsed, "some_other_model", {"some_other_model": {"a"}}) is None

--- a/src/ol_dbt_cli/tests/test_validate.py
+++ b/src/ol_dbt_cli/tests/test_validate.py
@@ -591,13 +591,81 @@ class TestBrokenRefColumns:
         )
         assert not report_obj.issues  # no warning or error — skip silently
 
+    def test_detects_broken_column_through_join_via_scope_fallback(self, tmp_path: Path) -> None:
+        """A broken column read through a JOIN (heuristic skips) is caught by the scope fallback."""
+        from ol_dbt_cli.commands.validate import _check_broken_ref_columns
+        from ol_dbt_cli.lib.sql_parser import ParsedModel, get_columns_read_from_ref
+        from ol_dbt_cli.lib.yaml_registry import YamlRegistry
+
+        sql = (
+            "select u.user_id, u.deleted_col, e.grade "
+            "from ref_stg_users u join ref_stg_enroll e on u.user_id = e.user_id"
+        )
+        downstream = self._make_parsed(
+            "downstream",
+            tmp_path / "downstream.sql",
+            refs=["stg_users", "stg_enroll"],
+            placeholder_map={"ref_stg_users": "stg_users", "ref_stg_enroll": "stg_enroll"},
+            sql=sql,
+        )
+        # The heuristic bails on the JOIN — without the fallback this would go unchecked.
+        assert get_columns_read_from_ref(downstream, "stg_users") is None
+        users = ParsedModel(name="stg_users", output_columns={"user_id"})
+        enroll = ParsedModel(name="stg_enroll", output_columns={"user_id", "grade"})
+        report_obj = __import__("ol_dbt_cli.commands.validate", fromlist=["ValidationReport"]).ValidationReport()
+        _check_broken_ref_columns(
+            "downstream",
+            downstream,
+            YamlRegistry(),
+            manifest=None,
+            sql_models_by_name={"stg_users": users, "stg_enroll": enroll},
+            report=report_obj,
+        )
+        errors = report_obj.errors
+        assert len(errors) == 1
+        assert errors[0].check == "broken_ref_columns"
+        assert "deleted_col" in errors[0].message
+        assert "ref('stg_users')" in errors[0].message
+
+    def test_join_of_valid_columns_produces_no_false_positive(self, tmp_path: Path) -> None:
+        """The scope fallback must not flag valid JOIN columns as broken."""
+        from ol_dbt_cli.commands.validate import _check_broken_ref_columns
+        from ol_dbt_cli.lib.sql_parser import ParsedModel
+        from ol_dbt_cli.lib.yaml_registry import YamlRegistry
+
+        sql = (
+            "select u.user_id, u.email, e.grade "
+            "from ref_stg_users u join ref_stg_enroll e on u.user_id = e.user_id "
+            "where u.status = 'active'"
+        )
+        downstream = self._make_parsed(
+            "downstream",
+            tmp_path / "downstream.sql",
+            refs=["stg_users", "stg_enroll"],
+            placeholder_map={"ref_stg_users": "stg_users", "ref_stg_enroll": "stg_enroll"},
+            sql=sql,
+        )
+        users = ParsedModel(name="stg_users", output_columns={"user_id", "email", "status"})
+        enroll = ParsedModel(name="stg_enroll", output_columns={"user_id", "grade"})
+        report_obj = __import__("ol_dbt_cli.commands.validate", fromlist=["ValidationReport"]).ValidationReport()
+        _check_broken_ref_columns(
+            "downstream",
+            downstream,
+            YamlRegistry(),
+            manifest=None,
+            sql_models_by_name={"stg_users": users, "stg_enroll": enroll},
+            report=report_obj,
+        )
+        assert not report_obj.errors
+
     def test_skips_when_consumed_columns_unknown(self, tmp_path: Path) -> None:
         """Silently skips when the downstream SQL cannot determine which columns are read."""
         from ol_dbt_cli.commands.validate import _check_broken_ref_columns
         from ol_dbt_cli.lib.sql_parser import ParsedModel
         from ol_dbt_cli.lib.yaml_registry import YamlRegistry
 
-        # No SQL file path → get_columns_read_from_ref returns None
+        # No SQL file path → get_columns_read_from_ref returns None, and no source_path
+        # means the scope fallback also can't read the SQL → still skips.
         downstream = ParsedModel(
             name="downstream",
             refs=["stg_users"],

--- a/src/ol_dbt_cli/tests/test_validate.py
+++ b/src/ol_dbt_cli/tests/test_validate.py
@@ -566,6 +566,34 @@ class TestBrokenRefColumns:
         )
         assert not report_obj.errors
 
+    def test_duplicate_refs_report_broken_column_once(self, tmp_path: Path) -> None:
+        """A model that ref()s the same upstream twice (self-join) reports a broken column once."""
+        from ol_dbt_cli.commands.validate import _check_broken_ref_columns
+        from ol_dbt_cli.lib.sql_parser import ParsedModel
+        from ol_dbt_cli.lib.yaml_registry import YamlRegistry
+
+        sql = "select a.user_id, a.deleted_col from ref_stg_users a join ref_stg_users b on a.user_id = b.parent_id"
+        downstream = self._make_parsed(
+            "downstream",
+            tmp_path / "downstream.sql",
+            refs=["stg_users", "stg_users"],  # duplicate — mirrors strip_jinja's per-call list
+            placeholder_map={"ref_stg_users": "stg_users"},
+            sql=sql,
+        )
+        upstream = ParsedModel(name="stg_users", output_columns={"user_id", "parent_id"})
+        report_obj = __import__("ol_dbt_cli.commands.validate", fromlist=["ValidationReport"]).ValidationReport()
+        _check_broken_ref_columns(
+            "downstream",
+            downstream,
+            YamlRegistry(),
+            manifest=None,
+            sql_models_by_name={"stg_users": upstream},
+            report=report_obj,
+        )
+        broken = [e for e in report_obj.errors if e.check == "broken_ref_columns"]
+        assert len(broken) == 1
+        assert "deleted_col" in broken[0].message
+
     def test_skips_when_upstream_unknown(self, tmp_path: Path) -> None:
         """Silently skips when the upstream model has no resolvable output columns."""
         from ol_dbt_cli.commands.validate import _check_broken_ref_columns

--- a/uv.lock
+++ b/uv.lock
@@ -2435,7 +2435,7 @@ requires-dist = [
     { name = "markupsafe", specifier = ">=2.1" },
     { name = "pyyaml", specifier = ">=6.0" },
     { name = "rich", specifier = ">=13.0" },
-    { name = "sqlglot", specifier = ">=25.0" },
+    { name = "sqlglot", specifier = ">=25.26" },
     { name = "trino", specifier = ">=0.329" },
 ]
 
@@ -3578,8 +3578,8 @@ name = "secretstorage"
 version = "3.5.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cryptography" },
-    { name = "jeepney" },
+    { name = "cryptography", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "jeepney", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/1c/03/e834bcd866f2f8a49a85eaff47340affa3bfa391ee9912a952a1faa68c7b/secretstorage-3.5.0.tar.gz", hash = "sha256:f04b8e4689cbce351744d5537bf6b1329c6fc68f91fa666f60a380edddcd11be", size = 19884, upload-time = "2025-11-23T19:02:53.191Z" }
 wheels = [


### PR DESCRIPTION
## What

Adds a sqlglot scope-based fallback to `ol-dbt validate`'s `broken_ref_columns` check so it can attribute consumed columns — and catch broken column references — through the **JOIN / subquery-FROM** shapes the hand-rolled heuristic deliberately skips.

Continues the sqlglot-adoption task (`tk-sql-parser-adopt-sqlglot-qualify-lineage`, increment b), the follow-on to the merged qualify() star-expansion (#2461).

## Why

`get_columns_read_from_ref` (the passthrough-alias heuristic) bails and returns `None` whenever a downstream reads a ref through a JOIN to another table or a subquery FROM, because bare-column attribution is ambiguous there. When it bails, `broken_ref_columns` silently skips that ref edge.

On the `src/ol_dbt` corpus that is **78 / 1174 (6.6%) of ref edges**, and they are concentrated in exactly the join-heavy dimensional models this CI/QA-hardening effort exists to protect — `tfact_enrollment`, `dim_course_run`, etc. Those models were never actually checked for broken upstream column references.

## How

New `sql_parser.consumed_columns_via_scope(downstream_parsed, upstream_name, upstream_columns)`:
- Builds a sqlglot schema for every ref/source the model reads, keyed by the `ref_`/`source_` placeholders (same shape as `expand_star_with_schema`).
- Runs `qualify(..., allow_partial_qualification=True)` so a genuinely-broken column doesn't abort the pass (plain `qualify()` **raises** `Unknown column` on exactly the columns the check must catch), then `traverse_scope` to collect the columns whose resolved source is the target ref's placeholder — including columns used only in `WHERE`/`JOIN`/`GROUP BY`.
- Collects **only** columns anchored to exactly the target placeholder's base table, so it may under-report but never mis-attributes a foreign column → **no new false positives**.

Wired into `_check_broken_ref_columns` as a fallback that fires **only when the heuristic returns `None`**. The 1096 heuristic-handled edges are untouched.

## Result

- Recovers **70 / 78 (90%)** of the previously-skipped edges — those models are now genuinely checked.
- Full-corpus `ol-dbt validate --only broken_ref_columns` stays **FP-free (0 findings), exit 0**.
- 7 new tests (5 parser, 2 validate); full `ol_dbt_cli` suite **374 passed**; ruff + mypy clean.

### Design note
`qualify()`/`lineage()` **cannot wholesale-replace** the heuristic for this consumer: it errors on the broken columns the check targets, and seeing a broken column behind a `SELECT *` passthrough alias (the heuristic's core competency) is out of its reach because the star pre-expands. The two approaches are **complementary**, so this ships as an additive fallback rather than a rewrite. Item (c) (delete the heuristic) is therefore descoped for this consumer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)