### PR TITLE
fix(openedx): fail with Studio's reason when a course cannot be queued

### DIFF
--- a/dg_projects/openedx/openedx/assets/openedx.py
+++ b/dg_projects/openedx/openedx/assets/openedx.py
@@ -37,6 +37,7 @@ from ol_orchestrate.lib.automation_policies import upstream_or_code_changes
 from ol_orchestrate.lib.openedx import (
     CourseExportOutcome,
     classify_course_export_state,
+    course_export_task_id,
     process_course_xml,
     process_course_xml_blocks,
     process_video_xml,
@@ -302,7 +303,13 @@ def course_xml(context: AssetExecutionContext):
         # Keyed by course id, so a failure or a timeout can say what Studio
         # last reported instead of just that something went wrong.
         last_seen_status: dict[str, str] = {}
-        tasks = exported_courses["upload_task_ids"]
+        # Only ever one course is requested, so the poll set is built from that
+        # course rather than from whatever the response happens to contain.
+        # Reading upload_task_ids directly meant a course Studio declined to
+        # queue produced an empty mapping: the loop ran zero times, nothing was
+        # recorded as failed, and execution fell through to a bare KeyError on
+        # upload_urls further down.
+        tasks = {course_key: course_export_task_id(course_key, exported_courses)}
         start_time = datetime.now(tz=UTC)
         while len(successful_exports.union(failed_exports)) < len(tasks):
             if (

--- a/packages/ol-orchestrate-lib/src/ol_orchestrate/lib/openedx.py
+++ b/packages/ol-orchestrate-lib/src/ol_orchestrate/lib/openedx.py
@@ -49,6 +49,40 @@ def classify_course_export_state(state: str | None) -> CourseExportOutcome:
     return CourseExportOutcome.PENDING
 
 
+class CourseExportNotQueuedError(Exception):
+    """Studio accepted the export request but queued no task for the course."""
+
+
+def course_export_task_id(course_key: str, export_response: dict[str, Any]) -> str:
+    """Pull the export task id for ``course_key``, or say why there isn't one.
+
+    ``export_courses`` returns HTTP 400 as a documented *partial* failure: the
+    courses that could not be queued are listed under ``failed_uploads`` and
+    are simply absent from ``upload_task_ids``. Callers that went straight to
+    ``upload_task_ids`` therefore got an empty mapping, polled nothing, decided
+    nothing had failed, and fell through to a ``KeyError`` on ``upload_urls``
+    -- discarding the reason Studio had put in the response.
+
+    Raises CourseExportNotQueuedError naming Studio's own explanation.
+    """
+    failed_uploads = export_response.get("failed_uploads") or {}
+    if course_key in failed_uploads:
+        msg = (
+            f"Studio declined to queue an export for {course_key}: "
+            f"{failed_uploads[course_key]}"
+        )
+        raise CourseExportNotQueuedError(msg)
+
+    task_id = (export_response.get("upload_task_ids") or {}).get(course_key)
+    if not task_id:
+        msg = (
+            f"Studio returned no export task for {course_key} and did not say "
+            f"why. Full response: {export_response}"
+        )
+        raise CourseExportNotQueuedError(msg)
+    return task_id
+
+
 def generate_block_indexes(
     course_structure: dict[str, Any], root_block_id: str
 ) -> dict[str, int]:

--- a/packages/ol-orchestrate-lib/tests/lib/test_openedx.py
+++ b/packages/ol-orchestrate-lib/tests/lib/test_openedx.py
@@ -4,13 +4,16 @@ import json
 import tarfile
 from pathlib import Path
 from tempfile import TemporaryDirectory
+from typing import Any
 
 import pytest
 from ol_orchestrate.lib.openedx import (
+    CourseExportNotQueuedError,
     CourseExportOutcome,
     CourseStaticAssetsBundle,
     CourseXmlBlock,
     classify_course_export_state,
+    course_export_task_id,
     generate_block_indexes,
     process_course_xml_blocks,
     un_nest_course_structure,
@@ -435,6 +438,67 @@ def test_retrying_then_succeeded_completes_the_export() -> None:
 
     assert succeeded == {course_id}
     assert failed == set()
+
+
+COURSE_KEY = "course-v1:MITxT+MITx+0T2026"
+
+
+def test_course_export_task_id_returns_the_queued_task() -> None:
+    """The happy path hands back the task id the poll loop needs."""
+    response = {
+        "failed_uploads": {},
+        "upload_task_ids": {COURSE_KEY: "f65e2212-fd97-4645-83cd-7f1c442efb21"},
+        "upload_urls": {COURSE_KEY: "https://example.s3.amazonaws.com/course.tar.gz"},
+    }
+
+    assert (
+        course_export_task_id(COURSE_KEY, response)
+        == "f65e2212-fd97-4645-83cd-7f1c442efb21"
+    )
+
+
+def test_course_export_task_id_surfaces_studios_queue_failure() -> None:
+    """A declined course must report Studio's reason, not a KeyError.
+
+    export_courses returns HTTP 400 as a documented partial failure: the
+    course lands in failed_uploads and is absent from upload_task_ids. Reading
+    upload_task_ids directly gave an empty poll set, so the loop ran zero
+    times, nothing was recorded as failed, and the asset fell through to
+    `exported_courses["upload_urls"][course_key]` -- a bare KeyError that
+    threw away the explanation sitting in the response.
+    """
+    response = {
+        "failed_uploads": {COURSE_KEY: "Course not found"},
+        "upload_task_ids": {},
+        "upload_urls": {},
+    }
+
+    with pytest.raises(CourseExportNotQueuedError) as exc_info:
+        course_export_task_id(COURSE_KEY, response)
+
+    assert COURSE_KEY in str(exc_info.value)
+    assert "Course not found" in str(exc_info.value)
+
+
+@pytest.mark.parametrize(
+    "response",
+    [
+        {"upload_task_ids": {}},
+        {"upload_task_ids": {"course-v1:Other+Course+1T2026": "abc"}},
+        {"upload_task_ids": {COURSE_KEY: None}},
+        {"upload_task_ids": {COURSE_KEY: ""}},
+        {},
+    ],
+    ids=["empty", "different-course", "null-task", "blank-task", "no-key"],
+)
+def test_course_export_task_id_rejects_a_response_with_no_task(
+    response: dict[str, Any],
+) -> None:
+    """No usable task id is terminal, whether or not Studio explained itself."""
+    with pytest.raises(CourseExportNotQueuedError) as exc_info:
+        course_export_task_id(COURSE_KEY, response)
+
+    assert COURSE_KEY in str(exc_info.value)
 
 
 def _block(category: str, children: list[str], display_name: str = "Block"):


### PR DESCRIPTION
### What are the relevant tickets?
Follow-up to #2528. Related Sentry issue: [DAGSTER-6](https://mit-office-of-digital-learning.sentry.io/issues/DAGSTER-6)

> **Stacked on #2528** — based on `fix/sentry-openedx-course-export-robustness`, not `main`, because it builds directly on that PR's changes to the same function. Please merge #2528 first; I'll rebase this onto `main` once it lands.

### Description (What does it do?)

#2528 unified how the `openedx` and `legacy_openedx` locations classify a Studio export *state*. Reviewing what remained uncovered in the poll loop turned up a live bug rather than just a coverage gap.

`export_courses` returns HTTP 400 as a **documented partial failure** — a course that could not be queued is listed under `failed_uploads` and is absent from `upload_task_ids`. The asset read `upload_task_ids` directly:

```python
tasks = exported_courses["upload_task_ids"]        # {}
while len(successful_exports | failed_exports) < len(tasks):   # 0 < 0 → never runs
    ...
if failed_exports:                                  # empty → no raise
    ...
s3_location = exported_courses["upload_urls"][course_key]      # KeyError
```

So for a declined course: the poll loop runs **zero** times, nothing is recorded as failed, the informative "Unable to export the course XML" error added in #2528 is skipped entirely, and execution reaches the download step and dies on a bare `KeyError` — throwing away the reason Studio had already put in the response.

Confirmed by walking the control flow against that payload shape:

```
NEW: raises CourseExportNotQueuedError: Studio declined to queue an export for
     course-v1:MITxT+X+1T2026: Course not found
OLD: poll iterations=0, failed_exports={}
OLD: reached download with KeyError('course-v1:MITxT+X+1T2026')
```

**What changed:** `course_export_task_id` in `ol_orchestrate.lib.openedx` raises `CourseExportNotQueuedError` naming Studio's own explanation, and the poll set is built from the requested course rather than from whatever the response contains. Only one course is ever requested (`export_courses(course_ids=[course_key])`), so keying off it is also more honest than iterating a mapping that could in principle describe others.

`legacy_openedx` **already had both guards** (`legacy_openedx/ops/open_edx.py:632-649` — it checks `failed_uploads`, then checks for a missing `task_id`). This brings the newer implementation up to the older one rather than the other way round.

### How can this be tested?

```bash
cd packages/ol-orchestrate-lib && uv run pytest tests/ -q   # 97 passed, 80 skipped
cd dg_projects/openedx && uv run pytest openedx_tests/ -q   # 14 passed
```

Seven new tests in `tests/lib/test_openedx.py`: the happy path, the `failed_uploads` case asserting Studio's reason reaches the message, and a parametrized set over the ways a response can carry no usable task id (empty mapping, a different course, `None`, `""`, key absent).

`pre-commit run --files <changed>` is clean (ruff format, ruff check, mypy).

### Additional Context

**A correction to my own earlier framing.** When I raised this I also listed "terminal courses keep getting re-polled" as worth fixing. That was overstated: this asset exports exactly one course per partition, so `tasks` never holds more than one entry and the redundancy never materialises. Narrowing the poll set here makes it structurally impossible rather than merely unlikely, but there was no repeated-API-call problem to fix. Not adding a filter for it.

**Still uncovered, deliberately.** Two behaviours in the loop remain untested because they need the Studio task API stubbed, which is the thing #2528's review steered away from:

- the 60-minute `TimeoutError` firing at the boundary, and its message carrying `last_seen_status`
- a mid-poll `check_course_export_status` raising (a 500, or the 429 path from #2527), which currently propagates and fails the asset outright

That second one is another divergence: `legacy_openedx` catches it and returns `None`. The two locations disagree on whether a transient Studio error should kill the run, and neither behaviour is pinned. Worth settling, but it is a behavioural decision rather than a bug fix, so I have left it alone.
