### PR TITLE
fix(mitxpro): dedupe ecommerce_linerunselection on line_id and courserun_id

### DIFF
--- a/src/ol_dbt/models/staging/mitxpro/stg__mitxpro__app__postgres__ecommerce_linerunselection.sql
+++ b/src/ol_dbt/models/staging/mitxpro/stg__mitxpro__app__postgres__ecommerce_linerunselection.sql
@@ -4,6 +4,7 @@ with source as (
 
 )
 
+{{ deduplicate_raw_table(order_by='updated_on', partition_columns='line_id, run_id') }}
 , renamed as (
 
     select
@@ -12,7 +13,7 @@ with source as (
         , run_id as courserun_id
         ,{{ cast_timestamp_to_iso8601('created_on') }} as linerunselection_created_on
         ,{{ cast_timestamp_to_iso8601('updated_on') }} as linerunselection_updated_on
-    from source
+    from most_recent_source
 
 )
 


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
NA
https://pipelines.odl.mit.edu/runs/2352b28d-80fd-4ac4-9f03-da620a87f612

```
[31mFailure in test dbt_expectations_expect_compound_columns_to_be_unique_stg__mitxpro__app__postgres__ecommerce_linerunselection_line_id__courserun_id (models/staging/mitxpro/_stg_mitxpro__models.yml)[0m

  Got 44 results, configured to fail if >10
```

### Description (What does it do?)
<!--- Describe your changes in detail -->
 Applies deduplication to stg__mitxpro__app__postgres__ecommerce_linerunselection to drop the 44 duplicate pairs that were failing the compound uniqueness test. The old rows are deleted in the source system. 

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->
dbt build --select stg__mitxpro__app__postgres__ecommerce_linerunselection
### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->


<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
