### PR TITLE
fix(dim_user): derive user_pk from durable ids instead of email

### DIFF
--- a/src/ol_dbt/models/dimensional/_dim__models.yml
+++ b/src/ol_dbt/models/dimensional/_dim__models.yml
@@ -287,7 +287,11 @@ models:
     where we are able to see they are the same person.
   columns:
   - name: user_pk
-    description: string, primary key for this user dim table
+    description: string, primary key for this user dim table. The grain is still one
+      row per shared email, but the key's value is derived from durable identifiers
+      - the user_global_id when the group has one, otherwise the highest-ranked platform
+      account id in the group - so it no longer changes when a user edits their email
+      address.
     tests:
     - not_null
     - unique
@@ -583,6 +587,15 @@ models:
   - name: user_fk
     description: string, foreign key to dim_user, referencing the user who triggered
       the event
+    tests:
+    # warn until the post-cutover full refresh clears the user_fk values this table
+    # persisted under the old email-derived key; raise to error afterwards.
+    - relationships:
+        to: ref('dim_user')
+        field: user_pk
+        where: "user_fk is not null"
+        config:
+          severity: warn
   - name: openedx_user_id
     description: int, user ID on the corresponding open edX platform
     tests:
@@ -657,6 +670,15 @@ models:
   columns:
   - name: user_fk
     description: string, foreign key to dim_user
+    tests:
+    # warn until the post-cutover full refresh clears the user_fk values this table
+    # persisted under the old email-derived key; raise to error afterwards.
+    - relationships:
+        to: ref('dim_user')
+        field: user_pk
+        where: "user_fk is not null"
+        config:
+          severity: warn
   - name: platform
     description: string, platform name (mitxonline, mitxpro, residential)
   - name: openedx_user_id

--- a/src/ol_dbt/models/dimensional/_dim__models.yml
+++ b/src/ol_dbt/models/dimensional/_dim__models.yml
@@ -295,6 +295,28 @@ models:
     tests:
     - not_null
     - unique
+  - name: user_pk_source
+    description: string, which identifier user_pk was derived from - global when the
+      group has a user_global_id, the platform name when it was keyed off a source
+      account id, or email when no durable id was available anywhere in the group.
+      Rows with email are the only ones that still re-key when the user edits their
+      email address. mitxonline covers accounts keyed off either the application user
+      id or the open edX user id.
+    tests:
+    - not_null
+    - accepted_values:
+        values:
+        - global
+        - mitlearn
+        - mitxonline
+        - edxorg
+        - micromasters
+        - mitxpro
+        - residential
+        - bootcamps
+        - emeritus
+        - global_alumni
+        - email
   - name: user_global_id
     description: string, a unique identifier for the user across all platforms
     tests:

--- a/src/ol_dbt/models/dimensional/_dim__models.yml
+++ b/src/ol_dbt/models/dimensional/_dim__models.yml
@@ -305,18 +305,8 @@ models:
     tests:
     - not_null
     - accepted_values:
-        values:
-        - global
-        - mitlearn
-        - mitxonline
-        - edxorg
-        - micromasters
-        - mitxpro
-        - residential
-        - bootcamps
-        - emeritus
-        - global_alumni
-        - email
+        values: ['global', 'mitlearn', 'mitxonline', 'edxorg', 'micromasters', 'mitxpro',
+          'residential', 'bootcamps', 'emeritus', 'global_alumni', 'email']
   - name: user_global_id
     description: string, a unique identifier for the user across all platforms
     tests:

--- a/src/ol_dbt/models/dimensional/_fact_tables.yml
+++ b/src/ol_dbt/models/dimensional/_fact_tables.yml
@@ -322,6 +322,15 @@ models:
       Foreign key to dim_user, resolved via the payment's order_id → tfact_order →
       dim_user chain. Null when no matching order exists for the payment or when the
       order cannot be mapped to a user in dim_user.
+    tests:
+    # warn until the post-cutover full refresh clears the user_fk values this table
+    # persisted under the old email-derived key; raise to error afterwards.
+    - relationships:
+        to: ref('dim_user')
+        field: user_pk
+        where: "user_fk is not null"
+        config:
+          severity: warn
   - name: platform_fk
     description: Foreign key to dim_platform
     tests:

--- a/src/ol_dbt/models/dimensional/dim_user.sql
+++ b/src/ol_dbt/models/dimensional/dim_user.sql
@@ -695,22 +695,23 @@ with mitx_users as (
     from account_identity
 )
 
--- coalesce, not greatest: each row nulls the join dates of platforms it isn't from, and
--- Trino's greatest() returns null if any argument is null, leaving no sort key at all.
+-- The base row is the one whose latest join date is newest. Each row nulls the join dates
+-- of platforms it isn't from and Trino's greatest() is null-propagating, so every argument
+-- is coalesced to '' first - these are ISO8601 strings, so '' sorts below any real date.
 , ranked_users as (
     select
         *
         , row_number() over (
             partition by user_pk
             order by
-                coalesce(
-                    user_joined_on_mitlearn
-                    , user_joined_on_mitxonline
-                    , user_joined_on_edxorg
-                    , user_joined_on_mitxpro
-                    , user_joined_on_residential
-                    , user_joined_on_bootcamps
-                ) desc nulls last
+                greatest(
+                    coalesce(user_joined_on_mitlearn, '')
+                    , coalesce(user_joined_on_mitxonline, '')
+                    , coalesce(user_joined_on_edxorg, '')
+                    , coalesce(user_joined_on_mitxpro, '')
+                    , coalesce(user_joined_on_residential, '')
+                    , coalesce(user_joined_on_bootcamps, '')
+                ) desc
                 , id_source
                 , id_source_user_id
         ) as row_num

--- a/src/ol_dbt/models/dimensional/dim_user.sql
+++ b/src/ol_dbt/models/dimensional/dim_user.sql
@@ -325,8 +325,8 @@ with mitx_users as (
              full outer join learn_user_view on mitx_users_view.user_global_id = learn_user_view.user_global_id
 )
 
--- One row per source account. MITx rows can carry several ids, so they take the
--- highest-ranked one.
+-- id_source is an id namespace, not a platform: the same integer means different people
+-- in mitxonline's application and open edX id spaces.
 , combined_accounts as (
     select
         case
@@ -335,14 +335,14 @@ with mitx_users as (
             when edxorg_openedx_user_id is not null then 'edxorg'
             when user_micromasters_id is not null then 'micromasters'
             when mitxonline_openedx_user_id is not null then 'mitxonline_openedx'
-        end as platform
+        end as id_source
         , coalesce(
             cast(mitlearn_user_id as varchar)
             , cast(mitxonline_application_user_id as varchar)
             , cast(edxorg_openedx_user_id as varchar)
             , cast(user_micromasters_id as varchar)
             , cast(mitxonline_openedx_user_id as varchar)
-        ) as platform_user_id
+        ) as id_source_user_id
         , user_global_id
         , mitlearn_user_id
         , mitlearn_openedx_user_id
@@ -388,8 +388,8 @@ with mitx_users as (
     union all
 
     select
-        'mitxpro' as platform
-        , cast(mitxpro_user_view.user_id as varchar) as platform_user_id
+        'mitxpro' as id_source
+        , cast(mitxpro_user_view.user_id as varchar) as id_source_user_id
         , null as user_global_id
         , null as mitlearn_user_id
         , null as mitlearn_openedx_user_id
@@ -441,9 +441,9 @@ with mitx_users as (
     union all
 
     select
-        'emeritus' as platform
+        'emeritus' as id_source
         -- null where Emeritus has no user_id: these accounts get keyed off the email below
-        , cast(user_id as varchar) as platform_user_id
+        , cast(user_id as varchar) as id_source_user_id
         , null as user_global_id
         , null as mitlearn_user_id
         , null as mitlearn_openedx_user_id
@@ -489,8 +489,8 @@ with mitx_users as (
     union all
 
     select
-        'global_alumni' as platform
-        , cast(user_id as varchar) as platform_user_id
+        'global_alumni' as id_source
+        , cast(user_id as varchar) as id_source_user_id
         , null as user_global_id
         , null as mitlearn_user_id
         , null as mitlearn_openedx_user_id
@@ -536,8 +536,8 @@ with mitx_users as (
     union all
 
     select
-        'residential' as platform
-        , cast(mitxresidential_user_view.user_id as varchar) as platform_user_id
+        'residential' as id_source
+        , cast(mitxresidential_user_view.user_id as varchar) as id_source_user_id
         , null as user_global_id
         , null as mitlearn_user_id
         , null as mitlearn_openedx_user_id
@@ -583,8 +583,8 @@ with mitx_users as (
     union all
 
     select
-        'bootcamps' as platform
-        , cast(bootcamps_user_view.user_id as varchar) as platform_user_id
+        'bootcamps' as id_source
+        , cast(bootcamps_user_view.user_id as varchar) as id_source_user_id
         , null as user_global_id
         , null as mitlearn_user_id
         , null as mitlearn_openedx_user_id
@@ -631,28 +631,33 @@ with mitx_users as (
 
 -- Shared email still groups accounts into one person: for MITx Pro, Bootcamps, Residential,
 -- Emeritus and Global Alumni it is the only signal we have. But the key is named after one
--- account in the group - global id first, else the highest-ranked platform - so a user
+-- account in the group - global id first, else the highest-ranked id source - so a user
 -- editing their email no longer re-keys them.
 -- Ranked so the key lands on the same account whose id agg_view's max() surfaces below.
 , ranked_accounts as (
     select
-        case when platform_user_id is null then 1 else 0 end as has_no_source_id
+        -- Outranks id_source_rank: an id-less emeritus row (9) must still lose to an
+        -- id-bearing global_alumni row (10).
+        case when id_source_user_id is null then 1 else 0 end as has_no_source_id
         , case
             when user_global_id is not null then 0
-            when platform = 'mitlearn' then 1
-            when platform = 'mitxonline' then 2
-            when platform = 'edxorg' then 3
-            when platform = 'micromasters' then 4
-            when platform = 'mitxonline_openedx' then 5
-            when platform = 'mitxpro' then 6
-            when platform = 'residential' then 7
-            when platform = 'bootcamps' then 8
-            when platform = 'emeritus' then 9
-            when platform = 'global_alumni' then 10
-        end as platform_rank
+            when id_source = 'mitlearn' then 1
+            when id_source = 'mitxonline' then 2
+            when id_source = 'edxorg' then 3
+            when id_source = 'micromasters' then 4
+            when id_source = 'mitxonline_openedx' then 5
+            when id_source = 'mitxpro' then 6
+            when id_source = 'residential' then 7
+            when id_source = 'bootcamps' then 8
+            when id_source = 'emeritus' then 9
+            when id_source = 'global_alumni' then 10
+        end as id_source_rank
+        -- Emeritus and Global Alumni ids are varchar, and agg_view surfaces them with a
+        -- lexicographic max(). Nulling sort_id falls the ordering through to the
+        -- lexicographic key below so the key names the account agg_view's ids come from.
         , case
-            when platform in ('emeritus', 'global_alumni') then null
-            else try_cast(platform_user_id as bigint)
+            when id_source in ('emeritus', 'global_alumni') then null
+            else try_cast(id_source_user_id as bigint)
         end as sort_id
         , combined_accounts.*
     from combined_accounts
@@ -662,28 +667,28 @@ with mitx_users as (
     select
         first_value(case
             when user_global_id is not null then 'global'
-            when platform_user_id is not null then platform
+            when id_source_user_id is not null then id_source
             else 'email'
-        end) over w as user_identity_platform
-        , first_value(coalesce(user_global_id, platform_user_id, lower(email)))
+        end) over w as user_identity_source
+        , first_value(coalesce(user_global_id, id_source_user_id, email))
             over w as user_identity_id
         , ranked_accounts.*
     from ranked_accounts
     window w as (
-        partition by lower(email)
+        partition by email
         order by
             has_no_source_id
-            , platform_rank
-            , user_global_id desc nulls last
+            , id_source_rank
+            , user_global_id desc
             , sort_id desc nulls last
-            , platform_user_id desc
+            , id_source_user_id desc
     )
 )
 
 , combined_users as (
     select
         {{ dbt_utils.generate_surrogate_key([
-            'user_identity_platform',
+            'user_identity_source',
             'user_identity_id'
         ]) }} as user_pk
         , account_identity.*
@@ -706,8 +711,8 @@ with mitx_users as (
                     , user_joined_on_residential
                     , user_joined_on_bootcamps
                 ) desc nulls last
-                , platform
-                , platform_user_id
+                , id_source
+                , id_source_user_id
         ) as row_num
     from combined_users
 )
@@ -786,6 +791,12 @@ with mitx_users as (
 
 select
     base.user_pk
+    -- Reported as the platform. The key still hashes the two mitxonline id namespaces
+    -- separately, or an application id and an open edX id of equal value would collide.
+    , case
+        when base.user_identity_source = 'mitxonline_openedx' then 'mitxonline'
+        else base.user_identity_source
+    end as user_pk_source
     , agg.user_global_id
     , agg.mitlearn_user_id
     , agg.mitlearn_openedx_user_id

--- a/src/ol_dbt/models/dimensional/dim_user.sql
+++ b/src/ol_dbt/models/dimensional/dim_user.sql
@@ -325,9 +325,24 @@ with mitx_users as (
              full outer join learn_user_view on mitx_users_view.user_global_id = learn_user_view.user_global_id
 )
 
-, combined_users as (
+-- One row per source account. MITx rows can carry several ids, so they take the
+-- highest-ranked one.
+, combined_accounts as (
     select
-        {{ dbt_utils.generate_surrogate_key(['lower(email)']) }} as user_pk
+        case
+            when mitlearn_user_id is not null then 'mitlearn'
+            when mitxonline_application_user_id is not null then 'mitxonline'
+            when edxorg_openedx_user_id is not null then 'edxorg'
+            when user_micromasters_id is not null then 'micromasters'
+            when mitxonline_openedx_user_id is not null then 'mitxonline_openedx'
+        end as platform
+        , coalesce(
+            cast(mitlearn_user_id as varchar)
+            , cast(mitxonline_application_user_id as varchar)
+            , cast(edxorg_openedx_user_id as varchar)
+            , cast(user_micromasters_id as varchar)
+            , cast(mitxonline_openedx_user_id as varchar)
+        ) as platform_user_id
         , user_global_id
         , mitlearn_user_id
         , mitlearn_openedx_user_id
@@ -373,7 +388,8 @@ with mitx_users as (
     union all
 
     select
-        {{ dbt_utils.generate_surrogate_key(['lower(mitxpro_user_view.user_email)']) }} as user_pk
+        'mitxpro' as platform
+        , cast(mitxpro_user_view.user_id as varchar) as platform_user_id
         , null as user_global_id
         , null as mitlearn_user_id
         , null as mitlearn_openedx_user_id
@@ -425,7 +441,9 @@ with mitx_users as (
     union all
 
     select
-        {{ dbt_utils.generate_surrogate_key(['lower(user_email)']) }} as user_pk
+        'emeritus' as platform
+        -- null where Emeritus has no user_id: these accounts get keyed off the email below
+        , cast(user_id as varchar) as platform_user_id
         , null as user_global_id
         , null as mitlearn_user_id
         , null as mitlearn_openedx_user_id
@@ -471,7 +489,8 @@ with mitx_users as (
     union all
 
     select
-        {{ dbt_utils.generate_surrogate_key(['lower(user_email)']) }} as user_pk
+        'global_alumni' as platform
+        , cast(user_id as varchar) as platform_user_id
         , null as user_global_id
         , null as mitlearn_user_id
         , null as mitlearn_openedx_user_id
@@ -517,7 +536,8 @@ with mitx_users as (
     union all
 
     select
-        {{ dbt_utils.generate_surrogate_key(['lower(mitxresidential_user_view.user_email)']) }} as user_pk
+        'residential' as platform
+        , cast(mitxresidential_user_view.user_id as varchar) as platform_user_id
         , null as user_global_id
         , null as mitlearn_user_id
         , null as mitlearn_openedx_user_id
@@ -563,7 +583,8 @@ with mitx_users as (
     union all
 
     select
-        {{ dbt_utils.generate_surrogate_key(['lower(bootcamps_user_view.user_email)']) }} as user_pk
+        'bootcamps' as platform
+        , cast(bootcamps_user_view.user_id as varchar) as platform_user_id
         , null as user_global_id
         , null as mitlearn_user_id
         , null as mitlearn_openedx_user_id
@@ -608,20 +629,85 @@ with mitx_users as (
 
 )
 
+-- Shared email still groups accounts into one person: for MITx Pro, Bootcamps, Residential,
+-- Emeritus and Global Alumni it is the only signal we have. But the key is named after one
+-- account in the group - global id first, else the highest-ranked platform - so a user
+-- editing their email no longer re-keys them.
+-- Ranked so the key lands on the same account whose id agg_view's max() surfaces below.
+, ranked_accounts as (
+    select
+        case when platform_user_id is null then 1 else 0 end as has_no_source_id
+        , case
+            when user_global_id is not null then 0
+            when platform = 'mitlearn' then 1
+            when platform = 'mitxonline' then 2
+            when platform = 'edxorg' then 3
+            when platform = 'micromasters' then 4
+            when platform = 'mitxonline_openedx' then 5
+            when platform = 'mitxpro' then 6
+            when platform = 'residential' then 7
+            when platform = 'bootcamps' then 8
+            when platform = 'emeritus' then 9
+            when platform = 'global_alumni' then 10
+        end as platform_rank
+        , case
+            when platform in ('emeritus', 'global_alumni') then null
+            else try_cast(platform_user_id as bigint)
+        end as sort_id
+        , combined_accounts.*
+    from combined_accounts
+)
+
+, account_identity as (
+    select
+        first_value(case
+            when user_global_id is not null then 'global'
+            when platform_user_id is not null then platform
+            else 'email'
+        end) over w as user_identity_platform
+        , first_value(coalesce(user_global_id, platform_user_id, lower(email)))
+            over w as user_identity_id
+        , ranked_accounts.*
+    from ranked_accounts
+    window w as (
+        partition by lower(email)
+        order by
+            has_no_source_id
+            , platform_rank
+            , user_global_id desc nulls last
+            , sort_id desc nulls last
+            , platform_user_id desc
+    )
+)
+
+, combined_users as (
+    select
+        {{ dbt_utils.generate_surrogate_key([
+            'user_identity_platform',
+            'user_identity_id'
+        ]) }} as user_pk
+        , account_identity.*
+    from account_identity
+)
+
+-- coalesce, not greatest: each row nulls the join dates of platforms it isn't from, and
+-- Trino's greatest() returns null if any argument is null, leaving no sort key at all.
 , ranked_users as (
     select
         *
         , row_number() over (
             partition by user_pk
             order by
-                greatest(
+                coalesce(
                     user_joined_on_mitlearn
                     , user_joined_on_mitxonline
                     , user_joined_on_edxorg
                     , user_joined_on_mitxpro
                     , user_joined_on_residential
                     , user_joined_on_bootcamps
-                ) desc
+                ) desc nulls last
+                , platform
+                , platform_user_id
         ) as row_num
     from combined_users
 )


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->

### Description (What does it do?)
<!--- Describe your changes in detail -->
This PR fixes `dim_user.user_pk` being derived from the mutable email, which silently re-keyed users, and orphaned user_fk in every incremental `tfact_` models, whenever someone changed their address.  


### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

dbt build --select dim_user

One-time full refresh of those models after the deployment
```
 dbt build --full-refresh --select tfact_certificate tfact_enrollment tfact_grade \                                                                               
    tfact_order tfact_payment tfact_problem_events tfact_studentmodule_problems   
```

### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->


<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
