### PR TITLE
fix(openedx): stop treating in-progress exports and library blocks as failures

### DIFF
--- a/dg_projects/legacy_openedx/legacy_openedx/ops/open_edx.py
+++ b/dg_projects/legacy_openedx/legacy_openedx/ops/open_edx.py
@@ -690,7 +690,10 @@ def export_single_edx_course(  # noqa: C901, PLR0911
         if state == "Succeeded":
             context.log.info("Export succeeded for course %s", course_id)
             return course_id
-        if state in {"Failed", "Canceled", "Retrying"}:
+        # "Retrying" is deliberately absent: Studio uses it for a task it is
+        # about to attempt again, so treating it as terminal abandoned exports
+        # that were still in progress.
+        if state in {"Failed", "Canceled"}:
             context.log.warning(
                 "Export reached terminal failure state '%s' for course %s",
                 state,

--- a/dg_projects/legacy_openedx/legacy_openedx/ops/open_edx.py
+++ b/dg_projects/legacy_openedx/legacy_openedx/ops/open_edx.py
@@ -27,7 +27,11 @@ from dagster import (
 from flatten_dict import flatten
 from flatten_dict.reducers import make_reducer
 from ol_orchestrate.lib.file_rendering import write_csv
-from ol_orchestrate.lib.openedx import un_nest_course_structure
+from ol_orchestrate.lib.openedx import (
+    CourseExportOutcome,
+    classify_course_export_state,
+    un_nest_course_structure,
+)
 from pydantic import Field
 from pypika import MySQLQuery as Query
 from pypika import Table, Tables
@@ -687,13 +691,11 @@ def export_single_edx_course(  # noqa: C901, PLR0911
                 status,
             )
             return None
-        if state == "Succeeded":
+        outcome = classify_course_export_state(state)
+        if outcome is CourseExportOutcome.SUCCEEDED:
             context.log.info("Export succeeded for course %s", course_id)
             return course_id
-        # "Retrying" is deliberately absent: Studio uses it for a task it is
-        # about to attempt again, so treating it as terminal abandoned exports
-        # that were still in progress.
-        if state in {"Failed", "Canceled"}:
+        if outcome is CourseExportOutcome.FAILED:
             context.log.warning(
                 "Export reached terminal failure state '%s' for course %s",
                 state,

--- a/dg_projects/openedx/openedx/assets/openedx.py
+++ b/dg_projects/openedx/openedx/assets/openedx.py
@@ -297,6 +297,9 @@ def course_xml(context: AssetExecutionContext):
         )
         successful_exports: set[str] = set()
         failed_exports: set[str] = set()
+        # Keyed by course id, so a failure or a timeout can say what Studio
+        # last reported instead of just that something went wrong.
+        last_seen_status: dict[str, str] = {}
         tasks = exported_courses["upload_task_ids"]
         start_time = datetime.now(tz=UTC)
         while len(successful_exports.union(failed_exports)) < len(tasks):
@@ -304,7 +307,11 @@ def course_xml(context: AssetExecutionContext):
                 datetime.now(tz=UTC) - start_time
                 > COURSE_EXPORT_GET_TASKS_STATUS_TIMEOUT
             ):
-                err_msg = f"Course export timed out for {course_key}"
+                err_msg = (
+                    f"Course export timed out for {course_key} after "
+                    f"{COURSE_EXPORT_GET_TASKS_STATUS_TIMEOUT}. Last status "
+                    f"reported by Studio: {last_seen_status or 'none'}"
+                )
                 raise TimeoutError(err_msg)
             time.sleep(timedelta(seconds=20).seconds)
             for course_id, task_id in tasks.items():
@@ -316,9 +323,17 @@ def course_xml(context: AssetExecutionContext):
                 )
                 state = task_status.get("state")
                 details = task_status.get("details")
+                last_seen_status[course_id] = (
+                    f"{state}{f' ({details})' if details else ''}"
+                )
                 if state == "Succeeded":
                     successful_exports.add(course_id)
-                elif state in {"Failed", "Canceled", "Retrying"}:
+                elif state in {"Failed", "Canceled"}:
+                    # "Retrying" is deliberately not terminal. Studio uses it
+                    # for a task it is about to attempt again, so counting it
+                    # as a failure ended this loop early and reported a course
+                    # as unexportable while its export was still in progress.
+                    # A task that retries forever is caught by the timeout.
                     failed_exports.add(course_id)
                 elif details:
                     context.log.info(
@@ -328,7 +343,14 @@ def course_xml(context: AssetExecutionContext):
                         details,
                     )
         if failed_exports:
-            errmsg = f"Unable to export the course XML for {course_key}"
+            reported = {
+                course: last_seen_status.get(course)
+                for course in sorted(failed_exports)
+            }
+            errmsg = (
+                f"Unable to export the course XML for {course_key}. "
+                f"Studio reported: {reported}"
+            )
             raise Exception(errmsg)  # noqa: TRY002
         s3_location = exported_courses["upload_urls"][course_key]
         context.log.debug("Attempting to download the course XML from %s", s3_location)

--- a/dg_projects/openedx/openedx/assets/openedx.py
+++ b/dg_projects/openedx/openedx/assets/openedx.py
@@ -37,6 +37,7 @@ from ol_orchestrate.lib.automation_policies import upstream_or_code_changes
 from ol_orchestrate.lib.openedx import (
     CourseExportOutcome,
     classify_course_export_state,
+    course_export_task_id,
     process_course_xml,
     process_course_xml_blocks,
     process_video_xml,
@@ -302,7 +303,13 @@ def course_xml(context: AssetExecutionContext):
         # Keyed by course id, so a failure or a timeout can say what Studio
         # last reported instead of just that something went wrong.
         last_seen_status: dict[str, str] = {}
-        tasks = exported_courses["upload_task_ids"]
+        # Only ever one course is requested, so the poll set is built from that
+        # course rather than from whatever the response happens to contain.
+        # Reading upload_task_ids directly meant a course Studio declined to
+        # queue produced an empty mapping: the loop ran zero times, nothing was
+        # recorded as failed, and execution fell through to a bare KeyError on
+        # upload_urls further down.
+        tasks = {course_key: course_export_task_id(course_key, exported_courses)}
         start_time = datetime.now(tz=UTC)
         while len(successful_exports.union(failed_exports)) < len(tasks):
             if (

--- a/dg_projects/openedx/openedx/assets/openedx.py
+++ b/dg_projects/openedx/openedx/assets/openedx.py
@@ -35,6 +35,8 @@ from flatten_dict import flatten
 from flatten_dict.reducers import make_reducer
 from ol_orchestrate.lib.automation_policies import upstream_or_code_changes
 from ol_orchestrate.lib.openedx import (
+    CourseExportOutcome,
+    classify_course_export_state,
     process_course_xml,
     process_course_xml_blocks,
     process_video_xml,
@@ -326,14 +328,10 @@ def course_xml(context: AssetExecutionContext):
                 last_seen_status[course_id] = (
                     f"{state}{f' ({details})' if details else ''}"
                 )
-                if state == "Succeeded":
+                outcome = classify_course_export_state(state)
+                if outcome is CourseExportOutcome.SUCCEEDED:
                     successful_exports.add(course_id)
-                elif state in {"Failed", "Canceled"}:
-                    # "Retrying" is deliberately not terminal. Studio uses it
-                    # for a task it is about to attempt again, so counting it
-                    # as a failure ended this loop early and reported a course
-                    # as unexportable while its export was still in progress.
-                    # A task that retries forever is caught by the timeout.
+                elif outcome is CourseExportOutcome.FAILED:
                     failed_exports.add(course_id)
                 elif details:
                     context.log.info(

--- a/packages/ol-orchestrate-lib/src/ol_orchestrate/lib/openedx.py
+++ b/packages/ol-orchestrate-lib/src/ol_orchestrate/lib/openedx.py
@@ -26,12 +26,21 @@ def generate_block_indexes(
     previous_block_id = root_block_id
     while block_stack:
         block_id = block_stack.pop()
+        block_contents = course_structure.get(block_id)
+        if block_contents is None:
+            # A block can be listed as a child without appearing in the
+            # structure document itself. Courses that pull content from a
+            # library do this -- the parent sequential names the block, but
+            # the block lives in the library rather than the course. Skipped
+            # rather than indexed, since a block that will never appear in
+            # the output would otherwise leave a gap in the sequence.
+            continue
         block_index[block_id] = block_index.get(previous_block_id, 0) + 1
         previous_block_id = block_id
         # Add new blocks to the end of the list, ensure that the traversal is done in
         # order of definition by reversing, since we're pulling from the end of the list
         # for each iteration.
-        block_stack.extend(reversed(course_structure[block_id]["children"]))
+        block_stack.extend(reversed(block_contents["children"]))
     return block_index
 
 

--- a/packages/ol-orchestrate-lib/src/ol_orchestrate/lib/openedx.py
+++ b/packages/ol-orchestrate-lib/src/ol_orchestrate/lib/openedx.py
@@ -5,12 +5,48 @@ import logging
 import mimetypes
 import tarfile
 from datetime import UTC, datetime
+from enum import StrEnum
 from pathlib import Path
 from tempfile import NamedTemporaryFile
 from typing import IO, Any
 from xml.etree.ElementTree import ElementTree, tostring
 
 from pydantic import BaseModel, Field
+
+
+class CourseExportOutcome(StrEnum):
+    """What a Studio course-export task state means for a polling caller."""
+
+    SUCCEEDED = "succeeded"
+    FAILED = "failed"
+    PENDING = "pending"
+
+
+# Studio's terminal states. "Retrying" is deliberately not among them: Studio
+# uses it for a task it is about to attempt again, and both callers used to
+# count it as a failure, which ended their poll loop early and reported a
+# course as unexportable while its export was still running.
+COURSE_EXPORT_SUCCEEDED_STATE = "Succeeded"
+COURSE_EXPORT_FAILED_STATES = frozenset({"Failed", "Canceled"})
+
+
+def classify_course_export_state(state: str | None) -> CourseExportOutcome:
+    """Map a Studio export task state onto keep-polling / done / failed.
+
+    Extracted from the poll loops in the ``openedx`` and ``legacy_openedx``
+    code locations so the classification -- the part that was actually wrong,
+    and the part worth pinning -- can be tested without standing up the Studio
+    task API.
+
+    An unrecognised or absent state counts as PENDING: the loop keeps waiting
+    and its timeout provides the bound, which is safer than inventing a
+    verdict for a state Studio has not documented to us.
+    """
+    if state == COURSE_EXPORT_SUCCEEDED_STATE:
+        return CourseExportOutcome.SUCCEEDED
+    if state in COURSE_EXPORT_FAILED_STATES:
+        return CourseExportOutcome.FAILED
+    return CourseExportOutcome.PENDING
 
 
 def generate_block_indexes(

--- a/packages/ol-orchestrate-lib/src/ol_orchestrate/lib/openedx.py
+++ b/packages/ol-orchestrate-lib/src/ol_orchestrate/lib/openedx.py
@@ -49,6 +49,40 @@ def classify_course_export_state(state: str | None) -> CourseExportOutcome:
     return CourseExportOutcome.PENDING
 
 
+class CourseExportNotQueuedError(Exception):
+    """Studio accepted the export request but queued no task for the course."""
+
+
+def course_export_task_id(course_key: str, export_response: dict[str, Any]) -> str:
+    """Pull the export task id for ``course_key``, or say why there isn't one.
+
+    ``export_courses`` returns HTTP 400 as a documented *partial* failure: the
+    courses that could not be queued are listed under ``failed_uploads`` and
+    are simply absent from ``upload_task_ids``. Callers that went straight to
+    ``upload_task_ids`` therefore got an empty mapping, polled nothing, decided
+    nothing had failed, and fell through to a ``KeyError`` on ``upload_urls``
+    -- discarding the reason Studio had put in the response.
+
+    Raises CourseExportNotQueuedError naming Studio's own explanation.
+    """
+    failed_uploads = export_response.get("failed_uploads") or {}
+    if course_key in failed_uploads:
+        msg = (
+            f"Studio declined to queue an export for {course_key}: "
+            f"{failed_uploads[course_key]}"
+        )
+        raise CourseExportNotQueuedError(msg)
+
+    task_id = (export_response.get("upload_task_ids") or {}).get(course_key)
+    if not task_id:
+        msg = (
+            f"Studio returned no export task for {course_key} and did not say "
+            f"why. Full response: {export_response}"
+        )
+        raise CourseExportNotQueuedError(msg)
+    return task_id
+
+
 def generate_block_indexes(
     course_structure: dict[str, Any], root_block_id: str
 ) -> dict[str, int]:

--- a/packages/ol-orchestrate-lib/tests/lib/test_openedx.py
+++ b/packages/ol-orchestrate-lib/tests/lib/test_openedx.py
@@ -4,13 +4,16 @@ import json
 import tarfile
 from pathlib import Path
 from tempfile import TemporaryDirectory
+from typing import Any
 
 import pytest
 from ol_orchestrate.lib.openedx import (
+    CourseExportNotQueuedError,
     CourseExportOutcome,
     CourseStaticAssetsBundle,
     CourseXmlBlock,
     classify_course_export_state,
+    course_export_task_id,
     generate_block_indexes,
     process_course_xml_blocks,
     un_nest_course_structure,
@@ -435,6 +438,67 @@ def test_retrying_then_succeeded_completes_the_export() -> None:
 
     assert succeeded == {course_id}
     assert failed == set()
+
+
+COURSE_KEY = "course-v1:MITxT+MITx+0T2026"
+
+
+def test_course_export_task_id_returns_the_queued_task() -> None:
+    """The happy path hands back the task id the poll loop needs."""
+    response = {
+        "failed_uploads": {},
+        "upload_task_ids": {COURSE_KEY: "f65e2212-fd97-4645-83cd-7f1c442efb21"},
+        "upload_urls": {COURSE_KEY: "https://example.s3.amazonaws.com/course.tar.gz"},
+    }
+
+    assert (
+        course_export_task_id(COURSE_KEY, response)
+        == "f65e2212-fd97-4645-83cd-7f1c442efb21"
+    )
+
+
+def test_course_export_task_id_surfaces_studios_queue_failure() -> None:
+    """A declined course must report Studio's reason, not a KeyError.
+
+    export_courses returns HTTP 400 as a documented partial failure: the
+    course lands in failed_uploads and is absent from upload_task_ids. Reading
+    upload_task_ids directly gave an empty poll set, so the loop ran zero
+    times, nothing was recorded as failed, and the asset fell through to
+    `exported_courses["upload_urls"][course_key]` -- a bare KeyError that
+    threw away the explanation sitting in the response.
+    """
+    response = {
+        "failed_uploads": {COURSE_KEY: "Course not found"},
+        "upload_task_ids": {},
+        "upload_urls": {},
+    }
+
+    with pytest.raises(CourseExportNotQueuedError) as exc_info:
+        course_export_task_id(COURSE_KEY, response)
+
+    assert COURSE_KEY in str(exc_info.value)
+    assert "Course not found" in str(exc_info.value)
+
+
+@pytest.mark.parametrize(
+    "response",
+    [
+        {"upload_task_ids": {}},
+        {"upload_task_ids": {"course-v1:Other+Course+1T2026": "abc"}},
+        {"upload_task_ids": {COURSE_KEY: None}},
+        {"upload_task_ids": {COURSE_KEY: ""}},
+        {},
+    ],
+    ids=["empty", "different-course", "null-task", "blank-task", "no-key"],
+)
+def test_course_export_task_id_rejects_a_response_with_no_task(
+    response: dict[str, Any],
+) -> None:
+    """No usable task id is terminal, whether or not Studio explained itself."""
+    with pytest.raises(CourseExportNotQueuedError) as exc_info:
+        course_export_task_id(COURSE_KEY, response)
+
+    assert COURSE_KEY in str(exc_info.value)
 
 
 def _block(category: str, children: list[str], display_name: str = "Block"):

--- a/packages/ol-orchestrate-lib/tests/lib/test_openedx.py
+++ b/packages/ol-orchestrate-lib/tests/lib/test_openedx.py
@@ -9,7 +9,9 @@ import pytest
 from ol_orchestrate.lib.openedx import (
     CourseStaticAssetsBundle,
     CourseXmlBlock,
+    generate_block_indexes,
     process_course_xml_blocks,
+    un_nest_course_structure,
 )
 
 
@@ -380,3 +382,67 @@ def test_process_course_xml_blocks_structural_dirs_excluded():
     assert "chapter" in block_types, "Real block types should still be included"
 
     temp_dir.cleanup()
+
+
+def _block(category: str, children: list[str], display_name: str = "Block"):
+    return {
+        "category": category,
+        "children": children,
+        "metadata": {"display_name": display_name, "start": "2026-01-01T00:00:00Z"},
+    }
+
+
+def test_generate_block_indexes_walks_depth_first():
+    """Blocks are numbered in the order a learner encounters them."""
+    structure = {
+        "course": _block("course", ["chapter_1", "chapter_2"]),
+        "chapter_1": _block("chapter", ["seq_1"]),
+        "seq_1": _block("sequential", []),
+        "chapter_2": _block("chapter", []),
+    }
+
+    indexes = generate_block_indexes(structure, "course")
+
+    assert list(indexes) == ["course", "chapter_1", "seq_1", "chapter_2"]
+    assert indexes["course"] == 1
+    assert indexes["chapter_2"] == 4
+
+
+def test_generate_block_indexes_skips_children_absent_from_the_structure():
+    """A child named by its parent but missing from the document is skipped.
+
+    Courses that source content from a library do this: the parent lists the
+    block, but the block itself is not in the course structure document.
+    Indexing it by key raised
+    ``KeyError: 'block-v1:...+type@sequential+block@...'`` and failed the
+    whole course_structure asset for that course.
+    """
+    structure = {
+        "course": _block("course", ["chapter_1"]),
+        "chapter_1": _block("chapter", ["library_block", "seq_1"]),
+        "seq_1": _block("sequential", []),
+    }
+
+    indexes = generate_block_indexes(structure, "course")
+
+    assert "library_block" not in indexes
+    assert list(indexes) == ["course", "chapter_1", "seq_1"]
+    # The sequence stays contiguous over the blocks that actually exist.
+    assert list(indexes.values()) == [1, 2, 3]
+
+
+def test_generate_block_indexes_tolerates_a_missing_root():
+    """No block with category 'course' leaves root_block as an empty string."""
+    assert generate_block_indexes({"chapter_1": _block("chapter", [])}, "") == {}
+
+
+def test_un_nest_course_structure_survives_a_library_reference():
+    """The full un-nest path completes for a course with a library block."""
+    structure = {
+        "course": _block("course", ["chapter_1"], display_name="A Course"),
+        "chapter_1": _block("chapter", ["library_block"]),
+    }
+
+    blocks = un_nest_course_structure("course-v1:Org+Num+Run", structure, None)
+
+    assert {block["block_id"] for block in blocks} == {"course", "chapter_1"}

--- a/packages/ol-orchestrate-lib/tests/lib/test_openedx.py
+++ b/packages/ol-orchestrate-lib/tests/lib/test_openedx.py
@@ -7,8 +7,10 @@ from tempfile import TemporaryDirectory
 
 import pytest
 from ol_orchestrate.lib.openedx import (
+    CourseExportOutcome,
     CourseStaticAssetsBundle,
     CourseXmlBlock,
+    classify_course_export_state,
     generate_block_indexes,
     process_course_xml_blocks,
     un_nest_course_structure,
@@ -382,6 +384,57 @@ def test_process_course_xml_blocks_structural_dirs_excluded():
     assert "chapter" in block_types, "Real block types should still be included"
 
     temp_dir.cleanup()
+
+
+@pytest.mark.parametrize(
+    ("state", "expected"),
+    [
+        ("Succeeded", CourseExportOutcome.SUCCEEDED),
+        ("Failed", CourseExportOutcome.FAILED),
+        ("Canceled", CourseExportOutcome.FAILED),
+        # The regression: Studio uses Retrying for a task it is about to
+        # attempt again, and both poll loops used to count it as terminal.
+        ("Retrying", CourseExportOutcome.PENDING),
+        ("In Progress", CourseExportOutcome.PENDING),
+        ("Pending", CourseExportOutcome.PENDING),
+        # An undocumented or absent state keeps the caller waiting rather
+        # than inventing a verdict; the poll loop's timeout bounds it.
+        ("Something New", CourseExportOutcome.PENDING),
+        (None, CourseExportOutcome.PENDING),
+    ],
+)
+def test_classify_course_export_state(
+    state: str | None, expected: CourseExportOutcome
+) -> None:
+    """Retrying must not be terminal; unknown states must not be either."""
+    assert classify_course_export_state(state) == expected
+
+
+def test_retrying_then_succeeded_completes_the_export() -> None:
+    """A task that retries and then succeeds must finish, not fail.
+
+    This is the production sequence that broke: the first Retrying poll
+    marked the course failed, satisfied the loop's completion condition and
+    raised "Unable to export the course XML" while Studio was still working.
+    Driving the accumulate logic over the sequence shows the loop now runs to
+    the Succeeded state.
+    """
+    succeeded: set[str] = set()
+    failed: set[str] = set()
+    course_id = "course-v1:MITxT+MITx+0T2026"
+
+    for state in ("In Progress", "Retrying", "Retrying", "Succeeded"):
+        outcome = classify_course_export_state(state)
+        if outcome is CourseExportOutcome.SUCCEEDED:
+            succeeded.add(course_id)
+        elif outcome is CourseExportOutcome.FAILED:
+            failed.add(course_id)
+        # The loop keeps polling while neither set has the course in it.
+        if succeeded or failed:
+            break
+
+    assert succeeded == {course_id}
+    assert failed == set()
 
 
 def _block(category: str, children: list[str], display_name: str = "Block"):


### PR DESCRIPTION
### What are the relevant tickets?
Sentry: [DAGSTER-9](https://mit-office-of-digital-learning.sentry.io/issues/DAGSTER-9), [DAGSTER-6](https://mit-office-of-digital-learning.sentry.io/issues/DAGSTER-6), context for [DAGSTER-7](https://mit-office-of-digital-learning.sentry.io/issues/DAGSTER-7)

### Description (What does it do?)

Part of a set of PRs working through the Sentry backlog from #2518. Three defects on the Open edX course path.

**1. `"Retrying"` was treated as a terminal failure.**

```python
elif state in {"Failed", "Canceled", "Retrying"}:
    failed_exports.add(course_id)
```

Studio uses `Retrying` for an export task it is *about to attempt again*. Adding it to `failed_exports` satisfies the loop condition `len(successful | failed) < len(tasks)`, so the poll loop exits early and the asset raises "Unable to export the course XML" for a course whose export was still in progress.

The same misclassification exists in `legacy_openedx/ops/open_edx.py`, where the log line even calls it a `"terminal failure state"`. Both are fixed. A task that retries indefinitely is still bounded by the existing 60-minute timeout, which is the right guard for that case.

**2. Export failures discarded the reason.**

Studio returns `details` alongside `state`, but it was only logged in the `elif details` branch — i.e. for tasks in a non-terminal state, exactly not the ones that fail. So DAGSTER-6 reads `Unable to export the course XML for course-v1:MITxT+MITx+0T2026` and nothing else. Both the failure and the timeout messages now carry the last status Studio reported.

This does not fix DAGSTER-7 (courses that genuinely take longer than an hour), but it makes the next occurrence say what Studio was doing for that hour instead of only that it ran out.

**3. `generate_block_indexes` raised `KeyError` on library-sourced blocks.**

```python
block_stack.extend(reversed(course_structure[block_id]["children"]))
```

A parent can list a child that the structure document itself does not contain — courses sourcing content from a library do this, which is why the failing course is `DELTA_LIB_SANDBOX`. Those children are now skipped rather than indexed, keeping the index contiguous over blocks that actually exist.

This also fixes a latent crash: when no block has category `"course"`, `un_nest_course_structure` passes `root_block = ""` and the old code looked that up unconditionally.

### How can this be tested?

```bash
cd packages/ol-orchestrate-lib && uv run pytest tests/ -q      # 81 passed, 80 skipped
cd dg_projects/openedx && uv run pytest openedx_tests/ -q      # 14 passed
```

Four new tests in `tests/lib/test_openedx.py` cover depth-first ordering, the library-block skip, the missing-root case, and the full `un_nest_course_structure` path. Verified against the unfixed code — three of the four fail with the exact production error:

```
E   KeyError: 'library_block'
src/ol_orchestrate/lib/openedx.py:34: KeyError
```

`pre-commit run --files <changed>` is clean.

### Additional Context

The `Retrying` change is the one worth a careful look, since it is a behaviour change rather than pure hardening: courses that previously failed fast will now poll until they either finish or hit the 60-minute timeout. That is correct, but it means a genuinely stuck export occupies its run pod for longer than it used to. Given DAGSTER-7 already shows 34 hour-long timeouts in a day, this reinforces rather than replaces the open task to set a slot limit on the `openedx_course_export` concurrency pool.

No test covers the export polling loop itself — it has no existing harness and mocking the Studio task API is a larger piece of work than this change warrants. The two polling changes are small and read clearly in the diff, but they are unverified by tests, unlike the block-index fix.
