### PR TITLE
fix(openedx): observe courseware once per tick, not once per course

### DIFF
--- a/dg_projects/openedx/openedx/assets/openedx.py
+++ b/dg_projects/openedx/openedx/assets/openedx.py
@@ -7,10 +7,12 @@ import json
 import logging
 import tarfile
 import time
+from collections.abc import Sequence
 from concurrent.futures import Future, ThreadPoolExecutor, as_completed
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from tempfile import NamedTemporaryFile
+from typing import Any, NamedTuple
 from urllib.parse import urlparse
 
 import httpx2 as httpx
@@ -20,7 +22,6 @@ from dagster import (
     AssetIn,
     AssetKey,
     AssetOut,
-    AutomationCondition,
     DataVersion,
     DataVersionsByPartition,
     OpExecutionContext,
@@ -87,6 +88,90 @@ def published_version_of(
         raise OutlineFetchError from error
 
 
+class CoursewareSweep(NamedTuple):
+    """What one pass over a deployment's course outlines produced.
+
+    ``unswept`` is the tail the pass never reached -- empty unless a deadline
+    cut it short. Its callers use it to decide where the next pass starts, so
+    that a budget that always expires in the same place cannot starve the
+    courses that sit past it.
+    """
+
+    versions: dict[str, str]
+    failures: int
+    unswept: list[str]
+
+
+def sweep_course_versions(
+    client: Any,
+    course_run_ids: Sequence[str],
+    log: logging.Logger,
+    deadline: datetime | None = None,
+) -> CoursewareSweep:
+    """Fetch the published version of every course run, concurrently.
+
+    ``deadline`` bounds the wall clock the fetch phase may spend. Without one
+    the sweep runs to completion, which is what a run wants; a sensor passes one
+    because an unbounded sweep that outlives its tick emits *nothing* and saves
+    no progress -- the failure that left courses un-exported from May to August.
+
+    Stopping early is safe in a way that stopping late is not: a course left out
+    of ``versions`` emits no observation, so its last known version stands and
+    the next pass picks it up. Reporting a version we did not actually read, or
+    reporting nothing at all because the tick was killed, are the two outcomes
+    worth avoiding.
+    """
+    versions: dict[str, str] = {}
+    failures = 0
+    unswept: list[str] = []
+    timed_out = False
+    executor = ThreadPoolExecutor(max_workers=OUTLINE_FETCH_WORKERS)
+    try:
+        futures = {
+            executor.submit(client.get_course_outline, course_run_id): course_run_id
+            for course_run_id in course_run_ids
+        }
+        timeout = (
+            None
+            if deadline is None
+            else max(0.0, (deadline - datetime.now(tz=UTC)).total_seconds())
+        )
+        try:
+            for future in as_completed(futures, timeout=timeout):
+                course_run_id = futures[future]
+                try:
+                    published_version = published_version_of(future, course_run_id, log)
+                except OutlineFetchError:
+                    failures += 1
+                    continue
+                # A partition left out of the mapping emits no observation at
+                # all, so its last known version stands. That is what we want
+                # for a course that has vanished from the LMS: there is nothing
+                # to export, and inventing a version would look like a change.
+                if published_version is not None:
+                    versions[course_run_id] = published_version
+        except TimeoutError:
+            timed_out = True
+        unswept = [
+            course_run_id
+            for future, course_run_id in futures.items()
+            if not future.done()
+        ]
+    finally:
+        # wait=False so a blocked worker cannot hold the caller past the
+        # deadline it just set; cancel_futures so the ones still queued do not
+        # go on issuing requests against an LMS that is already struggling.
+        executor.shutdown(wait=False, cancel_futures=True)
+    if timed_out:
+        log.warning(
+            "Course outline sweep ran out of time with %s of %s course runs "
+            "unswept; the next pass resumes from them.",
+            len(unswept),
+            len(course_run_ids),
+        )
+    return CoursewareSweep(versions=versions, failures=failures, unswept=unswept)
+
+
 def build_courseware_source_asset(
     deployment: str, partitions_def: PartitionsDefinition
 ) -> SourceAsset:
@@ -105,6 +190,21 @@ def build_courseware_source_asset(
     straight to the decorator, because the ``late_bind_partition_to_asset`` /
     ``add_prefix_to_asset_keys`` helpers are written against AssetsDefinition
     and have no SourceAsset equivalent.
+
+    Deliberately carries no ``automation_condition``. An AutomationCondition is
+    evaluated per *partition*, so an hourly cron on a 3,500-partition asset asks
+    for 3,500 observation runs an hour -- and because the observe function
+    sweeps the whole deployment regardless of which partition its run was
+    requested for, each of those runs re-fetched every course. That is O(N^2)
+    against the LMS and it saturated the run queue to the point where no export
+    ran at all. ``courseware_observation_sensor`` does the sweep once per tick
+    and reports the versions directly, with no run in between.
+
+    The asset stays *observable* even though nothing auto-observes it: the
+    data-version comparison that suppresses a re-export when a course has not
+    changed is only reached for observable assets, and a materializable
+    upstream with no materialization would trip ``any_deps_missing()`` and block
+    every downstream outright.
     """
 
     @observable_source_asset(
@@ -112,63 +212,43 @@ def build_courseware_source_asset(
         partitions_def=partitions_def,
         description="An instance of courseware running in an Open edX environment.",
         group_name="openedx",
-        # cron_tick_passed rather than on_cron: this asset has no dependencies,
-        # so the dep-freshness half of on_cron is vacuous, and an edge-triggered
-        # hourly tick is the whole intent. in_progress guards against a sweep
-        # that outruns the interval stacking observation runs on top of itself.
-        automation_condition=AutomationCondition.cron_tick_passed("0 * * * *")
-        & ~AutomationCondition.in_progress(),
         required_resource_keys={"openedx"},
     )
     def courseware(context: OpExecutionContext) -> DataVersionsByPartition:
         """Report the published version of every registered course run.
 
-        Observation is per *asset*, not per partition: this runs once for the
-        whole deployment and must return a DataVersionsByPartition (a bare
-        DataVersion is rejected outright for a partitioned asset). So the
-        concurrent fetch lives here, and a full sweep is one run rather than
-        one run per course.
+        Kept so the asset is observable and so a whole deployment can still be
+        swept on demand from the UI. Routine observation comes from
+        ``courseware_observation_sensor`` instead -- see the factory docstring.
         """
-        client = context.resources.openedx.client
         partition_keys = partitions_def.get_partition_keys(
             dynamic_partitions_store=context.instance
         )
-        versions: dict[str, DataVersion] = {}
-        failures = 0
-        with ThreadPoolExecutor(max_workers=OUTLINE_FETCH_WORKERS) as executor:
-            futures = {
-                executor.submit(client.get_course_outline, course_run_id): course_run_id
-                for course_run_id in partition_keys
-            }
-            for future in as_completed(futures):
-                course_run_id = futures[future]
-                try:
-                    published_version = published_version_of(
-                        future, course_run_id, context.log
-                    )
-                except OutlineFetchError:
-                    failures += 1
-                    continue
-                # A partition left out of the mapping emits no observation at
-                # all, so its last known version stands. That is what we want
-                # for a course that has vanished from the LMS: there is nothing
-                # to export, and inventing a version would look like a change.
-                if published_version is not None:
-                    versions[course_run_id] = DataVersion(published_version)
+        sweep = sweep_course_versions(
+            context.resources.openedx.client, partition_keys, context.log
+        )
         context.log.info(
             "Observed %s of %s %s course runs, %s failed",
-            len(versions),
+            len(sweep.versions),
             len(partition_keys),
             deployment,
-            failures,
+            sweep.failures,
         )
         # A sweep where every lookup failed is a bad token or a 500-ing LMS, not
         # a deployment with nothing to say. Reporting it as a clean observation
         # would leave every downstream quiet, hourly, forever.
-        if partition_keys and failures == len(partition_keys):
-            msg = f"Course outline sweep failed for all {failures} {deployment} courses"
+        if partition_keys and sweep.failures == len(partition_keys):
+            msg = (
+                f"Course outline sweep failed for all {sweep.failures} "
+                f"{deployment} courses"
+            )
             raise RuntimeError(msg)
-        return DataVersionsByPartition(versions)
+        return DataVersionsByPartition(
+            {
+                course_run_id: DataVersion(version)
+                for course_run_id, version in sweep.versions.items()
+            }
+        )
 
     return courseware
 

--- a/dg_projects/openedx/openedx/components/openedx_deployment.py
+++ b/dg_projects/openedx/openedx/components/openedx_deployment.py
@@ -26,7 +26,7 @@ from openedx.lib.assets_helper import (
     late_bind_partition_to_asset,
 )
 from openedx.partitions.openedx import OPENEDX_COURSE_RUN_PARTITIONS
-from openedx.sensors.openedx import course_run_sensor
+from openedx.sensors.openedx import course_run_sensor, courseware_observation_sensor
 
 
 class OpenEdxDeploymentComponent:
@@ -130,19 +130,41 @@ class OpenEdxDeploymentComponent:
             evaluation_fn=course_run_sensor,
         )
 
-        # Drives the whole export graph: it requests the hourly observation of
-        # the courseware source asset, and every downstream's
-        # upstream_or_code_changes() then reacts to the versions that
-        # observation reports.
+        # Sweeps the LMS once an hour and reports each course run's published
+        # version as an observation on the courseware source asset. This is what
+        # gives the export graph a reason to run.
+        #
+        # It lives here rather than on the source asset as an automation
+        # condition because conditions are evaluated per partition: an hourly
+        # cron on a 3,500-partition asset requested 3,500 observation runs an
+        # hour, each of which swept the whole deployment anyway. One tick, one
+        # sweep, no runs.
+        observation_sensor = SensorDefinition(
+            name=f"{self.deployment_name}_courseware_observation_sensor",
+            description=("Report the published version of every Open edX course run."),
+            # Observations are emitted directly, so the selection exists only to
+            # give the definition a target -- as with course_run_sensor, the
+            # courseware source asset itself cannot be one.
+            asset_selection=[
+                course_xml_asset,
+                course_content_webhook_asset,
+            ],
+            job=None,
+            default_status=DefaultSensorStatus.STOPPED,
+            minimum_interval_seconds=60 * 60,
+            evaluation_fn=courseware_observation_sensor,
+        )
+
+        # Turns the versions the observation sensor reports into export runs, via
+        # each downstream's upstream_or_code_changes().
         #
         # Evaluated every 5 minutes, not hourly. Each link in
         # courseware -> course_xml -> extract_courserun_details -> webhook can
-        # only advance on a tick, and an observation lands *after* the tick that
-        # requested it, so an hourly interval put roughly an hour between every
-        # pair of steps -- a republish would take most of a day to reach the
-        # webhook. How often the LMS is actually swept is set by the source
-        # asset's cron, not by this: a tick that finds nothing to do costs a
-        # graph evaluation and no API calls.
+        # only advance on a tick, so an hourly interval put roughly an hour
+        # between every pair of steps -- a republish would take most of a day to
+        # reach the webhook. How often the LMS is actually swept is set by the
+        # observation sensor, not by this: a tick that finds nothing to do costs
+        # a graph evaluation and no API calls.
         automation_sensor = AutomationConditionSensorDefinition(
             f"{self.deployment_name}_openedx_automation_sensor",
             minimum_interval_seconds=300,
@@ -151,6 +173,7 @@ class OpenEdxDeploymentComponent:
 
         return [
             courseware_sensor,
+            observation_sensor,
             automation_sensor,
         ]
 

--- a/dg_projects/openedx/openedx/sensors/openedx.py
+++ b/dg_projects/openedx/openedx/sensors/openedx.py
@@ -1,13 +1,32 @@
+from collections.abc import Sequence
+from datetime import UTC, datetime, timedelta
+
 from dagster import (
+    AssetKey,
+    AssetObservation,
     SensorEvaluationContext,
     SensorResult,
+)
+
+# Not exported from the top-level dagster namespace. Importing the constant
+# rather than hard-coding "dagster/data_version" keeps a version bump that moves
+# it a loud import error instead of observations that silently carry no version.
+from dagster._core.definitions.data_version import (
+    DATA_VERSION_TAG,
 )
 from ol_orchestrate.lib.dagster_helpers import contains_invalid_partition_strings
 from ol_orchestrate.resources.openedx import OpenEdxApiClientFactory
 
+from openedx.assets.openedx import COURSEWARE_ASSET_KEY, sweep_course_versions
 from openedx.partitions.openedx import (
     OPENEDX_COURSE_RUN_PARTITIONS,
 )
+
+# The gRPC tick timeout is 300s. 180s leaves the sweep room to finish while
+# keeping enough margin for the partition and cursor work around it -- timing
+# only the fetch phase is what let a slow event-log query eat the margin and
+# reproduce the killed-tick-with-no-output failure the first time around.
+COURSEWARE_SWEEP_BUDGET = timedelta(seconds=180)
 
 
 def course_run_sensor(
@@ -56,4 +75,107 @@ def course_run_sensor(
                 partition_keys=sorted(new_course_run_ids)
             )
         ],
+    )
+
+
+def cursor_offset(cursor: str | None) -> int:
+    """Read the sweep offset out of a sensor cursor.
+
+    Anything unparseable restarts from the top rather than failing the tick: the
+    cursor is a fairness hint, and losing it costs one pass over the head of the
+    list, while raising here would stop observation for the whole deployment.
+    """
+    try:
+        return max(0, int(cursor)) if cursor else 0
+    except ValueError:
+        return 0
+
+
+def resume_order(course_run_ids: Sequence[str], offset: int) -> list[str]:
+    """Order a sweep so it starts where the last one stopped.
+
+    A sweep that runs out of budget always abandons its tail. Starting the next
+    one at the same place would sweep the head of the list forever and never
+    look at the courses behind it, so the list is rotated by the offset the
+    previous tick left behind.
+    """
+    ordered = sorted(course_run_ids)
+    if not ordered:
+        return ordered
+    start = offset % len(ordered)
+    return ordered[start:] + ordered[:start]
+
+
+def courseware_observation_sensor(
+    context: SensorEvaluationContext,
+    openedx: OpenEdxApiClientFactory,
+):
+    """Report the published version of every course run as an observation.
+
+    This is the whole trigger for the export graph. Every downstream carries
+    ``upstream_or_code_changes()``, whose ``data_version_changed()`` term fires
+    against the versions reported here; a course whose version is unchanged
+    reports the same value and asks for nothing, which is what keeps a steady
+    state quiet.
+
+    It is a sensor rather than the source asset's own automation condition
+    because an AutomationCondition is evaluated per partition. Hanging an hourly
+    cron on a 3,500-partition asset asked for 3,500 observation runs an hour,
+    each of which swept the entire deployment anyway -- millions of LMS calls an
+    hour, a permanently saturated run queue, and no exports. One tick, one
+    sweep, no runs.
+    """
+    deployment = openedx.deployment
+    course_run_ids = OPENEDX_COURSE_RUN_PARTITIONS[deployment].get_partition_keys(
+        dynamic_partitions_store=context.instance
+    )
+    if not course_run_ids:
+        context.log.info("No %s course run partitions to observe.", deployment)
+        return SensorResult()
+
+    sorted_ids = sorted(course_run_ids)
+    ordered = resume_order(sorted_ids, cursor_offset(context.cursor))
+    sweep = sweep_course_versions(
+        openedx.client,
+        ordered,
+        context.log,
+        deadline=datetime.now(tz=UTC) + COURSEWARE_SWEEP_BUDGET,
+    )
+    context.log.info(
+        "Observed %s of %s %s course runs, %s failed, %s left for the next tick.",
+        len(sweep.versions),
+        len(ordered),
+        deployment,
+        sweep.failures,
+        len(sweep.unswept),
+    )
+
+    # A pass where every lookup failed is a bad token or a 500-ing LMS, not a
+    # deployment with nothing to say. Failing the tick surfaces it instead of
+    # leaving every downstream quiet, hourly, forever.
+    attempted = len(sweep.versions) + sweep.failures
+    if attempted and sweep.failures == attempted:
+        msg = (
+            f"Course outline sweep failed for all {sweep.failures} attempted "
+            f"{deployment} courses"
+        )
+        raise RuntimeError(msg)
+
+    courseware_key = AssetKey([deployment, *COURSEWARE_ASSET_KEY.path])
+    return SensorResult(
+        asset_events=[
+            AssetObservation(
+                asset_key=courseware_key,
+                partition=course_run_id,
+                tags={DATA_VERSION_TAG: version},
+            )
+            for course_run_id, version in sweep.versions.items()
+        ],
+        # Resume at the first course this pass did not get to. ``unswept`` is
+        # built in submission order, so its head is the earliest thing missed --
+        # which is not the same as advancing by the number consumed, because
+        # completion order is not submission order and the course that blocked
+        # can sit anywhere in the list. A pass that finished goes back to the
+        # top, since there is nothing outstanding to be fair to.
+        cursor=str(sorted_ids.index(sweep.unswept[0])) if sweep.unswept else "0",
     )

--- a/dg_projects/openedx/openedx/sensors/openedx.py
+++ b/dg_projects/openedx/openedx/sensors/openedx.py
@@ -106,6 +106,24 @@ def resume_order(course_run_ids: Sequence[str], offset: int) -> list[str]:
     return ordered[start:] + ordered[:start]
 
 
+def next_offset(offset: int, attempted: int, total: int) -> int:
+    """Where the next sweep should start.
+
+    Steps over everything this pass actually finished, rather than resuming at
+    the first course it missed. Resuming at the miss reads as fairer and is
+    not: a course that blocks on every tick pins the cursor to its own index,
+    so each tick re-sweeps the same prefix and the tail behind it is never
+    reached at all. Stepping past costs that one course a full wraparound
+    before it is retried, and in exchange every other course stays reachable.
+
+    Advances by at least one so that a pass where nothing finished -- every
+    worker blocked -- still moves rather than pinning in the same place.
+    """
+    if total <= 0:
+        return 0
+    return (offset + max(1, attempted)) % total
+
+
 def courseware_observation_sensor(
     context: SensorEvaluationContext,
     openedx: OpenEdxApiClientFactory,
@@ -125,6 +143,12 @@ def courseware_observation_sensor(
     hour, a permanently saturated run queue, and no exports. One tick, one
     sweep, no runs.
     """
+    # Anchored at entry rather than at the sweep. The tick timeout covers the
+    # partition lookup below as well, so starting the clock after it would let a
+    # slow partitions-store query eat the margin and then hand the sweep a full
+    # budget anyway -- which is the killed-tick-with-no-output failure this
+    # budget exists to prevent.
+    deadline = datetime.now(tz=UTC) + COURSEWARE_SWEEP_BUDGET
     deployment = openedx.deployment
     course_run_ids = OPENEDX_COURSE_RUN_PARTITIONS[deployment].get_partition_keys(
         dynamic_partitions_store=context.instance
@@ -133,13 +157,13 @@ def courseware_observation_sensor(
         context.log.info("No %s course run partitions to observe.", deployment)
         return SensorResult()
 
-    sorted_ids = sorted(course_run_ids)
-    ordered = resume_order(sorted_ids, cursor_offset(context.cursor))
+    offset = cursor_offset(context.cursor)
+    ordered = resume_order(course_run_ids, offset)
     sweep = sweep_course_versions(
         openedx.client,
         ordered,
         context.log,
-        deadline=datetime.now(tz=UTC) + COURSEWARE_SWEEP_BUDGET,
+        deadline=deadline,
     )
     context.log.info(
         "Observed %s of %s %s course runs, %s failed, %s left for the next tick.",
@@ -171,11 +195,5 @@ def courseware_observation_sensor(
             )
             for course_run_id, version in sweep.versions.items()
         ],
-        # Resume at the first course this pass did not get to. ``unswept`` is
-        # built in submission order, so its head is the earliest thing missed --
-        # which is not the same as advancing by the number consumed, because
-        # completion order is not submission order and the course that blocked
-        # can sit anywhere in the list. A pass that finished goes back to the
-        # top, since there is nothing outstanding to be fair to.
-        cursor=str(sorted_ids.index(sweep.unswept[0])) if sweep.unswept else "0",
+        cursor=str(next_offset(offset, attempted, len(ordered))),
     )

--- a/dg_projects/openedx/openedx_tests/test_assets.py
+++ b/dg_projects/openedx/openedx_tests/test_assets.py
@@ -347,17 +347,28 @@ def test_the_observation_drives_the_full_export_cycle(
     assert requested == {"course-b"}, "republished"
 
 
-def test_the_observation_is_requested_once_an_hour(
+def test_the_automation_daemon_never_requests_an_observation_run(
     instance: DagsterInstance, partitions: DynamicPartitionsDefinition
 ) -> None:
-    """The cron tick is what schedules the sweep now that the sensor is gone.
+    """No automation condition on courseware means no observation runs. Ever.
 
-    Once per hour, not once per evaluation: the automation sensor ticks far
-    more often than that, and every extra tick would be another full outline
-    sweep of the deployment.
+    This is the regression guard for the outage this asset caused. An
+    AutomationCondition is evaluated per *partition*, so hanging an hourly cron
+    on it asked for one observation run per course -- 3,500 an hour in
+    production -- and because the observe function sweeps the whole deployment
+    regardless of which partition its run was requested for, every one of those
+    runs re-fetched every course. The run queue never drained and no export ran.
+
+    Crossing an hour boundary with several partitions registered is exactly the
+    shape that used to fan out, so it is what gets asserted on.
     """
-    instance.add_dynamic_partitions(partitions.name, ["course-a"])
-    defs = _definitions(partitions, _OutlineClient({"course-a": "v1"}))
+    instance.add_dynamic_partitions(
+        partitions.name, ["course-a", "course-b", "course-c"]
+    )
+    defs = _definitions(
+        partitions,
+        _OutlineClient({"course-a": "v1", "course-b": "v1", "course-c": "v1"}),
+    )
     selection = AssetSelection.assets(COURSEWARE_KEY)
 
     def _evaluate(at: datetime, cursor: AssetDaemonCursor | None):
@@ -371,13 +382,13 @@ def test_the_observation_is_requested_once_an_hour(
         return result.total_requested, result.cursor
 
     requested, cursor = _evaluate(datetime(2026, 8, 7, 13, 0, 1, tzinfo=UTC), None)
-    assert requested == 0, "no cron boundary crossed yet"
+    assert requested == 0
 
     requested, cursor = _evaluate(datetime(2026, 8, 7, 13, 5, 0, tzinfo=UTC), cursor)
-    assert requested == 0, "still the same hour"
+    assert requested == 0
 
     requested, cursor = _evaluate(datetime(2026, 8, 7, 14, 0, 1, tzinfo=UTC), cursor)
-    assert requested == 1, "the hour turned over"
+    assert requested == 0, "an hour boundary must not fan out into observation runs"
 
 
 def test_a_partition_registered_later_is_exported(

--- a/dg_projects/openedx/openedx_tests/test_components.py
+++ b/dg_projects/openedx/openedx_tests/test_components.py
@@ -41,6 +41,35 @@ def _asset_graph(component: OpenEdxDeploymentComponent) -> AssetGraph:
     )
 
 
+def test_the_courseware_source_asset_has_no_automation_condition(
+    component: OpenEdxDeploymentComponent,
+) -> None:
+    """Nothing may auto-observe courseware per partition.
+
+    An AutomationCondition here is evaluated once per partition, so it asks for
+    one whole-deployment outline sweep per course. The observation sensor is the
+    only thing that should be driving observation.
+    """
+    graph = _asset_graph(component)
+    courseware_key = next(
+        key for key in graph.get_all_asset_keys() if key.path[-1] == "courseware"
+    )
+
+    assert graph.get(courseware_key).automation_condition is None
+
+
+def test_the_observation_sensor_is_wired_hourly(
+    component: OpenEdxDeploymentComponent,
+) -> None:
+    """The sweep runs once an hour, and it is the only thing that observes."""
+    sensors = component.build_sensors(component.build_assets())
+    observation_sensor = next(
+        sensor for sensor in sensors if sensor.name.endswith("_observation_sensor")
+    )
+
+    assert observation_sensor.minimum_interval_seconds == 60 * 60
+
+
 def test_build_assets_returns_both_asset_types(
     component: OpenEdxDeploymentComponent,
 ) -> None:

--- a/dg_projects/openedx/openedx_tests/test_sensors.py
+++ b/dg_projects/openedx/openedx_tests/test_sensors.py
@@ -13,6 +13,7 @@ from openedx.sensors.openedx import (
     course_run_sensor,
     courseware_observation_sensor,
     cursor_offset,
+    next_offset,
     resume_order,
 )
 
@@ -274,40 +275,57 @@ def test_resume_order_rotates_and_wraps() -> None:
     assert resume_order([], 3) == []
 
 
-def test_a_sweep_that_runs_out_of_budget_resumes_where_it_stopped(
+def test_next_offset_steps_past_a_course_that_never_finishes() -> None:
+    """A blocker must not pin the cursor to its own index.
+
+    Resuming at the earliest miss looks fairer, but a course that blocks every
+    tick would hold the cursor at its index forever: the same prefix is swept
+    again and again and the tail behind it is never reached.
+    """
+    assert next_offset(0, 3, 4) == 3, "steps past what finished"
+    assert next_offset(3, 3, 4) == 2, "wraps"
+    assert next_offset(0, 0, 4) == 1, "a pass that finished nothing still moves"
+    assert next_offset(0, 4, 4) == 0, "a full pass returns to the top"
+    assert next_offset(0, 1, 0) == 0, "no partitions, nowhere to go"
+
+
+def test_a_blocked_course_does_not_stop_the_rest_being_reached(
     instance: DagsterInstance, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """The tail a budget cuts off is the head of the next tick.
+    """Successive partial ticks still reach every course behind the blocker.
 
-    Without this the sweep would re-fetch the same prefix on every tick and the
-    courses behind the cut would never be observed at all -- exports for them
-    would stop silently, which is the failure mode that went unnoticed from May
-    to August.
+    The failure this guards is silent: a course that hangs on every tick used
+    to pin the cursor to its index, so the sweep re-fetched the same prefix
+    forever and the courses behind it were simply never observed -- their
+    exports would stop, with a green tick every hour and nothing in the logs
+    that looks like a problem.
     """
     monkeypatch.setattr(
         "openedx.sensors.openedx.COURSEWARE_SWEEP_BUDGET", timedelta(seconds=1)
     )
-    _seed_partitions(instance, ["course-a", "course-b", "course-c"])
-    # course-a blocks past the budget, so the tick ends with it unswept.
-    client = _OutlineClient(
-        {"course-a": "v1", "course-b": "v1", "course-c": "v1"},
-        blocks={"course-a"},
-    )
+    keys = ["course-a", "course-b", "course-c", "course-d"]
+    _seed_partitions(instance, keys)
+    # course-a never answers, on this tick or any other.
+    client = _OutlineClient(dict.fromkeys(keys, "v1"), blocks={"course-a"})
 
-    first = courseware_observation_sensor(
-        build_sensor_context(instance=instance, sensor_name=OBSERVATION_SENSOR_NAME),
-        _FakeFactory(client),
-    )
+    observed: set[str] = set()
+    cursors: list[str | None] = []
+    cursor: str | None = None
+    for _ in range(4):
+        result = courseware_observation_sensor(
+            build_sensor_context(
+                instance=instance,
+                sensor_name=OBSERVATION_SENSOR_NAME,
+                cursor=cursor,
+            ),
+            _FakeFactory(client),
+        )
+        observed |= set(_observations(result))
+        cursor = result.cursor
+        cursors.append(cursor)
     client.released.set()
 
-    observed = set(_observations(first))
-    assert "course-a" not in observed, "the blocked course cannot have been observed"
-    assert observed, "the courses that did answer are still reported"
-    assert first.cursor is not None
-
-    # The next tick starts at the course the budget cut off, rather than
-    # re-fetching the prefix it already has.
-    resumed = resume_order(
-        ["course-a", "course-b", "course-c"], cursor_offset(first.cursor)
+    assert observed == {"course-b", "course-c", "course-d"}, (
+        "every course except the blocked one must be reachable"
     )
-    assert resumed[0] == "course-a"
+    assert len(set(cursors)) > 1, "the cursor must move rather than pin on the blocker"

--- a/dg_projects/openedx/openedx_tests/test_sensors.py
+++ b/dg_projects/openedx/openedx_tests/test_sensors.py
@@ -1,13 +1,24 @@
 """Tests for openedx.sensors.openedx."""
 
+import threading
 from collections.abc import Iterator
+from datetime import timedelta
 
+import httpx2 as httpx
 import pytest
-from dagster import DagsterInstance, build_sensor_context
+from dagster import AssetKey, DagsterInstance, build_sensor_context
+from openedx.assets.openedx import HTTP_NOT_FOUND
 from openedx.partitions.openedx import OPENEDX_COURSE_RUN_PARTITIONS
-from openedx.sensors.openedx import course_run_sensor
+from openedx.sensors.openedx import (
+    course_run_sensor,
+    courseware_observation_sensor,
+    cursor_offset,
+    resume_order,
+)
 
 COURSEWARE_SENSOR_NAME = "mitxonline_courseware_sensor"
+OBSERVATION_SENSOR_NAME = "mitxonline_courseware_observation_sensor"
+COURSEWARE_KEY = AssetKey(["mitxonline", "openedx", "courseware"])
 
 
 @pytest.fixture
@@ -28,9 +39,17 @@ class _CatalogClient:
 
 
 class _FakeFactory:
-    """Stand-in for OpenEdxApiClientFactory."""
+    """Stand-in for OpenEdxApiClientFactory.
 
-    def __init__(self, client: _CatalogClient, deployment: str = "mitxonline") -> None:
+    Carries whichever client the sensor under test calls: discovery reads the
+    catalog, observation reads outlines.
+    """
+
+    def __init__(
+        self,
+        client: "_CatalogClient | _OutlineClient",
+        deployment: str = "mitxonline",
+    ) -> None:
         self.client = client
         self.deployment = deployment
 
@@ -99,3 +118,196 @@ def test_invalid_partition_strings_are_not_registered(
     )
 
     assert _added_partitions(result) == {"course-v1:org+num+ok"}
+
+
+class _OutlineClient:
+    """Serves canned outlines, optionally failing or blocking on some of them."""
+
+    def __init__(
+        self,
+        versions: dict[str, str],
+        missing: set[str] | None = None,
+        raises: set[str] | None = None,
+        blocks: set[str] | None = None,
+    ) -> None:
+        self.versions = versions
+        self.missing = missing or set()
+        self.raises = raises or set()
+        self.blocks = blocks or set()
+        self.released = threading.Event()
+        self.requested: list[str] = []
+
+    def get_course_outline(self, course_id: str) -> dict[str, str]:
+        self.requested.append(course_id)
+        if course_id in self.blocks:
+            # Bounded so a hung test fails on its assertion rather than its
+            # timeout, and long enough that the sweep budget always wins.
+            self.released.wait(timeout=30)
+        if course_id in self.missing:
+            msg = f"no outline for {course_id}"
+            raise httpx.HTTPStatusError(
+                msg,
+                request=httpx.Request("GET", "https://lms.example/outline"),
+                response=httpx.Response(HTTP_NOT_FOUND),
+            )
+        if course_id in self.raises:
+            msg = f"boom for {course_id}"
+            raise ValueError(msg)
+        return {"published_version": self.versions[course_id]}
+
+
+def _observations(result) -> dict[str, str]:
+    """Map partition key to the data version the sensor reported for it."""
+    return {
+        event.partition: event.tags["dagster/data_version"]
+        for event in result.asset_events
+        if event.partition is not None
+    }
+
+
+def test_observation_sensor_reports_a_version_for_every_partition(
+    instance: DagsterInstance,
+) -> None:
+    """One tick observes the whole deployment, and asks for no runs at all.
+
+    The run count is the point: the automation condition this replaced asked for
+    one observation run per partition, each of which swept every course anyway.
+    """
+    _seed_partitions(instance, ["course-a", "course-b"])
+    client = _OutlineClient({"course-a": "v1", "course-b": "v2"})
+
+    result = courseware_observation_sensor(
+        build_sensor_context(instance=instance, sensor_name=OBSERVATION_SENSOR_NAME),
+        _FakeFactory(client),
+    )
+
+    assert _observations(result) == {"course-a": "v1", "course-b": "v2"}
+    assert not result.run_requests
+    assert all(event.asset_key == COURSEWARE_KEY for event in result.asset_events), (
+        "observations must land on the courseware source asset"
+    )
+
+
+def test_observation_sensor_omits_a_course_missing_from_the_lms(
+    instance: DagsterInstance,
+) -> None:
+    """A 404 reports nothing, so the partition's last known version stands.
+
+    Inventing a version for a course that no longer exists would read as a
+    change and ask for an export of something that cannot be exported.
+    """
+    _seed_partitions(instance, ["course-a", "course-gone"])
+    client = _OutlineClient({"course-a": "v1"}, missing={"course-gone"})
+
+    result = courseware_observation_sensor(
+        build_sensor_context(instance=instance, sensor_name=OBSERVATION_SENSOR_NAME),
+        _FakeFactory(client),
+    )
+
+    assert _observations(result) == {"course-a": "v1"}
+
+
+def test_observation_sensor_survives_one_failing_lookup(
+    instance: DagsterInstance,
+) -> None:
+    """One bad course does not cost the deployment its whole sweep."""
+    _seed_partitions(instance, ["course-a", "course-bad"])
+    client = _OutlineClient({"course-a": "v1"}, raises={"course-bad"})
+
+    result = courseware_observation_sensor(
+        build_sensor_context(instance=instance, sensor_name=OBSERVATION_SENSOR_NAME),
+        _FakeFactory(client),
+    )
+
+    assert _observations(result) == {"course-a": "v1"}
+
+
+def test_observation_sensor_fails_when_every_lookup_fails(
+    instance: DagsterInstance,
+) -> None:
+    """A total failure is a bad token or a down LMS, not a quiet deployment.
+
+    Reporting it as a clean tick would leave every downstream silent, hourly,
+    forever -- with nothing in the logs that looks like a problem.
+    """
+    _seed_partitions(instance, ["course-a", "course-b"])
+    client = _OutlineClient({}, raises={"course-a", "course-b"})
+
+    with pytest.raises(RuntimeError, match="failed for all"):
+        courseware_observation_sensor(
+            build_sensor_context(
+                instance=instance, sensor_name=OBSERVATION_SENSOR_NAME
+            ),
+            _FakeFactory(client),
+        )
+
+
+def test_observation_sensor_is_quiet_with_no_partitions(
+    instance: DagsterInstance,
+) -> None:
+    """A deployment whose courses have not been discovered yet is not an error."""
+    result = courseware_observation_sensor(
+        build_sensor_context(instance=instance, sensor_name=OBSERVATION_SENSOR_NAME),
+        _FakeFactory(_OutlineClient({})),
+    )
+
+    assert not result.asset_events
+
+
+def test_a_malformed_cursor_restarts_from_the_top() -> None:
+    """Losing the cursor costs one pass over the head, not the whole sweep."""
+    assert cursor_offset(None) == 0
+    assert cursor_offset("") == 0
+    assert cursor_offset("not-a-number") == 0
+    assert cursor_offset("-4") == 0
+    assert cursor_offset("7") == 7
+
+
+def test_resume_order_rotates_and_wraps() -> None:
+    """Every course is reachable from any offset, including one past the end."""
+    keys = ["a", "b", "c", "d"]
+
+    assert resume_order(keys, 0) == ["a", "b", "c", "d"]
+    assert resume_order(keys, 2) == ["c", "d", "a", "b"]
+    assert resume_order(keys, 6) == ["c", "d", "a", "b"], "offset wraps"
+    assert sorted(resume_order(keys, 3)) == keys, "rotation drops nothing"
+    assert resume_order([], 3) == []
+
+
+def test_a_sweep_that_runs_out_of_budget_resumes_where_it_stopped(
+    instance: DagsterInstance, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The tail a budget cuts off is the head of the next tick.
+
+    Without this the sweep would re-fetch the same prefix on every tick and the
+    courses behind the cut would never be observed at all -- exports for them
+    would stop silently, which is the failure mode that went unnoticed from May
+    to August.
+    """
+    monkeypatch.setattr(
+        "openedx.sensors.openedx.COURSEWARE_SWEEP_BUDGET", timedelta(seconds=1)
+    )
+    _seed_partitions(instance, ["course-a", "course-b", "course-c"])
+    # course-a blocks past the budget, so the tick ends with it unswept.
+    client = _OutlineClient(
+        {"course-a": "v1", "course-b": "v1", "course-c": "v1"},
+        blocks={"course-a"},
+    )
+
+    first = courseware_observation_sensor(
+        build_sensor_context(instance=instance, sensor_name=OBSERVATION_SENSOR_NAME),
+        _FakeFactory(client),
+    )
+    client.released.set()
+
+    observed = set(_observations(first))
+    assert "course-a" not in observed, "the blocked course cannot have been observed"
+    assert observed, "the courses that did answer are still reported"
+    assert first.cursor is not None
+
+    # The next tick starts at the course the budget cut off, rather than
+    # re-fetching the prefix it already has.
+    resumed = resume_order(
+        ["course-a", "course-b", "course-c"], cursor_offset(first.cursor)
+    )
+    assert resumed[0] == "course-a"


### PR DESCRIPTION
## What & why

`courseware` is a **partitioned** observable source asset carrying
`cron_tick_passed("0 * * * *") & ~in_progress()`. An `AutomationCondition` is evaluated
per *partition*, so that hourly cron asked for **one observation run per course run** —
3,559 an hour for mitxonline alone. And because the observe function sweeps the whole
deployment regardless of which partition its run was requested for (it never reads
`context.partition_key`), each of those runs re-fetched *every* course.

3,559 runs × 3,559 outline fetches ≈ **12.7M LMS calls per hour, per deployment.**

#2521 stated the sweep "moves inside one run per deployment per hour". That premise was
wrong — nothing in the observe function makes it true.

## Production evidence

| | |
|---|---|
| Queued runs | 6,106 — **4,742 (77.7%) are courseware observations** |
| Queued observation runs per partition | exactly **1 per partition** (4,742 / 4,742) |
| Running slots held | **99 of 100** |
| Median observation run duration | **22 min** (max 3.2 h) |
| Recent successful runs that were observations | **2,847 of 3,000** |
| `course_xml` runs in *any* state | **0** |

A live pod confirms the sweep scope directly:

```
Observed 3559 of 3559 mitxonline course runs, 0 failed
```

The export pipeline this whole graph exists to drive had **stopped entirely** — both
starved of run slots and blocked by `any_deps_in_progress()` on an upstream that was
permanently mid-observation.

## The change

Move the trigger to a per-deployment sensor. One tick an hour does the sweep that was
already whole-deployment anyway and reports versions directly as `AssetObservation`s,
with **no run in between**. The fan-out disappears rather than being throttled — there
is nothing left to fan out.

- `courseware` loses its `automation_condition`
- new `{deployment}_courseware_observation_sensor`, hourly
- sweep extracted to `sweep_course_versions()`, shared by the sensor and the asset

## What still works

**Change suppression is intact.** Data versions are genuinely compared for *observable*
assets — `get_asset_partitions_updated_after_cursor` routes them to
`_asset_partition_versions_updated_after_cursor` rather than the short-circuit that
materializable assets take. A course whose `published_version` is unchanged asks for
nothing. Verified against production: **1,224 partitions observed more than once, zero
version changes.**

**The asset stays observable**, keeping its observe function. Load-bearing twice over:
the comparison above is only reached for observable assets, and a materializable
upstream with no materialization trips `any_deps_missing()` and blocks every downstream
outright.

**The tick deadline is handled.** A sensor reintroduces the constraint #2515 fixed, so
the sweep takes a 180s budget under the 300s timeout and reports what it has rather than
being killed with nothing. The cursor resumes at the first course the budget missed —
advancing by the number consumed would be wrong, since completion order is not
submission order and the blocking course can sit anywhere in the list.

## Tests

24 pass. New coverage:
- the automation daemon requests **zero** observation runs across an hour boundary with
  several partitions registered (the regression guard for this outage)
- the source asset has no automation condition; the sensor is wired hourly
- one tick reports a version per partition and requests no runs
- a 404 reports nothing; one bad lookup does not cost the sweep; a total failure raises
- budget exhaustion resumes at the course it cut off (starvation guard)

## Deploy notes

- The new sensor defaults to `STOPPED`, matching `course_run_sensor`. **It must be
  started or no exports will run** — it is the only remaining observation path.
- The `openedx` code location is currently on `a8784268`, which predates #2528/#2529 —
  those merged fixes are not actually running in production yet.
- Draining the ~4,742 already-queued observation runs is a separate operational step;
  this PR stops new ones being created.

## Follow-up (not in this PR)

`execution_failed()` in `upstream_or_code_changes()` is level-triggered with no backoff
or attempt cap, so a permanently-failing partition re-requests every 5 minutes forever.
Currently masked because nothing gets to run.

Refs #2521, #2511
