### PR TITLE
feat(ol-dbt): include already-migrated users in edxorg_to_mitxonline_users

### DIFF
--- a/src/ol_dbt/models/migration/_migration__models.yml
+++ b/src/ol_dbt/models/migration/_migration__models.yml
@@ -136,7 +136,7 @@ models:
     description: string, user gender
   - name: user_birth_year
     description: int, user birth year
-  - name: user_country
+  - name: user_address_country
     description: string, user address country
 
 - name: edxorg_to_mitxonline_program_certificates

--- a/src/ol_dbt/models/migration/_migration__models.yml
+++ b/src/ol_dbt/models/migration/_migration__models.yml
@@ -113,13 +113,19 @@ models:
 - name: edxorg_to_mitxonline_users
   description: >
     edX.org learners (certificate holders, program entitlement holders, and future
-    enrollment users) who do not yet have an account on MITx Online
+    enrollment users) in scope for migration to MITx Online, whether or not they
+    already have an MITx Online account
   columns:
   - name: user_email
     description: string, user email that user registered on edX.org platform.
     tests:
     - not_null
     - unique
+  - name: user_mitxonline_id
+    data_type: integer
+    description: >
+      int, user ID on the MITx Online platform. Null when the user has not been
+      migrated and still needs an account created.
   - name: user_full_name
     description: string, user full name on edX.org platform
     tests:

--- a/src/ol_dbt/models/migration/edxorg_to_mitxonline_users.sql
+++ b/src/ol_dbt/models/migration/edxorg_to_mitxonline_users.sql
@@ -66,8 +66,12 @@ with edx_certificate as (
 )
 
 , cert_users as (
-    select
+    select distinct
         lower(edx_certificate_user.user_email) as user_email
+        , coalesce(
+            mitx_user1.user_mitxonline_id
+            , mitx_user2.user_mitxonline_id
+        ) as user_mitxonline_id
         , nullif(trim(edx_certificate_user.user_full_name), '') as user_full_name
         , edx_certificate_user.user_gender
         , edx_certificate_user.user_birth_year
@@ -78,14 +82,16 @@ with edx_certificate as (
     left join retired_users on edx_certificate_user.user_id = retired_users.user_id
     where
         edx_certificate_user.row_number = 1
-        and mitx_user1.user_mitxonline_username is null
-        and mitx_user2.user_mitxonline_email is null
         and retired_users.user_id is null
 )
 
 , entitlement_users as (
     select distinct
         lower(program_entitlements.user_email) as user_email
+        , coalesce(
+            mitx_user.user_mitxonline_id
+            , mitx_user2.user_mitxonline_id
+        ) as user_mitxonline_id
         , coalesce(
             nullif(trim(mitx_user.user_full_name), '')
             , program_entitlements.user_full_name
@@ -98,14 +104,12 @@ with edx_certificate as (
          on program_entitlements.user_edxorg_id = mitx_user.user_edxorg_id
     left join mitx_user as mitx_user2
         on lower(program_entitlements.user_email) = lower(mitx_user2.user_mitxonline_email)
-    where
-        mitx_user.user_mitxonline_id is null
-        and mitx_user2.user_mitxonline_email is null
 )
 
 , cert_entitlement_users as (
     select
         coalesce(cert_users.user_email, entitlement_users.user_email) as user_email
+        , coalesce(cert_users.user_mitxonline_id, entitlement_users.user_mitxonline_id) as user_mitxonline_id
         , coalesce(cert_users.user_full_name, entitlement_users.user_full_name) as user_full_name
         , coalesce(cert_users.user_gender, entitlement_users.user_gender) as user_gender
         , coalesce(cert_users.user_birth_year, entitlement_users.user_birth_year) as user_birth_year
@@ -118,13 +122,13 @@ with edx_certificate as (
 , future_enrollment_users as (
     select distinct
         lower(user_email) as user_email
+        , user_mitxonline_id
         , nullif(trim(user_full_name), '') as user_full_name
         , user_gender
         , user_birth_year
         , user_country
     from {{ ref('edxorg_to_mitxonline_enrollments') }}
-    where user_mitxonline_id is null
-        and courseruncertificate_created_on is null
+    where courseruncertificate_created_on is null
 )
 
 , migration_users as (
@@ -139,15 +143,28 @@ with edx_certificate as (
     )
 )
 
+--- the username and email joins on mitx_user can match more than one MITx Online
+--- account, so collapse to one row per email, preferring a migrated account
+, deduplicated_users as (
+    select
+        *
+        , row_number() over (
+            partition by user_email order by user_mitxonline_id asc nulls last
+        ) as _row_num
+    from migration_users
+)
+
 select
-    migration_users.user_email
+    deduplicated_users.user_email
+    , deduplicated_users.user_mitxonline_id
     , coalesce(
-        migration_users.user_full_name
+        deduplicated_users.user_full_name
         , micromasters_user_full_name.user_full_name
     ) as user_full_name
-    , migration_users.user_gender
-    , migration_users.user_birth_year
-    , migration_users.user_country
-from migration_users
+    , deduplicated_users.user_gender
+    , deduplicated_users.user_birth_year
+    , deduplicated_users.user_country
+from deduplicated_users
 left join micromasters_user_full_name
-    on migration_users.user_email = micromasters_user_full_name.user_email
+    on deduplicated_users.user_email = micromasters_user_full_name.user_email
+where deduplicated_users._row_num = 1

--- a/src/ol_dbt/models/migration/edxorg_to_mitxonline_users.sql
+++ b/src/ol_dbt/models/migration/edxorg_to_mitxonline_users.sql
@@ -163,7 +163,7 @@ select
     ) as user_full_name
     , deduplicated_users.user_gender
     , deduplicated_users.user_birth_year
-    , deduplicated_users.user_country
+    , deduplicated_users.user_country as user_address_country
 from deduplicated_users
 left join micromasters_user_full_name
     on deduplicated_users.user_email = micromasters_user_full_name.user_email


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
NA

### Description (What does it do?)
<!--- Describe your changes in detail -->
Updates edxorg_to_mitxonline_users to include already-migrated users for backfilling the missing country and profile data

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

dbt build --select edxorg_to_mitxonline_users

### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->


<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
