### PR TITLE
fix(dbt): error on undocumented columns in ol-dbt validate; document the 145 pre-existing gaps

### DIFF
--- a/src/ol_dbt/models/integrations/learn/_integrations__learn__cohort2__schema.yml
+++ b/src/ol_dbt/models/integrations/learn/_integrations__learn__cohort2__schema.yml
@@ -27,16 +27,30 @@ models:
   - name: etl_source
     description: Always 'mit_climate'.
     tests: [not_null]
+  - name: description
+    description: Article summary.
   - name: url
     description: Absolute URL for the article (base URL prepended to the relative
       path).
   - name: image_url
     description: Absolute URL for the article cover image, or NULL if absent.
+  - name: image_alt
+    description: Alt text for the article cover image, or NULL if absent.
   - name: topics
     description: Comma-separated topic labels (normalized from pipe-separated raw
       field).
+  - name: footnotes
+    description: Article footnotes/citations, as raw text from the CMS.
+  - name: byline
+    description: Article author byline.
   - name: feed_type
     description: Source feed — 'explainer' or 'ask_mit_climate'.
+  - name: published
+    description: >
+      Always true; the MIT Climate API only returns published articles.
+  - name: platform
+    description: >
+      Always 'climate' (differs from etl_source, which is 'mit_climate').
 
 - name: integrations__learn__mitpe_courses
   description: >
@@ -62,6 +76,22 @@ models:
   - name: etl_source
     description: Always 'mitpe'.
     tests: [not_null]
+  - name: description
+    description: Course description.
+  - name: url
+    description: Absolute URL for the course (base URL prepended to the relative path).
+  - name: image_url
+    description: Absolute URL for the course's cover image, or NULL if absent.
+  - name: image_alt
+    description: Alt text for the course's cover image, or NULL if absent.
+  - name: topics
+    description: Comma-separated topic labels (normalized from pipe-separated raw
+      field).
+  - name: published
+    description: >
+      Always true; the MIT PE feeds API only returns published courses.
+  - name: platform
+    description: Always 'mitpe', matches etl_source.
   - name: resource_type
     description: Always 'course'.
 
@@ -87,6 +117,23 @@ models:
   - name: etl_source
     description: Always 'oll'.
     tests: [not_null]
+  - name: description
+    description: Course description from the OLL spreadsheet.
+  - name: url
+    description: Course URL from the OLL spreadsheet.
+  - name: image_url
+    description: Course image URL from the OLL spreadsheet.
+  - name: topics
+    description: Comma-separated topic labels (normalized from pipe-separated raw
+      field).
+  - name: published
+    description: >
+      Always true; only the most recent offering per course (by year, then
+      semester) is exposed.
+  - name: platform
+    description: Always 'oll', matches etl_source.
+  - name: resource_type
+    description: Always 'course'.
   - name: runs
     description: >
       Single run record in pipe-delimited format: run_id|||true
@@ -119,6 +166,12 @@ models:
   - name: etl_source
     description: Always 'mit_edx'.
     tests: [not_null]
+  - name: description
+    description: Program description from the edX.org Discovery API.
+  - name: url
+    description: Program marketing URL on edx.org.
+  - name: image_url
+    description: Program image URL from the edX.org Discovery API.
   - name: topics_json
     description: >
       JSON array string of subject objects: [{"name": "Engineering"}, ...].
@@ -135,5 +188,8 @@ models:
       being yielded -- this compares each row's _dlt_load_id against the
       table-wide max to distinguish still-active from merge-left-behind rows).
     tests: [not_null]
+  - name: platform
+    description: >
+      Always 'edxorg' (differs from etl_source, which is 'mit_edx').
   - name: resource_type
     description: Always 'program'.

--- a/src/ol_dbt/models/integrations/learn/_integrations__learn__schema.yml
+++ b/src/ol_dbt/models/integrations/learn/_integrations__learn__schema.yml
@@ -25,8 +25,36 @@ models:
   - name: etl_source
     description: Always 'ocw'.
     tests: [not_null]
+  - name: description
+    description: Course description from the OCW website.
+  - name: url
+    description: URL of the course on OCW production (ocw.mit.edu).
+  - name: image_url
+    description: Course image URL.
   - name: published
     description: Whether the course is live on ocw.mit.edu.
+  - name: platform
+    description: Always 'ocw', matches etl_source.
+  - name: level
+    description: >
+      Comma-separated course level(s), e.g. Undergraduate, Graduate,
+      Non-Credit, High School.
+  - name: term
+    description: Course term, e.g. Spring, Summer, Fall, January IAP, or blank.
+  - name: year
+    description: Course year.
+  - name: course_number
+    description: Primary course number, e.g. '21A.850J'.
+  - name: extra_course_numbers
+    description: Additional course numbers beyond the primary, e.g. 'STS.484J'.
+  - name: topics
+    description: >
+      Comma-separated topic labels, preferring speciality, then subtopic,
+      then topic.
+  - name: instructors
+    description: Comma-separated instructor names.
+  - name: departments
+    description: Comma-separated department names offering the course.
 
 - name: integrations__learn__mitxonline_courses
   description: >
@@ -47,6 +75,36 @@ models:
   - name: etl_source
     description: Always 'mitxonline'.
     tests: [not_null]
+  - name: description
+    description: Course description shown on the course's home/product page.
+  - name: url
+    description: MITx Online course page URL path (relative).
+  - name: image_url
+    description: Course image URL.
+  - name: published
+    description: Whether the course is live on mitxonline.mit.edu.
+  - name: platform
+    description: Always 'mitxonline', matches etl_source.
+  - name: page_slug
+    description: MITx Online CMS page slug, used for constructing the course page's
+      URL.
+  - name: topics
+    description: Comma-separated topic names for the course.
+  - name: instructors
+    description: Comma-separated instructor names for the course.
+  - name: certification_type
+    description: Either 'MicroMasters Credential' or 'Certificate of Completion'.
+  - name: price
+    description: >
+      Product price in plain text, e.g. '$250 - $1000 (financial assistance
+      available)'.
+  - name: length
+    description: >
+      Short description of how long the course takes to complete, e.g.
+      '4 weeks'.
+  - name: effort
+    description: >
+      Short description of expected weekly effort, e.g. '1-3 hours per week'.
   - name: runs
     description: >
       Pipe-delimited run metadata strings joined with semicolons.
@@ -72,6 +130,36 @@ models:
   - name: etl_source
     description: Always 'mitxonline'.
     tests: [not_null]
+  - name: description
+    description: Program description shown on the program's home/product page.
+  - name: url
+    description: MITx Online program page URL path (relative).
+  - name: image_url
+    description: Program image URL.
+  - name: published
+    description: Whether the program is live on mitxonline.mit.edu.
+  - name: platform
+    description: Always 'mitxonline', matches etl_source.
+  - name: program_type
+    description: >
+      Program type, free text from the source CMS, e.g. 'MicroMasters',
+      'Series'.
+  - name: certification_type
+    description: Either 'MicroMasters Credential' or 'Certificate of Completion'.
+  - name: topics
+    description: >
+      Comma-separated topic names aggregated across all courses in the
+      program.
+  - name: instructors
+    description: Comma-separated instructor names for the program.
+  - name: page_slug
+    description: MITx Online CMS page slug, used for constructing the program page's
+      URL.
+  - name: price
+    description: Product price in plain text, e.g. '$250 - $1000'.
+  - name: effort
+    description: >
+      Short description of expected weekly effort, e.g. '1-3 hours per week'.
   - name: courses
     description: Comma-separated list of course readable_ids belonging to this program.
 
@@ -94,6 +182,32 @@ models:
   - name: etl_source
     description: Always 'xpro'.
     tests: [not_null]
+  - name: description
+    description: Course description displayed on the xPRO course page.
+  - name: url
+    description: xPRO course page URL path (relative).
+  - name: image_url
+    description: Course image URL.
+  - name: published
+    description: Whether the course is live on xpro.mit.edu.
+  - name: platform
+    description: >
+      Platform name for the course, sourced from xPRO's platform dimension
+      table (e.g. 'xPRO'). Unlike etl_source, this is not a fixed literal.
+  - name: page_slug
+    description: xPRO CMS page slug, used for constructing the course page's URL.
+  - name: topics
+    description: Comma-separated topic names for the course.
+  - name: instructors
+    description: Comma-separated instructor names for the course.
+  - name: length
+    description: >
+      Short description of how long the course takes to complete, e.g.
+      '4 weeks'.
+  - name: effort
+    description: Short description of expected weekly time commitment.
+  - name: format
+    description: Course format, e.g. 'Online', 'Other'.
   - name: runs
     description: >
       Pipe-delimited run metadata strings joined with semicolons.
@@ -118,6 +232,32 @@ models:
   - name: etl_source
     description: Always 'xpro'.
     tests: [not_null]
+  - name: description
+    description: Program description displayed on the xPRO program page.
+  - name: url
+    description: xPRO program page URL path (relative).
+  - name: image_url
+    description: Program image URL.
+  - name: published
+    description: Whether the program is live on xpro.mit.edu.
+  - name: platform
+    description: >
+      Platform name for the program, sourced from xPRO's platform dimension
+      table (e.g. 'xPRO'). Unlike etl_source, this is not a fixed literal.
+  - name: page_slug
+    description: xPRO CMS page slug, used for constructing the program page's URL.
+  - name: topics
+    description: Comma-separated topic names for the program.
+  - name: instructors
+    description: Comma-separated instructor names for the program.
+  - name: length
+    description: >
+      Short description of how long the program takes to complete, e.g.
+      '4 weeks'.
+  - name: effort
+    description: Short description of expected weekly time commitment.
+  - name: format
+    description: Program format, e.g. 'Online', 'Other'.
   - name: courses
     description: Comma-separated list of course readable_ids belonging to this program.
 
@@ -144,6 +284,18 @@ models:
   - name: etl_source
     description: Always 'micromasters'.
     tests: [not_null]
+  - name: description
+    description: Program description.
+  - name: url
+    description: >
+      Absolute URL for the program's page on micromasters.mit.edu, or NULL
+      for unpublished pages.
+  - name: image_url
+    description: Absolute URL for the program's thumbnail image.
+  - name: published
+    description: Whether the program is live on micromasters.mit.edu.
+  - name: platform
+    description: Always 'micromasters', matches etl_source.
   - name: courses
     description: >
       Comma-separated list of course readable_ids ordered by position_in_program.
@@ -168,11 +320,41 @@ models:
   - name: etl_source
     description: Always 'mit_edx'.
     tests: [not_null]
-  - name: runs
+  - name: description
+    description: Short course description from the edX.org catalog API.
+  - name: url
+    description: URL for the course's About page on edx.org.
+  - name: image_url
+    description: URL for the course image from the edX.org catalog API.
+  - name: published
+    description: True if at least one course run is published.
+  - name: platform
     description: >
-      Pipe-delimited run metadata strings joined with semicolons.
-      Format per run: courserun_key|start_on|end_on|is_published
+      Always 'edxorg' (differs from etl_source, which is 'mit_edx').
+  - name: page_slug
+    description: >
+      Always NULL; edX.org courses have no CMS page slug (placeholder for
+      contract parity with other sources).
   - name: topics
     description: Comma-separated subject names from the edX.org course record.
   - name: instructors
     description: Comma-separated instructor names aggregated across all course runs.
+  - name: certification_type
+    description: >
+      Course type from the edX.org catalog API, e.g. audit, verified,
+      professional; used as this contract's certification_type.
+  - name: price
+    description: >
+      Maximum non-audit/honor seat price across all published runs, cast to
+      a string, or NULL if no priced seats.
+  - name: length
+    description: >
+      Max course run duration across published runs, e.g. '4 weeks'.
+  - name: effort
+    description: >
+      Max course run time commitment across published runs, e.g.
+      '5-7 hours per week'.
+  - name: runs
+    description: >
+      Pipe-delimited run metadata strings joined with semicolons.
+      Format per run: courserun_key|start_on|end_on|is_published

--- a/src/ol_dbt/models/intermediate/combined/_combined_models.yml
+++ b/src/ol_dbt/models/intermediate/combined/_combined_models.yml
@@ -148,6 +148,12 @@ models:
     description: timestamp, date and time when the course certificate was initially
       created on the corresponding platform; null when the learner has not yet earned
       a certificate
+  - name: courseruncertificate_issued_on
+    description: timestamp, date and time when the course certificate was issued to
+      the learner. For MITx Online, this is the actual issued_on date from the source
+      system. For other platforms, this falls back to courseruncertificate_created_on
+      as they don't track a separate issued date. Null when the learner has not yet
+      earned a certificate.
 
 - name: int__combined__courserun_certificates
   description: course certificates model combined from different platforms. It excludes

--- a/src/ol_dbt/models/intermediate/micromasters/_int_micromasters__models.yml
+++ b/src/ol_dbt/models/intermediate/micromasters/_int_micromasters__models.yml
@@ -172,6 +172,11 @@ models:
       website
     tests:
     - not_null
+  - name: program_page_url
+    description: str, fully-qualified live URL of the program's page on MicroMasters.
+      NULL for unpublished pages.
+  - name: program_image_url
+    description: str, fully-qualified image URL for the program's thumbnail image
   tests:
   - dbt_expectations.expect_table_row_count_to_equal_other_table:
       arguments:
@@ -209,6 +214,8 @@ models:
     description: int, indicating the number of required courses to earn certificate
     tests:
     - not_null
+  - name: course_position_in_program
+    description: int, sequential number indicating the course position in a program
 
 - name: int__micromasters__program_certificates
   description: MicroMasters program certificate earners. User's profile fields are

--- a/src/ol_dbt/models/intermediate/mitxonline/_int_mitxonline__models.yml
+++ b/src/ol_dbt/models/intermediate/mitxonline/_int_mitxonline__models.yml
@@ -515,6 +515,8 @@ models:
     - not_null
   - name: order_created_on
     description: timestamp, specifying when the order was initially created
+  - name: order_updated_on
+    description: timestamp, specifying when the order was most recently updated
   - name: order_reference_number
     description: string, readable id for the order. Shared with micromasters
     tests:
@@ -685,6 +687,10 @@ models:
     - not_null
   - name: courserunenrollment_created_on
     description: timestamp, specifying when an enrollment was initially created
+    tests:
+    - not_null
+  - name: courserunenrollment_updated_on
+    description: timestamp, specifying when an enrollment was most recently updated
     tests:
     - not_null
   - name: courserunenrollment_enrollment_mode
@@ -895,6 +901,10 @@ models:
     description: timestamp, specifying when an enrollment was initially created
     tests:
     - not_null
+  - name: programenrollment_updated_on
+    description: timestamp, specifying when an enrollment was most recently updated
+    tests:
+    - not_null
   - name: programenrollment_enrollment_mode
     description: str, enrollment mode for user
   - name: programenrollment_enrollment_status
@@ -989,6 +999,9 @@ models:
     description: timestamp, date and time when the course page was first published
   - name: course_page_last_published_on
     description: timestamp, date and time when the course page was last published
+  - name: course_image_url
+    description: str, fully-qualified URL for the course's featured image, resolved
+      from the course page's feature image in the Wagtail CMS
 
 - name: int__mitxonline__course_to_departments
   description: Intermediate model for MITxOnline course to department
@@ -1337,6 +1350,9 @@ models:
     description: timestamp, date and time when the page was first published
   - name: program_page_last_published_on
     description: timestamp, date and time when the page was last published
+  - name: program_image_url
+    description: str, fully-qualified URL for the program's featured image, resolved
+      from the program page's feature image in the Wagtail CMS
 
 - name: int__mitxonline__program_requirements
   columns:
@@ -1384,6 +1400,9 @@ models:
     description: int, indicating the number of required courses to earn certificate
     tests:
     - not_null
+  - name: course_order_in_program
+    description: int, sequential number indicating the display order of the course
+      within the program, derived from the course node's path in the MITx Online CMS
 
 - name: int__mitxonline__program_certificates
   columns:
@@ -2171,6 +2190,9 @@ models:
     description: int, foreign key to the courses_course table
     tests:
     - not_null
+  - name: instructor_source_id
+    description: str, platform-native stable identifier for the instructor (the Wagtail
+      page ID of the instructor's CMS page, cast to varchar)
   - name: instructor_name
     description: str, the name of the instructor.
     tests:

--- a/src/ol_dbt/models/intermediate/mitxpro/_int_mitxpro__models.yml
+++ b/src/ol_dbt/models/intermediate/mitxpro/_int_mitxpro__models.yml
@@ -1080,6 +1080,10 @@ models:
     description: timestamp, specifying when an enrollment was initially created
     tests:
     - not_null
+  - name: courserunenrollment_updated_on
+    description: timestamp, specifying when an enrollment was most recently updated
+    tests:
+    - not_null
   - name: courserunenrollment_enrollment_status
     description: str, enrollment status for users whose enrollment changed. Options
       are 'deferred', 'transferred', 'refunded', 'enrolled', 'unenrolled'
@@ -1267,6 +1271,9 @@ models:
     description: timestamp, date and time when the program page was first published
   - name: cms_programpage_last_published_on
     description: timestamp, date and time when the program page was last published
+  - name: cms_programpage_image_url
+    description: str, fully-qualified URL for the program's search/feature image,
+      resolved from the program page's search image in the Wagtail CMS
 
 - name: int__mitxpro__program_runs
   description: Intermediate model of program runs in MITxPro
@@ -1368,6 +1375,9 @@ models:
     description: timestamp, date and time when the course page was first published
   - name: cms_coursepage_last_published_on
     description: timestamp, date and time when the course page was last published
+  - name: cms_coursepage_image_url
+    description: str, fully-qualified URL for the course's search/feature image, resolved
+      from the course page's search image in the Wagtail CMS
 
 - name: int__mitxpro__course_runs
   description: Intermediate model of course runs in MIT xPro.
@@ -1934,6 +1944,10 @@ models:
     description: int, primary key in courses_program
     tests:
     - not_null
+  - name: course_order
+    description: int, sequential number (1-indexed) indicating the display order of
+      the course within the program, derived from the position of the course page
+      in cms_coursesinprogrampage_coursepage_wagtail_page_ids
   tests:
   - dbt_expectations.expect_compound_columns_to_be_unique:
       arguments:

--- a/src/ol_dbt/models/intermediate/ocw/_int_ocw__models.yml
+++ b/src/ol_dbt/models/intermediate/ocw/_int_ocw__models.yml
@@ -92,6 +92,11 @@ models:
     description: str, course learning resource types or features in comma-separated
       list. e.g. Lecture Notes, Problem Sets with Solutions,... Full list https://github.com/mitodl/ocw-hugo-projects/blob/049c85e6544a36ba69a89602e5014f6085ef8831/
       ocw-course-v2/ocw-studio.yaml#L163-L207
+  - name: course_image_url
+    description: str, fully-qualified URL for the course's featured image, constructed
+      by prepending the ocw_production_url dbt variable to the file path of the website
+      content referenced by course_image_text_id. Null when the course has no featured
+      image.
 
 - name: int__ocw__course_topics
   description: supporting table containing tabular course topic data for OCW courses

--- a/src/ol_dbt/models/staging/micromasters/_stg_micromasters__models.yml
+++ b/src/ol_dbt/models/staging/micromasters/_stg_micromasters__models.yml
@@ -76,8 +76,22 @@ models:
     description: int, FK to wagtailimages_image for the program thumbnail
   - name: cms_programpage_background_image_id
     description: int, FK to wagtailimages_image for the program hero background
+  - name: cms_programpage_letter_logo_id
+    description: int, FK to wagtailimages_image for the program's letter logo image
   - name: cms_programpage_description
     description: str, program description rendered in the CMS
+  - name: cms_programpage_faculty_description
+    description: str, faculty description rendered in the CMS
+  - name: cms_programpage_title_over_image
+    description: str, title text overlaid on the program's hero background image
+  - name: cms_programpage_home_page_url
+    description: str, URL the program page's home page link points to
+  - name: cms_programpage_home_page_url_title
+    description: str, link text/title displayed for the program home page URL
+  - name: cms_programpage_contact_email
+    description: str, email used to contact the program team
+  - name: cms_programpage_subscribe_link
+    description: str, URL for the program's mailing list subscribe link
 - name: stg__micromasters__app__postgres__courses_course
   columns:
   - name: course_id
@@ -1056,12 +1070,37 @@ models:
       and the page slug. NULL for unpublished pages.
   - name: wagtail_page_url_path
     description: str, internal Wagtail tree path (e.g. /home/scm/)
+  - name: wagtail_page_title
+    description: str, human-readable title of the page
   - name: wagtail_page_is_live
     description: boolean, whether the page is currently published
+  - name: wagtail_page_depth
+    description: int, depth of this page in the Wagtail page tree. A root node has
+      a depth of 1.
+  - name: wagtail_page_path
+    description: str, materialized path string used by Wagtail's tree implementation
+      to represent this page's position in the page tree
+  - name: wagtail_page_seo_title
+    description: str, alternate SEO-crafted title, for use in the page's <title> HTML
+      tag.
+  - name: wagtail_page_search_description
+    description: str, SEO-crafted description of the content, used for search indexing.
+      This is also suitable for the page's <meta name="description"> HTML tag.
+  - name: wagtail_page_has_unpublished_changes
+    description: boolean, set to True when the page is either in draft or published
+      with draft changes.
+  - name: content_type_id
+    description: int, foreign key to django_contenttype identifying the specific page
+      type (e.g. cms_programpage) for this page
+  - name: owner_id
+    description: int, foreign key to auth_user for the user who owns/created this
+      page
   - name: wagtail_page_first_published_on
     description: timestamp, when the page was first published
   - name: wagtail_page_last_published_on
     description: timestamp, when the page was most recently published
+  - name: wagtail_page_latest_revision_created_on
+    description: timestamp, date and time of the page's latest revision
 - name: stg__micromasters__app__postgres__wagtailimages_image
   description: Images uploaded to the MicroMasters Wagtail CMS image library. Used
     to resolve thumbnail_image_id foreign keys on cms_programpage to full image URLs.
@@ -1082,6 +1121,26 @@ models:
     description: int, image width in pixels
   - name: image_height
     description: int, image height in pixels
+  - name: image_file_hash
+    description: str, hash of the image file used for deduplication
+  - name: image_file_size
+    description: int, size of the image file in bytes
+  - name: image_created_on
+    description: timestamp, when the image was uploaded to the CMS
+  - name: collection_id
+    description: int, foreign key to the Wagtail collection this image belongs to
+  - name: image_focal_point_x
+    description: int, x coordinate of the focal point used for smart cropping
+  - name: image_focal_point_y
+    description: int, y coordinate of the focal point used for smart cropping
+  - name: image_focal_point_width
+    description: int, width of the focal point region used for smart cropping
+  - name: image_focal_point_height
+    description: int, height of the focal point region used for smart cropping
+  - name: uploaded_by_user_id
+    description: int, foreign key to auth_user for the user who uploaded the image
+  - name: image_description
+    description: str, optional description of the image as entered in the CMS
 - name: stg__micromasters__app__user_program_certificate_override_list
   description: Certain users should receive a certificate even though they do not
     meet all the program certificate requirements. This list has the user_id on user_edxorg

--- a/src/ol_dbt/models/staging/mitxonline/_stg_mitxonline__models.yml
+++ b/src/ol_dbt/models/staging/mitxonline/_stg_mitxonline__models.yml
@@ -1833,6 +1833,9 @@ models:
   - name: course_video_url
     description: str, URL to the video to be displayed for this course. It can be
       an HLS or Youtube video URL.
+  - name: course_feature_image_id
+    description: int, foreign key to wagtailimages_image for the course's feature
+      image
 
 - name: stg__mitxonline__app__postgres__cms_programpage
   description: program page metadata sourced from Wagtail CMS
@@ -1874,6 +1877,9 @@ models:
   - name: program_video_url
     description: str, URL to the video to be displayed for this program. It can be
       an HLS or Youtube video URL.
+  - name: program_feature_image_id
+    description: int, foreign key to wagtailimages_image for the program's feature
+      image
 
 - name: stg__mitxonline__app__postgres__courses_coursetopic
   columns:
@@ -2195,6 +2201,9 @@ models:
   - name: image_file
     description: str, path to the image file in storage. May be an S3 key or a CDN-relative
       path - prepend the MITx Online media base URL to form a full image URL.
+  - name: image_url
+    description: str, fully-qualified image URL constructed by prepending mitxonline_media_url
+      to image_file
   - name: image_title
     description: str, title/label for the image as entered in the CMS
   - name: image_width

--- a/src/ol_dbt/models/staging/mitxpro/_stg_mitxpro__models.yml
+++ b/src/ol_dbt/models/staging/mitxpro/_stg_mitxpro__models.yml
@@ -1626,6 +1626,8 @@ models:
     - not_null
   - name: cms_coursepage_external_marketing_url
     description: str,  the URL of the external course web page
+  - name: cms_coursepage_search_image_id
+    description: int, foreign key to wagtailimages_image for the course's search image
   - name: cms_coursepage_model
     description: str,  whether the course page record is in the cms_coursepage or
       cms_externalcoursepage table. This can not be used reliably to determine if
@@ -1764,6 +1766,9 @@ models:
     description: str,  the URL of the external program web page
   - name: cms_programpage_is_featured
     description: bool, whether the program is featured
+  - name: cms_programpage_search_image_id
+    description: int, foreign key to wagtailimages_image for the program's search
+      image
   - name: cms_programpage_model
     description: str,  whether the program page record is in the cms_programpage or
       cms_externalprogramepage table. This can not be used reliably to determine if

--- a/src/ol_dbt/models/staging/ocw/_stg_ocw__models.yml
+++ b/src/ol_dbt/models/staging/ocw/_stg_ocw__models.yml
@@ -185,6 +185,10 @@ models:
       21A.850J
   - name: course_extra_course_numbers
     description: str, the extra course number extracted from sitemetadata. e.g., STS.484J
+  - name: course_image_text_id
+    description: str, uuid string referencing the websitecontent_text_id of the website
+      content record for the course's featured image, extracted from the course_image
+      field in sitemetadata
   - name: websitecontent_deleted_on
     description: timestamp, date and time for the soft delete
   - name: websitecontent_created_on

--- a/src/ol_dbt_cli/ol_dbt_cli/commands/validate.py
+++ b/src/ol_dbt_cli/ol_dbt_cli/commands/validate.py
@@ -147,7 +147,7 @@ def _check_yaml_sql_sync(
     if undocumented:
         report.add(
             "yaml_sql_sync",
-            Severity.WARNING,
+            Severity.ERROR,
             model_name,
             f"Columns in SQL output but not documented in YAML: {sorted(undocumented)}",
             "Add these columns to the model's YAML schema file.",

--- a/src/ol_dbt_cli/tests/test_validate.py
+++ b/src/ol_dbt_cli/tests/test_validate.py
@@ -91,8 +91,8 @@ class TestYamlSqlSync:
         report = ValidationReport()
         _check_yaml_sql_sync("stg_users", yaml_registry, parsed, report)
 
-        warnings = [i for i in report.issues if i.severity == Severity.WARNING]
-        assert any("user_name" in i.message for i in warnings)
+        errors = [i for i in report.issues if i.severity == Severity.ERROR]
+        assert any("user_name" in i.message for i in errors)
 
     def test_no_issues_when_in_sync(self) -> None:
         registry = _simple_registry("user_id", "user_email")


### PR DESCRIPTION
### What are the relevant tickets?
N/A (witan task `tk-make-ol-dbt-validate-error-on-undocumented-colum-4d2b2d`)

### Description (What does it do?)
`_check_yaml_sql_sync` in `src/ol_dbt_cli/ol_dbt_cli/commands/validate.py` treated the two directions of SQL<->YAML drift asymmetrically: a YAML column with no matching SQL alias ("phantom") was an ERROR, but a SQL column nobody documented was only a WARNING. YAML completeness was a convention, not a contract.

- Documents the 145 previously-undocumented columns across 35 models (tail of single-column FK/timestamp gaps, the full `integrations__learn__*` family, and the micromasters Wagtail/CMS staging models) — first commit.
- Flips the `undocumented` branch of `_check_yaml_sql_sync` from `Severity.WARNING` to `Severity.ERROR`, and updates `test_validate.py` accordingly — second commit, landed only after the docs so it doesn't turn 35 models red at once.

Why this matters beyond docs hygiene: PR #2554 makes the Dagster StarRocks asset rebuild a materialized view when the live view is missing a column the manifest documents, driven off this same schema YAML. That comparison is deliberately one-directional (subset, not equality) *because* completeness was unenforced — under equality, the first undocumented column added to any model would make every MV look drifted on every run. Enforcing completeness here is what lets that comparison be tightened to a real set-equality check later (tracked as a follow-up).

**Scope note:** `b2b_analytics` (`mv_b2b_*`) is intentionally excluded — that folder's documentation gap is owned by #2554 (`worktree-b2b-analytics-mv-drift-refresh`), which documents it as part of wiring the MV drift check to the same YAML. Until #2554 merges, a full (non `--changed-only`) `ol-dbt validate` run will show 6 ERRORs there. This doesn't block CI, since `dbt_pr_ci.yaml` only runs `--changed-only` on PRs — only models actually touched by a given PR are gated.

### How can this be tested?
```
cd src/ol_dbt
uv run ol-dbt validate --format json | jq '[.[] | select(.check=="yaml_sql_sync" and (.message|startswith("Columns in SQL output but not documented")))] | length'
# -> 0 outside b2b_analytics (mv_b2b_*, owned by #2554)

cd ../ol_dbt_cli && uv run pytest -q
# -> 412 passed
```
Also ran `uv run pre-commit run --files <all changed files>` — yamlfmt/yamllint/ruff/mypy all pass.

### Additional Context
Sequencing with #2554: whichever of these two PRs merges second should re-run the measurement above to confirm 0 undocumented columns project-wide. No action needed if either lands independently — they touch disjoint files and neither is blocked on the other.
