### PR TITLE
fix(automation): retry failed executions so an upstream update is never dropped

### DIFF
--- a/packages/ol-orchestrate-lib/src/ol_orchestrate/lib/automation_policies.py
+++ b/packages/ol-orchestrate-lib/src/ol_orchestrate/lib/automation_policies.py
@@ -2,6 +2,23 @@ from dagster import AutomationCondition
 
 
 def upstream_or_code_changes() -> AutomationCondition:
+    """Materialize when an upstream's data version or this asset's code changed.
+
+    Includes a retry for failed executions. Without it an update can be dropped
+    outright: ``data_version_changed`` is edge-triggered, true only on the tick
+    where the upstream version moved, so if the run that tick launches fails,
+    the signal is gone and nothing ever asks again. The asset then sits
+    indefinitely on stale data while every tick reports nothing to do.
+
+    ``execution_failed`` is level-triggered -- true for as long as the latest
+    execution of the target is a failure -- so it keeps asking until a run
+    succeeds and goes quiet the moment one does. It is deliberately preferred
+    over latching the upstream signal with ``.since(newly_updated())``: a latch
+    only resets on an actual materialization, so an asset declared
+    ``output_required=False`` that legitimately produces nothing would be
+    re-requested on every tick forever. A run that succeeds without emitting an
+    output is not a failed execution, so this formulation stays quiet there.
+    """
     not_in_progress = ~AutomationCondition.in_progress()
     no_upstream_dependencies_in_process = ~AutomationCondition.any_deps_in_progress()
     has_upstream_changes = AutomationCondition.any_deps_updated().replace(
@@ -9,10 +26,16 @@ def upstream_or_code_changes() -> AutomationCondition:
     )
     has_code_changes = AutomationCondition.code_version_changed()
     newly_missing = AutomationCondition.newly_missing()
+    latest_execution_failed = AutomationCondition.execution_failed()
     all_upstream_dependencies_present = ~AutomationCondition.any_deps_missing()
     return (
         not_in_progress
         & no_upstream_dependencies_in_process
-        & (has_upstream_changes | has_code_changes | newly_missing)
+        & (
+            has_upstream_changes
+            | has_code_changes
+            | newly_missing
+            | latest_execution_failed
+        )
         & all_upstream_dependencies_present
     )

--- a/packages/ol-orchestrate-lib/tests/lib/test_automation_policies.py
+++ b/packages/ol-orchestrate-lib/tests/lib/test_automation_policies.py
@@ -1,0 +1,188 @@
+"""Tests for ol_orchestrate.lib.automation_policies.
+
+These drive real runs against an ephemeral instance rather than asserting on
+the shape of the condition tree, because the behaviour that matters -- whether
+an upstream update survives a failed run -- only shows up in the interaction
+between the condition, the event log, and actual run records.
+"""
+
+from collections.abc import Iterator
+
+import dagster as dg
+import pytest
+from dagster import AssetKey, DynamicPartitionsDefinition, Output
+from dagster._core.definitions.data_version import DATA_VERSION_TAG
+from ol_orchestrate.lib.automation_policies import upstream_or_code_changes
+
+PARTITIONS = DynamicPartitionsDefinition(name="test_course_run")
+UPSTREAM_KEY = AssetKey(["test", "upstream"])
+DOWNSTREAM_KEY = AssetKey(["test", "downstream"])
+PARTITION = "run-a"
+
+
+class DownstreamBehaviour:
+    """Controls what the downstream asset does when it executes."""
+
+    SUCCEED = "succeed"
+    FAIL = "fail"
+    NO_OUTPUT = "no_output"
+
+    def __init__(self) -> None:
+        self.mode = self.SUCCEED
+
+
+@pytest.fixture
+def behaviour() -> DownstreamBehaviour:
+    return DownstreamBehaviour()
+
+
+@pytest.fixture
+def instance() -> Iterator[dg.DagsterInstance]:
+    with dg.DagsterInstance.ephemeral() as ephemeral_instance:
+        ephemeral_instance.add_dynamic_partitions(PARTITIONS.name, [PARTITION])
+        yield ephemeral_instance
+
+
+@pytest.fixture
+def graph(behaviour: DownstreamBehaviour):
+    """Build an observable upstream feeding a downstream on the policy."""
+
+    @dg.observable_source_asset(key=UPSTREAM_KEY, partitions_def=PARTITIONS)
+    def upstream(context): ...
+
+    @dg.asset(
+        key=DOWNSTREAM_KEY,
+        partitions_def=PARTITIONS,
+        deps=[UPSTREAM_KEY],
+        automation_condition=upstream_or_code_changes(),
+        # Mirrors course_xml, which emits nothing when the course is gone.
+        output_required=False,
+    )
+    def downstream(context):  # noqa: ARG001
+        if behaviour.mode == DownstreamBehaviour.FAIL:
+            msg = "downstream blew up"
+            raise RuntimeError(msg)
+        if behaviour.mode == DownstreamBehaviour.NO_OUTPUT:
+            return
+        yield Output(None)
+
+    return dg.Definitions(assets=[upstream, downstream]), downstream
+
+
+class Harness:
+    """Drives automation ticks, observations, and runs against one instance."""
+
+    def __init__(self, defs, downstream_asset, instance) -> None:
+        self.defs = defs
+        self.downstream_asset = downstream_asset
+        self.instance = instance
+        self.cursor = None
+
+    def tick(self) -> list[str]:
+        result = dg.evaluate_automation_conditions(
+            defs=self.defs, instance=self.instance, cursor=self.cursor
+        )
+        self.cursor = result.cursor
+        return sorted(result.get_requested_partitions(DOWNSTREAM_KEY))
+
+    def observe(self, version: str) -> None:
+        self.instance.report_runless_asset_event(
+            dg.AssetObservation(
+                asset_key=UPSTREAM_KEY,
+                partition=PARTITION,
+                tags={DATA_VERSION_TAG: version},
+            )
+        )
+
+    def execute_downstream(self) -> None:
+        dg.materialize(
+            [self.downstream_asset],
+            instance=self.instance,
+            partition_key=PARTITION,
+            raise_on_error=False,
+        )
+
+    def reach_steady_state(self, behaviour: DownstreamBehaviour) -> None:
+        """Observe v1 and export it successfully, so nothing is outstanding."""
+        behaviour.mode = DownstreamBehaviour.SUCCEED
+        self.observe("v1")
+        self.tick()
+        self.execute_downstream()
+        assert self.tick() == []
+
+
+@pytest.fixture
+def harness(graph, instance) -> Harness:
+    defs, downstream_asset = graph
+    return Harness(defs, downstream_asset, instance)
+
+
+def test_upstream_version_change_requests_the_downstream(harness, behaviour) -> None:
+    """The baseline: a new upstream data version asks for a materialization."""
+    harness.reach_steady_state(behaviour)
+
+    harness.observe("v2")
+
+    assert harness.tick() == [PARTITION]
+
+
+def test_unchanged_upstream_version_requests_nothing(harness, behaviour) -> None:
+    """Re-observing the same version must not churn the downstream."""
+    harness.reach_steady_state(behaviour)
+
+    harness.observe("v1")
+
+    assert harness.tick() == []
+
+
+def test_update_is_retried_after_a_failed_run(harness, behaviour) -> None:
+    """An upstream update must survive the run it launches failing.
+
+    data_version_changed is edge-triggered, so without execution_failed the
+    signal is consumed by the first tick and a failed run drops the update
+    permanently -- the asset stays stale while every later tick reports
+    nothing to do. This is the regression that left Open edX course archives
+    un-exported for months (mitodl/hq#12739).
+    """
+    harness.reach_steady_state(behaviour)
+    harness.observe("v2")
+    assert harness.tick() == [PARTITION]
+
+    behaviour.mode = DownstreamBehaviour.FAIL
+    harness.execute_downstream()
+
+    assert harness.tick() == [PARTITION]
+    assert harness.tick() == [PARTITION]
+
+
+def test_retrying_stops_once_a_run_succeeds(harness, behaviour) -> None:
+    """The retry is level-triggered, so a success clears it."""
+    harness.reach_steady_state(behaviour)
+    harness.observe("v2")
+    harness.tick()
+    behaviour.mode = DownstreamBehaviour.FAIL
+    harness.execute_downstream()
+    assert harness.tick() == [PARTITION]
+
+    behaviour.mode = DownstreamBehaviour.SUCCEED
+    harness.execute_downstream()
+
+    assert harness.tick() == []
+
+
+def test_run_that_succeeds_without_output_is_not_retried(harness, behaviour) -> None:
+    """An output_required=False asset that emits nothing must not spin.
+
+    This is why the retry keys off execution_failed rather than latching the
+    upstream signal until the next materialization: a latch never resets for an
+    asset that legitimately produces nothing, so it would re-request forever.
+    """
+    harness.reach_steady_state(behaviour)
+    harness.observe("v2")
+    assert harness.tick() == [PARTITION]
+
+    behaviour.mode = DownstreamBehaviour.NO_OUTPUT
+    harness.execute_downstream()
+
+    assert harness.tick() == []
+    assert harness.tick() == []


### PR DESCRIPTION
> **Stacked on #2515.** Base is `fix/course-version-sensor-tick-timeout`, so review that first and this diff will shrink to a single file plus its tests once #2515 merges.

### What are the relevant tickets?

Refs https://github.com/mitodl/hq/issues/12739

### Description (What does it do?)

`upstream_or_code_changes()` triggers on `data_version_changed()`, which is **edge-triggered** — true only on the tick where the upstream's data version moved. If the run that tick launches fails, the signal is consumed and nothing ever asks again. The asset then sits indefinitely on stale data while every subsequent tick correctly reports that there is nothing to do.

That is the same defect class as the `course_version_sensor` cursor that #2515 removes — state recording that work was *requested* being mistaken for evidence that it *happened*. Unlike the sensor, this one is not confined to Open edX: the helper is applied at **30 call sites across 7 code locations**, including `_DBT_AUTOMATION_CONDITION` in lakehouse, the edxorg course archives, canvas, ovs_videos, and student_risk_probability.

The fix adds `AutomationCondition.execution_failed()`, which is **level-triggered** — true for as long as the target's latest execution is a failure. It keeps asking until a run succeeds and goes quiet the moment one does.

**Why not latch the upstream signal.** The obvious fix is `.since(AutomationCondition.newly_updated())`, latching the version-change signal until the asset next materializes. It is wrong, and the test for the empty-success case is what rules it out: a latch only resets on an actual materialization, so an asset declared `output_required=False` that legitimately produces nothing would be re-requested on every tick forever. `course_xml` is exactly that shape — it emits no output when the course is gone from the LMS. A run that succeeds without producing an output is not a failed execution, so keying off `execution_failed` stays quiet there.

Measured against a real instance, both scenarios driven by actual runs:

| variant | retries after a failed run | quiet after an empty success |
|---|---|---|
| current helper | ✗ | ✓ |
| `.since(newly_updated())` latch | ✓ | ✗ — re-requests forever |
| `\| execution_failed()` (this PR) | ✓ | ✓ |

### How can this be tested?

```
uv run pytest packages/ol-orchestrate-lib/tests/lib/test_automation_policies.py   # 5 passed
```

The tests drive genuine runs via `dg.materialize` against an ephemeral `DagsterInstance` rather than asserting on the shape of the condition tree, because the behaviour only emerges from the interaction between the condition, the event log, and real run records — a failed execution cannot be reported as a runless event. They cover: an upstream version change requesting the downstream, an unchanged version requesting nothing, the update surviving a failed run and continuing to retry, the retry clearing once a run succeeds, and an `output_required=False` asset that emits nothing not being retried.

Full suites for every code location that consumes the helper, all passing on this branch:

```
uv run pytest packages/ol-orchestrate-lib/tests -m "not integration"   # 58 passed
cd dg_projects/openedx        && uv run pytest    # 19 passed
cd dg_projects/lakehouse      && uv run pytest    # 36 passed
cd dg_projects/edxorg         && uv run pytest    # 32 passed
cd dg_projects/data_loading   && uv run pytest    # 18 passed
```

### Additional Context

**Deploy note.** Any asset whose latest execution is currently a failure becomes eligible on the first automation tick after this ships. That is the intended behaviour — those are exactly the updates being dropped today — but it means the first tick may request more than usual. Worth watching the run queue on the first tick after deploy, particularly in lakehouse where the dbt assets share this condition.

**This is a prerequisite for retiring `course_version_sensor` entirely.** With the version modelled as an observable source asset emitting `DataVersion(published_version)`, `upstream_or_code_changes()` on `course_xml` already expresses everything the sensor does by hand — `~in_progress()` is its in-flight check, `data_version_changed()` its version comparison, `newly_missing()` its never-exported case. I verified that end to end: observing an identical version requests nothing, a new version requests exactly that partition. But it is only safe once the failed-run gap in this PR is closed, otherwise the declarative version inherits the same dropped-update bug.

That conversion is deliberately **not** in this PR. It needs `openedx_live_courseware` turned into a source asset, `course_structure` and `course_xml` moved from `ins=` to `deps=` (`course_structure` already ignores the value — it carries `# noqa: ARG001`), `course_xml` fetching its own outline for the version metadata, `course_run_sensor`'s `asset_selection` reworked, and — the awkward part — `late_bind_partition_to_asset` and `add_prefix_to_asset_keys` in `dg_projects/openedx/openedx/lib/assets_helper.py` taught to handle `SourceAsset`, since both are written against `AssetsDefinition`. That is its own change with its own risk, and it should follow this one rather than ride along.
