### PR TITLE
fix(vault): flatten StarRocks Vault database mount to a single non-env-scoped path

### DIFF
--- a/bin/starrocks-auth
+++ b/bin/starrocks-auth
@@ -105,6 +105,11 @@ import hvac
 # Environment configuration
 # ---------------------------------------------------------------------------
 
+# Vault's "database-starrocks" mount is not environment-specific -- each
+# environment runs its own, entirely separate Vault deployment, so the Vault
+# server (vault_addr below), not the mount path, is what scopes the environment.
+_VAULT_MOUNT = "database-starrocks"
+
 ENVS: dict[str, dict[str, str]] = {
     "qa": {
         "issuer": "https://sso-qa.ol.mit.edu/realms/ol-data-platform",
@@ -113,7 +118,7 @@ ENVS: dict[str, dict[str, str]] = {
         "k8s_namespace": "starrocks",
         "fe_service": "lakehouse-starrocks-fe-service",
         "vault_addr": "https://vault-qa.odl.mit.edu",
-        "vault_mount": "database-starrocks-qa",
+        "vault_mount": _VAULT_MOUNT,
     },
     "production": {
         "issuer": "https://sso.ol.mit.edu/realms/ol-data-platform",
@@ -122,7 +127,7 @@ ENVS: dict[str, dict[str, str]] = {
         "k8s_namespace": "starrocks",
         "fe_service": "lakehouse-starrocks-fe-service",
         "vault_addr": "https://vault-production.odl.mit.edu",
-        "vault_mount": "database-starrocks-production",
+        "vault_mount": _VAULT_MOUNT,
     },
     "ci": {
         "issuer": "https://sso-ci.ol.mit.edu/realms/ol-data-platform",
@@ -131,7 +136,7 @@ ENVS: dict[str, dict[str, str]] = {
         "k8s_namespace": "starrocks",
         "fe_service": "lakehouse-starrocks-fe-service",
         "vault_addr": "https://vault-qa.odl.mit.edu",
-        "vault_mount": "database-starrocks-ci",
+        "vault_mount": _VAULT_MOUNT,
     },
 }
 

--- a/dg_projects/lakehouse/lakehouse/definitions.py
+++ b/dg_projects/lakehouse/lakehouse/definitions.py
@@ -79,14 +79,11 @@ starrocks_host_map = {
     "production": "lakehouse-starrocks-fe-service.starrocks.svc.cluster.local",
 }
 
-# Matches the database-starrocks-{env} mount convention used by
-# bin/starrocks-auth and ol_dbt_cli/commands/starrocks.py.
-starrocks_vault_mount_map = {
-    "dev": "database-starrocks-qa",
-    "ci": "database-starrocks-qa",
-    "qa": "database-starrocks-qa",
-    "production": "database-starrocks-production",
-}
+# QA and Production each run their own, entirely separate Vault deployment, so
+# the mount name itself doesn't carry an env suffix -- the Vault server (not
+# the mount path) is what scopes the environment. Matches the "database-starrocks"
+# mount convention used by bin/starrocks-auth and ol_dbt_cli/commands/starrocks.py.
+STARROCKS_VAULT_MOUNT = "database-starrocks"
 
 airbyte_host_map = {
     "dev": "https://api-airbyte-qa.odl.mit.edu",
@@ -416,7 +413,7 @@ resources_dict = {
     "github_api": GithubApiClientFactory(vault=vault),
     "starrocks": StarRocksResource(
         vault=vault,
-        vault_mount_point=starrocks_vault_mount_map[DAGSTER_ENV],
+        vault_mount_point=STARROCKS_VAULT_MOUNT,
         host=starrocks_host_map[DAGSTER_ENV],
         database="b2b_analytics",
     ),

--- a/dg_projects/lakehouse/lakehouse/resources/starrocks.py
+++ b/dg_projects/lakehouse/lakehouse/resources/starrocks.py
@@ -47,7 +47,8 @@ class StarRocksResource(ConfigurableResource["StarRocksResource"]):
     vault_mount_point: str = PydanticField(
         description=(
             "Vault database secrets engine mount point for StarRocks, "
-            "e.g. 'database-starrocks-production'."
+            "e.g. 'database-starrocks'. Not environment-specific -- each "
+            "environment runs its own separate Vault deployment."
         )
     )
     vault_role: str = PydanticField(

--- a/src/ol_dbt_cli/ol_dbt_cli/commands/starrocks.py
+++ b/src/ol_dbt_cli/ol_dbt_cli/commands/starrocks.py
@@ -57,6 +57,12 @@ _STARROCKS_PORT = 9030
 _PORT_FORWARD_TIMEOUT = 15
 
 # Mirrors ENVS in bin/starrocks-auth; keep in sync when adding environments.
+#
+# Vault's "database-starrocks" mount is not environment-specific -- each
+# environment runs its own, entirely separate Vault deployment, so the Vault
+# server (vault_addr below), not the mount path, is what scopes the environment.
+_VAULT_MOUNT = "database-starrocks"
+
 _ENVS: dict[str, dict[str, Any]] = {
     "qa": {
         "host": "lakehouse.qa.starrocks.ol.mit.edu",
@@ -64,7 +70,7 @@ _ENVS: dict[str, dict[str, Any]] = {
         "k8s_namespace": "starrocks",
         "fe_service": "lakehouse-starrocks-fe-service",
         "vault_addr": "https://vault-qa.odl.mit.edu",
-        "vault_mount": "database-starrocks-qa",
+        "vault_mount": _VAULT_MOUNT,
         "dbt_target": "starrocks_qa_vault",
     },
     "production": {
@@ -73,7 +79,7 @@ _ENVS: dict[str, dict[str, Any]] = {
         "k8s_namespace": "starrocks",
         "fe_service": "lakehouse-starrocks-fe-service",
         "vault_addr": "https://vault-production.odl.mit.edu",
-        "vault_mount": "database-starrocks-production",
+        "vault_mount": _VAULT_MOUNT,
         "dbt_target": "starrocks_production",
     },
     "ci": {
@@ -82,7 +88,7 @@ _ENVS: dict[str, dict[str, Any]] = {
         "k8s_namespace": "starrocks",
         "fe_service": "lakehouse-starrocks-fe-service",
         "vault_addr": "https://vault-qa.odl.mit.edu",
-        "vault_mount": "database-starrocks-ci",
+        "vault_mount": _VAULT_MOUNT,
         "dbt_target": "starrocks_production",
         "port_forward": False,
     },


### PR DESCRIPTION
### What are the relevant tickets?
N/A

### Description (What does it do?)
Companion change to mitodl/ol-infrastructure#5111, which fixes the Dagster `b2b_analytics` StarRocks dbt job failing in QA with:

```
hvac.exceptions.Forbidden: 1 error occurred:
    * permission denied
, on get https://vault-qa.odl.mit.edu/v1/database-starrocks-qa/creds/admin
```

QA/Production/CI each run their own, completely separate Vault deployment (`vault-qa.odl.mit.edu`, `vault-production.odl.mit.edu`, `vault-ci.odl.mit.edu`), so the Vault server itself already scopes the environment — the mount path doesn't need to duplicate that with a `-{env}` suffix. This collapses the per-env `database-starrocks-{qa,production,ci}` mount names down to a single `database-starrocks` on the consumer side, to match the ol-infrastructure change.

Changes:
- `dg_projects/lakehouse/lakehouse/definitions.py` — `starrocks_vault_mount_map` (per-env dict) replaced with a single `STARROCKS_VAULT_MOUNT = "database-starrocks"` constant
- `dg_projects/lakehouse/lakehouse/resources/starrocks.py` — docstring example updated
- `bin/starrocks-auth` — each env's `vault_mount` now points at a shared `_VAULT_MOUNT` constant instead of three separate literal mount names
- `src/ol_dbt_cli/ol_dbt_cli/commands/starrocks.py` — same

### How can this be tested?
`uv run pre-commit run --all-files` (ruff format/check, mypy) passes on all changed files. No behavior change to verify locally beyond confirming `starrocks-auth --env qa --mode vault` and `ol-dbt starrocks` still resolve to the `database-starrocks` mount once the ol-infrastructure side has been applied.

### Additional Context
This must land alongside/after mitodl/ol-infrastructure#5111 being applied — that PR renames the actual Vault mount for each environment (QA/Production first, since CI's Dagster/dbt path targets the QA mount, per `starrocks_host_map`/`STARROCKS_VAULT_MOUNT` in `definitions.py`). Until the ol-infrastructure change is applied, this repo's code assumes a mount name (`database-starrocks`) that doesn't exist yet.

Also noticed but **not touched** here: `bin/starrocks-auth`'s and `ol_dbt_cli`'s `"ci"` environment entries point `vault_addr` at `vault-qa.odl.mit.edu`, while the real `substructure/starrocks` CI stack (`Pulumi.lakehouse.CI.yaml` in ol-infrastructure) deploys against `vault-ci.odl.mit.edu`. That mismatch predates this change — flagging for a separate look, not fixed in either of these two PRs.