### PR TITLE
feat(dbt-docs): publish dbdocs site instead of dbt's docs bundle

### DIFF
--- a/.github/workflows/publish_dbt_docs.yaml
+++ b/.github/workflows/publish_dbt_docs.yaml
@@ -1,6 +1,18 @@
 ---
 name: "Publish dbt docs to GH Pages"
 
+# Builds the dbt documentation site with `dbdocs` and publishes it to GitHub
+# Pages. dbdocs replaces dbt's own docs bundle: same manifest.json +
+# catalog.json inputs, but it adds an entity-relationship diagram over the
+# `relationships` tests, column-level lineage, full-text search, and a project
+# health check. Site configuration lives in src/ol_dbt/dbdocs.yml.
+#
+# Like dbt PR CI, this runs entirely against the local DuckDB `dev` target, so
+# no Trino or AWS credentials are required.
+
+permissions:
+  contents: read
+
 # Triggers
 on:
   # Triggers the workflow on push to main branch
@@ -10,61 +22,68 @@ on:
   # Triggers the workflow manually from GUI
   workflow_dispatch:
 
+# Pages allows one concurrent deployment; queue pushes rather than racing them.
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
 jobs:
   # Build job
   build:
     runs-on: ubuntu-latest
     steps:
-    - name: "Step 01 - Checkout current branch"
-      id: step-01
+    - name: Checkout code
       uses: actions/checkout@v7
 
-    - name: "Step 02 - Install dbt"
-      id: step-02
-      run: pip3 install dbt-duckdb
+    - name: Install uv
+      uses: astral-sh/setup-uv@v9.0.0
+      with:
+        version: "0.12.1"
+        enable-cache: true
 
-    - name: "Step 03 - Verify dbt"
-      id: step-03
-      run: dbt --version
+    - name: Set up Python
+      run: uv python install 3.13
 
-    - name: "Step 04 - Compile dbt"
-      id: step-04
-      working-directory: ./src/ol_dbt/
+    - name: Install project
+      run: uv sync --all-extras
+
+    # `dbt compile` must run before `dbt docs generate`: it is what populates
+    # `compiled_code` in the manifest, and that compiled SQL is the only input
+    # dbdocs can derive column-level lineage from. `docs generate` preserves
+    # compiled_code, so this order yields lineage for ~87% of dimensional
+    # columns; skipping compile yields none.
+    #
+    # dbt-duckdb is pulled in ephemerally via `uv run --with` so it need not be
+    # a project dependency.
+    - name: Build dbt artifacts
+      working-directory: src/ol_dbt
+      env:
+        DBT_PROFILES_DIR: ${{ github.workspace }}/src/ol_dbt
       run: |
-        ls -ltra
-        export DBT_PROFILES_DIR=$PWD
-        dbt deps
-        dbt debug -t dev
-        dbt compile -t dev
+        uv run --with dbt-duckdb dbt deps
+        uv run --with dbt-duckdb dbt debug -t dev
+        uv run --with dbt-duckdb dbt compile -t dev
+        uv run --with dbt-duckdb dbt docs generate -t dev
 
-    - name: "Step 05 - Generate dbt docs"
-      id: step-05
-      working-directory: ./src/ol_dbt/
-      run: |
-        export DBT_PROFILES_DIR=$PWD
-        dbt deps
-        dbt docs generate -t dev
-        cd target
-        mkdir ${{ github.workspace }}/dbt_docs
-        cp *.json *.html graph.gpickle ${{ github.workspace }}/dbt_docs
-        ls -ltra ${{ github.workspace }}/dbt_docs
+    # Run isolated via `uv tool run` (not `uv run --with`) so dbdocs' sqlglot
+    # and dbterd pins cannot perturb the project environment. Version-pinned so
+    # a published site never changes shape without a deliberate bump.
+    - name: Generate docs site
+      working-directory: src/ol_dbt
+      run: uv tool run --from dbdocs==1.7.0 dbdocs generate
 
-    - name: "Step 06 - Upload pages to artifact"
-      id: step-06
+    - name: Upload pages artifact
       uses: actions/upload-pages-artifact@v5
       with:
-        path: ${{ github.workspace }}/dbt_docs
+        path: src/ol_dbt/target/site
 
-    - name: "Step 07 - Zip artifact"
-      id: step-07
-      run: zip -jrq dbt_docs.zip ${{ github.workspace }}/dbt_docs
-
-    - name: "Step 08 - Upload artifact for deployment job"
-      id: step-08
+    # Retained so the built site is downloadable from the run summary without
+    # waiting on a Pages deployment.
+    - name: Upload site as build artifact
       uses: actions/upload-artifact@v7
       with:
         name: dbt_docs
-        path: dbt_docs.zip
+        path: src/ol_dbt/target/site
 
   # Deploy to Github pages
   deploy-to-github-pages:

--- a/.github/workflows/publish_dbt_docs.yaml
+++ b/.github/workflows/publish_dbt_docs.yaml
@@ -52,18 +52,15 @@ jobs:
     # dbdocs can derive column-level lineage from. `docs generate` preserves
     # compiled_code, so this order yields lineage for ~87% of dimensional
     # columns; skipping compile yields none.
-    #
-    # dbt-duckdb is pulled in ephemerally via `uv run --with` so it need not be
-    # a project dependency.
     - name: Build dbt artifacts
       working-directory: src/ol_dbt
       env:
         DBT_PROFILES_DIR: ${{ github.workspace }}/src/ol_dbt
       run: |
-        uv run --with dbt-duckdb dbt deps
-        uv run --with dbt-duckdb dbt debug -t dev
-        uv run --with dbt-duckdb dbt compile -t dev
-        uv run --with dbt-duckdb dbt docs generate -t dev
+        uv run dbt deps
+        uv run dbt debug -t dev
+        uv run dbt compile -t dev
+        uv run dbt docs generate -t dev
 
     # Run isolated via `uv tool run` (not `uv run --with`) so dbdocs' sqlglot
     # and dbterd pins cannot perturb the project environment. Version-pinned so

--- a/src/ol_dbt/dbdocs.yml
+++ b/src/ol_dbt/dbdocs.yml
@@ -1,0 +1,37 @@
+---
+# Configuration for `dbdocs generate`, which builds the published dbt
+# documentation site (see .github/workflows/publish_dbt_docs.yaml).
+#
+# dbdocs reads target/manifest.json + target/catalog.json and renders a static
+# site with the catalog, lineage DAG, column-level lineage, a health check, and
+# an entity-relationship diagram driven by the `relationships` tests declared in
+# models/dimensional/*.yml. The ERD's "Focus a table" box walks that FK graph, so
+# a fact table resolves to its conformed dimensions -- including dim_date, which
+# is a declared FK but never a ref() parent (date keys are computed, not joined).
+
+site_name: MIT Open Learning dbt docs
+site_description: Catalog, lineage, and dimensional model explorer for the OL data
+  warehouse
+site_author: MIT Open Learning Engineering
+site_url: https://mitodl.github.io/ol-data-platform/
+repo_name: mitodl/ol-data-platform
+repo_url: https://github.com/mitodl/ol-data-platform
+project_name: ol_dbt
+show_buy_me_a_coffee: false
+
+readme: README.md
+
+target_dir: target
+output_dir: target/site
+
+# Models are authored in Trino SQL; the dbt `dev` target only swaps the relation
+# names, so the compiled SQL that column lineage is parsed from stays Trino
+# dialect. Parsing as `duckdb` fails on 11 models (json_query, array_join, ...)
+# versus 1 as `trino`, which costs ~7 percentage points of coverage across the
+# dimensional layer.
+dialect: trino
+
+dbterd:
+  # Render bare model names (dim_course_run) instead of the default
+  # resource.package.model (model.open_learning.dim_course_run).
+  entity_name_format: model


### PR DESCRIPTION
### What are the relevant tickets?

Relates to https://github.com/mitodl/ol-data-platform/issues/2407

### Description (What does it do?)

Replaces dbt's own docs bundle with [dbdocs](https://dbdocs.datnguye.me/latest/) in the GitHub Pages publishing workflow, and modernises that workflow to the uv conventions already used by `dbt_pr_ci.yaml`.

**Why.** The dimensional layer's star schema is already declared and CI-enforced — 52 `relationships` tests across `src/ol_dbt/models/dimensional/*.yml` — but nothing rendered it. dbt's docs bundle has a ref() DAG viewer and no entity-relationship view, so the only way to see which dimensions a fact joins to was reading YAML.

dbdocs consumes the same `manifest.json` + `catalog.json` and adds an ERD whose "Focus a table" box walks that FK graph, plus column-level lineage, client-side search, and a project health check.

Three decisions worth reviewer attention, all of them load-bearing:

1. **`dbt compile` now runs before `dbt docs generate`.** Only `compile` populates `compiled_code`, and that compiled SQL is the sole input for column-level lineage. `docs generate` preserves it, so this ordering yields lineage for 87% of dimensional columns; dropping the compile step yields zero. Easy to "tidy up" by mistake — hence the comment in the workflow.

2. **`dialect: trino`, not `duckdb`.** Models are authored in Trino SQL and the `dev` target only swaps relation names, so the compiled SQL stays Trino-flavoured. Parsing as duckdb fails on 11 models (`json_query`, `array_join`, …) versus 1 as trino — worth ~7 percentage points of column-lineage coverage.

3. **Publishing still goes through `upload-pages-artifact` / `deploy-pages`.** dbdocs ships a `deploy --push` flag, but it runs `git checkout -B gh-pages` + `git push --force origin gh-pages`, which would force-push the working tree onto a branch and abandon the existing artifact-based Pages setup. Plain `dbdocs generate` is used instead. This also means no version switcher: `deploy` writes to `site/<version>/` with no root `index.html`, and versions cannot accumulate across artifact-based runs anyway.

Also in this PR: `concurrency: group: pages` so pushes queue rather than race, `permissions: contents: read` at the top level, removal of a duplicated `dbt deps` invocation and the manual zip step (`upload-artifact` zips on its own), and `dbdocs` pinned to `1.7.0` and run via `uv tool run` so its sqlglot/dbterd pins cannot perturb the project environment.

Behaviour that does **not** change: the job stays credential-free on the local DuckDB `dev` target, triggers on push to `main` plus `workflow_dispatch`, and still uploads a downloadable build artifact named `dbt_docs`.

### How can this be tested?

Run the workflow manually from the Actions tab (`workflow_dispatch`), or reproduce locally — no Trino or AWS credentials needed:

\`\`\`bash
cd src/ol_dbt
export DBT_PROFILES_DIR=$PWD
uv run --with dbt-duckdb dbt deps
uv run --with dbt-duckdb dbt compile -t dev
uv run --with dbt-duckdb dbt docs generate -t dev
uv tool run --from dbdocs==1.7.0 dbdocs generate

# the site loads data over HTTP, so serve it rather than opening the file
python3 -m http.server 8000 --directory target/site
\`\`\`

Expected build output:

\`\`\`
Column lineage: skipped 1 model(s) that failed to parse.
Generated site at .../src/ol_dbt/target/site (1045 nodes, 3782 column-lineage edges).
\`\`\`

What to check in the browser:

- **Overview → Entity-relationship diagram → "Focus a table"**: enter \`tfact_enrollment\`. It should scope to \`dim_user\`, \`dim_course_run\`, \`dim_program\`, \`dim_platform\`, \`dim_date\` and \`tfact_enrollment_order\`. **\`dim_date\` is the one to verify** — it is a declared FK but never a \`ref()\` parent, since date keys are computed rather than joined, so its presence confirms the ERD walks the FK graph rather than the ref DAG.
- **Lineage / DAG** and **Health Check** pages render.
- Header reads "MIT Open Learning dbt docs" and links to \`mitodl/ol-data-platform\`.
- \`src/ol_dbt/README.md\` renders on the overview page.

Verified locally: 1045 nodes, 105 ERD edges project-wide, 52 in the dimensional layer — cross-checked against an independent extraction of the \`relationships\` tests straight from the YAML, and against \`dbterd\` run standalone. \`pre-commit\` passes on both changed files.

### Additional Context

**Pre-existing gap this PR does not close.** \`catalog.json\` comes back with 0 nodes, because \`dbt docs generate -t dev\` runs against an empty \`dev_dbs/dev.duckdb\`, so column data types render as \`unknown\`. This is equally true of the docs published today — the current workflow generates against the same empty database — so the new site is no worse. Closing it means feeding the production \`catalog.json\` already written to S3 under the \`openmetadata/dbt-artifacts\` prefix by \`DbtS3ArtifactsResource\`, which needs AWS credentials. No workflow in this repo currently configures any, so that is a separate OIDC-role change and is deliberately out of scope here.

**Dependency note.** dbdocs is a single-maintainer OSS project (same author as \`dbterd\`, which it vendors for ERD extraction). It is pinned here, but that is a bus-factor consideration worth a reviewer's opinion given this powers a public-facing site.

**Health check numbers.** The new Health Check page currently reports Testing 1% (649 issues) and Modeling 56% (455 issues). These are dbt-project-evaluator-style heuristics and need calibration before the scores mean much — flagging them as possibly interesting to #2407 rather than as a claim about warehouse quality.