### PR TITLE
Fail the build when Superset asset promotion actually fails

### DIFF
--- a/src/ol_superset/ol_superset/commands/promote.py
+++ b/src/ol_superset/ol_superset/commands/promote.py
@@ -197,10 +197,15 @@ def promote(
     print("Step 5: Promoting assets to production...")
     print()
 
+    # Tracks whether any push step failed, so a failure can't be masked by
+    # --force (which only skips interactive confirmations) or by falling
+    # through to the "Promotion Complete!" banner at the end.
+    promotion_failed = False
+
     # Push charts with dependencies
     print("Step 5a: Pushing datasets...")
     if counts["datasets"] > 0:
-        run_sup_command(
+        result = run_sup_command(
             [
                 "dataset",
                 "push",
@@ -211,7 +216,11 @@ def promote(
             ],
             check=False,
         )
-        print("  ✅ Datasets promoted")
+        if result.returncode == 0:
+            print("  ✅ Datasets promoted")
+        else:
+            print("  ❌ Dataset promotion failed")
+            promotion_failed = True
 
         # Superset's import API does not update physical table connections
         # (table_name, schema) for existing datasets — patch them directly.
@@ -239,6 +248,7 @@ def promote(
             print("  ✅ Charts promoted successfully")
         else:
             print("  ⚠️  Some charts may have failed - check logs above")
+            promotion_failed = True
     else:
         print("  No charts to promote")
 
@@ -261,6 +271,7 @@ def promote(
             print("  ✅ Dashboards promoted successfully")
         else:
             print("  ❌ Dashboard promotion failed")
+            promotion_failed = True
             if not force and not confirm_action("Continue anyway?"):
                 print("Promotion aborted")
                 run_sup_command(["instance", "use", "superset-qa"])
@@ -297,7 +308,7 @@ def promote(
 
     print()
     print("=" * 50)
-    print("Promotion Complete!")
+    print("Promotion Complete!" if not promotion_failed else "Promotion Finished")
     print("=" * 50)
     print()
     print("Next steps:")
@@ -314,5 +325,10 @@ def promote(
     run_sup_command(["instance", "use", "superset-qa"])
 
     print()
+    if promotion_failed:
+        print("❌ Promotion completed with errors — see failures above.")
+        print()
+        sys.exit(1)
+
     print("✅ Promotion complete! All assets deployed to production.")
     print()

--- a/src/ol_superset/tests/test_promote.py
+++ b/src/ol_superset/tests/test_promote.py
@@ -1,0 +1,145 @@
+"""Tests that promote() fails the build when any asset push actually fails."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from ol_superset.commands.promote import promote
+
+ASSET_COUNTS = {
+    "published_dashboards": 1,
+    "dashboards": 1,
+    "charts": 1,
+    "datasets": 1,
+}
+
+
+def _completed(returncode: int) -> subprocess.CompletedProcess[str]:
+    return subprocess.CompletedProcess(args=[], returncode=returncode)
+
+
+@pytest.fixture(autouse=True)
+def _common_mocks(tmp_path: Path):
+    """Stub out everything promote() touches except run_sup_command."""
+    assets_dir = tmp_path / "assets"
+    assets_dir.mkdir()
+    with (
+        patch("ol_superset.commands.promote.get_assets_dir", return_value=assets_dir),
+        patch("ol_superset.commands.promote.count_assets", return_value=ASSET_COUNTS),
+        patch(
+            "ol_superset.commands.promote.check_git_status",
+            return_value=(False, []),
+        ),
+        patch("ol_superset.commands.promote.map_database_uuids"),
+        patch("ol_superset.commands.promote.sync_physical_dataset_connections"),
+    ):
+        yield
+
+
+def _run_sup_side_effect(success_steps: set[str]):
+    def _side_effect(args, check=False):  # noqa: ARG001
+        step = args[0] if args else ""
+        if step in ("dataset", "chart", "dashboard"):
+            return _completed(0 if step in success_steps else 1)
+        return _completed(0)
+
+    return _side_effect
+
+
+def test_promote_succeeds_when_all_pushes_succeed():
+    with patch(
+        "ol_superset.commands.promote.run_sup_command",
+        side_effect=_run_sup_side_effect({"dataset", "chart", "dashboard"}),
+    ):
+        promote(force=True, skip_validation=True)
+
+
+def test_promote_fails_build_when_dataset_push_fails():
+    with (
+        patch(
+            "ol_superset.commands.promote.run_sup_command",
+            side_effect=_run_sup_side_effect({"chart", "dashboard"}),
+        ),
+        pytest.raises(SystemExit) as exc_info,
+    ):
+        promote(force=True, skip_validation=True)
+
+    assert exc_info.value.code == 1
+
+
+def test_promote_fails_build_when_chart_push_fails():
+    with (
+        patch(
+            "ol_superset.commands.promote.run_sup_command",
+            side_effect=_run_sup_side_effect({"dataset", "dashboard"}),
+        ),
+        pytest.raises(SystemExit) as exc_info,
+    ):
+        promote(force=True, skip_validation=True)
+
+    assert exc_info.value.code == 1
+
+
+def test_promote_fails_build_when_dashboard_push_fails_and_forced():
+    """--force must not silently swallow a dashboard push failure."""
+    with (
+        patch(
+            "ol_superset.commands.promote.run_sup_command",
+            side_effect=_run_sup_side_effect({"dataset", "chart"}),
+        ),
+        pytest.raises(SystemExit) as exc_info,
+    ):
+        promote(force=True, skip_validation=True)
+
+    assert exc_info.value.code == 1
+
+
+def _confirm_action_side_effect(continue_after_failure: bool):
+    def _side_effect(prompt, require_exact=None):  # noqa: ARG001
+        if prompt == "Continue anyway?":
+            return continue_after_failure
+        # The earlier "FINAL CONFIRMATION: Deploy ... PRODUCTION?" prompt
+        # (and any git-status prompt) must say yes so execution reaches the
+        # push steps under test.
+        return True
+
+    return _side_effect
+
+
+def test_promote_dashboard_failure_aborts_immediately_when_not_forced_and_declined():
+    with (
+        patch(
+            "ol_superset.commands.promote.run_sup_command",
+            side_effect=_run_sup_side_effect({"dataset", "chart"}),
+        ),
+        patch(
+            "ol_superset.commands.promote.confirm_action",
+            side_effect=_confirm_action_side_effect(continue_after_failure=False),
+        ),
+        pytest.raises(SystemExit) as exc_info,
+    ):
+        promote(force=False, skip_validation=True)
+
+    assert exc_info.value.code == 1
+
+
+def test_promote_dashboard_failure_still_fails_build_if_user_continues_anyway():
+    """Choosing to continue past a failure doesn't turn it into a success."""
+    with (
+        patch(
+            "ol_superset.commands.promote.run_sup_command",
+            side_effect=_run_sup_side_effect({"dataset", "chart"}),
+        ),
+        patch(
+            "ol_superset.commands.promote.confirm_action",
+            side_effect=_confirm_action_side_effect(continue_after_failure=True),
+        ),
+        pytest.raises(SystemExit) as exc_info,
+    ):
+        promote(force=False, skip_validation=True)
+
+    assert exc_info.value.code == 1


### PR DESCRIPTION
### What are the relevant tickets?
N/A

### Description (What does it do?)
`ol-superset promote` (used by the `ol-superset-deploy` Concourse pipeline in
[`ol-infrastructure`](https://github.com/mitodl/ol-infrastructure/blob/main/src/ol_concourse/pipelines/applications/ol_superset_deploy.py))
was reporting success even when every asset push to production had actually failed.

`promote()` in `src/ol_superset/ol_superset/commands/promote.py`:
- Never checked the dataset push's return code at all — it unconditionally printed
  `✅ Datasets promoted`.
- Checked the chart push's return code but only printed a warning on failure, never
  treated it as a build failure.
- Checked the dashboard push's return code, but the only abort path was
  `if not force and not confirm_action("Continue anyway?")`. Since the Concourse
  pipeline always passes `--force`, that condition can never be true, so the
  interactive-only abort logic silently accepted the failure in CI.
- Never called `sys.exit(1)` for any of this — it always fell through to the
  `✅ Promotion complete!` banner with exit code 0.

This was caught for real: build 98 of `deploy-superset-assets-to-production` hit an
OAuth2 client-credentials auth bug in
[`superset-sup`](https://github.com/mitodl/superset-sup) (fixed separately in
[mitodl/superset-sup@582de67](https://github.com/mitodl/superset-sup/commit/582de6701)),
printed `❌ Authentication configuration error: ...` for every dataset/chart/dashboard
import, and still ended with:

```
✅ Promotion complete! All assets deployed to production.
succeeded
```

No assets were actually promoted, and the Concourse job reported green.

This PR adds a `promotion_failed` flag that's set whenever any of the three push
steps fails (regardless of `--force`), and exits 1 at the end if it was ever set —
even if a human interactively chose "continue anyway" past a dashboard failure, since
that only means "keep trying the remaining steps," not "treat this as a success."

### Screenshots (if appropriate):
N/A — no UI changes.

### How can this be tested?
Added `src/ol_superset/tests/test_promote.py`, which mocks `run_sup_command` and the
other `promote()` dependencies (`get_assets_dir`, `count_assets`, `check_git_status`,
`map_database_uuids`, `sync_physical_dataset_connections`) and covers:

- All three pushes succeed → `promote()` returns normally (no `SystemExit`).
- Dataset push fails → `SystemExit(1)`.
- Chart push fails → `SystemExit(1)`.
- Dashboard push fails with `--force` → `SystemExit(1)` (this is the case that
  previously slipped through in CI).
- Dashboard push fails without `--force` and the user declines to continue →
  `SystemExit(1)` (pre-existing behavior, preserved).
- Dashboard push fails without `--force` and the user chooses to continue anyway →
  still `SystemExit(1)` at the end (previously this path had no exit code check at
  all after the confirmation).

Run:
```
cd src/ol_superset && uv run pytest tests/test_promote.py -v
```
All 6 new tests pass; the full `ol_superset` suite (121 tests) passes unchanged.

### Additional Context
Part of investigating why the `ol-superset-deploy` Concourse pipeline
(`deploy-superset-assets-to-production`) reported success on build 98 while nothing
was actually deployed. The other half of the fix,
[mitodl/superset-sup@582de67](https://github.com/mitodl/superset-sup/commit/582de6701)
on the `self_hosted_superset_oidc` branch, corrects the underlying OAuth2 auth
factory that rejected pure client-credentials configs (the mode this pipeline uses).
Both need to land — and the `ol-superset` image needs a rebuild — before rerunning
the Concourse job.
