### PR TITLE
ci: fix sqlfluff hook env exceeding pre-commit.ci 250MiB cap

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -77,9 +77,14 @@ repos:
   - id: sqlfluff-fix
       # Arbitrary arguments to show an example
       # args: [--rules, "L003,L014"]
-    additional_dependencies: ['dbt-trino']
+      # dbt-core is capped below 1.12 because 1.12.0 depends on
+      # dbt-core-experimental-parser, a 111MB binary that takes this env from 140MiB to
+      # 277MiB and over pre-commit.ci's 250MiB per-env cap. dbt-trino's own dbt-core range
+      # is wide, so it does not constrain this. Revisit when that binary becomes optional,
+      # or move sqlfluff to GitHub Actions where no cap applies.
+    additional_dependencies: ['dbt-trino==1.10.2', 'dbt-core<1.12']
   - id: sqlfluff-lint
       # For dbt projects, this installs the dbt "extras".
       # You will need to select the relevant dbt adapter for your dialect
       # (https://docs.getdbt.com/docs/available-adapters):
-    additional_dependencies: ['dbt-trino']
+    additional_dependencies: ['dbt-trino==1.10.2', 'dbt-core<1.12']


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
NA

### Description (What does it do?)
<!--- Describe your changes in detail -->

fixes sqlfluff hook env exceeding pre-commit.ci 250MiB cap

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->


<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
