### PR TITLE
feat(zendesk): add comment author user ID and email fields to ticket_comment

### DIFF
--- a/src/ol_dbt/models/intermediate/zendesk/_zendesk_models.yml
+++ b/src/ol_dbt/models/intermediate/zendesk/_zendesk_models.yml
@@ -113,8 +113,13 @@ models:
     description: array, list of tokens received from uploading files for comment attachments.
   - name: audit_id
     description: int, foreign key to the ticket audit record
+  - name: comment_author_user_id
+    description: int, foreign key to the user who created the comment
   - name: comment_author
     description: str, the name of the author of the comment.
+  - name: comment_author_email
+    description: str, the primary email address of the comment author. May be null
+      for permanently deleted users or authors absent from stg__zendesk__user.
   - name: comment_html_body
     description: text, the comment formatted as HTML
   - name: comment_plain_body

--- a/src/ol_dbt/models/intermediate/zendesk/int__zendesk__ticket_comment.sql
+++ b/src/ol_dbt/models/intermediate/zendesk/int__zendesk__ticket_comment.sql
@@ -12,7 +12,12 @@ select
     , ticket_comment.comment_type
     , ticket_comment.comment_is_public
     , ticket_comment.comment_uploads
+    -- from ticket_comment, not user: a comment whose author is missing from
+    -- stg__zendesk__user must still carry its author id or the requester-vs-agent
+    -- comparison silently drops the row
+    , ticket_comment.comment_author_user_id
     , user.user_name as comment_author
+    , user.user_email as comment_author_email
     , ticket_comment.audit_id
     , ticket_comment.comment_html_body
     , ticket_comment.comment_plain_body

--- a/src/ol_dbt/models/staging/zendesk/_stg_zendesk_models.yml
+++ b/src/ol_dbt/models/staging/zendesk/_stg_zendesk_models.yml
@@ -156,6 +156,8 @@ models:
     description: int, foreign key to the ticket audit record
   - name: comment_author_user_id
     description: int, foreign key to the user who created the comment
+    tests:
+    - not_null
   - name: comment_body_string
     description: text, the comment string.
   - name: comment_html_body


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
Close https://github.com/mitodl/ol-data-platform/issues/2535

### Description (What does it do?)
<!--- Describe your changes in detail -->
  Adds two columns, both already present upstream:                                                                                                                                                                                                                                                                                                                                                                                 
  - `comment_author_user_id` — selected from `ticket_comment`, **not** from `user`.                                                                                                           
  - `comment_author_email` — carried through so the feedback adapter doesn't need a second join to `stg__zendesk__user`. Nullable, as the upstream column already documents.     

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

`dbt build --select int__zendesk__ticket_comment --target dev_production` 

### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->


<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
