### PR TITLE
fix(dim_user): dedupe MITx Learn accounts by user_global_id 

### DIFF
--- a/src/ol_dbt/models/dimensional/dim_user.sql
+++ b/src/ol_dbt/models/dimensional/dim_user.sql
@@ -227,7 +227,7 @@ with mitx_users as (
         on mitxonline_app_openedxuser_mapping.openedxuser_username = mitlearn_openedx_users.user_username
 )
 
-, learn_user as (
+, learn_user_deduped_by_email as (
     select * from (
         select
             *
@@ -238,6 +238,22 @@ with mitx_users as (
         from {{ ref('stg__mitlearn__app__postgres__users_user') }}
     )
     where row_num = 1
+)
+
+-- Learn can hold two accounts per user_global_id, and this model joins Learn to MITx on
+-- global_id alone, so email-only dedup fans one MITx row into two user_pks. coalesce keeps
+-- null global_ids in their own partitions; nulls last because Trino sorts nulls largest.
+, learn_user as (
+    select * from (
+        select
+            *
+            , row_number() over (
+                partition by coalesce(user_global_id, concat('user-', cast(user_id as varchar)))
+                order by user_last_login desc nulls last, user_created_on desc
+            ) as global_id_row_num
+        from learn_user_deduped_by_email
+    )
+    where global_id_row_num = 1
 )
 
 , learn_profile as (

--- a/src/ol_dbt/models/dimensional/dim_user.sql
+++ b/src/ol_dbt/models/dimensional/dim_user.sql
@@ -240,16 +240,15 @@ with mitx_users as (
     where row_num = 1
 )
 
--- Learn can hold two accounts per user_global_id, and this model joins Learn to MITx on
--- global_id alone, so email-only dedup fans one MITx row into two user_pks. coalesce keeps
--- null global_ids in their own partitions; nulls last because Trino sorts nulls largest.
+-- Learn can hold two accounts per user_global_id, which fans out the join to MITx below.
+-- nulls last: Trino sorts nulls largest, ranking never-logged-in accounts first.
 , learn_user as (
     select * from (
         select
             *
             , row_number() over (
-                partition by coalesce(user_global_id, concat('user-', cast(user_id as varchar)))
-                order by user_last_login desc nulls last, user_created_on desc
+                partition by user_global_id, case when user_global_id is null then user_id end
+                order by user_last_login desc nulls last, user_created_on desc nulls last, user_id desc
             ) as global_id_row_num
         from learn_user_deduped_by_email
     )


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
NA

https://pipelines.odl.mit.edu/runs/5b952071-875d-4dc7-8b60-a8cce0a245dc

The `tfact_video_events` compound-uniqueness test was failing with 24 duplicate groups:  

```
1316 of 1749 FAIL 24 dbt_expectations_expect_compound_columns_to_be_unique_tfact_video_events_openedx_user_id__courserun_readable_id__video_block_fk__event_type__event_json__event_timestamp  [[31mFAIL 24[0m in 10.96s]

[31mFailure in test dbt_expectations_expect_compound_columns_to_be_unique_tfact_video_events_openedx_user_id__courserun_readable_id__video_block_fk__event_type__event_json__event_timestamp (models/dimensional/_dim__models.yml)[0m

  Got 24 results, configured to fail if >10

```

### Description (What does it do?)
<!--- Describe your changes in detail -->

This PR fixes duplicate user_pks in `dim_user` caused by two MITx Learn accounts sharing one `user_global_id`, which doubled a user's `tfact_video_events` rows.


### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

no error after running `dbt build --select dim_user tfact_video_events`

### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->


<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
