### PR TITLE
fix(migration): exclude retired users from edxorg_to_mitxonline_program_entitlements

### DIFF
--- a/src/ol_dbt/models/migration/edxorg_to_mitxonline_program_entitlements.sql
+++ b/src/ol_dbt/models/migration/edxorg_to_mitxonline_program_entitlements.sql
@@ -27,6 +27,7 @@ with mitxonline_programs as (
         , number_of_redeemed_entitlements
     from {{ ref('stg__edxorg__program_entitlement') }}
     where user_email is not null
+        and user_email not like 'retired__user%'
         and (
             expiration_date is null
             or expiration_date


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
https://github.com/mitodl/hq/issues/10382

### Description (What does it do?)
<!--- Describe your changes in detail -->
exclude retired users from edxorg_to_mitxonline_program_entitlements  


### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

dbt build --select edxorg_to_mitxonline_program_entitlements

### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->


<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
