### PR TITLE
fix(lakehouse): stop Superset dataset sync failing the nightly run

### DIFF
--- a/dg_projects/lakehouse/lakehouse/assets/superset.py
+++ b/dg_projects/lakehouse/lakehouse/assets/superset.py
@@ -66,8 +66,8 @@ def create_superset_asset(
         table_name = (
             dbt_model_name if database_name == "trino" else dbt_model_name.lower()
         )
-        # A dataset that Superset can't resolve or create is reported as a
-        # failed Output rather than raised: these assets fan out one step per
+        # A dataset that Superset can't resolve or create is reported as an
+        # error Output rather than raised: these assets fan out one step per
         # dbt model, and a single unusable dataset used to take the whole
         # nightly run down with it.
         try:

--- a/dg_projects/lakehouse/lakehouse/assets/superset.py
+++ b/dg_projects/lakehouse/lakehouse/assets/superset.py
@@ -66,12 +66,32 @@ def create_superset_asset(
         table_name = (
             dbt_model_name if database_name == "trino" else dbt_model_name.lower()
         )
-        dataset_id = superset_api.client.get_or_create_dataset(
-            schema_suffix=dbt_asset_group_name,
-            table_name=table_name,
-            database_id=database_id,
-            schema_base=schema_base,
-        )
+        # A dataset that Superset can't resolve or create is reported as a
+        # failed Output rather than raised: these assets fan out one step per
+        # dbt model, and a single unusable dataset used to take the whole
+        # nightly run down with it.
+        try:
+            dataset_id = superset_api.client.get_or_create_dataset(
+                schema_suffix=dbt_asset_group_name,
+                table_name=table_name,
+                database_id=database_id,
+                schema_base=schema_base,
+            )
+        except (httpx.HTTPError, RuntimeError) as e:
+            context.log.exception(
+                "Failed to get or create dataset for %s.%s",
+                dbt_asset_group_name,
+                dbt_model_name,
+            )
+            return Output(
+                value=None,
+                metadata={
+                    "status": "error",
+                    "error": str(e),
+                    "dbt_asset_group_name": dbt_asset_group_name,
+                    "dbt_model_name": dbt_model_name,
+                },
+            )
 
         if dataset_id is None:
             context.log.warning(
@@ -114,9 +134,9 @@ def create_superset_asset(
                     "dbt_model_name": dbt_model_name,
                 },
             )
-        except httpx.HTTPStatusError as e:
+        except httpx.HTTPError as e:
             context.log.exception(
-                "HTTPStatusError while refreshing dataset for %s.%s",
+                "HTTP error while refreshing dataset for %s.%s",
                 dbt_asset_group_name,
                 dbt_model_name,
             )

--- a/dg_projects/lakehouse/lakehouse/resources/superset_api.py
+++ b/dg_projects/lakehouse/lakehouse/resources/superset_api.py
@@ -170,7 +170,14 @@ class SupersetApiClient(OAuthApiClient):
         )
 
         if response.is_success:
-            return response.json()["id"]
+            response_body = response.json()
+            if "id" not in response_body:
+                msg = (
+                    f"Superset reported success creating dataset {payload!r} but "
+                    f"the response had no id: {response_body!r}"
+                )
+                raise RuntimeError(msg)
+            return response_body["id"]
 
         if response.status_code == UNPROCESSABLE_ENTITY:
             # Either the table genuinely isn't in this database, or another

--- a/dg_projects/lakehouse/lakehouse/resources/superset_api.py
+++ b/dg_projects/lakehouse/lakehouse/resources/superset_api.py
@@ -8,6 +8,8 @@ from ol_orchestrate.resources.oauth import OAuthApiClient
 from ol_orchestrate.resources.secrets.vault import Vault
 from pydantic import Field, PrivateAttr
 
+UNPROCESSABLE_ENTITY = 422
+
 
 class SupersetApiClient(OAuthApiClient):
     token_type: str = Field(
@@ -91,6 +93,92 @@ class SupersetApiClient(OAuthApiClient):
 
             page += 1
 
+    def find_dataset(
+        self, database_id: int, schema: str, table_name: str
+    ) -> int | None:
+        """Look up a dataset by its full (database, schema, table_name) identity.
+
+        Superset's own ``/api/v1/dataset/get_or_create/`` matches on
+        ``(database_id, table_name)`` alone via ``DatasetDAO.get_table_by_name``,
+        so it raises ``MultipleResultsFound`` -> HTTP 500 as soon as one
+        table_name repeats across two schemas in the same database. Filtering on
+        the schema too is both correct and immune to that. (Fixed upstream in
+        apache/superset#40494, which is unreleased as of Superset 6.1.0.)
+
+        Args:
+            database_id (int): The Superset database ID to search within.
+            schema (str): The fully qualified schema name.
+            table_name (str): The name of the table.
+
+        Returns:
+            int | None: The Superset dataset ID, or None if no dataset matches.
+        """
+        query_string = (
+            "(filters:!("
+            f"(col:database,opr:rel_o_m,value:{database_id}),"
+            f"(col:schema,opr:eq,value:'{schema}'),"
+            f"(col:table_name,opr:eq,value:'{table_name}')"
+            "))"
+        )
+        response_data = cast(
+            dict[str, Any],
+            self.fetch_with_auth(
+                f"{self.base_url}/api/v1/dataset/",
+                extra_params={"q": query_string},
+            ),
+        )
+        # min() rather than [0] so a pre-existing duplicate pair resolves to the
+        # same dataset on every run regardless of the API's result ordering.
+        return min(response_data.get("ids") or [], default=None)
+
+    def create_dataset(
+        self, database_id: int, schema: str, table_name: str
+    ) -> int | None:
+        """Create a physical dataset.
+
+        Args:
+            database_id (int): The Superset database ID to create the dataset in.
+            schema (str): The fully qualified schema name.
+            table_name (str): The name of the table.
+
+        Returns:
+            int | None: The new dataset's ID, or None if Superset rejected the
+                dataset as invalid -- which is the expected answer for a model
+                that has no table in this particular database (e.g. a Trino-only
+                dbt model whose StarRocks twin was never built).
+        """
+        payload = {
+            "database": database_id,
+            "schema": schema,
+            "table_name": table_name,
+        }
+        response = self.http_client.post(
+            f"{self.base_url}/api/v1/dataset/",
+            json=payload,
+            headers={
+                "Authorization": f"{self.token_type} {self._fetch_access_token()}",
+                "X-CSRFToken": self._get_csrf_token(),
+                "Referer": self._csrf_token_url,
+                "Content-Type": "application/json",
+            },
+            timeout=300,
+        )
+
+        if response.is_success:
+            return response.json()["id"]
+
+        if response.status_code == UNPROCESSABLE_ENTITY:
+            # Either the table genuinely isn't in this database, or another
+            # process won a create race between find_dataset() and here. A
+            # re-read distinguishes the two without parsing error strings.
+            return self.find_dataset(database_id, schema, table_name)
+
+        msg = (
+            f"Failed to create dataset {payload!r}: "
+            f"HTTP {response.status_code} — {response.text}"
+        )
+        raise RuntimeError(msg)
+
     def get_or_create_dataset(
         self,
         schema_suffix: str,
@@ -109,32 +197,11 @@ class SupersetApiClient(OAuthApiClient):
         Returns:
             int | None: The Superset table ID, or None if not found.
         """
-        request_url = f"{self.base_url}/api/v1/dataset/get_or_create/"
-        payload = {
-            "database_id": database_id,
-            "schema": f"{schema_base}_{schema_suffix}",
-            "table_name": table_name,
-        }
-        response = self.http_client.post(
-            request_url,
-            json=payload,
-            headers={
-                "Authorization": f"{self.token_type} {self._fetch_access_token()}",
-                "X-CSRFToken": self._get_csrf_token(),
-                "Referer": self._csrf_token_url,
-            },
-            timeout=300,
-        )
-
-        if not response.is_success:
-            msg = (
-                f"Failed to get_or_create dataset {payload!r}: "
-                f"HTTP {response.status_code} — {response.text}"
-            )
-            raise RuntimeError(msg)
-        response_data = response.json()
-
-        return response_data.get("result", {}).get("table_id")
+        schema = f"{schema_base}_{schema_suffix}"
+        dataset_id = self.find_dataset(database_id, schema, table_name)
+        if dataset_id is not None:
+            return dataset_id
+        return self.create_dataset(database_id, schema, table_name)
 
     def refresh_dataset(self, dataset_id: int) -> dict[str, Any]:
         """Refresh and update columns for a dataset in Superset."""

--- a/dg_projects/lakehouse/lakehouse/resources/superset_api.py
+++ b/dg_projects/lakehouse/lakehouse/resources/superset_api.py
@@ -195,7 +195,7 @@ class SupersetApiClient(OAuthApiClient):
             schema_base (str): The schema base prefix (without trailing underscore),
                 e.g. "ol_warehouse_production" or "ol_warehouse_qa".
         Returns:
-            int | None: The Superset table ID, or None if not found.
+            int | None: The Superset dataset ID, or None if not found.
         """
         schema = f"{schema_base}_{schema_suffix}"
         dataset_id = self.find_dataset(database_id, schema, table_name)

--- a/dg_projects/lakehouse/lakehouse/resources/superset_api.py
+++ b/dg_projects/lakehouse/lakehouse/resources/superset_api.py
@@ -129,7 +129,12 @@ class SupersetApiClient(OAuthApiClient):
         )
         # min() rather than [0] so a pre-existing duplicate pair resolves to the
         # same dataset on every run regardless of the API's result ordering.
-        return min(response_data.get("ids") or [], default=None)
+        # int() first since Superset's list endpoint can return ids as strings,
+        # which would otherwise sort lexicographically.
+        return min(
+            (int(dataset_id) for dataset_id in response_data.get("ids") or []),
+            default=None,
+        )
 
     def create_dataset(
         self, database_id: int, schema: str, table_name: str

--- a/dg_projects/lakehouse/lakehouse_tests/test_superset_api.py
+++ b/dg_projects/lakehouse/lakehouse_tests/test_superset_api.py
@@ -173,6 +173,17 @@ class TestCreateDataset:
         with pytest.raises(RuntimeError, match="Failed to create dataset"):
             client.create_dataset(1, "ol_warehouse_production_mart", "broken")
 
+    def test_success_response_missing_id_raises(self, client, monkeypatch):
+        """A 2xx response with no id is a malformed-API-response bug, not a
+        KeyError left to crash the Dagster step uncaught by the asset's
+        (httpx.HTTPError, RuntimeError) except clause.
+        """
+        http_client = FakeHttpClient([FakeResponse(201, {"result": {}})])
+        monkeypatch.setattr(SupersetApiClient, "http_client", http_client)
+
+        with pytest.raises(RuntimeError, match="no id"):
+            client.create_dataset(1, "ol_warehouse_production_mart", "malformed")
+
 
 class TestGetOrCreateDataset:
     def test_existing_dataset_short_circuits_before_creating(self, client, monkeypatch):

--- a/dg_projects/lakehouse/lakehouse_tests/test_superset_api.py
+++ b/dg_projects/lakehouse/lakehouse_tests/test_superset_api.py
@@ -1,0 +1,207 @@
+"""Tests for the Superset dataset lookup/create client.
+
+These cover the failure that motivated replacing Superset's
+``/api/v1/dataset/get_or_create/`` endpoint with an explicit
+find-then-create: that endpoint matches on ``(database_id, table_name)``
+only, so two datasets sharing a table_name across schemas made it return
+HTTP 500 ``MultipleResultsFound`` on every run (production run
+06561830, 2026-07-29 -- Enrollment_Activity_Counts_Dataset and
+combined_enrollments_with_gender_and_date failed 11 runs in a row).
+"""
+
+from typing import Any
+
+import pytest
+from lakehouse.resources.superset_api import SupersetApiClient
+
+BASE_URL = "https://bi.example.edu"
+DATASET_LIST_URL = f"{BASE_URL}/api/v1/dataset/"
+
+
+class FakeResponse:
+    def __init__(self, status_code: int, json_body=None, text: str = ""):
+        self.status_code = status_code
+        self._json_body = json_body
+        self.text = text
+
+    @property
+    def is_success(self) -> bool:
+        return 200 <= self.status_code < 300
+
+    def json(self):
+        return self._json_body
+
+
+class FakeHttpClient:
+    """Records POSTs and replays a queued response for each."""
+
+    def __init__(self, responses: list[FakeResponse]):
+        self.responses = list(responses)
+        self.posts: list[tuple[str, dict[str, Any]]] = []
+
+    def post(self, url, **kwargs):
+        self.posts.append((url, kwargs))
+        return self.responses.pop(0)
+
+
+@pytest.fixture
+def client(monkeypatch):
+    """Build a SupersetApiClient with its auth seams stubbed out."""
+    monkeypatch.setattr(
+        SupersetApiClient, "_fetch_access_token", lambda _self: "access-token"
+    )
+    monkeypatch.setattr(
+        SupersetApiClient, "_get_csrf_token", lambda _self: "csrf-token"
+    )
+    return SupersetApiClient(
+        client_id="test-client",
+        client_secret="test-secret",  # pragma: allowlist secret
+        base_url=BASE_URL,
+        token_url="https://sso.example.edu/token",
+    )
+
+
+def stub_list_responses(monkeypatch, *payloads):
+    """Replay one dataset-list payload per fetch_with_auth call, recording queries."""
+    queue = list(payloads)
+    queries: list[tuple[str, str | None]] = []
+
+    def fake_fetch_with_auth(_self, request_url, page_size=100, extra_params=None):  # noqa: ARG001
+        queries.append((request_url, (extra_params or {}).get("q")))
+        return queue.pop(0)
+
+    monkeypatch.setattr(SupersetApiClient, "fetch_with_auth", fake_fetch_with_auth)
+    return queries
+
+
+class TestFindDataset:
+    def test_filters_on_database_schema_and_table(self, client, monkeypatch):
+        """The schema filter is the whole point -- without it Superset 500s."""
+        queries = stub_list_responses(monkeypatch, {"count": 1, "ids": [42]})
+
+        dataset_id = client.find_dataset(
+            3, "ol_warehouse_production_dimensional", "tfact"
+        )
+
+        assert dataset_id == 42
+        request_url, query = queries[0]
+        assert request_url == DATASET_LIST_URL
+        assert "(col:database,opr:rel_o_m,value:3)" in query
+        assert (
+            "(col:schema,opr:eq,value:'ol_warehouse_production_dimensional')" in query
+        )
+        assert "(col:table_name,opr:eq,value:'tfact')" in query
+
+    def test_returns_none_when_no_dataset_matches(self, client, monkeypatch):
+        stub_list_responses(monkeypatch, {"count": 0, "ids": []})
+
+        assert client.find_dataset(1, "ol_warehouse_production_mart", "absent") is None
+
+    def test_missing_ids_key_is_not_an_error(self, client, monkeypatch):
+        stub_list_responses(monkeypatch, {"count": 0})
+
+        assert client.find_dataset(1, "ol_warehouse_production_mart", "absent") is None
+
+    def test_duplicate_matches_resolve_to_the_lowest_id(self, client, monkeypatch):
+        """Duplicates within one schema must still pin to one dataset per run,
+        whatever order the API returns them in.
+        """
+        stub_list_responses(monkeypatch, {"count": 2, "ids": [88, 42]})
+
+        assert client.find_dataset(1, "ol_warehouse_production_reporting", "dupe") == 42
+
+
+class TestCreateDataset:
+    def test_posts_physical_dataset_and_returns_new_id(self, client, monkeypatch):
+        http_client = FakeHttpClient([FakeResponse(201, {"id": 512})])
+        monkeypatch.setattr(SupersetApiClient, "http_client", http_client)
+
+        result = client.create_dataset(3, "ol_warehouse_production_reporting", "report")
+
+        assert result == 512
+        url, kwargs = http_client.posts[0]
+        assert url == DATASET_LIST_URL
+        assert kwargs["json"] == {
+            "database": 3,
+            "schema": "ol_warehouse_production_reporting",
+            "table_name": "report",
+        }
+        assert kwargs["headers"]["X-CSRFToken"] == "csrf-token"
+
+    def test_unprocessable_table_is_reported_as_absent(self, client, monkeypatch):
+        """422 for a model with no table in this database (e.g. a Trino-only
+        model whose StarRocks twin was never built) is a skip, not a failure.
+        """
+        http_client = FakeHttpClient(
+            [FakeResponse(422, {"message": "Table does not exist"})]
+        )
+        monkeypatch.setattr(SupersetApiClient, "http_client", http_client)
+        stub_list_responses(monkeypatch, {"count": 0, "ids": []})
+
+        result = client.create_dataset(3, "ol_warehouse_production_mart", "trino_only")
+
+        assert result is None
+
+    def test_lost_create_race_resolves_to_the_winners_dataset(
+        self, client, monkeypatch
+    ):
+        http_client = FakeHttpClient(
+            [FakeResponse(422, {"message": "Dataset already exists"})]
+        )
+        monkeypatch.setattr(SupersetApiClient, "http_client", http_client)
+        stub_list_responses(monkeypatch, {"count": 1, "ids": [77]})
+
+        assert client.create_dataset(1, "ol_warehouse_production_mart", "raced") == 77
+
+    def test_server_error_raises(self, client, monkeypatch):
+        http_client = FakeHttpClient(
+            [FakeResponse(500, text='{"message":"Fatal error"}')]
+        )
+        monkeypatch.setattr(SupersetApiClient, "http_client", http_client)
+
+        with pytest.raises(RuntimeError, match="Failed to create dataset"):
+            client.create_dataset(1, "ol_warehouse_production_mart", "broken")
+
+
+class TestGetOrCreateDataset:
+    def test_existing_dataset_short_circuits_before_creating(self, client, monkeypatch):
+        http_client = FakeHttpClient([])  # a POST would IndexError
+        monkeypatch.setattr(SupersetApiClient, "http_client", http_client)
+        queries = stub_list_responses(monkeypatch, {"count": 1, "ids": [9]})
+
+        result = client.get_or_create_dataset(
+            schema_suffix="dimensional",
+            table_name="tfact_order",
+            database_id=3,
+        )
+
+        assert result == 9
+        assert http_client.posts == []
+        assert "value:'ol_warehouse_production_dimensional'" in queries[0][1]
+
+    def test_absent_dataset_is_created(self, client, monkeypatch):
+        http_client = FakeHttpClient([FakeResponse(201, {"id": 1024})])
+        monkeypatch.setattr(SupersetApiClient, "http_client", http_client)
+        stub_list_responses(monkeypatch, {"count": 0, "ids": []})
+
+        result = client.get_or_create_dataset(
+            schema_suffix="reporting",
+            table_name="organization_administration_report",
+            database_id=3,
+        )
+
+        assert result == 1024
+        _url, kwargs = http_client.posts[0]
+        assert kwargs["json"]["schema"] == "ol_warehouse_production_reporting"
+
+    def test_schema_base_override_is_honoured(self, client, monkeypatch):
+        queries = stub_list_responses(monkeypatch, {"count": 1, "ids": [5]})
+
+        client.get_or_create_dataset(
+            schema_suffix="mart",
+            table_name="some_model",
+            database_id=1,
+            schema_base="ol_warehouse_qa",
+        )
+
+        assert "value:'ol_warehouse_qa_mart'" in queries[0][1]

--- a/dg_projects/lakehouse/lakehouse_tests/test_superset_api.py
+++ b/dg_projects/lakehouse/lakehouse_tests/test_superset_api.py
@@ -110,6 +110,17 @@ class TestFindDataset:
 
         assert client.find_dataset(1, "ol_warehouse_production_reporting", "dupe") == 42
 
+    def test_string_ids_still_resolve_to_the_numeric_minimum(self, client, monkeypatch):
+        """Superset's list endpoint can return ids as strings; a naive min()
+        over strings would pick "88" over "42" lexicographically.
+        """
+        stub_list_responses(monkeypatch, {"count": 2, "ids": ["88", "42"]})
+
+        dataset_id = client.find_dataset(1, "ol_warehouse_production_reporting", "dupe")
+
+        assert dataset_id == 42
+        assert isinstance(dataset_id, int)
+
 
 class TestCreateDataset:
     def test_posts_physical_dataset_and_returns_new_id(self, client, monkeypatch):


### PR DESCRIPTION
### What are the relevant tickets?

N/A

### Description (What does it do?)

Five `superset` dataset assets failed **11 consecutive production runs** — the same five every time. I scanned all 640 `dagster-run-*` pods in the `data-production` cluster; every failed run reported an identical step list:

| Asset | Superset DB |
|---|---|
| `superset/dataset/Enrollment_Activity_Counts_Dataset` | Trino (1) |
| `superset/dataset/combined_enrollments_with_gender_and_date` | Trino (1) |
| `superset/starrocks/dataset/organization_administration_report` | StarRocks (3) |
| `superset/starrocks/dataset/tfact_problem_events` | StarRocks (3) |
| `superset/starrocks/dataset/tfact_studentmodule_problems` | StarRocks (3) |

All five failed on the same call — `POST /api/v1/dataset/get_or_create/` returning `HTTP 500 {"message":"Fatal error"}` — but for **two unrelated reasons**, split cleanly along the Trino/StarRocks line. This PR fixes the Trino half plus the blast radius; the StarRocks half is server-side and lives in mitodl/ol-infrastructure#5170.

#### 1. Route around Superset's schema-blind `get_or_create` (the two Trino assets)

Superset resolves an existing dataset with `DatasetDAO.get_table_by_name(database_id, table_name)` — no schema, no catalog:

```python
# superset/daos/dataset.py
@staticmethod
def get_table_by_name(database_id: int, table_name: str) -> SqlaTable | None:
    return (
        db.session.query(SqlaTable)
        .filter_by(database_id=database_id, table_name=table_name)
        .one_or_none()
    )
```

So once a `table_name` repeats across two schemas in the same database, `.one_or_none()` raises and **every** subsequent sync of that name 500s forever:

```
2026-07-29 16:21:51,741:ERROR:flask_appbuilder.api:Multiple rows were found when one or none was required
  File "/app/superset/datasets/api.py", line 1097, in get_or_create_dataset
    if table := DatasetDAO.get_table_by_name(database_id, table_name):
  File "/app/superset/daos/dataset.py", line 407, in get_table_by_name
    .one_or_none()
sqlalchemy.exc.MultipleResultsFound: Multiple rows were found when one or none was required
```

which the Dagster side saw as:

```
RuntimeError: Failed to get_or_create dataset {'database_id': 1,
  'schema': 'ol_warehouse_production_reporting',
  'table_name': 'Enrollment_Activity_Counts_Dataset'}: HTTP 500 — {"message":"Fatal error"}
```

Upstream fixed this in [apache/superset#40494](https://github.com/apache/superset/pull/40494) (commit [`cb1694575c`](https://github.com/apache/superset/commit/cb1694575c)), which routes through `get_table_by_catalog_schema_and_name` when a `schema` is supplied. **That commit is on `master` but in no released tag** — `git tag --contains cb1694575c` is empty — so a version bump can't deliver it to the 6.1.0 image we deploy.

So we stop calling that endpoint. `get_or_create_dataset` now:

- `find_dataset(database_id, schema, table_name)` — queries `GET /api/v1/dataset/` filtered on the full identity, using the documented `search_columns` (`database`, `schema`, `table_name`). Resolves duplicates to `min(ids)` rather than `ids[0]`, so a pre-existing duplicate pair pins to the same dataset on every run regardless of API result ordering.
- `create_dataset(database_id, schema, table_name)` — `POST /api/v1/dataset/` when absent. A `422` is re-read rather than raised, which distinguishes the two legitimate cases without parsing error strings: the table genuinely isn't in that database (→ `None`, the asset's existing "skipped" path), or another process won a create race (→ the winner's id).

This is immune to the duplicate-name problem regardless of Superset version, and it's schema-correct, which the endpoint never was.

#### 2. Stop one bad dataset failing the whole run

`create_superset_asset` fans out one step per dbt model, but called `get_or_create_dataset` outside its `try`, and caught only `httpx.HTTPStatusError` while the client raises bare `RuntimeError`. So three unrelated StarRocks datasets tripping a dialect bug in Superset's reflection was enough to take down the entire nightly run — including every asset that had synced fine.

Failures are now reported as an error `Output`, matching how the refresh step already behaves. The refresh `except` also widens from `httpx.HTTPStatusError` to `httpx.HTTPError` so a transport-level timeout doesn't fail the step either.

### How can this be tested?

**New tests** — `dg_projects/lakehouse/lakehouse_tests/test_superset_api.py`, 11 cases covering the schema filter, absent/duplicate/missing-`ids` lookups, the `422`-as-skip and `422`-as-race paths, the short-circuit that must not POST, and `schema_base` override:

```
cd dg_projects/lakehouse && uv run --frozen pytest -q
34 passed, 1 warning in 0.58s
```

**Lint gates:**

```
uv run pre-commit run --files \
  dg_projects/lakehouse/lakehouse/resources/superset_api.py \
  dg_projects/lakehouse/lakehouse/assets/superset.py \
  dg_projects/lakehouse/lakehouse_tests/test_superset_api.py
  Detect secrets ... Passed
  ruff format ...... Passed
  ruff check ....... Passed
  mypy ............. Passed
```

**Reviewer validation.** Materialize `superset/dataset/Enrollment_Activity_Counts_Dataset` and `superset/dataset/combined_enrollments_with_gender_and_date` (both Trino) from the Dagster UI. Before this change both fail with the `HTTP 500 — {"message":"Fatal error"}` above; after, they resolve their existing dataset and refresh. The three `superset/starrocks/dataset/*` assets will still fail until the companion infra PR is deployed — but they will now fail *as three failed Outputs instead of a failed run*, which is the point of change #2 and is itself the thing to check.

### Additional Context

**These two PRs are independent and can merge in either order.** This one fixes the two Trino assets on its own. The three partitioned StarRocks datasets need the config change in mitodl/ol-infrastructure#5170 rolled out before they can be created at all — the reflection bug is entirely server-side.

**On the deliberate `except RuntimeError`.** This does mean a dataset can now fail to sync while the asset materializes "successfully". That is the intended trade — a nightly run failing wholesale because 3 of ~200 datasets are unusable is worse — and the outcome is recorded in asset metadata as `{"status": "error", "error": ...}` alongside the existing `refreshed`/`skipped` statuses, so it stays visible in the Dagster UI rather than being silently swallowed.

**The duplicate rows are still there.** This change no longer trips over them, but it doesn't clean them up. To see which datasets in Superset's metadata DB share a `table_name` within one database:

```sql
select table_name, count(*)
from tables
where database_id = 1
group by 1
having count(*) > 1;
```

Worth deleting or renaming the duplicates independently — they're also why those datasets are ambiguous to anyone browsing Superset, not just to this pipeline.

**Unrelated finding.** `superset.datasets.datetime_format_detector` logs `Unknown catalog 'ol_warehouse_production_dimensional'` on every StarRocks dataset refresh: Superset's StarRocks engine spec reads a dataset's `schema` as `catalog.database`, so the bare schema name these assets pass is parsed as a catalog. Datetime format detection therefore never works for StarRocks datasets. Not touched here; deserves its own issue.
