### PR TITLE
 fix(mitxpro): dedupe ecommerce_programrunline on line_id

### DIFF
--- a/src/ol_dbt/models/staging/mitxpro/stg__mitxpro__app__postgres__ecommerce_programrunline.sql
+++ b/src/ol_dbt/models/staging/mitxpro/stg__mitxpro__app__postgres__ecommerce_programrunline.sql
@@ -4,6 +4,7 @@ with source as (
 
 )
 
+{{ deduplicate_raw_table(order_by='updated_on', partition_columns='line_id') }}
 , renamed as (
 
     select
@@ -12,7 +13,7 @@ with source as (
         , program_run_id as programrun_id
         ,{{ cast_timestamp_to_iso8601('created_on') }} as programrunline_created_on
         ,{{ cast_timestamp_to_iso8601('updated_on') }} as programrunline_updated_on
-    from source
+    from most_recent_source
 
 )
 


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->

```
1324 of 2137 FAIL 13 unique_int__mitxpro__ecommerce_line_line_id ............... [[31mFAIL 13[0m in 0.60s]

[31mFailure in test unique_int__mitxpro__ecommerce_line_line_id (models/intermediate/mitxpro/_int_mitxpro__models.yml)[0m

  Got 13 results, configured to fail if >10
```

### Description (What does it do?)
<!--- Describe your changes in detail -->
 Applies the deduplicate_raw_table macro to `stg__mitxpro__app__postgres__ecommerce_programrunline`, Same fix as #2510 
### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

dbt build --select stg__mitxpro__app__postgres__ecommerce_programrunline int__mitxpro__ecommerce_line

### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->



<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
