### PR TITLE
fix(dbt): resolve qa explicitly, and separate cluster from data lake

### DIFF
--- a/dg_projects/lakehouse/Dockerfile
+++ b/dg_projects/lakehouse/Dockerfile
@@ -49,9 +49,16 @@ RUN /app/dg_projects/lakehouse/.venv/bin/dbt deps && \
 # below only need to satisfy profiles.yml's env_var() calls, not authenticate
 # against a real StarRocks cluster -- see lakehouse/assets/lakehouse/dbt_starrocks.py
 # for where real Vault-issued credentials are injected at run time.
+# DBT_DATA_LAKE_ENV is stated here rather than left to dbt_project.yml's
+# fallback, but the value is arbitrary: one image serves every environment, so
+# the baked manifest cannot name the right catalog for all of them. dbt records
+# the env vars used at parse time and forces a full re-parse when they differ,
+# so the run-time value injected by dbt.py / the starrocks CLI is what the
+# build actually reads.
 RUN DBT_STARROCKS_HOST=localhost \
     DBT_STARROCKS_USERNAME=build \
     DBT_STARROCKS_PASSWORD=build \
+    DBT_DATA_LAKE_ENV=production \
     /app/dg_projects/lakehouse/.venv/bin/dbt parse \
         --target starrocks_qa_vault --target-path target/starrocks
 

--- a/dg_projects/lakehouse/lakehouse/assets/lakehouse/dbt.py
+++ b/dg_projects/lakehouse/lakehouse/assets/lakehouse/dbt.py
@@ -20,36 +20,13 @@ from dagster_dbt import (
 from ol_orchestrate.lib.automation_policies import upstream_or_code_changes
 from ol_orchestrate.lib.constants import DAGSTER_ENV
 
+from lakehouse.lib.dbt_environment import DBT_TARGET
 from lakehouse.resources.dbt_s3_artifacts import DbtS3ArtifactsResource
 
 DBT_REPO_DIR = (
     Path(__file__).parents[5].joinpath("src/ol_dbt")
     if DAGSTER_ENV == "dev"
     else Path("/opt/dbt")
-)
-
-
-def resolve_dbt_target(
-    target_map: Mapping[str, str], *, override_env_var: str, default: str
-) -> str:
-    """Resolve the dbt profile target for this environment from *target_map*.
-
-    Single source of truth shared by a DbtProject (which parses the manifest,
-    and therefore the Dagster asset graph) and the DbtCliResource that executes
-    it, so the graph always matches what actually runs. *override_env_var*
-    takes precedence over the mapping when set. Shared across engine-scoped
-    dbt asset sets (see dbt_starrocks.py) so each just supplies its own map.
-    """
-    if override := os.environ.get(override_env_var):
-        return override
-    return target_map.get(DAGSTER_ENV, default)
-
-
-# qa and production both execute against the production target.
-DBT_TARGET = resolve_dbt_target(
-    {"dev": "dev_production", "ci": "ci"},
-    override_env_var="DAGSTER_DBT_TARGET",
-    default="production",
 )
 
 dbt_project = DbtProject(project_dir=DBT_REPO_DIR, target=DBT_TARGET)

--- a/dg_projects/lakehouse/lakehouse/assets/lakehouse/dbt_starrocks.py
+++ b/dg_projects/lakehouse/lakehouse/assets/lakehouse/dbt_starrocks.py
@@ -14,8 +14,8 @@ from dagster_dbt.errors import DagsterDbtCliRuntimeError
 from lakehouse.assets.lakehouse.dbt import (
     DBT_REPO_DIR,
     DbtAutomationTranslator,
-    resolve_dbt_target,
 )
+from lakehouse.lib.dbt_environment import STARROCKS_DBT_TARGET
 from lakehouse.lib.starrocks_dbt import (
     MAX_BUILD_ATTEMPTS,
     looks_retriable,
@@ -25,21 +25,16 @@ from lakehouse.resources.starrocks import StarRocksResource
 
 # tag:starrocks models (see dbt_project.yml) are additionally gated
 # `+enabled: "{{ target.type == 'starrocks' }}"`, so they only exist in a
-# manifest parsed against one of these targets -- full_dbt_project's manifest
-# is always parsed against a Trino target and never sees them. Matches the
-# dbt_target choices in src/ol_dbt_cli/ol_dbt_cli/commands/starrocks.py's
-# _ENVS map. Migrating an existing model onto StarRocks means tagging it here
-# (dbt_project.yml or model-level config) and giving it a matching +enabled
-# condition -- this asset set and full_dbt_project's exclude="tag:starrocks"
-# then pick it up automatically, no Python change needed.
-STARROCKS_DBT_TARGET_MAP = {
-    "dev": "starrocks_qa_vault",
-    # ci connects directly to its own FE service (no port-forward), same
-    # connection shape as production -- matches _ENVS["ci"]["dbt_target"].
-    "ci": "starrocks_production",
-    "qa": "starrocks_qa_vault",
-    "production": "starrocks_production",
-}
+# manifest parsed against a StarRocks target -- full_dbt_project's manifest is
+# always parsed against a Trino target and never sees them. Migrating an
+# existing model onto StarRocks means tagging it here (dbt_project.yml or
+# model-level config) and giving it a matching +enabled condition -- this asset
+# set and full_dbt_project's exclude="tag:starrocks" then pick it up
+# automatically, no Python change needed.
+#
+# The per-environment target map lives in lakehouse.lib.dbt_environment
+# alongside the Trino one, so the two cannot drift apart the way they did
+# before RFC 12711 step 1.
 
 # `prepare_if_dev()` below only ever parses (never opens a DB connection), but
 # profiles.yml's env_var() calls for the starrocks targets have no defaults and
@@ -55,11 +50,7 @@ os.environ.setdefault("DBT_STARROCKS_PASSWORD", "dev")
 # manifest at the default "target/" (both dbt projects share the same project_dir).
 starrocks_dbt_project = DbtProject(
     project_dir=DBT_REPO_DIR,
-    target=resolve_dbt_target(
-        STARROCKS_DBT_TARGET_MAP,
-        override_env_var="DAGSTER_DBT_STARROCKS_TARGET",
-        default="starrocks_production",
-    ),
+    target=STARROCKS_DBT_TARGET,
     target_path="target/starrocks",
 )
 starrocks_dbt_project.prepare_if_dev()

--- a/dg_projects/lakehouse/lakehouse/lib/dbt_environment.py
+++ b/dg_projects/lakehouse/lakehouse/lib/dbt_environment.py
@@ -1,0 +1,118 @@
+"""Per-environment dbt wiring: which target to write, which data lake to read.
+
+Lives in ``lakehouse.lib`` (rather than beside the assets that use it) so it
+can be unit-tested without a parsed dbt manifest on disk -- importing
+``assets.lakehouse.dbt`` evaluates a ``@dbt_assets`` decorator, which needs
+one. Same reason ``lakehouse.lib.starrocks_dbt`` exists.
+
+Two independent axes, and conflating them is what RFC 12711 step 1 exists to
+undo:
+
+* **target** -- which cluster to connect to, and which warehouse to WRITE.
+* **data lake env** -- which ``ol_data_lake_<env>`` catalog to READ.
+
+They diverge for ``dev``: a developer's StarRocks target port-forwards to the
+QA cluster but should read production data. The b2b sources used to infer the
+lake from ``'qa' in target.name``, which got that case wrong and made those
+models undevelopable locally.
+
+Every environment appears in every map. There is deliberately no fallback --
+``qa`` used to be absent from the Trino map and fell through to ``production``,
+so the QA code location wrote the production warehouse while the StarRocks
+project next to it targeted QA. The two disagreed for months because neither
+had to say what it meant.
+"""
+
+import os
+from collections.abc import Mapping
+
+from ol_orchestrate.lib.constants import DAGSTER_ENV
+
+# Trino. "qa" resolves to the QA warehouse, which is what the rest of the QA
+# code location was already configured for -- trino_host_map/trino_catalog_map
+# in definitions.py have pointed "qa" at the QA Starburst cluster and
+# ol_data_lake_qa all along. Only this map disagreed.
+#
+# NOTE: profiles.yml has no "ci" output, so that entry does not name a real
+# target. Pre-existing, and inert today because nothing runs dbt under
+# DAGSTER_ENVIRONMENT=ci; left alone rather than guessed at.
+DBT_TARGET_MAP: Mapping[str, str] = {
+    "dev": "dev_production",
+    "ci": "ci",
+    "qa": "qa",
+    "production": "production",
+}
+
+# StarRocks. These name a CLUSTER and its auth, not a data lake: dev and qa
+# share starrocks_qa_vault because a developer port-forwards to the QA cluster.
+# Which catalog each then reads is DATA_LAKE_ENV_MAP's job, not this map's.
+# Matches the dbt_target choices in ol_dbt_cli/commands/starrocks.py's _ENVS.
+STARROCKS_DBT_TARGET_MAP: Mapping[str, str] = {
+    "dev": "starrocks_qa_vault",
+    # ci connects directly to its own FE service (no port-forward), same
+    # connection shape as production -- matches _ENVS["ci"]["dbt_target"].
+    "ci": "starrocks_production",
+    "qa": "starrocks_qa_vault",
+    "production": "starrocks_production",
+}
+
+# Which lake each environment READS. Mirrors trino_catalog_map in
+# definitions.py (which cannot be imported here -- it imports the modules that
+# import this one); keep the two in step when adding an environment.
+DATA_LAKE_ENV_MAP: Mapping[str, str] = {
+    "dev": "production",
+    "ci": "qa",
+    "qa": "qa",
+    "production": "production",
+}
+
+
+def resolve_for_environment(
+    value_map: Mapping[str, str], *, override_env_var: str, what: str
+) -> str:
+    """Resolve *what* for this environment from *value_map*.
+
+    Single source of truth shared by a DbtProject (which parses the manifest,
+    and therefore the Dagster asset graph) and the DbtCliResource that executes
+    it, so the graph always matches what actually runs. *override_env_var*
+    takes precedence over the mapping when set.
+
+    Raises KeyError when the current environment is absent from *value_map*:
+    a fallback here is what let ``qa`` silently inherit production.
+    """
+    if override := os.environ.get(override_env_var):
+        return override
+    try:
+        return value_map[DAGSTER_ENV]
+    except KeyError:
+        msg = (
+            f"No {what} declared for DAGSTER_ENVIRONMENT={DAGSTER_ENV!r} "
+            f"(known: {sorted(value_map)}). Add an explicit entry -- a fallback "
+            f"here would let a new environment inherit another one's warehouse."
+        )
+        raise KeyError(msg) from None
+
+
+DBT_TARGET = resolve_for_environment(
+    DBT_TARGET_MAP,
+    override_env_var="DAGSTER_DBT_TARGET",
+    what="dbt target",
+)
+
+STARROCKS_DBT_TARGET = resolve_for_environment(
+    STARROCKS_DBT_TARGET_MAP,
+    override_env_var="DAGSTER_DBT_STARROCKS_TARGET",
+    what="StarRocks dbt target",
+)
+
+DATA_LAKE_ENV = resolve_for_environment(
+    DATA_LAKE_ENV_MAP,
+    override_env_var="DAGSTER_DBT_DATA_LAKE_ENV",
+    what="data lake environment",
+)
+
+# Exported to the dbt subprocess rather than passed as a --vars flag: dbt does
+# not recursively render dbt_project.yml `vars` values, and an env var reaches
+# both the manifest parse and the build without threading vars through
+# DbtProject. Read by _b2b_analytics__sources.yml.
+os.environ["DBT_DATA_LAKE_ENV"] = DATA_LAKE_ENV

--- a/dg_projects/lakehouse/lakehouse/lib/dbt_environment.py
+++ b/dg_projects/lakehouse/lakehouse/lib/dbt_environment.py
@@ -21,6 +21,20 @@ Every environment appears in every map. There is deliberately no fallback --
 so the QA code location wrote the production warehouse while the StarRocks
 project next to it targeted QA. The two disagreed for months because neither
 had to say what it meant.
+
+Adding an environment
+---------------------
+A fifth environment, ``local`` (k3d + Tilt, its own object store and Iceberg
+catalog), is planned -- see RFC 12711's Local-2/3/4 tasks, which specify that
+``local`` extends *this* convention rather than introducing a third resolution
+style. It is NOT a rename of ``dev``: ``dev`` connects to the remote QA cluster
+and reads the production lake, while ``local`` reaches neither and is fed by
+local ingest and fixtures. Both will need to exist.
+
+When it lands, ``DAGSTER_ENV`` gains the value and every map below needs an
+entry -- plus ``_ENVS`` in ``ol_dbt_cli/commands/starrocks.py``, which mirrors
+these. Until then ``resolve_for_environment`` raises on it, which is the point:
+the failure is a missing declaration, not a silently inherited warehouse.
 """
 
 import os

--- a/dg_projects/lakehouse/lakehouse_tests/test_dbt_environment.py
+++ b/dg_projects/lakehouse/lakehouse_tests/test_dbt_environment.py
@@ -1,0 +1,107 @@
+"""Tests for per-environment dbt target and data lake resolution.
+
+These lock down RFC 12711 step 1. The bug was not that any single value was
+wrong -- it was that nothing forced the two dbt projects in this code location
+to answer the same question the same way, and nothing forced an environment to
+answer at all. So the assertions here are mostly about agreement and
+exhaustiveness rather than about specific target names.
+"""
+
+import pytest
+from lakehouse.lib.dbt_environment import (
+    DATA_LAKE_ENV_MAP,
+    DBT_TARGET_MAP,
+    STARROCKS_DBT_TARGET_MAP,
+    resolve_for_environment,
+)
+
+ENVIRONMENTS = ("dev", "ci", "qa", "production")
+
+ALL_MAPS = pytest.mark.parametrize(
+    ("name", "value_map"),
+    [
+        ("DBT_TARGET_MAP", DBT_TARGET_MAP),
+        ("STARROCKS_DBT_TARGET_MAP", STARROCKS_DBT_TARGET_MAP),
+        ("DATA_LAKE_ENV_MAP", DATA_LAKE_ENV_MAP),
+    ],
+)
+
+
+@ALL_MAPS
+def test_every_environment_is_declared(name, value_map):
+    """No environment may be reached by falling through to a default.
+
+    `qa` was absent from the Trino map and inherited `default="production"`,
+    so the QA code location built the production warehouse while the StarRocks
+    project beside it targeted QA.
+    """
+    assert set(value_map) == set(ENVIRONMENTS), name
+
+
+@ALL_MAPS
+def test_unknown_environment_raises(name, value_map, monkeypatch):
+    """A new environment must fail loudly rather than inherit another's."""
+    monkeypatch.setattr("lakehouse.lib.dbt_environment.DAGSTER_ENV", "staging")
+    with pytest.raises(KeyError, match="staging"):
+        resolve_for_environment(
+            value_map, override_env_var="NOT_SET_ANYWHERE", what=name
+        )
+
+
+# `dev` is excluded deliberately: a laptop cannot reach the production
+# StarRocks FE (an in-cluster service), so the dev StarRocks target
+# port-forwards to the QA cluster while the dev Trino target is production.
+# That divergence is real, and it is exactly why "which cluster" and "which
+# lake" have to be separate axes -- dev's lake is pinned to production by
+# DATA_LAKE_ENV_MAP regardless of the cluster it connects to.
+DEPLOYED_ENVIRONMENTS = ("ci", "qa", "production")
+
+
+@pytest.mark.parametrize("environment", DEPLOYED_ENVIRONMENTS)
+def test_both_dbt_projects_agree_on_environment(environment, monkeypatch):
+    """The Trino and StarRocks projects must resolve to the same environment.
+
+    They are one Dagster code location, so `qa` meaning QA for one and
+    production for the other is always a bug -- the immediate cause of the B2B
+    dashboard 500s in RC. Compares which environment each target belongs to,
+    not the target strings, which differ by engine.
+    """
+    monkeypatch.setattr("lakehouse.lib.dbt_environment.DAGSTER_ENV", environment)
+    trino = resolve_for_environment(
+        DBT_TARGET_MAP, override_env_var="UNSET", what="trino"
+    )
+    starrocks = resolve_for_environment(
+        STARROCKS_DBT_TARGET_MAP, override_env_var="UNSET", what="starrocks"
+    )
+    assert ("qa" in trino) == ("qa" in starrocks), (
+        f"{environment}: trino -> {trino}, starrocks -> {starrocks}"
+    )
+
+
+def test_dev_reads_production_lake():
+    """`dev` connects to the QA StarRocks cluster but must READ production.
+
+    This is the case `'qa' in target.name` got wrong: the dev target is
+    `starrocks_qa_vault`, so the substring test sent local b2b builds at the
+    empty QA lake and the models could not be developed locally at all.
+    """
+    assert STARROCKS_DBT_TARGET_MAP["dev"] == "starrocks_qa_vault"
+    assert DATA_LAKE_ENV_MAP["dev"] == "production"
+
+
+def test_data_lake_env_values_are_real_catalogs():
+    """Values are interpolated into `ol_data_lake_<env>`, so typos are silent."""
+    assert set(DATA_LAKE_ENV_MAP.values()) <= {"qa", "production"}
+
+
+@ALL_MAPS
+def test_override_env_var_wins(name, value_map, monkeypatch):
+    monkeypatch.setenv("DAGSTER_DBT_OVERRIDE_UNDER_TEST", "an_explicit_override")
+    assert (
+        resolve_for_environment(
+            value_map,
+            override_env_var="DAGSTER_DBT_OVERRIDE_UNDER_TEST",
+            what=name,
+        )
+        == "an_explicit_override"
+    )

--- a/src/ol_dbt/models/b2b_analytics/_b2b_analytics__sources.yml
+++ b/src/ol_dbt/models/b2b_analytics/_b2b_analytics__sources.yml
@@ -6,10 +6,20 @@ sources:
     Dimensional-layer Iceberg tables, accessed from StarRocks via the
     `ol_data_lake_{qa,production}` external catalog. Same physical tables the
     Trino-backed ol_dbt project materializes into `ol_warehouse_{env}_dimensional`.
-  database: "{{ 'ol_data_lake_qa' if 'qa' in target.name else 'ol_data_lake_production'\
-    \ }}"
-  schema: "{{ 'ol_warehouse_qa_dimensional' if 'qa' in target.name else 'ol_warehouse_production_dimensional'\
-    \ }}"
+
+    Which catalog is read comes from DBT_DATA_LAKE_ENV, NOT from the target
+    name. The target names a CLUSTER and its auth; this names the lake the
+    cluster reads through its external catalog, and the two axes diverge --
+    a developer's StarRocks target port-forwards to the QA cluster but should
+    read production data. Inferring the lake from `'qa' in target.name` got
+    that case wrong and made these models undevelopable locally (RFC 12711
+    step 1). Set from a per-environment map that raises on an unknown
+    environment by lakehouse/assets/lakehouse/dbt.py (Dagster) and
+    ol_dbt_cli/commands/starrocks.py (local, CI); the default below is reached
+    only by a bare `dbt` invocation outside both, where reading production is
+    the sanctioned practice and a wrong value fails as a missing relation.
+  database: "ol_data_lake_{{ env_var('DBT_DATA_LAKE_ENV', 'production') }}"
+  schema: "ol_warehouse_{{ env_var('DBT_DATA_LAKE_ENV', 'production') }}_dimensional"
   tables:
   - name: dim_organization
     description: One row per organization per platform. organization_key is null for
@@ -37,11 +47,11 @@ sources:
 - name: reporting
   description: >
     Reporting-layer Iceberg tables, accessed from StarRocks via the
-    `ol_data_lake_{qa,production}` external catalog.
-  database: "{{ 'ol_data_lake_qa' if 'qa' in target.name else 'ol_data_lake_production'\
-    \ }}"
-  schema: "{{ 'ol_warehouse_qa_reporting' if 'qa' in target.name else 'ol_warehouse_production_reporting'\
-    \ }}"
+    `ol_data_lake_{qa,production}` external catalog, selected by
+    DBT_DATA_LAKE_ENV rather than the target name (see the dimensional source
+    above for why).
+  database: "ol_data_lake_{{ env_var('DBT_DATA_LAKE_ENV', 'production') }}"
+  schema: "ol_warehouse_{{ env_var('DBT_DATA_LAKE_ENV', 'production') }}_reporting"
   tables:
   - name: organization_administration_report
     description: >

--- a/src/ol_dbt_cli/ol_dbt_cli/commands/starrocks.py
+++ b/src/ol_dbt_cli/ol_dbt_cli/commands/starrocks.py
@@ -18,6 +18,9 @@ Workflow::
     # Explicit env / role
     ol-dbt starrocks run --env production --vault-role readonly
 
+    # Develop the b2b models: QA cluster to write to, production lake to read
+    ol-dbt starrocks run --env dev
+
     # Pass dbt flags through
     ol-dbt starrocks run --full-refresh --select my_model+
 
@@ -64,11 +67,31 @@ _PORT_FORWARD_TIMEOUT = 15
 _VAULT_MOUNT = "database-starrocks"
 
 # `dbt_target` names a CLUSTER and its auth; `data_lake_env` names the external
-# catalog the b2b models READ. They are separate axes -- ci connects to its own
-# FE service but reads the production lake -- and conflating them is what
-# RFC 12711 step 1 exists to undo. Both are stated per environment rather than
-# derived, so adding an environment forces both answers.
+# catalog the b2b models READ. They are separate axes, and `ci` shows all three
+# coming apart at once: the target is *called* starrocks_production, it connects
+# to the CI cluster's own FE, and it reads the QA lake. Inferring any one of
+# those from another -- which `'qa' in target.name` did -- is what RFC 12711
+# step 1 exists to undo. Both are stated per environment rather than derived,
+# so adding an environment forces both answers.
+#
+# Mirrors STARROCKS_DBT_TARGET_MAP / DATA_LAKE_ENV_MAP in
+# lakehouse.lib.dbt_environment; keep the two in step.
 _ENVS: dict[str, dict[str, Any]] = {
+    # QA cluster connectivity, production data. The combination local b2b
+    # development actually wants: the QA cluster is safe to write to, and the
+    # QA lake has no dimensional/reporting tables to read (RFC 12711 step 8).
+    # Matches DATA_LAKE_ENV_MAP["dev"] so `ol-dbt starrocks --env dev` and a
+    # bare `dagster dev` resolve identically.
+    "dev": {
+        "host": "lakehouse.qa.starrocks.ol.mit.edu",
+        "eks_context": "arn:aws:eks:us-east-1:610119931565:cluster/data-qa",
+        "k8s_namespace": "starrocks",
+        "fe_service": "lakehouse-starrocks-fe-service",
+        "vault_addr": "https://vault-qa.odl.mit.edu",
+        "vault_mount": _VAULT_MOUNT,
+        "dbt_target": "starrocks_qa_vault",
+        "data_lake_env": "production",
+    },
     "qa": {
         "host": "lakehouse.qa.starrocks.ol.mit.edu",
         "eks_context": "arn:aws:eks:us-east-1:610119931565:cluster/data-qa",
@@ -181,7 +204,12 @@ def run(  # noqa: PLR0913
     *,
     env: Annotated[
         str,
-        Parameter(name=["--env", "-e"], help="Target StarRocks environment (qa, production, ci)."),
+        Parameter(
+            name=["--env", "-e"],
+            help="Target StarRocks environment (dev, qa, production, ci). `dev` is the "
+            "QA cluster reading the production data lake -- what local b2b development "
+            "wants, since the QA lake has no dimensional/reporting tables yet.",
+        ),
     ] = "qa",
     vault_role: Annotated[
         str,
@@ -272,9 +300,10 @@ def run(  # noqa: PLR0913
     os.environ["DBT_STARROCKS_USERNAME"] = username
     os.environ["DBT_STARROCKS_PASSWORD"] = password
     os.environ["DBT_STARROCKS_HOST"] = host
-    # Read by dbt_project.yml's `data_lake_env` var. Set from --env even when
-    # --target overrides the cluster, so "which lake" stays the environment's
-    # answer rather than something inferred from a target name.
+    # Read by _b2b_analytics__sources.yml's env_var() to pick the external
+    # catalog. Set from --env even when --target overrides the cluster, so
+    # "which lake" stays the environment's answer rather than something
+    # inferred from a target name.
     os.environ["DBT_DATA_LAKE_ENV"] = env_cfg["data_lake_env"]
 
     # Default to the env-appropriate dbt target if the caller didn't specify one.

--- a/src/ol_dbt_cli/ol_dbt_cli/commands/starrocks.py
+++ b/src/ol_dbt_cli/ol_dbt_cli/commands/starrocks.py
@@ -63,6 +63,11 @@ _PORT_FORWARD_TIMEOUT = 15
 # server (vault_addr below), not the mount path, is what scopes the environment.
 _VAULT_MOUNT = "database-starrocks"
 
+# `dbt_target` names a CLUSTER and its auth; `data_lake_env` names the external
+# catalog the b2b models READ. They are separate axes -- ci connects to its own
+# FE service but reads the production lake -- and conflating them is what
+# RFC 12711 step 1 exists to undo. Both are stated per environment rather than
+# derived, so adding an environment forces both answers.
 _ENVS: dict[str, dict[str, Any]] = {
     "qa": {
         "host": "lakehouse.qa.starrocks.ol.mit.edu",
@@ -72,6 +77,7 @@ _ENVS: dict[str, dict[str, Any]] = {
         "vault_addr": "https://vault-qa.odl.mit.edu",
         "vault_mount": _VAULT_MOUNT,
         "dbt_target": "starrocks_qa_vault",
+        "data_lake_env": "qa",
     },
     "production": {
         "host": "lakehouse.starrocks.ol.mit.edu",
@@ -81,6 +87,7 @@ _ENVS: dict[str, dict[str, Any]] = {
         "vault_addr": "https://vault-production.odl.mit.edu",
         "vault_mount": _VAULT_MOUNT,
         "dbt_target": "starrocks_production",
+        "data_lake_env": "production",
     },
     "ci": {
         "host": "lakehouse.ci.starrocks.ol.mit.edu",
@@ -90,6 +97,8 @@ _ENVS: dict[str, dict[str, Any]] = {
         "vault_addr": "https://vault-qa.odl.mit.edu",
         "vault_mount": _VAULT_MOUNT,
         "dbt_target": "starrocks_production",
+        # Matches trino_catalog_map["ci"] in the lakehouse definitions.
+        "data_lake_env": "qa",
         "port_forward": False,
     },
 }
@@ -263,6 +272,10 @@ def run(  # noqa: PLR0913
     os.environ["DBT_STARROCKS_USERNAME"] = username
     os.environ["DBT_STARROCKS_PASSWORD"] = password
     os.environ["DBT_STARROCKS_HOST"] = host
+    # Read by dbt_project.yml's `data_lake_env` var. Set from --env even when
+    # --target overrides the cluster, so "which lake" stays the environment's
+    # answer rather than something inferred from a target name.
+    os.environ["DBT_DATA_LAKE_ENV"] = env_cfg["data_lake_env"]
 
     # Default to the env-appropriate dbt target if the caller didn't specify one.
     effective_target = target or env_cfg["dbt_target"]

--- a/src/ol_dbt_cli/ol_dbt_cli/commands/starrocks.py
+++ b/src/ol_dbt_cli/ol_dbt_cli/commands/starrocks.py
@@ -75,13 +75,23 @@ _VAULT_MOUNT = "database-starrocks"
 # so adding an environment forces both answers.
 #
 # Mirrors STARROCKS_DBT_TARGET_MAP / DATA_LAKE_ENV_MAP in
-# lakehouse.lib.dbt_environment; keep the two in step.
+# lakehouse.lib.dbt_environment; keep the two in step. A fifth environment,
+# `local` (k3d, its own object store and catalog), is planned in RFC 12711's
+# Local-2/3/4 and will need an entry in both places. It is NOT a rename of
+# `dev` below -- `dev` reaches the remote QA cluster and the production lake,
+# `local` reaches neither.
 _ENVS: dict[str, dict[str, Any]] = {
-    # QA cluster connectivity, production data. The combination local b2b
-    # development actually wants: the QA cluster is safe to write to, and the
-    # QA lake has no dimensional/reporting tables to read (RFC 12711 step 8).
+    # QA cluster connectivity, production data. The combination b2b development
+    # against real data wants: the QA cluster is safe to write to, and the QA
+    # lake has no dimensional/reporting tables to read (RFC 12711 step 8).
     # Matches DATA_LAKE_ENV_MAP["dev"] so `ol-dbt starrocks --env dev` and a
     # bare `dagster dev` resolve identically.
+    #
+    # Worth being honest about what this is: "local" development against a
+    # remote cluster and production data. It is the right mode for model-shape
+    # iteration and `ol-dbt diff`, where identity does not matter, and the
+    # wrong one for anything keyed on environment-scoped identity -- which is
+    # why `local` is coming rather than this being the end state.
     "dev": {
         "host": "lakehouse.qa.starrocks.ol.mit.edu",
         "eks_context": "arn:aws:eks:us-east-1:610119931565:cluster/data-qa",
@@ -278,8 +288,14 @@ def run(  # noqa: PLR0913
     env_cfg = _ENVS[env]
     if port_forward is None:
         port_forward = env_cfg.get("port_forward", True)
+    # Print the lake alongside the cluster. Which data you are reading is not
+    # inferable from the env name (`dev` is the QA cluster on production data),
+    # and "you cannot tell which mode you are in" is the specific failure this
+    # separation exists to fix -- so say it, every run.
     console.print(
         f"[bold]ol-dbt starrocks[/] — env: [cyan]{env}[/], "
+        f"cluster: [cyan]{env_cfg['host']}[/], "
+        f"reading: [cyan]ol_data_lake_{env_cfg['data_lake_env']}[/], "
         f"role: [cyan]{vault_role}[/], "
         f"port-forward: [cyan]{port_forward}[/]"
     )

--- a/src/ol_dbt_cli/tests/test_starrocks.py
+++ b/src/ol_dbt_cli/tests/test_starrocks.py
@@ -22,12 +22,37 @@ _REQUIRED_ENV_KEYS = {
     "vault_addr",
     "vault_mount",
     "dbt_target",
+    # Which lake to READ, independent of the cluster dbt_target connects to.
+    # Required so adding an environment cannot leave it to be inferred from a
+    # target name, which is the RFC 12711 step 1 defect.
+    "data_lake_env",
 }
 
 
 @pytest.mark.parametrize("env_name", list(_ENVS))
 def test_env_config_has_required_keys(env_name: str) -> None:
     assert _REQUIRED_ENV_KEYS <= _ENVS[env_name].keys()
+
+
+@pytest.mark.parametrize("env_name", list(_ENVS))
+def test_data_lake_env_is_a_real_catalog(env_name: str) -> None:
+    """Interpolated into `ol_data_lake_<env>`, so a typo fails only at query time."""
+    assert _ENVS[env_name]["data_lake_env"] in {"qa", "production"}
+
+
+def test_dev_is_qa_cluster_reading_production() -> None:
+    """The combination local b2b development needs, and the one that was missing.
+
+    `'qa' in target.name` could not express it: dev's target is
+    starrocks_qa_vault, so the substring test forced the (empty) QA lake and
+    the b2b models could not be developed locally at all. Mirrors
+    STARROCKS_DBT_TARGET_MAP["dev"] / DATA_LAKE_ENV_MAP["dev"] in
+    lakehouse.lib.dbt_environment, which the Dagster side resolves from.
+    """
+    assert _ENVS["dev"]["dbt_target"] == _ENVS["qa"]["dbt_target"]
+    assert _ENVS["dev"]["host"] == _ENVS["qa"]["host"]
+    assert _ENVS["dev"]["data_lake_env"] == "production"
+    assert _ENVS["qa"]["data_lake_env"] == "qa"
 
 
 def test_ci_connects_directly_like_production() -> None:
@@ -69,7 +94,12 @@ def test_port_is_free_false_when_bound() -> None:
 
 @pytest.fixture(autouse=True)
 def _clean_env(monkeypatch: pytest.MonkeyPatch) -> None:
-    for key in ("DBT_STARROCKS_USERNAME", "DBT_STARROCKS_PASSWORD", "DBT_STARROCKS_HOST"):
+    for key in (
+        "DBT_STARROCKS_USERNAME",
+        "DBT_STARROCKS_PASSWORD",
+        "DBT_STARROCKS_HOST",
+        "DBT_DATA_LAKE_ENV",
+    ):
         monkeypatch.delenv(key, raising=False)
 
 
@@ -99,6 +129,40 @@ def test_ci_env_skips_port_forward_by_default(mock_fetch, mock_port_forward, moc
     assert os.environ["DBT_STARROCKS_HOST"] == _ENVS["ci"]["host"]
     _, kwargs = mock_dbt_run.call_args
     assert kwargs["target"] == _ENVS["ci"]["dbt_target"]
+
+
+@patch("ol_dbt_cli.commands.starrocks._dbt_run")
+@patch("ol_dbt_cli.commands.starrocks._start_port_forward")
+@patch("ol_dbt_cli.commands.starrocks.fetch_vault_db_credentials")
+def test_dev_env_reads_production_lake_from_qa_cluster(mock_fetch, mock_port_forward, mock_dbt_run) -> None:
+    """`--env dev` must connect to QA but export the production lake."""
+    mock_fetch.return_value = ("user", "pass")
+    run(env="dev")
+
+    mock_port_forward.assert_called_once()
+    assert os.environ["DBT_DATA_LAKE_ENV"] == "production"
+    _, kwargs = mock_dbt_run.call_args
+    assert kwargs["target"] == "starrocks_qa_vault"
+
+
+@patch("ol_dbt_cli.commands.starrocks._dbt_run")
+@patch("ol_dbt_cli.commands.starrocks._start_port_forward")
+@patch("ol_dbt_cli.commands.starrocks.fetch_vault_db_credentials")
+def test_explicit_target_keeps_the_env_s_data_lake(mock_fetch, mock_port_forward, mock_dbt_run) -> None:
+    """--target moves the cluster; it must not move the lake with it.
+
+    The whole point of the split is that "which cluster" and "which lake" are
+    answered separately, so overriding one must leave the other alone.
+    """
+    mock_fetch.return_value = ("user", "pass")
+    run(env="dev", target="starrocks_production")
+
+    assert os.environ["DBT_DATA_LAKE_ENV"] == "production"
+    _, kwargs = mock_dbt_run.call_args
+    assert kwargs["target"] == "starrocks_production"
+
+    run(env="qa", target="starrocks_production")
+    assert os.environ["DBT_DATA_LAKE_ENV"] == "qa"
 
 
 @patch("ol_dbt_cli.commands.starrocks._dbt_run")


### PR DESCRIPTION
Step 1 of [RFC 12711](https://github.com/mitodl/hq/discussions/12711). Stacked on #2507
(the spec) — review that one first for context, or read this one standalone; it does not
depend on the spec's conclusions, only shares their motivation.

## The bug

The two dbt projects in the lakehouse code location disagreed about what
`DAGSTER_ENVIRONMENT=qa` meant. The Trino project's target map had no `qa` entry and fell
through to `default="production"`; the StarRocks project mapped `"qa"` to
`starrocks_qa_vault`. One code location, opposite environments — the immediate cause of the
B2B dashboard 500s in RC.

**The fall-through is the defect, not the value it landed on.** Nobody had to state what
`qa` meant, so nobody noticed the two answers differed. Both maps now list every environment
and raise on one they don't know.

`qa` resolves to QA, which is what the rest of the code location was already wired for —
`trino_host_map` and `trino_catalog_map` (`definitions.py:58-70`) have pointed `qa` at the QA
Starburst cluster and `ol_data_lake_qa` all along. Only the dbt target map disagreed.

## Reconciling the maps alone would have left local dev broken

The b2b sources chose their catalog with `'qa' in target.name` — a substring test — and the
dev StarRocks target is `starrocks_qa_vault`. So **a developer's local b2b build read the
empty QA lake**, and those models could not be developed locally at all, for the same reason
they 500 in RC. This was not in the RFC's audit; it turned up while verifying the first defect.

One string was answering two questions: *which cluster do I connect to* and *which lake do I
read*. Those genuinely diverge for `dev`, which port-forwards to the QA cluster but wants
production data. They are now separate axes, with the lake carried in `DBT_DATA_LAKE_ENV`.

| `DAGSTER_ENVIRONMENT` | Trino target | StarRocks target | lake read |
|---|---|---|---|
| `dev` | `dev_production` | `starrocks_qa_vault` | `production` ← was `qa` |
| `ci` | `ci` | `starrocks_production` | `qa` |
| `qa` | `qa` ← was `production` | `starrocks_qa_vault` | `qa` |
| `production` | `production` | `starrocks_production` | `production` |

## Two implementation notes

**Why an env var, not `--vars`.** dbt does not recursively render `dbt_project.yml` `vars`
values — a var holding `{{ env_var(...) }}` arrives at the source properties unrendered
(verified; the first attempt failed exactly this way). Macros aren't in the source-YAML render
context either. An env var also reaches both the manifest parse and the build without threading
vars through `DbtProject`.

**Why the maps moved to `lakehouse/lib/`.** So they can be tested without a parsed manifest on
disk — importing the asset modules evaluates a `@dbt_assets` decorator, which needs one. Same
reason `lib/starrocks_dbt.py` exists, and it puts both projects' targets in one file so they
cannot drift apart again.

## Verification

- `pre-commit run --all-files` clean; `mypy` clean
- 50 lakehouse tests, 404 `ol_dbt_cli` tests, 52 `packages/` tests pass
- New `test_dbt_environment.py` asserts **agreement and exhaustiveness** rather than specific
  target strings, since those are what actually broke. It caught a real distinction while being
  written: `dev` legitimately diverges between the two projects (no laptop-reachable production
  StarRocks FE), so the agreement invariant holds for deployed environments only — which is
  itself the argument for separating the two axes.
- `dbt parse --target starrocks_qa_vault` under both `DBT_DATA_LAKE_ENV` values resolves the b2b
  sources to `ol_data_lake_{production,qa}` correctly — the same target, two lakes, which is the
  case the substring test could not express.

## Before merging

Two things this PR deliberately does not do:

1. **Check `dbt_automation_sensor` in the QA Dagster UI.** It is defined with no environment gate
   (`definitions.py:441-453`). Combined with the *current* `default="production"`, a QA code
   location running it materializes dbt assets against the **production** Trino warehouse. That
   is an instance setting, not repo config, so I can't confirm it from here. This PR removes the
   fall-through that makes it dangerous, but if the sensor has been running, that's worth knowing
   about independently.
2. **Confirm the QA code location's Trino credentials.** `DBT_TRINO_USERNAME`/`PASSWORD` must be
   valid for the QA Starburst cluster now that `qa` actually targets it.

Expect QA dbt builds to be empty or partial until step 8 re-establishes the QA `app_postgres`
layer. That is correct, and is what the union-completeness contract (steps 4–5) exists to make
loud rather than silent.

Also noted in passing, not fixed: `profiles.yml` has no `ci` output, so the `ci` target entry
doesn't name a real target. Pre-existing and inert (nothing runs dbt under
`DAGSTER_ENVIRONMENT=ci`); left alone rather than guessed at, and now commented.

Task: `tk-step-1-reconcile-dbt-target-resolution-between-t-d88093`. Unblocks step 8 (B2B pilot).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K6WQSqfoDKwUxvdRdxY4zB
