### PR TITLE
feat(b2b_analytics): publish contract identity and contract-grained engagement views

### DIFF
--- a/src/ol_dbt/models/b2b_analytics/_b2b_analytics__models.yml
+++ b/src/ol_dbt/models/b2b_analytics/_b2b_analytics__models.yml
@@ -24,6 +24,13 @@ models:
     description: Display name of the organization.
   - name: contract_pk
     description: Surrogate key of the B2B contract.
+  - name: contract_id
+    description: >
+      mitxonline's ContractPage.page_ptr_id (dim_contract.contract_id) -- the
+      identifier that appears in mitxonline manager-dashboard URLs and that
+      ol-analytics-api filters contracts on. contract_pk above is the
+      dimensional surrogate (md5 of this value) and is the join key to
+      dim_contract; a caller holding a contract from mitxonline has this one.
   - name: b2b_contract_name
     description: Display name of the contract.
   - name: b2b_contract_is_active
@@ -65,6 +72,13 @@ models:
     description: Display name of the organization.
   - name: contract_pk
     description: Surrogate key of the B2B contract.
+  - name: contract_id
+    description: >
+      mitxonline's ContractPage.page_ptr_id (dim_contract.contract_id) -- the
+      identifier that appears in mitxonline manager-dashboard URLs and that
+      ol-analytics-api filters contracts on. contract_pk above is the
+      dimensional surrogate (md5 of this value) and is the join key to
+      dim_contract; a caller holding a contract from mitxonline has this one.
   - name: b2b_contract_name
     description: Display name of the contract.
   - name: courserun_pk
@@ -169,6 +183,13 @@ models:
     description: Display name of the organization.
   - name: contract_pk
     description: Surrogate key of the B2B contract.
+  - name: contract_id
+    description: >
+      mitxonline's ContractPage.page_ptr_id (dim_contract.contract_id) -- the
+      identifier that appears in mitxonline manager-dashboard URLs and that
+      ol-analytics-api filters contracts on. contract_pk above is the
+      dimensional surrogate (md5 of this value) and is the join key to
+      dim_contract; a caller holding a contract from mitxonline has this one.
   - name: b2b_contract_name
     description: Display name of the contract.
   - name: program_pk
@@ -279,6 +300,13 @@ models:
     description: Display name of the organization.
   - name: contract_pk
     description: Surrogate key of the B2B contract.
+  - name: contract_id
+    description: >
+      mitxonline's ContractPage.page_ptr_id (dim_contract.contract_id) -- the
+      identifier that appears in mitxonline manager-dashboard URLs and that
+      ol-analytics-api filters contracts on. contract_pk above is the
+      dimensional surrogate (md5 of this value) and is the join key to
+      dim_contract; a caller holding a contract from mitxonline has this one.
   - name: b2b_contract_name
     description: Display name of the contract.
   - name: b2b_contract_is_active
@@ -306,3 +334,167 @@ models:
       One of: inactive (contract not active), at_risk (utilization < 25% and
       expiring within 90 days), high_utilization (utilization >= 90%), healthy
       (utilization >= 50% and not at_risk), early_stage (everything else).
+- name: mv_b2b_contract_monthly_engagement_trend
+  description: >
+    Monthly engagement, enrollment, and content-interaction totals per org x
+    contract -- the contract-scoped sibling of mv_b2b_monthly_engagement_trend,
+    which stays at org x month. Both grains exist because the MIT Learn
+    dashboard mirrors mitxonline's manager dashboard, which is nested under
+    manager/organizations/{org}/contracts/{contract}, while the org-level
+    panels remain in service. Manual-refresh materialized view. Source:
+    organization_administration_report inner-joined to the dimensional
+    contract/course-run bridge, so free-text organization_key rows (which
+    resolve to no contract) are excluded here even though the org-level view
+    keeps them. Publishing both grains makes a suppressed contract recoverable
+    by subtraction from the org row once an org holds more than one contract --
+    see the complement-disclosure work in ol-analytics-api.
+    Consumers: L&D manager engagement trend chart, contract-scoped.
+  columns:
+  - name: organization_key
+    description: Org identifier, joined via dim_organization (platform='mitxonline'
+      only).
+  - name: sso_organization_id
+    description: >
+      Keycloak organization UUID (dim_organization.sso_organization_id) -- the
+      identifier the ol-analytics-api filters organizations on.
+  - name: organization_name
+    description: Display name of the organization.
+  - name: contract_pk
+    description: Surrogate key of the B2B contract.
+  - name: contract_id
+    description: >
+      mitxonline's ContractPage.page_ptr_id (dim_contract.contract_id) -- the
+      identifier that appears in mitxonline manager-dashboard URLs and that
+      ol-analytics-api filters contracts on.
+  - name: b2b_contract_name
+    description: Display name of the contract.
+  - name: activity_year_and_month
+    description: The month this row aggregates, from the source report.
+  - name: monthly_active_learners
+    description: >
+      Distinct learners with any activity in the month, under course runs
+      belonging to this contract. A learner active under two contracts counts
+      in both rows, so contract rows do not partition the org's learner count.
+  - name: new_enrollments
+    description: >
+      Sum of the daily enrolled_count flag within the month -- an EVENT count
+      (learner x course run), not a learner count. Floor it via
+      enrolling_learners, not via its own value.
+  - name: enrolling_learners
+    description: >
+      Distinct learners who newly enrolled in the month -- the cohort
+      new_enrollments is attributable to. Note enrolling does not by itself set
+      active_count, so this is not a subset of monthly_active_learners.
+  - name: certificates_earned
+    description: >
+      Certificates earned in the month -- an EVENT count (learner x course run).
+      Floor it via certified_learners.
+  - name: certified_learners
+    description: Distinct learners who earned a certificate in the month.
+  - name: total_videos_watched
+    description: >
+      Videos watched in the month -- an EVENT count. Floor it via video_watchers.
+  - name: video_watchers
+    description: >
+      Distinct learners who watched a video in the month -- the cohort
+      total_videos_watched is attributable to, and a strict subset of
+      monthly_active_learners.
+  - name: total_problems_attempted
+    description: >
+      Problems attempted in the month -- an EVENT count. Floor it via
+      problem_attempters.
+  - name: problem_attempters
+    description: >
+      Distinct learners who attempted a problem in the month -- the cohort
+      total_problems_attempted is attributable to.
+  - name: total_chatbot_interactions
+    description: >
+      Chatbot interactions in the month -- an EVENT count. Floor it via
+      chatbot_users.
+  - name: chatbot_users
+    description: >
+      Distinct learners who used the chatbot in the month -- the cohort
+      total_chatbot_interactions is attributable to.
+- name: mv_b2b_contract_content_engagement_depth
+  description: >
+    All-time content engagement depth per org x contract x course run -- the
+    contract-scoped sibling of mv_b2b_content_engagement_depth, which stays at
+    org x course run. Because a course run belongs to exactly one contract,
+    adding the contract labels rows rather than splitting them: every count
+    here equals its org-level counterpart for the same course run, which is
+    what makes the complement recoverable when only some contracts are
+    suppressed. Manual-refresh materialized view. Source:
+    organization_administration_report inner-joined to the dimensional
+    contract/course-run bridge.
+    Consumers: L&D manager content-engagement panel, contract-scoped.
+  columns:
+  - name: organization_key
+    description: Org identifier, joined via dim_organization (platform='mitxonline'
+      only).
+  - name: sso_organization_id
+    description: >
+      Keycloak organization UUID (dim_organization.sso_organization_id) -- the
+      identifier the ol-analytics-api filters organizations on.
+  - name: organization_name
+    description: Display name of the organization.
+  - name: contract_pk
+    description: Surrogate key of the B2B contract.
+  - name: contract_id
+    description: >
+      mitxonline's ContractPage.page_ptr_id (dim_contract.contract_id) -- the
+      identifier that appears in mitxonline manager-dashboard URLs and that
+      ol-analytics-api filters contracts on.
+  - name: b2b_contract_name
+    description: Display name of the contract.
+  - name: courserun_readable_id
+    description: Course run identifier (e.g. course-v1:MITx+6.00+2026).
+  - name: courserun_title
+    description: Display title of the course run.
+  - name: total_enrolled_learners
+    description: Distinct learners enrolled in this course run under this contract.
+  - name: engaged_learners
+    description: >
+      Distinct learners with any activity (active_count > 0) in this course run.
+  - name: engagement_rate_pct
+    description: engaged_learners as a percentage of total_enrolled_learners.
+  - name: total_videos_watched
+    description: >
+      Videos watched in this course run -- an EVENT count. Floor it via
+      video_watchers.
+  - name: video_watchers
+    description: >
+      Distinct learners who watched a video -- the cohort total_videos_watched
+      is attributable to, and a strict subset of engaged_learners.
+  - name: avg_videos_per_engaged_learner
+    description: >
+      total_videos_watched divided by engaged_learners. Derived from BOTH
+      cohorts: the denominator is engaged_learners, but the numerator is
+      contributed only by video_watchers, so an unsuppressed average times a
+      published engaged_learners recovers the total.
+  - name: total_problems_attempted
+    description: >
+      Problems attempted in this course run -- an EVENT count. Floor it via
+      problem_attempters.
+  - name: problem_attempters
+    description: >
+      Distinct learners who attempted a problem -- the cohort
+      total_problems_attempted is attributable to.
+  - name: avg_problems_per_engaged_learner
+    description: >
+      total_problems_attempted divided by engaged_learners. Derived from both
+      cohorts, for the same reason as avg_videos_per_engaged_learner.
+  - name: total_chatbot_interactions
+    description: >
+      Chatbot interactions in this course run -- an EVENT count. Floor it via
+      chatbot_users.
+  - name: chatbot_users
+    description: >
+      Distinct learners who used the chatbot -- the cohort
+      total_chatbot_interactions is attributable to.
+  - name: chatbot_adoption_pct
+    description: chatbot_users as a percentage of total_enrolled_learners.
+  - name: certificates_earned
+    description: >
+      Certificates earned in this course run -- an EVENT count. This view emits
+      no certified-learner cohort, so ol-analytics-api floors it as a count of
+      itself, which is weaker than flooring a cohort.

--- a/src/ol_dbt/models/b2b_analytics/mv_b2b_contract_content_engagement_depth.sql
+++ b/src/ol_dbt/models/b2b_analytics/mv_b2b_contract_content_engagement_depth.sql
@@ -1,0 +1,99 @@
+{{ config(
+    materialized='materialized_view',
+    distributed_by=['organization_key'],
+    buckets=8,
+    refresh_method='manual',
+) }}
+
+-- Grain: org x contract x course_run (all-time). Refreshed by the Dagster
+-- b2b_organization MV-refresh asset.
+--
+-- The contract-scoped sibling of mv_b2b_content_engagement_depth, which stays
+-- at org x course_run. See that model and
+-- mv_b2b_contract_monthly_engagement_trend for why both grains exist, for the
+-- complement-disclosure consequence of publishing both, and for why contract
+-- identity is emitted as both contract_pk (dimensional surrogate) and
+-- contract_id (mitxonline's ContractPage.page_ptr_id, the one a caller
+-- filters on).
+--
+-- Because a course run belongs to exactly one contract, this view's rows are a
+-- strict partition of the org-level view's rows: adding the contract does not
+-- split any course run, it only labels it. Every count here therefore equals
+-- its org-level counterpart for the same course run -- which is precisely what
+-- makes the complement recoverable when only some contracts are suppressed.
+--
+-- Every activity SUM here is contributed to by only the learners who did that
+-- specific thing, and those cohorts are strict subsets of engaged_learners
+-- (active_count is 1 on ANY activity -- see organization_administration_report).
+-- ol-analytics-api can only apply its k-anonymity floor to a cohort this view
+-- emits, so each such sum publishes its own contributing cohort count
+-- (video_watchers, problem_attempters, chatbot_users) alongside it. Do not add
+-- an activity aggregate without also emitting the cohort it is attributable to.
+with contract_courseruns as (
+    select
+        cr.courserun_readable_id,
+        cr.courserun_title,
+        c.contract_pk,
+        c.contract_id,
+        c.b2b_contract_name,
+        org.organization_key,
+        org.sso_organization_id,
+        org.organization_name
+    from {{ source('dimensional', 'bridge_organization_courserun') }} boc
+    join {{ source('dimensional', 'dim_contract') }} c
+        on boc.contract_fk = c.contract_pk
+    join {{ source('dimensional', 'dim_organization') }} org
+        on c.organization_fk = org.organization_pk
+    join {{ source('dimensional', 'dim_course_run') }} cr
+        on boc.courserun_fk = cr.courserun_pk
+    where org.platform = 'mitxonline'
+      and cr.is_current = true
+)
+
+select
+    cc.organization_key,
+    cc.sso_organization_id,
+    cc.organization_name,
+    cc.contract_pk,
+    cc.contract_id,
+    cc.b2b_contract_name,
+    cc.courserun_readable_id,
+    cc.courserun_title,
+    count(distinct oar.user_email)                                              as total_enrolled_learners,
+    count(distinct case when oar.active_count > 0 then oar.user_email end)      as engaged_learners,
+    round(100.0 * count(distinct case when oar.active_count > 0 then oar.user_email end)
+        / nullif(count(distinct oar.user_email), 0), 1)                         as engagement_rate_pct,
+    sum(oar.videos_watched)                                                     as total_videos_watched,
+    count(distinct case when oar.videos_watched > 0 then oar.user_email end)    as video_watchers,
+    round(
+        cast(sum(oar.videos_watched) as double)
+        / nullif(count(distinct case when oar.active_count > 0
+            then oar.user_email end), 0), 1
+    )                                                                           as avg_videos_per_engaged_learner,
+    sum(oar.problems_count)                                                     as total_problems_attempted,
+    count(distinct case when oar.problems_count > 0 then oar.user_email end)    as problem_attempters,
+    round(
+        cast(sum(oar.problems_count) as double)
+        / nullif(count(distinct case when oar.active_count > 0
+            then oar.user_email end), 0), 1
+    )                                                                           as avg_problems_per_engaged_learner,
+    sum(oar.chatbot_used_count)                                                 as total_chatbot_interactions,
+    count(distinct case when oar.chatbot_used_count > 0 then oar.user_email end) as chatbot_users,
+    round(100.0 * count(distinct case when oar.chatbot_used_count > 0
+        then oar.user_email end)
+        / nullif(count(distinct oar.user_email), 0), 1)                         as chatbot_adoption_pct,
+    sum(oar.certificate_count)                                                  as certificates_earned
+from {{ source('reporting', 'organization_administration_report') }} oar
+-- Inner join for the same reason as the contract-scoped trend view: a report
+-- row whose course run resolves to no contract has no row to sit under.
+join contract_courseruns cc
+    on oar.courserun_readable_id = cc.courserun_readable_id
+group by
+    cc.organization_key,
+    cc.sso_organization_id,
+    cc.organization_name,
+    cc.contract_pk,
+    cc.contract_id,
+    cc.b2b_contract_name,
+    cc.courserun_readable_id,
+    cc.courserun_title

--- a/src/ol_dbt/models/b2b_analytics/mv_b2b_contract_monthly_engagement_trend.sql
+++ b/src/ol_dbt/models/b2b_analytics/mv_b2b_contract_monthly_engagement_trend.sql
@@ -1,0 +1,101 @@
+{{ config(
+    materialized='materialized_view',
+    distributed_by=['organization_key'],
+    buckets=8,
+    refresh_method='manual',
+) }}
+
+-- Grain: org x contract x year_month. Refreshed by the Dagster b2b_organization MV-refresh asset.
+--
+-- The contract-scoped sibling of mv_b2b_monthly_engagement_trend, which stays
+-- at org x year_month. Both exist because the MIT Learn dashboard mirrors
+-- mitxonline's manager dashboard, which is nested under
+-- manager/organizations/{org}/contracts/{contract} -- while the org-level
+-- panels remain in service.
+--
+-- DISCLOSURE NOTE. Publishing the same learners at two grains makes the
+-- complement recoverable: an org's contracts sum to its org row, so a contract
+-- suppressed by ol-analytics-api's k-anonymity floor can be recovered as
+-- org_total - (the other contracts). That is inert while an org has one
+-- contract (the contract row IS the org row) and becomes live at two or more.
+-- Tracked as the complement-disclosure work in ol-analytics-api; do not treat
+-- the per-column floor alone as sufficient once orgs hold multiple contracts.
+--
+-- Contract identity is published as BOTH keys on purpose. contract_pk is the
+-- dimensional surrogate (md5 of the natural key) that joins to dim_contract;
+-- contract_id is mitxonline's ContractPage.page_ptr_id, which is what appears
+-- in that dashboard's URLs and therefore what a caller filters on. Emitting
+-- only the surrogate is what left the API unable to scope to a contract.
+--
+-- new_enrollments and certificates_earned count EVENTS (per learner per course
+-- run), not learners. The activity totals are likewise contributed to by only
+-- the learners who did that specific thing. ol-analytics-api can only apply its
+-- k-anonymity floor to a cohort this view emits, so each aggregate publishes
+-- the distinct learner count it is attributable to. Do not add an aggregate
+-- here without also emitting its cohort.
+--
+-- A learner is counted under the contract that owns the course run the
+-- activity happened in, so a learner active under two contracts contributes to
+-- both rows -- the contract rows therefore do not partition the org's learner
+-- count, and summing monthly_active_learners across contracts can exceed the
+-- org row.
+with contract_courseruns as (
+    -- courserun -> contract, resolved through the dimensional bridge. A course
+    -- run belongs to exactly one B2B contract (courses_courserun.b2b_contract_id),
+    -- so this cannot fan out the report rows it is joined to.
+    select
+        cr.courserun_readable_id,
+        c.contract_pk,
+        c.contract_id,
+        c.b2b_contract_name,
+        org.organization_key,
+        org.sso_organization_id,
+        org.organization_name
+    from {{ source('dimensional', 'bridge_organization_courserun') }} boc
+    join {{ source('dimensional', 'dim_contract') }} c
+        on boc.contract_fk = c.contract_pk
+    join {{ source('dimensional', 'dim_organization') }} org
+        on c.organization_fk = org.organization_pk
+    join {{ source('dimensional', 'dim_course_run') }} cr
+        on boc.courserun_fk = cr.courserun_pk
+    where org.platform = 'mitxonline'
+      and cr.is_current = true
+)
+
+select
+    cc.organization_key,
+    cc.sso_organization_id,
+    cc.organization_name,
+    cc.contract_pk,
+    cc.contract_id,
+    cc.b2b_contract_name,
+    oar.activity_year_and_month,
+    count(distinct case when oar.active_count > 0 then oar.user_email end)       as monthly_active_learners,
+    sum(oar.enrolled_count)                                                      as new_enrollments,
+    count(distinct case when oar.enrolled_count > 0 then oar.user_email end)     as enrolling_learners,
+    sum(oar.certificate_count)                                                   as certificates_earned,
+    count(distinct case when oar.certificate_count > 0 then oar.user_email end)  as certified_learners,
+    sum(oar.videos_watched)                                                      as total_videos_watched,
+    count(distinct case when oar.videos_watched > 0 then oar.user_email end)     as video_watchers,
+    sum(oar.problems_count)                                                      as total_problems_attempted,
+    count(distinct case when oar.problems_count > 0 then oar.user_email end)     as problem_attempters,
+    sum(oar.chatbot_used_count)                                                  as total_chatbot_interactions,
+    count(distinct case when oar.chatbot_used_count > 0 then oar.user_email end) as chatbot_users
+from {{ source('reporting', 'organization_administration_report') }} oar
+-- An inner join, unlike the org-level view's left join to dim_organization:
+-- a report row whose course run resolves to no contract has nothing to sit
+-- under here. That drops the free-text organization_key fallback rows
+-- (coalesce(b2b_contract_to_courseruns.organization_key,
+-- user_course_roles.organization) in the source report), which by definition
+-- never resolved to a contract-bearing course run.
+join contract_courseruns cc
+    on oar.courserun_readable_id = cc.courserun_readable_id
+where oar.activity_year_and_month is not null
+group by
+    cc.organization_key,
+    cc.sso_organization_id,
+    cc.organization_name,
+    cc.contract_pk,
+    cc.contract_id,
+    cc.b2b_contract_name,
+    oar.activity_year_and_month

--- a/src/ol_dbt/models/b2b_analytics/mv_b2b_contract_utilization.sql
+++ b/src/ol_dbt/models/b2b_analytics/mv_b2b_contract_utilization.sql
@@ -31,6 +31,7 @@ select
     org.sso_organization_id,
     org.organization_name,
     c.contract_pk,
+    c.contract_id,
     c.b2b_contract_name,
     c.b2b_contract_is_active,
     c.b2b_contract_start_date,
@@ -52,6 +53,6 @@ left join certificates cert on c.contract_pk = cert.contract_fk
 where org.platform = 'mitxonline'
 group by
     org.organization_key, org.sso_organization_id, org.organization_name,
-    c.contract_pk, c.b2b_contract_name, c.b2b_contract_is_active,
+    c.contract_pk, c.contract_id, c.b2b_contract_name, c.b2b_contract_is_active,
     c.b2b_contract_start_date, c.b2b_contract_end_date,
     c.b2b_contract_max_learners, c.b2b_contract_membership_type

--- a/src/ol_dbt/models/b2b_analytics/mv_b2b_enrollment_completion_funnel.sql
+++ b/src/ol_dbt/models/b2b_analytics/mv_b2b_enrollment_completion_funnel.sql
@@ -11,6 +11,7 @@ select
     org.sso_organization_id,
     org.organization_name,
     c.contract_pk,
+    c.contract_id,
     c.b2b_contract_name,
     cr.courserun_pk,
     cr.courserun_readable_id,
@@ -42,5 +43,5 @@ where org.platform = 'mitxonline'
   and cr.is_current = true
 group by
     org.organization_key, org.sso_organization_id, org.organization_name,
-    c.contract_pk, c.b2b_contract_name,
+    c.contract_pk, c.contract_id, c.b2b_contract_name,
     cr.courserun_pk, cr.courserun_readable_id, cr.courserun_title

--- a/src/ol_dbt/models/b2b_analytics/mv_b2b_mit_admin_contract_health.sql
+++ b/src/ol_dbt/models/b2b_analytics/mv_b2b_mit_admin_contract_health.sql
@@ -14,6 +14,7 @@ with contract_stats as (
         org.sso_organization_id,
         org.organization_name,
         c.contract_pk,
+        c.contract_id,
         c.b2b_contract_name,
         c.b2b_contract_is_active,
         c.b2b_contract_start_date,
@@ -38,7 +39,7 @@ with contract_stats as (
     where org.platform = 'mitxonline'
     group by
         org.organization_key, org.sso_organization_id, org.organization_name,
-        c.contract_pk, c.b2b_contract_name, c.b2b_contract_is_active,
+        c.contract_pk, c.contract_id, c.b2b_contract_name, c.b2b_contract_is_active,
         c.b2b_contract_start_date, c.b2b_contract_end_date,
         c.b2b_contract_max_learners, c.b2b_contract_membership_type
 )

--- a/src/ol_dbt/models/b2b_analytics/mv_b2b_program_funnel.sql
+++ b/src/ol_dbt/models/b2b_analytics/mv_b2b_program_funnel.sql
@@ -15,6 +15,7 @@ with org_program_runs as (
         org.sso_organization_id,
         org.organization_name,
         c.contract_pk,
+        c.contract_id,
         c.b2b_contract_name,
         bpc.program_fk,
         bpc.course_fk,
@@ -46,6 +47,7 @@ select
     opr.sso_organization_id,
     opr.organization_name,
     opr.contract_pk,
+    opr.contract_id,
     opr.b2b_contract_name,
     p.program_pk,
     p.program_title,
@@ -67,6 +69,6 @@ left join {{ source('dimensional', 'tfact_certificate') }} cert
     on e.user_fk = cert.user_fk and opr.courserun_fk = cert.courserun_fk
 group by
     opr.organization_key, opr.sso_organization_id, opr.organization_name,
-    opr.contract_pk, opr.b2b_contract_name,
+    opr.contract_pk, opr.contract_id, opr.b2b_contract_name,
     p.program_pk, p.program_title,
     pcc.total_courses


### PR DESCRIPTION
### What are the relevant tickets?

N/A — no GitHub issue. Tracked in the work graph as `tk-emit-contract-identity-in-the-b2b-analytics-mvs--1d3327`, which blocks `tk-scope-the-analytics-api-to-the-contract-mirrorin-cbcb6e` in ol-analytics-api. Part of the B2B self-serve analytics effort ([mitodl/hq discussion #11845](https://github.com/mitodl/hq/discussions/11845)).

### Description (What does it do?)

The analytics API is scoped to the organization at every layer, but it needs to mirror mitxonline's manager dashboard, which is nested under `manager/organizations/{org}/contracts/{contract}` ([b2b/views/v0/urls.py](https://github.com/mitodl/mitxonline/blob/main/b2b/views/v0/urls.py)). Two things in the warehouse blocked that.

- **Identifier mismatch.** mitxonline's contract URL segment is `ContractPage.page_ptr_id`. dbt has that value as `dim_contract.contract_id`, but every MV projected only `contract_pk` — the md5 surrogate — so a caller arriving from that dashboard held an integer no analytics column could be filtered on. Same shape as the `sso_organization_id` gap, same fix: emit the natural key alongside the surrogate. `contract_id` added to `mv_b2b_contract_utilization`, `mv_b2b_enrollment_completion_funnel`, `mv_b2b_program_funnel`, `mv_b2b_mit_admin_contract_health`. `contract_pk` stays — it is the join key to the dimensional layer.
- **Two views had no contract grain.** Adds `mv_b2b_contract_monthly_engagement_trend` (org × contract × month) and `mv_b2b_contract_content_engagement_depth` (org × contract × course run) as *siblings*, so the org-level views and the panels reading them are untouched. Both publish the contributing cohort next to every activity aggregate, per the convention #2520 established.

Adding alongside rather than re-graining in place was a deliberate call — see Additional Context for what it costs.

### How can this be tested?

`ol-dbt validate` — 0 errors (559 pre-existing warnings, unchanged in kind; the new models' `Cannot resolve column list for source(...)` warnings match what the existing `mv_b2b_content_engagement_depth` already emits). `pre-commit` — yamllint, sqlfluff-lint, sqlfluff-fix, detect-secrets all pass.

These models are `+enabled: target.type == 'starrocks'`, so they can't build on the local DuckDB target. Instead I rendered both (substituting `source()` for the production catalog) and ran them read-only against production StarRocks via `bin/starrocks-auth --env production --mode vault --vault-role readonly`:

- **They compile and return data.** 357 trend rows, 1093 depth rows, 61 distinct contracts, zero null `contract_id` on either.
- **The depth view is a clean partition of the deployed org-level view.** All 1093 shared `(organization_key, courserun_readable_id)` rows agree on all nine numeric columns under null-safe (`<=>`) comparison. Worth noting the false alarm: a first pass compared with `=` and reported 9 video mismatches — all 9 are rows where *both* sides are NULL, which `=` evaluates as unknown. There are zero real differences.
- **The trend view rolls back up.** Summing its contract rows to org × month matches the org-level view on 348/348 for video totals and 346/348 for `monthly_active_learners`. The two exceptions are `HZN_EVOCA` 2026-06 (71 vs 70) and 2026-07 (70 vs 69) — it holds two contracts and one learner is active under both. Distinct learner counts do not add across contracts; the model comments say so explicitly.

A reviewer can reproduce any of these with the same read-only role; the queries are plain `select`s over the rendered models.

### Additional Context

**Both new views inner-join through the contract bridge**, so report rows riding the free-text `organization_key` fallback are excluded — by definition they never resolved to a contract-bearing course run. That is 2800 org-level depth rows with no contract-view counterpart. The org-level views keep them.

**The complement-disclosure risk is live now, not later.** Publishing the same learners at two grains makes a suppressed contract recoverable as `org_total − (other contracts)`. I checked: **4 of 58 orgs already hold more than one contract** (one org with 2, three orgs with 3). The per-column k-anonymity floor in ol-analytics-api does not defend against this, and the org-level endpoints are staying. Whoever picks up `tk-k-anonymity-suppress-complement-disclosure-near--8818e9` should treat this as already reachable rather than hypothetical.

**No manual refresh needed.** #2554's drift detection compares each MV's live `information_schema` columns against the manifest and escalates to `--full-refresh`; verified end-to-end in production on 2026-08-14. The four altered views will rebuild on the next `b2b_analytics_starrocks_job` run, and the two new ones will be created. The Dagster refresh asset derives its list from the manifest, so it picks the new views up with no orchestration change.

**Deploy ordering.** ol-analytics-api's `build_select` projects each model's own field list, so the API change that consumes `contract_id` must deploy *after* that rebuild — same sequencing that applied to #2520.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QC8Vb9vZiGMPeHd97Fy4Gj