### PR TITLE
fix(edxorg): use chash.sha2_256() for polars_hash 0.9.1 compat

### DIFF
--- a/dg_projects/edxorg/edxorg/assets/edxorg_archive.py
+++ b/dg_projects/edxorg/edxorg/assets/edxorg_archive.py
@@ -295,7 +295,7 @@ def process_edxorg_archive_bundle(
                         ),
                         # Create a row hash to allow for deduplicating data
                         plh.concat_str(pl.all().fill_null(""))
-                        .chash.sha256()
+                        .chash.sha2_256()
                         .alias("row_hash"),
                     )
                     df.sink_csv(


### PR DESCRIPTION
### What are the relevant tickets?
N/A

### Description (What does it do?)
`process_edxorg_archive_bundle` in `dg_projects/edxorg/edxorg/assets/edxorg_archive.py` was failing in Dagster with:

```
AttributeError: 'CryptographicHashingNameSpace' object has no attribute 'sha256'. Did you mean: 'sha2_256'?
```

`polars_hash` 0.9.1 (resolved from the project's `polars-hash>=0.5.6` pin) renamed the `chash` namespace's `sha256()` method to `sha2_256()`. This updates the single call site that computes `row_hash` for db_table CSV exports to use the new method name.

### How can this be tested?
Ran the row-hash expression directly against the installed `polars_hash` 0.9.1 in the `dg_projects/edxorg` venv:

```python
import polars as pl
import polars_hash as plh

df = pl.DataFrame({"a": ["x", "y"], "b": ["1", "2"]}).lazy().with_columns(
    plh.concat_str(pl.all().fill_null("")).chash.sha2_256().alias("row_hash")
)
print(df.collect())
```

This produced hashed `row_hash` values with no error, confirming `chash.sha2_256()` is the correct method on the installed version. No other call sites in the repo use `chash.sha256()`.