### PR TITLE
fix(mitx-users): deduplicate users in int__mitx__users

### DIFF
--- a/src/ol_dbt/models/intermediate/mitx/_int_mitx__models.yml
+++ b/src/ol_dbt/models/intermediate/mitx/_int_mitx__models.yml
@@ -122,6 +122,11 @@ models:
   description: MITx users combined from MITx Online, MicroMasters, and edX.org. For
     users who exist on both platforms, their profile fields are selected in the order
     of MITx Online, MicroMasters, and edX.org, whichever is not null.
+  tests:
+  - dbt_expectations.expect_compound_columns_to_be_unique:
+      arguments:
+        column_list: ["user_edxorg_username", "user_micromasters_id"]
+        row_condition: "user_edxorg_username is not null"
   columns:
   - name: user_hashed_id
     description: str, primary key for this table to identify the user
@@ -153,9 +158,11 @@ models:
     tests:
     - unique
   - name: user_edxorg_username
-    description: str, username on edX.org
-    tests:
-    - unique
+    description: str, username on edX.org. Not unique on its own, a person holding
+      two MicroMasters accounts (one linked from edX.org, one from MITx Online) has
+      only one of those ids kept on the collapsed row, and the other account is appended
+      with the same edX.org username. Uniqueness is asserted per MicroMasters account
+      instead.
   - name: user_mitxonline_email
     description: str, user email on MITx Online
     tests:

--- a/src/ol_dbt/models/intermediate/mitx/int__mitx__users.sql
+++ b/src/ol_dbt/models/intermediate/mitx/int__mitx__users.sql
@@ -48,10 +48,11 @@ with users as (
         , coalesce(mitxonline_users.user_industry, micromasters_users.user_company_industry) as user_industry
         , coalesce(mitxonline_users.user_job_title, micromasters_users.user_job_position) as user_job_title
         , coalesce(
-            mitxonline_users.user_address_country, micromasters_users.user_address_country
+            nullif(mitxonline_users.user_address_country, ''), nullif(micromasters_users.user_address_country, '')
         ) as user_address_country
         , coalesce(
-            mitxonline_users.user_address_state, micromasters_users.user_address_state_or_territory
+            nullif(mitxonline_users.user_address_state, '')
+            , nullif(micromasters_users.user_address_state_or_territory, '')
         ) as user_address_state
         , coalesce(
             mitxonline_users.user_highest_education, micromasters_users.user_highest_education
@@ -85,8 +86,12 @@ with users as (
         , micromasters_users.user_street_address
         , micromasters_users.user_address_city
         , true as is_edxorg_user
-        , coalesce(micromasters_users.user_full_name, edxorg_users.user_full_name) as user_full_name
-        , coalesce(micromasters_users.user_address_country, edxorg_users.user_country) as user_address_country
+        , coalesce(
+            nullif(micromasters_users.user_full_name, ''), nullif(edxorg_users.user_full_name, '')
+        ) as user_full_name
+        , coalesce(
+            nullif(micromasters_users.user_address_country, ''), nullif(edxorg_users.user_country, '')
+        ) as user_address_country
         , coalesce(
             micromasters_users.user_highest_education, edxorg_users.user_highest_education
         ) as user_highest_education
@@ -96,6 +101,74 @@ with users as (
         ) as user_birth_year
     from edxorg_users
     left join micromasters_users on edxorg_users.user_username = micromasters_users.user_edxorg_username
+)
+
+---Primary link: the edX.org username on the MITx Online side. Sourced only from
+-- MicroMasters social auth, so populated for a minority of users.
+, username_links as (
+    select
+        mitxonline_users_view.user_mitxonline_id
+        , edxorg_users_view.user_edxorg_id
+    from mitxonline_users_view
+    inner join edxorg_users_view
+        on mitxonline_users_view.user_edxorg_username = edxorg_users_view.user_edxorg_username
+)
+
+, unlinked_mitxonline as (
+    select mitxonline_users_view.*
+    from mitxonline_users_view
+    left join username_links
+        on mitxonline_users_view.user_mitxonline_id = username_links.user_mitxonline_id
+    where username_links.user_mitxonline_id is null
+        and mitxonline_users_view.user_mitxonline_email is not null
+)
+
+, unlinked_edxorg as (
+    select edxorg_users_view.*
+    from edxorg_users_view
+    left join username_links on edxorg_users_view.user_edxorg_id = username_links.user_edxorg_id
+    where username_links.user_edxorg_id is null
+        and edxorg_users_view.user_edxorg_email is not null
+)
+
+---Fallback link on email, for users the username link cannot reach. A few addresses are
+-- shared by two accounts, so rank both directions and keep only mutual first choices:
+-- that caps the match at one account per side, which the unique tests depend on.
+, email_link_candidates as (
+    select
+        unlinked_mitxonline.user_mitxonline_id
+        , unlinked_edxorg.user_edxorg_id
+        , row_number() over (
+            partition by unlinked_mitxonline.user_mitxonline_id
+            order by
+                unlinked_edxorg.user_last_login desc nulls last
+                , unlinked_edxorg.user_joined_on desc nulls last
+                , unlinked_edxorg.user_edxorg_id asc
+        ) as edxorg_rank
+        , row_number() over (
+            partition by unlinked_edxorg.user_edxorg_id
+            order by
+                unlinked_mitxonline.user_last_login desc nulls last
+                , unlinked_mitxonline.user_joined_on desc nulls last
+                , unlinked_mitxonline.user_mitxonline_id asc
+        ) as mitxonline_rank
+    from unlinked_mitxonline
+    inner join unlinked_edxorg
+        on lower(unlinked_mitxonline.user_mitxonline_email) = lower(unlinked_edxorg.user_edxorg_email)
+)
+
+, email_links as (
+    select
+        user_mitxonline_id
+        , user_edxorg_id
+    from email_link_candidates
+    where edxorg_rank = 1 and mitxonline_rank = 1
+)
+
+, account_links as (
+    select * from username_links
+    union all
+    select * from email_links
 )
 
 , mitxonline_edxorg_users as (
@@ -118,13 +191,25 @@ with users as (
         , edxorg_users_view.user_address_city
         , coalesce(mitxonline_users_view.is_mitxonline_user is not null, false) as is_mitxonline_user
         , coalesce(edxorg_users_view.is_edxorg_user is not null, false) as is_edxorg_user
-        , coalesce(mitxonline_users_view.user_full_name, edxorg_users_view.user_full_name) as user_full_name
-        , coalesce(mitxonline_users_view.user_first_name, edxorg_users_view.user_first_name) as user_first_name
-        , coalesce(mitxonline_users_view.user_last_name, edxorg_users_view.user_last_name) as user_last_name
-        , coalesce(mitxonline_users_view.user_address_country, edxorg_users_view.user_address_country)
-            as user_address_country
-        , coalesce(mitxonline_users_view.user_address_state, edxorg_users_view.user_address_state_or_territory)
-            as user_address_state
+        -- nullif because the MITx Online legaladdress and name fields store blanks, not
+        -- nulls, and a blank would win the coalesce and mask a populated edX.org value.
+        , coalesce(
+            nullif(mitxonline_users_view.user_full_name, ''), nullif(edxorg_users_view.user_full_name, '')
+        ) as user_full_name
+        , coalesce(
+            nullif(mitxonline_users_view.user_first_name, ''), nullif(edxorg_users_view.user_first_name, '')
+        ) as user_first_name
+        , coalesce(
+            nullif(mitxonline_users_view.user_last_name, ''), nullif(edxorg_users_view.user_last_name, '')
+        ) as user_last_name
+        , coalesce(
+            nullif(mitxonline_users_view.user_address_country, '')
+            , nullif(edxorg_users_view.user_address_country, '')
+        ) as user_address_country
+        , coalesce(
+            nullif(mitxonline_users_view.user_address_state, '')
+            , nullif(edxorg_users_view.user_address_state_or_territory, '')
+        ) as user_address_state
         , coalesce(mitxonline_users_view.user_highest_education, edxorg_users_view.user_highest_education)
             as user_highest_education
         , coalesce(mitxonline_users_view.user_gender, edxorg_users_view.user_gender) as user_gender
@@ -139,8 +224,25 @@ with users as (
             mitxonline_users_view.user_micromasters_email, edxorg_users_view.user_micromasters_email
         ) as user_micromasters_email
     from mitxonline_users_view
-    full outer join edxorg_users_view
-        on mitxonline_users_view.user_edxorg_username = edxorg_users_view.user_edxorg_username
+    left join account_links on mitxonline_users_view.user_mitxonline_id = account_links.user_mitxonline_id
+    full outer join edxorg_users_view on account_links.user_edxorg_id = edxorg_users_view.user_edxorg_id
+)
+
+-- Usernames already claimed above. Two MicroMasters accounts can share one platform
+-- username, and only one id survives the user_micromasters_id coalesce, so the other is
+-- appended below with a duplicate username. Blanking it there keeps the account and its
+-- user_micromasters_id (which downstream MicroMasters models join on) while the username
+-- stays unique. distinct so the lookup joins cannot fan out.
+, claimed_edxorg_usernames as (
+    select distinct user_edxorg_username
+    from mitxonline_edxorg_users
+    where user_edxorg_username is not null
+)
+
+, claimed_mitxonline_usernames as (
+    select distinct user_mitxonline_username
+    from mitxonline_edxorg_users
+    where user_mitxonline_username is not null
 )
 
 select
@@ -192,8 +294,16 @@ select
     , null as user_mitxonline_id
     , null as user_edxorg_id
     , micromasters_users.user_id as user_micromasters_id
-    , micromasters_users.user_mitxonline_username
-    , micromasters_users.user_edxorg_username
+    -- the is_*_user flags above stay derived from the original values, so blanking a
+    -- claimed username does not change which platforms this account belongs to.
+    , case
+        when claimed_mitxonline_usernames.user_mitxonline_username is null
+            then micromasters_users.user_mitxonline_username
+    end as user_mitxonline_username
+    , case
+        when claimed_edxorg_usernames.user_edxorg_username is null
+            then micromasters_users.user_edxorg_username
+    end as user_edxorg_username
     , null as user_mitxonline_email
     , null as user_edxorg_email
     , micromasters_users.user_email as user_micromasters_email
@@ -221,4 +331,8 @@ select
 from micromasters_users
 left join mitxonline_edxorg_users
     on micromasters_users.user_id = mitxonline_edxorg_users.user_micromasters_id
+left join claimed_edxorg_usernames
+    on micromasters_users.user_edxorg_username = claimed_edxorg_usernames.user_edxorg_username
+left join claimed_mitxonline_usernames
+    on micromasters_users.user_mitxonline_username = claimed_mitxonline_usernames.user_mitxonline_username
 where mitxonline_edxorg_users.user_micromasters_id is null

--- a/src/ol_dbt/models/intermediate/mitx/int__mitx__users.sql
+++ b/src/ol_dbt/models/intermediate/mitx/int__mitx__users.sql
@@ -228,23 +228,6 @@ with users as (
     full outer join edxorg_users_view on account_links.user_edxorg_id = edxorg_users_view.user_edxorg_id
 )
 
--- Usernames already claimed above. Two MicroMasters accounts can share one platform
--- username, and only one id survives the user_micromasters_id coalesce, so the other is
--- appended below with a duplicate username. Blanking it there keeps the account and its
--- user_micromasters_id (which downstream MicroMasters models join on) while the username
--- stays unique. distinct so the lookup joins cannot fan out.
-, claimed_edxorg_usernames as (
-    select distinct user_edxorg_username
-    from mitxonline_edxorg_users
-    where user_edxorg_username is not null
-)
-
-, claimed_mitxonline_usernames as (
-    select distinct user_mitxonline_username
-    from mitxonline_edxorg_users
-    where user_mitxonline_username is not null
-)
-
 select
     is_mitxonline_user
     , is_edxorg_user
@@ -294,16 +277,8 @@ select
     , null as user_mitxonline_id
     , null as user_edxorg_id
     , micromasters_users.user_id as user_micromasters_id
-    -- the is_*_user flags above stay derived from the original values, so blanking a
-    -- claimed username does not change which platforms this account belongs to.
-    , case
-        when claimed_mitxonline_usernames.user_mitxonline_username is null
-            then micromasters_users.user_mitxonline_username
-    end as user_mitxonline_username
-    , case
-        when claimed_edxorg_usernames.user_edxorg_username is null
-            then micromasters_users.user_edxorg_username
-    end as user_edxorg_username
+    , micromasters_users.user_mitxonline_username
+    , micromasters_users.user_edxorg_username
     , null as user_mitxonline_email
     , null as user_edxorg_email
     , micromasters_users.user_email as user_micromasters_email
@@ -328,11 +303,12 @@ select
     , micromasters_users.user_company_industry as user_industry
     , micromasters_users.user_job_position as user_job_title
     , {{ generate_hash_id("cast(user_micromasters_id as varchar) || 'MicroMasters'") }} as user_hashed_id
+-- A person can hold two MicroMasters accounts, one reached from the edX.org side and one
+-- from MITx Online, but a collapsed row above keeps only one user_micromasters_id (MITx
+-- Online wins the coalesce). The other account is appended here and legitimately repeats
+-- the collapsed row's edX.org username, so user_edxorg_username is unique only per
+-- MicroMasters account -- see the compound test in _int_mitx__models.yml.
 from micromasters_users
 left join mitxonline_edxorg_users
     on micromasters_users.user_id = mitxonline_edxorg_users.user_micromasters_id
-left join claimed_edxorg_usernames
-    on micromasters_users.user_edxorg_username = claimed_edxorg_usernames.user_edxorg_username
-left join claimed_mitxonline_usernames
-    on micromasters_users.user_mitxonline_username = claimed_mitxonline_usernames.user_mitxonline_username
 where mitxonline_edxorg_users.user_micromasters_id is null

--- a/src/ol_dbt/models/reporting/combined_enrollments_with_gender_and_date.sql
+++ b/src/ol_dbt/models/reporting/combined_enrollments_with_gender_and_date.sql
@@ -6,6 +6,21 @@ with combined_users as (
     select * from {{ ref('marts__combined_course_enrollment_detail') }}
 )
 
+-- Fallback for edX.org enrollments. Once int__mitx__users links an edX.org account to a
+-- MITx Online one, combined_users carries only the MITx Online user_hashed_id, so
+-- enrollment rows keeping the edX.org hash no longer match. Resolve those by edX.org id.
+-- Aggregated to one row per id: combined_users has a duplicate user_edxorg_id that would
+-- otherwise fan out and inflate the row count.
+, edxorg_user_profile as (
+    select
+        user_edxorg_id
+        , max(user_job_title) as user_job_title
+        , max(user_industry) as user_industry
+    from combined_users
+    where user_edxorg_id is not null
+    group by user_edxorg_id
+)
+
 select
     enrollment_detail.platform
     , enrollment_detail.courserunenrollment_id
@@ -44,8 +59,13 @@ select
     , enrollment_detail.user_username
     , nullif(enrollment_detail.user_gender, '') as user_gender
     , substring(courserunenrollment_created_on, 1, 10) as courserunenrollment_created_on_date
-    , combined_users.user_job_title
-    , combined_users.user_industry
+    , coalesce(combined_users.user_job_title, edxorg_user_profile.user_job_title) as user_job_title
+    , coalesce(combined_users.user_industry, edxorg_user_profile.user_industry) as user_industry
 from enrollment_detail
 left join combined_users
     on enrollment_detail.user_hashed_id = combined_users.user_hashed_id
+-- cast the bigint to varchar, not the reverse: user_id is shared by every platform and is
+-- not guaranteed numeric on all of them.
+left join edxorg_user_profile
+    on enrollment_detail.platform = '{{ var("edxorg") }}'
+    and enrollment_detail.user_id = cast(edxorg_user_profile.user_edxorg_id as varchar)

--- a/src/ol_dbt/models/reporting/combined_enrollments_with_gender_and_date.sql
+++ b/src/ol_dbt/models/reporting/combined_enrollments_with_gender_and_date.sql
@@ -6,11 +6,9 @@ with combined_users as (
     select * from {{ ref('marts__combined_course_enrollment_detail') }}
 )
 
--- Fallback for edX.org enrollments. Once int__mitx__users links an edX.org account to a
--- MITx Online one, combined_users carries only the MITx Online user_hashed_id, so
--- enrollment rows keeping the edX.org hash no longer match. Resolve those by edX.org id.
--- Aggregated to one row per id: combined_users has a duplicate user_edxorg_id that would
--- otherwise fan out and inflate the row count.
+-- Resolves edX.org enrollments by edX.org id, since a learner linked to a MITx Online
+-- account is keyed on that platform's user_hashed_id and the join below misses them,
+-- grouped by id so that a duplicate user_edxorg_id cannot fan out enrollments.
 , edxorg_user_profile as (
     select
         user_edxorg_id

--- a/src/ol_dbt/models/reporting/edxorg_mitlearn_user_mapping.sql
+++ b/src/ol_dbt/models/reporting/edxorg_mitlearn_user_mapping.sql
@@ -1,7 +1,10 @@
--- Referencing bridge_user_account_link (not just dim_user) is intentional:
--- dim_user can fold unrelated accounts together when their computed emails
--- collide, and its own output is the thing being validated, so it can't be
--- used to catch its own collisions -- the bridge has the pre-collapse link.
+-- Referencing bridge_user_account_link (not just dim_user) is intentional: the bridge keeps
+-- one row per account edge, while dim_user groups by hashed email and max()-aggregates each
+-- id, so a person split across two dim_user rows keeps only one id per group.
+--
+-- It is NOT an independent check on email collisions: the bridge's mitxonline -> edxorg
+-- edges come from int__mitx__users, which now links on email, so they carry the same
+-- exposure as dim_user.
 with mitxonline_edxorg_link as (
     select from_user_id as mitxonline_application_user_id, to_user_id as user_edxorg_id
     from {{ ref('bridge_user_account_link') }}


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->

### Description (What does it do?)
<!--- Describe your changes in detail -->
deduplicate users in `int__mitx__users` who share an email across edX.org and MITx Online   
  - `int__mitx__users` only matched a user's edX.org and MITx Online accounts by an edX.org                                                                      
    username sourced from MicroMasters. Users without a MicroMasters record went unmatched                                                                       
    and appeared as two rows. Email is now used as a fallback: 11,564 → 437,704 linked.                                                                          
                                                                                                                                                                 
  - This treats a shared email as the same person. `dim_user` already collapsed on hashed                                                                        
    email, so the assumption isn't new — but it now also reaches `bridge_user_account_link`                                                                      
    and the migration models.                                                                                                                                    
                             
### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

dbt build --select int__mitx__users combined_enrollments_with_gender_and_date

```
-- returns 0 instead of 426k unmerged pairs on production
  with mx as (                                                                                                                                                   
      select lower(user_mitxonline_email) as email                                                                                                               
      from "ol_data_lake_production"."ol_warehouse_production_rlougee_intermediate"."int__mitx__users"                                                           
      where user_mitxonline_id is not null and user_edxorg_id is null                                                                                            
  )                                                                                                                                                              
                                                                                                                                                                 
  , ed as (                                                                                                                                                      
      select lower(user_edxorg_email) as email                                                                                                                   
      from "ol_data_lake_production"."ol_warehouse_production_rlougee_intermediate"."int__mitx__users"                                                           
      where user_edxorg_id is not null and user_mitxonline_id is null                                                                                            
  )                                                                                                                                                              
                                                                                                                                                                 
  select count(*) as unmerged_pairs                                                                                                                              
  from mx inner join ed on mx.email = ed.email  
```




### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->


<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
