### PR TITLE
fix(edxorg): skip re-uploading unchanged content-hash-keyed archive files

### DIFF
--- a/dg_projects/edxorg/edxorg/assets/edxorg_archive.py
+++ b/dg_projects/edxorg/edxorg/assets/edxorg_archive.py
@@ -206,7 +206,7 @@ class EdxorgArchiveProcessConfig(Config):
         "db_table__workflow_assessmentworkflowstep": DynamicOut(is_required=False),
     },
 )
-def process_edxorg_archive_bundle(
+def process_edxorg_archive_bundle(  # noqa: PLR0915
     context: OpExecutionContext,
     config: EdxorgArchiveProcessConfig,
     edxorg_raw_data_archive: Path,
@@ -351,6 +351,19 @@ def process_edxorg_archive_bundle(
             object_path = (
                 "s3://" + f"{config.s3_bucket}/{config.s3_prefix}/{object_key}"
             )
+            if UPath(object_path).exists():
+                # object_key is content-hash based, so an existing object here is
+                # byte-identical to archive_file -- re-uploading would just assign
+                # S3 a fresh ETag to the same key. That races with any edxorg_s3
+                # dlt read that already listed the old ETag and is mid-fetch,
+                # surfacing as s3fs.FileExpired/PreconditionFailed downstream.
+                context.log.debug(
+                    "Skipping upload of %s -- unchanged content already at %s",
+                    tinfo.name,
+                    object_path,
+                )
+                archive_file.unlink()
+                continue
             shared_metadata = {
                 "path": MetadataValue.path(object_path),
                 "object_key": object_key,

--- a/dg_projects/edxorg/edxorg/assets/edxorg_archive.py
+++ b/dg_projects/edxorg/edxorg/assets/edxorg_archive.py
@@ -144,6 +144,21 @@ class EdxorgArchiveProcessConfig(Config):
     )
 
 
+def _skip_upload_if_unchanged(archive_file: Path, object_path: str) -> bool:
+    """Delete ``archive_file`` and return True if ``object_path`` already exists.
+
+    object_key is a sha256 of the file contents, so an existing object at
+    object_path is guaranteed byte-identical to archive_file -- re-uploading
+    it would just assign S3 a fresh ETag to the same key. That races with any
+    edxorg_s3 dlt read that already listed the old ETag and is mid-fetch,
+    surfacing as s3fs.FileExpired/PreconditionFailed downstream.
+    """
+    if not UPath(object_path).exists():
+        return False
+    archive_file.unlink()
+    return True
+
+
 @op(
     name="process_edxorg_archive_bundle",
     required_resource_keys={"gcp_gcs"},
@@ -351,18 +366,12 @@ def process_edxorg_archive_bundle(  # noqa: PLR0915
             object_path = (
                 "s3://" + f"{config.s3_bucket}/{config.s3_prefix}/{object_key}"
             )
-            if UPath(object_path).exists():
-                # object_key is content-hash based, so an existing object here is
-                # byte-identical to archive_file -- re-uploading would just assign
-                # S3 a fresh ETag to the same key. That races with any edxorg_s3
-                # dlt read that already listed the old ETag and is mid-fetch,
-                # surfacing as s3fs.FileExpired/PreconditionFailed downstream.
+            if _skip_upload_if_unchanged(archive_file, object_path):
                 context.log.debug(
                     "Skipping upload of %s -- unchanged content already at %s",
                     tinfo.name,
                     object_path,
                 )
-                archive_file.unlink()
                 continue
             shared_metadata = {
                 "path": MetadataValue.path(object_path),

--- a/dg_projects/edxorg/edxorg_tests/test_edxorg_archive_skip_upload.py
+++ b/dg_projects/edxorg/edxorg_tests/test_edxorg_archive_skip_upload.py
@@ -1,0 +1,29 @@
+"""Coverage for the content-hash skip-if-unchanged guard in the archive op.
+
+object_key is a sha256 of the file contents, so an existing object at that
+path is guaranteed byte-identical to the local archive_file -- re-uploading
+it would just assign S3 a fresh ETag to the same key, racing with any
+in-flight edxorg_s3 dlt read (see edxorg_archive.py's
+_skip_upload_if_unchanged docstring for the full mechanism).
+"""
+
+from edxorg.assets.edxorg_archive import _skip_upload_if_unchanged
+
+
+def test_skips_and_deletes_when_object_already_exists(tmp_path):
+    archive_file = tmp_path / "archive.tsv"
+    archive_file.write_text("id\tuser_id\n1\t10\n")
+    existing_object = tmp_path / "already-uploaded.tsv"
+    existing_object.write_text("id\tuser_id\n1\t10\n")
+
+    assert _skip_upload_if_unchanged(archive_file, str(existing_object)) is True
+    assert not archive_file.exists()
+
+
+def test_does_not_skip_or_delete_when_object_is_new(tmp_path):
+    archive_file = tmp_path / "archive.tsv"
+    archive_file.write_text("id\tuser_id\n1\t10\n")
+    new_object_path = tmp_path / "not-yet-uploaded.tsv"
+
+    assert _skip_upload_if_unchanged(archive_file, str(new_object_path)) is False
+    assert archive_file.exists()


### PR DESCRIPTION
### What are the relevant tickets?
N/A

### Description (What does it do?)
The `edxorg_s3` dlt job has been intermittently failing on `auth_user` and other large tables with:

```
s3fs.utils.FileExpired: [Errno 16] The remote file corresponding to filename ...auth_user/prod/.../<hash>.tsv and Etag "..." no longer exists.
botocore.exceptions.ClientError: An error occurred (PreconditionFailed) when calling the GetObject operation
```

Root cause: `process_edxorg_archive_bundle` writes S3 object keys that are content-hash based (`sha256` of the file), so identical content should map to a stable key — but the op re-uploads every course/table on **every** weekly archive run regardless of whether the content changed, since there's no existence check before writing, and `FileObjectIOManager.handle_output` does an unconditional `write_bytes()`.

A fresh PUT to an existing key gets a **new ETag** even for byte-identical content (guaranteed once multipart upload kicks in for larger files). Meanwhile the downstream `edxorg_s3` dlt read lists files, caches each one's ETag, then streams it — `auth_user` spans thousands of per-course files, so that read can still be in flight when the next weekly archive run lands and overwrites a file already listed. The cached ETag goes stale mid-fetch, S3 rejects the conditional `GetObject`, and s3fs surfaces it as `FileExpired`, failing the whole resource.

Fix: skip the upload (and the resulting `AssetMaterialization`) when an object already exists at the content-hash key, since it's guaranteed byte-identical to what would be written. This removes the unnecessary re-upload that creates the ETag race, and as a side benefit stops re-triggering downstream `edxorg_s3` reprocessing for courses whose archived data hasn't changed (e.g. long-closed courses that still get re-exported every week).

### How can this be tested?
- `ruff check`/`ruff format`/`mypy` (via `pre-commit run --files dg_projects/edxorg/edxorg/assets/edxorg_archive.py`) all pass.
- Existing `edxorg_tests` suite (32 tests) passes unchanged.
- No new unit test added: `process_edxorg_archive_bundle` requires a live Dagster context and a real tar archive to exercise directly, which is why the existing `test_edxorg_archive_csv.py` file already scopes itself to just the CSV rewrite logic rather than the full op (see its module docstring). Verification of the actual fix is behavioral — watch the next scheduled `edxorg_s3_auth_user` (and other large-table) runs for the `PreconditionFailed`/`FileExpired` failure to stop recurring.

### Additional Context
Relevant files:
- https://github.com/mitodl/ol-data-platform/blob/main/dg_projects/edxorg/edxorg/assets/edxorg_archive.py
- https://github.com/mitodl/ol-data-platform/blob/main/src/ol_dlt/ol_dlt/sources/edxorg_s3/__init__.py
- https://github.com/mitodl/ol-data-platform/blob/main/packages/ol-orchestrate-lib/src/ol_orchestrate/io_managers/filepath.py
