### PR TITLE
fix(migration): limit edxorg future enrollments to active verified

### DIFF
--- a/src/ol_dbt/models/migration/edxorg_to_mitxonline_enrollments.sql
+++ b/src/ol_dbt/models/migration/edxorg_to_mitxonline_enrollments.sql
@@ -204,6 +204,8 @@ with combined_enrollments as (
     where
         courserun_platform = '{{ var("edxorg") }}'
         and courserunenrollment_courserun_readable_id is not null
+        and courserunenrollment_is_active = 1
+        and courserunenrollment_mode='verified'
 )
 
 , product_versions as (

--- a/src/ol_dbt/models/migration/edxorg_to_mitxonline_enrollments.sql
+++ b/src/ol_dbt/models/migration/edxorg_to_mitxonline_enrollments.sql
@@ -205,7 +205,7 @@ with combined_enrollments as (
         courserun_platform = '{{ var("edxorg") }}'
         and courserunenrollment_courserun_readable_id is not null
         and courserunenrollment_is_active = 1
-        and courserunenrollment_mode='verified'
+        and courserunenrollment_mode = 'verified'
 )
 
 , product_versions as (


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->


### Description (What does it do?)
<!--- Describe your changes in detail -->
Update the edxorg_future_enrollment CTE in edxorg_to_mitxonline_enrollments to enrollments that are active and in verified mode 


### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

dbt build --select edxorg_to_mitxonline_enrollments

### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->


<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
