### PR TITLE
fix(openedx): batch course_version_sensor so ticks finish and course archives get re-exported

### DIFF
--- a/dg_projects/openedx/openedx/components/openedx_deployment.py
+++ b/dg_projects/openedx/openedx/components/openedx_deployment.py
@@ -137,7 +137,13 @@ class OpenEdxDeploymentComponent:
             ],
             job=None,
             default_status=DefaultSensorStatus.STOPPED,
-            minimum_interval_seconds=60 * 60,
+            # TEMPORARY (mitodl/hq#12739): the sensor scans a bounded slice of the
+            # partitions per tick, so cadence sets how fast it works through the
+            # ~3 month backlog of un-exported course runs. Ticking every 5 minutes
+            # instead of hourly turns a multi-day first pass into a few hours. Put
+            # this back to `60 * 60` once the backlog is drained -- steady state
+            # needs nothing like this rate.
+            minimum_interval_seconds=5 * 60,
             evaluation_fn=course_version_sensor,
         )
 

--- a/dg_projects/openedx/openedx/sensors/openedx.py
+++ b/dg_projects/openedx/openedx/sensors/openedx.py
@@ -1,4 +1,5 @@
 import json
+from bisect import bisect_right
 from datetime import UTC, datetime, timedelta
 
 import httpx2 as httpx
@@ -17,12 +18,60 @@ from openedx.partitions.openedx import (
     OPENEDX_COURSE_RUN_PARTITIONS,
 )
 
+# `get_course_outline` is one HTTP round trip per course run and the sensor tick has a
+# hard timeout, so only a slice of the partitions is checked per tick. Deployments with
+# a few thousand runs cycle through everything in well under a day at hourly ticks.
+COURSE_VERSION_BATCH_SIZE = 250
+# How long after its end date a course run stops being polled for new versions.
+ENDED_COURSE_GRACE_PERIOD = timedelta(days=90)
+# Ended runs are still re-checked this often. Without it, a run whose end date is later
+# pushed out would stay skipped forever on the strength of the stale cached value.
+ENDED_COURSE_RECHECK_INTERVAL = timedelta(days=30)
+
 
 class CourseCursor(BaseModel):
     published_version: str
     published_at: datetime | None = None
     course_start: datetime | None = None
     course_end: datetime | None = None
+    last_checked: datetime | None = None
+
+
+class CourseVersionCursor(BaseModel):
+    """Sensor state: per-run course metadata plus the position of the batch scan."""
+
+    courses: dict[str, CourseCursor] = {}
+    last_scanned_course_run_id: str | None = None
+
+
+def _load_course_version_cursor(raw_cursor: str | None) -> CourseVersionCursor:
+    payload = json.loads(raw_cursor or "{}")
+    if "courses" not in payload:
+        # Migrate the pre-batching cursor, a flat {course_run_id: CourseCursor-as-JSON-
+        # string} map. Dropping it instead would re-request every partition at once.
+        payload = {"courses": {k: json.loads(v) for k, v in payload.items()}}
+    return CourseVersionCursor(**payload)
+
+
+def _skip_ended_course(course_cursor: CourseCursor, now: datetime) -> bool:
+    """Report whether a course run has been over long enough to stop polling it.
+
+    Self-paced runs carry no ``course_end`` and so are never skipped, and any run is
+    re-checked once per ``ENDED_COURSE_RECHECK_INTERVAL`` regardless.
+    """
+    if (
+        course_cursor.course_end is None
+        or course_cursor.course_end > now - ENDED_COURSE_GRACE_PERIOD
+    ):
+        return False
+    return (
+        course_cursor.last_checked is not None
+        and course_cursor.last_checked > now - ENDED_COURSE_RECHECK_INTERVAL
+    )
+
+
+def _parse_timestamp(value: str | None) -> datetime | None:
+    return datetime.fromisoformat(value) if value else None
 
 
 def course_run_sensor(
@@ -69,75 +118,83 @@ def course_run_sensor(
 def course_version_sensor(
     context: SensorEvaluationContext, openedx: OpenEdxApiClientFactory
 ):
-    course_run_ids = OPENEDX_COURSE_RUN_PARTITIONS[
-        openedx.deployment
-    ].get_partition_keys(dynamic_partitions_store=context.instance)
-    # There is a dictionary consisting of course_run_ids as the keys, and the values are
-    # instances of the CourseCursor pydantic class. This sensor calls the
-    # openedx.client.get_course_outline method for a given course_run_id to detect the
-    # current published_version and other metadata to populate an instance of the
-    # CourseCursor object. For any course runs that have course_end datetime that is
-    # more than 3 months in the past, don't bother fetching their versions. For any
-    # course_run_ids that don't have keys in the context cursor, create an entry in the
-    # cursor dictionary with the results of the call to the get_course_outline method.
-    # Returning a SensorResult with a list of RunRequest objects for each course_run_id
-    # instead of AssetMaterialization objects should trigger pipeline runs for the
-    # updated course runs instead of recording asset events.
+    """Request a re-export of any course run whose published version has changed.
 
-    cursor: dict[str, str] = json.loads(context.cursor or "{}")
-    run_requests = []
-    for course_run_id in course_run_ids:
-        course_cursor = CourseCursor(
-            **json.loads(
-                cursor.get(
-                    course_run_id,
-                    CourseCursor(
-                        published_version="",
-                        course_end=datetime(9999, 12, 31, tzinfo=UTC),
-                    ).model_dump_json(),
-                )
-            )
+    ``get_course_outline`` is called for one batch of partitions per tick, resuming from
+    where the previous tick stopped, so that every tick completes within the sensor
+    timeout and commits its progress. Scanning the whole deployment in a single tick
+    made the sensor time out before it emitted any runs or saved any cursor, which is
+    what stalled re-exports for months (mitodl/hq#12739).
+    """
+    course_run_ids = sorted(
+        OPENEDX_COURSE_RUN_PARTITIONS[openedx.deployment].get_partition_keys(
+            dynamic_partitions_store=context.instance
         )
-        if (
-            course_cursor
-            and course_cursor.course_end
-            and course_cursor.course_end <= datetime.now(tz=UTC) - timedelta(days=90)
-        ):
+    )
+    cursor = _load_course_version_cursor(context.cursor)
+
+    # Resume by course run ID rather than by index: the sorted key list shifts as
+    # partitions are added and removed, and an index would silently skip or repeat runs.
+    resume_from = (
+        bisect_right(course_run_ids, cursor.last_scanned_course_run_id)
+        if cursor.last_scanned_course_run_id is not None
+        else 0
+    )
+    if resume_from >= len(course_run_ids):
+        resume_from = 0
+    batch = course_run_ids[resume_from : resume_from + COURSE_VERSION_BATCH_SIZE]
+
+    now = datetime.now(tz=UTC)
+    run_requests = []
+    for course_run_id in batch:
+        course_cursor = cursor.courses.get(course_run_id)
+        if course_cursor and _skip_ended_course(course_cursor, now):
             continue
         try:
             response = openedx.client.get_course_outline(course_run_id)
         except httpx.HTTPStatusError as e:
             if e.response.status_code != HTTP_NOT_FOUND:
                 raise
-            context.log.exception("Course outline not found for key %s", course_run_id)
+            context.log.warning("Course outline not found for key %s", course_run_id)
             continue
-        if response["published_version"] != course_cursor.published_version:
-            course_update = CourseCursor(
-                published_version=response["published_version"],
-                published_at=datetime.fromisoformat(response["published_at"]),
-                course_start=datetime.fromisoformat(response["course_start"])
-                if response["course_start"]
-                else None,
-                course_end=datetime.fromisoformat(response["course_end"])
-                if response["course_end"]
-                else None,
+        published_version = response["published_version"]
+        # Refresh the entry on every successful fetch, not only when the version
+        # changes, so that course_end can never go stale enough to strand a run that
+        # ends up being extended.
+        cursor.courses[course_run_id] = CourseCursor(
+            published_version=published_version,
+            published_at=_parse_timestamp(response["published_at"]),
+            course_start=_parse_timestamp(response["course_start"]),
+            course_end=_parse_timestamp(response["course_end"]),
+            last_checked=now,
+        )
+        if course_cursor and published_version == course_cursor.published_version:
+            continue
+        run_requests.append(
+            RunRequest(
+                run_key=f"{course_run_id}:{published_version}",
+                asset_selection=[
+                    AssetKey((openedx.deployment, "openedx", "courseware")),
+                    AssetKey((openedx.deployment, "openedx", "raw_data", "course_xml")),
+                    AssetKey((openedx.deployment, "openedx", "course_content_webhook")),
+                ],
+                partition_key=course_run_id,
+                tags={"published_version": published_version},
             )
-            run_requests.append(
-                RunRequest(
-                    asset_selection=[
-                        AssetKey((openedx.deployment, "openedx", "courseware")),
-                        AssetKey(
-                            (openedx.deployment, "openedx", "raw_data", "course_xml")
-                        ),
-                        AssetKey(
-                            (openedx.deployment, "openedx", "course_content_webhook")
-                        ),
-                    ],
-                    partition_key=course_run_id,
-                    tags={"published_version": response["published_version"]},
-                )
-            )
-            cursor[course_run_id] = course_update.model_dump_json()
+        )
 
-    context.update_cursor(json.dumps(cursor))
-    return SensorResult(run_requests=run_requests)
+    # An empty batch means there are no partitions at all; otherwise the next tick picks
+    # up after the last key handled here, wrapping to the start once the list is spent.
+    cursor.last_scanned_course_run_id = batch[-1] if batch else None
+    context.log.info(
+        "Checked %s of %s %s course runs (offset %s), requesting %s re-exports.",
+        len(batch),
+        len(course_run_ids),
+        openedx.deployment,
+        resume_from,
+        len(run_requests),
+    )
+    return SensorResult(
+        run_requests=run_requests,
+        cursor=cursor.model_dump_json(exclude_none=True),
+    )

--- a/dg_projects/openedx/openedx/sensors/openedx.py
+++ b/dg_projects/openedx/openedx/sensors/openedx.py
@@ -18,10 +18,17 @@ from openedx.partitions.openedx import (
     OPENEDX_COURSE_RUN_PARTITIONS,
 )
 
-# `get_course_outline` is one HTTP round trip per course run and the sensor tick has a
-# hard timeout, so only a slice of the partitions is checked per tick. Deployments with
-# a few thousand runs cycle through everything in well under a day at hourly ticks.
-COURSE_VERSION_BATCH_SIZE = 250
+# `get_course_outline` is one HTTP round trip per course run, and the tick runs inside
+# Dagster's sensor gRPC timeout -- 60s by default, and nothing in this deployment raises
+# it. The scan is bounded twice over, because a count alone does not bound wall clock:
+# whichever of these two limits is reached first ends the tick, and the cursor is saved
+# either way. Only actual fetches count against the limit; runs skipped by
+# `_skip_ended_course` cost nothing and so must not consume the budget, or a deployment
+# full of long-finished runs would spend every tick skipping and never reach a live one.
+COURSE_VERSION_MAX_FETCHES_PER_TICK = 100
+# Deliberately well under the 60s timeout: a single slow response must not push the tick
+# past it, since a tick that never returns is a tick whose cursor is never written.
+COURSE_VERSION_TICK_BUDGET = timedelta(seconds=30)
 # How long after its end date a course run stops being polled for new versions.
 ENDED_COURSE_GRACE_PERIOD = timedelta(days=90)
 # Ended runs are still re-checked this often. Without it, a run whose end date is later
@@ -120,11 +127,11 @@ def course_version_sensor(
 ):
     """Request a re-export of any course run whose published version has changed.
 
-    ``get_course_outline`` is called for one batch of partitions per tick, resuming from
-    where the previous tick stopped, so that every tick completes within the sensor
-    timeout and commits its progress. Scanning the whole deployment in a single tick
-    made the sensor time out before it emitted any runs or saved any cursor, which is
-    what stalled re-exports for months (mitodl/hq#12739).
+    ``get_course_outline`` is called for a bounded slice of the partitions per tick,
+    resuming from where the previous tick stopped, so that every tick completes within
+    the sensor timeout and commits its progress. Scanning the whole deployment in a
+    single tick made the sensor time out before it emitted any runs or saved any cursor,
+    which is what stalled re-exports for months (mitodl/hq#12739).
     """
     course_run_ids = sorted(
         OPENEDX_COURSE_RUN_PARTITIONS[openedx.deployment].get_partition_keys(
@@ -142,20 +149,41 @@ def course_version_sensor(
     )
     if resume_from >= len(course_run_ids):
         resume_from = 0
-    batch = course_run_ids[resume_from : resume_from + COURSE_VERSION_BATCH_SIZE]
 
-    now = datetime.now(tz=UTC)
+    started = datetime.now(tz=UTC)
     run_requests = []
-    for course_run_id in batch:
+    last_scanned_course_run_id = None
+    fetched = 0
+    failed = 0
+    last_error: httpx.HTTPStatusError | None = None
+    for course_run_id in course_run_ids[resume_from:]:
+        now = datetime.now(tz=UTC)
+        if (
+            fetched >= COURSE_VERSION_MAX_FETCHES_PER_TICK
+            or now - started >= COURSE_VERSION_TICK_BUDGET
+        ):
+            break
+        last_scanned_course_run_id = course_run_id
         course_cursor = cursor.courses.get(course_run_id)
         if course_cursor and _skip_ended_course(course_cursor, now):
             continue
+        fetched += 1
         try:
             response = openedx.client.get_course_outline(course_run_id)
         except httpx.HTTPStatusError as e:
-            if e.response.status_code != HTTP_NOT_FOUND:
-                raise
-            context.log.warning("Course outline not found for key %s", course_run_id)
+            if e.response.status_code == HTTP_NOT_FOUND:
+                context.log.warning(
+                    "Course outline not found for key %s", course_run_id
+                )
+                continue
+            # Log and move on rather than aborting: re-raising here would discard the
+            # whole tick's progress, so one course run that reliably errors would pin
+            # the scan at its offset and nothing past it would ever be checked again.
+            context.log.warning(
+                "Failed to fetch course outline for key %s: %s", course_run_id, e
+            )
+            last_error = e
+            failed += 1
             continue
         published_version = response["published_version"]
         # Refresh the entry on every successful fetch, not only when the version
@@ -172,7 +200,6 @@ def course_version_sensor(
             continue
         run_requests.append(
             RunRequest(
-                run_key=f"{course_run_id}:{published_version}",
                 asset_selection=[
                     AssetKey((openedx.deployment, "openedx", "courseware")),
                     AssetKey((openedx.deployment, "openedx", "raw_data", "course_xml")),
@@ -183,15 +210,32 @@ def course_version_sensor(
             )
         )
 
-    # An empty batch means there are no partitions at all; otherwise the next tick picks
-    # up after the last key handled here, wrapping to the start once the list is spent.
-    cursor.last_scanned_course_run_id = batch[-1] if batch else None
+    if failed and failed == fetched and last_error is not None:
+        # Nothing this tick succeeded, so the LMS is down rather than one course run
+        # being broken. Fail the tick visibly and leave the cursor untouched instead of
+        # advancing past a slice that was never really checked.
+        raise last_error
+
+    # `last_scanned_course_run_id` is None only when there are no partitions at all;
+    # otherwise the next tick resumes after the last key handled here, wrapping to the
+    # start of the list once it is spent.
+    cursor.last_scanned_course_run_id = last_scanned_course_run_id
+    # Drop entries for partitions that no longer exist, so the cursor blob -- read and
+    # rewritten in full on every tick -- doesn't grow without bound as runs churn.
+    live_course_run_ids = set(course_run_ids)
+    cursor.courses = {
+        key: value
+        for key, value in cursor.courses.items()
+        if key in live_course_run_ids
+    }
     context.log.info(
-        "Checked %s of %s %s course runs (offset %s), requesting %s re-exports.",
-        len(batch),
+        "Fetched %s of %s %s course outlines (offset %s, %s failed), "
+        "requesting %s re-exports.",
+        fetched,
         len(course_run_ids),
         openedx.deployment,
         resume_from,
+        failed,
         len(run_requests),
     )
     return SensorResult(

--- a/dg_projects/openedx/openedx_tests/test_sensors.py
+++ b/dg_projects/openedx/openedx_tests/test_sensors.py
@@ -1,0 +1,285 @@
+"""Tests for course_version_sensor's batching, cursor, and skip behaviour.
+
+The failure these guard against (mitodl/hq#12739) was a tick that never finished:
+because the run requests and the cursor write both happened after a loop over every
+partition in the deployment, a timeout mid-loop discarded the whole tick's work and the
+next tick started over from the same place.
+"""
+
+import json
+from datetime import UTC, datetime, timedelta
+
+import dagster as dg
+import httpx2 as httpx
+import pytest
+from openedx.partitions.openedx import OPENEDX_COURSE_RUN_PARTITIONS
+from openedx.sensors.openedx import (
+    ENDED_COURSE_GRACE_PERIOD,
+    ENDED_COURSE_RECHECK_INTERVAL,
+    CourseCursor,
+    CourseVersionCursor,
+    course_version_sensor,
+)
+
+DEPLOYMENT = "mitxonline"
+
+
+def http_error(status_code: int) -> httpx.HTTPStatusError:
+    request = httpx.Request("GET", "https://lms.example.edu")
+    message = f"HTTP {status_code}"
+    return httpx.HTTPStatusError(
+        message, request=request, response=httpx.Response(status_code, request=request)
+    )
+
+
+class FakeOpenEdxClient:
+    """Stands in for OpenEdxApiClient, recording which outlines were requested."""
+
+    def __init__(self, outlines: dict[str, dict[str, str | None]]):
+        self.outlines = outlines
+        self.requested: list[str] = []
+
+    def get_course_outline(self, course_id: str) -> dict[str, str | None]:
+        self.requested.append(course_id)
+        if course_id not in self.outlines:
+            raise http_error(404)
+        return self.outlines[course_id]
+
+
+class FakeOpenEdxApiClientFactory:
+    def __init__(self, client: FakeOpenEdxClient, deployment: str = DEPLOYMENT):
+        self.client = client
+        self.deployment = deployment
+
+
+def outline(
+    published_version: str,
+    course_end: str | None = None,
+    published_at: str = "2026-08-05T00:00:00+00:00",
+    course_start: str | None = "2026-01-01T00:00:00+00:00",
+) -> dict[str, str | None]:
+    return {
+        "published_version": published_version,
+        "published_at": published_at,
+        "course_start": course_start,
+        "course_end": course_end,
+    }
+
+
+def run_key(course_run_id: str) -> str:
+    return f"course-v1:MITx+{course_run_id}+1T2026"
+
+
+@pytest.fixture
+def instance() -> dg.DagsterInstance:
+    return dg.DagsterInstance.ephemeral()
+
+
+def add_partitions(instance: dg.DagsterInstance, course_run_ids: list[str]) -> None:
+    instance.add_dynamic_partitions(
+        OPENEDX_COURSE_RUN_PARTITIONS[DEPLOYMENT].name, course_run_ids
+    )
+
+
+def evaluate(
+    instance: dg.DagsterInstance,
+    client: FakeOpenEdxClient,
+    cursor: str | None = None,
+) -> dg.SensorResult:
+    context = dg.build_sensor_context(instance=instance, cursor=cursor)
+    return course_version_sensor(context, FakeOpenEdxApiClientFactory(client))
+
+
+def parse_cursor(result: dg.SensorResult) -> CourseVersionCursor:
+    return CourseVersionCursor(**json.loads(result.cursor))
+
+
+def test_batches_partitions_and_resumes_across_ticks(instance, monkeypatch):
+    """Each tick checks one batch and the next picks up where it left off."""
+    monkeypatch.setattr("openedx.sensors.openedx.COURSE_VERSION_BATCH_SIZE", 2)
+    course_run_ids = [run_key(f"C{n}") for n in range(5)]
+    add_partitions(instance, course_run_ids)
+    client = FakeOpenEdxClient({key: outline("v1") for key in course_run_ids})
+
+    cursor = None
+    seen: list[str] = []
+    for _ in range(3):
+        result = evaluate(instance, client, cursor)
+        cursor = result.cursor
+        seen.extend(request.partition_key for request in result.run_requests)
+
+    assert seen == course_run_ids
+    assert client.requested == course_run_ids
+
+
+def test_wraps_to_the_start_once_every_partition_is_scanned(instance, monkeypatch):
+    """After the last partition the scan restarts, so versions keep being re-checked."""
+    monkeypatch.setattr("openedx.sensors.openedx.COURSE_VERSION_BATCH_SIZE", 2)
+    course_run_ids = [run_key(f"C{n}") for n in range(3)]
+    add_partitions(instance, course_run_ids)
+    client = FakeOpenEdxClient({key: outline("v1") for key in course_run_ids})
+
+    cursor = None
+    for _ in range(2):
+        cursor = evaluate(instance, client, cursor).cursor
+    client.requested.clear()
+
+    result = evaluate(instance, client, cursor)
+
+    assert client.requested == course_run_ids[:2]
+    assert parse_cursor(result).last_scanned_course_run_id == course_run_ids[1]
+
+
+def test_resume_position_survives_partitions_being_removed(instance, monkeypatch):
+    """Resuming by course run ID, not by index, so a shrinking list can't skip runs."""
+    monkeypatch.setattr("openedx.sensors.openedx.COURSE_VERSION_BATCH_SIZE", 2)
+    course_run_ids = [run_key(f"C{n}") for n in range(6)]
+    add_partitions(instance, course_run_ids)
+    client = FakeOpenEdxClient({key: outline("v1") for key in course_run_ids})
+
+    cursor = evaluate(instance, client).cursor
+    instance.delete_dynamic_partition(
+        OPENEDX_COURSE_RUN_PARTITIONS[DEPLOYMENT].name, course_run_ids[0]
+    )
+    client.requested.clear()
+
+    evaluate(instance, client, cursor)
+
+    assert client.requested == course_run_ids[2:4]
+
+
+def test_only_requests_runs_for_changed_versions(instance):
+    course_run_id = run_key("C0")
+    add_partitions(instance, [course_run_id])
+    client = FakeOpenEdxClient({course_run_id: outline("v1")})
+
+    first = evaluate(instance, client)
+    second = evaluate(instance, client, first.cursor)
+
+    assert [request.partition_key for request in first.run_requests] == [course_run_id]
+    assert first.run_requests[0].tags["published_version"] == "v1"
+    assert second.run_requests == []
+
+    client.outlines[course_run_id] = outline("v2")
+    third = evaluate(instance, client, second.cursor)
+
+    assert [request.partition_key for request in third.run_requests] == [course_run_id]
+    assert third.run_requests[0].tags["published_version"] == "v2"
+
+
+def test_cursor_is_refreshed_even_when_the_version_is_unchanged(instance):
+    """A run whose version never changes still gets fresh metadata each pass.
+
+    The old sensor only wrote the cursor on a version change, so a cached course_end
+    could age past the grace period and strand the run permanently.
+    """
+    course_run_id = run_key("C0")
+    add_partitions(instance, [course_run_id])
+    ends_at = (datetime.now(tz=UTC) + timedelta(days=30)).isoformat()
+    client = FakeOpenEdxClient({course_run_id: outline("v1", course_end=ends_at)})
+
+    first = evaluate(instance, client)
+    extended_end = (datetime.now(tz=UTC) + timedelta(days=365)).isoformat()
+    client.outlines[course_run_id] = outline("v1", course_end=extended_end)
+    second = evaluate(instance, client, first.cursor)
+
+    assert second.run_requests == []
+    assert parse_cursor(second).courses[
+        course_run_id
+    ].course_end == datetime.fromisoformat(extended_end)
+
+
+def test_skips_long_ended_runs_but_rechecks_them_periodically(instance):
+    recently_checked, overdue, self_paced = (
+        run_key("C0"),
+        run_key("C1"),
+        run_key("C2"),
+    )
+    add_partitions(instance, [recently_checked, overdue, self_paced])
+    now = datetime.now(tz=UTC)
+    ended = now - ENDED_COURSE_GRACE_PERIOD - timedelta(days=1)
+    cursor = CourseVersionCursor(
+        courses={
+            recently_checked: CourseCursor(
+                published_version="v1", course_end=ended, last_checked=now
+            ),
+            overdue: CourseCursor(
+                published_version="v1",
+                course_end=ended,
+                last_checked=now - ENDED_COURSE_RECHECK_INTERVAL - timedelta(days=1),
+            ),
+            # Self-paced runs have no end date and must never be skipped.
+            self_paced: CourseCursor(
+                published_version="v1", course_end=None, last_checked=now
+            ),
+        }
+    )
+    client = FakeOpenEdxClient(
+        {
+            recently_checked: outline("v2", course_end=ended.isoformat()),
+            overdue: outline("v2", course_end=ended.isoformat()),
+            self_paced: outline("v2"),
+        }
+    )
+
+    result = evaluate(instance, client, cursor.model_dump_json())
+
+    assert client.requested == [overdue, self_paced]
+    assert sorted(request.partition_key for request in result.run_requests) == sorted(
+        [overdue, self_paced]
+    )
+
+
+def test_missing_outline_is_skipped_without_failing_the_tick(instance):
+    present, missing = run_key("C0"), run_key("C1")
+    add_partitions(instance, [present, missing])
+    client = FakeOpenEdxClient({present: outline("v1")})
+
+    result = evaluate(instance, client)
+
+    assert [request.partition_key for request in result.run_requests] == [present]
+    assert parse_cursor(result).last_scanned_course_run_id == missing
+
+
+def test_non_404_errors_are_not_swallowed(instance):
+    course_run_id = run_key("C0")
+    add_partitions(instance, [course_run_id])
+
+    class ExplodingClient(FakeOpenEdxClient):
+        def get_course_outline(self, course_id: str) -> dict[str, str | None]:
+            self.requested.append(course_id)
+            raise http_error(500)
+
+    with pytest.raises(httpx.HTTPStatusError):
+        evaluate(instance, ExplodingClient({}))
+
+
+def test_legacy_flat_cursor_is_migrated_without_re_requesting_everything(instance):
+    """The pre-batching cursor must be honoured, not discarded.
+
+    Dropping it would make the first tick after deploy request a re-export of every
+    partition in the deployment at once.
+    """
+    course_run_id = run_key("C0")
+    add_partitions(instance, [course_run_id])
+    legacy_cursor = json.dumps(
+        {
+            course_run_id: CourseCursor(
+                published_version="v1",
+                published_at=datetime(2026, 5, 1, tzinfo=UTC),
+            ).model_dump_json()
+        }
+    )
+    client = FakeOpenEdxClient({course_run_id: outline("v1")})
+
+    result = evaluate(instance, client, legacy_cursor)
+
+    assert result.run_requests == []
+    assert parse_cursor(result).courses[course_run_id].published_version == "v1"
+
+
+def test_empty_deployment_produces_no_runs(instance):
+    result = evaluate(instance, FakeOpenEdxClient({}))
+
+    assert result.run_requests == []
+    assert parse_cursor(result).last_scanned_course_run_id is None

--- a/dg_projects/openedx/openedx_tests/test_sensors.py
+++ b/dg_projects/openedx/openedx_tests/test_sensors.py
@@ -96,7 +96,9 @@ def parse_cursor(result: dg.SensorResult) -> CourseVersionCursor:
 
 def test_batches_partitions_and_resumes_across_ticks(instance, monkeypatch):
     """Each tick checks one batch and the next picks up where it left off."""
-    monkeypatch.setattr("openedx.sensors.openedx.COURSE_VERSION_BATCH_SIZE", 2)
+    monkeypatch.setattr(
+        "openedx.sensors.openedx.COURSE_VERSION_MAX_FETCHES_PER_TICK", 2
+    )
     course_run_ids = [run_key(f"C{n}") for n in range(5)]
     add_partitions(instance, course_run_ids)
     client = FakeOpenEdxClient({key: outline("v1") for key in course_run_ids})
@@ -114,7 +116,9 @@ def test_batches_partitions_and_resumes_across_ticks(instance, monkeypatch):
 
 def test_wraps_to_the_start_once_every_partition_is_scanned(instance, monkeypatch):
     """After the last partition the scan restarts, so versions keep being re-checked."""
-    monkeypatch.setattr("openedx.sensors.openedx.COURSE_VERSION_BATCH_SIZE", 2)
+    monkeypatch.setattr(
+        "openedx.sensors.openedx.COURSE_VERSION_MAX_FETCHES_PER_TICK", 2
+    )
     course_run_ids = [run_key(f"C{n}") for n in range(3)]
     add_partitions(instance, course_run_ids)
     client = FakeOpenEdxClient({key: outline("v1") for key in course_run_ids})
@@ -132,7 +136,9 @@ def test_wraps_to_the_start_once_every_partition_is_scanned(instance, monkeypatc
 
 def test_resume_position_survives_partitions_being_removed(instance, monkeypatch):
     """Resuming by course run ID, not by index, so a shrinking list can't skip runs."""
-    monkeypatch.setattr("openedx.sensors.openedx.COURSE_VERSION_BATCH_SIZE", 2)
+    monkeypatch.setattr(
+        "openedx.sensors.openedx.COURSE_VERSION_MAX_FETCHES_PER_TICK", 2
+    )
     course_run_ids = [run_key(f"C{n}") for n in range(6)]
     add_partitions(instance, course_run_ids)
     client = FakeOpenEdxClient({key: outline("v1") for key in course_run_ids})
@@ -241,9 +247,37 @@ def test_missing_outline_is_skipped_without_failing_the_tick(instance):
     assert parse_cursor(result).last_scanned_course_run_id == missing
 
 
-def test_non_404_errors_are_not_swallowed(instance):
-    course_run_id = run_key("C0")
-    add_partitions(instance, [course_run_id])
+def test_one_broken_course_run_does_not_pin_the_scan(instance):
+    """A run that reliably 500s must not stop every run after it being checked.
+
+    Re-raising would discard the tick's progress, so the next tick would restart at the
+    same offset, raise at the same key, and never reach the rest of the deployment.
+    """
+    broken, healthy = run_key("C0"), run_key("C1")
+    add_partitions(instance, [broken, healthy])
+
+    class PartiallyBrokenClient(FakeOpenEdxClient):
+        def get_course_outline(self, course_id: str) -> dict[str, str | None]:
+            self.requested.append(course_id)
+            if course_id == broken:
+                raise http_error(500)
+            return self.outlines[course_id]
+
+    client = PartiallyBrokenClient({healthy: outline("v1")})
+    result = evaluate(instance, client)
+
+    assert client.requested == [broken, healthy]
+    assert [request.partition_key for request in result.run_requests] == [healthy]
+    assert parse_cursor(result).last_scanned_course_run_id == healthy
+
+
+def test_a_total_upstream_outage_fails_the_tick(instance):
+    """When nothing succeeds it's the LMS, not one course: fail loudly, keep the cursor.
+
+    Advancing past a slice that was never really checked would hide the outage and
+    delay those runs by a full cycle.
+    """
+    add_partitions(instance, [run_key("C0"), run_key("C1")])
 
     class ExplodingClient(FakeOpenEdxClient):
         def get_course_outline(self, course_id: str) -> dict[str, str | None]:
@@ -252,6 +286,50 @@ def test_non_404_errors_are_not_swallowed(instance):
 
     with pytest.raises(httpx.HTTPStatusError):
         evaluate(instance, ExplodingClient({}))
+
+
+def test_skipped_runs_do_not_consume_the_fetch_budget(instance, monkeypatch):
+    """Only real HTTP calls count, so long-finished runs can't starve the live ones."""
+    monkeypatch.setattr(
+        "openedx.sensors.openedx.COURSE_VERSION_MAX_FETCHES_PER_TICK", 1
+    )
+    ended_runs = [run_key(f"C{n}") for n in range(4)]
+    live_run = run_key("C9")
+    add_partitions(instance, [*ended_runs, live_run])
+    now = datetime.now(tz=UTC)
+    cursor = CourseVersionCursor(
+        courses={
+            key: CourseCursor(
+                published_version="v1",
+                course_end=now - ENDED_COURSE_GRACE_PERIOD - timedelta(days=1),
+                last_checked=now,
+            )
+            for key in ended_runs
+        }
+    )
+    client = FakeOpenEdxClient({live_run: outline("v1")})
+
+    result = evaluate(instance, client, cursor.model_dump_json())
+
+    assert client.requested == [live_run]
+    assert [request.partition_key for request in result.run_requests] == [live_run]
+
+
+def test_cursor_drops_entries_for_deleted_partitions(instance):
+    """The cursor is rewritten in full every tick, so it must not grow without bound."""
+    kept, removed = run_key("C0"), run_key("C1")
+    add_partitions(instance, [kept, removed])
+    client = FakeOpenEdxClient({kept: outline("v1"), removed: outline("v1")})
+
+    first = evaluate(instance, client)
+    assert set(parse_cursor(first).courses) == {kept, removed}
+
+    instance.delete_dynamic_partition(
+        OPENEDX_COURSE_RUN_PARTITIONS[DEPLOYMENT].name, removed
+    )
+    second = evaluate(instance, client, first.cursor)
+
+    assert set(parse_cursor(second).courses) == {kept}
 
 
 def test_legacy_flat_cursor_is_migrated_without_re_requesting_everything(instance):

--- a/dg_projects/openedx/pyproject.toml
+++ b/dg_projects/openedx/pyproject.toml
@@ -22,7 +22,11 @@ dependencies = [
 dev = [
     "dagster-dg-cli>=1.12.10",
     "dagster-webserver",
+    "pytest>=9.0.1,<10",
 ]
+
+[tool.pytest.ini_options]
+testpaths = ["openedx_tests"]
 
 [build-system]
 requires = ["setuptools"]

--- a/dg_projects/openedx/uv.lock
+++ b/dg_projects/openedx/uv.lock
@@ -1217,6 +1217,15 @@ wheels = [
 ]
 
 [[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
 name = "jinja2"
 version = "3.1.6"
 source = { registry = "https://pypi.org/simple" }
@@ -1581,6 +1590,7 @@ dependencies = [
 dev = [
     { name = "dagster-dg-cli" },
     { name = "dagster-webserver" },
+    { name = "pytest" },
 ]
 
 [package.metadata]
@@ -1601,6 +1611,7 @@ requires-dist = [
 dev = [
     { name = "dagster-dg-cli", specifier = ">=1.12.10" },
     { name = "dagster-webserver" },
+    { name = "pytest", specifier = ">=9.0.1,<10" },
 ]
 
 [[package]]
@@ -1680,6 +1691,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/78/9b/560e4be8e26f6fd133a03630a8df0c663b9e8d61b4ade152b72005aec83b/platformdirs-4.11.0.tar.gz", hash = "sha256:0555d18370482847566ffabcaa53ad7c6c1c29f195989ae1ed634a05f76ea1e0", size = 31953, upload-time = "2026-07-21T13:09:36.565Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/7d/68/d8d58938dfb1370b266a1a729e6d77a985be23689a0496498ee17b2cbf90/platformdirs-4.11.0-py3-none-any.whl", hash = "sha256:360ccded2b7fce0af0ff80cc8f5942a1c5d99b0e856033acb030bfc634709e74", size = 23247, upload-time = "2026-07-21T13:09:35.422Z" },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
 ]
 
 [[package]]
@@ -2056,6 +2076,22 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/43/6d/f991526fdef3cf7739f6db0cdf12b157e840e0ddd4a7e1c2a477da9072d6/pyroaring-1.1.0-cp314-cp314t-win32.whl", hash = "sha256:1fc112b9a9890f89cc645a16604783ed7fa25299f149b0ef7b45a5e2e3c1f31f", size = 241484, upload-time = "2026-04-24T21:29:06.114Z" },
     { url = "https://files.pythonhosted.org/packages/2e/6e/fb9876940acb50df355a473c087b9924e7b3368070403683941653b6fabc/pyroaring-1.1.0-cp314-cp314t-win_amd64.whl", hash = "sha256:d92a0f4c7e6bb7deeafac68c79c92ef9340895fe825cf1a31078443753ab6756", size = 304537, upload-time = "2026-04-24T21:29:07.312Z" },
     { url = "https://files.pythonhosted.org/packages/8a/e0/39afe4bddbed6276c54e35e310aa345fbeb00f8890e96e7f48cdc2be9c66/pyroaring-1.1.0-cp314-cp314t-win_arm64.whl", hash = "sha256:99c42fe1449acfbf130da65e66b4d5b2726aba4497be359bae7672e38a15fc62", size = 234615, upload-time = "2026-04-24T21:29:08.751Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e4/47/b9efed96c114afcfa3c9d3fe98a76a1d14c74a9e266d397cf6eb64be5e01/pytest-9.1.1.tar.gz", hash = "sha256:1088fbde8f2b49d95a549a195707afa7a76a3ce9bcadc26b6d71f0ffda5fe313", size = 1636369, upload-time = "2026-06-19T10:58:32.857Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/24/25/1de2678b631f5a49215c6c96fff41ba892b0a34df68d6d80292b1b48aa7f/pytest-9.1.1-py3-none-any.whl", hash = "sha256:37a86b45efb9a47a61a36449063e8e18d0cab3161329fc099eb21783169c4f0c", size = 386536, upload-time = "2026-06-19T10:58:31.347Z" },
 ]
 
 [[package]]

--- a/packages/ol-orchestrate-lib/src/ol_orchestrate/resources/oauth.py
+++ b/packages/ol-orchestrate-lib/src/ol_orchestrate/resources/oauth.py
@@ -35,6 +35,7 @@ class OAuthApiClient(ConfigurableResource):
     _access_token: str | None = PrivateAttr(default=None)
     _access_token_expires: datetime | None = PrivateAttr(default=None)
     _http_client: httpx.Client | None = PrivateAttr(default=None)
+    _cached_username: str | None = PrivateAttr(default=None)
 
     @property
     def http_client(self) -> httpx.Client:
@@ -68,12 +69,17 @@ class OAuthApiClient(ConfigurableResource):
 
     @property
     def _username(self) -> str:
-        response = self.http_client.get(
-            f"{self.base_url}/api/user/v1/me",
-            headers={"Authorization": f"JWT {self._fetch_access_token()}"},
-        )
-        response.raise_for_status()
-        return response.json()["username"]
+        # Every fetch_with_auth call passes this as a query param, so resolving it per
+        # request doubles the number of HTTP round trips the client makes. It is fixed
+        # for the lifetime of the OAuth credentials, so cache it on the client.
+        if self._cached_username is None:
+            response = self.http_client.get(
+                f"{self.base_url}/api/user/v1/me",
+                headers={"Authorization": f"JWT {self._fetch_access_token()}"},
+            )
+            response.raise_for_status()
+            self._cached_username = response.json()["username"]
+        return self._cached_username
 
     def fetch_with_auth(
         self,

--- a/packages/ol-orchestrate-lib/tests/resources/test_oauth.py
+++ b/packages/ol-orchestrate-lib/tests/resources/test_oauth.py
@@ -1,0 +1,73 @@
+"""Tests for ol_orchestrate.resources.oauth."""
+
+from unittest.mock import MagicMock
+
+import httpx2 as httpx
+import pytest
+from ol_orchestrate.resources.oauth import OAuthApiClient
+
+BASE_URL = "https://lms.example.edu"
+
+
+def _json_response(payload: dict[str, object]) -> MagicMock:
+    response = MagicMock(spec=httpx.Response)
+    response.status_code = 200
+    response.json.return_value = payload
+    response.raise_for_status = MagicMock()
+    return response
+
+
+def build_client(token_url: str | None = None) -> OAuthApiClient:
+    api_client = OAuthApiClient(
+        client_id="test-id",
+        client_secret="test-secret",  # pragma: allowlist secret
+        base_url=BASE_URL,
+        token_url=token_url or f"{BASE_URL}/oauth2/access_token",
+    )
+    http_client = MagicMock(spec=httpx.Client)
+    http_client.post.return_value = _json_response(
+        {"access_token": "test-token", "expires_in": 3600}
+    )
+    api_client._http_client = http_client
+    return api_client
+
+
+@pytest.fixture
+def client() -> OAuthApiClient:
+    return build_client()
+
+
+def test_username_is_fetched_once_and_reused(client):
+    """The /me lookup is cached, so it does not double the request count.
+
+    fetch_with_auth passes the username as a query param on every call; re-resolving
+    it per request is what made the course version sensor issue two HTTP round trips
+    per course run (mitodl/hq#12739).
+    """
+    client.http_client.get.side_effect = [
+        _json_response({"username": "service-account"}),
+        _json_response({"result": "first"}),
+        _json_response({"result": "second"}),
+    ]
+
+    assert client.fetch_with_auth(f"{BASE_URL}/api/thing/") == {"result": "first"}
+    assert client.fetch_with_auth(f"{BASE_URL}/api/thing/") == {"result": "second"}
+
+    me_calls = [
+        call
+        for call in client.http_client.get.call_args_list
+        if call.args and call.args[0].endswith("/api/user/v1/me")
+    ]
+    assert len(me_calls) == 1
+    for call in client.http_client.get.call_args_list[1:]:
+        assert call.kwargs["params"]["username"] == "service-account"
+
+
+def test_username_is_not_requested_for_non_openedx_token_urls():
+    """Clients whose token URL is external don't get the username param at all."""
+    client = build_client(token_url="https://auth.example.com/oauth2/token")
+    client.http_client.get.side_effect = [_json_response({"result": "first"})]
+
+    client.fetch_with_auth(f"{BASE_URL}/api/thing/")
+
+    assert "username" not in client.http_client.get.call_args.kwargs["params"]


### PR DESCRIPTION
### What are the relevant tickets?

Fixes https://github.com/mitodl/hq/issues/12739

### Description (What does it do?)

`course_version_sensor` called `get_course_outline` once per partition across the entire deployment, then emitted its run requests and wrote its cursor only after that loop finished. Once a deployment grew past what fits in a tick, the tick timed out mid-loop and threw away all of its work — no runs requested, no progress saved — so it failed identically every hour. On `mitxonline` that stalled every `openedx/raw_data/course_xml` re-export for roughly three months: a run was exported once, when `mitxonline_courseware_sensor` first discovered its partition, and never again. The same function backs `mitx` and `xpro`, so all three deployments are fixed here.

**Bound the scan and persist the position.** Each tick now stops at whichever comes first — `COURSE_VERSION_MAX_FETCHES_PER_TICK` (100) outline calls or `COURSE_VERSION_TICK_BUDGET` (30s) of wall clock — and records where it stopped, so the tick completes inside the sensor timeout and commits its progress. Both bounds are needed: a count alone doesn't bound time, and Dagster's sensor evaluation runs under `default_sensor_grpc_timeout()`, which is 60s ([`dagster/_grpc/utils.py`](https://github.com/dagster-io/dagster/blob/master/python_modules/dagster/dagster/_grpc/utils.py)) with nothing in this deployment setting `DAGSTER_SENSOR_GRPC_TIMEOUT_SECONDS`, while the HTTP client's own timeout is itself 60s. Only real fetches count against the limit — runs skipped as long-finished cost nothing, so a deployment full of them can't spend its whole budget skipping and never reach a live run.

The resume point is a course run ID resolved with `bisect_right` over the sorted partition list, not an index — partitions are added and removed between ticks, and an index would silently skip or repeat runs. Once the list is exhausted the scan wraps to the start.

**Don't let one broken course run pin the scan.** Non-404 errors previously propagated, which discards the tick's progress; with a resumable scan that turns a single reliably-500ing run into a permanent stall, since every later tick would restart at the same offset, raise at the same key, and never reach anything past it. Those are now logged and skipped. The tick still fails when *every* fetch failed, because that's the LMS being down rather than one bad run, and advancing the cursor past a slice that was never actually checked would hide the outage.

**Preserve the existing cursor.** The pre-batching cursor was a flat `{course_run_id: CourseCursor-as-JSON-string}` map; it is migrated into the new envelope on read. Discarding it would make the first tick after deploy request a re-export of every partition in the deployment at once. Entries for partitions that no longer exist are now pruned, so the blob — deserialized and rewritten in full every tick — stays bounded as runs churn.

**Refresh cursor entries on every successful fetch, not only on a version change.** The old behavior meant a cached `course_end` could age past the 90-day grace period and strand a run permanently, even after its end date was extended. Ended runs are also re-checked every 30 days rather than skipped forever, and self-paced runs (`course_end: null`) are never skipped — which is the case for the UAI runs in the issue.

**Cache the service username on the OAuth client.** `fetch_with_auth` passes `username` as a query param on every request and was re-resolving it from `/api/user/v1/me` each time, doubling the HTTP round trips for every Open edX API call we make. It is fixed for the lifetime of the credentials, so it is now fetched once per client.

### How can this be tested?

Automated — both suites run in the `pytest` workflow (the `openedx` project had no test suite before; this PR adds `openedx_tests` and wires `pytest` into its dev group, and `.github/scripts/discover_pytest_suites.py` picks it up automatically):

```
cd dg_projects/openedx && uv run pytest        # 13 passed
uv run pytest packages/ol-orchestrate-lib/tests # 54 passed, 80 skipped
```

`dg_projects/openedx/openedx_tests/test_sensors.py` drives the sensor against an ephemeral `DagsterInstance` with real dynamic partitions and a fake API client, covering: bounded scanning and resumption across ticks, wrapping at the end of the list, resuming correctly when a partition is deleted mid-scan, skipped runs not consuming the fetch budget, requesting runs only on a version change, the cursor being refreshed when the version is unchanged, the ended-run skip and its periodic re-check, self-paced runs never being skipped, a 404 outline being skipped without failing the tick, one persistently-failing run not blocking the runs after it, a total outage still failing the tick, cursor entries being pruned for deleted partitions, and the legacy flat cursor being migrated without re-requesting everything.

`packages/ol-orchestrate-lib/tests/resources/test_oauth.py` asserts `/api/user/v1/me` is hit once across multiple `fetch_with_auth` calls and that the username param is still omitted for clients whose token URL is not an Open edX one.

Manual validation after deploy, on `mitxonline_course_version_sensor`:

1. Ticks should now succeed rather than timing out. Each tick logs `Fetched <n> of <total> mitxonline course outlines (offset <n>, <n> failed), requesting <n> re-exports.`
2. The `offset` in that log line should advance each tick and wrap to 0 after a full pass. Watch the `failed` count — a persistently non-zero value points at specific broken runs, which are now skipped rather than fatal.
3. Spot-check a stale run against the issue, e.g. `course-v1:UAI_SOURCE+UAI.GS.1+1T2026`: compare `published_at` from `GET https://courses.learn.mit.edu/api/learning_sequences/v1/course_outline/<run>` against the newest object under `openedx/raw_data/course_xml/<run>/` in the landing-zone bucket. After the scan reaches that partition, a fresh archive should appear.

### Additional Context

**The backfill the issue asks for should happen on its own.** Because the old cursor was only written when a version changed, and the sensor last succeeded around early May 2026, the surviving cursor holds each run's May version. Every run published since then differs from it, so a re-export is requested as the scan reaches that partition. At 100 fetches per hourly tick a few thousand active runs take a couple of days for the first full pass; if the resulting run volume needs spreading further, or the deployment turns out to tolerate more, `COURSE_VERSION_MAX_FETCHES_PER_TICK` and `COURSE_VERSION_TICK_BUDGET` in `dg_projects/openedx/openedx/sensors/openedx.py` are the knobs. Raising `DAGSTER_SENSOR_GRPC_TIMEOUT_SECONDS` on the deployment would let the time budget go up with it.

**Known remaining exposure:** `fetch_with_auth` sleeps in-line for up to 60s on an HTTP 429 and the client's request timeout is 60s, so a single rate-limited or very slow response can still overrun a tick. That is now a lost tick rather than a lost sensor — the next one resumes from the saved cursor — but it's the reason the time budget is set at half the gRPC timeout rather than close to it.

**Not addressed here:** the issue also notes that `mitxonline_courseware_sensor` only requests runs for newly discovered partitions, so `course_version_sensor` remains the only path that re-exports an existing run — still a single point of failure, just one that now works. Worth a separate issue if we want a second path.

`mitx` and `xpro` share this code path and are fixed by the same change, but their sensors' tick history should be checked after deploy to confirm they were failing for the same reason and are now green.
