### PR TITLE
fix(sentry): unwrap Dagster's error wrapper so the sensor matches the hook

### DIFF
--- a/dg_projects/data_platform/data_platform/definitions.py
+++ b/dg_projects/data_platform/data_platform/definitions.py
@@ -120,6 +120,51 @@ def will_be_retried(run: DagsterRun, instance: Any) -> bool:
     return retry_number < max_retries
 
 
+# Dagster wraps anything raised by user code in one of these before putting it
+# on the step failure event, so the serialized error's cls_name is the wrapper
+# rather than the exception the in-process hook saw. Sourced from the concrete
+# subclasses of DagsterUserCodeExecutionError.
+DAGSTER_USER_CODE_WRAPPERS = frozenset(
+    {
+        "DagsterConfigMappingFunctionError",
+        "DagsterExecutionHandleOutputError",
+        "DagsterExecutionLoadInputError",
+        "DagsterExecutionStepExecutionError",
+        "DagsterResourceFunctionError",
+        "DagsterTypeCheckError",
+        "DagsterTypeLoadingError",
+        "DagsterUserCodeExecutionError",
+        "DagsterUserCodeLoadError",
+    }
+)
+
+# The wrapping is one level deep in practice. The bound only stops a malformed
+# or self-referential cause chain from spinning.
+MAX_ERROR_CAUSE_DEPTH = 5
+
+
+def user_code_error_type(error: Any) -> str:
+    """Name the exception the user's code raised, not Dagster's wrapper.
+
+    A step that raises FileNotFoundError serializes as
+
+        cls_name = "DagsterExecutionStepExecutionError"
+        cause.cls_name = "FileNotFoundError"
+
+    while the in-process hook records ``type(exception).__name__`` -- the
+    FileNotFoundError. Fingerprinting on the un-unwrapped cls_name therefore
+    never matched the hook, and every step failure raised two Sentry issues:
+    one from the hook and one from this sensor. Unwrapping the wrapper
+    recovers the name the hook used.
+    """
+    for _ in range(MAX_ERROR_CAUSE_DEPTH):
+        cause = getattr(error, "cause", None)
+        if cause is None or error.cls_name not in DAGSTER_USER_CODE_WRAPPERS:
+            break
+        error = cause
+    return error.cls_name
+
+
 def sentry_fingerprint(context: RunFailureSensorContext) -> list[str]:
     """Build a fingerprint matching the one the in-process hook uses.
 
@@ -140,9 +185,9 @@ def sentry_fingerprint(context: RunFailureSensorContext) -> list[str]:
 
     failure = step_failures[0]
     error = getattr(failure.event_specific_data, "error", None)
-    # cls_name is the serialized form of the same type(exception).__name__ the
-    # hook captures in-process.
-    error_type = getattr(error, "cls_name", None) or "run_failure"
+    error_type = (
+        user_code_error_type(error) if error is not None else None
+    ) or "run_failure"
     return [run.job_name, failure.step_key, error_type]
 
 

--- a/dg_projects/data_platform/data_platform/definitions.py
+++ b/dg_projects/data_platform/data_platform/definitions.py
@@ -123,7 +123,12 @@ def will_be_retried(run: DagsterRun, instance: Any) -> bool:
 # Dagster wraps anything raised by user code in one of these before putting it
 # on the step failure event, so the serialized error's cls_name is the wrapper
 # rather than the exception the in-process hook saw. Sourced from the concrete
-# subclasses of DagsterUserCodeExecutionError.
+# subclasses of DagsterUserCodeExecutionError, plus RetryRequestedFromPolicy,
+# which is not one of those but wraps the same way: an op with a RetryPolicy
+# that exhausts its attempts serializes as
+# ``RetryRequestedFromPolicy -> <the user's exception>`` while the hook still
+# reports the user's exception. Several learning_resources assets carry a
+# RetryPolicy, so this is a live path, not a hypothetical one.
 DAGSTER_USER_CODE_WRAPPERS = frozenset(
     {
         "DagsterConfigMappingFunctionError",
@@ -135,6 +140,7 @@ DAGSTER_USER_CODE_WRAPPERS = frozenset(
         "DagsterTypeLoadingError",
         "DagsterUserCodeExecutionError",
         "DagsterUserCodeLoadError",
+        "RetryRequestedFromPolicy",
     }
 )
 

--- a/dg_projects/data_platform/data_platform_tests/test_definitions.py
+++ b/dg_projects/data_platform/data_platform_tests/test_definitions.py
@@ -6,7 +6,7 @@ from types import SimpleNamespace
 from typing import Any
 
 import pytest
-from dagster import AssetCheckSeverity
+from dagster import AssetCheckSeverity, RetryPolicy
 from data_platform.definitions import (
     MAX_CHECK_EVALUATIONS_PER_TICK,
     MAX_RETRIES_TAG,
@@ -246,22 +246,47 @@ def test_sensor_fingerprint_keeps_a_wrapper_with_no_cause() -> None:
     assert sentry_fingerprint(context)[2] == "DagsterExecutionStepExecutionError"
 
 
-def test_sensor_fingerprint_matches_a_real_dagster_step_failure() -> None:
-    """End-to-end against a genuinely executed job.
+@pytest.mark.parametrize(
+    "retry_policy", [None, RetryPolicy(max_retries=1)], ids=["plain", "retried"]
+)
+def test_sensor_fingerprint_matches_a_real_dagster_step_failure(
+    retry_policy: RetryPolicy | None,
+) -> None:
+    """End-to-end: the sensor and the hook must agree on a real failure.
 
     The hand-built fixtures above are only as good as our model of Dagster's
     serialization -- and the original bug survived precisely because the old
     fixture set cls_name to the user exception directly, which is not what
-    Dagster produces. This runs a real job so the event is the real shape.
-    """
-    from dagster import DagsterEventType, job, op  # noqa: PLC0415
+    Dagster produces. This executes a real job and compares the sensor's
+    fingerprint against what the *actual* hook records, rather than against a
+    hardcoded string, so neither side can drift without failing here.
 
-    @op
+    The ``retried`` case covers an op whose RetryPolicy is exhausted, which
+    Dagster serializes as ``RetryRequestedFromPolicy -> <user exception>``.
+    Several learning_resources assets carry a RetryPolicy, so that wrapper is
+    on a live path.
+    """
+    from dagster import (  # noqa: PLC0415
+        DagsterEventType,
+        HookContext,
+        failure_hook,
+        job,
+        op,
+    )
+
+    hook_recorded: dict[str, str] = {}
+
+    @failure_hook(name="record")
+    def record(context: HookContext) -> None:
+        # Mirrors ol_orchestrate.lib.sentry.capture_exception_to_sentry.
+        hook_recorded[context.step_key] = type(context.op_exception).__name__
+
+    @op(retry_policy=retry_policy)
     def raises_file_not_found():
         msg = "The specified key does not exist."
         raise FileNotFoundError(msg)
 
-    @job
+    @job(hooks={record})
     def a_job():
         raises_file_not_found()
 
@@ -271,15 +296,10 @@ def test_sensor_fingerprint_matches_a_real_dagster_step_failure() -> None:
         for event in result.all_events
         if event.event_type == DagsterEventType.STEP_FAILURE
     ]
-    context = _context(step_failures)
+    fingerprint = sentry_fingerprint(_context(step_failures))
 
-    # The third element is what the in-process hook records as
-    # type(exception).__name__.
-    assert sentry_fingerprint(context) == [
-        "a_job",
-        "raises_file_not_found",
-        "FileNotFoundError",
-    ]
+    assert fingerprint[2] == hook_recorded["raises_file_not_found"]
+    assert fingerprint == ["a_job", "raises_file_not_found", "FileNotFoundError"]
 
 
 # ── dbt error extraction ──────────────────────────────────────────────────────

--- a/dg_projects/data_platform/data_platform_tests/test_definitions.py
+++ b/dg_projects/data_platform/data_platform_tests/test_definitions.py
@@ -51,11 +51,18 @@ def _context(step_failure_events: list[Any], failure_message: str = "") -> Any:
     )
 
 
-def _step_failure(step_key: str, error_text: str, cls_name: str = "ValueError") -> Any:
+def _step_failure(
+    step_key: str,
+    error_text: str,
+    cls_name: str = "ValueError",
+    cause: Any = None,
+) -> Any:
     return SimpleNamespace(
         step_key=step_key,
         event_specific_data=SimpleNamespace(
-            error=SimpleNamespace(to_string=lambda: error_text, cls_name=cls_name)
+            error=SimpleNamespace(
+                to_string=lambda: error_text, cls_name=cls_name, cause=cause
+            )
         ),
     )
 
@@ -172,6 +179,107 @@ def test_sensor_fingerprint_survives_a_missing_error_payload() -> None:
     context = _context([failure])
 
     assert sentry_fingerprint(context) == ["a_job", "some_model", "run_failure"]
+
+
+def test_sensor_fingerprint_unwraps_dagsters_user_code_wrapper() -> None:
+    """The serialized error is Dagster's wrapper, not what user code raised.
+
+    A step raising FileNotFoundError serializes with
+    ``cls_name="DagsterExecutionStepExecutionError"`` and the real exception one
+    level down in ``cause``. Fingerprinting the wrapper never matched the hook's
+    ``type(exception).__name__``, so every step failure raised two Sentry issues
+    instead of one -- DAGSTER-3 from the hook and DAGSTER-5 from this sensor,
+    for the identical failures.
+    """
+    context = _context(
+        [
+            _step_failure(
+                "extract_edxorg_courserun_metadata",
+                "boom",
+                cls_name="DagsterExecutionStepExecutionError",
+                cause=SimpleNamespace(cls_name="FileNotFoundError", cause=None),
+            )
+        ]
+    )
+
+    assert sentry_fingerprint(context) == [
+        "a_job",
+        "extract_edxorg_courserun_metadata",
+        "FileNotFoundError",
+    ]
+
+
+def test_sensor_fingerprint_unwraps_only_the_dagster_layer() -> None:
+    """Unwrapping stops at the first non-Dagster class.
+
+    The hook captures the exception user code raised, not whatever that was
+    chained from, so descending the whole cause chain would miss it in the
+    other direction.
+    """
+    context = _context(
+        [
+            _step_failure(
+                "some_model",
+                "boom",
+                cls_name="DagsterExecutionLoadInputError",
+                cause=SimpleNamespace(
+                    cls_name="FileNotFoundError",
+                    cause=SimpleNamespace(cls_name="NoSuchKey", cause=None),
+                ),
+            )
+        ]
+    )
+
+    assert sentry_fingerprint(context)[2] == "FileNotFoundError"
+
+
+def test_sensor_fingerprint_keeps_a_wrapper_with_no_cause() -> None:
+    """A wrapper that serialized without a cause still names something."""
+    context = _context(
+        [
+            _step_failure(
+                "some_model", "boom", cls_name="DagsterExecutionStepExecutionError"
+            )
+        ]
+    )
+
+    assert sentry_fingerprint(context)[2] == "DagsterExecutionStepExecutionError"
+
+
+def test_sensor_fingerprint_matches_a_real_dagster_step_failure() -> None:
+    """End-to-end against a genuinely executed job.
+
+    The hand-built fixtures above are only as good as our model of Dagster's
+    serialization -- and the original bug survived precisely because the old
+    fixture set cls_name to the user exception directly, which is not what
+    Dagster produces. This runs a real job so the event is the real shape.
+    """
+    from dagster import DagsterEventType, job, op  # noqa: PLC0415
+
+    @op
+    def raises_file_not_found():
+        msg = "The specified key does not exist."
+        raise FileNotFoundError(msg)
+
+    @job
+    def a_job():
+        raises_file_not_found()
+
+    result = a_job.execute_in_process(raise_on_error=False)
+    step_failures = [
+        event
+        for event in result.all_events
+        if event.event_type == DagsterEventType.STEP_FAILURE
+    ]
+    context = _context(step_failures)
+
+    # The third element is what the in-process hook records as
+    # type(exception).__name__.
+    assert sentry_fingerprint(context) == [
+        "a_job",
+        "raises_file_not_found",
+        "FileNotFoundError",
+    ]
 
 
 # ── dbt error extraction ──────────────────────────────────────────────────────


### PR DESCRIPTION
### What are the relevant tickets?
Sentry: [DAGSTER-5](https://mit-office-of-digital-learning.sentry.io/issues/DAGSTER-5) / [DAGSTER-3](https://mit-office-of-digital-learning.sentry.io/issues/DAGSTER-3) (duplicate grouping)

### Description (What does it do?)

Last of a set of PRs working through the Sentry backlog from #2518.

`sentry_fingerprint` exists to produce the same triple as the in-process hook in `ol_orchestrate.lib.sentry`, so a step failure raises **one** Sentry issue rather than one from each reporting path. It never actually did.

Dagster wraps anything user code raises in a `DagsterUserCodeExecutionError` subclass before serializing it onto the step failure event. So the serialized `cls_name` is the wrapper, while the hook records `type(exception).__name__` of the exception itself. Verified by executing a job whose op raises `FileNotFoundError`:

```
cls_name       : DagsterExecutionStepExecutionError
cause[1]       : FileNotFoundError
cause[2]       : KeyError
```

The sensor was therefore fingerprinting `[job, step, "DagsterExecutionStepExecutionError"]` against the hook's `[job, step, "FileNotFoundError"]`, and every step failure raised two issues.

That is precisely the DAGSTER-3 / DAGSTER-5 split. Aggregating DAGSTER-5 confirms they are the same failures:

```
search_events(query="issue:DAGSTER-5", fields=["dagster_code_location","dagster_step","count()"])
→ [{"dagster_step": "extract_edxorg_courserun_metadata", "count()": 505}]   # 100%
```

Unwrapping stops at the first non-Dagster class rather than descending the whole cause chain, because the hook captures what user code raised, not what that was chained from — `FileNotFoundError`, not the `NoSuchKey` underneath it.

### How can this be tested?

```bash
cd dg_projects/data_platform && uv run pytest data_platform_tests/ -q
# 26 passed
```

Four new tests: the wrapper unwrap, that unwrapping stops at the first non-Dagster layer, a wrapper serialized without a cause, and an end-to-end case that executes a real job and fingerprints the actual `STEP_FAILURE` event.

All three of the meaningful ones fail against the unfixed code, including the end-to-end one — which is the real evidence that this is what production produces, not just what I think it produces.

`pre-commit run --files <changed>` is clean.

### Additional Context

Worth calling out for review: **the existing alignment test passed the whole time.** Its fixture builds the error with `cls_name="ValueError"` — the user exception directly, which is not a shape Dagster ever produces. The test encoded the intended behaviour rather than the real one, so it asserted the bug into correctness. That is why the new end-to-end test runs a real job: it fails if Dagster changes its wrapping, whereas the hand-built fixtures only fail if someone changes our model of it.

This does not reduce event volume on its own — the hook still fires per retry attempt, and the underlying edxorg failures are addressed in #2525. What it does is collapse the duplicate issues so the two reporting paths stop double-counting, which matters once you start setting alert thresholds on issue frequency.
