### PR TITLE
fix(b2b_analytics): rebuild a StarRocks MV when its columns drift from dbt

### DIFF
--- a/dg_projects/lakehouse/lakehouse/assets/lakehouse/dbt_starrocks.py
+++ b/dg_projects/lakehouse/lakehouse/assets/lakehouse/dbt_starrocks.py
@@ -20,10 +20,10 @@ from lakehouse.lib.dbt_environment import STARROCKS_DBT_TARGET
 from lakehouse.lib.starrocks_dbt import (
     MAX_BUILD_ATTEMPTS,
     documented_columns,
-    drifted_relations,
     live_column_query,
     live_columns,
     looks_retriable,
+    relations_missing_columns,
     retry_delay,
 )
 from lakehouse.resources.starrocks import StarRocksResource
@@ -82,8 +82,10 @@ _ENV_LOCK = threading.Lock()
 # which needs one).
 
 
-def _stale_materialized_views(starrocks: StarRocksResource) -> list[str]:
-    """MVs whose columns in StarRocks disagree with the dbt manifest.
+def _stale_materialized_views(
+    context: AssetExecutionContext, starrocks: StarRocksResource
+) -> list[str]:
+    """MVs in StarRocks that are missing a column the dbt manifest documents.
 
     dbt cannot find these itself. dbt-core only replaces an existing
     materialized view under --full-refresh, and asks the adapter for
@@ -100,8 +102,20 @@ def _stale_materialized_views(starrocks: StarRocksResource) -> list[str]:
     """
     manifest = json.loads(starrocks_dbt_project.manifest_path.read_text())
     documented = documented_columns(manifest)
+    if not documented:
+        # Nothing to compare against, and `live_column_query` would build an
+        # empty `IN ()` -- a syntax error. Logged rather than passed over in
+        # silence: it means the schema YAML lost its `columns:`, which also
+        # disables the rebuild these models depend on.
+        context.log.warning(
+            "No StarRocks materialized view documents any columns -- skipping "
+            "the column-drift check. An edited MV SELECT will not be rebuilt."
+        )
+        return []
     query, params = live_column_query(documented)
-    return drifted_relations(documented, live_columns(starrocks.fetch(query, params)))
+    return relations_missing_columns(
+        documented, live_columns(starrocks.fetch(query, params))
+    )
 
 
 @dbt_assets(
@@ -127,18 +141,18 @@ def starrocks_dbt_assets(
     `starrocks` resource (and Vault mount) as `refresh_starrocks_analytics_mvs`,
     which depends on this asset.
 
-    Escalates to --full-refresh when a materialized view's columns in StarRocks
-    have fallen behind the manifest, since a plain build would not notice --
-    see `_stale_materialized_views`.
+    Escalates to --full-refresh when a materialized view in StarRocks is
+    missing a column the manifest documents, since a plain build would not
+    notice -- see `_stale_materialized_views`.
     """
     build_args = ["build"]
-    stale = _stale_materialized_views(starrocks)
+    stale = _stale_materialized_views(context, starrocks)
     if stale:
         # --full-refresh drops and recreates every selected MV, not just the
-        # drifted ones, which is why it is conditional: each recreated view is
+        # stale ones, which is why it is conditional: each recreated view is
         # briefly absent, and ol-analytics-api queries these live.
         context.log.info(
-            "Materialized views whose columns differ from the dbt manifest -- "
+            "Materialized views missing a column the dbt manifest documents -- "
             "building with --full-refresh so the new SELECT actually lands: %s",
             ", ".join(stale),
         )

--- a/dg_projects/lakehouse/lakehouse/assets/lakehouse/dbt_starrocks.py
+++ b/dg_projects/lakehouse/lakehouse/assets/lakehouse/dbt_starrocks.py
@@ -1,3 +1,4 @@
+import json
 import os
 import threading
 import time
@@ -18,6 +19,10 @@ from lakehouse.assets.lakehouse.dbt import (
 from lakehouse.lib.dbt_environment import STARROCKS_DBT_TARGET
 from lakehouse.lib.starrocks_dbt import (
     MAX_BUILD_ATTEMPTS,
+    documented_columns,
+    drifted_relations,
+    live_column_query,
+    live_columns,
     looks_retriable,
     retry_delay,
 )
@@ -71,9 +76,32 @@ starrocks_dbt_cli = DbtCliResource(project_dir=starrocks_dbt_project)
 # os.environ at that point; nothing after that call can still race).
 _ENV_LOCK = threading.Lock()
 
-# Retry knobs and the retriable-error classifier live in lakehouse.lib so they
-# can be unit-tested without a parsed dbt manifest on disk (importing this
-# module evaluates the @dbt_assets decorator below, which needs one).
+# Retry knobs, the retriable-error classifier, and the column-drift comparison
+# live in lakehouse.lib so they can be unit-tested without a parsed dbt manifest
+# on disk (importing this module evaluates the @dbt_assets decorator below,
+# which needs one).
+
+
+def _stale_materialized_views(starrocks: StarRocksResource) -> list[str]:
+    """MVs whose columns in StarRocks disagree with the dbt manifest.
+
+    dbt cannot find these itself. dbt-core only replaces an existing
+    materialized view under --full-refresh, and asks the adapter for
+    configuration changes otherwise -- but dbt-starrocks'
+    `starrocks__get_materialized_view_configuration_changes` returns nothing,
+    so a plain build logs "no configuration changes were identified" and leaves
+    the old SELECT in place. Green build, green refresh, change never landed.
+
+    That made shipping a column a two-step release with a hand-run
+    `dbt run --full-refresh --select b2b_analytics` in the middle, and nothing
+    but memory enforcing the order -- while ol-analytics-api's `build_select`
+    projects each model's own field list, so deploying the consumer first turns
+    the miss into an unknown-column error at request time.
+    """
+    manifest = json.loads(starrocks_dbt_project.manifest_path.read_text())
+    documented = documented_columns(manifest)
+    query, params = live_column_query(documented)
+    return drifted_relations(documented, live_columns(starrocks.fetch(query, params)))
 
 
 @dbt_assets(
@@ -98,7 +126,24 @@ def starrocks_dbt_assets(
     engine and must be generated fresh for this run. Shares the same
     `starrocks` resource (and Vault mount) as `refresh_starrocks_analytics_mvs`,
     which depends on this asset.
+
+    Escalates to --full-refresh when a materialized view's columns in StarRocks
+    have fallen behind the manifest, since a plain build would not notice --
+    see `_stale_materialized_views`.
     """
+    build_args = ["build"]
+    stale = _stale_materialized_views(starrocks)
+    if stale:
+        # --full-refresh drops and recreates every selected MV, not just the
+        # drifted ones, which is why it is conditional: each recreated view is
+        # briefly absent, and ol-analytics-api queries these live.
+        context.log.info(
+            "Materialized views whose columns differ from the dbt manifest -- "
+            "building with --full-refresh so the new SELECT actually lands: %s",
+            ", ".join(stale),
+        )
+        build_args.append("--full-refresh")
+
     last_exc: DagsterDbtCliRuntimeError | None = None
     for attempt in range(MAX_BUILD_ATTEMPTS):
         if attempt:
@@ -118,7 +163,7 @@ def starrocks_dbt_assets(
             os.environ["DBT_STARROCKS_USERNAME"] = username
             os.environ["DBT_STARROCKS_PASSWORD"] = password
             os.environ["DBT_STARROCKS_HOST"] = starrocks.host
-            invocation = starrocks_dbt.cli(["build"], context=context)
+            invocation = starrocks_dbt.cli(build_args, context=context)
 
         # The subprocess above is already spawned (and has already inherited
         # the env set under the lock) by the time .cli() returns -- streaming

--- a/dg_projects/lakehouse/lakehouse/assets/lakehouse/dbt_starrocks.py
+++ b/dg_projects/lakehouse/lakehouse/assets/lakehouse/dbt_starrocks.py
@@ -20,10 +20,10 @@ from lakehouse.lib.dbt_environment import STARROCKS_DBT_TARGET
 from lakehouse.lib.starrocks_dbt import (
     MAX_BUILD_ATTEMPTS,
     documented_columns,
+    drifted_relations,
     live_column_query,
     live_columns,
     looks_retriable,
-    relations_missing_columns,
     retry_delay,
 )
 from lakehouse.resources.starrocks import StarRocksResource
@@ -85,7 +85,7 @@ _ENV_LOCK = threading.Lock()
 def _stale_materialized_views(
     context: AssetExecutionContext, starrocks: StarRocksResource
 ) -> list[str]:
-    """MVs in StarRocks that are missing a column the dbt manifest documents.
+    """MVs whose columns in StarRocks disagree with the dbt manifest.
 
     dbt cannot find these itself. dbt-core only replaces an existing
     materialized view under --full-refresh, and asks the adapter for
@@ -113,9 +113,7 @@ def _stale_materialized_views(
         )
         return []
     query, params = live_column_query(documented)
-    return relations_missing_columns(
-        documented, live_columns(starrocks.fetch(query, params))
-    )
+    return drifted_relations(documented, live_columns(starrocks.fetch(query, params)))
 
 
 @dbt_assets(
@@ -141,8 +139,8 @@ def starrocks_dbt_assets(
     `starrocks` resource (and Vault mount) as `refresh_starrocks_analytics_mvs`,
     which depends on this asset.
 
-    Escalates to --full-refresh when a materialized view in StarRocks is
-    missing a column the manifest documents, since a plain build would not
+    Escalates to --full-refresh when a materialized view's columns in StarRocks
+    have fallen out of step with the manifest, since a plain build would not
     notice -- see `_stale_materialized_views`.
     """
     build_args = ["build"]
@@ -152,7 +150,7 @@ def starrocks_dbt_assets(
         # stale ones, which is why it is conditional: each recreated view is
         # briefly absent, and ol-analytics-api queries these live.
         context.log.info(
-            "Materialized views missing a column the dbt manifest documents -- "
+            "Materialized views whose columns differ from the dbt manifest -- "
             "building with --full-refresh so the new SELECT actually lands: %s",
             ", ".join(stale),
         )

--- a/dg_projects/lakehouse/lakehouse/lib/starrocks_dbt.py
+++ b/dg_projects/lakehouse/lakehouse/lib/starrocks_dbt.py
@@ -8,7 +8,7 @@ or dbt.
 """
 
 import re
-from collections.abc import Mapping
+from collections.abc import Iterator, Mapping
 from typing import Any
 
 # Retries are of the whole `dbt build`, since dbt-starrocks has no adapter-level
@@ -87,10 +87,7 @@ def materialized_view_relations(manifest: Mapping[str, Any]) -> list[str]:
     """
     relations = sorted(
         f"{node['schema']}.{node['alias']}"
-        for node in manifest["nodes"].values()
-        if node["resource_type"] == "model"
-        and node["config"]["materialized"] == "materialized_view"
-        and STARROCKS_TAG in node["tags"]
+        for node in _materialized_view_nodes(manifest)
     )
     if not relations:
         # Not defensive: an empty list would make the refresh asset a silent
@@ -102,3 +99,91 @@ def materialized_view_relations(manifest: Mapping[str, Any]) -> list[str]:
         )
         raise ValueError(msg)
     return relations
+
+
+def _materialized_view_nodes(
+    manifest: Mapping[str, Any],
+) -> Iterator[Mapping[str, Any]]:
+    return (
+        node
+        for node in manifest["nodes"].values()
+        if node["resource_type"] == "model"
+        and node["config"]["materialized"] == "materialized_view"
+        and STARROCKS_TAG in node["tags"]
+    )
+
+
+def documented_columns(manifest: Mapping[str, Any]) -> dict[str, set[str]]:
+    """Map each StarRocks MV to the column set it is *supposed* to have.
+
+    Read from the manifest's `columns` -- i.e. the schema YAML -- rather than by
+    parsing the model's SELECT. `+meta: required_docs: true` on b2b_analytics
+    makes that YAML mandatory and `ol-dbt validate` holds it to the SQL, so it
+    is the contract both this repo and ol-analytics-api are written against.
+
+    A model with no documented columns is omitted rather than treated as
+    "expects nothing": an empty set would differ from every live MV and so
+    would force a full refresh on every run.
+    """
+    return {
+        f"{node['schema']}.{node['alias']}": {
+            name.lower() for name in node.get("columns", {})
+        }
+        for node in _materialized_view_nodes(manifest)
+        if node.get("columns")
+    }
+
+
+def live_column_query(relations: Mapping[str, Any]) -> tuple[str, tuple[str, ...]]:
+    """Build a parameterized information_schema query for *relations*' schemas.
+
+    Filtering by schema rather than by name keeps the statement short and the
+    parameter list to one entry per schema (in practice: one). Rows for tables
+    dbt doesn't own come back too and are dropped by the relation lookup in
+    `drifted_relations`.
+    """
+    schemas = sorted({relation.split(".", 1)[0] for relation in relations})
+    placeholders = ", ".join(["%s"] * len(schemas))
+    # S608: the only thing interpolated is a run of `%s` placeholders -- the
+    # schema names themselves are bound by the driver, never formatted in.
+    query = (
+        "select table_schema, table_name, column_name "  # noqa: S608
+        "from information_schema.columns "
+        f"where table_schema in ({placeholders})"
+    )
+    return query, tuple(schemas)
+
+
+def live_columns(rows: list[Mapping[str, Any]]) -> dict[str, set[str]]:
+    """Fold `live_column_query` rows into {relation: {column, ...}}.
+
+    Keys are the lowercase labels the query selects; values are lowercased to
+    match `documented_columns`, since a column name is case-insensitive over
+    the MySQL wire protocol but the two sources spell it independently.
+    """
+    columns: dict[str, set[str]] = {}
+    for row in rows:
+        relation = f"{row['table_schema']}.{row['table_name']}"
+        columns.setdefault(relation, set()).add(row["column_name"].lower())
+    return columns
+
+
+def drifted_relations(
+    documented: Mapping[str, set[str]], live: Mapping[str, set[str]]
+) -> list[str]:
+    """MVs whose columns in StarRocks no longer match what dbt says they are.
+
+    These need `dbt build --full-refresh` to actually change: dbt-core only
+    replaces an existing materialized view under that flag, and
+    dbt-starrocks' `get_materialized_view_configuration_changes` is an empty
+    macro, so an edited SELECT is otherwise a silent no-op (a plain build logs
+    "no configuration changes were identified" and the MV keeps its old query).
+
+    A relation missing from *live* does not exist yet -- this build creates it
+    with the current SELECT, so it is not drift.
+    """
+    return sorted(
+        relation
+        for relation, columns in documented.items()
+        if relation in live and live[relation] != columns
+    )

--- a/dg_projects/lakehouse/lakehouse/lib/starrocks_dbt.py
+++ b/dg_projects/lakehouse/lakehouse/lib/starrocks_dbt.py
@@ -26,10 +26,11 @@ RETRY_BASE_DELAY = 30
 
 # Error signatures worth another attempt, in two families.
 #
-# 1044/1045/2003/2006/2013 -- MySQL wire-protocol codes.
-# StarRocksResource._RETRIABLE_ERRORS carries the same set minus 2003
-# CR_CONN_HOST_ERROR, which only a *fresh* connect to an already-gone FE returns
-# and which the resource therefore never sees (it connects once, up front).
+# 1044/1045/2003/2006/2013 -- MySQL wire-protocol codes, the same set
+# StarRocksResource._RETRIABLE_ERRORS retries. (It used to omit 2003
+# CR_CONN_HOST_ERROR on the theory that the resource never sees a failed
+# connect; it does -- every attempt in _run() opens its own connection, and an
+# FE rolling restart is exactly how that fails.)
 # 1044/1045 are the Vault case: a just-created dynamic user may not be visible
 # yet on the FE node dbt happened to connect to.
 #
@@ -114,16 +115,22 @@ def _materialized_view_nodes(
 
 
 def documented_columns(manifest: Mapping[str, Any]) -> dict[str, set[str]]:
-    """Map each StarRocks MV to the column set it is *supposed* to have.
+    """Map each StarRocks MV to the columns its schema YAML documents.
 
-    Read from the manifest's `columns` -- i.e. the schema YAML -- rather than by
-    parsing the model's SELECT. `+meta: required_docs: true` on b2b_analytics
-    makes that YAML mandatory and `ol-dbt validate` holds it to the SQL, so it
-    is the contract both this repo and ol-analytics-api are written against.
+    Read from the manifest's `columns` rather than by parsing the model's
+    SELECT, because the YAML is the contract ol-analytics-api is written
+    against: a column nobody documented is a column no consumer projects.
 
-    A model with no documented columns is omitted rather than treated as
-    "expects nothing": an empty set would differ from every live MV and so
-    would force a full refresh on every run.
+    Treat it as a subset of the model's output, not as the full schema.
+    b2b_analytics documents every emitted column today and its YAML says so,
+    but nothing enforces that: `+meta: required_docs: true` only requires a
+    model-level description and `ol-dbt validate` merely warns about
+    undocumented columns. `relations_missing_columns` compares
+    one-directionally for that reason -- an equality check would turn the
+    first undocumented column anyone adds into "drift on every run".
+
+    A model with no documented columns at all is omitted -- there is nothing
+    to check it against.
     """
     return {
         f"{node['schema']}.{node['alias']}": {
@@ -168,22 +175,32 @@ def live_columns(rows: list[Mapping[str, Any]]) -> dict[str, set[str]]:
     return columns
 
 
-def drifted_relations(
+def relations_missing_columns(
     documented: Mapping[str, set[str]], live: Mapping[str, set[str]]
 ) -> list[str]:
-    """MVs whose columns in StarRocks no longer match what dbt says they are.
+    """MVs that lack a column their schema YAML documents.
 
-    These need `dbt build --full-refresh` to actually change: dbt-core only
-    replaces an existing materialized view under that flag, and
-    dbt-starrocks' `get_materialized_view_configuration_changes` is an empty
-    macro, so an edited SELECT is otherwise a silent no-op (a plain build logs
-    "no configuration changes were identified" and the MV keeps its old query).
+    These need `dbt build --full-refresh` to catch up: dbt-core only replaces
+    an existing materialized view under that flag, and dbt-starrocks'
+    `get_materialized_view_configuration_changes` is an empty macro, so an
+    edited SELECT is otherwise a silent no-op (a plain build logs "no
+    configuration changes were identified" and the MV keeps its old query).
+
+    Deliberately one-directional -- documented columns absent from the view,
+    not set inequality. Nothing enforces that the YAML lists every emitted
+    column (see `documented_columns`), and under equality the first
+    undocumented column anyone adds would make every MV look drifted on every
+    run, full-refreshing views the dashboard reads live. A column ADDED to a
+    model is documented and absent, so it is caught; a RENAME is caught the
+    same way, via the new name. The blind spot is a pure removal -- dropped
+    from both SQL and YAML, still present in the view -- which leaves a stale
+    column that consumers do not project and so does not break them.
 
     A relation missing from *live* does not exist yet -- this build creates it
-    with the current SELECT, so it is not drift.
+    with the current SELECT, so there is nothing to rebuild.
     """
     return sorted(
         relation
         for relation, columns in documented.items()
-        if relation in live and live[relation] != columns
+        if relation in live and columns - live[relation]
     )

--- a/dg_projects/lakehouse/lakehouse/lib/starrocks_dbt.py
+++ b/dg_projects/lakehouse/lakehouse/lib/starrocks_dbt.py
@@ -121,13 +121,14 @@ def documented_columns(manifest: Mapping[str, Any]) -> dict[str, set[str]]:
     SELECT, because the YAML is the contract ol-analytics-api is written
     against: a column nobody documented is a column no consumer projects.
 
-    Treat it as a subset of the model's output, not as the full schema.
-    b2b_analytics documents every emitted column today and its YAML says so,
-    but nothing enforces that: `+meta: required_docs: true` only requires a
-    model-level description and `ol-dbt validate` merely warns about
-    undocumented columns. `relations_missing_columns` compares
-    one-directionally for that reason -- an equality check would turn the
-    first undocumented column anyone adds into "drift on every run".
+    This is the model's FULL output schema, which is what lets
+    `drifted_relations` compare by equality. `ol-dbt validate`'s yaml_sql_sync
+    check errors in both directions -- a documented column with no matching
+    SQL alias, and a SQL column the YAML omits (ol-data-platform#2555) -- so a
+    model whose YAML and SELECT disagree cannot merge. If that check is ever
+    relaxed back to a warning, or starts skipping these models (it skips any
+    model whose SELECT * sqlglot cannot expand; none do today), this stops
+    being a full schema and the equality check has to weaken with it.
 
     A model with no documented columns at all is omitted -- there is nothing
     to check it against.
@@ -175,10 +176,10 @@ def live_columns(rows: list[Mapping[str, Any]]) -> dict[str, set[str]]:
     return columns
 
 
-def relations_missing_columns(
+def drifted_relations(
     documented: Mapping[str, set[str]], live: Mapping[str, set[str]]
 ) -> list[str]:
-    """MVs that lack a column their schema YAML documents.
+    """MVs whose columns in StarRocks no longer match what dbt says they are.
 
     These need `dbt build --full-refresh` to catch up: dbt-core only replaces
     an existing materialized view under that flag, and dbt-starrocks'
@@ -186,15 +187,9 @@ def relations_missing_columns(
     edited SELECT is otherwise a silent no-op (a plain build logs "no
     configuration changes were identified" and the MV keeps its old query).
 
-    Deliberately one-directional -- documented columns absent from the view,
-    not set inequality. Nothing enforces that the YAML lists every emitted
-    column (see `documented_columns`), and under equality the first
-    undocumented column anyone adds would make every MV look drifted on every
-    run, full-refreshing views the dashboard reads live. A column ADDED to a
-    model is documented and absent, so it is caught; a RENAME is caught the
-    same way, via the new name. The blind spot is a pure removal -- dropped
-    from both SQL and YAML, still present in the view -- which leaves a stale
-    column that consumers do not project and so does not break them.
+    Set equality, so an added, renamed, or removed column all count. That
+    rests on `documented_columns` being the model's full output schema, which
+    ol-dbt validate now enforces -- read the caveat there before weakening it.
 
     A relation missing from *live* does not exist yet -- this build creates it
     with the current SELECT, so there is nothing to rebuild.
@@ -202,5 +197,5 @@ def relations_missing_columns(
     return sorted(
         relation
         for relation, columns in documented.items()
-        if relation in live and columns - live[relation]
+        if relation in live and columns != live[relation]
     )

--- a/dg_projects/lakehouse/lakehouse/resources/starrocks.py
+++ b/dg_projects/lakehouse/lakehouse/resources/starrocks.py
@@ -35,8 +35,11 @@ def _make_ssl_context() -> ssl.SSLContext:
 # MySQL-wire-protocol error codes that warrant a fresh Vault credential + retry.
 # 1044 ER_DBACCESS_DENIED_ERROR / 1045 ER_ACCESS_DENIED_ERROR - the dynamic user
 #   Vault just created hasn't propagated across StarRocks FE nodes yet.
+# 2003 CR_CONN_HOST_ERROR - the connect() below failed outright, which is what
+#   an FE rolling restart looks like from here. Every attempt opens its own
+#   connection, so this is reachable on all of them, not just the first.
 # 2006 CR_SERVER_GONE_ERROR / 2013 CR_SERVER_LOST - dropped connection.
-_RETRIABLE_ERRORS: frozenset[int] = frozenset({1044, 1045, 2006, 2013})
+_RETRIABLE_ERRORS: frozenset[int] = frozenset({1044, 1045, 2003, 2006, 2013})
 _MAX_ATTEMPTS = 3
 _RETRY_BASE_DELAY = 1  # seconds; doubles each attempt
 

--- a/dg_projects/lakehouse/lakehouse/resources/starrocks.py
+++ b/dg_projects/lakehouse/lakehouse/resources/starrocks.py
@@ -8,6 +8,7 @@ connection -- no passwords are held in Dagster config.
 import logging
 import ssl
 import time
+from typing import Any
 
 from dagster import ConfigurableResource, ResourceDependency
 from ol_orchestrate.resources.secrets.vault import Vault
@@ -86,6 +87,24 @@ class StarRocksResource(ConfigurableResource["StarRocksResource"]):
         generating a new one and retrying gives replication another round to catch
         up rather than reusing credentials known to be affected.
         """
+        self._run(sql)
+
+    def fetch(self, sql: str, params: tuple[str, ...] = ()) -> list[dict[str, Any]]:
+        """Run *sql* and return its rows, with `execute`'s credential retry.
+
+        *params* are passed through to the driver's own placeholder
+        substitution (`%s`) rather than interpolated into *sql*.
+
+        Retrying a SELECT is unconditionally safe; `execute` shares this path
+        because everything it runs (REFRESH MATERIALIZED VIEW, DDL) is
+        idempotent too, and a retry only happens when the previous attempt
+        failed to connect or died mid-statement.
+        """
+        return self._run(sql, params) or []
+
+    def _run(
+        self, sql: str, params: tuple[str, ...] | None = None
+    ) -> list[dict[str, Any]] | None:
         last_exc: OperationalError | None = None
         for attempt in range(_MAX_ATTEMPTS):
             if attempt:
@@ -119,7 +138,8 @@ class StarRocksResource(ConfigurableResource["StarRocksResource"]):
 
             try:
                 with conn.cursor() as cursor:
-                    cursor.execute(sql)
+                    cursor.execute(sql, params)
+                    rows = cursor.fetchall()
                 conn.commit()
             except OperationalError as exc:
                 if exc.args[0] not in _RETRIABLE_ERRORS:
@@ -127,7 +147,7 @@ class StarRocksResource(ConfigurableResource["StarRocksResource"]):
                 last_exc = exc
                 continue
             else:
-                return
+                return list(rows)
             finally:
                 conn.close()
 

--- a/dg_projects/lakehouse/lakehouse_tests/test_starrocks_dbt.py
+++ b/dg_projects/lakehouse/lakehouse_tests/test_starrocks_dbt.py
@@ -13,11 +13,11 @@ from lakehouse.lib.starrocks_dbt import (
     RETRIABLE_ERROR_PATTERN,
     RETRY_BASE_DELAY,
     documented_columns,
+    drifted_relations,
     live_column_query,
     live_columns,
     looks_retriable,
     materialized_view_relations,
-    relations_missing_columns,
     retry_delay,
 )
 from lakehouse.resources.starrocks import _RETRIABLE_ERRORS
@@ -378,41 +378,29 @@ class TestLiveColumns:
         }
 
 
-class TestRelationsMissingColumns:
+class TestDriftedRelations:
     def test_added_column_is_drift(self):
         """PR #2520: the dbt model grew five cohort columns and the deployed MV
         kept the old SELECT, which a plain `dbt build` reports as success.
         """
         documented = {"b2b_analytics.mv_a": {"org_key", "video_watchers"}}
         live = {"b2b_analytics.mv_a": {"org_key"}}
-        assert relations_missing_columns(documented, live) == ["b2b_analytics.mv_a"]
+        assert drifted_relations(documented, live) == ["b2b_analytics.mv_a"]
 
     def test_renamed_column_is_drift(self):
-        """A rename reaches this as an add of the new name, so it is caught by
-        the same one-directional check.
-        """
         documented = {"b2b_analytics.mv_a": {"org_key", "video_watchers"}}
         live = {"b2b_analytics.mv_a": {"org_key", "video_viewers"}}
-        assert relations_missing_columns(documented, live) == ["b2b_analytics.mv_a"]
+        assert drifted_relations(documented, live) == ["b2b_analytics.mv_a"]
 
-    def test_an_undocumented_live_column_is_not_drift(self):
-        """The whole reason this is a subset check and not set equality. Nothing
-        enforces that the YAML lists every emitted column, and under equality
-        one undocumented column would full-refresh the dashboard's views on
-        every scheduled run.
-        """
-        documented = {"b2b_analytics.mv_a": {"org_key"}}
-        live = {"b2b_analytics.mv_a": {"org_key", "organization_name"}}
-        assert relations_missing_columns(documented, live) == []
-
-    def test_a_pure_removal_is_the_known_blind_spot(self):
-        """Dropped from the SQL and the YAML, still present in the view: not
-        reported. Documented as acceptable -- the leftover column is stale but
-        harmless, since ol-analytics-api projects its own field list.
+    def test_removed_column_is_drift(self):
+        """Only reachable as equality, not as "documented columns are missing".
+        Safe to assert because ol-dbt validate errors on a SQL column the YAML
+        omits (#2555), so a live column absent from `documented` really is one
+        the model no longer emits -- not one nobody got around to documenting.
         """
         documented = {"b2b_analytics.mv_a": {"org_key"}}
         live = {"b2b_analytics.mv_a": {"org_key", "dropped_col"}}
-        assert relations_missing_columns(documented, live) == []
+        assert drifted_relations(documented, live) == ["b2b_analytics.mv_a"]
 
     def test_matching_columns_are_not_drift(self):
         """The common case -- it must not force a full refresh, since that drops
@@ -420,7 +408,7 @@ class TestRelationsMissingColumns:
         """
         columns = {"org_key", "video_watchers"}
         assert (
-            relations_missing_columns(
+            drifted_relations(
                 {"b2b_analytics.mv_a": columns}, {"b2b_analytics.mv_a": columns}
             )
             == []
@@ -428,9 +416,7 @@ class TestRelationsMissingColumns:
 
     def test_a_view_that_does_not_exist_yet_is_not_drift(self):
         """This build creates it with the current SELECT; nothing to refresh."""
-        assert (
-            relations_missing_columns({"b2b_analytics.mv_new": {"org_key"}}, {}) == []
-        )
+        assert drifted_relations({"b2b_analytics.mv_new": {"org_key"}}, {}) == []
 
     def test_ignores_live_relations_dbt_does_not_own(self):
         """The query filters by schema, so tables created outside dbt come back
@@ -441,7 +427,7 @@ class TestRelationsMissingColumns:
             "b2b_analytics.mv_a": {"org_key"},
             "b2b_analytics.some_manual_table": {"whatever"},
         }
-        assert relations_missing_columns(documented, live) == []
+        assert drifted_relations(documented, live) == []
 
     def test_result_is_sorted(self):
         documented = {
@@ -449,7 +435,7 @@ class TestRelationsMissingColumns:
             "b2b_analytics.mv_a": {"org_key", "new_col"},
         }
         live = {"b2b_analytics.mv_a": {"org_key"}, "b2b_analytics.mv_b": {"org_key"}}
-        assert relations_missing_columns(documented, live) == [
+        assert drifted_relations(documented, live) == [
             "b2b_analytics.mv_a",
             "b2b_analytics.mv_b",
         ]

--- a/dg_projects/lakehouse/lakehouse_tests/test_starrocks_dbt.py
+++ b/dg_projects/lakehouse/lakehouse_tests/test_starrocks_dbt.py
@@ -9,6 +9,10 @@ import pytest
 from lakehouse.lib.starrocks_dbt import (
     MAX_BUILD_ATTEMPTS,
     RETRY_BASE_DELAY,
+    documented_columns,
+    drifted_relations,
+    live_column_query,
+    live_columns,
     looks_retriable,
     materialized_view_relations,
     retry_delay,
@@ -124,13 +128,16 @@ class TestRetryDelay:
         assert RETRY_BASE_DELAY >= 30
 
 
-def _model_node(name, *, schema="b2b_analytics", materialized, tags):
+def _model_node(name, *, schema="b2b_analytics", materialized, tags, columns=None):
     return {
         "resource_type": "model",
         "schema": schema,
         "alias": name,
         "tags": tags,
         "config": {"materialized": materialized, "tags": tags},
+        # dbt keys `columns` by name and nests the docs under it; only the keys
+        # matter here.
+        "columns": {name: {"name": name} for name in columns or []},
     }
 
 
@@ -256,3 +263,149 @@ class TestMaterializedViewRelations:
         )
         with pytest.raises(ValueError, match="No materialized_view models tagged"):
             materialized_view_relations(manifest)
+
+
+def _mv_node(name, columns, *, schema="b2b_analytics"):
+    return _model_node(
+        name,
+        schema=schema,
+        materialized="materialized_view",
+        tags=["starrocks"],
+        columns=columns,
+    )
+
+
+def _rows(relation, columns):
+    schema, table = relation.split(".")
+    return [
+        {"table_schema": schema, "table_name": table, "column_name": column}
+        for column in columns
+    ]
+
+
+class TestDocumentedColumns:
+    def test_keys_by_relation_and_lowercases(self):
+        manifest = _manifest(
+            [_mv_node("mv_b2b_program_funnel", ["Org_Key", "STARTED"])]
+        )
+        assert documented_columns(manifest) == {
+            "b2b_analytics.mv_b2b_program_funnel": {"org_key", "started"}
+        }
+
+    def test_omits_models_with_no_documented_columns(self):
+        """An empty set differs from every live MV, so treating "undocumented"
+        as "expects nothing" would drop and recreate the view on every run.
+        `+meta: required_docs: true` should keep this unreachable.
+        """
+        manifest = _manifest([_mv_node("mv_b2b_program_funnel", [])])
+        assert documented_columns(manifest) == {}
+
+    def test_ignores_tables_and_other_engines(self):
+        manifest = _manifest(
+            [
+                _mv_node("mv_b2b_program_funnel", ["org_key"]),
+                _model_node(
+                    "b2b_seed_table",
+                    materialized="table",
+                    tags=["starrocks"],
+                    columns=["org_key"],
+                ),
+                _model_node(
+                    "some_trino_mv",
+                    schema="ol_warehouse_production_mart",
+                    materialized="materialized_view",
+                    tags=["mart"],
+                    columns=["org_key"],
+                ),
+            ]
+        )
+        assert set(documented_columns(manifest)) == {
+            "b2b_analytics.mv_b2b_program_funnel"
+        }
+
+
+class TestLiveColumnQuery:
+    def test_one_placeholder_per_distinct_schema(self):
+        query, params = live_column_query(
+            {
+                "b2b_analytics.mv_a": set(),
+                "b2b_analytics.mv_b": set(),
+                "b2b_analytics_qa.mv_a": set(),
+            }
+        )
+        assert params == ("b2b_analytics", "b2b_analytics_qa")
+        assert query.count("%s") == len(params)
+
+    def test_schema_names_are_bound_not_interpolated(self):
+        query, params = live_column_query({"b2b_analytics.mv_a": set()})
+        assert "b2b_analytics" not in query
+        assert params == ("b2b_analytics",)
+
+
+class TestLiveColumns:
+    def test_folds_rows_into_relations(self):
+        rows = _rows("b2b_analytics.mv_a", ["org_key", "started"]) + _rows(
+            "b2b_analytics.mv_b", ["org_key"]
+        )
+        assert live_columns(rows) == {
+            "b2b_analytics.mv_a": {"org_key", "started"},
+            "b2b_analytics.mv_b": {"org_key"},
+        }
+
+    def test_lowercases_column_names(self):
+        assert live_columns(_rows("b2b_analytics.mv_a", ["Org_Key"])) == {
+            "b2b_analytics.mv_a": {"org_key"}
+        }
+
+
+class TestDriftedRelations:
+    def test_added_column_is_drift(self):
+        """PR #2520: the dbt model grew five cohort columns and the deployed MV
+        kept the old SELECT, which a plain `dbt build` reports as success.
+        """
+        documented = {"b2b_analytics.mv_a": {"org_key", "video_watchers"}}
+        live = {"b2b_analytics.mv_a": {"org_key"}}
+        assert drifted_relations(documented, live) == ["b2b_analytics.mv_a"]
+
+    def test_removed_column_is_drift(self):
+        documented = {"b2b_analytics.mv_a": {"org_key"}}
+        live = {"b2b_analytics.mv_a": {"org_key", "dropped_col"}}
+        assert drifted_relations(documented, live) == ["b2b_analytics.mv_a"]
+
+    def test_matching_columns_are_not_drift(self):
+        """The common case -- it must not force a full refresh, since that drops
+        and recreates views ol-analytics-api is serving from.
+        """
+        columns = {"org_key", "video_watchers"}
+        assert (
+            drifted_relations(
+                {"b2b_analytics.mv_a": columns}, {"b2b_analytics.mv_a": columns}
+            )
+            == []
+        )
+
+    def test_a_view_that_does_not_exist_yet_is_not_drift(self):
+        """This build creates it with the current SELECT; nothing to refresh."""
+        assert drifted_relations({"b2b_analytics.mv_new": {"org_key"}}, {}) == []
+
+    def test_ignores_live_relations_dbt_does_not_own(self):
+        """The query filters by schema, so tables created outside dbt come back
+        in the same result set.
+        """
+        documented = {"b2b_analytics.mv_a": {"org_key"}}
+        live = {
+            "b2b_analytics.mv_a": {"org_key"},
+            "b2b_analytics.some_manual_table": {"whatever"},
+        }
+        assert drifted_relations(documented, live) == []
+
+    def test_result_is_sorted(self):
+        documented = {
+            "b2b_analytics.mv_b": {"org_key", "new_col"},
+            "b2b_analytics.mv_a": {"org_key", "new_col"},
+        }
+        live = {"b2b_analytics.mv_a": {"org_key"}, "b2b_analytics.mv_b": {"org_key"}}
+        assert drifted_relations(documented, live) == [
+            "b2b_analytics.mv_a",
+            "b2b_analytics.mv_b",
+        ]

--- a/dg_projects/lakehouse/lakehouse_tests/test_starrocks_dbt.py
+++ b/dg_projects/lakehouse/lakehouse_tests/test_starrocks_dbt.py
@@ -5,18 +5,22 @@ motivated this module (run acc2b10c, 2026-07-22), not invented -- the point of
 the retry pattern is that it matches what StarRocks actually emits.
 """
 
+import re
+
 import pytest
 from lakehouse.lib.starrocks_dbt import (
     MAX_BUILD_ATTEMPTS,
+    RETRIABLE_ERROR_PATTERN,
     RETRY_BASE_DELAY,
     documented_columns,
-    drifted_relations,
     live_column_query,
     live_columns,
     looks_retriable,
     materialized_view_relations,
+    relations_missing_columns,
     retry_delay,
 )
+from lakehouse.resources.starrocks import _RETRIABLE_ERRORS
 
 # Verbatim from the failed run: an FE rolling restart began 39s into the build,
 # so the follower dbt was connected to could no longer forward DDL to the leader.
@@ -92,6 +96,22 @@ class TestLooksRetriable:
 
     def test_embedded_digits_do_not_trip_the_word_boundary(self):
         assert not looks_retriable(Exception("Rows affected: 20130, 12006, 110445"))
+
+
+class TestRetriableCodesAgreeWithTheResource:
+    def test_same_wire_protocol_codes_on_both_paths(self):
+        """The drift preflight runs through StarRocksResource, not through the
+        dbt build's retry loop, so a code the classifier here treats as
+        transient but the resource re-raises would abort the whole asset before
+        the build ever starts. 2003 CR_CONN_HOST_ERROR was exactly that gap.
+        """
+        classifier_codes = {
+            int(code) for code in re.findall(r"\d{4}", RETRIABLE_ERROR_PATTERN.pattern)
+        }
+        assert classifier_codes == set(_RETRIABLE_ERRORS)
+
+    def test_a_failed_connect_is_retriable(self):
+        assert 2003 in _RETRIABLE_ERRORS
 
 
 class TestRetryDelay:
@@ -358,19 +378,41 @@ class TestLiveColumns:
         }
 
 
-class TestDriftedRelations:
+class TestRelationsMissingColumns:
     def test_added_column_is_drift(self):
         """PR #2520: the dbt model grew five cohort columns and the deployed MV
         kept the old SELECT, which a plain `dbt build` reports as success.
         """
         documented = {"b2b_analytics.mv_a": {"org_key", "video_watchers"}}
         live = {"b2b_analytics.mv_a": {"org_key"}}
-        assert drifted_relations(documented, live) == ["b2b_analytics.mv_a"]
+        assert relations_missing_columns(documented, live) == ["b2b_analytics.mv_a"]
 
-    def test_removed_column_is_drift(self):
+    def test_renamed_column_is_drift(self):
+        """A rename reaches this as an add of the new name, so it is caught by
+        the same one-directional check.
+        """
+        documented = {"b2b_analytics.mv_a": {"org_key", "video_watchers"}}
+        live = {"b2b_analytics.mv_a": {"org_key", "video_viewers"}}
+        assert relations_missing_columns(documented, live) == ["b2b_analytics.mv_a"]
+
+    def test_an_undocumented_live_column_is_not_drift(self):
+        """The whole reason this is a subset check and not set equality. Nothing
+        enforces that the YAML lists every emitted column, and under equality
+        one undocumented column would full-refresh the dashboard's views on
+        every scheduled run.
+        """
+        documented = {"b2b_analytics.mv_a": {"org_key"}}
+        live = {"b2b_analytics.mv_a": {"org_key", "organization_name"}}
+        assert relations_missing_columns(documented, live) == []
+
+    def test_a_pure_removal_is_the_known_blind_spot(self):
+        """Dropped from the SQL and the YAML, still present in the view: not
+        reported. Documented as acceptable -- the leftover column is stale but
+        harmless, since ol-analytics-api projects its own field list.
+        """
         documented = {"b2b_analytics.mv_a": {"org_key"}}
         live = {"b2b_analytics.mv_a": {"org_key", "dropped_col"}}
-        assert drifted_relations(documented, live) == ["b2b_analytics.mv_a"]
+        assert relations_missing_columns(documented, live) == []
 
     def test_matching_columns_are_not_drift(self):
         """The common case -- it must not force a full refresh, since that drops
@@ -378,7 +420,7 @@ class TestDriftedRelations:
         """
         columns = {"org_key", "video_watchers"}
         assert (
-            drifted_relations(
+            relations_missing_columns(
                 {"b2b_analytics.mv_a": columns}, {"b2b_analytics.mv_a": columns}
             )
             == []
@@ -386,7 +428,9 @@ class TestDriftedRelations:
 
     def test_a_view_that_does_not_exist_yet_is_not_drift(self):
         """This build creates it with the current SELECT; nothing to refresh."""
-        assert drifted_relations({"b2b_analytics.mv_new": {"org_key"}}, {}) == []
+        assert (
+            relations_missing_columns({"b2b_analytics.mv_new": {"org_key"}}, {}) == []
+        )
 
     def test_ignores_live_relations_dbt_does_not_own(self):
         """The query filters by schema, so tables created outside dbt come back
@@ -397,7 +441,7 @@ class TestDriftedRelations:
             "b2b_analytics.mv_a": {"org_key"},
             "b2b_analytics.some_manual_table": {"whatever"},
         }
-        assert drifted_relations(documented, live) == []
+        assert relations_missing_columns(documented, live) == []
 
     def test_result_is_sorted(self):
         documented = {
@@ -405,7 +449,7 @@ class TestDriftedRelations:
             "b2b_analytics.mv_a": {"org_key", "new_col"},
         }
         live = {"b2b_analytics.mv_a": {"org_key"}, "b2b_analytics.mv_b": {"org_key"}}
-        assert drifted_relations(documented, live) == [
+        assert relations_missing_columns(documented, live) == [
             "b2b_analytics.mv_a",
             "b2b_analytics.mv_b",
         ]

--- a/src/ol_dbt/dbt_project.yml
+++ b/src/ol_dbt/dbt_project.yml
@@ -151,10 +151,10 @@ models:
       # dbt-starrocks reports no configuration changes otherwise. The Dagster
       # asset compares each MV's live columns against this project's manifest
       # and escalates to --full-refresh on a mismatch (see
-      # lakehouse/assets/lakehouse/dbt_starrocks.py), so a column add/rename
-      # lands on the next scheduled build -- but it is driven by the `columns:`
-      # in the schema YAML, so document a new column there or the rebuild will
-      # not trigger. Consumers that project the column (ol-analytics-api's
+      # lakehouse/assets/lakehouse/dbt_starrocks.py), so a column add, rename or
+      # removal lands on the next scheduled build. It reads the `columns:` in
+      # the schema YAML, which ol-dbt validate holds to the SQL in both
+      # directions. Consumers that project the column (ol-analytics-api's
       # build_select) must still deploy AFTER that build, or their SELECT errors
       # on an unknown column.
       +materialized: table

--- a/src/ol_dbt/dbt_project.yml
+++ b/src/ol_dbt/dbt_project.yml
@@ -148,10 +148,15 @@ models:
       +enabled: "{{ target.type == 'starrocks' }}"
       # Editing an MV's SELECT is a silent no-op on a plain `dbt build`: dbt only
       # replaces an existing materialized view on --full-refresh, and
-      # dbt-starrocks reports no configuration changes otherwise. Ship a column
-      # add/rename here with a one-off `dbt run --full-refresh --select
-      # b2b_analytics` (or drop the MV) BEFORE any consumer projects the new
-      # column, or ol-analytics-api's SELECT of it errors on an unknown column.
+      # dbt-starrocks reports no configuration changes otherwise. The Dagster
+      # asset compares each MV's live columns against this project's manifest
+      # and escalates to --full-refresh on a mismatch (see
+      # lakehouse/assets/lakehouse/dbt_starrocks.py), so a column add/rename
+      # lands on the next scheduled build -- but it is driven by the `columns:`
+      # in the schema YAML, so document a new column there or the rebuild will
+      # not trigger. Consumers that project the column (ol-analytics-api's
+      # build_select) must still deploy AFTER that build, or their SELECT errors
+      # on an unknown column.
       +materialized: table
       # The engine-scoping label: dbt_starrocks.py's dbt_assets selects
       # `tag:starrocks`, and dbt.py's Trino-scoped set excludes it. Moving a

--- a/src/ol_dbt/models/b2b_analytics/_b2b_analytics__models.yml
+++ b/src/ol_dbt/models/b2b_analytics/_b2b_analytics__models.yml
@@ -1,10 +1,9 @@
 ---
 # Every column each model emits is documented here, in SELECT order. That is a
 # contract, not a courtesy: the Dagster StarRocks asset compares this list
-# against the live materialized view and rebuilds the view when a documented
-# column is missing from it (lakehouse/lib/starrocks_dbt.py). A column added to
-# the SQL but not listed here will not trigger that rebuild, so the deployed MV
-# silently keeps its old SELECT.
+# against the live materialized view and rebuilds the view when the two differ
+# (lakehouse/lib/starrocks_dbt.py). ol-dbt validate errors in both directions,
+# so the lists cannot fall out of step without CI saying so.
 version: 2
 models:
 - name: mv_b2b_contract_utilization

--- a/src/ol_dbt/models/b2b_analytics/_b2b_analytics__models.yml
+++ b/src/ol_dbt/models/b2b_analytics/_b2b_analytics__models.yml
@@ -1,4 +1,10 @@
 ---
+# Every column each model emits is documented here, in SELECT order. That is a
+# contract, not a courtesy: the Dagster StarRocks asset compares this list
+# against the live materialized view and rebuilds the view when a documented
+# column is missing from it (lakehouse/lib/starrocks_dbt.py). A column added to
+# the SQL but not listed here will not trigger that rebuild, so the deployed MV
+# silently keeps its old SELECT.
 version: 2
 models:
 - name: mv_b2b_contract_utilization
@@ -7,18 +13,30 @@ models:
     materialized view, refreshed by the Dagster b2b_organization MV-refresh asset.
     Consumers: L&D manager dashboard header card, MIT admin overview.
   columns:
+  - name: organization_key
+    description: Org identifier, joined via dim_organization (platform='mitxonline'
+      only).
   - name: sso_organization_id
     description: >
       Keycloak organization UUID (dim_organization.sso_organization_id) -- the
       identifier the ol-analytics-api filters organizations on. Null for
       organization_keys that don't resolve to a mitxonline org.
-  - name: organization_key
-    description: Org identifier, joined via dim_organization (platform='mitxonline'
-      only).
+  - name: organization_name
+    description: Display name of the organization.
   - name: contract_pk
     description: Surrogate key of the B2B contract.
+  - name: b2b_contract_name
+    description: Display name of the contract.
+  - name: b2b_contract_is_active
+    description: Whether the contract is currently active.
+  - name: b2b_contract_start_date
+    description: Contract start date.
+  - name: b2b_contract_end_date
+    description: Contract end date -- drives the at_risk window in mv_b2b_mit_admin_contract_health.
   - name: seat_limit
     description: b2b_contract_max_learners.
+  - name: b2b_contract_membership_type
+    description: Contract membership type.
   - name: seats_consumed
     description: Distinct learners enrolled in any course run under this contract.
   - name: active_learners
@@ -36,11 +54,26 @@ models:
     course_run. Manual-refresh materialized view. Consumers: L&D manager course-level
     drill-down.
   columns:
+  - name: organization_key
+    description: Org identifier, joined via dim_organization (platform='mitxonline'
+      only).
   - name: sso_organization_id
     description: >
       Keycloak organization UUID (dim_organization.sso_organization_id) -- the
       identifier the ol-analytics-api filters organizations on. Null for
       organization_keys that don't resolve to a mitxonline org.
+  - name: organization_name
+    description: Display name of the organization.
+  - name: contract_pk
+    description: Surrogate key of the B2B contract.
+  - name: b2b_contract_name
+    description: Display name of the contract.
+  - name: courserun_pk
+    description: Surrogate key of the course run.
+  - name: courserun_readable_id
+    description: Human-readable course run identifier.
+  - name: courserun_title
+    description: Course run title.
   - name: enrolled_learners
     description: Distinct learners enrolled in this course run.
   - name: active_learners
@@ -49,6 +82,10 @@ models:
     description: Distinct learners with a passing grade.
   - name: certified_learners
     description: Distinct learners with a non-revoked certificate.
+  - name: active_rate_pct
+    description: active_learners / enrolled_learners * 100.
+  - name: completion_rate_pct
+    description: certified_learners / enrolled_learners * 100.
 
 - name: mv_b2b_monthly_engagement_trend
   description: >
@@ -58,11 +95,19 @@ models:
     free-text fallback values; those resolve to a null sso_organization_id).
     Consumers: L&D manager engagement trend chart.
   columns:
+  - name: organization_key
+    description: >
+      Org identifier from organization_administration_report. Includes free-text
+      fallback values that resolve to no mitxonline org.
   - name: sso_organization_id
     description: >
       Keycloak organization UUID (dim_organization.sso_organization_id) -- the
       identifier the ol-analytics-api filters organizations on. Null for
       organization_keys that don't resolve to a mitxonline org.
+  - name: organization_name
+    description: Display name of the organization.
+  - name: activity_year_and_month
+    description: The month this row aggregates, from the source report.
   - name: monthly_active_learners
     description: Distinct learners with any activity in the month.
   - name: new_enrollments
@@ -81,15 +126,26 @@ models:
       Floor it via certified_learners.
   - name: certified_learners
     description: Distinct learners who earned a certificate in the month.
+  - name: total_videos_watched
+    description: >
+      Videos watched in the month -- an EVENT count. Floor it via video_watchers.
   - name: video_watchers
     description: >
       Distinct learners who watched a video in the month -- the cohort
       total_videos_watched is attributable to, and a strict subset of
       monthly_active_learners.
+  - name: total_problems_attempted
+    description: >
+      Problems attempted in the month -- an EVENT count. Floor it via
+      problem_attempters.
   - name: problem_attempters
     description: >
       Distinct learners who attempted a problem in the month -- the cohort
       total_problems_attempted is attributable to.
+  - name: total_chatbot_interactions
+    description: >
+      Chatbot interactions in the month -- an EVENT count. Floor it via
+      chatbot_users.
   - name: chatbot_users
     description: >
       Distinct learners who used the chatbot in the month -- the cohort
@@ -102,11 +158,29 @@ models:
     (cert in any program course) until tfact_program_certificate ships.
     Consumers: L&D manager program progression view.
   columns:
+  - name: organization_key
+    description: Org identifier, joined via dim_organization (platform='mitxonline'
+      only).
   - name: sso_organization_id
     description: >
       Keycloak organization UUID (dim_organization.sso_organization_id) -- the
       identifier the ol-analytics-api filters organizations on. Null for
       organization_keys that don't resolve to a mitxonline org.
+  - name: organization_name
+    description: Display name of the organization.
+  - name: contract_pk
+    description: Surrogate key of the B2B contract.
+  - name: b2b_contract_name
+    description: Display name of the contract.
+  - name: program_pk
+    description: Surrogate key of the program.
+  - name: program_title
+    description: Program title.
+  - name: total_courses
+    description: >
+      Distinct courses in this program that the contract actually covers -- the
+      denominator is scoped to (contract, program), not to the full program, so
+      completion rates aren't understated for partial-program contracts.
   - name: enrolled_in_contract_courses
     description: Learners enrolled in any contract course belonging to this program.
   - name: enrolled_via_program
@@ -123,30 +197,67 @@ models:
     values; those resolve to a null sso_organization_id). Consumers: L&D manager
     course detail panel.
   columns:
+  - name: organization_key
+    description: >
+      Org identifier from organization_administration_report. Includes free-text
+      fallback values that resolve to no mitxonline org.
   - name: sso_organization_id
     description: >
       Keycloak organization UUID (dim_organization.sso_organization_id) -- the
       identifier the ol-analytics-api filters organizations on. Null for
       organization_keys that don't resolve to a mitxonline org.
+  - name: organization_name
+    description: Display name of the organization.
+  - name: courserun_readable_id
+    description: Human-readable course run identifier.
+  - name: courserun_title
+    description: Course run title.
+  - name: total_enrolled_learners
+    description: Distinct learners appearing for this org x course run.
+  - name: engaged_learners
+    description: >
+      Distinct learners with any activity (active_count > 0) -- the denominator
+      of both avg_* columns and of engagement_rate_pct.
   - name: engagement_rate_pct
     description: engaged_learners / total_enrolled_learners * 100.
-  - name: avg_videos_per_engaged_learner
+  - name: total_videos_watched
     description: >
-      total_videos_watched / engaged_learners -- averaged across every engaged
-      learner, so learners who watched nothing count as 0.
+      Videos watched, all-time -- an EVENT count. Floor it via video_watchers.
   - name: video_watchers
     description: >
       Distinct learners who watched at least one video -- the cohort
       total_videos_watched is attributable to, and a strict subset of
       engaged_learners.
-  - name: avg_problems_per_engaged_learner
+  - name: avg_videos_per_engaged_learner
     description: >
-      total_problems_attempted / engaged_learners -- averaged across every
-      engaged learner, so learners who attempted nothing count as 0.
+      total_videos_watched / engaged_learners -- averaged across every engaged
+      learner, so learners who watched nothing count as 0.
+  - name: total_problems_attempted
+    description: >
+      Problems attempted, all-time -- an EVENT count. Floor it via
+      problem_attempters.
   - name: problem_attempters
     description: >
       Distinct learners who attempted at least one problem -- the cohort
       total_problems_attempted is attributable to.
+  - name: avg_problems_per_engaged_learner
+    description: >
+      total_problems_attempted / engaged_learners -- averaged across every
+      engaged learner, so learners who attempted nothing count as 0.
+  - name: total_chatbot_interactions
+    description: >
+      Chatbot interactions, all-time -- an EVENT count. Floor it via
+      chatbot_users.
+  - name: chatbot_users
+    description: >
+      Distinct learners who used the chatbot -- the cohort
+      total_chatbot_interactions is attributable to.
+  - name: chatbot_adoption_pct
+    description: chatbot_users / total_enrolled_learners * 100.
+  - name: certificates_earned
+    description: >
+      Certificates earned, all-time -- an EVENT count (learner x course run), so
+      it is not a learner cohort and cannot floor itself.
 
 - name: mv_b2b_mit_admin_contract_health
   description: >
@@ -154,11 +265,43 @@ models:
     requesting org) -- MIT admin view only. Manual-refresh materialized view.
     Consumers: MIT contract admin dashboard.
   columns:
+  # The model selects * from its contract_stats CTE, so unlike the other five
+  # there is no literal column list in the SQL to read these off -- the CTE's
+  # own SELECT is the source of truth.
+  - name: organization_key
+    description: Org identifier, joined via dim_organization (platform='mitxonline'
+      only).
   - name: sso_organization_id
     description: >
       Keycloak organization UUID (dim_organization.sso_organization_id) -- the
       identifier the ol-analytics-api filters organizations on. Null for
       organization_keys that don't resolve to a mitxonline org.
+  - name: organization_name
+    description: Display name of the organization.
+  - name: contract_pk
+    description: Surrogate key of the B2B contract.
+  - name: b2b_contract_name
+    description: Display name of the contract.
+  - name: b2b_contract_is_active
+    description: Whether the contract is currently active -- drives the inactive health_status.
+  - name: b2b_contract_start_date
+    description: Contract start date.
+  - name: b2b_contract_end_date
+    description: Contract end date -- drives the at_risk 90-day window.
+  - name: seat_limit
+    description: b2b_contract_max_learners.
+  - name: b2b_contract_membership_type
+    description: Contract membership type.
+  - name: seats_consumed
+    description: Distinct learners enrolled in any course run under this contract.
+  - name: active_learners
+    description: Distinct learners with an active enrollment under this contract.
+  - name: certified_learners
+    description: Distinct learners holding a non-revoked certificate under this contract.
+  - name: seat_utilization_pct
+    description: seats_consumed / seat_limit * 100.
+  - name: completion_rate_pct
+    description: certified_learners / seats_consumed * 100.
   - name: health_status
     description: >
       One of: inactive (contract not active), at_risk (utilization < 25% and


### PR DESCRIPTION
### What are the relevant tickets?
Follow-on to #2520.

### Description (What does it do?)
- Editing a materialized view's SELECT never reaches StarRocks on a plain `dbt build`: dbt-core only replaces an existing MV under `--full-refresh`, and dbt-starrocks' `starrocks__get_materialized_view_configuration_changes` is an empty macro, so dbt logs "no configuration changes were identified" and executes nothing. `refresh_starrocks_analytics_mvs` then re-runs the *stored* (old) query. Both assets go green; the change never landed.
- `starrocks_dbt_assets` now compares each MV's live `information_schema.columns` against the columns documented in the dbt manifest, and escalates that build to `--full-refresh` when they disagree.
- Conditional rather than unconditional: `--full-refresh` drops and recreates every selected view, and ol-analytics-api serves the B2B dashboard off them live.
- Adds `StarRocksResource.fetch()` — `execute()`'s Vault-credential retry loop, but returning rows and taking bound parameters.
- The comparison is driven by the `columns:` in the schema YAML (`+meta: required_docs: true` makes those mandatory, and `ol-dbt validate` holds them to the SQL). A model with no documented columns is skipped rather than treated as "expects nothing", which would force a rebuild on every run.

This is what #2520 needs to actually reach production: it added five cohort columns to `mv_b2b_monthly_engagement_trend` and two to `mv_b2b_content_engagement_depth`, and those columns are in the manifest but not in StarRocks. It also removes the hand-remembered ordering step in front of the ol-analytics-api CohortPolicy change, whose `build_select` projects each model's own field list — deploying it against an un-rebuilt MV is an unknown-column error at request time, not at deploy time.

### How can this be tested?
Run locally, no warehouse credentials needed:

```
cd dg_projects/lakehouse && uv run pytest lakehouse_tests -q   # 63 passed
uv run pre-commit run --files <the five changed files>          # ruff + mypy green
```

The new unit tests cover the comparison itself: an added column (the #2520 case) and a removed column are drift; identical columns are not; an MV that does not exist yet is not drift (this build creates it); relations in the schema that dbt does not own are ignored; schema names are bound, not interpolated.

Not exercised locally: the live `information_schema` query and the `--full-refresh` build itself, neither of which runs without a StarRocks cluster. On the first materialization after this merges, the run log should name the two MVs from #2520 and show `--full-refresh` on the dbt command line; a second run right after should log neither and issue a plain `build`. `DESC b2b_analytics.mv_b2b_monthly_engagement_trend` is the direct confirmation that the seven columns landed.

`uv run dg check defs` fails on this branch, but identically on an unmodified `main` — `Required var 'schema_suffix' not found in config` from the Trino project's `prepare_if_dev()`, unrelated to this change.

### Additional Context
Worth a look during review: the drift check opens its own StarRocks connection before the build's retry loop, so it leans on `StarRocksResource`'s 3-attempt Vault/connection retry rather than the build's 4-attempt one. That seemed right — it is a cheap SELECT, and failing before a 20-minute build is the better failure — but it is a deliberate choice, not an oversight.
