### PR TITLE
 fix(dagster): report each failure once, with the error that caused it

### DIFF
--- a/dg_projects/data_platform/data_platform/definitions.py
+++ b/dg_projects/data_platform/data_platform/definitions.py
@@ -9,6 +9,7 @@ message can carry the resulting event ID, which is what turns a notification
 into something you can actually go and look up.
 """
 
+import re
 from collections.abc import Sequence
 from typing import Any
 
@@ -75,6 +76,17 @@ def truncate_text(text: str, max_length: int = MAX_SLACK_TEXT_LENGTH) -> str:
 
 DBT_ERROR_MARKER = "dagster_dbt.errors.DagsterDbtCliRuntimeError"
 DBT_LOG_PREAMBLE = "Errors parsed from dbt logs:\n\n"
+# dbt's per-node result line, e.g. "46 of 65 ERROR accepted_values_foo [ERROR in 260s]".
+DBT_FAILED_NODE_RE = re.compile(r"^\d+ of \d+ ERROR", re.MULTILINE)
+
+
+def count_dbt_failures(dbt_log_msg: str) -> int:
+    """How many dbt nodes failed, counted before any truncation.
+
+    The log is cut at MAX_SLACK_ERROR_LENGTH, so a run failing more nodes than
+    fit would otherwise read as though the ones that fit were all of them.
+    """
+    return len(DBT_FAILED_NODE_RE.findall(dbt_log_msg))
 
 
 def get_exception(text: str, substring: str = "\n\nStack Trace:") -> str:
@@ -88,8 +100,10 @@ def get_exception(text: str, substring: str = "\n\nStack Trace:") -> str:
         # error -- "Model x failed" arrived as "l x failed".
         dbt_log_index = text.find(DBT_LOG_PREAMBLE) + len(DBT_LOG_PREAMBLE)
         dbt_log_msg = text[dbt_log_index:index] if index != -1 else text[dbt_log_index:]
+        failed = count_dbt_failures(dbt_log_msg)
+        header = f"*DBT Error* ({failed} failed):" if failed else "*DBT Error:*"
         body = truncate_text(dbt_log_msg, MAX_SLACK_ERROR_LENGTH)
-        return f"*DBT Error:*\n```{body}```"
+        return f"{header}\n```{body}```"
     else:
         # Return full text if substring not found
         body = truncate_text(

--- a/dg_projects/data_platform/data_platform/definitions.py
+++ b/dg_projects/data_platform/data_platform/definitions.py
@@ -32,12 +32,10 @@ from slack_sdk import WebClient
 
 init_sentry("data_platform")
 
-# Dagster's own run tags. Hardcoded rather than imported: the constants live in
-# dagster._core.storage.tags, which is private, but the tag strings themselves
-# are stable and documented.
-WILL_RETRY_TAG = "dagster/will_retry"
+# Dagster's own run tag. Hardcoded rather than imported: the constant lives in
+# dagster._core.storage.tags, which is private, but the tag string itself is
+# stable and documented.
 RETRY_NUMBER_TAG = "dagster/retry_number"
-MAX_RETRIES_TAG = "dagster/max_retries"
 
 DAGSTER_URL_BY_ENV = {
     "dev": "http://localhost:3000",
@@ -100,26 +98,20 @@ def get_exception(text: str, substring: str = "\n\nStack Trace:") -> str:
         return f"*Error:*\n```{body}```"
 
 
-def will_be_retried(run: DagsterRun, instance: Any) -> bool:
-    """Whether Dagster is going to automatically retry this failed run.
+def is_retry_of_a_reported_failure(run: DagsterRun) -> bool:
+    """Whether an earlier attempt of this run already raised the alert.
 
-    Without this check the sensor fires once per attempt, so a single broken
-    model becomes four identical alerts under the deployment's
-    ``run_retries.max_retries: 3``.
+    The deployment runs ``run_retries.max_retries: 3``, and the sensor fires per
+    attempt, so a broken model would otherwise produce four identical alerts.
 
-    Prefers the daemon's own recorded decision. The tag is written by the
-    auto-reexecution daemon, which can lag this sensor's tick, so fall back to
-    the same arithmetic the daemon uses.
+    Reporting the first attempt and skipping its retries is what bounds that to
+    one. Skipping every attempt Dagster *might* retry -- what this used to do --
+    bounded it to one only when the run kept failing: a transient failure that
+    passed on retry had every attempt suppressed and was never reported at all.
+    That is the common case for infrastructure races, which are exactly the
+    failures worth seeing once.
     """
-    will_retry_tag = run.tags.get(WILL_RETRY_TAG)
-    if will_retry_tag is not None:
-        return will_retry_tag.lower() == "true"
-
-    if not instance.run_retries_enabled:
-        return False
-    retry_number = int(run.tags.get(RETRY_NUMBER_TAG, 0))
-    max_retries = int(run.tags.get(MAX_RETRIES_TAG, instance.run_retries_max_retries))
-    return retry_number < max_retries
+    return int(run.tags.get(RETRY_NUMBER_TAG, 0)) > 0
 
 
 # Dagster wraps anything raised by user code in one of these before putting it
@@ -354,18 +346,20 @@ def get_slack_token() -> str:
     default_status=DefaultSensorStatus.STOPPED,
     description=(
         "Reports run failures across all code locations to Sentry and Slack. "
-        "Suppresses attempts that Dagster is going to retry automatically."
+        "Reports the first failed attempt and suppresses its automatic retries, "
+        "so a failure is announced once whether or not a retry clears it."
     ),
 )
 def run_failure_notification_sensor(context: RunFailureSensorContext) -> None:
     """Report a failed run to Sentry, then announce it in Slack."""
     run = context.dagster_run
 
-    if will_be_retried(run, context.instance):
+    if is_retry_of_a_reported_failure(run):
         context.log.info(
-            "Skipping notification for run %s: Dagster will retry it "
-            "automatically. The final attempt will be reported.",
+            "Skipping notification for run %s: it is retry %s of a failure "
+            "already reported on the first attempt.",
             run.run_id,
+            run.tags.get(RETRY_NUMBER_TAG),
         )
         return
 
@@ -380,6 +374,24 @@ def run_failure_notification_sensor(context: RunFailureSensorContext) -> None:
         blocks=error_message(context, sentry_event_id),
         text=f"Dagster {DAGSTER_ENV} run failure: {run.job_name}",
     )
+
+
+def is_reported_by_the_run_failure_sensor(evaluation: Any) -> bool:
+    """Whether a failed check's run already reported this with full detail.
+
+    A failing dbt test makes ``dbt build`` exit non-zero, which fails the step
+    and the run, so the run failure sensor announces it with dbt's own error
+    text -- naming every failed test and the database error underneath. Repeating
+    it here added a second message that named the check but not the cause, and
+    described a test that errored before evaluating anything in the same words
+    as a violated assertion.
+
+    dagster-dbt stamps the dbt node status onto each check evaluation it emits;
+    freshness checks and native Dagster asset checks carry none. Those two have
+    no failed run behind them, so this sensor is the only thing that will ever
+    report them.
+    """
+    return "status" in (evaluation.metadata or {})
 
 
 def asset_check_failure_message(
@@ -460,11 +472,14 @@ def collect_new_check_failures(
         )
         for record in records
     ]
-    # WARN-severity checks are advisory; only ERROR is worth a notification.
+    # WARN-severity checks are advisory; only ERROR is worth a notification. dbt
+    # tests are dropped because their run failure already reports them in full.
     failures = [
         (run_id, evaluation)
         for run_id, evaluation in evaluations
-        if not evaluation.passed and evaluation.severity == AssetCheckSeverity.ERROR
+        if not evaluation.passed
+        and evaluation.severity == AssetCheckSeverity.ERROR
+        and not is_reported_by_the_run_failure_sensor(evaluation)
     ]
     # The newest record of an ascending batch: nothing older is left behind,
     # nothing newer is re-delivered.
@@ -476,9 +491,10 @@ def collect_new_check_failures(
     minimum_interval_seconds=300,
     default_status=DefaultSensorStatus.STOPPED,
     description=(
-        "Announces ERROR-severity asset check failures, including the freshness "
-        "checks, in Slack. Asset checks do not fail their run, so the run "
-        "failure sensor never sees them."
+        "Announces ERROR-severity failures of checks that have no failed run "
+        "behind them -- the freshness checks and any native Dagster asset check "
+        "-- in Slack. A failing dbt test does fail its run, so it is left to the "
+        "run failure sensor, which reports it with dbt's own error text."
     ),
 )
 def asset_check_failure_sensor(context: SensorEvaluationContext) -> None:

--- a/dg_projects/data_platform/data_platform/definitions.py
+++ b/dg_projects/data_platform/data_platform/definitions.py
@@ -62,6 +62,11 @@ slack_channel = SLACK_CHANNEL_BY_ENV[DAGSTER_ENV]
 # block per failure, and Slack rejects a chat.postMessage over 50 blocks.
 MAX_CHECK_EVALUATIONS_PER_TICK = 49
 
+# Metadata dagster-dbt stamps on every check evaluation it builds from a dbt
+# result. Matched as a set: any one of these keys can occur on a hand-written
+# check, but the three together identify the evaluation as dbt's.
+DBT_PROVENANCE_KEYS = frozenset({"unique_id", "invocation_id", "status"})
+
 MAX_SLACK_TEXT_LENGTH = 3000
 # Leaves room for the surrounding header and step key within Slack's limit.
 MAX_SLACK_ERROR_LENGTH = 2900
@@ -76,8 +81,10 @@ def truncate_text(text: str, max_length: int = MAX_SLACK_TEXT_LENGTH) -> str:
 
 DBT_ERROR_MARKER = "dagster_dbt.errors.DagsterDbtCliRuntimeError"
 DBT_LOG_PREAMBLE = "Errors parsed from dbt logs:\n\n"
-# dbt's per-node result line, e.g. "46 of 65 ERROR accepted_values_foo [ERROR in 260s]".
-DBT_FAILED_NODE_RE = re.compile(r"^\d+ of \d+ ERROR", re.MULTILINE)
+# dbt's per-node result line. Both terminal states count: a test that could not
+# run logs ERROR ("46 of 65 ERROR accepted_values_foo"), a test whose assertion
+# was violated logs FAIL with its row count ("46 of 65 FAIL 12 not_null_foo").
+DBT_FAILED_NODE_RE = re.compile(r"^\d+ of \d+ (?:ERROR|FAIL)\b", re.MULTILINE)
 
 
 def count_dbt_failures(dbt_log_msg: str) -> int:
@@ -400,12 +407,17 @@ def is_reported_by_the_run_failure_sensor(evaluation: Any) -> bool:
     described a test that errored before evaluating anything in the same words
     as a violated assertion.
 
-    dagster-dbt stamps the dbt node status onto each check evaluation it emits;
-    freshness checks and native Dagster asset checks carry none. Those two have
-    no failed run behind them, so this sensor is the only thing that will ever
-    report them.
+    Identified by dagster-dbt's full provenance, not by ``status`` alone:
+    ``status`` is caller-defined metadata that a native check is free to record
+    (``{"status": "unhealthy"}``), and dropping those would silence a check
+    nothing else reports. All three keys together are stamped only by
+    dagster-dbt's own result-to-evaluation conversion.
+
+    Freshness checks and native Dagster asset checks carry no such signature.
+    Those have no failed run behind them, so this sensor is the only thing that
+    will ever report them.
     """
-    return "status" in (evaluation.metadata or {})
+    return set(evaluation.metadata or {}) >= DBT_PROVENANCE_KEYS
 
 
 def asset_check_failure_message(

--- a/dg_projects/data_platform/data_platform_tests/test_definitions.py
+++ b/dg_projects/data_platform/data_platform_tests/test_definitions.py
@@ -9,18 +9,17 @@ import pytest
 from dagster import AssetCheckSeverity, RetryPolicy
 from data_platform.definitions import (
     MAX_CHECK_EVALUATIONS_PER_TICK,
-    MAX_RETRIES_TAG,
     RETRY_NUMBER_TAG,
-    WILL_RETRY_TAG,
     asset_check_failure_message,
     collect_new_check_failures,
     dagster_url,
     defs,
     error_message,
     get_exception,
+    is_reported_by_the_run_failure_sensor,
+    is_retry_of_a_reported_failure,
     sentry_fingerprint,
     truncate_text,
-    will_be_retried,
 )
 
 ERROR = AssetCheckSeverity.ERROR
@@ -34,13 +33,6 @@ def _run(**tags: str) -> Any:
         tags=tags,
         run_id="0123abcd-4567-89ef-0123-456789abcdef",
         job_name="a_job",
-    )
-
-
-def _instance(*, enabled: bool = True, max_retries: int = 3) -> Any:
-    return SimpleNamespace(
-        run_retries_enabled=enabled,
-        run_retries_max_retries=max_retries,
     )
 
 
@@ -79,28 +71,29 @@ def _block_text(blocks: list[dict[str, Any]]) -> str:
 # ── Retry suppression ─────────────────────────────────────────────────────────
 
 
-def test_will_be_retried_trusts_the_daemon_tag() -> None:
-    assert will_be_retried(_run(**{WILL_RETRY_TAG: "true"}), _instance()) is True
-    assert will_be_retried(_run(**{WILL_RETRY_TAG: "false"}), _instance()) is False
+def test_the_first_attempt_of_a_failure_is_reported() -> None:
+    """Regression: suppressing every attempt Dagster might retry meant a
+    transient failure that passed on the next attempt was never reported.
+
+    An Iceberg split on a __dbt_tmp path or a staging table that vanished
+    mid-test clears on rerun, so each of those runs had all of its failed
+    attempts suppressed and the only surviving alert was the asset check
+    message, which carries no error text.
+    """
+    assert is_retry_of_a_reported_failure(_run()) is False
 
 
-def test_will_be_retried_falls_back_when_tag_not_yet_written() -> None:
-    """The auto-reexecution daemon can lag this sensor's tick."""
-    assert will_be_retried(_run(), _instance(max_retries=3)) is True
-    assert (
-        will_be_retried(_run(**{RETRY_NUMBER_TAG: "3"}), _instance(max_retries=3))
-        is False
-    )
+@pytest.mark.parametrize("retry_number", ["1", "2", "3"])
+def test_automatic_retries_of_a_reported_failure_are_suppressed(
+    retry_number: str,
+) -> None:
+    """One alert per broken run, not one per attempt: under the deployment's
+    run_retries.max_retries of 3 a persistent failure would otherwise announce
+    itself four times.
+    """
+    run = _run(**{RETRY_NUMBER_TAG: retry_number})
 
-
-def test_will_be_retried_is_false_when_retries_disabled() -> None:
-    assert will_be_retried(_run(), _instance(enabled=False)) is False
-
-
-def test_will_be_retried_prefers_per_run_max_retries_tag() -> None:
-    run = _run(**{RETRY_NUMBER_TAG: "1", MAX_RETRIES_TAG: "1"})
-
-    assert will_be_retried(run, _instance(max_retries=99)) is False
+    assert is_retry_of_a_reported_failure(run) is True
 
 
 # ── Message formatting ────────────────────────────────────────────────────────
@@ -348,13 +341,19 @@ def test_sensors_are_defined_without_vault_or_sentry() -> None:
 
 
 def _evaluation(
-    *, asset: str, check: str = "freshness_check", passed: bool, severity: Any
+    *,
+    asset: str,
+    check: str = "freshness_check",
+    passed: bool,
+    severity: Any,
+    metadata: dict[str, Any] | None = None,
 ) -> Any:
     return SimpleNamespace(
         asset_key=SimpleNamespace(to_user_string=lambda: asset),
         check_name=check,
         passed=passed,
         severity=severity,
+        metadata=metadata or {},
     )
 
 
@@ -474,14 +473,81 @@ def test_collect_reports_no_cursor_when_there_is_nothing_new() -> None:
     assert next_cursor is None
 
 
-def _check_failure(run_id: str, asset: str) -> tuple[str, Any]:
+def _check_failure(
+    run_id: str,
+    asset: str,
+    metadata: dict[str, Any] | None = None,
+    check_name: str = "freshness_check",
+) -> tuple[str, Any]:
     return (
         run_id,
         SimpleNamespace(
             asset_key=SimpleNamespace(to_user_string=lambda: asset),
-            check_name="freshness_check",
+            check_name=check_name,
+            metadata=metadata or {},
         ),
     )
+
+
+@pytest.mark.parametrize("status", ["error", "fail"])
+def test_dbt_test_failures_are_left_to_the_run_failure_sensor(status: str) -> None:
+    """Regression: a failing dbt test was announced twice, and the second
+    message named the check without the cause.
+
+    An accepted_values check on a gender column read as invalid production data
+    when the test had errored on ICEBERG_CANNOT_OPEN_SPLIT before evaluating
+    anything. dbt build exits non-zero on either status, so the run fails and
+    the run failure sensor reports it with dbt's own error text.
+    """
+    evaluation = _check_failure("run-1", "mart/x", {"status": status})[1]
+
+    assert is_reported_by_the_run_failure_sensor(evaluation) is True
+
+
+def test_freshness_checks_are_still_reported_here() -> None:
+    """These have no run behind them at all, so nothing else will report them.
+
+    Their passed=False genuinely means the asset is stale, and dagster-dbt's
+    node status -- the marker for a dbt-sourced check -- is absent.
+    """
+    evaluation = _check_failure("run-1", "mart/enrollments")[1]
+
+    assert is_reported_by_the_run_failure_sensor(evaluation) is False
+
+
+def test_a_check_with_no_metadata_at_all_is_reported_here() -> None:
+    """A native Dagster asset check need not attach metadata, and a failing one
+    does not fail its run the way a dbt test does.
+    """
+    evaluation = SimpleNamespace(metadata=None)
+
+    assert is_reported_by_the_run_failure_sensor(evaluation) is False
+
+
+def test_collect_drops_dbt_tests_but_keeps_freshness_checks() -> None:
+    """The filter has to run inside the collector, not the formatter, or the
+    sensor posts an empty message for a batch of nothing but dbt tests.
+    """
+    records = [
+        _record(1, _evaluation(asset="mart/x", passed=False, severity=ERROR)),
+        _record(
+            2,
+            _evaluation(
+                asset="mart/y",
+                passed=False,
+                severity=ERROR,
+                metadata={"status": "error"},
+            ),
+        ),
+    ]
+
+    failures, next_cursor = collect_new_check_failures(
+        _instance_returning(records, {}), None
+    )
+
+    assert [e.asset_key.to_user_string() for _, e in failures] == ["mart/x"]
+    # The cursor still advances past the dropped record, or it is rescanned.
+    assert next_cursor == "2"
 
 
 def test_asset_check_failure_message_lists_each_failed_check() -> None:

--- a/dg_projects/data_platform/data_platform_tests/test_definitions.py
+++ b/dg_projects/data_platform/data_platform_tests/test_definitions.py
@@ -314,11 +314,24 @@ def test_get_exception_extracts_dbt_errors() -> None:
 
 
 def test_get_exception_counts_the_failed_dbt_nodes() -> None:
+    """Both terminal states count: a test that could not run and one that failed."""
     text = (
         "dagster_dbt.errors.DagsterDbtCliRuntimeError: oh no\n"
         "Errors parsed from dbt logs:\n\n"
         "46 of 65 ERROR accepted_values_gender  [ERROR in 260.14s]\n\n"
+        "51 of 65 FAIL 12 not_null_user_username  [FAIL 12 in 4.02s]\n\n"
         "59 of 65 ERROR unique_program_enrollment  [ERROR in 262.23s]\n"
+    )
+
+    assert "*DBT Error* (3 failed):" in get_exception(text)
+
+
+def test_a_run_with_only_assertion_failures_is_still_counted() -> None:
+    text = (
+        "dagster_dbt.errors.DagsterDbtCliRuntimeError: oh no\n"
+        "Errors parsed from dbt logs:\n\n"
+        "3 of 65 FAIL 1 not_null_courserun_readable_id  [FAIL 1 in 2.10s]\n\n"
+        "4 of 65 FAIL 908 accepted_values_platform  [FAIL 908 in 3.44s]\n"
     )
 
     assert "*DBT Error* (2 failed):" in get_exception(text)
@@ -527,9 +540,40 @@ def test_dbt_test_failures_are_left_to_the_run_failure_sensor(status: str) -> No
     anything. dbt build exits non-zero on either status, so the run fails and
     the run failure sensor reports it with dbt's own error text.
     """
-    evaluation = _check_failure("run-1", "mart/x", {"status": status})[1]
+    evaluation = _check_failure(
+        "run-1",
+        "mart/x",
+        {"status": status, "unique_id": "test.open_learning.x", "invocation_id": "abc"},
+    )[1]
 
     assert is_reported_by_the_run_failure_sensor(evaluation) is True
+
+
+def test_a_native_check_recording_its_own_status_is_reported_here() -> None:
+    """``status`` is caller-defined, so it cannot identify a check as dbt's.
+
+    A native check is free to record {"status": "unhealthy"}, and no run failure
+    stands behind it -- dropping it would silence it everywhere.
+    """
+    evaluation = _check_failure("run-1", "mart/x", {"status": "unhealthy"})[1]
+
+    assert is_reported_by_the_run_failure_sensor(evaluation) is False
+
+
+@pytest.mark.parametrize(
+    "metadata",
+    [
+        {"unique_id": "test.open_learning.x", "invocation_id": "abc"},
+        {"status": "fail", "invocation_id": "abc"},
+        {"status": "fail", "unique_id": "test.open_learning.x"},
+    ],
+)
+def test_a_partial_dbt_signature_is_not_enough_to_drop_a_check(
+    metadata: dict[str, Any],
+) -> None:
+    evaluation = _check_failure("run-1", "mart/x", metadata)[1]
+
+    assert is_reported_by_the_run_failure_sensor(evaluation) is False
 
 
 def test_freshness_checks_are_still_reported_here() -> None:
@@ -564,7 +608,11 @@ def test_collect_drops_dbt_tests_but_keeps_freshness_checks() -> None:
                 asset="mart/y",
                 passed=False,
                 severity=ERROR,
-                metadata={"status": "error"},
+                metadata={
+                    "status": "error",
+                    "unique_id": "test.open_learning.y",
+                    "invocation_id": "abc",
+                },
             ),
         ),
     ]

--- a/dg_projects/data_platform/data_platform_tests/test_definitions.py
+++ b/dg_projects/data_platform/data_platform_tests/test_definitions.py
@@ -313,6 +313,34 @@ def test_get_exception_extracts_dbt_errors() -> None:
     assert "irrelevant" not in result
 
 
+def test_get_exception_counts_the_failed_dbt_nodes() -> None:
+    text = (
+        "dagster_dbt.errors.DagsterDbtCliRuntimeError: oh no\n"
+        "Errors parsed from dbt logs:\n\n"
+        "46 of 65 ERROR accepted_values_gender  [ERROR in 260.14s]\n\n"
+        "59 of 65 ERROR unique_program_enrollment  [ERROR in 262.23s]\n"
+    )
+
+    assert "*DBT Error* (2 failed):" in get_exception(text)
+
+
+def test_the_failed_count_reflects_nodes_truncation_drops() -> None:
+    """The count is what tells you a truncated list is not the whole story."""
+    text = (
+        "dagster_dbt.errors.DagsterDbtCliRuntimeError: oh no\n"
+        "Errors parsed from dbt logs:\n\n"
+        + "".join(
+            f"{n} of 99 ERROR test_{n}  [ERROR in 1s]\n" + "x" * 200 + "\n"
+            for n in range(1, 41)
+        )
+    )
+
+    result = get_exception(text)
+
+    assert "*DBT Error* (40 failed):" in result
+    assert result.endswith("...```")
+
+
 def test_get_exception_formats_generic_errors() -> None:
     result = get_exception("ValueError: nope\n\nStack Trace:\nirrelevant")
 


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
NA

<img width="764" height="203" alt="image" src="https://github.com/user-attachments/assets/4d58b88b-23a4-4dae-8174-453888210b8b" />

https://pipelines.odl.mit.edu/runs/12364e87-5cc1-4e6c-b232-05cc46e44f3b

### Description (What does it do?)
<!--- Describe your changes in detail -->
  Makes each Dagster failure produce exactly one Slack alert, carrying the error that actually caused it.                                                                                                                                       
                                                                                                                                                                 
  Three changes to the notification sensors:                                                                                                                     
                                                                                                                                                                 
  1. The run failure sensor reports the **first** failed attempt and suppresses its                                                                              
     automatic retries. It previously did the reverse — suppressing anything Dagster                                                                             
     might retry and reporting only the last attempt — which meant a failure that                                                                                
     cleared on retry was never reported at all.                                                                                                                 
  2. The asset check sensor skips dbt tests, which already fail their run and get                                                                                
     announced by the run failure sensor with dbt's parsed log. The check message                                                                                
     named only the asset and check, which can point at a wholly different model                                                                                 
     than the one that broke. Freshness and native Dagster checks still alert there.                                                                             
  3. The dbt error block leads with the failed node count, taken before the 2900                                                                                 
     character truncation, so a cut-off list is visibly cut off.                                                                                                 
                                                                     
### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->
**Unit tests** — `cd dg_projects/data_platform && uv run pytest data_platform_tests/test_definitions.py`                                                       
                                                                                                                                                                 
  Covers the first-attempt-reported / retries-suppressed gating, the dbt-vs-freshness                                                                            
  filter on the check sensor, and the failed-node count including the case where the                                                                             
  log is truncated.                                                                                                                                              
                                                                                         