### PR TITLE
fix(dagster): link asset check Slack alerts to the failing run

### DIFF
--- a/dg_projects/data_platform/data_platform/definitions.py
+++ b/dg_projects/data_platform/data_platform/definitions.py
@@ -58,8 +58,10 @@ SLACK_CHANNEL_BY_ENV = {
 slack_channel = SLACK_CHANNEL_BY_ENV[DAGSTER_ENV]
 
 # Bounds a single tick's Slack payload and its event-log scan. A backlog larger
-# than this is drained over subsequent ticks via the cursor.
-MAX_CHECK_EVALUATIONS_PER_TICK = 50
+# than this is drained over subsequent ticks via the cursor. Capped at 49, not
+# 50: asset_check_failure_message adds one header block on top of one detail
+# block per failure, and Slack rejects a chat.postMessage over 50 blocks.
+MAX_CHECK_EVALUATIONS_PER_TICK = 49
 
 MAX_SLACK_TEXT_LENGTH = 3000
 # Leaves room for the surrounding header and step key within Slack's limit.

--- a/dg_projects/data_platform/data_platform/definitions.py
+++ b/dg_projects/data_platform/data_platform/definitions.py
@@ -381,9 +381,13 @@ def run_failure_notification_sensor(context: RunFailureSensorContext) -> None:
 
 
 def asset_check_failure_message(
-    records: Sequence[Any],
+    failures: Sequence[tuple[str, Any]],
 ) -> list[dict[str, Any]]:
-    """Format a batch of failed asset check evaluations for Slack."""
+    """Format a batch of failed asset check evaluations for Slack.
+
+    Each failure links to the run that produced it rather than a shared link,
+    since a single batch can span multiple runs.
+    """
     detail_blocks = [
         {
             "type": "section",
@@ -394,8 +398,13 @@ def asset_check_failure_message(
                     f"`{evaluation.check_name}`"
                 ),
             },
+            "accessory": {
+                "type": "button",
+                "text": {"type": "plain_text", "text": "View run"},
+                "url": f"{dagster_url}/runs/{run_id}",
+            },
         }
-        for evaluation in records
+        for run_id, evaluation in failures
     ]
     return [
         {
@@ -404,31 +413,25 @@ def asset_check_failure_message(
                 "type": "plain_text",
                 "text": (
                     f"Dagster {DAGSTER_ENV.capitalize()} Asset Check Failure "
-                    f"({len(records)})"
+                    f"({len(failures)})"
                 ),
             },
         },
         *detail_blocks,
-        {
-            "type": "actions",
-            "elements": [
-                {
-                    "type": "button",
-                    "text": {"type": "plain_text", "text": "View asset checks"},
-                    "url": f"{dagster_url}/asset-groups",
-                }
-            ],
-        },
     ]
 
 
 def collect_new_check_failures(
     instance: Any, cursor: int | None
-) -> tuple[list[Any], str | None]:
+) -> tuple[list[tuple[str, Any]], str | None]:
     """Read the next batch of asset check evaluations above ``cursor``.
 
-    Returns the ERROR-severity failures in that batch and the cursor to store,
-    or an empty list and None when there is nothing new.
+    Returns (run_id, evaluation) pairs for the ERROR-severity failures in that
+    batch and the cursor to store, or an empty list and None when there is
+    nothing new. The run_id travels with each evaluation because
+    ``AssetCheckEvaluation`` itself carries none -- it is only on the
+    surrounding event log record -- and the Slack message needs it to link
+    back to the run that raised the failure.
 
     ``ascending=True`` is load-bearing. The storage layer applies the LIMIT
     after ordering, so descending order returns the *newest* batch above the
@@ -449,12 +452,16 @@ def collect_new_check_failures(
         return [], None
 
     evaluations = [
-        record.event_log_entry.dagster_event.event_specific_data for record in records
+        (
+            record.event_log_entry.run_id,
+            record.event_log_entry.dagster_event.event_specific_data,
+        )
+        for record in records
     ]
     # WARN-severity checks are advisory; only ERROR is worth a notification.
     failures = [
-        evaluation
-        for evaluation in evaluations
+        (run_id, evaluation)
+        for run_id, evaluation in evaluations
         if not evaluation.passed and evaluation.severity == AssetCheckSeverity.ERROR
     ]
     # The newest record of an ascending batch: nothing older is left behind,

--- a/dg_projects/data_platform/data_platform_tests/test_definitions.py
+++ b/dg_projects/data_platform/data_platform_tests/test_definitions.py
@@ -437,6 +437,23 @@ def test_collect_reads_oldest_first_so_a_backlog_cannot_be_skipped() -> None:
     assert next_cursor == str(backlog[-1].storage_id)
 
 
+def test_a_full_batch_of_failures_stays_within_slacks_block_limit() -> None:
+    """Regression: Slack rejects chat.postMessage payloads over 50 blocks.
+
+    asset_check_failure_message adds one header block on top of one detail
+    block per failure, so a full MAX_CHECK_EVALUATIONS_PER_TICK-sized batch
+    of failures must leave room for that header.
+    """
+    failures = [
+        _check_failure(f"run-{i}", f"asset_{i}")
+        for i in range(MAX_CHECK_EVALUATIONS_PER_TICK)
+    ]
+
+    blocks = asset_check_failure_message(failures)
+
+    assert len(blocks) <= 50
+
+
 def test_collect_advances_cursor_even_when_nothing_failed() -> None:
     """A batch of passing checks must not be re-scanned forever."""
     captured: dict[str, Any] = {}

--- a/dg_projects/data_platform/data_platform_tests/test_definitions.py
+++ b/dg_projects/data_platform/data_platform_tests/test_definitions.py
@@ -14,6 +14,7 @@ from data_platform.definitions import (
     WILL_RETRY_TAG,
     asset_check_failure_message,
     collect_new_check_failures,
+    dagster_url,
     defs,
     error_message,
     get_exception,
@@ -357,11 +358,12 @@ def _evaluation(
     )
 
 
-def _record(storage_id: int, evaluation: Any) -> Any:
+def _record(storage_id: int, evaluation: Any, run_id: str = "a-run-id") -> Any:
     return SimpleNamespace(
         storage_id=storage_id,
         event_log_entry=SimpleNamespace(
-            dagster_event=SimpleNamespace(event_specific_data=evaluation)
+            run_id=run_id,
+            dagster_event=SimpleNamespace(event_specific_data=evaluation),
         ),
     )
 
@@ -389,7 +391,22 @@ def test_collect_keeps_only_error_severity_failures() -> None:
         _instance_returning(records, captured), None
     )
 
-    assert [f.asset_key.to_user_string() for f in failures] == ["a"]
+    assert [e.asset_key.to_user_string() for _, e in failures] == ["a"]
+
+
+def test_collect_pairs_each_failure_with_its_run_id() -> None:
+    """The run_id must survive alongside the evaluation for Slack to link to it."""
+    captured: dict[str, Any] = {}
+    records = [
+        _record(1, _evaluation(asset="a", passed=False, severity=ERROR), run_id="r1"),
+        _record(2, _evaluation(asset="b", passed=False, severity=ERROR), run_id="r2"),
+    ]
+
+    failures, _ = collect_new_check_failures(
+        _instance_returning(records, captured), None
+    )
+
+    assert [run_id for run_id, _ in failures] == ["r1", "r2"]
 
 
 def test_collect_reads_oldest_first_so_a_backlog_cannot_be_skipped() -> None:
@@ -440,21 +457,44 @@ def test_collect_reports_no_cursor_when_there_is_nothing_new() -> None:
     assert next_cursor is None
 
 
+def _check_failure(run_id: str, asset: str) -> tuple[str, Any]:
+    return (
+        run_id,
+        SimpleNamespace(
+            asset_key=SimpleNamespace(to_user_string=lambda: asset),
+            check_name="freshness_check",
+        ),
+    )
+
+
 def test_asset_check_failure_message_lists_each_failed_check() -> None:
-    evaluations = [
-        SimpleNamespace(
-            asset_key=SimpleNamespace(to_user_string=lambda: "mart/enrollments"),
-            check_name="freshness_check",
-        ),
-        SimpleNamespace(
-            asset_key=SimpleNamespace(to_user_string=lambda: "reporting/revenue"),
-            check_name="freshness_check",
-        ),
+    failures = [
+        _check_failure("run-1", "mart/enrollments"),
+        _check_failure("run-2", "reporting/revenue"),
     ]
 
-    blocks = asset_check_failure_message(evaluations)
+    blocks = asset_check_failure_message(failures)
 
     text = _block_text(blocks)
     assert "mart/enrollments" in text
     assert "reporting/revenue" in text
     assert "(2)" in blocks[0]["text"]["text"]
+
+
+def test_asset_check_failure_message_links_each_check_to_its_own_run() -> None:
+    """Regression: each check must link to the run that surfaced it, not the
+    generic asset graph -- a batch of failures can span multiple runs.
+    """
+    failures = [
+        _check_failure("run-1", "mart/enrollments"),
+        _check_failure("run-2", "reporting/revenue"),
+    ]
+
+    blocks = asset_check_failure_message(failures)
+
+    detail_blocks = [b for b in blocks if b["type"] == "section"]
+    urls = [b["accessory"]["url"] for b in detail_blocks]
+    assert urls == [
+        f"{dagster_url}/runs/run-1",
+        f"{dagster_url}/runs/run-2",
+    ]


### PR DESCRIPTION
### What are the relevant tickets?
N/A -- reported directly by a user noticing the regression in Slack; introduced in https://github.com/mitodl/ol-data-platform/pull/2518

### Description (What does it do?)
The `asset_check_failure_sensor` (added in #2518) posts a "View asset checks" button in its Slack alert that links to the static `/asset-groups` page instead of the run that actually surfaced the failure -- a UX regression relative to the run-failure sensor's alert, which correctly links to `/runs/<run_id>`.

Root cause: `collect_new_check_failures` in [`dg_projects/data_platform/data_platform/definitions.py`](https://github.com/mitodl/ol-data-platform/blob/main/dg_projects/data_platform/data_platform/definitions.py) discarded `event_log_entry.run_id` when pulling the `AssetCheckEvaluation` out of each event record, and `AssetCheckEvaluation` itself carries no run_id of its own. By the time `asset_check_failure_message` built the Slack blocks there was no run_id left in scope, so it fell back to a hardcoded link to the full asset graph.

Fix:
- `collect_new_check_failures` now returns `(run_id, evaluation)` pairs instead of bare evaluations, carrying the run_id from `event_log_entry.run_id` through to the message builder.
- `asset_check_failure_message` gives each failed check its own "View run" button (as a section `accessory`) pointed at `{dagster_url}/runs/{run_id}`, replacing the single shared bottom button -- necessary because one batched Slack message can report checks from different runs.

### Screenshots (if appropriate):
N/A -- Slack message layout change; no UI screenshots available from this session. Before: a single "View asset checks" button linking to `/asset-groups` at the bottom of the message. After: each check line has its own "View run" button linking to `/runs/<run_id>`.

### How can this be tested?
- `uv run pytest data_platform_tests/test_definitions.py -q` from `dg_projects/data_platform/` -- 29 tests pass, including two new regression tests:
  - `test_collect_pairs_each_failure_with_its_run_id` -- asserts the run_id from `event_log_entry.run_id` survives into `collect_new_check_failures`'s return value.
  - `test_asset_check_failure_message_links_each_check_to_its_own_run` -- asserts each check's Slack button URL is `{dagster_url}/runs/<its own run_id>`, not a shared/generic link.
- `ruff check` / `ruff format --check` / `mypy` all pass via pre-commit.
- Manual validation in a real Dagster instance: trigger an ERROR-severity asset check failure, let `asset_check_failure_sensor` tick, and confirm the Slack message's "View run" button opens the run page for the run that evaluated the check (not the asset graph).

### Additional Context
N/A
