### PR TITLE
fix(b2b_analytics): publish the cohort every activity aggregate is attributable to

### DIFF
--- a/src/ol_dbt/dbt_project.yml
+++ b/src/ol_dbt/dbt_project.yml
@@ -146,6 +146,12 @@ models:
         select: ["read_only_production", "ol_data_analyst", "reverse_etl", "mit_learn_etl"]
     b2b_analytics:
       +enabled: "{{ target.type == 'starrocks' }}"
+      # Editing an MV's SELECT is a silent no-op on a plain `dbt build`: dbt only
+      # replaces an existing materialized view on --full-refresh, and
+      # dbt-starrocks reports no configuration changes otherwise. Ship a column
+      # add/rename here with a one-off `dbt run --full-refresh --select
+      # b2b_analytics` (or drop the MV) BEFORE any consumer projects the new
+      # column, or ol-analytics-api's SELECT of it errors on an unknown column.
       +materialized: table
       # The engine-scoping label: dbt_starrocks.py's dbt_assets selects
       # `tag:starrocks`, and dbt.py's Trino-scoped set excludes it. Moving a

--- a/src/ol_dbt/models/b2b_analytics/_b2b_analytics__models.yml
+++ b/src/ol_dbt/models/b2b_analytics/_b2b_analytics__models.yml
@@ -66,7 +66,34 @@ models:
   - name: monthly_active_learners
     description: Distinct learners with any activity in the month.
   - name: new_enrollments
-    description: Sum of the daily enrolled_count flag within the month.
+    description: >
+      Sum of the daily enrolled_count flag within the month -- an EVENT count
+      (learner x course run), not a learner count. Floor it via
+      enrolling_learners, not via its own value.
+  - name: enrolling_learners
+    description: >
+      Distinct learners who newly enrolled in the month -- the cohort
+      new_enrollments is attributable to. Note enrolling does not by itself set
+      active_count, so this is not a subset of monthly_active_learners.
+  - name: certificates_earned
+    description: >
+      Certificates earned in the month -- an EVENT count (learner x course run).
+      Floor it via certified_learners.
+  - name: certified_learners
+    description: Distinct learners who earned a certificate in the month.
+  - name: video_watchers
+    description: >
+      Distinct learners who watched a video in the month -- the cohort
+      total_videos_watched is attributable to, and a strict subset of
+      monthly_active_learners.
+  - name: problem_attempters
+    description: >
+      Distinct learners who attempted a problem in the month -- the cohort
+      total_problems_attempted is attributable to.
+  - name: chatbot_users
+    description: >
+      Distinct learners who used the chatbot in the month -- the cohort
+      total_chatbot_interactions is attributable to.
 
 - name: mv_b2b_program_funnel
   description: >
@@ -104,7 +131,22 @@ models:
   - name: engagement_rate_pct
     description: engaged_learners / total_enrolled_learners * 100.
   - name: avg_videos_per_engaged_learner
-    description: total_videos_watched / count of learners with videos_watched > 0.
+    description: >
+      total_videos_watched / engaged_learners -- averaged across every engaged
+      learner, so learners who watched nothing count as 0.
+  - name: video_watchers
+    description: >
+      Distinct learners who watched at least one video -- the cohort
+      total_videos_watched is attributable to, and a strict subset of
+      engaged_learners.
+  - name: avg_problems_per_engaged_learner
+    description: >
+      total_problems_attempted / engaged_learners -- averaged across every
+      engaged learner, so learners who attempted nothing count as 0.
+  - name: problem_attempters
+    description: >
+      Distinct learners who attempted at least one problem -- the cohort
+      total_problems_attempted is attributable to.
 
 - name: mv_b2b_mit_admin_contract_health
   description: >

--- a/src/ol_dbt/models/b2b_analytics/mv_b2b_content_engagement_depth.sql
+++ b/src/ol_dbt/models/b2b_analytics/mv_b2b_content_engagement_depth.sql
@@ -10,6 +10,14 @@
 -- sso_organization_id (the Keycloak org UUID the ol-analytics-api filters on) is
 -- joined from dim_organization on organization_key; null for free-text
 -- organization_keys that don't resolve to a known mitxonline org.
+--
+-- Every activity SUM here is contributed to by only the learners who did that
+-- specific thing, and those cohorts are strict subsets of engaged_learners
+-- (active_count is 1 on ANY activity -- see organization_administration_report).
+-- ol-analytics-api can only apply its k-anonymity floor to a cohort this view
+-- emits, so each such sum publishes its own contributing cohort count
+-- (video_watchers, problem_attempters, chatbot_users) alongside it. Do not add
+-- an activity aggregate without also emitting the cohort it is attributable to.
 select
     oar.organization_key,
     org.sso_organization_id,
@@ -21,15 +29,17 @@ select
     round(100.0 * count(distinct case when oar.active_count > 0 then oar.user_email end)
         / nullif(count(distinct oar.user_email), 0), 1)                         as engagement_rate_pct,
     sum(oar.videos_watched)                                                     as total_videos_watched,
+    count(distinct case when oar.videos_watched > 0 then oar.user_email end)    as video_watchers,
     round(
         cast(sum(oar.videos_watched) as double)
-        / nullif(count(distinct case when oar.videos_watched > 0
+        / nullif(count(distinct case when oar.active_count > 0
             then oar.user_email end), 0), 1
     )                                                                           as avg_videos_per_engaged_learner,
     sum(oar.problems_count)                                                     as total_problems_attempted,
+    count(distinct case when oar.problems_count > 0 then oar.user_email end)    as problem_attempters,
     round(
         cast(sum(oar.problems_count) as double)
-        / nullif(count(distinct case when oar.problems_count > 0
+        / nullif(count(distinct case when oar.active_count > 0
             then oar.user_email end), 0), 1
     )                                                                           as avg_problems_per_engaged_learner,
     sum(oar.chatbot_used_count)                                                 as total_chatbot_interactions,

--- a/src/ol_dbt/models/b2b_analytics/mv_b2b_monthly_engagement_trend.sql
+++ b/src/ol_dbt/models/b2b_analytics/mv_b2b_monthly_engagement_trend.sql
@@ -12,17 +12,32 @@
 -- sso_organization_id (the Keycloak org UUID the ol-analytics-api filters on) is
 -- joined from dim_organization on organization_key; it is null for free-text
 -- organization_keys that don't resolve to a known mitxonline org.
+--
+-- new_enrollments and certificates_earned count EVENTS (per learner per course
+-- run), not learners: one learner enrolling in six runs reads as six. The
+-- activity totals are likewise contributed to by only the learners who did that
+-- specific thing, and every one of those cohorts is a strict subset of
+-- monthly_active_learners (active_count is 1 on ANY activity, and enrolling
+-- alone doesn't set it at all). ol-analytics-api can only apply its k-anonymity
+-- floor to a cohort this view emits, so each aggregate publishes the distinct
+-- learner count it is attributable to. Do not add an aggregate here without
+-- also emitting its cohort.
 select
     oar.organization_key,
     org.sso_organization_id,
     oar.organization_name,
     oar.activity_year_and_month,
-    count(distinct case when oar.active_count > 0 then oar.user_email end)  as monthly_active_learners,
-    sum(oar.enrolled_count)                                                 as new_enrollments,
-    sum(oar.certificate_count)                                              as certificates_earned,
-    sum(oar.videos_watched)                                                 as total_videos_watched,
-    sum(oar.problems_count)                                                 as total_problems_attempted,
-    sum(oar.chatbot_used_count)                                             as total_chatbot_interactions
+    count(distinct case when oar.active_count > 0 then oar.user_email end)       as monthly_active_learners,
+    sum(oar.enrolled_count)                                                      as new_enrollments,
+    count(distinct case when oar.enrolled_count > 0 then oar.user_email end)     as enrolling_learners,
+    sum(oar.certificate_count)                                                   as certificates_earned,
+    count(distinct case when oar.certificate_count > 0 then oar.user_email end)  as certified_learners,
+    sum(oar.videos_watched)                                                      as total_videos_watched,
+    count(distinct case when oar.videos_watched > 0 then oar.user_email end)     as video_watchers,
+    sum(oar.problems_count)                                                      as total_problems_attempted,
+    count(distinct case when oar.problems_count > 0 then oar.user_email end)     as problem_attempters,
+    sum(oar.chatbot_used_count)                                                  as total_chatbot_interactions,
+    count(distinct case when oar.chatbot_used_count > 0 then oar.user_email end) as chatbot_users
 from {{ source('reporting', 'organization_administration_report') }} oar
 -- Dedupe to one row per organization_key so this join can never fan out and
 -- inflate the aggregates. organization_key is unique per mitxonline org today


### PR DESCRIPTION
### What are the relevant tickets?
N/A — found during the B2B analytics k-anonymity verification pass ([RFC discussion](https://github.com/mitodl/hq/discussions/11845)). Follow-up work in `mitodl/ol-analytics-api` is tracked separately (see Checklist).

### Description (What does it do?)
`ol-analytics-api` enforces the B2B dashboard's k-anonymity floor **per column**, driven by a `CohortPolicy` each response model declares — and it can only floor a cohort the materialized view actually emits ([`core/anonymization.py`](https://github.com/mitodl/ol-analytics-api/blob/main/src/ol_analytics_api/core/anonymization.py)). Both engagement MVs published aggregates whose contributing cohort was never emitted, so a row could clear the primary floor and still disclose a value belonging to a single learner.

The root cause is a semantic one: `active_count` in `organization_administration_report` is 1 on **any** activity — navigation, discussion, video, problem, chatbot, or certificate ([`organization_administration_report.sql#L301-L307`](https://github.com/mitodl/ol-data-platform/blob/main/src/ol_dbt/models/reporting/organization_administration_report.sql#L301-L307)). So the per-activity cohorts (video-watchers, problem-attempters, chatbot-users) are **strict subsets** of `engaged_learners` / `monthly_active_learners`, and clearing the primary floor says nothing about them.

Three concrete defects, all fixed here:

1. **`mv_b2b_content_engagement_depth`: `avg_*_per_engaged_learner` did not divide by `engaged_learners`.** It divided by `count(distinct case when videos_watched > 0 ...)` — a cohort the view never emitted. A row with 30 engaged learners could carry an "average" taken over one watcher, which *is* that learner's exact video count. Both averages now divide by `engaged_learners`, matching their names and making the API's existing `avg_* -> engaged_learners` mapping exactly correct.

2. **Activity SUMs were attributable to unpublished cohorts** in both views. `total_videos_watched`, `total_problems_attempted`, and `total_chatbot_interactions` are plain SUMs, so only the learners who did that specific thing contribute. Each now publishes its contributing distinct-learner count (`video_watchers`, `problem_attempters`, `chatbot_users`) so the API can floor it. `mv_b2b_content_engagement_depth` already emitted `chatbot_users`; this brings the other columns — and the whole monthly view — to parity.

3. **`new_enrollments` / `certificates_earned` count events, not learners.** Both are SUMs of per-learner-per-day 0/1 markers aggregated across a month and across course runs, so one learner enrolling in six courses reads as `new_enrollments = 6` and clears a floor of 5 unaided — yet the API declared them as `secondary` *cohort* counts. They keep event semantics (the more useful trend metric) and are now documented as event counts, with `enrolling_learners` and `certified_learners` emitted alongside so the API can reclassify them from `secondary` to `derived` over a real learner cohort.

**All changes are additive — no renames.** `ol-analytics-api`'s `build_select` projects each model's own field list rather than `SELECT *`, so the deployed service is unaffected until it opts into the new columns.

Also adds a note to the `b2b_analytics` block of `dbt_project.yml` about a deploy trap this change runs into: editing a materialized view's `SELECT` is a **silent no-op** on a plain `dbt build`. dbt only replaces an existing MV under `--full-refresh`, and `dbt-starrocks`' `starrocks__get_materialized_view_configuration_changes` is an empty macro, so dbt reports no configuration changes and executes nothing. The Dagster asset runs a plain `dbt build`, and the MV-refresh asset issues `REFRESH MATERIALIZED VIEW ... WITH SYNC MODE`, which re-runs the *stored* (old) query. Both look green while the change never lands.

### How can this be tested?

These models are StarRocks-only (`+enabled: "{{ target.type == 'starrocks' }}"`), so the SQL was validated credential-free and the semantics were checked against production data on the local DuckDB/Iceberg target.

**Static checks** (no warehouse credentials required):

```bash
ol-dbt validate --model b2b_analytics   # 0 errors
ol-dbt impact                           # 0 breaking, additive-only on both models
prek run --files src/ol_dbt/models/b2b_analytics/* src/ol_dbt/dbt_project.yml   # all green (incl. sqlfluff)
```

`ol-dbt impact` reports the added columns and no breaking downstream impact:

```
ℹ️  INFO mv_b2b_content_engagement_depth
   Column(s) added — no breaking downstream impact detected.
     ➕ problem_attempters   ➕ video_watchers
ℹ️  INFO mv_b2b_monthly_engagement_trend
   Column(s) added — no breaking downstream impact detected.
     ➕ certified_learners  ➕ chatbot_users  ➕ enrolling_learners
     ➕ problem_attempters  ➕ video_watchers
```

**Semantic verification against production data.** The new aggregate expressions were run over `ol_warehouse_production_reporting.organization_administration_report` via the locally registered Glue/Iceberg views (read-only, zero-copy — `ol-dbt local register --database ol_warehouse_production_reporting`), checking both the invariants and how much the change actually protects:

`mv_b2b_monthly_engagement_trend` — 1127 org × month rows:

```
bad_video_subset          0   -- every activity cohort <= monthly_active_learners
bad_problem_subset        0
bad_chatbot_subset        0
bad_enroll_events         0   -- no event sum below its distinct-learner cohort
bad_cert_events           0
rows_newly_protected    139   -- rows clearing k=5 that publish an activity total
                              -- contributed by a 1-4 learner cohort
enroll_event_masking     12   -- new_enrollments >= 5 from only 1-4 learners
cert_event_masking       13   -- certificates_earned >= 5 from only 1-4 learners
```

`mv_b2b_content_engagement_depth` — 3875 org × course_run rows:

```
bad_video_subset             0
bad_problem_subset           0
new_avg_above_old            0    -- the new average never exceeds the old (larger denominator)
rows_newly_protected       134    -- rows with engaged_learners >= 5 whose video average
                                  -- was taken over 1-4 watchers
worst_single_watcher_avg  22.0    -- one learner's exact video count, published as an "average"
```

**Reviewer validation.** The invariants are structural and re-runnable — any of the `bad_*` counters being nonzero would mean a cohort is not the subset the model claims. To check on a live cluster after merge:

```sql
-- every activity cohort must be a subset of the primary cohort
SELECT count(*) FROM b2b_analytics.mv_b2b_monthly_engagement_trend
WHERE video_watchers > monthly_active_learners
   OR problem_attempters > monthly_active_learners
   OR chatbot_users > monthly_active_learners;   -- expect 0

SELECT count(*) FROM b2b_analytics.mv_b2b_content_engagement_depth
WHERE video_watchers > engaged_learners
   OR problem_attempters > engaged_learners;     -- expect 0
```

### Additional Context

**Why emit cohorts rather than rename columns.** Fixing the averages by renaming them to `avg_videos_per_watcher` (and keeping the current denominators) was the alternative. It was rejected because `ol-analytics-api` projects its models' column lists explicitly, so any rename is a breaking change that must be deployed in lockstep. Emitting the cohorts is additive and lets the two repos ship independently, in either order — the API simply cannot floor the new cohorts until it maps them.

**Why `new_enrollments` stays an event count.** For a monthly trend chart "how many enrollments started this month" is the metric a L&D manager expects; converting it to distinct learners would silently change a published number. Publishing `enrolling_learners` next to it gives the API something real to floor without changing the metric.

**What this does *not* fix.** The suppression itself lives in `ol-analytics-api` — this PR only makes the correct suppression *possible*. Until the API-side `CohortPolicy` maps the new columns, the sub-floor disclosures above remain reachable through the endpoints. That change is tracked and must land after the MVs are recreated (below).

### Checklist:
- [ ] After merge, run `dbt run --full-refresh --select b2b_analytics` against the target StarRocks cluster (or drop the MVs) — a plain `dbt build` will **not** apply these column changes.
- [ ] Confirm the new columns exist (`DESC b2b_analytics.mv_b2b_monthly_engagement_trend`) before deploying any consumer that projects them.
- [ ] Then land the `ol-analytics-api` `CohortPolicy` update that floors `enrolling_learners` / `certified_learners` / `video_watchers` / `problem_attempters` / `chatbot_users`, and remove the two `KNOWN SUPPRESSION GAP` docstrings in `tenants/b2b_dashboard/models.py`.
