### PR TITLE
refactor(openedx): drive course exports from an observable source asset

### DIFF
--- a/dg_projects/openedx/openedx/assets/openedx.py
+++ b/dg_projects/openedx/openedx/assets/openedx.py
@@ -4,8 +4,10 @@
 import hashlib
 import io
 import json
+import logging
 import tarfile
 import time
+from concurrent.futures import Future, ThreadPoolExecutor, as_completed
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from tempfile import NamedTemporaryFile
@@ -18,10 +20,16 @@ from dagster import (
     AssetIn,
     AssetKey,
     AssetOut,
+    AutomationCondition,
     DataVersion,
+    DataVersionsByPartition,
+    OpExecutionContext,
     Output,
+    PartitionsDefinition,
+    SourceAsset,
     asset,
     multi_asset,
+    observable_source_asset,
 )
 from flatten_dict import flatten
 from flatten_dict.reducers import make_reducer
@@ -38,34 +46,132 @@ HTTP_SUCCESS = 200
 HTTP_NOT_FOUND = 404
 COURSE_EXPORT_GET_TASKS_STATUS_TIMEOUT = timedelta(minutes=60)
 
+COURSEWARE_ASSET_KEY = AssetKey(["openedx", "courseware"])
 
-@asset(
-    description=("An instance of courseware running in an Open edX environment."),
-    group_name="openedx",
-    key=AssetKey(["openedx", "courseware"]),
-    required_resource_keys={"openedx"},
-)
-def openedx_live_courseware(context: AssetExecutionContext):
-    courserun_id = context.partition_key
-    # Retrieve the last published timestamp from
-    # /learning_sequences/v1/course_outline/{course_key_str}, using the last published
-    # information as the data version
-    course_outline = context.resources.openedx.client.get_course_outline(courserun_id)
-    return Output(
-        course_outline,
-        data_version=DataVersion(course_outline["published_version"]),
-        metadata={
-            "course_key": courserun_id,
-            "course_title": course_outline["title"],
-            "courseware_published_version": course_outline["published_version"],
-            "courseware_published_at": course_outline["published_at"],
-        },
+# 16 workers measured at ~53 outline fetches/sec against mitxonline with no
+# throttling. ceiling: raise only with fresh numbers from the authenticated
+# endpoint, which is slower than the anonymous one used to measure.
+OUTLINE_FETCH_WORKERS = 16
+
+
+class OutlineFetchError(Exception):
+    """An outline fetch failed in a way that counts against the sweep's tally.
+
+    A course that has vanished from the LMS (404) is deliberately not one of
+    these: there is nothing left to export, so it is not a symptom of trouble.
+    """
+
+
+def published_version_of(
+    future: "Future[dict[str, str]]", course_run_id: str, log: logging.Logger
+) -> str | None:
+    """Resolve one outline fetch into a published version.
+
+    Returns None when the course no longer exists in the LMS, and raises
+    OutlineFetchError when the fetch failed for any other reason.
+    """
+    try:
+        return future.result()["published_version"]
+    except httpx.HTTPStatusError as error:
+        if error.response.status_code == HTTP_NOT_FOUND:
+            log.info("Course outline not found for key %s", course_run_id)
+            return None
+        log.exception("Failed to fetch the course outline for %s", course_run_id)
+        raise OutlineFetchError from error
+    except Exception as error:
+        log.exception("Failed to fetch the course outline for %s", course_run_id)
+        raise OutlineFetchError from error
+
+
+def build_courseware_source_asset(
+    deployment: str, partitions_def: PartitionsDefinition
+) -> SourceAsset:
+    """Build the observable source asset for one deployment's live courseware.
+
+    Courseware lives in the LMS, not in our warehouse, so it is a source asset
+    rather than something we materialize. Observing it is what gives the rest
+    of the graph a reason to run: every downstream carries
+    ``upstream_or_code_changes()``, whose ``data_version_changed()`` term only
+    fires against an *observable source* asset - an AssetObservation reported
+    against a materializable asset does not drive it at all, and a
+    never-materialized materializable upstream trips ``any_deps_missing()`` and
+    blocks the downstream outright.
+
+    Built per deployment by a factory, with the key and partitions passed
+    straight to the decorator, because the ``late_bind_partition_to_asset`` /
+    ``add_prefix_to_asset_keys`` helpers are written against AssetsDefinition
+    and have no SourceAsset equivalent.
+    """
+
+    @observable_source_asset(
+        key=AssetKey([deployment, *COURSEWARE_ASSET_KEY.path]),
+        partitions_def=partitions_def,
+        description="An instance of courseware running in an Open edX environment.",
+        group_name="openedx",
+        # cron_tick_passed rather than on_cron: this asset has no dependencies,
+        # so the dep-freshness half of on_cron is vacuous, and an edge-triggered
+        # hourly tick is the whole intent. in_progress guards against a sweep
+        # that outruns the interval stacking observation runs on top of itself.
+        automation_condition=AutomationCondition.cron_tick_passed("0 * * * *")
+        & ~AutomationCondition.in_progress(),
+        required_resource_keys={"openedx"},
     )
+    def courseware(context: OpExecutionContext) -> DataVersionsByPartition:
+        """Report the published version of every registered course run.
+
+        Observation is per *asset*, not per partition: this runs once for the
+        whole deployment and must return a DataVersionsByPartition (a bare
+        DataVersion is rejected outright for a partitioned asset). So the
+        concurrent fetch lives here, and a full sweep is one run rather than
+        one run per course.
+        """
+        client = context.resources.openedx.client
+        partition_keys = partitions_def.get_partition_keys(
+            dynamic_partitions_store=context.instance
+        )
+        versions: dict[str, DataVersion] = {}
+        failures = 0
+        with ThreadPoolExecutor(max_workers=OUTLINE_FETCH_WORKERS) as executor:
+            futures = {
+                executor.submit(client.get_course_outline, course_run_id): course_run_id
+                for course_run_id in partition_keys
+            }
+            for future in as_completed(futures):
+                course_run_id = futures[future]
+                try:
+                    published_version = published_version_of(
+                        future, course_run_id, context.log
+                    )
+                except OutlineFetchError:
+                    failures += 1
+                    continue
+                # A partition left out of the mapping emits no observation at
+                # all, so its last known version stands. That is what we want
+                # for a course that has vanished from the LMS: there is nothing
+                # to export, and inventing a version would look like a change.
+                if published_version is not None:
+                    versions[course_run_id] = DataVersion(published_version)
+        context.log.info(
+            "Observed %s of %s %s course runs, %s failed",
+            len(versions),
+            len(partition_keys),
+            deployment,
+            failures,
+        )
+        # A sweep where every lookup failed is a bad token or a 500-ing LMS, not
+        # a deployment with nothing to say. Reporting it as a clean observation
+        # would leave every downstream quiet, hourly, forever.
+        if partition_keys and failures == len(partition_keys):
+            msg = f"Course outline sweep failed for all {failures} {deployment} courses"
+            raise RuntimeError(msg)
+        return DataVersionsByPartition(versions)
+
+    return courseware
 
 
 @multi_asset(
     group_name="openedx",
-    ins={"courseware": AssetIn(key=AssetKey(["openedx", "courseware"]))},
+    deps=[COURSEWARE_ASSET_KEY],
     outs={
         "course_blocks": AssetOut(
             automation_condition=upstream_or_code_changes(),
@@ -87,7 +193,7 @@ def openedx_live_courseware(context: AssetExecutionContext):
     },
     required_resource_keys={"openedx"},
 )
-def course_structure(context: AssetExecutionContext, courseware):  # noqa: ARG001
+def course_structure(context: AssetExecutionContext):
     course_id = context.partition_key
     course_status = context.resources.openedx.client.check_course_status(course_id)
     context.log.info("Course status for %s: %s", course_id, course_status)
@@ -156,17 +262,29 @@ def course_structure(context: AssetExecutionContext, courseware):  # noqa: ARG00
         "An importable artifact representing the contents of an Open edX course."
     ),
     group_name="openedx",
-    ins={"courseware": AssetIn(key=AssetKey(["openedx", "courseware"]))},
+    deps=[COURSEWARE_ASSET_KEY],
     io_manager_key="s3file_io_manager",
     key=AssetKey(["openedx", "raw_data", "course_xml"]),
     required_resource_keys={"openedx", "s3"},
     output_required=False,
+    # Exports are slow (they poll Studio for minutes) and arrive in bursts: a
+    # republished term, or a fresh deployment where every course is new, asks
+    # for all of them at once. Their own pool keeps that from filling the
+    # global run slots and queueing every unrelated pipeline behind it.
+    pool="openedx_course_export",
 )
-def course_xml(context: AssetExecutionContext, courseware):
+def course_xml(context: AssetExecutionContext):
     course_key = context.partition_key
     course_status = context.resources.openedx.client.check_course_status(course_key)
     # if the course is found, trigger the XML export
     if course_status == HTTP_SUCCESS:
+        # Read before the export is triggered so the version recorded below is
+        # the one this archive reflects, not one published while it ran. The
+        # upstream observation is what got us here, so this lookup is known to
+        # have just succeeded for this course.
+        published_version = context.resources.openedx.client.get_course_outline(
+            course_key
+        )["published_version"]
         exported_courses = context.resources.openedx.client.export_courses(
             course_ids=[course_key],
         )
@@ -225,9 +343,7 @@ def course_xml(context: AssetExecutionContext, courseware):
             metadata={
                 "course_id": course_key,
                 "object_key": target_path,
-                # Read by course_version_sensor to decide whether the archive in
-                # S3 is older than the course's current published version.
-                "courseware_published_version": courseware["published_version"],
+                "courseware_published_version": published_version,
             },
         )
     # if the course is not found, refer to the last successful materialization

--- a/dg_projects/openedx/openedx/assets/openedx.py
+++ b/dg_projects/openedx/openedx/assets/openedx.py
@@ -269,8 +269,12 @@ def course_structure(context: AssetExecutionContext):
     output_required=False,
     # Exports are slow (they poll Studio for minutes) and arrive in bursts: a
     # republished term, or a fresh deployment where every course is new, asks
-    # for all of them at once. Their own pool keeps that from filling the
-    # global run slots and queueing every unrelated pipeline behind it.
+    # for all of them at once, which without a limit of its own fills the
+    # global run slots and queues every unrelated pipeline behind it.
+    #
+    # Naming the pool here only makes that limit *settable*; it does not impose
+    # one. Until a slot limit is configured for `openedx_course_export` on the
+    # instance (Deployment -> Concurrency), these runs are still unbounded.
     pool="openedx_course_export",
 )
 def course_xml(context: AssetExecutionContext):

--- a/dg_projects/openedx/openedx/components/openedx_deployment.py
+++ b/dg_projects/openedx/openedx/components/openedx_deployment.py
@@ -9,24 +9,25 @@ from dagster import (
     DefaultSensorStatus,
     Definitions,
     SensorDefinition,
+    SourceAsset,
 )
 from ol_orchestrate.lib.constants import DAGSTER_ENV
 from ol_orchestrate.resources.openedx import OpenEdxApiClientFactory
 from ol_orchestrate.resources.secrets.vault import Vault
 
 from openedx.assets.openedx import (
+    build_courseware_source_asset,
     course_structure,
     course_xml,
     extract_courserun_details,
     openedx_course_content_webhook,
-    openedx_live_courseware,
 )
 from openedx.lib.assets_helper import (
     add_prefix_to_asset_keys,
     late_bind_partition_to_asset,
 )
 from openedx.partitions.openedx import OPENEDX_COURSE_RUN_PARTITIONS
-from openedx.sensors.openedx import course_run_sensor, course_version_sensor
+from openedx.sensors.openedx import course_run_sensor
 
 
 class OpenEdxDeploymentComponent:
@@ -53,16 +54,18 @@ class OpenEdxDeploymentComponent:
         self.deployment_name = deployment_name
         self.vault = vault
 
-    def build_assets(self) -> dict[str, AssetsDefinition]:
+    def build_assets(self) -> dict[str, AssetsDefinition | SourceAsset]:
         """Build asset definitions for the deployment.
 
         Returns:
             Dictionary of asset definitions with deployment-specific prefixes and
             partitions.
         """
-        # Create the main courseware asset with deployment-specific partitioning
-        course_version_asset = late_bind_partition_to_asset(
-            add_prefix_to_asset_keys(openedx_live_courseware, self.deployment_name),
+        # The courseware source asset takes its key and partitions directly
+        # rather than through the prefix/late-bind helpers, which only know how
+        # to rewrite an AssetsDefinition.
+        courseware_asset = build_courseware_source_asset(
+            self.deployment_name,
             OPENEDX_COURSE_RUN_PARTITIONS[self.deployment_name],
         )
 
@@ -89,7 +92,7 @@ class OpenEdxDeploymentComponent:
         )
 
         return {
-            "course_version_asset": course_version_asset,
+            "courseware_asset": courseware_asset,
             "course_structure_asset": course_structure_asset,
             "course_xml_asset": course_xml_asset,
             "courserun_detail_asset": courserun_detail_asset,
@@ -97,27 +100,28 @@ class OpenEdxDeploymentComponent:
         }
 
     def build_sensors(
-        self, assets: dict[str, AssetsDefinition]
+        self, assets: dict[str, AssetsDefinition | SourceAsset]
     ) -> list[SensorDefinition]:
         """Build sensor definitions for the deployment.
 
         Args:
-            assets: List of assets to monitor (used for course_version_sensor)
+            assets: The deployment's assets, used to target the sensors.
 
         Returns:
             List of sensor definitions
         """
         # Access individual assets by their keys
-        course_version_asset = assets["course_version_asset"]
         course_xml_asset = assets["course_xml_asset"]
         course_content_webhook_asset = assets["course_content_webhook_asset"]
 
-        # Create asset-bound courseware sensor
+        # Discovery only -- this sensor registers partitions and requests no
+        # runs, so the selection exists purely to give the definition a target.
+        # The courseware source asset is deliberately not in it: a sensor
+        # cannot target something it can never materialize.
         courseware_sensor = SensorDefinition(
             name=f"{self.deployment_name}_courseware_sensor",
             description="Query a running Open edX system for a list of course runs.",
             asset_selection=[
-                course_version_asset,
                 course_xml_asset,
                 course_content_webhook_asset,
             ],
@@ -127,21 +131,10 @@ class OpenEdxDeploymentComponent:
             evaluation_fn=course_run_sensor,
         )
 
-        # Create asset-bound course version sensor
-        asset_bound_course_version_sensor = SensorDefinition(
-            name=f"{self.deployment_name}_course_version_sensor",
-            asset_selection=[
-                course_version_asset,
-                course_xml_asset,
-                course_content_webhook_asset,
-            ],
-            job=None,
-            default_status=DefaultSensorStatus.STOPPED,
-            minimum_interval_seconds=60 * 60,
-            evaluation_fn=course_version_sensor,
-        )
-
-        # Create automation condition sensor
+        # Drives the whole export graph: it requests the hourly observation of
+        # the courseware source asset, and every downstream's
+        # upstream_or_code_changes() then reacts to the versions that
+        # observation reports.
         automation_sensor = AutomationConditionSensorDefinition(
             f"{self.deployment_name}_openedx_automation_sensor",
             minimum_interval_seconds=300 if DAGSTER_ENV == "dev" else 60 * 60,
@@ -150,7 +143,6 @@ class OpenEdxDeploymentComponent:
 
         return [
             courseware_sensor,
-            asset_bound_course_version_sensor,
             automation_sensor,
         ]
 

--- a/dg_projects/openedx/openedx/components/openedx_deployment.py
+++ b/dg_projects/openedx/openedx/components/openedx_deployment.py
@@ -11,7 +11,6 @@ from dagster import (
     SensorDefinition,
     SourceAsset,
 )
-from ol_orchestrate.lib.constants import DAGSTER_ENV
 from ol_orchestrate.resources.openedx import OpenEdxApiClientFactory
 from ol_orchestrate.resources.secrets.vault import Vault
 
@@ -135,9 +134,18 @@ class OpenEdxDeploymentComponent:
         # the courseware source asset, and every downstream's
         # upstream_or_code_changes() then reacts to the versions that
         # observation reports.
+        #
+        # Evaluated every 5 minutes, not hourly. Each link in
+        # courseware -> course_xml -> extract_courserun_details -> webhook can
+        # only advance on a tick, and an observation lands *after* the tick that
+        # requested it, so an hourly interval put roughly an hour between every
+        # pair of steps -- a republish would take most of a day to reach the
+        # webhook. How often the LMS is actually swept is set by the source
+        # asset's cron, not by this: a tick that finds nothing to do costs a
+        # graph evaluation and no API calls.
         automation_sensor = AutomationConditionSensorDefinition(
             f"{self.deployment_name}_openedx_automation_sensor",
-            minimum_interval_seconds=300 if DAGSTER_ENV == "dev" else 60 * 60,
+            minimum_interval_seconds=300,
             target=list(assets.values()),
         )
 

--- a/dg_projects/openedx/openedx/sensors/openedx.py
+++ b/dg_projects/openedx/openedx/sensors/openedx.py
@@ -1,88 +1,13 @@
-import logging
-import time
-from collections.abc import Collection
-from concurrent.futures import Future, ThreadPoolExecutor, as_completed
-from datetime import timedelta
-
-import httpx2 as httpx
 from dagster import (
-    AssetKey,
-    DagsterEventType,
-    DagsterInstance,
-    RunRequest,
-    RunsFilter,
     SensorEvaluationContext,
     SensorResult,
 )
-from dagster._core.event_api import AssetRecordsFilter
-from dagster._core.storage.dagster_run import NOT_FINISHED_STATUSES
-from dagster._core.storage.tags import PARTITION_NAME_TAG, SENSOR_NAME_TAG
 from ol_orchestrate.lib.dagster_helpers import contains_invalid_partition_strings
 from ol_orchestrate.resources.openedx import OpenEdxApiClientFactory
 
-from openedx.lib.magic_numbers import HTTP_NOT_FOUND
 from openedx.partitions.openedx import (
     OPENEDX_COURSE_RUN_PARTITIONS,
 )
-
-COURSEWARE_PUBLISHED_VERSION_METADATA = "courseware_published_version"
-
-
-def exported_versions(
-    instance: DagsterInstance, asset_key: AssetKey, partition_keys: Collection[str]
-) -> dict[str, str | None]:
-    """Map each partition to the course version recorded on its latest export.
-
-    A partition is absent from the result when it has never been exported, and
-    maps to None when it was exported before course_xml started recording the
-    version - both of which mean "we do not know what is in S3", so the caller
-    should re-export.
-
-    Batched deliberately: two queries for the whole deployment rather than one
-    per partition. In steady state almost every partition matches, so the sweep
-    examines all of them, and a per-partition lookup would put a few thousand
-    round trips on the event log inside every tick.
-    """
-    latest_storage_ids = instance.get_latest_storage_id_by_partition(
-        asset_key,
-        DagsterEventType.ASSET_MATERIALIZATION,
-        partitions=set(partition_keys),
-    )
-    if not latest_storage_ids:
-        return {}
-    storage_ids = list(latest_storage_ids.values())
-    records = instance.fetch_materializations(
-        AssetRecordsFilter(asset_key=asset_key, storage_ids=storage_ids),
-        limit=len(storage_ids),
-    ).records
-    versions: dict[str, str | None] = {}
-    for record in records:
-        materialization = record.asset_materialization
-        if materialization is None or materialization.partition is None:
-            continue
-        version = materialization.metadata.get(COURSEWARE_PUBLISHED_VERSION_METADATA)
-        versions[materialization.partition] = str(version.value) if version else None
-    return versions
-
-
-def in_flight_partitions(instance: DagsterInstance, sensor_name: str) -> set[str]:
-    """Return partition keys whose export run this sensor has already launched.
-
-    An export can outlive the tick interval, so without this the sensor would
-    re-request a partition whose run is still queued or running. NOT_FINISHED
-    rather than IN_PROGRESS: the latter omits QUEUED and NOT_STARTED, which is
-    exactly the case a full run queue produces.
-    """
-    return {
-        record.dagster_run.tags[PARTITION_NAME_TAG]
-        for record in instance.get_run_records(
-            RunsFilter(
-                tags={SENSOR_NAME_TAG: sensor_name},
-                statuses=list(NOT_FINISHED_STATUSES),
-            )
-        )
-        if PARTITION_NAME_TAG in record.dagster_run.tags
-    }
 
 
 def course_run_sensor(
@@ -91,19 +16,15 @@ def course_run_sensor(
 ):
     """Register a dynamic partition for every course run the LMS reports.
 
-    Partition discovery only. Exports are left entirely to
-    course_version_sensor, which already treats a partition with no course_xml
-    materialization as needing one, so a new course is picked up on its next
-    tick without this sensor requesting anything.
+    Partition discovery only. Exports are left entirely to the asset graph: the
+    openedx/courseware observable source asset picks up the new partition on its
+    next observation, and ``upstream_or_code_changes()`` on course_xml treats a
+    partition with no materialization as needing one.
 
-    Requesting runs here as well used to double-export every new course:
-    in_flight_partitions filters run records by sensor name, so the run this
-    sensor launched was invisible to course_version_sensor, which then launched
-    a second one for the same partition. It also bypassed
-    MAX_RUN_REQUESTS_PER_TICK entirely -- one unthrottled run per new course,
-    so a bulk course creation or a fresh deployment flooded the run queue no
-    matter how carefully the other sensor was capped. Keeping every export
-    behind a single throttled path is what makes that cap mean anything.
+    Requesting runs here as well used to double-export every new course, and it
+    bypassed the throttling that kept a bulk course creation from flooding the
+    run queue. Leaving every export to the automation condition is what keeps
+    the export path single and observable.
     """
     # Enumerate the course-run IDs from edX via the API
     course_id_generator = openedx.client.get_edx_course_ids()
@@ -136,161 +57,3 @@ def course_run_sensor(
             )
         ],
     )
-
-
-# 16 workers measured at ~53 outline fetches/sec against mitxonline with no
-# throttling. ceiling: raise only with fresh numbers from the authenticated
-# endpoint, which is slower than the anonymous one used to measure.
-OUTLINE_FETCH_WORKERS = 16
-# The deployment sets DAGSTER_SENSOR_GRPC_TIMEOUT_SECONDS=300 in
-# ol-infrastructure applications/dagster/__main__.py. Change these together.
-SWEEP_TIME_BUDGET = timedelta(seconds=200)
-# Each request is one run holding a slot in a global pool of 30 while it polls
-# Studio. ceiling: raise this only after export runs get their own concurrency
-# pool, or unrelated pipelines queue behind catch-up exports.
-MAX_RUN_REQUESTS_PER_TICK = 8
-
-
-class OutlineFetchError(Exception):
-    """An outline fetch failed in a way that counts against the sweep's tally.
-
-    A course that has vanished from the LMS (404) is deliberately not one of
-    these: there is nothing left to export, so it is not a symptom of trouble.
-    """
-
-
-def published_version_of(
-    future: "Future[dict[str, str]]", course_run_id: str, log: logging.Logger
-) -> str | None:
-    """Resolve one outline fetch into a published version.
-
-    Returns None when the course no longer exists in the LMS, and raises
-    OutlineFetchError when the fetch failed for any other reason.
-    """
-    try:
-        return future.result()["published_version"]
-    except httpx.HTTPStatusError as error:
-        if error.response.status_code == HTTP_NOT_FOUND:
-            log.info("Course outline not found for key %s", course_run_id)
-            return None
-        log.exception("Failed to fetch the course outline for %s", course_run_id)
-        raise OutlineFetchError from error
-    except Exception as error:
-        log.exception("Failed to fetch the course outline for %s", course_run_id)
-        raise OutlineFetchError from error
-
-
-def course_version_sensor(
-    context: SensorEvaluationContext, openedx: OpenEdxApiClientFactory
-) -> SensorResult:
-    """Request an export for every course whose published version changed.
-
-    Stateless by design: materialization metadata says what was exported and run
-    records say what is already in flight, so there is no cursor to lose. A tick
-    cut short by the budget or the cap simply emits what it collected - the work
-    it did not reach still mismatches and gets picked up next tick.
-    """
-    # The clock starts here, before the event-log queries below, because the
-    # gRPC tick timeout covers those too. Timing only the fetch phase would let
-    # a slow partition or materialization query eat the margin between the
-    # budget and the timeout and still hand the sweep a full budget after it --
-    # reproducing the killed-tick-with-no-output failure this sensor exists to
-    # fix.
-    sweep_start = time.monotonic()
-    deadline = sweep_start + SWEEP_TIME_BUDGET.total_seconds()
-
-    deployment = openedx.deployment
-    partition_keys = OPENEDX_COURSE_RUN_PARTITIONS[deployment].get_partition_keys(
-        dynamic_partitions_store=context.instance
-    )
-    course_xml_key = AssetKey((deployment, "openedx", "raw_data", "course_xml"))
-    skip_keys = in_flight_partitions(context.instance, context.sensor_name)
-    pending_keys = [key for key in partition_keys if key not in skip_keys]
-    exported = exported_versions(context.instance, course_xml_key, pending_keys)
-
-    run_requests: list[RunRequest] = []
-    examined = 0
-    failures = 0
-
-    executor = ThreadPoolExecutor(max_workers=OUTLINE_FETCH_WORKERS)
-    try:
-        futures = {
-            executor.submit(openedx.client.get_course_outline, key): key
-            for key in pending_keys
-        }
-        # Only whatever is left of the budget after the queries above, so the
-        # total stays bounded however long they took. Floored above zero
-        # because as_completed treats a non-positive timeout as "already
-        # expired" and would skip even futures that are ready.
-        remaining = max(deadline - time.monotonic(), 0.1)
-        # timeout so a rate-limit storm that blocks every worker (see
-        # fetch_with_auth's rate-limited retry) still lets the tick return
-        # instead of hanging until the gRPC server kills it. The timeout is
-        # caught only around advancing the iterator, so a TimeoutError raised
-        # from within the loop body still propagates instead of being
-        # swallowed.
-        completed = as_completed(futures, timeout=remaining)
-        # Both limits are checked before advancing the iterator, not after.
-        # Advancing blocks until another fetch finishes, so testing them after
-        # the fact makes the tick wait on work whose result it has already
-        # decided to discard.
-        while (
-            len(run_requests) < MAX_RUN_REQUESTS_PER_TICK
-            and time.monotonic() <= deadline
-        ):
-            try:
-                future = next(completed)
-            except StopIteration:
-                break
-            except TimeoutError:
-                context.log.info(
-                    "Sweep time budget exhausted while workers were still in flight"
-                )
-                break
-            course_run_id = futures[future]
-            examined += 1
-            try:
-                published_version = published_version_of(
-                    future, course_run_id, context.log
-                )
-            except OutlineFetchError:
-                failures += 1
-                continue
-            if published_version is None:
-                continue
-            # `.get` covers both "never exported" (absent) and "exported before
-            # the version was recorded" (None); a real version never equals
-            # either, so both re-export.
-            if published_version == exported.get(course_run_id):
-                continue
-            run_requests.append(
-                RunRequest(
-                    asset_selection=[
-                        AssetKey((deployment, "openedx", "courseware")),
-                        course_xml_key,
-                        AssetKey((deployment, "openedx", "course_content_webhook")),
-                    ],
-                    partition_key=course_run_id,
-                    tags={"published_version": published_version},
-                )
-            )
-    finally:
-        # Not the `with` form: its __exit__ waits for in-flight workers, which
-        # would block the tick for up to 60s if one is inside the 429 backoff.
-        executor.shutdown(wait=False, cancel_futures=True)
-
-    sweep_duration = time.monotonic() - sweep_start
-    context.log.info(
-        "Examined %s of %s partitions (%s in flight, skipped), %s failed, "
-        "requesting %s exports in %.1fs",
-        examined,
-        len(partition_keys),
-        len(skip_keys),
-        failures,
-        len(run_requests),
-        sweep_duration,
-    )
-    if examined > 0 and failures == examined:
-        msg = f"Course outline sweep failed for all {examined} examined partitions"
-        raise RuntimeError(msg)
-    return SensorResult(run_requests=run_requests)

--- a/dg_projects/openedx/openedx_tests/test_assets.py
+++ b/dg_projects/openedx/openedx_tests/test_assets.py
@@ -1,0 +1,310 @@
+"""Tests for the openedx/courseware observable source asset and what it drives."""
+
+from collections.abc import Iterator
+from datetime import UTC, datetime
+
+import httpx2 as httpx
+import pytest
+from dagster import (
+    AssetKey,
+    AssetMaterialization,
+    AssetSelection,
+    DagsterInstance,
+    Definitions,
+    DynamicPartitionsDefinition,
+    IOManager,
+    ResourceDefinition,
+    evaluate_automation_conditions,
+)
+from dagster._core.definitions.asset_daemon_cursor import AssetDaemonCursor
+from dagster._core.definitions.observe import observe
+from openedx.assets.openedx import (
+    HTTP_NOT_FOUND,
+    build_courseware_source_asset,
+    course_xml,
+)
+from openedx.lib.assets_helper import (
+    add_prefix_to_asset_keys,
+    late_bind_partition_to_asset,
+)
+
+DEPLOYMENT = "mitxonline"
+COURSEWARE_KEY = AssetKey([DEPLOYMENT, "openedx", "courseware"])
+COURSE_XML_KEY = AssetKey([DEPLOYMENT, "openedx", "raw_data", "course_xml"])
+
+
+@pytest.fixture
+def partitions() -> DynamicPartitionsDefinition:
+    """Return a dynamic partitions definition isolated to a single test."""
+    return DynamicPartitionsDefinition(name="test_openedx_course_run")
+
+
+@pytest.fixture
+def instance() -> Iterator[DagsterInstance]:
+    """Return a throwaway Dagster instance for event-log assertions."""
+    with DagsterInstance.ephemeral() as ephemeral_instance:
+        yield ephemeral_instance
+
+
+class _OutlineClient:
+    """Serves canned course outlines, and can be made to fail for some of them."""
+
+    def __init__(
+        self,
+        versions: dict[str, str],
+        missing: set[str] | None = None,
+        raises: set[str] | None = None,
+    ) -> None:
+        self.versions = versions
+        self.missing = missing or set()
+        self.raises = raises or set()
+
+    def get_course_outline(self, course_id: str) -> dict[str, str]:
+        if course_id in self.missing:
+            msg = f"no outline for {course_id}"
+            raise httpx.HTTPStatusError(
+                msg,
+                request=httpx.Request("GET", "https://lms.example/outline"),
+                response=httpx.Response(HTTP_NOT_FOUND),
+            )
+        if course_id in self.raises:
+            msg = f"boom for {course_id}"
+            raise ValueError(msg)
+        return {"published_version": self.versions[course_id]}
+
+
+class _FakeOpenEdx:
+    """Stand-in for OpenEdxApiClientFactory holding a fixed outline client."""
+
+    def __init__(self, client: _OutlineClient) -> None:
+        self.client = client
+        self.deployment = DEPLOYMENT
+
+
+class _NoopIOManager(IOManager):
+    def handle_output(self, context, obj) -> None:
+        """Never called: these tests evaluate conditions, they do not execute."""
+
+    def load_input(self, context):
+        """Never called: these tests evaluate conditions, they do not execute."""
+
+
+def _definitions(
+    partitions: DynamicPartitionsDefinition, client: _OutlineClient
+) -> Definitions:
+    """Build courseware plus the course_xml that reacts to it, as production does."""
+    return Definitions(
+        assets=[
+            build_courseware_source_asset(DEPLOYMENT, partitions),
+            late_bind_partition_to_asset(
+                add_prefix_to_asset_keys(course_xml, DEPLOYMENT), partitions
+            ),
+        ],
+        resources={
+            "openedx": ResourceDefinition.hardcoded_resource(_FakeOpenEdx(client)),
+            "s3": ResourceDefinition.hardcoded_resource(None),
+            "s3file_io_manager": _NoopIOManager(),
+        },
+    )
+
+
+def _observe(defs: Definitions, instance: DagsterInstance) -> None:
+    """Run the courseware observation the way the automation sensor would."""
+    source_asset = defs.get_repository_def().source_assets_by_key[COURSEWARE_KEY]
+    assert observe([source_asset], instance=instance).success
+
+
+def _observed_versions(instance: DagsterInstance) -> dict[str, str | None]:
+    """Map partition key to the data version its latest observation reported."""
+    records = instance.fetch_observations(COURSEWARE_KEY, limit=100).records
+    versions: dict[str, str | None] = {}
+    for record in reversed(records):
+        observation = record.asset_observation
+        if observation is None or observation.partition is None:
+            continue
+        versions[observation.partition] = observation.tags.get("dagster/data_version")
+    return versions
+
+
+def test_every_registered_partition_is_observed(
+    instance: DagsterInstance, partitions: DynamicPartitionsDefinition
+) -> None:
+    """One observation run reports a version for the whole deployment.
+
+    Observation is per asset, not per partition, so this is the property that
+    makes a few thousand course runs affordable: the concurrent sweep happens
+    inside a single run rather than one run per course.
+    """
+    instance.add_dynamic_partitions(partitions.name, ["course-a", "course-b"])
+    defs = _definitions(
+        partitions, _OutlineClient({"course-a": "v1", "course-b": "v2"})
+    )
+
+    _observe(defs, instance)
+
+    assert _observed_versions(instance) == {"course-a": "v1", "course-b": "v2"}
+
+
+def test_a_course_missing_from_the_lms_is_not_observed(
+    instance: DagsterInstance, partitions: DynamicPartitionsDefinition
+) -> None:
+    """A 404 leaves the partition out entirely so its last version stands.
+
+    Emitting anything for it - even a null version - would read as a change and
+    ask for an export of a course that is no longer there to export.
+    """
+    instance.add_dynamic_partitions(partitions.name, ["course-a", "course-gone"])
+    defs = _definitions(
+        partitions,
+        _OutlineClient({"course-a": "v1"}, missing={"course-gone"}),
+    )
+
+    _observe(defs, instance)
+
+    assert _observed_versions(instance) == {"course-a": "v1"}
+
+
+def test_one_failing_lookup_does_not_stop_the_sweep(
+    instance: DagsterInstance, partitions: DynamicPartitionsDefinition
+) -> None:
+    """A single broken course is skipped; the rest of the deployment reports."""
+    instance.add_dynamic_partitions(partitions.name, ["course-a", "course-bad"])
+    defs = _definitions(
+        partitions,
+        _OutlineClient({"course-a": "v1", "course-bad": "v9"}, raises={"course-bad"}),
+    )
+
+    _observe(defs, instance)
+
+    assert _observed_versions(instance) == {"course-a": "v1"}
+
+
+def test_every_lookup_failing_fails_the_observation(
+    instance: DagsterInstance, partitions: DynamicPartitionsDefinition
+) -> None:
+    """A bad token or a 500-ing LMS must not look like a clean sweep.
+
+    Succeeding with an empty mapping would leave every downstream quiet,
+    hourly, forever, with a green run to say so.
+    """
+    keys = ["course-a", "course-b"]
+    instance.add_dynamic_partitions(partitions.name, keys)
+    defs = _definitions(
+        partitions,
+        _OutlineClient(dict.fromkeys(keys, "v1"), raises=set(keys)),
+    )
+    source_asset = defs.get_repository_def().source_assets_by_key[COURSEWARE_KEY]
+
+    result = observe([source_asset], instance=instance, raise_on_error=False)
+
+    assert not result.success
+
+
+def _requested(
+    defs: Definitions, instance: DagsterInstance, cursor: AssetDaemonCursor | None
+):
+    """Evaluate course_xml's automation condition and return what it asks for."""
+    result = evaluate_automation_conditions(
+        defs=defs,
+        instance=instance,
+        asset_selection=AssetSelection.assets(COURSE_XML_KEY),
+        cursor=cursor,
+    )
+    return set(result.get_requested_partitions(COURSE_XML_KEY)), result.cursor
+
+
+def _record_export(instance: DagsterInstance, partition_key: str) -> None:
+    """Stand in for a successful course_xml run for one partition."""
+    instance.report_runless_asset_event(
+        AssetMaterialization(asset_key=COURSE_XML_KEY, partition=partition_key)
+    )
+
+
+def test_the_observation_drives_the_full_export_cycle(
+    instance: DagsterInstance, partitions: DynamicPartitionsDefinition
+) -> None:
+    """The asset graph alone covers everything course_version_sensor hand-rolled.
+
+    Never exported, already exported, re-observed unchanged, republished: each
+    step is a plain consequence of ``upstream_or_code_changes()`` reading the
+    data versions the observation reports, with no reconciliation of our own.
+    """
+    instance.add_dynamic_partitions(partitions.name, ["course-a", "course-b"])
+    client = _OutlineClient({"course-a": "v1", "course-b": "v1"})
+    defs = _definitions(partitions, client)
+
+    _observe(defs, instance)
+    requested, cursor = _requested(defs, instance, None)
+    assert requested == {"course-a", "course-b"}, "never exported"
+
+    _record_export(instance, "course-a")
+    _record_export(instance, "course-b")
+    requested, cursor = _requested(defs, instance, cursor)
+    assert requested == set(), "exported at the observed version"
+
+    _observe(defs, instance)
+    requested, cursor = _requested(defs, instance, cursor)
+    assert requested == set(), "re-observed unchanged"
+
+    client.versions["course-b"] = "v2"
+    _observe(defs, instance)
+    requested, cursor = _requested(defs, instance, cursor)
+    assert requested == {"course-b"}, "republished"
+
+
+def test_the_observation_is_requested_once_an_hour(
+    instance: DagsterInstance, partitions: DynamicPartitionsDefinition
+) -> None:
+    """The cron tick is what schedules the sweep now that the sensor is gone.
+
+    Once per hour, not once per evaluation: the automation sensor ticks far
+    more often than that, and every extra tick would be another full outline
+    sweep of the deployment.
+    """
+    instance.add_dynamic_partitions(partitions.name, ["course-a"])
+    defs = _definitions(partitions, _OutlineClient({"course-a": "v1"}))
+    selection = AssetSelection.assets(COURSEWARE_KEY)
+
+    def _evaluate(at: datetime, cursor: AssetDaemonCursor | None):
+        result = evaluate_automation_conditions(
+            defs=defs,
+            instance=instance,
+            asset_selection=selection,
+            evaluation_time=at,
+            cursor=cursor,
+        )
+        return result.total_requested, result.cursor
+
+    requested, cursor = _evaluate(datetime(2026, 8, 7, 13, 0, 1, tzinfo=UTC), None)
+    assert requested == 0, "no cron boundary crossed yet"
+
+    requested, cursor = _evaluate(datetime(2026, 8, 7, 13, 5, 0, tzinfo=UTC), cursor)
+    assert requested == 0, "still the same hour"
+
+    requested, cursor = _evaluate(datetime(2026, 8, 7, 14, 0, 1, tzinfo=UTC), cursor)
+    assert requested == 1, "the hour turned over"
+
+
+def test_a_partition_registered_later_is_exported(
+    instance: DagsterInstance, partitions: DynamicPartitionsDefinition
+) -> None:
+    """A course run discovered after the first sweep still gets exported.
+
+    This is the whole job the discovery sensor hands off: it registers the
+    partition and stops, and the next observation is what makes the graph ask
+    for the export.
+    """
+    instance.add_dynamic_partitions(partitions.name, ["course-a"])
+    client = _OutlineClient({"course-a": "v1", "course-new": "v1"})
+    defs = _definitions(partitions, client)
+
+    _observe(defs, instance)
+    _requested(defs, instance, None)
+    _record_export(instance, "course-a")
+    _, cursor = _requested(defs, instance, None)
+
+    instance.add_dynamic_partitions(partitions.name, ["course-new"])
+    _observe(defs, instance)
+    requested, _ = _requested(defs, instance, cursor)
+
+    assert requested == {"course-new"}

--- a/dg_projects/openedx/openedx_tests/test_assets.py
+++ b/dg_projects/openedx/openedx_tests/test_assets.py
@@ -1,5 +1,6 @@
 """Tests for the openedx/courseware observable source asset and what it drives."""
 
+import time
 from collections.abc import Iterator
 from datetime import UTC, datetime
 
@@ -18,6 +19,15 @@ from dagster import (
 )
 from dagster._core.definitions.asset_daemon_cursor import AssetDaemonCursor
 from dagster._core.definitions.observe import observe
+from dagster._core.events import (
+    AssetMaterializationPlannedData,
+    DagsterEvent,
+    DagsterEventType,
+)
+from dagster._core.events.log import EventLogEntry
+from dagster._core.storage.dagster_run import DagsterRunStatus
+from dagster._core.storage.tags import PARTITION_NAME_TAG
+from dagster._core.test_utils import create_run_for_test
 from openedx.assets.openedx import (
     HTTP_NOT_FOUND,
     build_courseware_source_asset,
@@ -31,6 +41,7 @@ from openedx.lib.assets_helper import (
 DEPLOYMENT = "mitxonline"
 COURSEWARE_KEY = AssetKey([DEPLOYMENT, "openedx", "courseware"])
 COURSE_XML_KEY = AssetKey([DEPLOYMENT, "openedx", "raw_data", "course_xml"])
+EXPORT_JOB = "__ASSET_JOB"
 
 
 @pytest.fixture
@@ -218,6 +229,90 @@ def _record_export(instance: DagsterInstance, partition_key: str) -> None:
     instance.report_runless_asset_event(
         AssetMaterialization(asset_key=COURSE_XML_KEY, partition=partition_key)
     )
+
+
+def _start_export_run(instance: DagsterInstance, partition_key: str):
+    """Stage an export run that Dagster reports as in flight for course_xml.
+
+    The MATERIALIZATION_PLANNED event is the load-bearing part -- that is what
+    in_progress() reads for a partitioned asset, not the run record.
+    """
+    run = create_run_for_test(
+        instance,
+        job_name=EXPORT_JOB,
+        status=DagsterRunStatus.STARTED,
+        asset_selection={COURSE_XML_KEY},
+        tags={PARTITION_NAME_TAG: partition_key},
+    )
+    instance.handle_new_event(
+        EventLogEntry(
+            error_info=None,
+            level="debug",
+            user_message="",
+            run_id=run.run_id,
+            timestamp=time.time(),
+            dagster_event=DagsterEvent(
+                event_type_value=DagsterEventType.ASSET_MATERIALIZATION_PLANNED.value,
+                job_name=EXPORT_JOB,
+                event_specific_data=AssetMaterializationPlannedData(
+                    asset_key=COURSE_XML_KEY, partition=partition_key
+                ),
+            ),
+        )
+    )
+    return run
+
+
+def _finish_export_run(instance: DagsterInstance, run, partition_key: str) -> None:
+    """Complete a staged export run successfully, archive and all."""
+    _record_export(instance, partition_key)
+    instance.handle_new_event(
+        EventLogEntry(
+            error_info=None,
+            level="debug",
+            user_message="",
+            run_id=run.run_id,
+            timestamp=time.time(),
+            dagster_event=DagsterEvent(
+                event_type_value=DagsterEventType.RUN_SUCCESS.value,
+                job_name=EXPORT_JOB,
+            ),
+        )
+    )
+
+
+def test_a_republish_during_an_export_is_not_lost(
+    instance: DagsterInstance, partitions: DynamicPartitionsDefinition
+) -> None:
+    """A course republished mid-export still gets exported afterwards.
+
+    Exports poll Studio for minutes and the sweep runs on a cron, so a
+    republish landing inside a running export is routine rather than exotic.
+    Without the latch in upstream_or_code_changes() the only tick where
+    data_version_changed is true is the one ~in_progress() suppresses, and the
+    running export then succeeds -- so nothing fails, nothing re-fires, and the
+    archive silently stays a version behind until the course changes again.
+    """
+    instance.add_dynamic_partitions(partitions.name, ["course-a"])
+    client = _OutlineClient({"course-a": "v1"})
+    defs = _definitions(partitions, client)
+
+    _observe(defs, instance)
+    requested, cursor = _requested(defs, instance, None)
+    assert requested == {"course-a"}
+    _record_export(instance, "course-a")
+    requested, cursor = _requested(defs, instance, cursor)
+    assert requested == set(), "v1 is exported"
+
+    in_flight = _start_export_run(instance, "course-a")
+    client.versions["course-a"] = "v2"
+    _observe(defs, instance)
+    requested, cursor = _requested(defs, instance, cursor)
+    assert requested == set(), "suppressed while the earlier export runs"
+
+    _finish_export_run(instance, in_flight, "course-a")
+    requested, cursor = _requested(defs, instance, cursor)
+    assert requested == {"course-a"}, "v2 must still be exported"
 
 
 def test_the_observation_drives_the_full_export_cycle(

--- a/dg_projects/openedx/openedx_tests/test_components.py
+++ b/dg_projects/openedx/openedx_tests/test_components.py
@@ -1,0 +1,94 @@
+"""Tests for OpenEdxDeploymentComponent's definition wiring."""
+
+import pytest
+from dagster import AssetsDefinition, FilesystemIOManager, SourceAsset
+from dagster._core.definitions.assets.graph.asset_graph import AssetGraph
+from dagster_aws.s3 import S3Resource
+from ol_orchestrate.lib.constants import VAULT_ADDRESS
+from ol_orchestrate.lib.utils import unauthenticated_vault
+from openedx.components.openedx_deployment import OpenEdxDeploymentComponent
+
+DEPLOYMENT = "mitxonline"
+
+# Stand-ins for what definitions.py supplies at the code-location level. The
+# tests inspect definitions rather than executing them, so only the keys have
+# to line up.
+SHARED_RESOURCES = {
+    "io_manager": FilesystemIOManager(),
+    "s3file_io_manager": FilesystemIOManager(),
+    "s3": S3Resource(),
+    "learn_api": None,
+}
+
+
+@pytest.fixture
+def component() -> OpenEdxDeploymentComponent:
+    """Build the component with a Vault resource that is never dereferenced.
+
+    Nothing here touches `.client`; the tests inspect definitions only.
+    """
+    return OpenEdxDeploymentComponent(
+        deployment_name=DEPLOYMENT, vault=unauthenticated_vault(VAULT_ADDRESS)
+    )
+
+
+def _asset_graph(component: OpenEdxDeploymentComponent) -> AssetGraph:
+    """Resolve the component's full asset graph, source assets included."""
+    return (
+        component.build_definitions(shared_resources=SHARED_RESOURCES)
+        .get_repository_def()
+        .asset_graph
+    )
+
+
+def test_build_assets_returns_both_asset_types(
+    component: OpenEdxDeploymentComponent,
+) -> None:
+    """Courseware is a SourceAsset while everything downstream is materializable."""
+    assets = component.build_assets()
+
+    assert isinstance(assets["courseware_asset"], SourceAsset)
+    assert all(
+        isinstance(asset, AssetsDefinition)
+        for name, asset in assets.items()
+        if name != "courseware_asset"
+    )
+
+
+def test_the_automation_sensor_targets_the_courseware_source_asset(
+    component: OpenEdxDeploymentComponent,
+) -> None:
+    """A SourceAsset in the sensor target is supported, and load-bearing.
+
+    The automation sensor is the only thing that requests the courseware
+    observation, and the observation is the only thing that gives the rest of
+    the graph a data version to react to. Filtering the target down to
+    AssetsDefinitions -- the obvious-looking way to keep the list homogeneous --
+    would silently stop every course export in the deployment.
+    """
+    assets = component.build_assets()
+    sensors = component.build_sensors(assets)
+    automation_sensor = next(
+        sensor for sensor in sensors if sensor.name.endswith("_automation_sensor")
+    )
+
+    graph = _asset_graph(component)
+    targeted = automation_sensor.asset_selection.resolve(graph)
+
+    assert assets["courseware_asset"].key in targeted
+    assert targeted == graph.get_all_asset_keys(), "nothing dropped from the target"
+
+
+def test_the_discovery_sensor_does_not_target_the_source_asset(
+    component: OpenEdxDeploymentComponent,
+) -> None:
+    """course_run_sensor can only select assets it could materialize."""
+    assets = component.build_assets()
+    sensors = component.build_sensors(assets)
+    courseware_sensor = next(
+        sensor for sensor in sensors if sensor.name.endswith("_courseware_sensor")
+    )
+
+    targeted = courseware_sensor.asset_selection.resolve(_asset_graph(component))
+
+    assert assets["courseware_asset"].key not in targeted

--- a/dg_projects/openedx/openedx_tests/test_sensors.py
+++ b/dg_projects/openedx/openedx_tests/test_sensors.py
@@ -1,31 +1,13 @@
 """Tests for openedx.sensors.openedx."""
 
-import threading
-import time
 from collections.abc import Iterator
-from datetime import timedelta
-from typing import Protocol
 
 import pytest
-from dagster import (
-    AssetKey,
-    AssetMaterialization,
-    DagsterInstance,
-    build_sensor_context,
-)
-from dagster._core.storage.dagster_run import DagsterRunStatus
-from dagster._core.storage.tags import PARTITION_NAME_TAG, SENSOR_NAME_TAG
-from dagster._core.test_utils import create_run_for_test
+from dagster import DagsterInstance, build_sensor_context
 from openedx.partitions.openedx import OPENEDX_COURSE_RUN_PARTITIONS
-from openedx.sensors.openedx import (
-    course_run_sensor,
-    course_version_sensor,
-    exported_versions,
-    in_flight_partitions,
-)
+from openedx.sensors.openedx import course_run_sensor
 
-COURSE_XML_KEY = AssetKey(("mitxonline", "openedx", "raw_data", "course_xml"))
-SENSOR_NAME = "mitxonline_course_version_sensor"
+COURSEWARE_SENSOR_NAME = "mitxonline_courseware_sensor"
 
 
 @pytest.fixture
@@ -33,428 +15,6 @@ def instance() -> Iterator[DagsterInstance]:
     """Return a throwaway Dagster instance for event-log assertions."""
     with DagsterInstance.ephemeral() as ephemeral_instance:
         yield ephemeral_instance
-
-
-def _record_export(
-    instance: DagsterInstance, partition_key: str, version: str | None
-) -> None:
-    """Record a course_xml materialization, optionally without the version key."""
-    metadata = {"courseware_published_version": version} if version else {}
-    instance.report_runless_asset_event(
-        AssetMaterialization(
-            asset_key=COURSE_XML_KEY, partition=partition_key, metadata=metadata
-        )
-    )
-
-
-def test_exported_versions_reads_the_latest_materialization(
-    instance: DagsterInstance,
-) -> None:
-    """The most recent materialization's recorded version wins."""
-    _record_export(instance, "course-v1:org+num+run", "version-one")
-    _record_export(instance, "course-v1:org+num+run", "version-two")
-
-    result = exported_versions(instance, COURSE_XML_KEY, ["course-v1:org+num+run"])
-
-    assert result == {"course-v1:org+num+run": "version-two"}
-
-
-def test_exported_versions_omits_partitions_never_exported(
-    instance: DagsterInstance,
-) -> None:
-    """A partition with no materialization has no exported version."""
-    result = exported_versions(instance, COURSE_XML_KEY, ["course-v1:org+num+run"])
-
-    assert result == {}
-    assert result.get("course-v1:org+num+run") is None
-
-
-def test_exported_versions_is_none_for_pre_existing_archives(
-    instance: DagsterInstance,
-) -> None:
-    """Archives materialized before the metadata key existed count as unknown."""
-    _record_export(instance, "course-v1:org+num+run", None)
-
-    result = exported_versions(instance, COURSE_XML_KEY, ["course-v1:org+num+run"])
-
-    assert result == {"course-v1:org+num+run": None}
-
-
-def test_exported_versions_resolves_each_partition_independently(
-    instance: DagsterInstance,
-) -> None:
-    """One batched lookup must not cross-contaminate partitions.
-
-    The batched form fetches every partition's latest record in a single query,
-    so this guards against the records being matched back to the wrong keys.
-    """
-    _record_export(instance, "course-v1:org+num+a", "a-one")
-    _record_export(instance, "course-v1:org+num+b", "b-one")
-    _record_export(instance, "course-v1:org+num+a", "a-two")
-    _record_export(instance, "course-v1:org+num+c", "c-one")
-
-    result = exported_versions(
-        instance,
-        COURSE_XML_KEY,
-        [
-            "course-v1:org+num+a",
-            "course-v1:org+num+b",
-            "course-v1:org+num+c",
-            "course-v1:org+num+never",
-        ],
-    )
-
-    assert result == {
-        "course-v1:org+num+a": "a-two",
-        "course-v1:org+num+b": "b-one",
-        "course-v1:org+num+c": "c-one",
-    }
-
-
-def _record_run(
-    instance: DagsterInstance,
-    partition_key: str,
-    status: DagsterRunStatus,
-    sensor_name: str = SENSOR_NAME,
-) -> None:
-    """Create a run tagged the way a sensor-launched partitioned run is tagged."""
-    create_run_for_test(
-        instance,
-        job_name="openedx_course_export",
-        status=status,
-        tags={SENSOR_NAME_TAG: sensor_name, PARTITION_NAME_TAG: partition_key},
-    )
-
-
-def test_in_flight_partitions_includes_runs_not_yet_started(
-    instance: DagsterInstance,
-) -> None:
-    """A run waiting in the queue counts as in flight.
-
-    NOT_STARTED and QUEUED are excluded from IN_PROGRESS_RUN_STATUSES, so this
-    fails if the implementation reaches for that constant instead of
-    NOT_FINISHED_STATUSES.
-    """
-    _record_run(instance, "course-v1:org+num+queued", DagsterRunStatus.NOT_STARTED)
-
-    assert in_flight_partitions(instance, SENSOR_NAME) == {"course-v1:org+num+queued"}
-
-
-def test_in_flight_partitions_includes_started_runs(
-    instance: DagsterInstance,
-) -> None:
-    """A running export counts as in flight."""
-    _record_run(instance, "course-v1:org+num+running", DagsterRunStatus.STARTED)
-
-    assert in_flight_partitions(instance, SENSOR_NAME) == {"course-v1:org+num+running"}
-
-
-def test_in_flight_partitions_excludes_finished_runs(
-    instance: DagsterInstance,
-) -> None:
-    """Failed and successful runs are finished, so they do not suppress a retry."""
-    _record_run(instance, "course-v1:org+num+failed", DagsterRunStatus.FAILURE)
-    _record_run(instance, "course-v1:org+num+ok", DagsterRunStatus.SUCCESS)
-
-    assert in_flight_partitions(instance, SENSOR_NAME) == set()
-
-
-def test_in_flight_partitions_ignores_other_sensors(
-    instance: DagsterInstance,
-) -> None:
-    """Runs launched by a different sensor are not this sensor's business."""
-    _record_run(
-        instance,
-        "course-v1:org+num+other",
-        DagsterRunStatus.STARTED,
-        sensor_name="some_other_sensor",
-    )
-
-    assert in_flight_partitions(instance, SENSOR_NAME) == set()
-
-
-class _OutlineClient(Protocol):
-    """Structural type shared by every outline-client test double."""
-
-    def get_course_outline(self, course_id: str) -> dict[str, str]: ...
-
-
-class _CatalogSource(Protocol):
-    """Structural type for a double that enumerates the LMS course catalog."""
-
-    def get_edx_course_ids(self) -> Iterator[list[dict[str, str]]]: ...
-
-
-class _FakeClient:
-    """Stand-in for OpenEdxApiClient that serves canned outlines."""
-
-    def __init__(
-        self, versions: dict[str, str], raises: set[str] | None = None
-    ) -> None:
-        self.versions = versions
-        self.raises = raises or set()
-        self.calls: list[str] = []
-
-    def get_course_outline(self, course_id: str) -> dict[str, str]:
-        self.calls.append(course_id)
-        if course_id in self.raises:
-            msg = f"boom for {course_id}"
-            raise ValueError(msg)
-        return {"published_version": self.versions[course_id]}
-
-
-class _FakeFactory:
-    """Stand-in for OpenEdxApiClientFactory."""
-
-    def __init__(
-        self,
-        client: _OutlineClient | _CatalogSource,
-        deployment: str = "mitxonline",
-    ) -> None:
-        self.client = client
-        self.deployment = deployment
-
-
-def _seed_partitions(instance: DagsterInstance, keys: list[str]) -> None:
-    """Register dynamic partitions for the mitxonline deployment."""
-    instance.add_dynamic_partitions(
-        OPENEDX_COURSE_RUN_PARTITIONS["mitxonline"].name, keys
-    )
-
-
-def _requested_partitions(result) -> set[str]:
-    """Collect the partition keys a SensorResult asks to run."""
-    return {request.partition_key for request in result.run_requests}
-
-
-def test_only_changed_courses_are_requested(instance: DagsterInstance) -> None:
-    """A partition whose recorded version matches the live one is left alone."""
-    _seed_partitions(instance, ["course-v1:org+num+same", "course-v1:org+num+changed"])
-    _record_export(instance, "course-v1:org+num+same", "version-one")
-    _record_export(instance, "course-v1:org+num+changed", "version-one")
-    factory = _FakeFactory(
-        _FakeClient(
-            {
-                "course-v1:org+num+same": "version-one",
-                "course-v1:org+num+changed": "version-two",
-            }
-        )
-    )
-
-    result = course_version_sensor(
-        build_sensor_context(instance=instance, sensor_name=SENSOR_NAME), factory
-    )
-
-    assert _requested_partitions(result) == {"course-v1:org+num+changed"}
-
-
-def test_never_exported_course_is_requested(instance: DagsterInstance) -> None:
-    """No materialization means we do not know what is in S3, so re-export."""
-    _seed_partitions(instance, ["course-v1:org+num+new"])
-    factory = _FakeFactory(_FakeClient({"course-v1:org+num+new": "version-one"}))
-
-    result = course_version_sensor(
-        build_sensor_context(instance=instance, sensor_name=SENSOR_NAME), factory
-    )
-
-    assert _requested_partitions(result) == {"course-v1:org+num+new"}
-
-
-def test_requests_carry_the_published_version_tag(instance: DagsterInstance) -> None:
-    """Run tags record which version triggered the export."""
-    _seed_partitions(instance, ["course-v1:org+num+new"])
-    factory = _FakeFactory(_FakeClient({"course-v1:org+num+new": "version-one"}))
-
-    result = course_version_sensor(
-        build_sensor_context(instance=instance, sensor_name=SENSOR_NAME), factory
-    )
-
-    assert result.run_requests[0].tags["published_version"] == "version-one"
-
-
-def test_in_flight_partitions_are_not_requested_again(
-    instance: DagsterInstance,
-) -> None:
-    """A partition with an unfinished run is skipped even though it mismatches."""
-    _seed_partitions(instance, ["course-v1:org+num+busy"])
-    _record_run(instance, "course-v1:org+num+busy", DagsterRunStatus.NOT_STARTED)
-    factory = _FakeFactory(_FakeClient({"course-v1:org+num+busy": "version-two"}))
-
-    result = course_version_sensor(
-        build_sensor_context(instance=instance, sensor_name=SENSOR_NAME), factory
-    )
-
-    assert result.run_requests == []
-
-
-def test_failed_run_does_not_block_a_retry(instance: DagsterInstance) -> None:
-    """A failed export is finished, so the mismatch is retried."""
-    _seed_partitions(instance, ["course-v1:org+num+retry"])
-    _record_run(instance, "course-v1:org+num+retry", DagsterRunStatus.FAILURE)
-    factory = _FakeFactory(_FakeClient({"course-v1:org+num+retry": "version-two"}))
-
-    result = course_version_sensor(
-        build_sensor_context(instance=instance, sensor_name=SENSOR_NAME), factory
-    )
-
-    assert _requested_partitions(result) == {"course-v1:org+num+retry"}
-
-
-def test_run_requests_are_capped(
-    instance: DagsterInstance, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    """The cap bounds how many exports one tick can launch."""
-    monkeypatch.setattr("openedx.sensors.openedx.MAX_RUN_REQUESTS_PER_TICK", 2)
-    keys = [f"course-v1:org+num+{index}" for index in range(6)]
-    _seed_partitions(instance, keys)
-    factory = _FakeFactory(_FakeClient(dict.fromkeys(keys, "version-one")))
-
-    result = course_version_sensor(
-        build_sensor_context(instance=instance, sensor_name=SENSOR_NAME), factory
-    )
-
-    assert len(result.run_requests) == 2
-
-
-def test_a_failing_outline_lookup_does_not_stop_the_sweep(
-    instance: DagsterInstance,
-) -> None:
-    """One broken course is skipped; the rest of the sweep still reports."""
-    _seed_partitions(instance, ["course-v1:org+num+bad", "course-v1:org+num+good"])
-    factory = _FakeFactory(
-        _FakeClient(
-            {"course-v1:org+num+bad": "x", "course-v1:org+num+good": "version-one"},
-            raises={"course-v1:org+num+bad"},
-        )
-    )
-
-    result = course_version_sensor(
-        build_sensor_context(instance=instance, sensor_name=SENSOR_NAME), factory
-    )
-
-    assert _requested_partitions(result) == {"course-v1:org+num+good"}
-
-
-def test_exhausted_time_budget_returns_what_it_collected(
-    instance: DagsterInstance, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    """A budget of zero ends the tick cleanly instead of raising."""
-    monkeypatch.setattr(
-        "openedx.sensors.openedx.SWEEP_TIME_BUDGET", timedelta(seconds=0)
-    )
-    keys = [f"course-v1:org+num+{index}" for index in range(4)]
-    _seed_partitions(instance, keys)
-    factory = _FakeFactory(_FakeClient(dict.fromkeys(keys, "version-one")))
-
-    result = course_version_sensor(
-        build_sensor_context(instance=instance, sensor_name=SENSOR_NAME), factory
-    )
-
-    assert result.run_requests == []
-
-
-class _BlockingClient:
-    """Stand-in whose outline lookups never return within the test.
-
-    Simulates every worker stuck in fetch_with_auth's unbounded 429 backoff:
-    no future ever completes, so only a timeout on as_completed itself (not
-    the in-loop deadline check, which only runs between completions) can end
-    the tick.
-    """
-
-    def __init__(self) -> None:
-        self.release = threading.Event()
-
-    def get_course_outline(self, course_id: str) -> dict[str, str]:  # noqa: ARG002
-        self.release.wait(timeout=5)
-        return {"published_version": "unused"}
-
-
-def test_blocked_workers_do_not_hang_the_tick(
-    instance: DagsterInstance, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    """as_completed's own timeout ends the tick when no future ever completes.
-
-    This is the exact failure mode this branch exists to fix: without a
-    timeout on as_completed, a rate-limit storm blocking every worker would
-    hang the sweep loop until the gRPC tick timeout killed it, producing and
-    saving nothing. The elapsed-time assertion is what pins that: the
-    empty-result assertion alone would still hold even if the as_completed
-    timeout were removed entirely, since _BlockingClient self-releases after
-    5s and the in-loop deadline check would then end the tick anyway - just
-    much slower. See test_body_timeout_is_not_swallowed_as_an_exhausted_budget
-    below for the regression test that pins the narrowed except clause
-    itself (a timeout from inside the loop body must propagate, not be
-    caught by the same handler that ends the sweep on a genuine budget
-    exhaustion).
-    """
-    monkeypatch.setattr(
-        "openedx.sensors.openedx.SWEEP_TIME_BUDGET", timedelta(seconds=0.05)
-    )
-    keys = [f"course-v1:org+num+{index}" for index in range(4)]
-    _seed_partitions(instance, keys)
-    client = _BlockingClient()
-    factory = _FakeFactory(client)
-
-    try:
-        start = time.monotonic()
-        result = course_version_sensor(
-            build_sensor_context(instance=instance, sensor_name=SENSOR_NAME), factory
-        )
-        elapsed = time.monotonic() - start
-    finally:
-        client.release.set()
-
-    assert result.run_requests == []
-    assert elapsed < 2.0
-
-
-def test_event_log_timeout_is_not_swallowed_as_an_exhausted_budget(
-    instance: DagsterInstance, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    """A TimeoutError from the event-log lookup must propagate.
-
-    exported_versions does a Postgres event-log query, so a genuine socket or
-    database timeout there is a TimeoutError (socket.timeout is an alias of it
-    since Python 3.10). The except TimeoutError around the as_completed advance
-    must not also catch this, or a real timeout gets mislabeled in the logs as
-    an exhausted sweep budget and silently swallowed instead of surfacing as a
-    failed tick. The lookup is hoisted out of the loop precisely so it cannot
-    land inside that handler's reach.
-    """
-    keys = ["course-v1:org+num+run"]
-    _seed_partitions(instance, keys)
-    factory = _FakeFactory(_FakeClient({"course-v1:org+num+run": "version-one"}))
-
-    def _raise_timeout(*_args: object, **_kwargs: object) -> dict[str, str | None]:
-        msg = "simulated database timeout"
-        raise TimeoutError(msg)
-
-    monkeypatch.setattr("openedx.sensors.openedx.exported_versions", _raise_timeout)
-
-    with pytest.raises(TimeoutError):
-        course_version_sensor(
-            build_sensor_context(instance=instance, sensor_name=SENSOR_NAME), factory
-        )
-
-
-def test_every_partition_failing_raises(instance: DagsterInstance) -> None:
-    """A sweep where every examined lookup failed must not report a green tick.
-
-    Swallowing every exception silently would reproduce the original bug: a
-    bad token or a 500-ing LMS producing a green tick with zero run requests,
-    hourly, forever.
-    """
-    keys = [f"course-v1:org+num+{index}" for index in range(3)]
-    _seed_partitions(instance, keys)
-    factory = _FakeFactory(
-        _FakeClient(dict.fromkeys(keys, "version-one"), raises=set(keys))
-    )
-
-    with pytest.raises(RuntimeError, match="failed for all 3"):
-        course_version_sensor(
-            build_sensor_context(instance=instance, sensor_name=SENSOR_NAME), factory
-        )
 
 
 class _CatalogClient:
@@ -467,7 +27,19 @@ class _CatalogClient:
         yield [{"id": course_run_id} for course_run_id in self.course_run_ids]
 
 
-COURSEWARE_SENSOR_NAME = "mitxonline_courseware_sensor"
+class _FakeFactory:
+    """Stand-in for OpenEdxApiClientFactory."""
+
+    def __init__(self, client: _CatalogClient, deployment: str = "mitxonline") -> None:
+        self.client = client
+        self.deployment = deployment
+
+
+def _seed_partitions(instance: DagsterInstance, keys: list[str]) -> None:
+    """Register dynamic partitions for the mitxonline deployment."""
+    instance.add_dynamic_partitions(
+        OPENEDX_COURSE_RUN_PARTITIONS["mitxonline"].name, keys
+    )
 
 
 def _added_partitions(result) -> set[str]:
@@ -497,13 +69,11 @@ def test_course_run_sensor_registers_unseen_course_runs(
 
 
 def test_course_run_sensor_requests_no_runs(instance: DagsterInstance) -> None:
-    """Discovery only: launching exports is course_version_sensor's job alone.
+    """Discovery only: launching exports belongs to the asset graph alone.
 
-    Requesting runs here as well double-exported every new course, because
-    in_flight_partitions filters run records by sensor name and so could not
-    see the run this sensor launched. It also bypassed
-    MAX_RUN_REQUESTS_PER_TICK, which made that cap meaningless for any burst
-    of new courses.
+    Requesting runs here as well double-exported every new course and bypassed
+    every throttle, because a sensor-launched run is invisible to the
+    reconciliation that decides whether an export is still needed.
     """
     factory = _FakeFactory(_CatalogClient(["course-v1:org+num+new"]))
 
@@ -515,85 +85,17 @@ def test_course_run_sensor_requests_no_runs(instance: DagsterInstance) -> None:
     assert not result.run_requests
 
 
-def test_a_new_course_run_is_exported_exactly_once(instance: DagsterInstance) -> None:
-    """The two sensors together produce exactly one export for a new course.
-
-    course_run_sensor registers the partition and stops; course_version_sensor
-    finds no course_xml materialization for it and requests the only export.
-    """
-    new_key = "course-v1:org+num+new"
-    discovery = course_run_sensor(
-        build_sensor_context(instance=instance, sensor_name=COURSEWARE_SENSOR_NAME),
-        _FakeFactory(_CatalogClient([new_key])),
-    )
-    instance.add_dynamic_partitions(
-        OPENEDX_COURSE_RUN_PARTITIONS["mitxonline"].name,
-        sorted(_added_partitions(discovery)),
-    )
-
-    version_result = course_version_sensor(
-        build_sensor_context(instance=instance, sensor_name=SENSOR_NAME),
-        _FakeFactory(_FakeClient({new_key: "version-one"})),
-    )
-
-    assert not discovery.run_requests
-    assert _requested_partitions(version_result) == {new_key}
-
-
-class _PartlyBlockingClient:
-    """Serves a few outlines instantly, then blocks on everything else."""
-
-    def __init__(self, fast: dict[str, str]) -> None:
-        self.fast = fast
-        self.release = threading.Event()
-
-    def get_course_outline(self, course_id: str) -> dict[str, str]:
-        if course_id in self.fast:
-            return {"published_version": self.fast[course_id]}
-        self.release.wait(timeout=5)
-        return {"published_version": "unused"}
-
-
-def test_reaching_the_cap_returns_without_awaiting_more_fetches(
-    instance: DagsterInstance, monkeypatch: pytest.MonkeyPatch
+def test_invalid_partition_strings_are_not_registered(
+    instance: DagsterInstance,
 ) -> None:
-    """Hitting MAX_RUN_REQUESTS_PER_TICK must end the tick immediately.
-
-    Checking the cap after advancing as_completed means the tick blocks on one
-    more fetch whose result it has already decided to discard -- which, when
-    the LMS is slow, is exactly when the sensor can least afford to wait. The
-    elapsed assertion is what pins it: the run-request assertion alone holds
-    either way.
-    """
-    monkeypatch.setattr("openedx.sensors.openedx.MAX_RUN_REQUESTS_PER_TICK", 2)
-    fast = {f"course-v1:org+num+fast{index}": "version-one" for index in range(2)}
-    slow = [f"course-v1:org+num+slow{index}" for index in range(4)]
-    _seed_partitions(instance, [*fast, *slow])
-    client = _PartlyBlockingClient(fast)
-
-    try:
-        start = time.monotonic()
-        result = course_version_sensor(
-            build_sensor_context(instance=instance, sensor_name=SENSOR_NAME),
-            _FakeFactory(client),
-        )
-        elapsed = time.monotonic() - start
-    finally:
-        client.release.set()
-
-    assert len(result.run_requests) == 2
-    assert elapsed < 2.0
-
-
-def test_an_in_flight_export_is_not_duplicated(instance: DagsterInstance) -> None:
-    """Once this sensor's export is running, the next tick leaves it alone."""
-    new_key = "course-v1:org+num+new"
-    _seed_partitions(instance, [new_key])
-    _record_run(instance, new_key, DagsterRunStatus.STARTED)
-
-    result = course_version_sensor(
-        build_sensor_context(instance=instance, sensor_name=SENSOR_NAME),
-        _FakeFactory(_FakeClient({new_key: "version-one"})),
+    """A course id Dagster cannot use as a partition key is dropped, not raised."""
+    factory = _FakeFactory(
+        _CatalogClient(["course-v1:org+num+ok", "course-v1:org+num+ba\nd"])
     )
 
-    assert _requested_partitions(result) == set()
+    result = course_run_sensor(
+        build_sensor_context(instance=instance, sensor_name=COURSEWARE_SENSOR_NAME),
+        factory,
+    )
+
+    assert _added_partitions(result) == {"course-v1:org+num+ok"}

--- a/packages/ol-orchestrate-lib/src/ol_orchestrate/lib/automation_policies.py
+++ b/packages/ol-orchestrate-lib/src/ol_orchestrate/lib/automation_policies.py
@@ -12,17 +12,44 @@ def upstream_or_code_changes() -> AutomationCondition:
 
     ``execution_failed`` is level-triggered -- true for as long as the latest
     execution of the target is a failure -- so it keeps asking until a run
-    succeeds and goes quiet the moment one does. It is deliberately preferred
-    over latching the upstream signal with ``.since(newly_updated())``: a latch
-    only resets on an actual materialization, so an asset declared
-    ``output_required=False`` that legitimately produces nothing would be
-    re-requested on every tick forever. A run that succeeds without emitting an
-    output is not a failed execution, so this formulation stays quiet there.
+    succeeds and goes quiet the moment one does. That covers the run that fails.
+
+    The upstream signal is latched on top of it, because failure is not the only
+    way the edge gets lost. ``~in_progress()`` gates the whole conjunction, so an
+    upstream version that moves *while a run is already going* is suppressed on
+    the one tick where ``data_version_changed`` is true. That run then succeeds
+    -- it was launched for the older version, but it succeeded -- leaving no
+    failure to retry and no edge to re-fire. The asset sits on the older
+    upstream until the upstream happens to change again, silently.
+
+    The reset is ``newly_requested``, deliberately NOT the ``newly_updated`` that
+    ``.since_last_handled()`` would also include. A run launched for the older
+    version emits its own materialization, and counting that as handling would
+    clear the latch for a version it never read -- reintroducing the same loss it
+    is here to prevent. Requesting is the honest reset: it means this condition
+    got its run.
+
+    ``newly_requested`` also avoids the failure mode that kept the signal
+    unlatched until now. A latch reset only by ``newly_updated`` never clears for
+    an asset declared ``output_required=False`` that legitimately produces
+    nothing, so it would re-request on every tick forever; a request is recorded
+    whether or not the run emits an output, so this formulation stays quiet
+    there.
+
+    Trade: a materialization from outside this condition -- a manual run, a
+    backfill -- no longer clears a pending upstream change, so one automation run
+    can follow it. That is the conservative direction to err in, and it settles
+    after that single run.
     """
     not_in_progress = ~AutomationCondition.in_progress()
     no_upstream_dependencies_in_process = ~AutomationCondition.any_deps_in_progress()
-    has_upstream_changes = AutomationCondition.any_deps_updated().replace(
-        "newly_updated", AutomationCondition.data_version_changed()
+    has_upstream_changes = (
+        AutomationCondition.any_deps_updated()
+        .replace("newly_updated", AutomationCondition.data_version_changed())
+        .since(
+            AutomationCondition.newly_requested()
+            | AutomationCondition.initial_evaluation()
+        )
     )
     has_code_changes = AutomationCondition.code_version_changed()
     newly_missing = AutomationCondition.newly_missing()

--- a/packages/ol-orchestrate-lib/src/ol_orchestrate/resources/oauth.py
+++ b/packages/ol-orchestrate-lib/src/ol_orchestrate/resources/oauth.py
@@ -40,8 +40,8 @@ class OAuthApiClient(ConfigurableResource):
     _access_token_expires: datetime | None = PrivateAttr(default=None)
     _cached_username: str | None = PrivateAttr(default=None)
     _http_client: httpx.Client | None = PrivateAttr(default=None)
-    # This client is shared across worker threads (course_version_sensor fans
-    # outline fetches out over a pool), so the lazily-populated caches below
+    # This client is shared across worker threads (the openedx/courseware
+    # observation fans outline fetches out over a pool), so the caches below
     # need guarding: an unsynchronized check-then-set lets every thread observe
     # a cold cache at once and issue its own token or /me request.
     _token_lock: threading.Lock = PrivateAttr(default_factory=threading.Lock)
@@ -139,9 +139,9 @@ class OAuthApiClient(ConfigurableResource):
             response.raise_for_status()
         except httpx.HTTPStatusError as error_response:
             # Bounded on purpose. Retrying forever means a caller can never be
-            # sure this returns, and callers that abandon their threads --
-            # course_version_sensor shuts its pool down with wait=False -- would
-            # then accumulate a fresh set of immortal workers every tick under a
+            # sure this returns. The openedx/courseware observation waits on
+            # its whole worker pool, so one thread parked in an unbounded
+            # backoff would hang the observation run indefinitely under a
             # sustained rate limit.
             if (
                 error_response.response.status_code == TOO_MANY_REQUESTS

--- a/packages/ol-orchestrate-lib/tests/lib/test_automation_policies.py
+++ b/packages/ol-orchestrate-lib/tests/lib/test_automation_policies.py
@@ -6,18 +6,29 @@ an upstream update survives a failed run -- only shows up in the interaction
 between the condition, the event log, and actual run records.
 """
 
+import time
 from collections.abc import Iterator
 
 import dagster as dg
 import pytest
 from dagster import AssetKey, DynamicPartitionsDefinition, Output
 from dagster._core.definitions.data_version import DATA_VERSION_TAG
+from dagster._core.events import (
+    AssetMaterializationPlannedData,
+    DagsterEvent,
+    DagsterEventType,
+)
+from dagster._core.events.log import EventLogEntry
+from dagster._core.storage.dagster_run import DagsterRunStatus
+from dagster._core.storage.tags import PARTITION_NAME_TAG
+from dagster._core.test_utils import create_run_for_test
 from ol_orchestrate.lib.automation_policies import upstream_or_code_changes
 
 PARTITIONS = DynamicPartitionsDefinition(name="test_course_run")
 UPSTREAM_KEY = AssetKey(["test", "upstream"])
 DOWNSTREAM_KEY = AssetKey(["test", "downstream"])
 PARTITION = "run-a"
+IN_FLIGHT_JOB = "__ASSET_JOB"
 
 
 class DownstreamBehaviour:
@@ -102,6 +113,57 @@ class Harness:
             raise_on_error=False,
         )
 
+    def _log(self, run_id: str, dagster_event: DagsterEvent) -> None:
+        self.instance.handle_new_event(
+            EventLogEntry(
+                error_info=None,
+                level="debug",
+                user_message="",
+                run_id=run_id,
+                timestamp=time.time(),
+                dagster_event=dagster_event,
+            )
+        )
+
+    def start_downstream_run(self):
+        """Put a downstream run in flight without finishing it.
+
+        materialize() is synchronous, so an in-progress run has to be staged by
+        hand. The MATERIALIZATION_PLANNED event is the part that matters: that
+        is what in_progress() reads for a partitioned asset, not the run record.
+        """
+        run = create_run_for_test(
+            self.instance,
+            job_name=IN_FLIGHT_JOB,
+            status=DagsterRunStatus.STARTED,
+            asset_selection={DOWNSTREAM_KEY},
+            tags={PARTITION_NAME_TAG: PARTITION},
+        )
+        self._log(
+            run.run_id,
+            DagsterEvent(
+                event_type_value=DagsterEventType.ASSET_MATERIALIZATION_PLANNED.value,
+                job_name=IN_FLIGHT_JOB,
+                event_specific_data=AssetMaterializationPlannedData(
+                    asset_key=DOWNSTREAM_KEY, partition=PARTITION
+                ),
+            ),
+        )
+        return run
+
+    def finish_downstream_run(self, run) -> None:
+        """Complete the staged run successfully, materialization and all."""
+        self.instance.report_runless_asset_event(
+            dg.AssetMaterialization(asset_key=DOWNSTREAM_KEY, partition=PARTITION)
+        )
+        self._log(
+            run.run_id,
+            DagsterEvent(
+                event_type_value=DagsterEventType.RUN_SUCCESS.value,
+                job_name=IN_FLIGHT_JOB,
+            ),
+        )
+
     def reach_steady_state(self, behaviour: DownstreamBehaviour) -> None:
         """Observe v1 and export it successfully, so nothing is outstanding."""
         behaviour.mode = DownstreamBehaviour.SUCCEED
@@ -167,6 +229,51 @@ def test_retrying_stops_once_a_run_succeeds(harness, behaviour) -> None:
     behaviour.mode = DownstreamBehaviour.SUCCEED
     harness.execute_downstream()
 
+    assert harness.tick() == []
+
+
+def test_update_survives_a_run_that_was_already_in_flight(harness, behaviour) -> None:
+    """An upstream update during an in-flight run must not be swallowed.
+
+    ~in_progress() gates the whole condition, so the one tick where
+    data_version_changed is true for v2 is suppressed because the v1 run is
+    still going. That run then succeeds -- it exported v1, but it succeeded --
+    so execution_failed never fires and, unlatched, the v2 edge is gone for
+    good: the asset sits on v1 until the upstream happens to change again.
+
+    The window is not narrow in practice. Open edX exports poll Studio for
+    minutes, and the LMS is swept on a cron, so a republish landing inside
+    someone else's export is routine (mitodl/hq#12755).
+    """
+    harness.reach_steady_state(behaviour)
+    in_flight = harness.start_downstream_run()
+    assert harness.tick() == [], "a run is already going"
+
+    harness.observe("v2")
+    assert harness.tick() == [], "still suppressed by in_progress"
+
+    harness.finish_downstream_run(in_flight)
+
+    assert harness.tick() == [PARTITION], "v2 must still be asked for"
+
+
+def test_the_latch_clears_once_the_update_is_requested(harness, behaviour) -> None:
+    """The re-request is one run, not a loop.
+
+    The latch resets on newly_requested, so it clears whether or not that run
+    ends up emitting anything -- which is what keeps this from reintroducing
+    the forever-spinning behaviour the no-output test below pins.
+    """
+    harness.reach_steady_state(behaviour)
+    in_flight = harness.start_downstream_run()
+    harness.observe("v2")
+    harness.tick()
+    harness.finish_downstream_run(in_flight)
+    assert harness.tick() == [PARTITION]
+
+    harness.execute_downstream()
+
+    assert harness.tick() == []
     assert harness.tick() == []
 
 

--- a/packages/ol-orchestrate-lib/tests/resources/test_oauth.py
+++ b/packages/ol-orchestrate-lib/tests/resources/test_oauth.py
@@ -84,10 +84,10 @@ def test_username_is_fetched_once(client: OAuthApiClient) -> None:
 def test_username_is_fetched_once_under_concurrent_first_access() -> None:
     """A cold client hit from many threads must still make one /me request.
 
-    course_version_sensor fans outline fetches over a worker pool, and each of
-    those calls fetch_with_auth, which reads this property. An unsynchronized
-    check-then-set lets every worker observe the cold cache at once and issue
-    its own lookup -- an authentication burst on the first tick of every fresh
+    The openedx/courseware observation fans outline fetches over a worker pool,
+    and each of those calls fetch_with_auth, which reads this property. An
+    unsynchronized check-then-set lets every worker observe the cold cache at
+    once and issue its own lookup -- an authentication burst on every fresh
     resource instance, which is exactly what the cache exists to prevent.
     """
     workers = 8
@@ -110,9 +110,9 @@ def test_username_is_fetched_once_under_concurrent_first_access() -> None:
 def test_rate_limit_retries_are_bounded() -> None:
     """429 retries stop, so a caller is guaranteed a return or an exception.
 
-    Retrying forever means a worker thread can outlive the tick that spawned
-    it; course_version_sensor abandons its pool with wait=False, so under a
-    sustained rate limit every tick would leak another set of immortal threads.
+    The openedx/courseware observation waits on its whole worker pool, so a
+    thread parked in an unbounded 429 backoff would hang the observation run
+    for as long as the rate limit lasted.
     """
     client = _build_client()
     throttling = _ThrottlingClient()


### PR DESCRIPTION
### What are the relevant tickets?
Closes https://github.com/mitodl/hq/issues/12755

### Description (What does it do?)
Retires `course_version_sensor` and lets the asset graph drive Open edX course exports on its own.

The sensor hand-rolled reconciliation the graph already expresses. `upstream_or_code_changes()` on `course_xml` covers version-change, never-exported, in-flight suppression, and (since #2517) retry-on-failure. The only thing missing was a reason for it to fire: `openedx/courseware` was never re-observed, so `data_version_changed()` never went true.

**`openedx/courseware` becomes an observable source asset**, built per deployment by `build_courseware_source_asset()`. Three things about that are worth calling out, because they are not obvious and each one was verified against a real `DagsterInstance`:

1. **The source-asset conversion is required, not stylistic.** An `AssetObservation` reported against a materializable `@asset` does not drive `data_version_changed()` at all, and a never-materialized materializable upstream also trips `~any_deps_missing()` in `upstream_or_code_changes()`, blocking the downstream outright. There is no way to keep the asset materializable and drive downstream automation from observations.

2. **Observation is per *asset*, not per partition.** A partitioned observable source asset rejects a bare `DataVersion` and requires `DataVersionsByPartition`; the observe fn runs once for the whole asset. So a full sweep of a deployment is **one run per hour**, not ~2k runs — the 16-worker concurrent outline fetch moves wholesale inside it. This is cheaper than the sensor tick it replaces, not more expensive.

3. **Built by a factory rather than through the existing helpers.** Passing `key`/`partitions_def` straight to the decorator avoids needing `SourceAsset` support in `late_bind_partition_to_asset` / `add_prefix_to_asset_keys`, which are written against `AssetsDefinition`.

Also in this change:

- `course_structure` and `course_xml` move from `ins=` to `deps=` (nothing consumed the loaded value; `course_structure` already carried `# noqa: ARG001` for it). `course_xml` fetches its own outline for the `courseware_published_version` metadata, which is now purely diagnostic — no sensor reads it.
- `course_run_sensor` keeps its single job of registering dynamic partitions. Its `asset_selection` drops the courseware asset: a sensor cannot target something it can never materialize.
- `course_version_sensor` and its 24 tests are deleted, along with the `exported_versions` / `in_flight_partitions` event-log helpers that existed only to serve it.
- Comments in `OAuthApiClient` that justified the token lock and the bounded 429 retry by naming `course_version_sensor` now name the observation, which fans out over a worker pool the same way.

**Scope widened during review.** Copilot found a real edge-loss bug that this PR activates, and the fix lands in the shared `upstream_or_code_changes()` helper rather than in openedx — so this PR now changes automation behaviour for **nine asset modules** (dbt, canvas, edxorg, superset, learning_resources, student_risk_probability, openedx). Reviewers should weigh that deliberately; it is not incidental to the diff.

When an upstream data version moves *during* a run, `~in_progress()` suppresses the one tick where `data_version_changed()` is true, and the running job then succeeds — so `execution_failed()` never fires and the update is lost silently. This is the sibling of what #2517 fixed: that covered the run that *fails*, nothing covered the run that *succeeds while the upstream moves underneath it*. Reproduced before fixing, and pinned by three tests verified to fail without the change.

The non-obvious part: `.since_last_handled()` does **not** work, because it also resets on `newly_updated` and the stale run emits its own materialization — clearing the latch for a version the asset never read. The reset has to be `newly_requested` alone, which also preserves the reason the signal was left unlatched until now (an `output_required=False` asset that emits nothing still records a *request*, so it does not re-request forever). Side effect to know about: a manual run or backfill no longer clears a pending upstream change, so one automation run can follow it.

Also from review: the automation sensor is now evaluated every 5 minutes rather than hourly. Each link in `courseware -> course_xml -> extract -> webhook` advances one tick at a time and an observation lands *after* the tick that requested it, so an hourly interval put roughly four hours between a republish and the webhook. How often the LMS is swept is set by the source asset's cron, not by this, so a tick that finds nothing costs a graph evaluation and no API calls.

**One deliberate trade.** Exports lose the sensor's `MAX_RUN_REQUESTS_PER_TICK = 8` cap, so `course_xml` gets `pool="openedx_course_export"` instead. That is exactly the swap the sensor's own comment asked for — the cap existed to stop catch-up exports filling the global pool of 30 run slots and queueing unrelated pipelines behind them, and a dedicated pool bounds that without also bounding how quickly a genuine republish is noticed. **The pool has no slot limit until one is set on the instance** (see checklist below); until then a large catch-up can still contend for global slots.

### How can this be tested?

Automated — a new `dg_projects/openedx/openedx_tests/test_assets.py` runs the real observe fn and the real automation conditions against an ephemeral `DagsterInstance`:

```
cd dg_projects/openedx && uv run --project . pytest openedx_tests -q     # 14 passed
cd packages/ol-orchestrate-lib && uv run --project . pytest tests -q      # 77 passed, 80 skipped
cd dg_projects/lakehouse && uv run --project . pytest lakehouse_tests -q  # 36 passed (helper consumer)
cd dg_projects/edxorg && uv run --project . pytest edxorg_tests -q        # 32 passed (helper consumer)
uv run pre-commit run --files <changed files>                            # ruff + mypy clean
cd dg_projects/openedx && uv run --project . dg check defs               # definitions load
```

`test_a_republish_during_an_export_is_not_lost` covers the edge-loss bug above end to end, and `packages/ol-orchestrate-lib/tests/lib/test_automation_policies.py` pins the same two properties generically for every consumer of the helper (`test_update_survives_a_run_that_was_already_in_flight`, `test_the_latch_clears_once_the_update_is_requested`). All three were verified to fail with the latch removed. `openedx_tests/test_components.py` covers the mixed `SourceAsset`/`AssetsDefinition` sensor target.

`test_the_observation_drives_the_full_export_cycle` is the one that matters: it walks never-exported → requested, exported → quiet, re-observed unchanged → quiet, republished → exactly that partition, threading the `AssetDaemonCursor` between evaluations so the edge-triggered conditions behave as they do in the daemon. The rest pin the sweep's failure handling (a 404 course emits no observation so its last version stands; one broken lookup is skipped; *every* lookup failing fails the run rather than reporting a green empty sweep) and that `cron_tick_passed` asks for the observation once an hour rather than once per sensor tick.

Manual validation after deploy, per deployment:

1. Confirm `<deployment>_openedx_automation_sensor` is **RUNNING**. This is now the only thing that launches exports — see the checklist.
2. Watch for one `<deployment>__openedx__courseware` observation run at the top of the hour and check its log line: `Observed N of N <deployment> course runs, 0 failed`.
3. Republish a course in Studio, then confirm the next hour's observation is followed by a `course_xml` run for exactly that partition.
4. Confirm no `course_xml` runs are launched for partitions whose published version did not move.

### Additional Context

**Deployment-critical:** exports were previously launched by `<deployment>_course_version_sensor`, which ships `DefaultSensorStatus.STOPPED` and is enabled per instance. After this change, `<deployment>_openedx_automation_sensor` is the *only* path that launches an export. If it is not running in production, course exports stop entirely and silently. Worth confirming its state before merging, not after.

`<deployment>_courseware_sensor` (partition discovery) is unaffected and still needs to be running for new course runs to be picked up.

The first automation tick after deploy is quiet by design: `cron_tick_passed` needs a previous evaluation time to compare against, so the first observation happens at the next hour boundary rather than immediately.

**Known limitation, filed as follow-up:** the sweep observes every registered partition, including the long archived tail of finished courses on `mitx` and `xpro`. That is not a regression — `course_version_sensor` swept all partitions too — but it is work the graph does hourly for courses that will never change again. Skipping archived runs is tracked separately.

### Checklist:
- [ ] Set a slot limit for the `openedx_course_export` concurrency pool in the Dagster instance UI (Deployment → Concurrency). Suggested starting point: 8, matching the `MAX_RUN_REQUESTS_PER_TICK` cap it replaces.
- [ ] Confirm `<deployment>_openedx_automation_sensor` is RUNNING in production for mitx, mitxonline, and xpro before merging.
