### PR TITLE
fix(migration): clean up edxorg_to_mitxonline_users retired users and full names 

### DIFF
--- a/src/ol_dbt/dbt_project.yml
+++ b/src/ol_dbt/dbt_project.yml
@@ -53,6 +53,8 @@ vars:
     dedp_mitxonline_public_policy_program_id: 2
     dedp_mitxonline_good_economics_for_hard_times_course_number: "14.009x"
     dedp_mitxonline_good_economics_for_hard_times_internation_development_cutoff: "2023-08-01"
+    # Entitlements expiring before this date are not migrated to MITx Online
+    edxorg_migration_entitlement_expiration_cutoff: "2026-01-01"
     ocw_production_url: "https://ocw.mit.edu/"
     mitxonline_openedx_url: "https://courses.learn.mit.edu"
     mitxpro_openedx_url: "https://courses.xpro.mit.edu"

--- a/src/ol_dbt/models/migration/_migration__models.yml
+++ b/src/ol_dbt/models/migration/_migration__models.yml
@@ -122,6 +122,10 @@ models:
     - unique
   - name: user_full_name
     description: string, user full name on edX.org platform
+    tests:
+    - not_null:
+        config:
+          severity: warn
   - name: user_gender
     description: string, user gender
   - name: user_birth_year

--- a/src/ol_dbt/models/migration/edxorg_to_mitxonline_program_entitlements.sql
+++ b/src/ol_dbt/models/migration/edxorg_to_mitxonline_program_entitlements.sql
@@ -27,7 +27,11 @@ with mitxonline_programs as (
         , number_of_redeemed_entitlements
     from {{ ref('stg__edxorg__program_entitlement') }}
     where user_email is not null
-        and (expiration_date is null or expiration_date >= date '2026-01-01')
+        and (
+            expiration_date is null
+            or expiration_date
+            >= date '{{ var("edxorg_migration_entitlement_expiration_cutoff") }}'
+        )
 )
 
 , deduped_program_entitlements as (

--- a/src/ol_dbt/models/migration/edxorg_to_mitxonline_users.sql
+++ b/src/ol_dbt/models/migration/edxorg_to_mitxonline_users.sql
@@ -6,12 +6,39 @@ with edx_certificate as (
     where user_email not like 'retired__user%' and user_username not like 'retired__user%'
 )
 
+--- one name per email. A small number of MicroMasters emails appear on two rows
+--- with differing names, which would otherwise duplicate a user_email downstream.
+, micromasters_user_full_name as (
+    select
+        user_email
+        , user_full_name
+    from (
+        select
+            lower(user_email) as user_email
+            , nullif(trim(user_full_name), '') as user_full_name
+            , row_number() over (
+                partition by lower(user_email) order by user_joined_on desc nulls last
+            ) as _row_num
+        from {{ ref('int__micromasters__users') }}
+        where user_email is not null and nullif(trim(user_full_name), '') is not null
+    ) as ranked_micromasters_users
+    where _row_num = 1
+)
+
 , program_entitlements as (
     select distinct
         user_email
         , user_id as user_edxorg_id
-        , user_full_name
+        , nullif(trim(user_full_name), '') as user_full_name
     from {{ ref('stg__edxorg__program_entitlement') }}
+    where user_email is not null
+        and user_email not like 'retired__user%'
+        --- expired entitlements don't need an MITx Online account created
+        and (
+            expiration_date is null
+            or expiration_date
+            >= date '{{ var("edxorg_migration_entitlement_expiration_cutoff") }}'
+        )
 )
 
 , retired_users as (
@@ -41,7 +68,7 @@ with edx_certificate as (
 , cert_users as (
     select
         lower(edx_certificate_user.user_email) as user_email
-        , edx_certificate_user.user_full_name
+        , nullif(trim(edx_certificate_user.user_full_name), '') as user_full_name
         , edx_certificate_user.user_gender
         , edx_certificate_user.user_birth_year
         , edx_certificate_user.user_address_country as user_country
@@ -59,7 +86,10 @@ with edx_certificate as (
 , entitlement_users as (
     select distinct
         lower(program_entitlements.user_email) as user_email
-        , coalesce(mitx_user.user_full_name, program_entitlements.user_full_name, '') as user_full_name
+        , coalesce(
+            nullif(trim(mitx_user.user_full_name), '')
+            , program_entitlements.user_full_name
+        ) as user_full_name
         , mitx_user.user_gender
         , mitx_user.user_birth_year
         , mitx_user.user_address_country as user_country
@@ -88,7 +118,7 @@ with edx_certificate as (
 , future_enrollment_users as (
     select distinct
         lower(user_email) as user_email
-        , user_full_name
+        , nullif(trim(user_full_name), '') as user_full_name
         , user_gender
         , user_birth_year
         , user_country
@@ -97,12 +127,27 @@ with edx_certificate as (
         and courseruncertificate_created_on is null
 )
 
-select * from cert_entitlement_users
+, migration_users as (
+    select * from cert_entitlement_users
 
-union all
+    union all
 
-select * from future_enrollment_users
-where not exists (
-    select 1 from cert_entitlement_users
-    where cert_entitlement_users.user_email = future_enrollment_users.user_email
+    select * from future_enrollment_users
+    where not exists (
+        select 1 from cert_entitlement_users
+        where cert_entitlement_users.user_email = future_enrollment_users.user_email
+    )
 )
+
+select
+    migration_users.user_email
+    , coalesce(
+        migration_users.user_full_name
+        , micromasters_user_full_name.user_full_name
+    ) as user_full_name
+    , migration_users.user_gender
+    , migration_users.user_birth_year
+    , migration_users.user_country
+from migration_users
+left join micromasters_user_full_name
+    on migration_users.user_email = micromasters_user_full_name.user_email


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
https://github.com/mitodl/hq/issues/10382

### Description (What does it do?)
<!--- Describe your changes in detail -->

Cleans up `edxorg_to_mitxonline_users` so retired and expired entitlement accounts aren't queued for MITx Online account creation, and backfills missing names from MicroMasters.  

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

dbt build --select edxorg_to_mitxonline_users edxorg_to_mitxonline_program_entitlements --target dev_production 

### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->


<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
