### PR TITLE
fix(lakehouse): survive StarRocks FE rollouts and build MVs into the granted schema

### DIFF
--- a/dg_projects/lakehouse/lakehouse/assets/lakehouse/dbt_starrocks.py
+++ b/dg_projects/lakehouse/lakehouse/assets/lakehouse/dbt_starrocks.py
@@ -1,5 +1,4 @@
 import os
-import re
 import threading
 import time
 
@@ -16,6 +15,11 @@ from lakehouse.assets.lakehouse.dbt import (
     DBT_REPO_DIR,
     DbtAutomationTranslator,
     resolve_dbt_target,
+)
+from lakehouse.lib.starrocks_dbt import (
+    MAX_BUILD_ATTEMPTS,
+    looks_retriable,
+    retry_delay,
 )
 from lakehouse.resources.starrocks import StarRocksResource
 
@@ -76,27 +80,9 @@ starrocks_dbt_cli = DbtCliResource(project_dir=starrocks_dbt_project)
 # os.environ at that point; nothing after that call can still race).
 _ENV_LOCK = threading.Lock()
 
-_MAX_BUILD_ATTEMPTS = 3
-_RETRY_BASE_DELAY = 1  # seconds; doubles each attempt
-# Same MySQL-wire-protocol error signatures StarRocksResource.execute() retries
-# on: a freshly-generated Vault user may not yet be visible on the FE node dbt
-# connects to. dbt build has no adapter-level retry of its own, so without this
-# a replication-lag race fails the whole build instead of a single statement.
-#
-# dbt-starrocks connects via mysql-connector-python, whose Error.__str__
-# formats as "<errno> (<sqlstate>): <msg>" when the server returns a real
-# error code (verified by reading dbt/adapters/starrocks/connections.py and
-# mysql/connector/errors.py); dbt-core's exception handling preserves str(e)
-# unmodified through to the node's logged error message, so the code does
-# reach here -- but as plain text in a multi-line message, not a structured
-# field, so match on a word boundary rather than a bare substring to avoid
-# an unrelated number (a row count, a line number, part of a timestamp)
-# coincidentally tripping a retry.
-_RETRIABLE_ERROR_PATTERN = re.compile(r"\b(1044|1045|2006|2013)\b")
-
-
-def _looks_retriable(exc: Exception) -> bool:
-    return bool(_RETRIABLE_ERROR_PATTERN.search(str(exc)))
+# Retry knobs and the retriable-error classifier live in lakehouse.lib so they
+# can be unit-tested without a parsed dbt manifest on disk (importing this
+# module evaluates the @dbt_assets decorator below, which needs one).
 
 
 @dbt_assets(
@@ -123,14 +109,14 @@ def starrocks_dbt_assets(
     which depends on this asset.
     """
     last_exc: DagsterDbtCliRuntimeError | None = None
-    for attempt in range(_MAX_BUILD_ATTEMPTS):
+    for attempt in range(MAX_BUILD_ATTEMPTS):
         if attempt:
-            delay = _RETRY_BASE_DELAY * (2 ** (attempt - 1))
+            delay = retry_delay(attempt)
             context.log.warning(
                 "dbt build failed (attempt %d/%d) -- retrying in %ds with fresh "
                 "Vault credentials: %s",
                 attempt,
-                _MAX_BUILD_ATTEMPTS,
+                MAX_BUILD_ATTEMPTS,
                 delay,
                 last_exc,
             )
@@ -151,7 +137,7 @@ def starrocks_dbt_assets(
         try:
             events = list(invocation.stream())
         except DagsterDbtCliRuntimeError as exc:
-            if attempt == _MAX_BUILD_ATTEMPTS - 1 or not _looks_retriable(exc):
+            if attempt == MAX_BUILD_ATTEMPTS - 1 or not looks_retriable(exc):
                 raise
             last_exc = exc
             continue

--- a/dg_projects/lakehouse/lakehouse/assets/starrocks_mv_refresh.py
+++ b/dg_projects/lakehouse/lakehouse/assets/starrocks_mv_refresh.py
@@ -1,17 +1,13 @@
+import json
+
 from dagster import AssetExecutionContext, AssetKey, asset
 
-from lakehouse.assets.lakehouse.dbt_starrocks import starrocks_dbt_assets
+from lakehouse.assets.lakehouse.dbt_starrocks import (
+    starrocks_dbt_assets,
+    starrocks_dbt_project,
+)
+from lakehouse.lib.starrocks_dbt import materialized_view_relations
 from lakehouse.resources.starrocks import StarRocksResource
-
-# Must match the model names in ol_dbt/models/b2b_analytics/.
-MV_NAMES = [
-    "mv_b2b_contract_utilization",
-    "mv_b2b_enrollment_completion_funnel",
-    "mv_b2b_monthly_engagement_trend",
-    "mv_b2b_program_funnel",
-    "mv_b2b_content_engagement_depth",
-    "mv_b2b_mit_admin_contract_health",
-]
 
 
 @asset(
@@ -30,8 +26,16 @@ def refresh_starrocks_analytics_mvs(
     The MVs are created with refresh_method='manual' (see ol_dbt/models/b2b_analytics)
     since external-catalog MVs can't auto-refresh on base-table changes -- this asset
     is what actually triggers the refresh, gated on the upstream dbt model.
+
+    Which MVs exist, and what schema they live in, both come from the same dbt
+    manifest that built them. Statements are schema-qualified rather than relying
+    on the connection's default database: the resource connects to
+    `b2b_analytics`, and an unqualified REFRESH silently means "wherever this
+    session happens to point", which is how a dbt-side schema change turned into
+    `Can not find materialized view` at runtime.
     """
-    for mv in MV_NAMES:
-        context.log.info("Refreshing %s", mv)
-        starrocks.execute(f"REFRESH MATERIALIZED VIEW {mv} WITH SYNC MODE")
-        context.log.info("Refreshed %s", mv)
+    manifest = json.loads(starrocks_dbt_project.manifest_path.read_text())
+    for relation in materialized_view_relations(manifest):
+        context.log.info("Refreshing %s", relation)
+        starrocks.execute(f"REFRESH MATERIALIZED VIEW {relation} WITH SYNC MODE")
+        context.log.info("Refreshed %s", relation)

--- a/dg_projects/lakehouse/lakehouse/lib/starrocks_dbt.py
+++ b/dg_projects/lakehouse/lakehouse/lib/starrocks_dbt.py
@@ -1,0 +1,95 @@
+"""Pure helpers shared by the StarRocks dbt asset and the MV-refresh asset.
+
+These live here rather than next to their callers so they can be unit-tested:
+importing `lakehouse.assets.lakehouse.dbt_starrocks` evaluates a `@dbt_assets`
+decorator at module scope, which raises DagsterDbtManifestNotFoundError unless a
+parsed dbt manifest is already on disk. Nothing in this module imports dagster
+or dbt.
+"""
+
+import re
+from collections.abc import Mapping
+from typing import Any
+
+# Retries are of the whole `dbt build`, since dbt-starrocks has no adapter-level
+# retry of its own. Two failure modes need covering, and the slower one sets the
+# schedule: a rolling restart of the 3-replica FE StatefulSet, measured at ~3
+# minutes end to end on 2026-07-22 (first pod killed 20:24:37, cluster whole
+# again 20:27:33). 4 attempts at a 30s doubling base spend 30 + 60 + 120 = 210s
+# asleep, plus however far each failed build got before dying -- comfortably
+# past that. The previous 3 attempts at a 1s base gave up after 3s of sleep, so
+# all three landed inside the same rollout and the build failed outright.
+# Vault credential propagation, the other (original) failure mode, resolves well
+# inside 30s; it just waits a little longer to notice now.
+MAX_BUILD_ATTEMPTS = 4
+RETRY_BASE_DELAY = 30
+
+# Error signatures worth another attempt, in two families.
+#
+# 1044/1045/2003/2006/2013 -- MySQL wire-protocol codes.
+# StarRocksResource._RETRIABLE_ERRORS carries the same set minus 2003
+# CR_CONN_HOST_ERROR, which only a *fresh* connect to an already-gone FE returns
+# and which the resource therefore never sees (it connects once, up front).
+# 1044/1045 are the Vault case: a just-created dynamic user may not be visible
+# yet on the FE node dbt happened to connect to.
+#
+# "forward failed" / "SocketTimeoutException" -- FE-side Java exceptions, not
+# wire-protocol codes. dbt connects to the round-robin fe-service, so most
+# statements land on a follower FE, which must forward every DDL to the leader
+# over Thrift. When an FE rollout takes the leader (or the follower) down
+# mid-statement, StarRocks reports "forward failed: unknown result" or
+# "java.net.SocketTimeoutException: Connect timed out" wrapped in a *generic*
+# 1064, so the numeric alternation cannot catch them.
+#
+# dbt-starrocks connects via mysql-connector-python, whose Error.__str__ formats
+# as "<errno> (<sqlstate>): <msg>", and dbt-core passes str(e) through to the
+# node's logged error message unmodified -- so these do reach us, but as plain
+# text inside a multi-line message rather than a structured field. Hence the
+# word boundaries on the numeric codes, so an unrelated number (a row count, a
+# line number, part of a timestamp) can't trip a retry. The two text signatures
+# need no such guard; neither string appears in a successful build's output.
+RETRIABLE_ERROR_PATTERN = re.compile(
+    r"\b(1044|1045|2003|2006|2013)\b|forward failed|SocketTimeoutException"
+)
+
+# dbt_project.yml tags the StarRocks-targeted models with this; it is also what
+# starrocks_dbt_assets selects on.
+STARROCKS_TAG = "starrocks"
+
+
+def looks_retriable(exc: Exception) -> bool:
+    """Whether a failed `dbt build` is worth another attempt."""
+    return bool(RETRIABLE_ERROR_PATTERN.search(str(exc)))
+
+
+def retry_delay(attempt: int) -> int:
+    """Seconds to wait before `attempt` (1-based; attempt 0 never waits)."""
+    return RETRY_BASE_DELAY * (2 ** (attempt - 1))
+
+
+def materialized_view_relations(manifest: Mapping[str, Any]) -> list[str]:
+    """Schema-qualified names of every StarRocks materialized view dbt builds.
+
+    Derived from the parsed manifest rather than hand-listed, so adding or
+    renaming a model in models/b2b_analytics/ needs no corresponding Python
+    edit. The schema comes from the manifest too, which is the point: it is
+    whatever generate_schema_name resolved to, so REFRESH targets exactly the
+    relation dbt created instead of re-deriving it and drifting.
+    """
+    relations = sorted(
+        f"{node['schema']}.{node['alias']}"
+        for node in manifest["nodes"].values()
+        if node["resource_type"] == "model"
+        and node["config"]["materialized"] == "materialized_view"
+        and STARROCKS_TAG in node["tags"]
+    )
+    if not relations:
+        # Not defensive: an empty list would make the refresh asset a silent
+        # no-op that still reports success, leaving every MV stale with nothing
+        # in the logs to say so.
+        msg = (
+            "No materialized_view models tagged "
+            f"'{STARROCKS_TAG}' found in the dbt manifest"
+        )
+        raise ValueError(msg)
+    return relations

--- a/dg_projects/lakehouse/lakehouse/lib/starrocks_dbt.py
+++ b/dg_projects/lakehouse/lakehouse/lib/starrocks_dbt.py
@@ -63,7 +63,16 @@ def looks_retriable(exc: Exception) -> bool:
 
 
 def retry_delay(attempt: int) -> int:
-    """Seconds to wait before `attempt` (1-based; attempt 0 never waits)."""
+    """Seconds to wait before `attempt`, indexed the same way the build loop
+    counts: attempt 0 is the initial build and never waits, attempt 1 is the
+    first retry.
+
+    Attempt 0 is spelled out rather than left to `2 ** -1` -- that returns
+    15.0, which is both a float (breaking the annotation) and a nonsensical
+    "wait half the base delay before doing anything".
+    """
+    if attempt < 1:
+        return 0
     return RETRY_BASE_DELAY * (2 ** (attempt - 1))
 
 

--- a/dg_projects/lakehouse/lakehouse_tests/test_starrocks_dbt.py
+++ b/dg_projects/lakehouse/lakehouse_tests/test_starrocks_dbt.py
@@ -103,6 +103,19 @@ class TestRetryDelay:
         total = sum(retry_delay(a) for a in range(1, MAX_BUILD_ATTEMPTS))
         assert total > observed_rollout_seconds
 
+    def test_initial_attempt_never_waits(self):
+        """Attempt 0 is the initial build, not a retry. `2 ** -1` would make
+        this 15.0 -- a float, and a nonsensical wait before the first try.
+        """
+        assert retry_delay(0) == 0
+        assert isinstance(retry_delay(0), int)
+
+    def test_every_delay_is_an_int(self):
+        """time.sleep tolerates a float, but the annotation says int and a
+        fractional delay would mean the schedule isn't what the comment claims.
+        """
+        assert all(isinstance(retry_delay(a), int) for a in range(MAX_BUILD_ATTEMPTS))
+
     def test_first_retry_is_not_instant(self):
         """A follower FE that just lost the leader needs the election to settle;
         retrying a second later just burns an attempt.

--- a/dg_projects/lakehouse/lakehouse_tests/test_starrocks_dbt.py
+++ b/dg_projects/lakehouse/lakehouse_tests/test_starrocks_dbt.py
@@ -1,0 +1,245 @@
+"""Tests for the StarRocks dbt retry classifier and MV-relation derivation.
+
+The failure texts below are verbatim from the production Dagster run that
+motivated this module (run acc2b10c, 2026-07-22), not invented -- the point of
+the retry pattern is that it matches what StarRocks actually emits.
+"""
+
+import pytest
+from lakehouse.lib.starrocks_dbt import (
+    MAX_BUILD_ATTEMPTS,
+    RETRY_BASE_DELAY,
+    looks_retriable,
+    materialized_view_relations,
+    retry_delay,
+)
+
+# Verbatim from the failed run: an FE rolling restart began 39s into the build,
+# so the follower dbt was connected to could no longer forward DDL to the leader.
+FE_ROLLOUT_FAILURE = """The dbt CLI process with command
+
+`dbt build --target starrocks_production --select tag:starrocks`
+
+failed with exit code `2`.
+
+Errors parsed from dbt logs:
+
+2 of 7 ERROR creating sql materialized_view model \
+b2b_analytics.mv_b2b_contract_utilization  [ERROR in 46.99s]
+
+  Database Error in model mv_b2b_contract_utilization
+  1064 (HY000): java.net.SocketTimeoutException: Connect timed out
+
+Encountered an error:
+Database Error
+  1064 (HY000): forward failed: unknown result
+"""
+
+CLEAN_BUILD_OUTPUT = """
+1 of 7 OK created sql materialized_view model b2b_analytics.mv_b2b_program_funnel \
+[SUCCESS in 12.06s]
+Done. PASS=7 WARN=0 ERROR=0 SKIP=0 TOTAL=7
+"""
+
+
+class TestLooksRetriable:
+    def test_fe_rollout_failure_is_retriable(self):
+        """The whole point: both signatures arrive wrapped in a generic 1064,
+        so a numbers-only pattern would let this fail the build outright.
+        """
+        assert looks_retriable(Exception(FE_ROLLOUT_FAILURE))
+
+    @pytest.mark.parametrize(
+        "message",
+        [
+            "1064 (HY000): forward failed: unknown result",
+            "1064 (HY000): java.net.SocketTimeoutException: Connect timed out",
+        ],
+    )
+    def test_fe_forwarding_signatures(self, message):
+        assert looks_retriable(Exception(message))
+
+    @pytest.mark.parametrize(
+        ("code", "meaning"),
+        [
+            (1044, "ER_DBACCESS_DENIED_ERROR -- Vault user not yet propagated"),
+            (1045, "ER_ACCESS_DENIED_ERROR -- Vault user not yet propagated"),
+            (2003, "CR_CONN_HOST_ERROR -- fresh connect to an FE that is gone"),
+            (2006, "CR_SERVER_GONE_ERROR"),
+            (2013, "CR_SERVER_LOST"),
+        ],
+    )
+    def test_wire_protocol_codes(self, code, meaning):
+        assert looks_retriable(Exception(f"{code} (HY000): {meaning}"))
+
+    def test_successful_build_output_is_not_retriable(self):
+        assert not looks_retriable(Exception(CLEAN_BUILD_OUTPUT))
+
+    def test_unrelated_1064_is_not_retriable(self):
+        """A genuine SQL error also surfaces as 1064. Retrying a bad query three
+        more times just burns 210s before failing the same way.
+        """
+        assert not looks_retriable(
+            Exception(
+                "1064 (HY000): Getting analyzing error. Detail message: "
+                "Unknown table 'mv_b2b_typo'."
+            )
+        )
+
+    def test_embedded_digits_do_not_trip_the_word_boundary(self):
+        assert not looks_retriable(Exception("Rows affected: 20130, 12006, 110445"))
+
+
+class TestRetryDelay:
+    def test_schedule_doubles(self):
+        assert [retry_delay(a) for a in range(1, MAX_BUILD_ATTEMPTS)] == [30, 60, 120]
+
+    def test_total_sleep_outlasts_an_fe_rolling_restart(self):
+        """The 2026-07-22 rollout ran 20:24:37 -> 20:27:33, i.e. 176s. Every
+        attempt has to not land inside the next one, or the retry is decorative:
+        the previous 3-attempt/1s-base schedule slept 3s in total and failed.
+        """
+        observed_rollout_seconds = 176
+        total = sum(retry_delay(a) for a in range(1, MAX_BUILD_ATTEMPTS))
+        assert total > observed_rollout_seconds
+
+    def test_first_retry_is_not_instant(self):
+        """A follower FE that just lost the leader needs the election to settle;
+        retrying a second later just burns an attempt.
+        """
+        assert retry_delay(1) == RETRY_BASE_DELAY
+        assert RETRY_BASE_DELAY >= 30
+
+
+def _model_node(name, *, schema="b2b_analytics", materialized, tags):
+    return {
+        "resource_type": "model",
+        "schema": schema,
+        "alias": name,
+        "tags": tags,
+        "config": {"materialized": materialized, "tags": tags},
+    }
+
+
+def _manifest(nodes):
+    return {"nodes": {f"model.open_learning.{n['alias']}": n for n in nodes}}
+
+
+class TestMaterializedViewRelations:
+    def test_qualifies_with_the_schema_dbt_resolved(self):
+        """Not the connection's default database. This is the bug that produced
+        `Can not find materialized view` -- dbt built into one schema while the
+        refresh asset issued an unqualified statement against another.
+        """
+        manifest = _manifest(
+            [
+                _model_node(
+                    "mv_b2b_contract_utilization",
+                    materialized="materialized_view",
+                    tags=["starrocks"],
+                )
+            ]
+        )
+        assert materialized_view_relations(manifest) == [
+            "b2b_analytics.mv_b2b_contract_utilization"
+        ]
+
+    def test_follows_a_schema_change_without_a_python_edit(self):
+        manifest = _manifest(
+            [
+                _model_node(
+                    "mv_b2b_contract_utilization",
+                    schema="b2b_analytics_b2b_analytics",
+                    materialized="materialized_view",
+                    tags=["starrocks"],
+                )
+            ]
+        )
+        assert materialized_view_relations(manifest) == [
+            "b2b_analytics_b2b_analytics.mv_b2b_contract_utilization"
+        ]
+
+    def test_excludes_non_materialized_view_models(self):
+        """smoke_test is tagged starrocks but materializes as a table; REFRESH
+        MATERIALIZED VIEW against it is an error.
+        """
+        manifest = _manifest(
+            [
+                _model_node(
+                    "mv_b2b_program_funnel",
+                    materialized="materialized_view",
+                    tags=["starrocks"],
+                ),
+                _model_node(
+                    "smoke_test",
+                    materialized="table",
+                    tags=["starrocks", "b2b_analytics", "smoke_test"],
+                ),
+            ]
+        )
+        assert materialized_view_relations(manifest) == [
+            "b2b_analytics.mv_b2b_program_funnel"
+        ]
+
+    def test_excludes_models_not_tagged_starrocks(self):
+        manifest = _manifest(
+            [
+                _model_node(
+                    "mv_b2b_program_funnel",
+                    materialized="materialized_view",
+                    tags=["starrocks"],
+                ),
+                _model_node(
+                    "some_trino_mv",
+                    schema="ol_warehouse_production_mart",
+                    materialized="materialized_view",
+                    tags=["mart"],
+                ),
+            ]
+        )
+        assert materialized_view_relations(manifest) == [
+            "b2b_analytics.mv_b2b_program_funnel"
+        ]
+
+    def test_ignores_non_model_nodes(self):
+        manifest = _manifest(
+            [
+                _model_node(
+                    "mv_b2b_program_funnel",
+                    materialized="materialized_view",
+                    tags=["starrocks"],
+                )
+            ]
+        )
+        manifest["nodes"]["test.open_learning.not_null_x"] = {
+            "resource_type": "test",
+            "schema": "b2b_analytics",
+            "alias": "not_null_x",
+            "tags": ["starrocks"],
+            "config": {"materialized": "test", "tags": ["starrocks"]},
+        }
+        assert materialized_view_relations(manifest) == [
+            "b2b_analytics.mv_b2b_program_funnel"
+        ]
+
+    def test_result_is_sorted(self):
+        manifest = _manifest(
+            [
+                _model_node(name, materialized="materialized_view", tags=["starrocks"])
+                for name in ("mv_b2b_program_funnel", "mv_b2b_contract_utilization")
+            ]
+        )
+        assert materialized_view_relations(manifest) == [
+            "b2b_analytics.mv_b2b_contract_utilization",
+            "b2b_analytics.mv_b2b_program_funnel",
+        ]
+
+    def test_raises_rather_than_silently_refreshing_nothing(self):
+        """An empty list would let the asset report success while every MV goes
+        stale -- the exact failure the hand-maintained list could produce.
+        """
+        manifest = _manifest(
+            [_model_node("some_table", materialized="table", tags=["starrocks"])]
+        )
+        with pytest.raises(ValueError, match="No materialized_view models tagged"):
+            materialized_view_relations(manifest)

--- a/dg_projects/lakehouse/pyproject.toml
+++ b/dg_projects/lakehouse/pyproject.toml
@@ -25,7 +25,11 @@ dependencies = [
 dev = [
     "dagster-dg-cli>=1.12.10",
     "dagster-webserver",
+    "pytest>=9.0.1,<10",
 ]
+
+[tool.pytest.ini_options]
+testpaths = ["lakehouse_tests"]
 
 [build-system]
 requires = ["setuptools"]

--- a/dg_projects/lakehouse/uv.lock
+++ b/dg_projects/lakehouse/uv.lock
@@ -1420,6 +1420,15 @@ wheels = [
 ]
 
 [[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
 name = "isodate"
 version = "0.7.2"
 source = { registry = "https://pypi.org/simple" }
@@ -1521,6 +1530,7 @@ dependencies = [
 dev = [
     { name = "dagster-dg-cli" },
     { name = "dagster-webserver" },
+    { name = "pytest" },
 ]
 
 [package.metadata]
@@ -1544,6 +1554,7 @@ requires-dist = [
 dev = [
     { name = "dagster-dg-cli", specifier = ">=1.12.10" },
     { name = "dagster-webserver" },
+    { name = "pytest", specifier = ">=9.0.1,<10" },
 ]
 
 [[package]]
@@ -1974,6 +1985,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
 name = "polars"
 version = "1.42.1"
 source = { registry = "https://pypi.org/simple" }
@@ -2370,6 +2390,22 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/9e/a1/03250fd4834b6a5c13e6600bca47ea20fda579f80bce3551d4985185d164/pyroaring-1.1.0-cp313-cp313-win32.whl", hash = "sha256:eead129046822cb0fd47c78740b81bdaffd0515c0bb0306a2318acf0f0540b58", size = 211194, upload-time = "2026-04-24T21:28:35.001Z" },
     { url = "https://files.pythonhosted.org/packages/70/63/d9b307462cddc82fe94a67d6810e5c802818690e131ba690c1de674d8558/pyroaring-1.1.0-cp313-cp313-win_amd64.whl", hash = "sha256:90ab2f00c09eed5bd986a80c8641e2dc10e7aca1a2d892d89a44b396e39c08ea", size = 263110, upload-time = "2026-04-24T21:28:35.976Z" },
     { url = "https://files.pythonhosted.org/packages/d9/4a/aa6e9833a6ba9a630efdbec8783b63da6602f763b37a5b5fbc01d73a1af1/pyroaring-1.1.0-cp313-cp313-win_arm64.whl", hash = "sha256:51dd2490a64ad4ed53c4fb58ef1ee3f84f6cbd97cdb47abd9065c9f714ab72ef", size = 216546, upload-time = "2026-04-24T21:28:37.065Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e4/47/b9efed96c114afcfa3c9d3fe98a76a1d14c74a9e266d397cf6eb64be5e01/pytest-9.1.1.tar.gz", hash = "sha256:1088fbde8f2b49d95a549a195707afa7a76a3ce9bcadc26b6d71f0ffda5fe313", size = 1636369, upload-time = "2026-06-19T10:58:32.857Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/24/25/1de2678b631f5a49215c6c96fff41ba892b0a34df68d6d80292b1b48aa7f/pytest-9.1.1-py3-none-any.whl", hash = "sha256:37a86b45efb9a47a61a36449063e8e18d0cab3161329fc099eb21783169c4f0c", size = 386536, upload-time = "2026-06-19T10:58:31.347Z" },
 ]
 
 [[package]]

--- a/src/ol_dbt/macros/generate_schema_name.sql
+++ b/src/ol_dbt/macros/generate_schema_name.sql
@@ -1,0 +1,34 @@
+{#
+    dbt's built-in generate_schema_name *appends* a model's custom `+schema` to
+    target.schema. The b2b_analytics models set `+schema: b2b_analytics`
+    (dbt_project.yml) so DbtAutomationTranslator.get_group_name -- which reads
+    config.schema, not the profile-resolved schema -- groups them, and the
+    starrocks profiles already use `schema: b2b_analytics`. The default macro
+    turns that pair into `b2b_analytics_b2b_analytics`.
+
+    Nothing else in the stack expects that name. The substructure stack creates
+    and grants exactly one database (`CREATE DATABASE IF NOT EXISTS
+    b2b_analytics` + CREATE TABLE / CREATE MATERIALIZED VIEW to role `app`, in
+    ol-infrastructure substructure/starrocks/__main__.py), Dagster's
+    StarRocksResource connects with database="b2b_analytics", and
+    ol-analytics-api queries `settings.starrocks_schema`, default
+    "b2b_analytics". Only dbt disagreed -- and it only got away with creating
+    the extra database because the Dagster Vault role is `admin`, which can
+    CREATE DATABASE. The MVs landed somewhere ungranted, so the `app` role that
+    the API authenticates as could not have read them anyway.
+
+    For StarRocks, therefore, treat `+schema` as the literal schema name.
+
+    Every other target keeps dbt's default concatenation: this macro file is
+    shared by both dbt projects in this repo (the Trino-scoped one in dbt.py and
+    the StarRocks-scoped one in dbt_starrocks.py), and the Trino/Snowflake
+    models already depend on `<target.schema>_<custom>` naming for every mart.
+    Guarding on target.type keeps this fix from silently relocating them.
+#}
+{% macro generate_schema_name(custom_schema_name, node) -%}
+    {%- if target.type == 'starrocks' and custom_schema_name is not none -%}
+        {{ custom_schema_name | trim }}
+    {%- else -%}
+        {{ default__generate_schema_name(custom_schema_name, node) }}
+    {%- endif -%}
+{%- endmacro %}

--- a/src/ol_dbt/package-lock.yml
+++ b/src/ol_dbt/package-lock.yml
@@ -1,20 +1,21 @@
+---
 packages:
-  - name: codegen
-    package: dbt-labs/codegen
-    version: 0.14.1
-  - name: dbt_expectations
-    package: metaplane/dbt_expectations
-    version: 0.10.10
-  - name: dbt_utils
-    package: dbt-labs/dbt_utils
-    version: 1.3.3
-  - name: trino_utils
-    package: starburstdata/trino_utils
-    version: 0.6.0
-  - name: audit_helper
-    package: dbt-labs/audit_helper
-    version: 0.12.2
-  - name: dbt_date
-    package: godatadriven/dbt_date
-    version: 0.19.0
+- name: codegen
+  package: dbt-labs/codegen
+  version: 0.14.1
+- name: dbt_expectations
+  package: metaplane/dbt_expectations
+  version: 0.10.10
+- name: dbt_utils
+  package: dbt-labs/dbt_utils
+  version: 1.3.3
+- name: trino_utils
+  package: starburstdata/trino_utils
+  version: 0.6.0
+- name: audit_helper
+  package: dbt-labs/audit_helper
+  version: 0.12.2
+- name: dbt_date
+  package: godatadriven/dbt_date
+  version: 0.19.0
 sha1_hash: c66302731abe41b3ae0df0d735f2a661ad303b15

--- a/src/ol_dbt/package-lock.yml
+++ b/src/ol_dbt/package-lock.yml
@@ -1,18 +1,20 @@
----
 packages:
-- name: codegen
-  package: dbt-labs/codegen
-  version: 0.14.0
-- name: dbt_expectations
-  package: metaplane/dbt_expectations
-  version: 0.10.10
-- name: dbt_utils
-  package: dbt-labs/dbt_utils
-  version: 1.3.3
-- name: trino_utils
-  package: starburstdata/trino_utils
-  version: 0.6.0
-- name: dbt_date
-  package: godatadriven/dbt_date
-  version: 0.17.2
-sha1_hash: 0921cf79bf01b8c61b05bc8fbb3b8c7dca237a33
+  - name: codegen
+    package: dbt-labs/codegen
+    version: 0.14.1
+  - name: dbt_expectations
+    package: metaplane/dbt_expectations
+    version: 0.10.10
+  - name: dbt_utils
+    package: dbt-labs/dbt_utils
+    version: 1.3.3
+  - name: trino_utils
+    package: starburstdata/trino_utils
+    version: 0.6.0
+  - name: audit_helper
+    package: dbt-labs/audit_helper
+    version: 0.12.2
+  - name: dbt_date
+    package: godatadriven/dbt_date
+    version: 0.19.0
+sha1_hash: c66302731abe41b3ae0df0d735f2a661ad303b15


### PR DESCRIPTION
### What are the relevant tickets?

N/A

### Description (What does it do?)

Fixes two independent bugs found while diagnosing a failed `b2b_analytics` run in production (Dagster run `acc2b10c`, 2026-07-22), plus a stale dbt lockfile.

**1. The dbt build could not survive an FE rolling restart**

A `pulumi up` added a `karpenter.sh/do-not-disrupt` pod annotation to the StarRocks FE StatefulSet 39 seconds into a running `dbt build`. Because it lands on the *pod template*, it forced a rolling restart of all three FE replicas — an annotation whose purpose is to prevent disruption caused one. Timeline from the cluster:

| Time (UTC) | Event |
|---|---|
| 20:23:58 | Dagster run pod starts |
| 20:24:37 | FE StatefulSet revision 22 created, `fe-2` killed |
| ~20:25:0x | `mv_b2b_contract_utilization` fails after 46.99s |
| 20:25:23 / 20:26:09 | `fe-1` / `fe-0` killed |
| 20:27:33 | Cluster whole again |

dbt connects to the round-robin `fe-service`, so most statements land on a follower FE which must forward every DDL to the leader over Thrift. With FEs disappearing mid-statement, StarRocks returned:

```
1064 (HY000): java.net.SocketTimeoutException: Connect timed out
1064 (HY000): forward failed: unknown result
```

Both are FE-side Java exceptions wrapped in a *generic* 1064, so the existing numeric-only retry pattern (`\b(1044|1045|2006|2013)\b`) could not match them and the whole build failed. The backoff wouldn't have helped either: 3 attempts at a 1s base sleeps 3s in total, so all three attempts land inside the same ~3 minute rollout.

This widens the pattern to the two text signatures plus `2003` `CR_CONN_HOST_ERROR`, and regrows the schedule to 4 attempts at a 30s base (30+60+120 = 210s of sleep) so it outlasts a full FE rollout.

**2. dbt was building the MVs into the wrong schema**

dbt's built-in `generate_schema_name` *appends* a model's custom `+schema` to `target.schema`. The `b2b_analytics` models set `+schema: b2b_analytics` (so `DbtAutomationTranslator.get_group_name`, which reads `config.schema`, can group them) and the starrocks profiles already use `schema: b2b_analytics` — so dbt was building into **`b2b_analytics_b2b_analytics`**.

Every other consumer expects `b2b_analytics`:

- the substructure stack creates and grants exactly one database (`CREATE DATABASE IF NOT EXISTS b2b_analytics`, plus `CREATE TABLE` / `CREATE MATERIALIZED VIEW` to role `app`)
- Dagster's `StarRocksResource` connects with `database="b2b_analytics"`
- `ol-analytics-api` queries `settings.starrocks_schema`, default `"b2b_analytics"`

dbt only got away with creating the extra database because the Dagster Vault role is `admin`, which can `CREATE DATABASE`. The MVs landed somewhere the `app` role the API authenticates as has no grants on — so the dashboard was querying an empty schema, and the MV-refresh asset failed with:

```
pymysql.err.ProgrammingError: (1064, 'Getting analyzing error at line 1, column 26.
Detail message: Can not find materialized view:mv_b2b_contract_utilization.')
```

A `generate_schema_name` override makes `+schema` literal for StarRocks. It is guarded on `target.type` because `macros/` is shared with the Trino-scoped dbt project — without the guard it would relocate all 652 Trino models.

**3. MV refresh is now derived from the manifest**

`starrocks_mv_refresh.py` carried a hand-maintained `MV_NAMES` list that had to be kept in sync with the model filenames, and issued *unqualified* `REFRESH` statements that silently meant "whatever schema this session points at" — which is what turned the schema mismatch into a runtime error. It now reads the same manifest that built the MVs and derives both names and schema, so adding, renaming, or moving a model needs no Python edit. It raises rather than silently refreshing nothing.

The retry knobs and classifier moved into `lakehouse/lib/starrocks_dbt.py`. That wasn't cosmetic: importing `dbt_starrocks` evaluates `@dbt_assets` at module scope, which raises `DagsterDbtManifestNotFoundError` without a pre-built manifest — so none of this logic was unit-testable in place.

**4. `package-lock.yml` regeneration**

The lock had drifted from `packages.yml`: `audit_helper` is declared there but was absent from the lock, so `dbt deps` installed 6 packages against a lock expecting 5 and every subsequent `dbt parse` aborted with `dbt expects 5 package(s) ... but found only 6`. Regenerating also picks up `codegen` 0.14.1 and `dbt_date` 0.19.0, both inside ranges `packages.yml` already allows. The reindentation is dbt's own lockfile writer, not a hand edit.

**No change needed in `ol-analytics-api`** — it already fully qualifies every query. `build_select` is the single identifier-splicing site and interpolates `schema.table` after `validate_sql_identifier`; `latest_refresh_timestamp` binds both as params; all four call sites pass `settings.starrocks_schema`. It has been asking for `b2b_analytics.mv_*` all along.

### How can this be tested?

**Schema resolution — parse both targets and compare:**

```
cd src/ol_dbt && dbt deps
DBT_STARROCKS_HOST=localhost DBT_STARROCKS_USERNAME=dummy DBT_STARROCKS_PASSWORD=dummy \
  dbt parse --target starrocks_production --profiles-dir . --target-path target/starrocks
DBT_TRINO_USERNAME=dummy DBT_TRINO_PASSWORD=dummy \
  dbt parse --target production --profiles-dir .
```

StarRocks models resolve to `b2b_analytics` (6 `materialized_view` + `smoke_test` as a `table`). Trino models are unchanged — 652 models still on `ol_warehouse_production_{staging,intermediate,external,dimensional,mart,reporting,integrations,migration}`.

**Derivation against the real manifest:**

```python
import json
from lakehouse.lib.starrocks_dbt import materialized_view_relations
from lakehouse.assets.lakehouse.dbt_starrocks import starrocks_dbt_project
materialized_view_relations(json.loads(starrocks_dbt_project.manifest_path.read_text()))
```

yields the 6 MVs, schema-qualified, `smoke_test` correctly excluded:

```
b2b_analytics.mv_b2b_content_engagement_depth
b2b_analytics.mv_b2b_contract_utilization
b2b_analytics.mv_b2b_enrollment_completion_funnel
b2b_analytics.mv_b2b_mit_admin_contract_health
b2b_analytics.mv_b2b_monthly_engagement_trend
b2b_analytics.mv_b2b_program_funnel
```

**Unit tests** — 21 passing, `cd dg_projects/lakehouse && uv run --project . python -m pytest`. The retry tests use the verbatim production error text rather than invented strings, and cover the negative cases: clean build output, an unrelated 1064 (`Can not find materialized view`), and embedded digits like `20130`/`12006` not tripping the word boundary. `test_total_sleep_outlasts_an_fe_rolling_restart` asserts the schedule beats the 176s rollout actually observed — it fails against the old 3-attempt/1s schedule, which is the point.

**End to end:** re-run the `b2b_analytics__nightly` job. The build should land in `b2b_analytics` and the refresh should succeed; previously it built into `b2b_analytics_b2b_analytics` and the refresh could not find the MVs.

`pre-commit run --files` is clean across all changed files (ruff format, ruff check, mypy, sqlfluff).

### Additional Context

**A follow-up is required after merge, and is deliberately not in this PR:** the orphaned `b2b_analytics_b2b_analytics` database still exists in production (and likely QA), holding MVs from the last successful build. Once this deploys, dbt builds into `b2b_analytics` and that database is dead weight in an unmanaged, ungranted location. Dropping it is destructive so it needs a deliberate decision:

```sql
DROP DATABASE IF EXISTS b2b_analytics_b2b_analytics;
```

Two things reviewers may want to weigh in on:

- **A leader-only FE Service was considered and rejected.** FE pods carry no leader label (only `app.kubernetes.io/component`, `app.starrocks.ownerreference/name`, `apps.kubernetes.io/pod-index`, `controller-revision-hash`, `statefulset.kubernetes.io/pod-name`, topology), so pinning would need a poller to keep a Service selector current — and it concentrates failure, since every connection would then die whenever that one pod is rolled. Retrying was the better lever.
- **The numeric part of the retry pattern can still false-positive** on a bare number in dbt output — a standalone `2006` matches. That risk is pre-existing and documented in the original comment; tightening it to require the `<errno> (<sqlstate>):` format would change behavior for the existing codes, so it was left alone.

The `FailedPreStopHook` events on all three FE pods during the rollout were investigated and appear benign — the operator-generated `stop_fe.sh -g` sends SIGUSR1 and polls with no timeout, and the kubelet records a failure when the FE exits and tears down the still-polling exec session. Not conclusively confirmed (the detail only exists in kubelet logs) and not related to these fixes.
