### PR TITLE
feat(b2b_analytics): expose sso_organization_id on the mv_b2b_* views

### DIFF
--- a/src/ol_dbt/models/b2b_analytics/_b2b_analytics__models.yml
+++ b/src/ol_dbt/models/b2b_analytics/_b2b_analytics__models.yml
@@ -54,7 +54,8 @@ models:
   description: >
     Monthly engagement, enrollment, and content-interaction totals per org.
     Manual-refresh materialized view. Source: organization_administration_report,
-    filtered to rows with a confirmed (non-fallback) organization_key.
+    filtered to rows with a non-null organization_key (which still includes
+    free-text fallback values; those resolve to a null sso_organization_id).
     Consumers: L&D manager engagement trend chart.
   columns:
   - name: sso_organization_id
@@ -91,8 +92,9 @@ models:
   description: >
     All-time content engagement depth per org x course_run. Manual-refresh
     materialized view. Source: organization_administration_report, filtered to rows
-    with a confirmed (non-fallback) organization_key. Consumers: L&D manager course
-    detail panel.
+    with a non-null organization_key (which still includes free-text fallback
+    values; those resolve to a null sso_organization_id). Consumers: L&D manager
+    course detail panel.
   columns:
   - name: sso_organization_id
     description: >

--- a/src/ol_dbt/models/b2b_analytics/_b2b_analytics__models.yml
+++ b/src/ol_dbt/models/b2b_analytics/_b2b_analytics__models.yml
@@ -7,6 +7,11 @@ models:
     materialized view, refreshed by the Dagster b2b_organization MV-refresh asset.
     Consumers: L&D manager dashboard header card, MIT admin overview.
   columns:
+  - name: sso_organization_id
+    description: >
+      Keycloak organization UUID (dim_organization.sso_organization_id) -- the
+      identifier the ol-analytics-api filters organizations on. Null for
+      organization_keys that don't resolve to a mitxonline org.
   - name: organization_key
     description: Org identifier, joined via dim_organization (platform='mitxonline'
       only).
@@ -31,6 +36,11 @@ models:
     course_run. Manual-refresh materialized view. Consumers: L&D manager course-level
     drill-down.
   columns:
+  - name: sso_organization_id
+    description: >
+      Keycloak organization UUID (dim_organization.sso_organization_id) -- the
+      identifier the ol-analytics-api filters organizations on. Null for
+      organization_keys that don't resolve to a mitxonline org.
   - name: enrolled_learners
     description: Distinct learners enrolled in this course run.
   - name: active_learners
@@ -47,6 +57,11 @@ models:
     filtered to rows with a confirmed (non-fallback) organization_key.
     Consumers: L&D manager engagement trend chart.
   columns:
+  - name: sso_organization_id
+    description: >
+      Keycloak organization UUID (dim_organization.sso_organization_id) -- the
+      identifier the ol-analytics-api filters organizations on. Null for
+      organization_keys that don't resolve to a mitxonline org.
   - name: monthly_active_learners
     description: Distinct learners with any activity in the month.
   - name: new_enrollments
@@ -59,6 +74,11 @@ models:
     (cert in any program course) until tfact_program_certificate ships.
     Consumers: L&D manager program progression view.
   columns:
+  - name: sso_organization_id
+    description: >
+      Keycloak organization UUID (dim_organization.sso_organization_id) -- the
+      identifier the ol-analytics-api filters organizations on. Null for
+      organization_keys that don't resolve to a mitxonline org.
   - name: enrolled_in_contract_courses
     description: Learners enrolled in any contract course belonging to this program.
   - name: enrolled_via_program
@@ -74,6 +94,11 @@ models:
     with a confirmed (non-fallback) organization_key. Consumers: L&D manager course
     detail panel.
   columns:
+  - name: sso_organization_id
+    description: >
+      Keycloak organization UUID (dim_organization.sso_organization_id) -- the
+      identifier the ol-analytics-api filters organizations on. Null for
+      organization_keys that don't resolve to a mitxonline org.
   - name: engagement_rate_pct
     description: engaged_learners / total_enrolled_learners * 100.
   - name: avg_videos_per_engaged_learner
@@ -85,6 +110,11 @@ models:
     requesting org) -- MIT admin view only. Manual-refresh materialized view.
     Consumers: MIT contract admin dashboard.
   columns:
+  - name: sso_organization_id
+    description: >
+      Keycloak organization UUID (dim_organization.sso_organization_id) -- the
+      identifier the ol-analytics-api filters organizations on. Null for
+      organization_keys that don't resolve to a mitxonline org.
   - name: health_status
     description: >
       One of: inactive (contract not active), at_risk (utilization < 25% and

--- a/src/ol_dbt/models/b2b_analytics/mv_b2b_content_engagement_depth.sql
+++ b/src/ol_dbt/models/b2b_analytics/mv_b2b_content_engagement_depth.sql
@@ -39,9 +39,18 @@ select
         / nullif(count(distinct oar.user_email), 0), 1)                         as chatbot_adoption_pct,
     sum(oar.certificate_count)                                                  as certificates_earned
 from {{ source('reporting', 'organization_administration_report') }} oar
-left join {{ source('dimensional', 'dim_organization') }} org
-    on oar.organization_key = org.organization_key
-    and org.platform = 'mitxonline'
+-- Dedupe to one row per organization_key so this join can never fan out and
+-- inflate the aggregates. organization_key is unique per mitxonline org today
+-- (source-enforced), so the group by is a no-op now but keeps the model correct
+-- if that ever regresses.
+left join (
+    select
+        organization_key,
+        min(sso_organization_id) as sso_organization_id
+    from {{ source('dimensional', 'dim_organization') }}
+    where platform = 'mitxonline' and organization_key is not null
+    group by organization_key
+) org on oar.organization_key = org.organization_key
 where oar.organization_key is not null
 group by
     oar.organization_key,

--- a/src/ol_dbt/models/b2b_analytics/mv_b2b_content_engagement_depth.sql
+++ b/src/ol_dbt/models/b2b_analytics/mv_b2b_content_engagement_depth.sql
@@ -7,37 +7,45 @@
 
 -- Grain: org x course_run (all-time). Refreshed by the Dagster b2b_organization MV-refresh asset.
 -- Same organization_key reliability caveat as mv_b2b_monthly_engagement_trend.
+-- sso_organization_id (the Keycloak org UUID the ol-analytics-api filters on) is
+-- joined from dim_organization on organization_key; null for free-text
+-- organization_keys that don't resolve to a known mitxonline org.
 select
-    organization_key,
-    organization_name,
-    courserun_readable_id,
-    courserun_title,
-    count(distinct user_email)                                                 as total_enrolled_learners,
-    count(distinct case when active_count > 0 then user_email end)             as engaged_learners,
-    round(100.0 * count(distinct case when active_count > 0 then user_email end)
-        / nullif(count(distinct user_email), 0), 1)                            as engagement_rate_pct,
-    sum(videos_watched)                                                        as total_videos_watched,
+    oar.organization_key,
+    org.sso_organization_id,
+    oar.organization_name,
+    oar.courserun_readable_id,
+    oar.courserun_title,
+    count(distinct oar.user_email)                                              as total_enrolled_learners,
+    count(distinct case when oar.active_count > 0 then oar.user_email end)      as engaged_learners,
+    round(100.0 * count(distinct case when oar.active_count > 0 then oar.user_email end)
+        / nullif(count(distinct oar.user_email), 0), 1)                         as engagement_rate_pct,
+    sum(oar.videos_watched)                                                     as total_videos_watched,
     round(
-        cast(sum(videos_watched) as double)
-        / nullif(count(distinct case when videos_watched > 0
-            then user_email end), 0), 1
-    )                                                                          as avg_videos_per_engaged_learner,
-    sum(problems_count)                                                        as total_problems_attempted,
+        cast(sum(oar.videos_watched) as double)
+        / nullif(count(distinct case when oar.videos_watched > 0
+            then oar.user_email end), 0), 1
+    )                                                                           as avg_videos_per_engaged_learner,
+    sum(oar.problems_count)                                                     as total_problems_attempted,
     round(
-        cast(sum(problems_count) as double)
-        / nullif(count(distinct case when problems_count > 0
-            then user_email end), 0), 1
-    )                                                                          as avg_problems_per_engaged_learner,
-    sum(chatbot_used_count)                                                    as total_chatbot_interactions,
-    count(distinct case when chatbot_used_count > 0 then user_email end)       as chatbot_users,
-    round(100.0 * count(distinct case when chatbot_used_count > 0
-        then user_email end)
-        / nullif(count(distinct user_email), 0), 1)                            as chatbot_adoption_pct,
-    sum(certificate_count)                                                     as certificates_earned
-from {{ source('reporting', 'organization_administration_report') }}
-where organization_key is not null
+        cast(sum(oar.problems_count) as double)
+        / nullif(count(distinct case when oar.problems_count > 0
+            then oar.user_email end), 0), 1
+    )                                                                           as avg_problems_per_engaged_learner,
+    sum(oar.chatbot_used_count)                                                 as total_chatbot_interactions,
+    count(distinct case when oar.chatbot_used_count > 0 then oar.user_email end) as chatbot_users,
+    round(100.0 * count(distinct case when oar.chatbot_used_count > 0
+        then oar.user_email end)
+        / nullif(count(distinct oar.user_email), 0), 1)                         as chatbot_adoption_pct,
+    sum(oar.certificate_count)                                                  as certificates_earned
+from {{ source('reporting', 'organization_administration_report') }} oar
+left join {{ source('dimensional', 'dim_organization') }} org
+    on oar.organization_key = org.organization_key
+    and org.platform = 'mitxonline'
+where oar.organization_key is not null
 group by
-    organization_key,
-    organization_name,
-    courserun_readable_id,
-    courserun_title
+    oar.organization_key,
+    org.sso_organization_id,
+    oar.organization_name,
+    oar.courserun_readable_id,
+    oar.courserun_title

--- a/src/ol_dbt/models/b2b_analytics/mv_b2b_contract_utilization.sql
+++ b/src/ol_dbt/models/b2b_analytics/mv_b2b_contract_utilization.sql
@@ -28,6 +28,7 @@ certificates as (
 
 select
     org.organization_key,
+    org.sso_organization_id,
     org.organization_name,
     c.contract_pk,
     c.b2b_contract_name,
@@ -50,7 +51,7 @@ left join enrollments e on c.contract_pk = e.contract_fk
 left join certificates cert on c.contract_pk = cert.contract_fk
 where org.platform = 'mitxonline'
 group by
-    org.organization_key, org.organization_name,
+    org.organization_key, org.sso_organization_id, org.organization_name,
     c.contract_pk, c.b2b_contract_name, c.b2b_contract_is_active,
     c.b2b_contract_start_date, c.b2b_contract_end_date,
     c.b2b_contract_max_learners, c.b2b_contract_membership_type

--- a/src/ol_dbt/models/b2b_analytics/mv_b2b_enrollment_completion_funnel.sql
+++ b/src/ol_dbt/models/b2b_analytics/mv_b2b_enrollment_completion_funnel.sql
@@ -8,6 +8,7 @@
 -- Grain: org x contract x course_run. Refreshed by the Dagster b2b_organization MV-refresh asset.
 select
     org.organization_key,
+    org.sso_organization_id,
     org.organization_name,
     c.contract_pk,
     c.b2b_contract_name,
@@ -40,6 +41,6 @@ left join {{ source('dimensional', 'tfact_certificate') }} cert
 where org.platform = 'mitxonline'
   and cr.is_current = true
 group by
-    org.organization_key, org.organization_name,
+    org.organization_key, org.sso_organization_id, org.organization_name,
     c.contract_pk, c.b2b_contract_name,
     cr.courserun_pk, cr.courserun_readable_id, cr.courserun_title

--- a/src/ol_dbt/models/b2b_analytics/mv_b2b_mit_admin_contract_health.sql
+++ b/src/ol_dbt/models/b2b_analytics/mv_b2b_mit_admin_contract_health.sql
@@ -11,6 +11,7 @@
 with contract_stats as (
     select
         org.organization_key,
+        org.sso_organization_id,
         org.organization_name,
         c.contract_pk,
         c.b2b_contract_name,
@@ -36,7 +37,7 @@ with contract_stats as (
         and cert.certificate_is_revoked = false
     where org.platform = 'mitxonline'
     group by
-        org.organization_key, org.organization_name,
+        org.organization_key, org.sso_organization_id, org.organization_name,
         c.contract_pk, c.b2b_contract_name, c.b2b_contract_is_active,
         c.b2b_contract_start_date, c.b2b_contract_end_date,
         c.b2b_contract_max_learners, c.b2b_contract_membership_type

--- a/src/ol_dbt/models/b2b_analytics/mv_b2b_monthly_engagement_trend.sql
+++ b/src/ol_dbt/models/b2b_analytics/mv_b2b_monthly_engagement_trend.sql
@@ -9,20 +9,28 @@
 -- Note: organization_key is COALESCE(b2b_contract_to_courseruns.organization_key, user_course_roles.organization)
 -- in the source report. The fallback is free-text and unreliable, so rows without a
 -- confirmed organization_key are dropped -- acceptable for MVP.
+-- sso_organization_id (the Keycloak org UUID the ol-analytics-api filters on) is
+-- joined from dim_organization on organization_key; it is null for free-text
+-- organization_keys that don't resolve to a known mitxonline org.
 select
-    organization_key,
-    organization_name,
-    activity_year_and_month,
-    count(distinct case when active_count > 0 then user_email end)  as monthly_active_learners,
-    sum(enrolled_count)                                              as new_enrollments,
-    sum(certificate_count)                                           as certificates_earned,
-    sum(videos_watched)                                              as total_videos_watched,
-    sum(problems_count)                                              as total_problems_attempted,
-    sum(chatbot_used_count)                                          as total_chatbot_interactions
-from {{ source('reporting', 'organization_administration_report') }}
-where organization_key is not null
-  and activity_year_and_month is not null
+    oar.organization_key,
+    org.sso_organization_id,
+    oar.organization_name,
+    oar.activity_year_and_month,
+    count(distinct case when oar.active_count > 0 then oar.user_email end)  as monthly_active_learners,
+    sum(oar.enrolled_count)                                                 as new_enrollments,
+    sum(oar.certificate_count)                                              as certificates_earned,
+    sum(oar.videos_watched)                                                 as total_videos_watched,
+    sum(oar.problems_count)                                                 as total_problems_attempted,
+    sum(oar.chatbot_used_count)                                             as total_chatbot_interactions
+from {{ source('reporting', 'organization_administration_report') }} oar
+left join {{ source('dimensional', 'dim_organization') }} org
+    on oar.organization_key = org.organization_key
+    and org.platform = 'mitxonline'
+where oar.organization_key is not null
+  and oar.activity_year_and_month is not null
 group by
-    organization_key,
-    organization_name,
-    activity_year_and_month
+    oar.organization_key,
+    org.sso_organization_id,
+    oar.organization_name,
+    oar.activity_year_and_month

--- a/src/ol_dbt/models/b2b_analytics/mv_b2b_monthly_engagement_trend.sql
+++ b/src/ol_dbt/models/b2b_analytics/mv_b2b_monthly_engagement_trend.sql
@@ -24,9 +24,18 @@ select
     sum(oar.problems_count)                                                 as total_problems_attempted,
     sum(oar.chatbot_used_count)                                             as total_chatbot_interactions
 from {{ source('reporting', 'organization_administration_report') }} oar
-left join {{ source('dimensional', 'dim_organization') }} org
-    on oar.organization_key = org.organization_key
-    and org.platform = 'mitxonline'
+-- Dedupe to one row per organization_key so this join can never fan out and
+-- inflate the aggregates. organization_key is unique per mitxonline org today
+-- (source-enforced), so the group by is a no-op now but keeps the model correct
+-- if that ever regresses.
+left join (
+    select
+        organization_key,
+        min(sso_organization_id) as sso_organization_id
+    from {{ source('dimensional', 'dim_organization') }}
+    where platform = 'mitxonline' and organization_key is not null
+    group by organization_key
+) org on oar.organization_key = org.organization_key
 where oar.organization_key is not null
   and oar.activity_year_and_month is not null
 group by

--- a/src/ol_dbt/models/b2b_analytics/mv_b2b_program_funnel.sql
+++ b/src/ol_dbt/models/b2b_analytics/mv_b2b_program_funnel.sql
@@ -12,6 +12,7 @@ with org_program_runs as (
     -- Resolve org -> contract -> course_run -> course -> program
     select distinct
         org.organization_key,
+        org.sso_organization_id,
         org.organization_name,
         c.contract_pk,
         c.b2b_contract_name,
@@ -42,6 +43,7 @@ program_course_counts as (
 
 select
     opr.organization_key,
+    opr.sso_organization_id,
     opr.organization_name,
     opr.contract_pk,
     opr.b2b_contract_name,
@@ -64,7 +66,7 @@ left join {{ source('dimensional', 'tfact_enrollment') }} e
 left join {{ source('dimensional', 'tfact_certificate') }} cert
     on e.user_fk = cert.user_fk and opr.courserun_fk = cert.courserun_fk
 group by
-    opr.organization_key, opr.organization_name,
+    opr.organization_key, opr.sso_organization_id, opr.organization_name,
     opr.contract_pk, opr.b2b_contract_name,
     p.program_pk, p.program_title,
     pcc.total_courses


### PR DESCRIPTION
## Why

ol-analytics-api is moving to key organizations on the **Keycloak org UUID** (`sso_organization_id`) — the one identifier stable across the JWT, MITx Online, and StarRocks (see mitodl/ol-analytics-api#13 and the identifier analysis on mitodl/hq#11845). The `b2b_analytics` MVs only carried `organization_key` (the mitx `org_key`, e.g. `MIT504`), so the API's `WHERE sso_organization_id = %s` filter had nothing to match.

## What

Add `sso_organization_id` (from `dim_organization`) to all six `mv_b2b_*` views:

- **Four** already join `dim_organization` (`org.…`) — one `select` + `group by` column each: `mv_b2b_contract_utilization`, `mv_b2b_enrollment_completion_funnel`, `mv_b2b_program_funnel`, `mv_b2b_mit_admin_contract_health`.
- **Two** read the raw `organization_administration_report` with no org join, so they gain a `LEFT JOIN dim_organization ON organization_key AND platform='mitxonline'` (columns qualified with `oar.` per convention): `mv_b2b_monthly_engagement_trend`, `mv_b2b_content_engagement_depth`. `sso_organization_id` is null for free-text `organization_key`s that don't resolve to a known org — expected, since those orgs have no Keycloak identity and aren't reachable via the UUID path.

`distributed_by` stays `organization_key` (proven layout; redistributing to `sso_organization_id` is a separate optimization). New column documented in `_b2b_analytics__models.yml`.

## Deploy note

Definition change, so the async MVs are recreated + re-refreshed by the Dagster `refresh_starrocks_analytics_mvs` asset. Data-side half of the org-UUID work; ol-analytics-api #13 and the mitxonline manager-endpoint filter are the other two pieces.

## Validation
- `sqlfluff` lint + fix clean on all six models.
- `dbt parse` (starrocks target) clean; all six `mv_b2b_*` manifest nodes carry `sso_organization_id`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)