### PR TITLE
fix(edxorg): stop losing and corrupting rows in the edxorg TSV round trip

### DIFF
--- a/dg_projects/edxorg/edxorg/assets/edxorg_archive.py
+++ b/dg_projects/edxorg/edxorg/assets/edxorg_archive.py
@@ -302,12 +302,26 @@ def process_edxorg_archive_bundle(
                         archive_file,
                         include_header=True,
                         separator="\t",
-                        # Use no quoting to match how the source TSVs are read
-                        # (quote_char=None in scan_csv). This prevents DuckDB from
-                        # seeing quoted vs. unquoted values for the same column across
-                        # files, which was a contributing factor to type inference
-                        # mismatches when loading into iceberg tables.
-                        quote_style="never",
+                        # Quote only the fields that need it. These tables carry
+                        # user-entered free text (auth_userprofile.bio, .goals,
+                        # .mailing_address), so a value occasionally contains a raw
+                        # CR/LF or tab. Writing those unquoted makes the row
+                        # unrecoverable -- the reader cannot tell a CR inside a bio
+                        # from a CR ending the record, so it drops the row, and a
+                        # bare CR additionally makes the file mixed-newline, which
+                        # aborts DuckDB's dialect sniffer for the whole file.
+                        #
+                        # This used to be quote_style="never" to keep DuckDB from
+                        # inferring different types for the same column across
+                        # quoted and unquoted files. That no longer applies: the
+                        # dlt reader passes all_varchar=True, so every column is
+                        # VARCHAR and quoted and unquoted input parse to identical
+                        # types and values.
+                        #
+                        # row_hash above is computed on the in-memory values, before
+                        # serialization, so quoting does not change any existing
+                        # row's hash or churn the downstream merge key.
+                        quote_style="necessary",
                         lazy=False,
                         check_extension=False,
                     )

--- a/dg_projects/edxorg/edxorg_tests/test_edxorg_archive_csv.py
+++ b/dg_projects/edxorg/edxorg_tests/test_edxorg_archive_csv.py
@@ -1,0 +1,166 @@
+"""Round-trip coverage for the TSV rewrite in ``process_edxorg_archive_bundle``.
+
+The asset itself needs a Dagster context and a real tar archive, so it is not
+exercised here. What *is* exercised is the part that silently lost data: the
+``scan_csv`` -> ``sink_csv`` pairing, and whether the file it emits can still be
+read back by the downstream ``ol_dlt`` edxorg_s3 source.
+
+These tables carry user-entered free text (``auth_userprofile.bio``, ``.goals``,
+``.mailing_address``), so a value occasionally holds a raw CR. Written unquoted,
+that row becomes unrecoverable -- and a bare CR also makes the file
+mixed-newline, which aborts DuckDB's dialect sniffer for the *whole* file.
+"""
+
+import io
+
+import duckdb
+import polars as pl
+import pytest
+
+# Mirrors the scan_csv call in edxorg.assets.edxorg_archive.
+_SCAN_OPTIONS = {
+    "has_header": True,
+    "separator": "\t",
+    "quote_char": None,
+    "infer_schema": False,
+    "truncate_ragged_lines": True,
+    "ignore_errors": True,
+}
+
+# Mirrors _CSV_READER_OPTIONS in ol_dlt.sources.edxorg_s3, which is what
+# ultimately consumes the file this asset writes.
+_DOWNSTREAM_READER_OPTIONS = {
+    "delimiter": "\t",
+    "ignore_errors": True,
+    "all_varchar": True,
+    "strict_mode": False,
+    "quotechar": '"',
+    "escapechar": '"',
+}
+
+# A raw edX dump whose `bio` holds a bare CR, in an otherwise LF-terminated file.
+_SOURCE_TSV = (
+    b"id\tuser_id\tbio\tgoals\n"
+    b"1\t10\tI want to learn\rand grow\tlearn\n"
+    b"2\t20\tplain bio\tgrow\n"
+)
+
+_EXPECTED = [
+    ("1", "10", "I want to learn\rand grow", "learn"),
+    ("2", "20", "plain bio", "grow"),
+]
+
+
+def _rewrite_frame(frame: pl.DataFrame, quote_style: str) -> bytes:
+    """Serialize a frame the way the archive asset's sink_csv call does."""
+    sink = io.BytesIO()
+    frame.write_csv(sink, separator="\t", include_header=True, quote_style=quote_style)
+    return sink.getvalue()
+
+
+def _rewrite(quote_style: str) -> bytes:
+    """Read a raw dump and re-emit it the way the archive asset does."""
+    frame = pl.scan_csv(io.BytesIO(_SOURCE_TSV), **_SCAN_OPTIONS).collect()
+    return _rewrite_frame(frame, quote_style)
+
+
+def test_polars_reads_the_carriage_return_row_intact() -> None:
+    """The CR survives parsing -- nothing is lost on the way in."""
+    frame = pl.scan_csv(io.BytesIO(_SOURCE_TSV), **_SCAN_OPTIONS).collect()
+    assert frame.rows() == _EXPECTED
+
+
+def test_rewritten_tsv_round_trips_through_the_downstream_reader() -> None:
+    """The emitted file must give the dlt reader back every row, CR included."""
+    relation = duckdb.from_csv_auto(
+        io.BytesIO(_rewrite("necessary")), **_DOWNSTREAM_READER_OPTIONS
+    )
+    assert relation.columns == ["id", "user_id", "bio", "goals"]
+    assert relation.fetchall() == _EXPECTED
+
+
+def test_quote_style_never_would_drop_the_row() -> None:
+    """Guard the fix: prove the previous quote_style is what lost the data.
+
+    Without this, ``test_rewritten_tsv_round_trips...`` would still pass if
+    someone reverted the writer *and* the fixture stopped containing a CR.
+    """
+    rows = duckdb.from_csv_auto(
+        io.BytesIO(_rewrite("never")), **_DOWNSTREAM_READER_OPTIONS
+    ).fetchall()
+    assert rows == [("2", "20", "plain bio", "grow")]
+
+
+def test_quoting_survives_duckdb_strict_mode() -> None:
+    """A properly quoted file needs no strict-mode relief to parse.
+
+    ``strict_mode=False`` in the reader is the safety net; correct quoting here
+    is the actual fix.
+    """
+    strict = {**_DOWNSTREAM_READER_OPTIONS, "strict_mode": True}
+    assert (
+        duckdb.from_csv_auto(io.BytesIO(_rewrite("necessary")), **strict).fetchall()
+        == _EXPECTED
+    )
+
+    with pytest.raises(duckdb.InvalidInputException, match="sniffing"):
+        duckdb.from_csv_auto(io.BytesIO(_rewrite("never")), **strict)
+
+
+@pytest.mark.parametrize(
+    ("column", "value"),
+    [
+        ("bio", "tab\there"),
+        ("bio", "newline\nhere"),
+        ("bio", "carriage\rreturn"),
+        # RFC-4180 doubling: polars writes this as `"quote "" here"`, and the
+        # reader only undoubles it because escapechar is pinned to the quote
+        # character. Without that pin it reads back as `quote "" here`.
+        ("goals", 'quote " here'),
+        ("goals", 'both "quotes" and\ttab'),
+        ("bio", r"back\slash"),
+    ],
+)
+def test_other_separator_characters_also_round_trip(column: str, value: str) -> None:
+    """A CR is not the only character that needs quoting to survive."""
+    frame = pl.DataFrame({"id": ["1"], "bio": ["plain"], "goals": ["plain"]})
+    frame = frame.with_columns(pl.lit(value).alias(column))
+    sink = io.BytesIO()
+    frame.write_csv(sink, separator="\t", include_header=True, quote_style="necessary")
+
+    relation = duckdb.from_csv_auto(
+        io.BytesIO(sink.getvalue()), **_DOWNSTREAM_READER_OPTIONS
+    )
+    assert relation.fetchall() == [tuple(frame.rows()[0])]
+
+
+def test_unquoted_tab_corrupts_field_alignment() -> None:
+    """quote_style="never" did worse than drop rows -- it shifted fields.
+
+    A raw tab in `bio` was indistinguishable from a column separator, so the
+    row parsed with `goals` holding what came after the tab and the real
+    `goals` value falling off the end. Silent corruption, not a skipped row.
+    """
+    frame = pl.DataFrame({"id": ["1"], "bio": ["tab\there"], "goals": ["real goal"]})
+    rows = duckdb.from_csv_auto(
+        io.BytesIO(_rewrite_frame(frame, "never")), **_DOWNSTREAM_READER_OPTIONS
+    ).fetchall()
+    assert rows == [("1", "tab", "here")]  # "real goal" is gone
+
+    assert duckdb.from_csv_auto(
+        io.BytesIO(_rewrite_frame(frame, "necessary")), **_DOWNSTREAM_READER_OPTIONS
+    ).fetchall() == [("1", "tab\there", "real goal")]
+
+
+def test_quoting_does_not_alter_clean_values() -> None:
+    """Rows needing no quoting are emitted byte-identically either way."""
+    clean = b"id\tbio\n1\tplain bio\n2\tanother\n"
+    frame = pl.scan_csv(io.BytesIO(clean), **_SCAN_OPTIONS).collect()
+
+    outputs = {}
+    for style in ("never", "necessary"):
+        sink = io.BytesIO()
+        frame.write_csv(sink, separator="\t", include_header=True, quote_style=style)
+        outputs[style] = sink.getvalue()
+
+    assert outputs["never"] == outputs["necessary"] == clean

--- a/src/ol_dlt/ol_dlt/sources/edxorg_s3/README.md
+++ b/src/ol_dlt/ol_dlt/sources/edxorg_s3/README.md
@@ -326,6 +326,23 @@ MemoryError: Unable to allocate array
 - Reduce chunk size in `read_csv(chunksize=...)`
 - Use production environment with more resources
 
+### CSV Dialect Sniffing Errors
+
+```
+Invalid Input Error: Error when sniffing file "DUCKDB_INTERNAL_OBJECTSTORE://..."
+It was not possible to automatically detect the CSV parsing dialect
+```
+
+**Cause**: a free-text column (`auth_userprofile.bio`, `.goals`,
+`.mailing_address`, …) contains a bare `\r` or a `\r\n` while the rest of the
+file is `\n`-terminated. DuckDB's strict mode treats mixed newlines as a dialect
+violation, and the sniffer runs *before* `ignore_errors` applies — so one stray
+carriage return aborts the whole resource instead of skipping one row.
+
+**Solution**: already handled — the reader runs with `strict_mode=False` (see
+`_CSV_READER_OPTIONS` in `__init__.py`). If this resurfaces, check whether the
+options were changed rather than the data.
+
 ### Empty Results
 
 **Check**:

--- a/src/ol_dlt/ol_dlt/sources/edxorg_s3/README.md
+++ b/src/ol_dlt/ol_dlt/sources/edxorg_s3/README.md
@@ -343,6 +343,18 @@ carriage return aborts the whole resource instead of skipping one row.
 `_CSV_READER_OPTIONS` in `__init__.py`). If this resurfaces, check whether the
 options were changed rather than the data.
 
+The upstream `edxorg_archive` asset also writes with `quote_style="necessary"`,
+so fields containing a CR/LF/tab are quoted rather than emitted raw. That is the
+actual fix; `strict_mode=False` is the safety net for files written before it.
+
+### Doubled Quotes in `meta` (or Other JSON Columns)
+
+If a JSON-bearing column comes back as `{""key"": ""value""}` instead of
+`{"key": "value"}`, the reader lost its escape character. `_CSV_READER_OPTIONS`
+pins `quotechar='"'` and `escapechar='"'` precisely to undouble RFC-4180
+escaping — without them DuckDB's sniffer picks a pair that leaves the doubling
+in place, silently corrupting every quoted JSON value.
+
 ### Empty Results
 
 **Check**:

--- a/src/ol_dlt/ol_dlt/sources/edxorg_s3/__init__.py
+++ b/src/ol_dlt/ol_dlt/sources/edxorg_s3/__init__.py
@@ -58,6 +58,19 @@ _CSV_READER_OPTIONS: dict[str, Any] = {
     # header it would materialise synthetic `columnN` columns, which vary per
     # file and would churn the destination schema.
     "strict_mode": False,
+    # Pin the quote/escape dialect instead of letting the sniffer guess it.
+    # The upstream edxorg_archive asset writes these files with polars'
+    # quote_style="necessary", which uses RFC-4180 doubling -- an embedded `"`
+    # is written as `""` inside a quoted field. Left to its own devices the
+    # sniffer picks a quote/escape pair that does NOT undouble it, so
+    # `he said "hi"` silently reads back as `he said ""hi""`. Setting escapechar
+    # to the quote character makes the undoubling explicit.
+    #
+    # This is also correct for the older, entirely unquoted files still sitting
+    # in the landing zone: with nothing quoted there is nothing to unescape, and
+    # they parse identically with or without these pinned.
+    "quotechar": '"',
+    "escapechar": '"',
     # Force all columns to VARCHAR to prevent pyarrow schema mismatches across
     # files (e.g. TIMESTAMP vs VARCHAR for a column that is empty in some
     # files). dbt casts downstream.

--- a/src/ol_dlt/ol_dlt/sources/edxorg_s3/__init__.py
+++ b/src/ol_dlt/ol_dlt/sources/edxorg_s3/__init__.py
@@ -39,6 +39,31 @@ _EDXORG_LANDING_BUCKET = (
 
 _EDXORG_PRIMARY_KEY = ["row_hash", "extracted_course_key"]
 
+# Options handed to DuckDB's CSV reader for every edxorg TSV.
+_CSV_READER_OPTIONS: dict[str, Any] = {
+    "delimiter": "\t",  # TSV files use tabs
+    "ignore_errors": True,
+    # These are dumps of user-entered free text (auth_userprofile.bio, .goals,
+    # .mailing_address and friends), so a field occasionally carries a bare CR
+    # or a CRLF while the rest of the file is LF-terminated. DuckDB's strict
+    # mode treats mixed newlines as a dialect violation, and the dialect sniffer
+    # runs BEFORE ignore_errors can suppress anything -- so one stray CR kills
+    # the entire resource with "It was not possible to automatically detect the
+    # CSV parsing dialect" instead of skipping the one bad row. Relaxing strict
+    # mode lets the sniffer settle on a dialect and routes the malformed rows to
+    # ignore_errors, where they belong. Clean LF and clean CRLF files parse
+    # identically either way.
+    #
+    # Deliberately NOT setting null_padding: on a row with more fields than the
+    # header it would materialise synthetic `columnN` columns, which vary per
+    # file and would churn the destination schema.
+    "strict_mode": False,
+    # Force all columns to VARCHAR to prevent pyarrow schema mismatches across
+    # files (e.g. TIMESTAMP vs VARCHAR for a column that is empty in some
+    # files). dbt casts downstream.
+    "all_varchar": True,
+}
+
 
 def _make_deduplicator():  # noqa: ANN202
     """Return a stateful per-run deduplication function for use with add_map.
@@ -177,18 +202,7 @@ def edxorg_s3_source(
         # *returns* another DltResource would replace the outer resource and
         # discard its name/hints; applying hints on the pipe avoids that.
         yield (
-            (
-                files
-                | read_csv_duckdb(
-                    use_pyarrow=True,
-                    delimiter="\t",  # TSV files use tabs
-                    ignore_errors=True,
-                    # Force all columns to VARCHAR to prevent pyarrow schema
-                    # mismatches across files (e.g. TIMESTAMP vs VARCHAR for a
-                    # column that is empty in some files). dbt casts downstream.
-                    all_varchar=True,
-                )
-            )
+            (files | read_csv_duckdb(use_pyarrow=True, **_CSV_READER_OPTIONS))
             .with_name(resource_name)
             # Drop rows whose (row_hash, extracted_course_key) was already seen
             # earlier in this run (see _make_deduplicator docstring).

--- a/src/ol_dlt/pyproject.toml
+++ b/src/ol_dlt/pyproject.toml
@@ -9,7 +9,8 @@ dependencies = [
     "dlt[filesystem,parquet,pyiceberg]>=1.28,<2",
     "pyiceberg[glue]>=0.9",
     "requests>=2.32",
-    "duckdb>=1.0,!=1.5.0,!=1.5.1",
+    # >=1.2 for the CSV reader's `strict_mode` argument (edxorg_s3 source).
+    "duckdb>=1.2,!=1.5.0,!=1.5.1",
     "defusedxml>=0.7",
 ]
 

--- a/src/ol_dlt/tests/sources/test_edxorg_s3.py
+++ b/src/ol_dlt/tests/sources/test_edxorg_s3.py
@@ -7,6 +7,7 @@ subtle correctness bugs lived.
 """
 
 import io
+import json
 from typing import Any
 
 import duckdb
@@ -117,6 +118,59 @@ def test_reader_options_leave_well_formed_tsv_unchanged() -> None:
     )
     assert relaxed.columns == strict.columns
     assert relaxed.fetchall() == strict.fetchall()
+
+
+def test_reader_options_undouble_rfc4180_quotes() -> None:
+    """An embedded `"` must survive, not come back doubled.
+
+    The upstream edxorg_archive asset writes with polars'
+    ``quote_style="necessary"``, which escapes a `"` inside a quoted field by
+    doubling it. Left to the sniffer, DuckDB picks a quote/escape pair that
+    does not undouble it -- so pinning ``escapechar`` is what keeps the value
+    intact rather than silently gaining a character.
+    """
+    quoted = b'id\tbio\n1\t"he said ""hi"" loudly"\n'
+    relation = duckdb.from_csv_auto(io.BytesIO(quoted), **edxorg_s3._CSV_READER_OPTIONS)
+    assert relation.fetchall() == [("1", 'he said "hi" loudly')]
+
+    unpinned = {
+        k: v
+        for k, v in edxorg_s3._CSV_READER_OPTIONS.items()
+        if k not in {"quotechar", "escapechar"}
+    }
+    assert duckdb.from_csv_auto(io.BytesIO(quoted), **unpinned).fetchall() == [
+        ("1", 'he said ""hi"" loudly')
+    ]
+
+
+def test_reader_options_still_read_legacy_unquoted_files() -> None:
+    """Bare values in the older files must parse exactly as they always did."""
+    legacy = b"id\tbio\tgoals\n1\tplain bio\tlearn\n2\tC:\\Users\\bob\tgrow\n"
+    expected = [("1", "plain bio", "learn"), ("2", "C:\\Users\\bob", "grow")]
+
+    assert (
+        duckdb.from_csv_auto(
+            io.BytesIO(legacy), **edxorg_s3._CSV_READER_OPTIONS
+        ).fetchall()
+        == expected
+    )
+
+
+def test_reader_options_repair_json_in_existing_files() -> None:
+    """Pinning escapechar also fixes files already sitting in the landing zone.
+
+    ``auth_userprofile.meta`` holds JSON, and edX's original dump quotes it.
+    The archive asset reads with ``quote_char=None``, so that quoting survives
+    into the landing-zone file as literal text. Without a pinned escapechar the
+    reader strips the outer quotes but leaves the inner doubling, yielding
+    invalid JSON -- measured at 4,646 unparseable ``meta`` values across a
+    77-file production sample, versus 182 with the pins in place.
+    """
+    meta = b'id\tmeta\n1\t"{""skills_builder"": """", ""rv"": """"}"\n'
+    (row,) = duckdb.from_csv_auto(
+        io.BytesIO(meta), **edxorg_s3._CSV_READER_OPTIONS
+    ).fetchall()
+    assert json.loads(row[1]) == {"skills_builder": "", "rv": ""}
 
 
 def test_reader_options_do_not_pad_ragged_rows() -> None:

--- a/src/ol_dlt/tests/sources/test_edxorg_s3.py
+++ b/src/ol_dlt/tests/sources/test_edxorg_s3.py
@@ -82,12 +82,20 @@ def test_deduplicator_passes_through_without_key_columns() -> None:
 
 
 def test_reader_options_parse_tsv_with_mixed_newlines() -> None:
-    """A stray CR in a free-text column must not abort the resource."""
+    """A stray CR in a free-text column must not abort the resource.
+
+    The bare CR splits row 1 into two ragged fragments, so ``ignore_errors``
+    drops it -- losing that row is the accepted cost. What matters is that the
+    loss stays confined to the offending row: row 2 must survive intact rather
+    than the sniffer taking the whole table down with it.
+    """
     relation = duckdb.from_csv_auto(
         io.BytesIO(_MIXED_NEWLINE_TSV), **edxorg_s3._CSV_READER_OPTIONS
     )
     assert relation.columns == ["id", "user_id", "bio", "goals"]
-    assert relation.fetchall()  # the well-formed rows still land
+    # Exact contents, not just "non-empty": the well-formed row lands whole and
+    # the malformed one is the only casualty.
+    assert relation.fetchall() == [("2", "20", "plain bio", "grow")]
 
 
 def test_reader_options_disable_strict_mode() -> None:

--- a/src/ol_dlt/tests/sources/test_edxorg_s3.py
+++ b/src/ol_dlt/tests/sources/test_edxorg_s3.py
@@ -2,18 +2,38 @@
 
 Materialization is not tested here: the source reads TSVs from the production S3
 landing zone and cannot run hermetically. Coverage focuses on the pure per-run
-deduplication logic, which is where the subtle correctness bug lived.
+deduplication logic and on the DuckDB CSV reader options, which are where the
+subtle correctness bugs lived.
 """
 
+import io
 from typing import Any
 
+import duckdb
 import pyarrow as pa
+import pytest
 
 from ol_dlt.sources import edxorg_s3
 
 
 def _table(rows: list[dict[str, Any]]) -> pa.Table:
     return pa.Table.from_pylist(rows)
+
+
+# An auth_userprofile-shaped dump whose free-text `bio` carries a bare CR while
+# the file is otherwise LF-terminated -- exactly what a user pasting into a
+# textarea produces. Mixed newlines are a strict-mode dialect violation, and the
+# sniffer runs before ignore_errors, so under strict mode this one row takes the
+# whole resource down with "It was not possible to automatically detect the CSV
+# parsing dialect".
+_MIXED_NEWLINE_TSV = (
+    b"id\tuser_id\tbio\tgoals\n"
+    b"1\t10\tI want to learn\rand grow\tlearn\n"
+    b"2\t20\tplain bio\tgrow\n"
+)
+
+# The same table with consistent LF endings: must parse the same either way.
+_CLEAN_TSV = b"id\tuser_id\tbio\tgoals\n1\t10\tbio one\tlearn\n2\t20\tbio two\tgrow\n"
 
 
 def test_deduplicator_drops_repeat_keys_within_run() -> None:
@@ -59,6 +79,44 @@ def test_deduplicator_passes_through_without_key_columns() -> None:
     tbl = _table([{"some_col": "x"}, {"some_col": "x"}])
     # Missing primary-key columns: do not drop anything.
     assert dedup(tbl).num_rows == 2  # noqa: PLR2004
+
+
+def test_reader_options_parse_tsv_with_mixed_newlines() -> None:
+    """A stray CR in a free-text column must not abort the resource."""
+    relation = duckdb.from_csv_auto(
+        io.BytesIO(_MIXED_NEWLINE_TSV), **edxorg_s3._CSV_READER_OPTIONS
+    )
+    assert relation.columns == ["id", "user_id", "bio", "goals"]
+    assert relation.fetchall()  # the well-formed rows still land
+
+
+def test_reader_options_disable_strict_mode() -> None:
+    """Guard the specific option, and prove it is what saves the parse."""
+    assert edxorg_s3._CSV_READER_OPTIONS["strict_mode"] is False
+
+    strict = {**edxorg_s3._CSV_READER_OPTIONS, "strict_mode": True}
+    with pytest.raises(duckdb.InvalidInputException, match="sniffing"):
+        duckdb.from_csv_auto(io.BytesIO(_MIXED_NEWLINE_TSV), **strict)
+
+
+def test_reader_options_leave_well_formed_tsv_unchanged() -> None:
+    """Relaxing strict mode must not alter parsing of clean dumps."""
+    relaxed = duckdb.from_csv_auto(
+        io.BytesIO(_CLEAN_TSV), **edxorg_s3._CSV_READER_OPTIONS
+    )
+    strict = duckdb.from_csv_auto(
+        io.BytesIO(_CLEAN_TSV), **{**edxorg_s3._CSV_READER_OPTIONS, "strict_mode": True}
+    )
+    assert relaxed.columns == strict.columns
+    assert relaxed.fetchall() == strict.fetchall()
+
+
+def test_reader_options_do_not_pad_ragged_rows() -> None:
+    """null_padding would invent per-file `columnN` columns and churn schemas."""
+    assert "null_padding" not in edxorg_s3._CSV_READER_OPTIONS
+    ragged = b"id\tbio\n1\tbio\n2\tbio\twith\textra\ttabs\n"
+    relation = duckdb.from_csv_auto(io.BytesIO(ragged), **edxorg_s3._CSV_READER_OPTIONS)
+    assert relation.columns == ["id", "bio"]
 
 
 def test_source_yields_one_resource_per_table() -> None:

--- a/src/ol_dlt/uv.lock
+++ b/src/ol_dlt/uv.lock
@@ -788,7 +788,7 @@ dev = [
 requires-dist = [
     { name = "defusedxml", specifier = ">=0.7" },
     { name = "dlt", extras = ["filesystem", "parquet", "pyiceberg"], specifier = ">=1.28,<2" },
-    { name = "duckdb", specifier = ">=1.0,!=1.5.0,!=1.5.1" },
+    { name = "duckdb", specifier = ">=1.2,!=1.5.0,!=1.5.1" },
     { name = "pyiceberg", extras = ["glue"], specifier = ">=0.9" },
     { name = "requests", specifier = ">=2.32" },
 ]


### PR DESCRIPTION
### What are the relevant tickets?

N/A — reported from a production Dagster failure.

### Description (What does it do?)

Started as a crash fix, and the investigation turned up two silent data-integrity bugs behind it. Three related changes across the write and read sides of the edxorg TSV round trip.

#### 1. The crash: a stray CR killed the whole load

`edxorg_s3_auth_userprofile` was failing with:

```
Invalid Input Error: Error when sniffing file "DUCKDB_INTERNAL_OBJECTSTORE://b4c2d21034716ba2".
It was not possible to automatically detect the CSV parsing dialect
```

**Root cause: mixed line endings**, not a delimiter or encoding problem despite what the error's suggested fixes imply. A free-text value carries a bare `\r` while the file is otherwise LF-terminated. DuckDB's strict mode treats mixed newlines as a dialect violation, and the sniffer runs *before* `ignore_errors` applies — so one carriage return aborts the entire resource instead of skipping one row.

Confirmed complete, not merely plausible: fuzzing **3,000 inputs with CR removed from the alphabet produced 0 sniff failures**. Every failure requires a CR. With CR included, the current options fail 477/500; `strict_mode=False` fails 0/500. No other option helped (`null_padding` 480/500, `quotechar=""` 484/500).

#### 2. The real cause: we wrote files that couldn't be read back

`strict_mode=False` stops the crash but still *drops* the row. The row is unrecoverable only because of how the archive asset writes it — `sink_csv(quote_style="never")` emits a raw CR/LF/tab verbatim.

polars parses these values correctly on the way in; we destroy recoverability on the way out:

| Stage | Result |
|---|---|
| edX dump → `pl.scan_csv` | CR row reads perfectly, all columns intact |
| → `sink_csv(quote_style="never")` | written unquoted → **row unrecoverable** |
| → `sink_csv(quote_style="necessary")` | written as `"…\r…"` → **row recovered, CR preserved** |

**And it was worse than dropping rows.** An unquoted tab shifted field alignment — `bio="tab\there"` parsed as `bio="tab"`, `goals="here"`, with the real `goals` value falling off the end. Silent corruption, no error.

The old comment justified `"never"` as preventing DuckDB type-inference mismatches across files. That no longer applies: the reader passes `all_varchar=True`, and I verified quoted and unquoted input yield identical types *and* values.

#### 3. Quoting on write required a reader fix — which repairs existing data

polars escapes an embedded quote by doubling it (RFC 4180). DuckDB's sniffer picks a quote/escape pair that does **not** undouble it, so `he said "hi"` reads back as `he said ""hi""`. Pinning `quotechar='"'` and `escapechar='"'` makes the undoubling explicit.

That pin also fixes data **already in the landing zone**. `auth_userprofile.meta` holds JSON that edX's original dump quotes; the archive asset reads with `quote_char=None`, so the quoting survives into our files as literal text. Measured against **77 real production files**:

| Reader options | `meta` values that are valid JSON |
|---|---|
| current | 138,965 valid / **4,646 invalid** (96.8%) |
| with pins | 143,429 valid / **182 invalid** (99.9%) |

`stg__edxorg__s3__user_profile.sql:11` passes `meta` straight through untransformed, so nothing downstream compensates for the doubling — this is strictly a repair.

`row_hash` is computed on in-memory values *before* serialization, so quoting changes no existing row's hash and doesn't churn the merge key.

### How can this be tested?

Two hermetic suites, no S3 or AWS credentials required:

```bash
cd src/ol_dlt && uv run pytest tests/ -q          # 53 passed
cd dg_projects/edxorg && uv run pytest edxorg_tests/ -q   # 32 passed
```

New coverage, written so each test fails if the specific fix is reverted rather than passing vacuously:

- **`edxorg_tests/test_edxorg_archive_csv.py`** (new) — the `scan_csv` → `sink_csv` → DuckDB round trip. Asserts the CR row survives; that `quote_style="never"` *would* drop it; that an unquoted tab corrupts field alignment while a quoted one doesn't; that quoting satisfies even `strict_mode=True`; and that rows needing no quoting are emitted byte-identically under both styles.
- **`tests/sources/test_edxorg_s3.py`** — exact-row assertions on the mixed-newline fixture, a strict-mode guard that *does* raise when reverted, RFC-4180 undoubling (with the unpinned config asserted to produce the corrupted form), a real `meta` JSON repair case, and legacy-unquoted parsing left unchanged.

`ruff format`, `ruff check`, `mypy` and the full `pre-commit` set are green.

To validate end-to-end: re-run `edxorg_s3_auth_userprofile` in Dagster. It should complete rather than abort. Newly written archives will carry quoted free-text fields; existing files benefit from the reader pins immediately.

### Additional Context

Three things worth a reviewer's attention:

1. **This changes parsed values for existing data.** 27 of 77 sampled production files parse differently — all of them `meta`-column JSON that was previously corrupted. Row counts are identical in every file; only values change, and only in the repair direction. If any consumer has quietly adapted to the doubled-quote form, it would need updating — I checked the edxorg staging model and it passes `meta` through untouched.

2. **The writer fix only helps newly written archives.** Rows already lost to unquoted CR/LF/tab in existing landing-zone files stay lost; recovering them needs the archives reprocessed. Worth noting the loss is rare — across 77 files / 561,235 rows I found **zero** bare CRs, so a small number of outlier files were taking down entire table loads.

3. **Out of scope, but noticed:** `ignore_errors=True` drops rows silently. A gzipped, UTF-16, or badly ragged file loads **zero rows with no error at all**. Separate blind spot from this bug; a row-count expectation on the loaded assets would catch it. Happy to open a follow-up issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
