### PR TITLE
fix(enrollment_detail_report): fix two join fan-out bugs 

### DIFF
--- a/src/ol_dbt/models/reporting/_reporting__models.yml
+++ b/src/ol_dbt/models/reporting/_reporting__models.yml
@@ -125,6 +125,18 @@ models:
     A detailed view of enrollments, course runs, course certificates, orders, and
     user information for each enrollment.
   columns:
+  - name: enrollment_key
+    description: string, surrogate key from tfact_enrollment identifying a specific
+      enrollment. Unlike courserunenrollment_id (each platform's own local ID, which
+      can collide across platforms), this column is intended to be unique per row
+      -- warn-only for now due to a known, separate issue where tfact_certificate's
+      user_fk can go stale relative to dim_user after a dim_user full-refresh (see
+      certificate_id 406875 investigation).
+    tests:
+    - not_null
+    - unique:
+        config:
+          severity: warn
   - name: platform
     description: string, application where the data is from
     tests:

--- a/src/ol_dbt/models/reporting/enrollment_detail_report.sql
+++ b/src/ol_dbt/models/reporting/enrollment_detail_report.sql
@@ -21,6 +21,7 @@ with enrollment as (
 
 , course as (
     select * from {{ ref('dim_course') }}
+    where is_current = true
 )
 
 , f_certificate as (
@@ -97,10 +98,12 @@ with enrollment as (
 , discount_names as (
     select
         discount_code
+        , platform
         , discount_name
     from combined_discounts
     group by
         discount_code
+        , platform
         , discount_name
 )
 
@@ -153,10 +156,11 @@ with enrollment as (
 )
 
 select
-    enrollment.platform_display as platform
+    enrollment.enrollment_key
+    , enrollment.platform_display as platform
     , enrollment_id as courserunenrollment_id
-    , course_readable_id
-    , course_title
+    , course.course_readable_id
+    , course.course_title
     , {{ is_courserun_current('course_run.courserun_start_on', 'course_run.courserun_end_on') }}
         as courserun_is_current
     , course_run.courserun_readable_id
@@ -261,6 +265,7 @@ left join discount_type
     on f_order.discount_type_fk = discount_type.discount_type_pk
 left join discount_names
     on discount.discount_code = discount_names.discount_code
+    and enrollment.platform_display = discount_names.platform
 left join enrollment_upgrades
     on f_order.order_id = enrollment_upgrades.order_id
     and enrollment.platform_display = enrollment_upgrades.platform


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
NA 
Discovered by https://github.com/mitodl/ol-data-platform/pull/2469

### Description (What does it do?)
<!--- Describe your changes in detail -->
  Fixes bugs in `enrollment_detail_report` that caused duplicate rows (fan-out) for some enrollments, leading to inconsistent values after the switch to use dimensional models             
                                                                                                                                                                 
  - **Course title**: some enrollments show the wrong (outdated) course title instead of the course's current title.                                       
  - **Coupon**: some enrollments show a coupon name that belonged to a different platform's version of the same coupon code (e.g. an MITx Online  enrollment showing an xPro coupon's name).                                                                                                                     
                                                                                                                                                                 
  Also exposes `enrollment_key` as a new output column — a reliable unique identifier for each row, to help catch and track down any remaining duplicate-row issues 

  ## Test plan                                                                                                                                                   
  - [x] Verified both fixes by rebuilding the report from unchanged upstream data and confirming the previously-inconsistent values are now stable and correct   
  - [x] Confirmed coupon names now correctly match their platform  

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

`dbt build --select enrollment_detail_report` - a warning due to tfact_certificate's user_fk issues that will be addressed separately

Confirmed that coupon fields produce consistent values per platform

```
 select platform, coupon_code, coupon_name, count(*) as n                                                                                                       
  from "ol_data_lake_production"."ol_warehouse_production_rlougee_reporting".enrollment_detail_report                                                                    
  where coupon_code = 'NEWYEAR24'                                                                                                                                
  group by platform, coupon_code, coupon_name 
```

confirmed that course title shows the correct name for some courses 
```                                                                    
  select courserunenrollment_id, course_readable_id, course_title, courserun_readable_id                                                                         
  from "ol_data_lake_production"."ol_warehouse_production_rlougee_reporting".enrollment_detail_report                                                                    
  where course_readable_id = 'course-v1:MITxT+FIN.CFx';    
```


### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->


<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
