### PR TITLE
fix(io-managers): fail loudly and once when an upstream object is missing

### DIFF
--- a/packages/ol-orchestrate-lib/src/ol_orchestrate/io_managers/filepath.py
+++ b/packages/ol-orchestrate-lib/src/ol_orchestrate/io_managers/filepath.py
@@ -5,6 +5,7 @@ from dagster import (
     ConfigurableIOManager,
     DagsterEventType,
     EventRecordsFilter,
+    Failure,
     InputContext,
     MetadataValue,
     OutputContext,
@@ -17,6 +18,12 @@ from upath import UPath
 
 from ol_orchestrate.resources.secrets.vault import Vault
 
+# How far back through an asset partition's materialization history to look for
+# an event that records a `path`. Only guards against a handful of malformed
+# events at the head of the history -- if the most recent dozen all lack a
+# location there is a real problem to surface, not to paper over.
+MATERIALIZATION_LOOKBACK = 10
+
 
 class FileObjectIOManager(ConfigurableIOManager):
     path_prefix: str | None = None
@@ -28,20 +35,84 @@ class FileObjectIOManager(ConfigurableIOManager):
     _s3_fs: S3FileSystem = PrivateAttr(default=None)
 
     def load_input(self, context: InputContext) -> UPath:
-        asset_dep = context.instance.get_event_records(
+        """Resolve an upstream asset partition to the object it was written to.
+
+        The location is read back out of the upstream materialization event
+        rather than recomputed, so this is only ever as trustworthy as the
+        event log. Three things can go wrong, and all three used to surface as
+        an opaque ``KeyError``/``IndexError`` inside the io manager or as a
+        ``NoSuchKey`` from fsspec several frames later:
+
+        * the partition has never been materialized,
+        * the newest materialization carries no ``path`` metadata,
+        * the recorded object is no longer in the bucket.
+
+        None of those are fixable by running the step again, so each raises a
+        ``Failure`` naming the asset, the partition and the path, with retries
+        disabled. Retrying a missing S3 key just multiplies the alert.
+        """
+        asset_label = context.asset_key.to_user_string()
+        records = context.instance.get_event_records(
             event_records_filter=EventRecordsFilter(
                 asset_key=context.asset_key,
                 event_type=DagsterEventType.ASSET_MATERIALIZATION,
                 asset_partitions=[context.partition_key],
             ),
-            limit=1,
-        )[0]
+            limit=MATERIALIZATION_LOOKBACK,
+        )
+        if not records:
+            raise Failure(
+                description=(
+                    f"No materialization of {asset_label} partition "
+                    f"{context.partition_key!r} has been recorded, so there is "
+                    "no location to load from. Materialize the upstream asset "
+                    "for this partition first."
+                ),
+                allow_retries=False,
+            )
 
-        asset_path = UPath(asset_dep.asset_materialization.metadata["path"].value)
-        return UPath(
+        # Newest first. Deliberately does not fall back to an older event when
+        # the newest one points at a missing object: these paths are content
+        # hashed, so an earlier event is an earlier *version* of the data, and
+        # silently loading it would trade a loud failure for stale results.
+        # Only events with no location at all get skipped over.
+        path_metadata = next(
+            (
+                metadata
+                for record in records
+                if (metadata := record.asset_materialization.metadata.get("path"))
+                is not None
+            ),
+            None,
+        )
+        if path_metadata is None:
+            raise Failure(
+                description=(
+                    f"None of the last {len(records)} materializations of "
+                    f"{asset_label} partition {context.partition_key!r} recorded "
+                    "a 'path'. The upstream asset emitted materialization events "
+                    "without a location, so there is nothing to load."
+                ),
+                allow_retries=False,
+            )
+
+        asset_path = UPath(path_metadata.value)
+        resolved_path = UPath(
             asset_path,
             **self.configure_path_fs(asset_path.protocol).storage_options,
         )
+        if not resolved_path.exists():
+            raise Failure(
+                description=(
+                    f"{asset_label} partition {context.partition_key!r} points at "
+                    f"{asset_path}, which does not exist. The materialization "
+                    "event outlived the object it describes -- re-materialize the "
+                    "upstream asset to write it again."
+                ),
+                metadata={"path": MetadataValue.path(str(asset_path))},
+                allow_retries=False,
+            )
+        return resolved_path
 
     def handle_output(self, context: OutputContext, obj: tuple[Path, str]) -> None:
         context.log.info("Writing contents of %s to %s", *obj)

--- a/packages/ol-orchestrate-lib/src/ol_orchestrate/io_managers/filepath.py
+++ b/packages/ol-orchestrate-lib/src/ol_orchestrate/io_managers/filepath.py
@@ -48,8 +48,18 @@ class FileObjectIOManager(ConfigurableIOManager):
         * the recorded object is no longer in the bucket.
 
         None of those are fixable by running the step again, so each raises a
-        ``Failure`` naming the asset, the partition and the path, with retries
-        disabled. Retrying a missing S3 key just multiplies the alert.
+        ``Failure`` naming the asset, the partition and the path -- which is
+        the actual win here, since the previous errors named none of them.
+
+        ``allow_retries=False`` is set for correctness but does less than it
+        sounds like: Dagster only consults it when the op or asset carries a
+        ``RetryPolicy`` (see
+        ``dagster._core.execution.plan.utils.op_execution_error_boundary``).
+        The run-level auto-reexecution daemon decides from run status and the
+        ``dagster/max_retries`` / ``dagster/retry_on_asset_or_op_failure``
+        tags and never looks at it, so these failures are still re-run by
+        ``run_retries``. Suppressing that would mean a run-tag or instance
+        level change, which is deliberately out of scope here.
         """
         asset_label = context.asset_key.to_user_string()
         records = context.instance.get_event_records(

--- a/packages/ol-orchestrate-lib/tests/io_managers/test_filepath.py
+++ b/packages/ol-orchestrate-lib/tests/io_managers/test_filepath.py
@@ -1,0 +1,125 @@
+"""Tests for ol_orchestrate.io_managers.filepath."""
+
+from pathlib import Path
+
+import pytest
+from dagster import AssetKey, Failure, MetadataValue
+from ol_orchestrate.io_managers.filepath import (
+    MATERIALIZATION_LOOKBACK,
+    LocalFileObjectIOManager,
+)
+
+
+class _Materialization:
+    def __init__(self, metadata: dict[str, MetadataValue]) -> None:
+        self.metadata = metadata
+
+
+class _Record:
+    def __init__(self, metadata: dict[str, MetadataValue]) -> None:
+        self.asset_materialization = _Materialization(metadata)
+
+
+class _Instance:
+    """Stands in for DagsterInstance, returning canned materialization records."""
+
+    def __init__(self, records: list[_Record]) -> None:
+        self._records = records
+        self.requested_limit: int | None = None
+
+    def get_event_records(self, event_records_filter, limit):  # noqa: ARG002
+        self.requested_limit = limit
+        return self._records[:limit]
+
+
+class _InputContext:
+    def __init__(self, records: list[_Record]) -> None:
+        self.asset_key = AssetKey(("edxorg", "raw_data", "course_xml"))
+        self.partition_key = "MITx-3.012Sx-3T2021|prod"
+        self.instance = _Instance(records)
+
+
+def _path_record(path: Path | str) -> _Record:
+    """Build a record the way LocalFileObjectIOManager.handle_output does.
+
+    The ``file://`` scheme matters: ``configure_path_fs`` dispatches on the
+    URL protocol, and a bare filesystem path carries an empty one.
+    """
+    return _Record({"path": MetadataValue.path(f"file://{path}")})
+
+
+def test_load_input_returns_recorded_path(tmp_path: Path) -> None:
+    """The happy path resolves to the object the upstream asset wrote."""
+    target = tmp_path / "course.xml.tar.gz"
+    target.write_bytes(b"archive")
+
+    resolved = LocalFileObjectIOManager().load_input(
+        _InputContext([_path_record(target)])
+    )
+
+    assert resolved.exists()
+    assert str(resolved).endswith(str(target))
+
+
+def test_load_input_skips_materializations_without_a_path(tmp_path: Path) -> None:
+    """A newer event lacking 'path' must not mask the one that has it.
+
+    Regression test for the KeyError that took down every downstream step
+    whenever an upstream materialization was emitted without a location.
+    """
+    target = tmp_path / "course.xml.tar.gz"
+    target.write_bytes(b"archive")
+    records = [
+        _Record({"object_key": MetadataValue.text("no/path/here")}),
+        _path_record(target),
+    ]
+
+    resolved = LocalFileObjectIOManager().load_input(_InputContext(records))
+
+    assert resolved.exists()
+    assert str(resolved).endswith(str(target))
+
+
+def test_load_input_fails_without_retries_when_object_is_gone(tmp_path: Path) -> None:
+    """A path recorded for an object that no longer exists is terminal.
+
+    Retrying cannot conjure the key back, so retries are disabled rather than
+    letting run_retries multiply one dead partition into four alerts.
+    """
+    missing = tmp_path / "expired.xml.tar.gz"
+
+    with pytest.raises(Failure) as exc_info:
+        LocalFileObjectIOManager().load_input(_InputContext([_path_record(missing)]))
+
+    assert exc_info.value.allow_retries is False
+    assert str(missing) in str(exc_info.value.description)
+
+
+def test_load_input_fails_when_partition_never_materialized() -> None:
+    """No materialization at all gets a message naming the partition."""
+    with pytest.raises(Failure) as exc_info:
+        LocalFileObjectIOManager().load_input(_InputContext([]))
+
+    assert exc_info.value.allow_retries is False
+    assert "MITx-3.012Sx-3T2021|prod" in str(exc_info.value.description)
+
+
+def test_load_input_fails_when_no_event_records_a_path() -> None:
+    """Every event lacking a location is a real problem, not one to skip past."""
+    records = [_Record({"object_key": MetadataValue.text("no/path/here")})] * 3
+
+    with pytest.raises(Failure) as exc_info:
+        LocalFileObjectIOManager().load_input(_InputContext(records))
+
+    assert exc_info.value.allow_retries is False
+    assert "recorded a 'path'" in str(exc_info.value.description)
+
+
+def test_load_input_bounds_the_history_scan() -> None:
+    """The event-log query stays bounded rather than walking all of history."""
+    context = _InputContext([])
+
+    with pytest.raises(Failure):
+        LocalFileObjectIOManager().load_input(context)
+
+    assert context.instance.requested_limit == MATERIALIZATION_LOOKBACK

--- a/packages/ol-orchestrate-lib/tests/io_managers/test_filepath.py
+++ b/packages/ol-orchestrate-lib/tests/io_managers/test_filepath.py
@@ -83,8 +83,11 @@ def test_load_input_skips_materializations_without_a_path(tmp_path: Path) -> Non
 def test_load_input_fails_without_retries_when_object_is_gone(tmp_path: Path) -> None:
     """A path recorded for an object that no longer exists is terminal.
 
-    Retrying cannot conjure the key back, so retries are disabled rather than
-    letting run_retries multiply one dead partition into four alerts.
+    Retrying cannot conjure the key back, so the Failure is marked
+    non-retryable and names the path that is missing. Note that
+    ``allow_retries`` only governs an op/asset ``RetryPolicy`` -- the
+    run-level auto-reexecution daemon ignores it -- so this asserts the
+    property, not that the run is spared a re-run.
     """
     missing = tmp_path / "expired.xml.tar.gz"
 


### PR DESCRIPTION
### What are the relevant tickets?
Sentry: [DAGSTER-3](https://mit-office-of-digital-learning.sentry.io/issues/DAGSTER-3), [DAGSTER-2](https://mit-office-of-digital-learning.sentry.io/issues/DAGSTER-2), [DAGSTER-1](https://mit-office-of-digital-learning.sentry.io/issues/DAGSTER-1)

### Description (What does it do?)

First of a set of PRs working through the Sentry backlog that appeared when error tracking landed in #2518. This one is the big one: **8,079 of the 8,692 events in the project's first day come from this single code path.**

`FileObjectIOManager.load_input` resolved an upstream asset partition by taking the single newest materialization event and trusting `metadata["path"]`:

```python
asset_dep = context.instance.get_event_records(..., limit=1)[0]
asset_path = UPath(asset_dep.asset_materialization.metadata["path"].value)
```

Three things go wrong with that, and all three were showing up in production:

| Failure | Sentry | Events | How it surfaced |
|---|---|---|---|
| Newest event carries no `path` | DAGSTER-2, DAGSTER-1 | 181 | `KeyError: 'path'`, naming neither asset nor partition |
| Partition never materialized | — | — | `IndexError` on `[0]` |
| Recorded object is gone from the bucket | DAGSTER-3 | 7,898 | `NoSuchKey` out of fsspec, several frames away |

None of the three can be fixed by running the step again, yet all three reach `run_retries.max_retries: 3` and are retried four times apiece. That multiplication is why a handful of dead partitions produced thousands of events. Suppressing it needs a run-tag or instance-level change, which is deliberately out of scope here — this PR makes each failure say which partition to fix.

**What changed:**

- Each case now raises `Failure(..., allow_retries=False)` naming the asset, the partition and the path. **Correction after review:** an earlier version of this description claimed `allow_retries=False` collapses the event volume. It does not — Dagster only consults it when the op/asset carries a `RetryPolicy` (`dagster._core.execution.plan.utils.op_execution_error_boundary`), while the run-level auto-reexecution daemon decides from run status and the `dagster/max_retries` / `dagster/retry_on_asset_or_op_failure` tags. These failures are still re-run under `run_retries`. The flag is kept because it is correct for any asset that does have a `RetryPolicy`, but the value of this PR is the actionable message, not the retry count.
- Events lacking a `path` are skipped in favour of the most recent event that has one, bounded to a `MATERIALIZATION_LOOKBACK` of 10. A materialization with no location is a malformed event, not a deliberate version choice.
- A recorded path pointing at a **missing object deliberately does not** fall back to an older event. These keys are content-hashed, so an earlier event is earlier *data*; quietly loading it would trade a loud failure for a silently stale result.
- Added `packages/ol-orchestrate-lib/tests/io_managers/test_filepath.py` covering all four paths plus the lookback bound.

### How can this be tested?

```bash
cd packages/ol-orchestrate-lib && uv run pytest tests/ -q
# 83 passed, 80 skipped
```

`pre-commit run --files <changed>` is clean (ruff format, ruff check, mypy).

The behaviour change is observable in Sentry: DAGSTER-3 should stop growing at ~4x the rate of the underlying partition failures, and the DAGSTER-2/DAGSTER-1 `KeyError`s should be replaced by messages that name the partition.

### Additional Context

**This does not explain why the edxorg archive objects are missing.** The failing paths look like

```
s3://ol-data-lake-landing-zone-production/edxorg/raw_data/course_xml/prod/MITxPRO-AMxBIntro-2T2019/<sha256>.xml.tar.gz
```

for courses dating back to 2019. Either a lifecycle rule expired them or they were written to a different bucket in an earlier deployment — I could not check the bucket from here, and there is no lifecycle configuration in this repo. Worth an S3 check against the landing zone before deciding whether those partitions should be re-materialized or retired.

The change is in shared lib code, so it also applies to the `openedx`, `canvas`, `learning_resources`, `b2b_organization` and `student_risk_probability` code locations. That is intended — they have the same exposure. It does add one existence check (an S3 HEAD) per input load, which is cheap next to the run it replaces.

