### PR TITLE
fix(dlt): cap edxorg_s3 in-process concurrency to stop OOMKill retry storm

### DIFF
--- a/dg_projects/data_loading/data_loading/defs/ingestion/sensor.py
+++ b/dg_projects/data_loading/data_loading/defs/ingestion/sensor.py
@@ -14,9 +14,25 @@ _EDXORG_UPSTREAM_ASSET_KEYS = [
     dg.AssetKey(["edxorg", "raw_data", "db_table", t]) for t in EDXORG_DB_TABLES
 ]
 
+# Caps how many of the ~44 per-table edxorg_s3 ops run concurrently inside this
+# job's single run pod (8Gi limit). The pool="edxorg_s3" tag on each op (see
+# assets.py) only throttles concurrency *across* runs via the instance-wide
+# concurrency-slots API -- it does nothing to the *in-process* fan-out within
+# one run, which is governed entirely by the multiprocess executor's own
+# max_concurrent. Left unset, that defaults to multiprocessing.cpu_count()
+# (the node's logical CPU count, not the pod's cgroup CPU limit), so every
+# table -- including the multi-GB courseware_studentmodule table -- launched
+# as a subprocess within ~150ms of each other and OOMKilled the pod almost
+# immediately (confirmed in production logs 2026-07-23: repeated "Run has not
+# completed but K8s job has no active pods" within ~2 minutes of each start,
+# exhausting the daemon's 3 resume attempts twice in a row).
+# 4 is a conservative starting point given unknown per-table memory profiles;
+# override per-launch via run config (execution.config.multiprocess.config.
+# max_concurrent) to tune without a redeploy.
 edxorg_s3_ingest_job = dg.define_asset_job(
     name="edxorg_s3_ingest_job",
     selection=dg.AssetSelection.keys(*_EDXORG_S3_ASSET_KEYS),
+    executor_def=dg.multiprocess_executor.configured({"max_concurrent": 4}),
     description=(
         "Loads all edxorg database tables from S3 into the raw warehouse layer."
     ),


### PR DESCRIPTION
### What are the relevant tickets?
N/A

### Description (What does it do?)
`edxorg_s3_ingest_job` wraps ~44 per-table dlt ops, each tagged `pool="edxorg_s3"` (added in #2429 to parallelize per-table loading instead of one giant sequential op). That pool tag only throttles concurrency *across separate runs* via Dagster's instance-wide concurrency-slots API — it has no effect on in-process fan-out *within* a single run. With no `executor_def` override, the default multiprocess executor's `max_concurrent` falls back to `multiprocessing.cpu_count()` (the node's logical CPU count, not the pod's 8Gi/3-core cgroup limits from the `data_loading` deployment). So every table — including the multi-GB `courseware_studentmodule` table — launches as a subprocess within milliseconds of every other table, all sharing one 8Gi pod.

Confirmed as the live cause in production logs on 2026-07-23: three consecutive `edxorg_s3_ingest_job` runs each died within ~2 minutes of every worker start (`dagster.daemon.MonitoringDaemon: Detected run worker status FAILED: 'Run has not completed but K8s job has no active pods'`), exhausting the daemon's 3-attempt resume limit twice in a row — an active retry storm, not a one-off:

```
20:11:46 run 9f452ffb started -> resumed 3x -> marked failed at 20:19:42 (max resume attempts)
20:19:54 run 4719498e started -> resumed 3x -> marked failed at 20:27:42 (max resume attempts)
20:27:54 run 746ee409 started -> mid-retry as of writing
```

And directly in the run's own step logs, 16+ `STEP_WORKER_STARTING` events (including `edxorg_s3_courseware_studentmodule`) fired within 141ms of each other at run start — i.e. effectively unbounded concurrency.

Sets `executor_def=multiprocess_executor.configured({"max_concurrent": 4})` on the job so the executor itself — not the cross-run pool — bounds actual in-pod parallelism. 4 is a conservative starting point given no empirical per-table memory profile exists yet; it can be tuned per-launch via run config (`execution.config.multiprocess.config.max_concurrent`) without a redeploy if 4 proves too conservative or still too high.

The existing `pool="edxorg_s3"` tags are left in place — they still provide useful cross-run protection (e.g. if a sensor retry ever overlaps with a still-finishing prior run).

### How can this be tested?
- `cd dg_projects/data_loading && uv run python -m pytest data_loading_tests/` — 18 passed.
- `uv run dg list defs` — `edxorg_s3_ingest_job` loads cleanly.
- `uv run ruff check dg_projects/data_loading/data_loading/defs/ingestion/sensor.py` — clean.
- In production: trigger `edxorg_s3_ingest_job` and confirm via the Dagster UI / pod logs that no more than 4 `edxorg_s3_*` steps are `STARTED` at once, and the run's pod memory stays well under its 8Gi limit instead of the prior all-at-once launch pattern.

### Additional Context
This is a follow-up to #2429, which introduced per-table ops with a `pool="edxorg_s3"` tag under the (incorrect) assumption that the pool tag alone would bound concurrency within a single run. It doesn't — pools and executor `max_concurrent` are two separate concurrency mechanisms in Dagster, and only the latter governs in-process fan-out for a single run's multiprocess executor.

`4` is a starting guess, not a measured optimum — there's no historical per-table memory profile for edxorg_s3 tables to size against. Worth revisiting once a few runs complete and we can see actual peak memory per concurrency level.