### PR TITLE
fix(legacy_openedx): keep the code location loadable when Vault is down

### DIFF
--- a/dg_projects/legacy_openedx/legacy_openedx/definitions.py
+++ b/dg_projects/legacy_openedx/legacy_openedx/definitions.py
@@ -210,10 +210,24 @@ _base_production_resources = {
 
 def _job_default_config(
     deployment: Literal["mitx", "mitxonline", "xpro"],
-) -> dict[str, object]:
-    """Return a default run config for the launchpad when Vault is available."""
+) -> dict[str, object] | None:
+    """Return a default run config for the launchpad when Vault is available.
+
+    Returns ``None`` -- not ``{}`` -- when there is no config to offer.
+    ``to_job(config={})`` does not mean "no default"; Dagster treats any
+    mapping as a default run config and validates it against the job's schema,
+    so an empty one fails with
+
+        Missing required config entries ['ops', 'resources'] at the root
+
+    That error is raised while the repository is being constructed, which
+    kills the gRPC server for the whole code location rather than just
+    leaving the launchpad blank. ``config=None`` skips the validation
+    entirely, which is the graceful degradation this function was written to
+    provide.
+    """
     if not vault_authenticated:
-        return {}
+        return None
     try:
         return open_edx_export_irx_job_config(deployment, DAGSTER_ENV)
     except Exception:
@@ -224,7 +238,7 @@ def _job_default_config(
             deployment,
             exc_info=True,
         )
-        return {}
+        return None
 
 
 residential_edx_job = edx_course_pipeline.to_job(

--- a/dg_projects/legacy_openedx/legacy_openedx_tests/test_definitions.py
+++ b/dg_projects/legacy_openedx/legacy_openedx_tests/test_definitions.py
@@ -1,0 +1,55 @@
+"""Tests for the legacy_openedx code location definitions."""
+
+import warnings
+
+import pytest
+
+
+@pytest.fixture
+def definitions(monkeypatch: pytest.MonkeyPatch):
+    """Import the code location with Vault unreachable.
+
+    Points Vault at a closed port so ``authenticate_vault`` fails fast rather
+    than blocking on a network timeout. This is the degraded path the module's
+    resilient loading is written for, and the one that used to take the whole
+    code location down.
+    """
+    monkeypatch.setenv("VAULT_ADDR", "http://127.0.0.1:1")
+    monkeypatch.setenv("VAULT_ADDRESS", "http://127.0.0.1:1")
+    monkeypatch.setenv("DAGSTER_ENVIRONMENT", "qa")
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        # Deferred on purpose: the module does its Vault authentication at
+        # import time, so it has to be imported after the environment above
+        # is in place.
+        import legacy_openedx.definitions as definitions_module  # noqa: PLC0415
+    return definitions_module
+
+
+def test_repository_builds_without_vault(definitions) -> None:
+    """The code location must stay loadable when Vault is unavailable.
+
+    Regression test for DAGSTER-F. ``_job_default_config`` returned ``{}`` on
+    the no-Vault path, and ``to_job(config={})`` does not mean "no default" --
+    Dagster validates the empty mapping against the job's config schema and
+    raises
+
+        Missing required config entries ['ops', 'resources'] at the root
+
+    That happens while the repository is being constructed, so it killed the
+    gRPC server for the entire code location -- all three jobs and all three
+    schedules -- rather than merely leaving the launchpad unpopulated.
+    """
+    repository = definitions.defs.get_repository_def()
+
+    job_names = {job.name for job in repository.get_all_jobs()}
+    assert {
+        "residential_edx_course_pipeline",
+        "xpro_edx_course_pipeline",
+        "mitxonline_edx_course_pipeline",
+    } <= job_names
+
+
+def test_job_default_config_is_none_without_vault(definitions) -> None:
+    """The degraded default must be None, not an empty mapping."""
+    assert definitions._job_default_config("mitx") is None

--- a/dg_projects/legacy_openedx/legacy_openedx_tests/test_definitions.py
+++ b/dg_projects/legacy_openedx/legacy_openedx_tests/test_definitions.py
@@ -7,6 +7,15 @@ import pytest
 
 MODULE_UNDER_TEST = "legacy_openedx.definitions"
 
+# ol_orchestrate.lib.constants snapshots DAGSTER_ENVIRONMENT and VAULT_ADDR
+# into module-level DAGSTER_ENV/VAULT_ADDRESS at import, and the module under
+# test imports those *values*. Evicting only the leaf leaves the cached
+# constants in place, so `definitions` would rebind to a VAULT_ADDRESS
+# resolved from whatever environment imported constants first -- in practice
+# the real vault-qa host, which turns a fast connection refusal into a network
+# timeout and quietly stops testing the degraded path.
+MODULES_TO_EVICT = (MODULE_UNDER_TEST, "ol_orchestrate.lib.constants")
+
 
 def _import_with_vault_unreachable(monkeypatch: pytest.MonkeyPatch):
     """Import the code location fresh, with Vault unreachable.
@@ -19,13 +28,15 @@ def _import_with_vault_unreachable(monkeypatch: pytest.MonkeyPatch):
     Everything being set up here happens at *import* time, so a cached entry
     in ``sys.modules`` would hand back a module built under whatever
     environment imported it first and none of the patching would apply.
-    Evicting it forces re-execution against this environment; monkeypatch
-    restores the previous entry on teardown so the eviction cannot leak.
+    Evicting forces re-execution against this environment; monkeypatch
+    restores the previous entries on teardown so the eviction cannot leak.
+    The constants module has to go too -- see MODULES_TO_EVICT.
     """
     monkeypatch.setenv("VAULT_ADDR", "http://127.0.0.1:1")
     monkeypatch.setenv("VAULT_ADDRESS", "http://127.0.0.1:1")
     monkeypatch.setenv("DAGSTER_ENVIRONMENT", "qa")
-    monkeypatch.delitem(sys.modules, MODULE_UNDER_TEST, raising=False)
+    for module_name in MODULES_TO_EVICT:
+        monkeypatch.delitem(sys.modules, module_name, raising=False)
     with warnings.catch_warnings():
         warnings.simplefilter("ignore")
         # Deferred on purpose: the module does its Vault authentication at
@@ -55,6 +66,35 @@ def test_import_is_not_served_from_the_module_cache(
     second = _import_with_vault_unreachable(monkeypatch)
 
     assert first is not second
+
+
+def test_vault_address_comes_from_this_test_environment(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The module must see the closed port, not a stale real Vault host.
+
+    ol_orchestrate.lib.constants resolves VAULT_ADDRESS at import time, and
+    legacy_openedx.definitions imports the resolved value. Evicting only
+    definitions left the cached constants in place, so an earlier import
+    anywhere in the session would leave this pointed at vault-qa.odl.mit.edu
+    -- a network timeout instead of an immediate connection refusal, and no
+    longer a test of the degraded path at all.
+
+    Primes the cache with constants resolved against a *different* address
+    first, which is what any earlier import in the session does. Without the
+    constants eviction the assertion below sees that stale host instead.
+    """
+    monkeypatch.delitem(sys.modules, "ol_orchestrate.lib.constants", raising=False)
+    monkeypatch.setenv("VAULT_ADDR", "https://vault-qa.odl.mit.edu")
+    monkeypatch.setenv("DAGSTER_ENVIRONMENT", "qa")
+    import ol_orchestrate.lib.constants as stale_constants  # noqa: PLC0415
+
+    assert stale_constants.VAULT_ADDRESS == "https://vault-qa.odl.mit.edu"
+
+    definitions = _import_with_vault_unreachable(monkeypatch)
+
+    assert definitions.VAULT_ADDRESS == "http://127.0.0.1:1"
+    assert definitions.vault_authenticated is False
 
 
 def test_repository_builds_without_vault(definitions) -> None:

--- a/dg_projects/legacy_openedx/legacy_openedx_tests/test_definitions.py
+++ b/dg_projects/legacy_openedx/legacy_openedx_tests/test_definitions.py
@@ -1,22 +1,31 @@
 """Tests for the legacy_openedx code location definitions."""
 
+import sys
 import warnings
 
 import pytest
 
+MODULE_UNDER_TEST = "legacy_openedx.definitions"
 
-@pytest.fixture
-def definitions(monkeypatch: pytest.MonkeyPatch):
-    """Import the code location with Vault unreachable.
+
+def _import_with_vault_unreachable(monkeypatch: pytest.MonkeyPatch):
+    """Import the code location fresh, with Vault unreachable.
 
     Points Vault at a closed port so ``authenticate_vault`` fails fast rather
     than blocking on a network timeout. This is the degraded path the module's
     resilient loading is written for, and the one that used to take the whole
     code location down.
+
+    Everything being set up here happens at *import* time, so a cached entry
+    in ``sys.modules`` would hand back a module built under whatever
+    environment imported it first and none of the patching would apply.
+    Evicting it forces re-execution against this environment; monkeypatch
+    restores the previous entry on teardown so the eviction cannot leak.
     """
     monkeypatch.setenv("VAULT_ADDR", "http://127.0.0.1:1")
     monkeypatch.setenv("VAULT_ADDRESS", "http://127.0.0.1:1")
     monkeypatch.setenv("DAGSTER_ENVIRONMENT", "qa")
+    monkeypatch.delitem(sys.modules, MODULE_UNDER_TEST, raising=False)
     with warnings.catch_warnings():
         warnings.simplefilter("ignore")
         # Deferred on purpose: the module does its Vault authentication at
@@ -24,6 +33,28 @@ def definitions(monkeypatch: pytest.MonkeyPatch):
         # is in place.
         import legacy_openedx.definitions as definitions_module  # noqa: PLC0415
     return definitions_module
+
+
+@pytest.fixture
+def definitions(monkeypatch: pytest.MonkeyPatch):
+    """Build a fresh legacy_openedx.definitions with Vault unavailable."""
+    return _import_with_vault_unreachable(monkeypatch)
+
+
+def test_import_is_not_served_from_the_module_cache(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Each import must re-execute the module rather than reuse a cached one.
+
+    Without the sys.modules eviction, the second call here returns the object
+    built by the first, so any test after the first one in a session would
+    silently assert against a module created under a different environment --
+    passing or failing on import order rather than on behaviour.
+    """
+    first = _import_with_vault_unreachable(monkeypatch)
+    second = _import_with_vault_unreachable(monkeypatch)
+
+    assert first is not second
 
 
 def test_repository_builds_without_vault(definitions) -> None:


### PR DESCRIPTION
### What are the relevant tickets?
Sentry: [DAGSTER-F](https://mit-office-of-digital-learning.sentry.io/issues/DAGSTER-F)

### Description (What does it do?)

Part of a set of PRs working through the Sentry backlog from #2518.

This issue logged only **one** event, which badly understates it: `mechanism: excepthook`, `handled: no`, on the `dagster-user-code-...-legacy-openedx` pod. It is not a step failure — it is the gRPC server for the whole code location failing to start.

`_job_default_config` returns a default run config so the launchpad is pre-populated for ad-hoc runs, and is written to degrade gracefully when Vault is unreachable at load time. On that degraded path it returned `{}`:

```python
if not vault_authenticated:
    return {}
```

But `config={}` does not mean "no default". Dagster treats any mapping as a default run config and validates it against the job's schema, so an empty one fails:

```
DagsterInvalidConfigError: Error in config when building job 'residential_edx_course_pipeline':
  Missing required config entries ['ops', 'resources'] at the root.
```

That validation runs inside `build_caching_repository_data_from_list` → `job.partitions_def` → `_resolve_configs`, i.e. while the repository is being constructed. So the fallback meant to keep the location alive was the thing killing it — and it takes down **all three jobs and all three schedules**, not just the residential one named in the message.

Returning `None` skips default-config validation entirely and leaves the launchpad unpopulated, which is the degraded behaviour the function was written to provide.

### How can this be tested?

Reproduced directly, with Vault pointed at a closed port so `authenticate_vault` fails fast:

```bash
cd dg_projects/legacy_openedx
VAULT_ADDR=http://127.0.0.1:1 VAULT_ADDRESS=http://127.0.0.1:1 DAGSTER_ENVIRONMENT=qa \
  uv run python -c "import legacy_openedx.definitions as d; d.defs.get_repository_def()"
```

- Before: `DagsterInvalidConfigError: ... missing required fields or contains invalid entries`
- After: `repository OK: 3 jobs`

Note the failure does **not** reproduce on plain `import` — it needs the repository construction step, which is what the gRPC server does at startup.

Both cases are covered by the new `legacy_openedx_tests/test_definitions.py` (this code location had no tests before):

```bash
cd dg_projects/legacy_openedx && uv run pytest legacy_openedx_tests/ -q
# 2 passed
```

`pre-commit run --files <changed>` is clean.

### Additional Context

Worth confirming after deploy that the `legacy_openedx` location is actually up in production — the single Sentry event suggests it crashed once rather than crash-looping, which would mean it came back when Vault recovered and this is a latent trap rather than a current outage. The `mitxonline_edx_course_pipeline` run in [DAGSTER-E](https://mit-office-of-digital-learning.sentry.io/issues/DAGSTER-E) four minutes earlier indicates the location was healthy immediately before.
