### PR TITLE
chore(b2b_analytics): remove StarRocks connectivity smoke-test model

### DIFF
--- a/dg_projects/lakehouse/lakehouse_tests/test_starrocks_dbt.py
+++ b/dg_projects/lakehouse/lakehouse_tests/test_starrocks_dbt.py
@@ -173,8 +173,8 @@ class TestMaterializedViewRelations:
         ]
 
     def test_excludes_non_materialized_view_models(self):
-        """smoke_test is tagged starrocks but materializes as a table; REFRESH
-        MATERIALIZED VIEW against it is an error.
+        """A starrocks-tagged model that materializes as a table must be left
+        out: REFRESH MATERIALIZED VIEW against a plain table is an error.
         """
         manifest = _manifest(
             [
@@ -184,9 +184,9 @@ class TestMaterializedViewRelations:
                     tags=["starrocks"],
                 ),
                 _model_node(
-                    "smoke_test",
+                    "b2b_seed_table",
                     materialized="table",
-                    tags=["starrocks", "b2b_analytics", "smoke_test"],
+                    tags=["starrocks", "b2b_analytics"],
                 ),
             ]
         )

--- a/src/ol_dbt/models/b2b_analytics/_b2b_analytics__models.yml
+++ b/src/ol_dbt/models/b2b_analytics/_b2b_analytics__models.yml
@@ -1,19 +1,6 @@
 ---
 version: 2
 models:
-- name: smoke_test
-  description: >
-    Connectivity smoke-test for the dbt-starrocks adapter. Creates a single-row table
-    in the StarRocks b2b_analytics database to confirm the adapter can authenticate
-    and create tables. Run via `ol-dbt starrocks run --select b2b_analytics` (fetches
-    Vault dynamic credentials automatically), or manually with
-    --target starrocks_qa_vault or --target starrocks_production.
-  columns:
-  - name: smoke_test_value
-    description: int, always 1
-  - name: run_at
-    description: datetime, timestamp when the model was materialized
-
 - name: mv_b2b_contract_utilization
   description: >
     Seat utilization and completion rate per org x contract. Manual-refresh

--- a/src/ol_dbt/models/b2b_analytics/smoke_test.sql
+++ b/src/ol_dbt/models/b2b_analytics/smoke_test.sql
@@ -1,8 +1,0 @@
-{{
-    config(
-        materialized="table",
-        tags=["b2b_analytics", "smoke_test"],
-    )
-}}
-
-select 1 as smoke_test_value, now() as run_at


### PR DESCRIPTION
## What

Removes the `smoke_test` model from `models/b2b_analytics/`:
- deletes `smoke_test.sql`
- drops its `_b2b_analytics__models.yml` doc block
- renames the stand-in fixture in `test_starrocks_dbt.py` so it no longer references the deleted model (the exclusion test itself is unchanged in intent)

## Why

`smoke_test` was bring-up scaffolding — a single-row `select 1` table whose only job was to prove the `dbt-starrocks` adapter could authenticate and `CREATE TABLE` against the `b2b_analytics` database. That path is now exercised for real on every scheduled run by the six `mv_b2b_*` materialized views, which (as of the latest run) build and refresh end-to-end against production StarRocks. The smoke test is redundant and just leaves a stray table sitting in the schema.

## Verification

- `dbt parse --target starrocks_production` clean; manifest still contains all six `mv_b2b_*` models tagged `starrocks`, no `smoke_test`.
- `pytest lakehouse_tests/test_starrocks_dbt.py` — 23 passed.
- pre-commit (ruff, mypy, yamllint, detect-secrets) clean on changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)