### PR TITLE
Replace Vault GitHub PAT auth with host-side OIDC for local Dagster

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,5 @@
-#vault
-GITHUB_TOKEN=
+# Vault auth needs no secret here -- run `bin/vault-login` (or just
+# `bin/dagster-up`) to mint a short-lived token via the Keycloak browser flow.
 
 #run dbt with your schema as the target in dagster
 DBT_SCHEMA_SUFFIX=

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -62,6 +62,7 @@ repos:
     args:
     - --explicit-package-bases
     - --namespace-packages
+    - --scripts-are-modules
     - --config-file=pyproject.toml
     - --warn-unused-configs
     additional_dependencies:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,7 +32,8 @@ This guide provides essential information for coding agents working with the MIT
 ```bash
 # 1. Copy environment template
 cp .env.example .env
-# Edit .env with: GITHUB_TOKEN, DBT_TRINO_USERNAME, DBT_TRINO_PASSWORD, AWS keys, DBT_SCHEMA_SUFFIX
+# Edit .env with: DBT_TRINO_USERNAME, DBT_TRINO_PASSWORD, AWS keys, DBT_SCHEMA_SUFFIX
+# Vault needs no entry here -- `bin/vault-login` handles it via the browser flow
 
 # 2. Sync dependencies (10-30 seconds)
 uv sync
@@ -340,13 +341,17 @@ incremental until `--full-refresh` is used.
 ## Environment Variables
 
 **Required in `.env`** (from `.env.example`):
-- `GITHUB_TOKEN`: GitHub PAT for auth
 - `DBT_TRINO_USERNAME`, `DBT_TRINO_PASSWORD`: Starburst credentials
 - `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`: S3 access
 - `DBT_SCHEMA_SUFFIX`: Your dev schema suffix (e.g., username)
 
 **Runtime**:
 - `DAGSTER_ENV`: dev|qa|production (selects resource config)
+- `DAGSTER_VAULT_ROLE`: Vault OIDC role to request locally (default `developer`)
+- `VAULT_TOKEN_CACHE_DIR`: where the Vault token cache lives (default
+  `~/.cache/vault`); compose points the containers at the read-only mount
+- `VAULT_OIDC_NONINTERACTIVE`: set in the containers so a cache miss fails with
+  "run `bin/vault-login`" instead of hanging on a browser that cannot open
 
 ## Trust These Instructions
 

--- a/README.md
+++ b/README.md
@@ -15,9 +15,9 @@ building data applications.
     `bin/dagster-up`
 - Navigate to localhost:3000 to access the Dagster UI
 
-`bin/dagster-up` authenticates to Vault for you and then runs `docker compose up
---build`. Vault uses the Keycloak OIDC browser flow, so there is no token to
-create or paste into `.env`.
+`bin/dagster-up` authenticates to Vault for you and then runs
+`docker compose up --build`. Vault uses the Keycloak OIDC browser flow, so there
+is no token to create or paste into `.env`.
 
 The containers cannot open a browser or receive the OIDC redirect on
 `localhost:8250`, so the login happens on the host: `bin/vault-login` caches a
@@ -33,8 +33,15 @@ bin/vault-login --env production
 bin/vault-login --force          # discard the cached token and re-authenticate
 ```
 
-If a code location fails to start with "No valid cached Vault token", the token
-expired — run `bin/vault-login` and restart.
+If the token expires, code locations warn `Failed to authenticate with Vault: No
+valid cached Vault token ... Using mock configuration` and load against mock
+config rather than real secrets. `edxorg` is the exception — it reads a Vault
+secret at import time, so it fails to start outright. Either way the fix is to
+run `bin/vault-login` and restart the stack.
+
+`bin/vault-login` and the containers agree on the cache location via
+`VAULT_TOKEN_CACHE_DIR`; set it on the host to move the cache, and compose
+mounts whatever it points at.
 
 # dbt Staging Model Generation
 

--- a/README.md
+++ b/README.md
@@ -9,17 +9,32 @@ building data applications.
     https://www.docker.com/products/docker-desktop/
 - Install docker compose. Check the documentation and requirements for your specific machine.
     https://docs.docker.com/compose/install/
-- Ensure you are able to authenticate into GitHub + Vault
-    https://github.com/mitodl/ol-data-platform/tree/main
-    https://vault-qa.odl.mit.edu/v1/auth/github/login
-    `vault login -address=https://vault-qa.odl.mit.edu -method=github`
-    https://vault-production.odl.mit.edu/v1/auth/github/login
-    `vault login -address=https://vault-production.odl.mit.edu -method=github`
 - Ensure you create your .env file and populate it with the environment variables.
     `cp .env.example .env`
-- Call docker compose up
-    `docker compose up --build`
+- Start the stack
+    `bin/dagster-up`
 - Navigate to localhost:3000 to access the Dagster UI
+
+`bin/dagster-up` authenticates to Vault for you and then runs `docker compose up
+--build`. Vault uses the Keycloak OIDC browser flow, so there is no token to
+create or paste into `.env`.
+
+The containers cannot open a browser or receive the OIDC redirect on
+`localhost:8250`, so the login happens on the host: `bin/vault-login` caches a
+short-lived token in `~/.cache/vault`, and the code-location containers mount
+that directory read-only. One login is shared by every container and is reused
+until it expires — re-running is a no-op while the token is still valid.
+
+To authenticate by hand, or against production:
+
+```bash
+bin/vault-login                  # qa, which is what local dev targets
+bin/vault-login --env production
+bin/vault-login --force          # discard the cached token and re-authenticate
+```
+
+If a code location fails to start with "No valid cached Vault token", the token
+expired — run `bin/vault-login` and restart.
 
 # dbt Staging Model Generation
 

--- a/bin/dagster-up
+++ b/bin/dagster-up
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+"""Start the local Dagster stack, minting a Vault token first if needed.
+
+Wraps ``bin/vault-login`` and ``docker compose up`` so the everyday command
+stays a single invocation. The login step is a no-op while the cached token is
+valid, so a browser only opens when the token has actually expired.
+
+    bin/dagster-up                     # vault-login (if needed) + compose up --build
+    bin/dagster-up --detach
+    bin/dagster-up --env production
+    bin/dagster-up -- dagster_canvas   # extra args go to `docker compose up`
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+import cyclopts
+
+BIN_DIR = Path(__file__).resolve().parent
+REPO_ROOT = BIN_DIR.parent
+
+app = cyclopts.App(name="dagster-up", help=__doc__)
+
+
+@app.default
+def main(
+    compose_args: list[str] | None = None,
+    *,
+    env: str = "qa",
+    role: str = "developer",
+    detach: bool = False,
+    build: bool = True,
+) -> None:
+    """Authenticate to Vault if required, then bring the compose stack up.
+
+    Parameters
+    ----------
+    compose_args
+        Extra arguments forwarded to ``docker compose up`` (e.g. service names).
+    env
+        Which Vault to authenticate against. ``DAGSTER_ENV=dev`` targets ``qa``.
+    role
+        Vault OIDC role to request. Must match ``DAGSTER_VAULT_ROLE``.
+    detach
+        Run the stack in the background.
+    build
+        Rebuild images before starting. Pass ``--no-build`` to skip.
+
+    """
+    login = subprocess.run(  # noqa: S603
+        [
+            sys.executable,
+            str(BIN_DIR / "vault-login"),
+            "--env",
+            env,
+            "--role",
+            role,
+            "--quiet",
+        ],
+        cwd=REPO_ROOT,
+        check=False,
+    )
+    if login.returncode != 0:
+        sys.exit(login.returncode)
+
+    command = ["docker", "compose", "up"]
+    if build:
+        command.append("--build")
+    if detach:
+        command.append("--detach")
+    command.extend(compose_args or [])
+
+    sys.exit(subprocess.run(command, cwd=REPO_ROOT, check=False).returncode)  # noqa: S603
+
+
+if __name__ == "__main__":
+    app()

--- a/bin/vault-login
+++ b/bin/vault-login
@@ -1,0 +1,193 @@
+#!/usr/bin/env python3
+"""Mint a Vault token on the host via the Keycloak OIDC browser flow.
+
+The Dagster compose stack authenticates to Vault from inside its containers,
+which have no browser and cannot receive the OIDC redirect on
+``localhost:8250``. This command performs the interactive flow on the host and
+writes the resulting token to ``~/.cache/vault``. ``docker-compose.yaml`` mounts
+that directory into the code-location containers read-only, so every container
+reuses one token and never attempts a browser flow of its own.
+
+The cache path and filename match ``Vault._get_token_cache_path()`` in
+ol-orchestrate-lib, which is what the containers read.
+
+Typical use -- ``bin/dagster-up`` calls this for you, but it is safe to run
+directly and is a no-op while the cached token is still valid:
+
+    bin/vault-login                 # qa (what DAGSTER_ENV=dev targets)
+    bin/vault-login --env production
+    bin/vault-login --force         # discard the cached token and re-auth
+"""
+
+from __future__ import annotations
+
+import http.server
+import json
+import os
+import sys
+import threading
+import urllib.parse
+import webbrowser
+from pathlib import Path
+
+import cyclopts
+import hvac
+
+CALLBACK_PORT = 8250
+REDIRECT_URI = f"http://localhost:{CALLBACK_PORT}/oidc/callback"
+
+# DAGSTER_ENV=dev talks to the QA Vault -- see ol_orchestrate.lib.constants.
+VAULT_ADDRESSES = {
+    "qa": "https://vault-qa.odl.mit.edu",
+    "production": "https://vault-production.odl.mit.edu",
+}
+
+app = cyclopts.App(name="vault-login", help=__doc__)
+
+
+def cache_path(vault_addr: str, role: str) -> Path:
+    """Return the token cache path, matching Vault._get_token_cache_path().
+
+    Keep this in lockstep with
+    ``ol_orchestrate.resources.secrets.vault.Vault._get_token_cache_path`` --
+    the containers read exactly this filename.
+    """
+    cache_dir = Path(
+        os.environ.get("VAULT_TOKEN_CACHE_DIR")
+        or Path(os.environ.get("XDG_CACHE_HOME") or Path.home() / ".cache") / "vault"
+    )
+    cache_key = f"{vault_addr}_{role}".replace("/", "_").replace(":", "_")
+    return cache_dir / f"{cache_key}.json"
+
+
+def cached_token_is_valid(vault_addr: str, path: Path) -> bool:
+    """Return True when *path* holds a token Vault still accepts."""
+    if not path.exists():
+        return False
+    try:
+        token = json.loads(path.read_text()).get("token", "")
+    except (json.JSONDecodeError, OSError):
+        return False
+    if not token:
+        return False
+    return hvac.Client(url=vault_addr, token=token).is_authenticated()
+
+
+def await_callback(expected_state: str) -> str:
+    """Serve one request on CALLBACK_PORT and return the authorization code.
+
+    The ``state`` check matters: without it the local listener cannot tell a
+    genuine redirect from Vault apart from an attacker pointing the browser at
+    localhost:8250/oidc/callback?code=... directly.
+    """
+    result: dict[str, str] = {}
+
+    class Handler(http.server.BaseHTTPRequestHandler):
+        def log_message(self, *_args: object) -> None:
+            """Silence the default stderr request logging."""
+
+        def do_GET(self) -> None:
+            params = dict(
+                urllib.parse.parse_qsl(urllib.parse.urlparse(self.path).query)
+            )
+            if error := params.get("error"):
+                result["error"] = error
+                body = f"Vault authentication failed: {error}."
+                self.send_response(400)
+            elif params.get("state") != expected_state:
+                result["error"] = "state mismatch"
+                body = "Vault authentication failed: state mismatch."
+                self.send_response(400)
+            else:
+                result["code"] = params.get("code", "")
+                body = "Vault authentication successful."
+                self.send_response(200)
+            self.end_headers()
+            self.wfile.write(f"<h2>{body} You can close this tab.</h2>".encode())
+            threading.Thread(target=self.server.shutdown, daemon=True).start()
+
+    server = http.server.HTTPServer(("localhost", CALLBACK_PORT), Handler)
+    server.serve_forever()
+
+    if "error" in result:
+        sys.exit(f"Vault OIDC authentication denied: {result['error']}")
+    if not result.get("code"):
+        sys.exit("Vault OIDC callback received no authorization code")
+    return result["code"]
+
+
+def login(vault_addr: str, role: str) -> str:
+    """Run the OIDC browser flow against *vault_addr* and return a token."""
+    client = hvac.Client(url=vault_addr)
+    auth_response = client.auth.oidc.oidc_authorization_url_request(
+        role=role,
+        redirect_uri=REDIRECT_URI,
+    )
+    auth_url = auth_response["data"]["auth_url"]
+    if not auth_url:
+        sys.exit(
+            f"Vault at {vault_addr} returned no auth URL -- is the '{role}' OIDC "
+            "role configured?"
+        )
+
+    query = urllib.parse.parse_qs(urllib.parse.urlparse(auth_url).query)
+    nonce, state = query["nonce"][0], query["state"][0]
+
+    print(f"Opening browser for Vault login ({vault_addr})…", file=sys.stderr)  # noqa: T201
+    print(f"If it does not open, visit:\n{auth_url}\n", file=sys.stderr)  # noqa: T201
+    webbrowser.open(auth_url)
+
+    code = await_callback(state)
+    result = client.auth.oidc.oidc_callback(code=code, nonce=nonce, state=state)
+    return str(result["auth"]["client_token"])
+
+
+@app.default
+def main(
+    *,
+    env: str = "qa",
+    role: str = "developer",
+    vault_addr: str | None = None,
+    force: bool = False,
+    quiet: bool = False,
+) -> None:
+    """Ensure a valid cached Vault token exists for the compose stack.
+
+    Parameters
+    ----------
+    env
+        Which Vault to authenticate against. ``DAGSTER_ENV=dev`` targets ``qa``.
+    role
+        Vault OIDC role to request. Must match ``DAGSTER_VAULT_ROLE``.
+    vault_addr
+        Override the Vault address derived from ``--env``.
+    force
+        Re-authenticate even when the cached token is still valid.
+    quiet
+        Only emit output when a browser login is actually required.
+
+    """
+    if vault_addr is None:
+        if env not in VAULT_ADDRESSES:
+            sys.exit(f"Unknown --env {env!r}; choose from {sorted(VAULT_ADDRESSES)}")
+        vault_addr = os.environ.get("VAULT_ADDR") or VAULT_ADDRESSES[env]
+
+    path = cache_path(vault_addr, role)
+
+    if not force and cached_token_is_valid(vault_addr, path):
+        if not quiet:
+            print(  # noqa: T201
+                f"Cached Vault token for {vault_addr} ({role}) is still valid."
+            )
+        return
+
+    token = login(vault_addr, role)
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps({"token": token}))
+    path.chmod(0o600)
+    print(f"Vault token cached at {path}")  # noqa: T201
+
+
+if __name__ == "__main__":
+    app()

--- a/dg_projects/b2b_organization/b2b_organization/definitions.py
+++ b/dg_projects/b2b_organization/b2b_organization/definitions.py
@@ -10,7 +10,7 @@ from ol_orchestrate.lib.dagster_helpers import (
     default_file_object_io_manager,
     default_io_manager,
 )
-from ol_orchestrate.lib.utils import authenticate_vault
+from ol_orchestrate.lib.utils import authenticate_vault, unauthenticated_vault
 
 b2b_bucket_map = {
     "dev": {"bucket": "ol-devops-sandbox", "prefix": "pipeline-storage"},
@@ -26,13 +26,11 @@ try:
 except Exception as e:  # noqa: BLE001 (resilient loading)
     import warnings
 
-    from ol_orchestrate.resources.secrets.vault import Vault
-
     warnings.warn(
         f"Failed to authenticate with Vault: {e}. Using mock configuration.",
         stacklevel=2,
     )
-    vault = Vault(vault_addr=VAULT_ADDRESS, vault_auth_type="oidc")
+    vault = unauthenticated_vault(VAULT_ADDRESS)
     vault_authenticated = False
 
 

--- a/dg_projects/b2b_organization/b2b_organization/definitions.py
+++ b/dg_projects/b2b_organization/b2b_organization/definitions.py
@@ -32,7 +32,7 @@ except Exception as e:  # noqa: BLE001 (resilient loading)
         f"Failed to authenticate with Vault: {e}. Using mock configuration.",
         stacklevel=2,
     )
-    vault = Vault(vault_addr=VAULT_ADDRESS, vault_auth_type="github")
+    vault = Vault(vault_addr=VAULT_ADDRESS, vault_auth_type="oidc")
     vault_authenticated = False
 
 

--- a/dg_projects/canvas/canvas/definitions.py
+++ b/dg_projects/canvas/canvas/definitions.py
@@ -42,7 +42,7 @@ except Exception as e:  # noqa: BLE001 (resilient loading)
         f"Failed to authenticate with Vault: {e}. Using mock configuration.",
         stacklevel=2,
     )
-    vault = Vault(vault_addr=VAULT_ADDRESS, vault_auth_type="github")
+    vault = Vault(vault_addr=VAULT_ADDRESS, vault_auth_type="oidc")
     vault_authenticated = False
 
 # Get Google Sheets credentials

--- a/dg_projects/canvas/canvas/definitions.py
+++ b/dg_projects/canvas/canvas/definitions.py
@@ -19,7 +19,11 @@ from ol_orchestrate.lib.dagster_helpers import (
     default_file_object_io_manager,
     default_io_manager,
 )
-from ol_orchestrate.lib.utils import authenticate_vault, s3_uploads_bucket
+from ol_orchestrate.lib.utils import (
+    authenticate_vault,
+    s3_uploads_bucket,
+    unauthenticated_vault,
+)
 from ol_orchestrate.resources.api_client_factory import ApiClientFactory
 
 from canvas.assets.canvas import (
@@ -36,13 +40,11 @@ try:
 except Exception as e:  # noqa: BLE001 (resilient loading)
     import warnings
 
-    from ol_orchestrate.resources.secrets.vault import Vault
-
     warnings.warn(
         f"Failed to authenticate with Vault: {e}. Using mock configuration.",
         stacklevel=2,
     )
-    vault = Vault(vault_addr=VAULT_ADDRESS, vault_auth_type="oidc")
+    vault = unauthenticated_vault(VAULT_ADDRESS)
     vault_authenticated = False
 
 # Get Google Sheets credentials

--- a/dg_projects/data_platform/data_platform/definitions.py
+++ b/dg_projects/data_platform/data_platform/definitions.py
@@ -10,8 +10,7 @@ from typing import Any
 from dagster import DefaultSensorStatus, Definitions, RunFailureSensorContext
 from dagster_slack import make_slack_on_run_failure_sensor
 from ol_orchestrate.lib.constants import DAGSTER_ENV, VAULT_ADDRESS
-from ol_orchestrate.lib.utils import authenticate_vault
-from ol_orchestrate.resources.secrets.vault import Vault
+from ol_orchestrate.lib.utils import authenticate_vault, unauthenticated_vault
 
 # Determine dagster URL based on environment
 if DAGSTER_ENV == "dev":
@@ -36,7 +35,7 @@ except Exception as e:  # noqa: BLE001 (resilient loading)
         f"Failed to authenticate with Vault: {e}. Using mock configuration.",
         stacklevel=2,
     )
-    vault = Vault(vault_addr=VAULT_ADDRESS, vault_auth_type="oidc")
+    vault = unauthenticated_vault(VAULT_ADDRESS)
     vault_authenticated = False
     dagster_url = "http://localhost:3000"
 

--- a/dg_projects/data_platform/data_platform/definitions.py
+++ b/dg_projects/data_platform/data_platform/definitions.py
@@ -36,7 +36,7 @@ except Exception as e:  # noqa: BLE001 (resilient loading)
         f"Failed to authenticate with Vault: {e}. Using mock configuration.",
         stacklevel=2,
     )
-    vault = Vault(vault_addr=VAULT_ADDRESS, vault_auth_type="github")
+    vault = Vault(vault_addr=VAULT_ADDRESS, vault_auth_type="oidc")
     vault_authenticated = False
     dagster_url = "http://localhost:3000"
 

--- a/dg_projects/edxorg/edxorg/definitions.py
+++ b/dg_projects/edxorg/edxorg/definitions.py
@@ -78,7 +78,7 @@ except Exception as e:  # noqa: BLE001 (resilient loading)
         f"Failed to authenticate with Vault: {e}. Using mock configuration.",
         stacklevel=2,
     )
-    vault = Vault(vault_addr=VAULT_ADDRESS, vault_auth_type="github")
+    vault = Vault(vault_addr=VAULT_ADDRESS, vault_auth_type="oidc")
     vault_authenticated = False
 
 

--- a/dg_projects/edxorg/edxorg/definitions.py
+++ b/dg_projects/edxorg/edxorg/definitions.py
@@ -26,12 +26,11 @@ from ol_orchestrate.io_managers.filepath import (
 )
 from ol_orchestrate.lib.constants import DAGSTER_ENV, VAULT_ADDRESS
 from ol_orchestrate.lib.dagster_helpers import default_io_manager
-from ol_orchestrate.lib.utils import authenticate_vault
+from ol_orchestrate.lib.utils import authenticate_vault, unauthenticated_vault
 from ol_orchestrate.resources.api_client_factory import ApiClientFactory
 from ol_orchestrate.resources.gcp_gcs import GCSConnection
 from ol_orchestrate.resources.openedx import OpenEdxApiClientFactory
 from ol_orchestrate.resources.outputs import DailyResultsDir, SimpleResultsDir
-from ol_orchestrate.resources.secrets.vault import Vault
 from ol_orchestrate.sensors.object_storage import (
     gcs_multi_file_sensor,
     s3_multi_file_sensor,
@@ -78,7 +77,7 @@ except Exception as e:  # noqa: BLE001 (resilient loading)
         f"Failed to authenticate with Vault: {e}. Using mock configuration.",
         stacklevel=2,
     )
-    vault = Vault(vault_addr=VAULT_ADDRESS, vault_auth_type="oidc")
+    vault = unauthenticated_vault(VAULT_ADDRESS)
     vault_authenticated = False
 
 

--- a/dg_projects/lakehouse/lakehouse/definitions.py
+++ b/dg_projects/lakehouse/lakehouse/definitions.py
@@ -125,7 +125,7 @@ except Exception as e:  # noqa: BLE001 (resilient loading)
         f"Failed to authenticate with Vault: {e}. Using mock configuration.",
         stacklevel=2,
     )
-    vault = Vault(vault_addr=VAULT_ADDRESS, vault_auth_type="github")
+    vault = Vault(vault_addr=VAULT_ADDRESS, vault_auth_type="oidc")
     vault_authenticated = False
     dagster_url = "http://localhost:3000"
 

--- a/dg_projects/lakehouse/lakehouse/definitions.py
+++ b/dg_projects/lakehouse/lakehouse/definitions.py
@@ -22,9 +22,8 @@ from dagster_dbt import (
     DbtCliResource,
 )
 from ol_orchestrate.lib.constants import DAGSTER_ENV, VAULT_ADDRESS
-from ol_orchestrate.lib.utils import authenticate_vault
+from ol_orchestrate.lib.utils import authenticate_vault, unauthenticated_vault
 from ol_orchestrate.resources.github import GithubApiClientFactory
-from ol_orchestrate.resources.secrets.vault import Vault
 from ol_orchestrate.resources.trino_maintenance import TrinoMaintenanceResource
 
 from lakehouse.assets.iceberg_maintenance import (
@@ -125,7 +124,7 @@ except Exception as e:  # noqa: BLE001 (resilient loading)
         f"Failed to authenticate with Vault: {e}. Using mock configuration.",
         stacklevel=2,
     )
-    vault = Vault(vault_addr=VAULT_ADDRESS, vault_auth_type="oidc")
+    vault = unauthenticated_vault(VAULT_ADDRESS)
     vault_authenticated = False
     dagster_url = "http://localhost:3000"
 

--- a/dg_projects/learning_resources/CONTRIBUTING.md
+++ b/dg_projects/learning_resources/CONTRIBUTING.md
@@ -45,12 +45,12 @@ export VAULT_ADDR=http://localhost:8200   # not contacted unless authenticated
 export SKIP_VAULT=1                        # prevents blocking on Vault auth
 ```
 
-If you need to test actual API calls, ask the platform team for a Vault GitHub
-token and run:
+If you need to test actual API calls, authenticate to Vault with the OIDC
+browser flow — no token to request from the platform team:
 
 ```bash
-export VAULT_ADDR=https://vault.odl.mit.edu
-export VAULT_GITHUB_TOKEN=<your-token>
+export VAULT_ADDR=https://vault-qa.odl.mit.edu
+bin/vault-login
 ```
 
 ### Running tests

--- a/dg_projects/learning_resources/learning_resources/definitions.py
+++ b/dg_projects/learning_resources/learning_resources/definitions.py
@@ -54,7 +54,7 @@ except Exception as e:  # noqa: BLE001 (resilient loading)
         f"Failed to authenticate with Vault: {e}. Using mock configuration.",
         stacklevel=2,
     )
-    vault = Vault(vault_addr=VAULT_ADDRESS, vault_auth_type="github")
+    vault = Vault(vault_addr=VAULT_ADDRESS, vault_auth_type="oidc")
 
 
 # Daily schedules for REST API webhook delivery sources.

--- a/dg_projects/learning_resources/learning_resources/definitions.py
+++ b/dg_projects/learning_resources/learning_resources/definitions.py
@@ -19,7 +19,11 @@ from dagster_aws.s3 import S3Resource
 from ol_orchestrate.io_managers.filepath import S3FileObjectIOManager
 from ol_orchestrate.lib.constants import DAGSTER_ENV, VAULT_ADDRESS
 from ol_orchestrate.lib.dagster_helpers import default_io_manager
-from ol_orchestrate.lib.utils import authenticate_vault, s3_uploads_bucket
+from ol_orchestrate.lib.utils import (
+    authenticate_vault,
+    s3_uploads_bucket,
+    unauthenticated_vault,
+)
 from ol_orchestrate.resources.api_client_factory import ApiClientFactory
 from ol_orchestrate.resources.oauth import OAuthApiClientFactory
 
@@ -48,13 +52,12 @@ try:
 except Exception as e:  # noqa: BLE001 (resilient loading)
     import warnings
 
-    from ol_orchestrate.resources.secrets.vault import Vault
-
     warnings.warn(
         f"Failed to authenticate with Vault: {e}. Using mock configuration.",
         stacklevel=2,
     )
-    vault = Vault(vault_addr=VAULT_ADDRESS, vault_auth_type="oidc")
+    vault = unauthenticated_vault(VAULT_ADDRESS)
+    vault_authenticated = False
 
 
 # Daily schedules for REST API webhook delivery sources.

--- a/dg_projects/legacy_openedx/legacy_openedx/definitions.py
+++ b/dg_projects/legacy_openedx/legacy_openedx/definitions.py
@@ -15,11 +15,10 @@ from dagster import Definitions, RunRequest, ScheduleEvaluationContext, schedule
 from dagster_aws.s3 import S3Resource
 from dagster_aws.s3.resources import s3_resource
 from ol_orchestrate.lib.constants import DAGSTER_ENV, VAULT_ADDRESS
-from ol_orchestrate.lib.utils import authenticate_vault
+from ol_orchestrate.lib.utils import authenticate_vault, unauthenticated_vault
 from ol_orchestrate.resources.gcp_gcs import GCSConnection
 from ol_orchestrate.resources.openedx import OpenEdxApiClient
 from ol_orchestrate.resources.outputs import DailyResultsDir
-from ol_orchestrate.resources.secrets.vault import Vault
 
 from legacy_openedx.jobs.open_edx import edx_course_pipeline
 from legacy_openedx.resources.healthchecks import HealthchecksIO
@@ -38,7 +37,7 @@ except Exception as e:  # noqa: BLE001 (resilient loading)
         f"Failed to authenticate with Vault: {e}. Using mock configuration.",
         stacklevel=2,
     )
-    vault = Vault(vault_addr=VAULT_ADDRESS, vault_auth_type="oidc")
+    vault = unauthenticated_vault(VAULT_ADDRESS)
     vault_authenticated = False
 
 # Initialize GCS connection with resilient loading

--- a/dg_projects/legacy_openedx/legacy_openedx/definitions.py
+++ b/dg_projects/legacy_openedx/legacy_openedx/definitions.py
@@ -38,7 +38,7 @@ except Exception as e:  # noqa: BLE001 (resilient loading)
         f"Failed to authenticate with Vault: {e}. Using mock configuration.",
         stacklevel=2,
     )
-    vault = Vault(vault_addr=VAULT_ADDRESS, vault_auth_type="github")
+    vault = Vault(vault_addr=VAULT_ADDRESS, vault_auth_type="oidc")
     vault_authenticated = False
 
 # Initialize GCS connection with resilient loading

--- a/dg_projects/openedx/openedx/definitions.py
+++ b/dg_projects/openedx/openedx/definitions.py
@@ -39,7 +39,7 @@ except Exception as e:  # noqa: BLE001 (resilient loading)
         f"Failed to authenticate with Vault: {e}. Using mock configuration.",
         stacklevel=2,
     )
-    vault = Vault(vault_addr=VAULT_ADDRESS, vault_auth_type="github")
+    vault = Vault(vault_addr=VAULT_ADDRESS, vault_auth_type="oidc")
     vault_authenticated = False
 
 dagster_env: Literal["dev", "ci", "qa", "production"] = os.environ.get(  # type: ignore  # noqa: PGH003

--- a/dg_projects/openedx/openedx/definitions.py
+++ b/dg_projects/openedx/openedx/definitions.py
@@ -18,9 +18,8 @@ from ol_orchestrate.lib.dagster_helpers import (
     default_file_object_io_manager,
     default_io_manager,
 )
-from ol_orchestrate.lib.utils import authenticate_vault
+from ol_orchestrate.lib.utils import authenticate_vault, unauthenticated_vault
 from ol_orchestrate.resources.api_client_factory import ApiClientFactory
-from ol_orchestrate.resources.secrets.vault import Vault
 
 from openedx.components import OpenEdxDeploymentComponent
 from openedx.jobs.normalize_logs import (
@@ -39,7 +38,7 @@ except Exception as e:  # noqa: BLE001 (resilient loading)
         f"Failed to authenticate with Vault: {e}. Using mock configuration.",
         stacklevel=2,
     )
-    vault = Vault(vault_addr=VAULT_ADDRESS, vault_auth_type="oidc")
+    vault = unauthenticated_vault(VAULT_ADDRESS)
     vault_authenticated = False
 
 dagster_env: Literal["dev", "ci", "qa", "production"] = os.environ.get(  # type: ignore  # noqa: PGH003

--- a/dg_projects/student_risk_probability/student_risk_probability/definitions.py
+++ b/dg_projects/student_risk_probability/student_risk_probability/definitions.py
@@ -11,7 +11,11 @@ from ol_orchestrate.lib.constants import DAGSTER_ENV, VAULT_ADDRESS
 from ol_orchestrate.lib.dagster_helpers import (
     default_file_object_io_manager,
 )
-from ol_orchestrate.lib.utils import authenticate_vault, s3_uploads_bucket
+from ol_orchestrate.lib.utils import (
+    authenticate_vault,
+    s3_uploads_bucket,
+    unauthenticated_vault,
+)
 from student_risk_probability.assets.risk_probability import student_risk_probability
 
 # Initialize vault with resilient loading
@@ -21,13 +25,11 @@ try:
 except Exception as e:  # noqa: BLE001 (resilient loading)
     import warnings
 
-    from ol_orchestrate.resources.secrets.vault import Vault
-
     warnings.warn(
         f"Failed to authenticate with Vault: {e}. Using mock configuration.",
         stacklevel=2,
     )
-    vault = Vault(vault_addr=VAULT_ADDRESS, vault_auth_type="oidc")
+    vault = unauthenticated_vault(VAULT_ADDRESS)
     vault_authenticated = False
 
 if DAGSTER_ENV == "dev":

--- a/dg_projects/student_risk_probability/student_risk_probability/definitions.py
+++ b/dg_projects/student_risk_probability/student_risk_probability/definitions.py
@@ -27,7 +27,7 @@ except Exception as e:  # noqa: BLE001 (resilient loading)
         f"Failed to authenticate with Vault: {e}. Using mock configuration.",
         stacklevel=2,
     )
-    vault = Vault(vault_addr=VAULT_ADDRESS, vault_auth_type="github")
+    vault = Vault(vault_addr=VAULT_ADDRESS, vault_auth_type="oidc")
     vault_authenticated = False
 
 if DAGSTER_ENV == "dev":

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -123,7 +123,7 @@ services:
       AWS_SECRET_ACCESS_KEY: ${AWS_SECRET_ACCESS_KEY}
     volumes:
     - /tmp/io_manager_storage:/tmp/io_manager_storage
-    - ${HOME}/.cache/vault:/vault/token-cache:ro
+    - ${VAULT_TOKEN_CACHE_DIR:-${XDG_CACHE_HOME:-${HOME}/.cache}/vault}:/vault/token-cache:ro
     - ./dg_projects/canvas/canvas:/app/canvas
 
   # Code location: data_platform
@@ -144,7 +144,7 @@ services:
       DAGSTER_ENV: dev
     volumes:
     - /tmp/io_manager_storage:/tmp/io_manager_storage
-    - ${HOME}/.cache/vault:/vault/token-cache:ro
+    - ${VAULT_TOKEN_CACHE_DIR:-${XDG_CACHE_HOME:-${HOME}/.cache}/vault}:/vault/token-cache:ro
     - ./dg_projects/data_platform/data_platform:/app/data_platform
 
   # Code location: edxorg
@@ -171,7 +171,7 @@ services:
       DAGSTER_PG_DB: dagster
     volumes:
     - /tmp/io_manager_storage:/tmp/io_manager_storage
-    - ${HOME}/.cache/vault:/vault/token-cache:ro
+    - ${VAULT_TOKEN_CACHE_DIR:-${XDG_CACHE_HOME:-${HOME}/.cache}/vault}:/vault/token-cache:ro
     - ./dg_projects/edxorg/edxorg:/app/edxorg
 
   # Code location: lakehouse
@@ -204,7 +204,7 @@ services:
       DAGSTER_PG_DB: dagster
     volumes:
     - /tmp/io_manager_storage:/tmp/io_manager_storage
-    - ${HOME}/.cache/vault:/vault/token-cache:ro
+    - ${VAULT_TOKEN_CACHE_DIR:-${XDG_CACHE_HOME:-${HOME}/.cache}/vault}:/vault/token-cache:ro
     - ./dg_projects/lakehouse/lakehouse:/app/lakehouse
     - ./src/ol_dbt:/opt/dbt
 
@@ -234,7 +234,7 @@ services:
       DAGSTER_PG_DB: dagster
     volumes:
     - /tmp/io_manager_storage:/tmp/io_manager_storage
-    - ${HOME}/.cache/vault:/vault/token-cache:ro
+    - ${VAULT_TOKEN_CACHE_DIR:-${XDG_CACHE_HOME:-${HOME}/.cache}/vault}:/vault/token-cache:ro
     - ./dg_projects/learning_resources/learning_resources:/app/learning_resources
 
   # Code location: legacy_openedx
@@ -257,7 +257,7 @@ services:
       AWS_SECRET_ACCESS_KEY: ${AWS_SECRET_ACCESS_KEY}
     volumes:
     - /tmp/io_manager_storage:/tmp/io_manager_storage
-    - ${HOME}/.cache/vault:/vault/token-cache:ro
+    - ${VAULT_TOKEN_CACHE_DIR:-${XDG_CACHE_HOME:-${HOME}/.cache}/vault}:/vault/token-cache:ro
     - ./dg_projects/legacy_openedx/legacy_openedx:/app/legacy_openedx
 
   # Code location: openedx
@@ -284,7 +284,7 @@ services:
       DAGSTER_PG_DB: dagster
     volumes:
     - /tmp/io_manager_storage:/tmp/io_manager_storage
-    - ${HOME}/.cache/vault:/vault/token-cache:ro
+    - ${VAULT_TOKEN_CACHE_DIR:-${XDG_CACHE_HOME:-${HOME}/.cache}/vault}:/vault/token-cache:ro
     - ./dg_projects/openedx/openedx:/app/openedx
 
   # Code location: b2b_organization
@@ -311,7 +311,7 @@ services:
       DAGSTER_PG_DB: dagster
     volumes:
     - /tmp/io_manager_storage:/tmp/io_manager_storage
-    - ${HOME}/.cache/vault:/vault/token-cache:ro
+    - ${VAULT_TOKEN_CACHE_DIR:-${XDG_CACHE_HOME:-${HOME}/.cache}/vault}:/vault/token-cache:ro
     - ./dg_projects/b2b_organization/b2b_organization:/app/b2b_organization
 
     # Code location: student_risk_probability
@@ -339,7 +339,7 @@ services:
       DAGSTER_PG_DB: dagster
     volumes:
     - /tmp/io_manager_storage:/tmp/io_manager_storage
-    - ${HOME}/.cache/vault:/vault/token-cache:ro
+    - ${VAULT_TOKEN_CACHE_DIR:-${XDG_CACHE_HOME:-${HOME}/.cache}/vault}:/vault/token-cache:ro
     - ./dg_projects/student_risk_probability/student_risk_probability:/app/student_risk_probability
 
   postgres:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -18,7 +18,6 @@ services:
       DBT_SCHEMA_SUFFIX: ${DBT_SCHEMA_SUFFIX}
       DBT_TRINO_USERNAME: ${DBT_TRINO_USERNAME}
       DBT_TRINO_PASSWORD: ${DBT_TRINO_PASSWORD}
-      GITHUB_TOKEN: ${GITHUB_TOKEN}
       AWS_ACCESS_KEY_ID: ${AWS_ACCESS_KEY_ID}
       AWS_SECRET_ACCESS_KEY: ${AWS_SECRET_ACCESS_KEY}
       DAGSTER_CURRENT_IMAGE: "mitodl/dagster-lakehouse:dev"
@@ -55,7 +54,6 @@ services:
       DBT_SCHEMA_SUFFIX: ${DBT_SCHEMA_SUFFIX}
       DBT_TRINO_USERNAME: ${DBT_TRINO_USERNAME}
       DBT_TRINO_PASSWORD: ${DBT_TRINO_PASSWORD}
-      GITHUB_TOKEN: ${GITHUB_TOKEN}
       AWS_ACCESS_KEY_ID: ${AWS_ACCESS_KEY_ID}
       AWS_SECRET_ACCESS_KEY: ${AWS_SECRET_ACCESS_KEY}
       DAGSTER_CURRENT_IMAGE: "mitodl/dagster-lakehouse:dev"
@@ -93,7 +91,6 @@ services:
       DBT_TRINO_PASSWORD: ${DBT_TRINO_PASSWORD}
       AWS_ACCESS_KEY_ID: ${AWS_ACCESS_KEY_ID}
       AWS_SECRET_ACCESS_KEY: ${AWS_SECRET_ACCESS_KEY}
-      GITHUB_TOKEN: ${GITHUB_TOKEN}
       DAGSTER_CURRENT_IMAGE: "mitodl/dagster-lakehouse:dev"
       DAGSTER_PG_USERNAME: postgres
       DAGSTER_PG_PASSWORD: postgres # pragma: allowlist secret
@@ -119,12 +116,14 @@ services:
     - "4000:4000"
     environment:
       DAGSTER_CURRENT_IMAGE: "mitodl/dagster-canvas:dev"
+      VAULT_TOKEN_CACHE_DIR: /vault/token-cache
+      VAULT_OIDC_NONINTERACTIVE: "1"
       DAGSTER_ENV: dev
-      GITHUB_TOKEN: ${GITHUB_TOKEN}
       AWS_ACCESS_KEY_ID: ${AWS_ACCESS_KEY_ID}
       AWS_SECRET_ACCESS_KEY: ${AWS_SECRET_ACCESS_KEY}
     volumes:
     - /tmp/io_manager_storage:/tmp/io_manager_storage
+    - ${HOME}/.cache/vault:/vault/token-cache:ro
     - ./dg_projects/canvas/canvas:/app/canvas
 
   # Code location: data_platform
@@ -140,10 +139,12 @@ services:
     - "4001:4001"
     environment:
       DAGSTER_CURRENT_IMAGE: "mitodl/dagster-data_platform:dev"
+      VAULT_TOKEN_CACHE_DIR: /vault/token-cache
+      VAULT_OIDC_NONINTERACTIVE: "1"
       DAGSTER_ENV: dev
-      GITHUB_TOKEN: ${GITHUB_TOKEN}
     volumes:
     - /tmp/io_manager_storage:/tmp/io_manager_storage
+    - ${HOME}/.cache/vault:/vault/token-cache:ro
     - ./dg_projects/data_platform/data_platform:/app/data_platform
 
   # Code location: edxorg
@@ -159,8 +160,9 @@ services:
     - "4002:4002"
     environment:
       DAGSTER_CURRENT_IMAGE: "mitodl/dagster-edxorg:dev"
+      VAULT_TOKEN_CACHE_DIR: /vault/token-cache
+      VAULT_OIDC_NONINTERACTIVE: "1"
       DAGSTER_ENV: dev
-      GITHUB_TOKEN: ${GITHUB_TOKEN}
       AWS_ACCESS_KEY_ID: ${AWS_ACCESS_KEY_ID}
       AWS_SECRET_ACCESS_KEY: ${AWS_SECRET_ACCESS_KEY}
       DAGSTER_PG_USERNAME: postgres
@@ -169,6 +171,7 @@ services:
       DAGSTER_PG_DB: dagster
     volumes:
     - /tmp/io_manager_storage:/tmp/io_manager_storage
+    - ${HOME}/.cache/vault:/vault/token-cache:ro
     - ./dg_projects/edxorg/edxorg:/app/edxorg
 
   # Code location: lakehouse
@@ -187,11 +190,12 @@ services:
     - "4003:4003"
     environment:
       DAGSTER_CURRENT_IMAGE: "mitodl/dagster-lakehouse:dev"
+      VAULT_TOKEN_CACHE_DIR: /vault/token-cache
+      VAULT_OIDC_NONINTERACTIVE: "1"
       DAGSTER_ENVIRONMENT: qa
       DBT_SCHEMA_SUFFIX: ${DBT_SCHEMA_SUFFIX}
       DBT_TRINO_USERNAME: ${DBT_TRINO_USERNAME}
       DBT_TRINO_PASSWORD: ${DBT_TRINO_PASSWORD}
-      GITHUB_TOKEN: ${GITHUB_TOKEN}
       AWS_ACCESS_KEY_ID: ${AWS_ACCESS_KEY_ID}
       AWS_SECRET_ACCESS_KEY: ${AWS_SECRET_ACCESS_KEY}
       DAGSTER_PG_USERNAME: postgres
@@ -200,6 +204,7 @@ services:
       DAGSTER_PG_DB: dagster
     volumes:
     - /tmp/io_manager_storage:/tmp/io_manager_storage
+    - ${HOME}/.cache/vault:/vault/token-cache:ro
     - ./dg_projects/lakehouse/lakehouse:/app/lakehouse
     - ./src/ol_dbt:/opt/dbt
 
@@ -216,8 +221,9 @@ services:
     - "4004:4004"
     environment:
       DAGSTER_CURRENT_IMAGE: "mitodl/dagster-learning_resources:dev"
+      VAULT_TOKEN_CACHE_DIR: /vault/token-cache
+      VAULT_OIDC_NONINTERACTIVE: "1"
       DAGSTER_ENV: dev
-      GITHUB_TOKEN: ${GITHUB_TOKEN}
       AWS_ACCESS_KEY_ID: ${AWS_ACCESS_KEY_ID}
       AWS_SECRET_ACCESS_KEY: ${AWS_SECRET_ACCESS_KEY}
       MIT_LEARN_BASE_URL: ${MIT_LEARN_BASE_URL}
@@ -228,6 +234,7 @@ services:
       DAGSTER_PG_DB: dagster
     volumes:
     - /tmp/io_manager_storage:/tmp/io_manager_storage
+    - ${HOME}/.cache/vault:/vault/token-cache:ro
     - ./dg_projects/learning_resources/learning_resources:/app/learning_resources
 
   # Code location: legacy_openedx
@@ -243,12 +250,14 @@ services:
     - "4005:4005"
     environment:
       DAGSTER_CURRENT_IMAGE: "mitodl/dagster-legacy_openedx:dev"
+      VAULT_TOKEN_CACHE_DIR: /vault/token-cache
+      VAULT_OIDC_NONINTERACTIVE: "1"
       DAGSTER_ENV: dev
-      GITHUB_TOKEN: ${GITHUB_TOKEN}
       AWS_ACCESS_KEY_ID: ${AWS_ACCESS_KEY_ID}
       AWS_SECRET_ACCESS_KEY: ${AWS_SECRET_ACCESS_KEY}
     volumes:
     - /tmp/io_manager_storage:/tmp/io_manager_storage
+    - ${HOME}/.cache/vault:/vault/token-cache:ro
     - ./dg_projects/legacy_openedx/legacy_openedx:/app/legacy_openedx
 
   # Code location: openedx
@@ -264,8 +273,9 @@ services:
     - "4006:4006"
     environment:
       DAGSTER_CURRENT_IMAGE: "mitodl/dagster-openedx:dev"
+      VAULT_TOKEN_CACHE_DIR: /vault/token-cache
+      VAULT_OIDC_NONINTERACTIVE: "1"
       DAGSTER_ENV: dev
-      GITHUB_TOKEN: ${GITHUB_TOKEN}
       AWS_ACCESS_KEY_ID: ${AWS_ACCESS_KEY_ID}
       AWS_SECRET_ACCESS_KEY: ${AWS_SECRET_ACCESS_KEY}
       DAGSTER_PG_USERNAME: postgres
@@ -274,6 +284,7 @@ services:
       DAGSTER_PG_DB: dagster
     volumes:
     - /tmp/io_manager_storage:/tmp/io_manager_storage
+    - ${HOME}/.cache/vault:/vault/token-cache:ro
     - ./dg_projects/openedx/openedx:/app/openedx
 
   # Code location: b2b_organization
@@ -289,8 +300,9 @@ services:
     - "4007:4007"
     environment:
       DAGSTER_CURRENT_IMAGE: "mitodl/dagster-b2b_organization:dev"
+      VAULT_TOKEN_CACHE_DIR: /vault/token-cache
+      VAULT_OIDC_NONINTERACTIVE: "1"
       DAGSTER_ENV: dev
-      GITHUB_TOKEN: ${GITHUB_TOKEN}
       AWS_ACCESS_KEY_ID: ${AWS_ACCESS_KEY_ID}
       AWS_SECRET_ACCESS_KEY: ${AWS_SECRET_ACCESS_KEY}
       DAGSTER_PG_USERNAME: postgres
@@ -299,6 +311,7 @@ services:
       DAGSTER_PG_DB: dagster
     volumes:
     - /tmp/io_manager_storage:/tmp/io_manager_storage
+    - ${HOME}/.cache/vault:/vault/token-cache:ro
     - ./dg_projects/b2b_organization/b2b_organization:/app/b2b_organization
 
     # Code location: student_risk_probability
@@ -314,9 +327,10 @@ services:
     - "4008:4008"
     environment:
       DAGSTER_CURRENT_IMAGE: "mitodl/dagster-student_risk_probability:dev"
+      VAULT_TOKEN_CACHE_DIR: /vault/token-cache
+      VAULT_OIDC_NONINTERACTIVE: "1"
       DAGSTER_ENV: dev
       DBT_SCHEMA_SUFFIX: ${DBT_SCHEMA_SUFFIX}
-      GITHUB_TOKEN: ${GITHUB_TOKEN}
       AWS_ACCESS_KEY_ID: ${AWS_ACCESS_KEY_ID}
       AWS_SECRET_ACCESS_KEY: ${AWS_SECRET_ACCESS_KEY}
       DAGSTER_PG_USERNAME: postgres
@@ -325,6 +339,7 @@ services:
       DAGSTER_PG_DB: dagster
     volumes:
     - /tmp/io_manager_storage:/tmp/io_manager_storage
+    - ${HOME}/.cache/vault:/vault/token-cache:ro
     - ./dg_projects/student_risk_probability/student_risk_probability:/app/student_risk_probability
 
   postgres:

--- a/packages/ol-orchestrate-lib/src/ol_orchestrate/lib/utils.py
+++ b/packages/ol-orchestrate-lib/src/ol_orchestrate/lib/utils.py
@@ -42,6 +42,29 @@ def authenticate_vault(dagster_env: str, vault_address: str) -> Vault:
     return vault
 
 
+def unauthenticated_vault(vault_address: str) -> Vault:
+    """Build an unauthenticated Vault resource for resilient-loading fallbacks.
+
+    Code locations catch authentication failures at import and fall back to mock
+    configuration. The fallback resource must still carry the same role as
+    authenticate_vault() would pick, because the OIDC token cache is keyed by
+    role: a resource built without one looks for a 'default' cache entry that
+    bin/vault-login never writes, so any later access to .client fails on a
+    cache miss instead of reusing the token that is sitting right there.
+
+    Parameters:
+        vault_address (str): The address of the Vault server.
+
+    Returns:
+        Vault: An unauthenticated Vault client.
+    """
+    return Vault(
+        vault_addr=vault_address,
+        vault_auth_type="oidc",
+        vault_role=os.environ.get("DAGSTER_VAULT_ROLE", "developer"),
+    )
+
+
 def s3_uploads_bucket(
     dagster_env: Literal["dev", "ci", "qa", "production"],
 ) -> dict[str, Any]:

--- a/packages/ol-orchestrate-lib/src/ol_orchestrate/lib/utils.py
+++ b/packages/ol-orchestrate-lib/src/ol_orchestrate/lib/utils.py
@@ -24,16 +24,11 @@ def authenticate_vault(dagster_env: str, vault_address: str) -> Vault:
         Vault: An authenticated Vault client.
     """
     if dagster_env == "dev":
-        if os.environ.get("GITHUB_TOKEN"):
-            auth_method = "github"
-            vault = Vault(vault_addr=vault_address, vault_auth_type=auth_method)
-        else:
-            auth_method = "oidc"
-            vault = Vault(
-                vault_addr=vault_address,
-                vault_auth_type=auth_method,
-                vault_role=os.environ.get("DAGSTER_VAULT_ROLE", "developer"),
-            )
+        vault = Vault(
+            vault_addr=vault_address,
+            vault_auth_type="oidc",
+            vault_role=os.environ.get("DAGSTER_VAULT_ROLE", "developer"),
+        )
     else:
         vault_role = os.getenv("DAGSTER_VAULT_ROLE", "dagster")
         vault_mount = os.getenv("DAGSTER_VAULT_MOUNT", "k8s-data")

--- a/packages/ol-orchestrate-lib/src/ol_orchestrate/resources/secrets/vault.py
+++ b/packages/ol-orchestrate-lib/src/ol_orchestrate/resources/secrets/vault.py
@@ -1,3 +1,4 @@
+import contextlib
 import json
 import os
 from pathlib import Path
@@ -12,7 +13,7 @@ class Vault(ConfigurableResource):
     vault_addr: str
     vault_token: str | None = None
     vault_role: str | None = None
-    # can be one of ["github", "aws-iam", "token", "kubernetes", "oidc", "jwt"]
+    # can be one of ["aws-iam", "token", "kubernetes", "oidc", "jwt"]
     vault_auth_type: str = "kubernetes"
     auth_mount: str | None = None
     verify_tls: bool = True
@@ -32,15 +33,6 @@ class Vault(ConfigurableResource):
             mount_point=self.auth_mount or "aws",
         )
 
-    def _auth_github(self):
-        self._initialize_client()
-        gh_token = os.environ.get("GITHUB_TOKEN")
-        self._client.auth.github.login(
-            token=gh_token,
-            use_token=True,
-            mount_point=self.auth_mount or "github",
-        )
-
     def _auth_kubernetes(self):
         self._initialize_client()
         with Path("/var/run/secrets/kubernetes.io/serviceaccount/token").open() as f:
@@ -53,9 +45,22 @@ class Vault(ConfigurableResource):
         )
 
     def _get_token_cache_path(self) -> Path:
-        """Get the path to the token cache file."""
-        cache_dir = Path.home() / ".vault" / "token_cache"
-        cache_dir.mkdir(parents=True, exist_ok=True)
+        """Get the path to the token cache file.
+
+        Defaults to ``$XDG_CACHE_HOME/vault`` (``~/.cache/vault``). ``~/.vault``
+        is avoided because the Vault CLI writes a ``~/.vault`` *file* there.
+        ``VAULT_TOKEN_CACHE_DIR`` overrides the location, which is how the
+        containers in docker-compose reuse a token minted on the host.
+        """
+        cache_override = os.environ.get("VAULT_TOKEN_CACHE_DIR")
+        if cache_override:
+            cache_dir = Path(cache_override)
+        else:
+            xdg_cache = os.environ.get("XDG_CACHE_HOME") or Path.home() / ".cache"
+            cache_dir = Path(xdg_cache) / "vault"
+        # Read-only bind mount in the compose stack -- reads still work.
+        with contextlib.suppress(OSError):
+            cache_dir.mkdir(parents=True, exist_ok=True)
         # Use vault_addr and role to create unique cache file
         cache_key = f"{self.vault_addr}_{self.vault_role or 'default'}".replace(
             "/", "_"
@@ -142,8 +147,13 @@ class Vault(ConfigurableResource):
         This method requires an interactive environment with a web browser.
         It opens a browser window for authentication and handles the OAuth callback.
 
-        Tokens are cached in ~/.vault/token_cache/ to avoid repeated browser flows.
-        The cache is keyed by vault_addr and vault_role.
+        Tokens are cached in ~/.cache/vault to avoid repeated browser flows, keyed
+        by vault_addr and vault_role. See _get_token_cache_path().
+
+        Containers cannot open a browser or receive the localhost:8250 redirect,
+        so the compose stack mounts a token minted on the host by bin/vault-login
+        and sets VAULT_OIDC_NONINTERACTIVE, which turns a cache miss into a clear
+        error rather than a hang.
 
         Note: This method is not suitable for automated/non-interactive environments
         like Kubernetes pods or CI/CD pipelines. Use 'jwt' auth_type instead for
@@ -155,6 +165,14 @@ class Vault(ConfigurableResource):
         cached_token = self._load_cached_token()
         if cached_token:
             return
+
+        if os.environ.get("VAULT_OIDC_NONINTERACTIVE"):
+            err_msg = (
+                "No valid cached Vault token, and the OIDC browser flow is "
+                "disabled in this environment. Run `bin/vault-login` on the "
+                "host to mint a token, then restart the stack."
+            )
+            raise RuntimeError(err_msg)
 
         # Import here to avoid dependency issues if not using interactive OIDC
         import urllib.parse  # noqa: PLC0415
@@ -257,8 +275,6 @@ window.onload = function load() {
     def authenticate(self):
         if self.vault_auth_type == "aws-iam":
             self._auth_aws_iam()
-        elif self.vault_auth_type == "github":
-            self._auth_github()
         elif self.vault_auth_type == "kubernetes":
             self._auth_kubernetes()
         elif self.vault_auth_type == "jwt":

--- a/packages/ol-orchestrate-lib/src/ol_orchestrate/resources/secrets/vault.py
+++ b/packages/ol-orchestrate-lib/src/ol_orchestrate/resources/secrets/vault.py
@@ -89,13 +89,26 @@ class Vault(ConfigurableResource):
                 return cached_token
 
             # Token is invalid, remove cache file
-            cache_path.unlink(missing_ok=True)
+            self._discard_cached_token(cache_path)
 
         except (json.JSONDecodeError, OSError):
             # Cache file is corrupted or unreadable, remove it
-            cache_path.unlink(missing_ok=True)
+            self._discard_cached_token(cache_path)
 
         return None
+
+    @staticmethod
+    def _discard_cached_token(cache_path: Path) -> None:
+        """Delete a stale cache entry, tolerating a read-only cache directory.
+
+        The compose stack mounts the cache read-only, so unlink raises
+        PermissionError there. Discarding is only an optimisation -- the caller
+        re-authenticates either way -- and letting it propagate would replace
+        the actionable message _auth_oidc raises next with a bare traceback.
+        Note missing_ok only covers FileNotFoundError, not PermissionError.
+        """
+        with contextlib.suppress(OSError):
+            cache_path.unlink(missing_ok=True)
 
     def _save_token_to_cache(self, token: str):
         """Save a token to the cache file."""


### PR DESCRIPTION
### What are the relevant tickets?
N/A

### Description (What does it do?)
Local Dagster development authenticated to Vault with a GitHub personal access token pasted into `.env`. That couples two independent systems — a single stolen token grants both Vault access and whatever that token can reach on GitHub — and it means a long-lived plaintext secret lives on every developer machine.

This switches local dev to the Keycloak OIDC backend, which needs no stored secret.

**Why this wasn't already a one-line change.** `authenticate_vault()` already fell back to OIDC whenever `GITHUB_TOKEN` was unset, and Vault's OIDC `developer` role already carried the same `readonly` + `developer` policies the GitHub team mapping granted — so there was no policy gap. The blocker was that code locations authenticate from *inside* their containers, which have no browser and cannot receive the OIDC redirect on `localhost:8250`. With nine code locations, each would want its own browser flow and its own bind on port 8250.

**How it's resolved.** The interactive login happens once on the host and the resulting token is shared:

- `bin/vault-login` (cyclopts) runs the browser flow and caches a short-lived token. It is idempotent — while the cached token is still valid it's a no-op, so it's safe to run unconditionally.
- `docker-compose.yaml` mounts that cache read-only into the nine code-location services. `Vault._auth_oidc` already checked the cache before doing anything else, so the containers short-circuit and never attempt a browser flow.
- `VAULT_OIDC_NONINTERACTIVE` is set in the containers so a cache miss raises an actionable error instead of hanging on a browser that cannot open.
- `bin/dagster-up` wraps login + `docker compose up --build`, so the everyday command stays a single invocation and only prompts when the token has genuinely expired.

**Other changes**

- The token cache moves to `~/.cache/vault` (XDG-aware, overridable via `VAULT_TOKEN_CACHE_DIR`). The previous `~/.vault/` directory collides with the `~/.vault` file the Vault CLI writes.
- `_auth_github` is deleted rather than deprecated, so the pattern cannot quietly return. `GITHUB_TOKEN` had no other consumer — the GitHub API resource fetches its token *from* Vault.
- `GITHUB_TOKEN` is removed from all 12 compose services. The three core services (`dagster_init`, `dagster_webserver`, `dagster_daemon`) never needed it: they load code over gRPC and never call `authenticate_vault()`.
- Docs updated: `README.md`, `AGENTS.md`, `.env.example`, `dg_projects/learning_resources/CONTRIBUTING.md`.
- `--scripts-are-modules` added to the mypy pre-commit hook; without it, two extensionless `bin/` scripts both resolve to module `__main__` and mypy errors.

### How can this be tested?

Developers no longer create or paste any token. From a clean checkout:

```bash
cp .env.example .env     # note: no GITHUB_TOKEN line any more
bin/dagster-up
```

A browser opens for Keycloak login, the token lands in `~/.cache/vault`, and the stack comes up. Confirm the Dagster UI at `localhost:3000` loads and that code locations report healthy rather than falling back to mock configuration.

Then verify the shared-token behaviour:

```bash
bin/vault-login          # should print "Cached Vault token ... is still valid." and not open a browser
bin/vault-login --force  # should re-run the browser flow
```

Verify the containers actually consume the host token:

```bash
docker compose exec dagster_canvas ls /vault/token-cache
```

Automated checks run in this branch:

- `pre-commit run --files ...` — all hooks pass (ruff format, ruff check, mypy, detect-secrets, yamllint).
- `docker compose config` validates.
- Cache-path parity between `bin/vault-login` and `Vault._get_token_cache_path()` was verified directly for both `qa`/`developer` and `production`/`admin`, and for the `VAULT_TOKEN_CACHE_DIR` container override. This matters: if the two ever disagree, containers silently miss the cache.
- The non-interactive guard was exercised against an empty cache dir and raises the intended message; `vault_auth_type="github"` now raises `Invalid auth type: github`.

### Additional Context

**Ordering.** The GitHub auth method is already disabled on the Vault servers, so `GITHUB_TOKEN` no longer works for anyone today. This PR is what restores local development, and it pairs with https://github.com/mitodl/ol-infrastructure/pull/5133, which removes the backend from Pulumi so it cannot be recreated.

**Two pre-existing issues found while working here, deliberately left alone** — both change behaviour beyond this PR's scope:

1. `packages/ol-orchestrate-lib/src/ol_orchestrate/lib/constants.py` reads `DAGSTER_ENVIRONMENT`, but every compose service sets `DAGSTER_ENV`. The `"dev"` default masks the mismatch everywhere except `dagster_lakehouse`, which sets `DAGSTER_ENVIRONMENT: qa` and therefore takes the *kubernetes* auth path locally and lands in the mock-config `except` branch. Unchanged by this PR, but it means lakehouse never really authenticates locally.
2. `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` remain long-lived static secrets in `.env`. Now that Vault needs no stored credential, these are the largest remaining plaintext secrets on developer machines — and they are issuable from Vault via `aws-mitx/creds/*`.

**Possible follow-up.** For anyone working on a headless remote box where `localhost:8250` isn't reachable from their browser, a Keycloak device-authorization flow would remove the callback requirement entirely. `Vault._auth_jwt()` already exists, so that would be purely additive — a new public Keycloak client, a Vault `jwt` role, and a `--device` flag on `bin/vault-login`. Not needed for the standard laptop workflow.
