### PR TITLE
fix(dagster): bound failure retries and make the failure signal legible

### DIFF
--- a/dg_projects/b2b_organization/b2b_organization/definitions.py
+++ b/dg_projects/b2b_organization/b2b_organization/definitions.py
@@ -10,7 +10,8 @@ from ol_orchestrate.lib.dagster_helpers import (
     default_file_object_io_manager,
     default_io_manager,
 )
-from ol_orchestrate.lib.sentry import init_sentry, with_sentry_hooks
+from ol_orchestrate.lib.failures import with_failure_hooks
+from ol_orchestrate.lib.sentry import init_sentry
 from ol_orchestrate.lib.utils import authenticate_vault, unauthenticated_vault
 
 b2b_bucket_map = {
@@ -54,7 +55,7 @@ defs = Definitions(
         "vault": vault,
         "s3": S3Resource(),
     },
-    assets=with_sentry_hooks([export_b2b_organization_data]),
+    assets=with_failure_hooks([export_b2b_organization_data]),
     jobs=[b2b_organization_data_export_job],
     sensors=[b2b_organization_list_sensor],
 )

--- a/dg_projects/canvas/canvas/assets/canvas.py
+++ b/dg_projects/canvas/canvas/assets/canvas.py
@@ -10,6 +10,7 @@ from dagster import (
     AssetOut,
     DataVersion,
     DynamicPartitionsDefinition,
+    Failure,
     Output,
     asset,
     multi_asset,
@@ -19,6 +20,7 @@ from ol_orchestrate.lib.constants import (
     EXPORT_TYPE_COMMON_CARTRIDGE,
     EXPORT_TYPE_EXTENSIONS,
 )
+from ol_orchestrate.lib.failures import permanent_failure
 from ol_orchestrate.lib.http_errors import http_failure
 from ol_orchestrate.lib.utils import compute_zip_content_hash
 
@@ -129,9 +131,21 @@ def export_course_content(context: AssetExecutionContext):
             )
             break
         elif export_status["workflow_state"] in ["failed", "error"]:
-            message = f"Export failed for course {course_id}"
-            context.log.error(message)
-            raise Exception(message)  # noqa: TRY002
+            context.log.error("Export failed for course %s", course_id)
+            # Canvas has reached a terminal state for this export. Asking again
+            # produces the same state, so this must not go back on the retry
+            # treadmill.
+            message = (
+                "Canvas reported a terminal failure state for this course "
+                "export. Rerunning will not change it."
+            )
+            raise permanent_failure(
+                message,
+                metadata={
+                    "course_id": course_id,
+                    "workflow_state": export_status["workflow_state"],
+                },
+            )
         else:
             context.log.info(
                 "Waiting for course content export (state: %s)",
@@ -140,9 +154,23 @@ def export_course_content(context: AssetExecutionContext):
             retry_count += 1
             time.sleep(120)
     else:
-        message = f"Course content export timed out for {course_id}"
-        context.log.error(message)
-        raise Exception(message)  # noqa: TRY002
+        context.log.error("Course content export timed out for %s", course_id)
+        # Deliberately NOT a permanent_failure. A slow export is the ordinary
+        # reason for this, and a later attempt can genuinely succeed -- the
+        # problem with DAGSTER-7 was never that it retried, it was that the
+        # retry was unbounded. The M1 cap in upstream_or_code_changes() is what
+        # bounds it; claiming permanence here would suppress a real retry.
+        raise Failure(
+            description=(
+                "Canvas did not finish the course content export within the "
+                "polling window. A later attempt may succeed."
+            ),
+            metadata={
+                "course_id": course_id,
+                "polling_attempts": retry_count,
+                "last_workflow_state": export_status["workflow_state"],
+            },
+        )
 
     course_content_path = Path(f"{course_id}_course_content.{extension}")
     downloaded_path = context.resources.canvas_api.client.download_course_export(

--- a/dg_projects/canvas/canvas/definitions.py
+++ b/dg_projects/canvas/canvas/definitions.py
@@ -19,7 +19,8 @@ from ol_orchestrate.lib.dagster_helpers import (
     default_file_object_io_manager,
     default_io_manager,
 )
-from ol_orchestrate.lib.sentry import init_sentry, with_sentry_hooks
+from ol_orchestrate.lib.failures import with_failure_hooks
+from ol_orchestrate.lib.sentry import init_sentry
 from ol_orchestrate.lib.utils import (
     authenticate_vault,
     s3_uploads_bucket,
@@ -126,7 +127,7 @@ defs = Definitions(
         ),
         "google_sheet_config": GoogleSheetConfig(service_account_json=gs_secrets),
     },
-    assets=with_sentry_hooks([export_course_content, course_content_metadata]),
+    assets=with_failure_hooks([export_course_content, course_content_metadata]),
     schedules=[canvas_course_export_schedule],
     sensors=[canvas_google_sheet_course_id_sensor],
 )

--- a/dg_projects/canvas/canvas/lib/canvas.py
+++ b/dg_projects/canvas/canvas/lib/canvas.py
@@ -5,15 +5,23 @@ from dagster import OpExecutionContext
 from google.oauth2 import service_account
 
 
-def fetch_canvas_course_ids_from_google_sheet(context: OpExecutionContext):
-    """
-    Fetch all canvas course IDs from a Google Sheet
+def fetch_canvas_course_ids_from_google_sheet(
+    context: OpExecutionContext,
+) -> set[str] | None:
+    """Fetch all canvas course IDs from a Google Sheet.
+
+    Returns ``None`` when the sheet could not be read, and a set -- possibly
+    empty -- when it could. The caller diffs this against the existing dynamic
+    partitions and deletes the difference, so "we could not read the sheet" and
+    "the sheet lists no courses" cannot both be ``set()``: the first would delete
+    every Canvas partition, taking any in-flight run for one down with it
+    (DAGSTER-2B).
     """
     sheet_config = context.resources.google_sheet_config
 
     if sheet_config.service_account_json is None:
         context.log.error("No google service account credentials found in vault")
-        return set()
+        return None
 
     creds_dict = (
         sheet_config.service_account_json
@@ -46,7 +54,7 @@ def fetch_canvas_course_ids_from_google_sheet(context: OpExecutionContext):
     )
     if worksheet is None:
         context.log.error("No worksheet found with gid %s", sheet_config.worksheet_id)
-        return set()
+        return None
 
     # Get all values from the first column and filter to only numeric values
     column_values = worksheet.get_col(1, include_tailing_empty=False)

--- a/dg_projects/canvas/canvas/sensors/canvas.py
+++ b/dg_projects/canvas/canvas/sensors/canvas.py
@@ -3,15 +3,74 @@ import json
 from dagster import (
     AddDynamicPartitionsRequest,
     AssetKey,
+    DagsterRunStatus,
     DefaultSensorStatus,
     DeleteDynamicPartitionsRequest,
     RunRequest,
+    RunsFilter,
     SensorResult,
     SkipReason,
     sensor,
 )
 
 from canvas.lib.canvas import fetch_canvas_course_ids_from_google_sheet
+
+# Dagster's own run tag. Hardcoded rather than imported: the constant lives in
+# the private dagster._core.storage.tags, but the tag string itself is stable
+# and documented.
+PARTITION_NAME_TAG = "dagster/partition"
+
+# Every status a run can hold while it still intends to execute. Deliberately
+# wider than dagster's IN_PROGRESS_RUN_STATUSES, which omits QUEUED and
+# NOT_STARTED -- a queued run whose partition is deleted before it starts fails
+# exactly the same way as one already running.
+PENDING_RUN_STATUSES = [
+    DagsterRunStatus.QUEUED,
+    DagsterRunStatus.NOT_STARTED,
+    DagsterRunStatus.STARTING,
+    DagsterRunStatus.STARTED,
+    DagsterRunStatus.CANCELING,
+]
+
+
+def partitions_with_a_run_in_flight(context) -> set[str]:
+    """Canvas partitions that some run is currently counting on existing.
+
+    Deleting a dynamic partition out from under a run does not cancel it. The
+    run keeps going and dies when it tries to store its output, because
+    ``get_output_context`` resolves the partition key range against the *current*
+    partitions definition:
+
+        DagsterInvalidInvocationError: Partition range 33842 to 33842 is not a
+        valid range. Nonexistent partition keys: ['33842']
+
+    The work is already done at that point -- the export ran, the file was
+    fetched -- and it is thrown away.
+    """
+    runs = context.instance.get_runs(RunsFilter(statuses=PENDING_RUN_STATUSES))
+    return {
+        partition
+        for run in runs
+        if (partition := run.tags.get(PARTITION_NAME_TAG)) is not None
+    }
+
+
+def partition_changes(
+    sheet_course_ids: set[str],
+    existing_partitions: set[str],
+    in_flight: set[str],
+) -> tuple[set[str], set[str]]:
+    """Which partitions to add and which to delete, given the sheet and the runs.
+
+    Deletion of a partition with a run in flight is deferred rather than
+    dropped: the diff is recomputed from the live partition set every tick, so
+    once the run reaches a terminal status the partition is cleaned up on the
+    next pass with no bookkeeping. A course lingering one extra hour costs
+    nothing next to discarding a completed export.
+    """
+    to_add = sheet_course_ids - existing_partitions
+    to_delete = (existing_partitions - sheet_course_ids) - in_flight
+    return to_add, to_delete
 
 
 @sensor(
@@ -27,6 +86,10 @@ from canvas.lib.canvas import fetch_canvas_course_ids_from_google_sheet
 )
 def canvas_google_sheet_course_id_sensor(context):
     google_sheet_course_ids = fetch_canvas_course_ids_from_google_sheet(context)
+    if google_sheet_course_ids is None:
+        # A failed read is not an empty sheet. Treating it as one would diff
+        # every existing partition into removed_course_ids and delete the lot.
+        return SkipReason("Could not read the Canvas course ID sheet")
     context.log.info("google_sheet_course_ids: %s", google_sheet_course_ids)
 
     # Existing dynamic partitions
@@ -35,9 +98,15 @@ def canvas_google_sheet_course_id_sensor(context):
     )
     context.log.info("existing_partitions: %s", existing_partitions)
 
-    # Register any new course IDs as partitions
-    new_course_ids = google_sheet_course_ids - existing_partitions
-    removed_course_ids = existing_partitions - google_sheet_course_ids
+    in_flight = partitions_with_a_run_in_flight(context)
+    new_course_ids, removed_course_ids = partition_changes(
+        google_sheet_course_ids, existing_partitions, in_flight
+    )
+    if deferred := (existing_partitions - google_sheet_course_ids) & in_flight:
+        context.log.info(
+            "Deferring deletion of %s: a run is still in flight for each.",
+            sorted(deferred),
+        )
 
     if not new_course_ids and not removed_course_ids:
         return SkipReason("No changes in canvas course IDs")

--- a/dg_projects/canvas/canvas_tests/test_course_id_sensor.py
+++ b/dg_projects/canvas/canvas_tests/test_course_id_sensor.py
@@ -1,0 +1,213 @@
+"""Tests for the Canvas course-ID sensor's dynamic partition management.
+
+The sensor diffs a Google Sheet against the existing dynamic partitions and
+deletes the difference. Both halves of that had a way to delete a partition
+something was still using, and deleting a dynamic partition does not cancel the
+run using it -- the run completes its export and then dies storing its output
+(DAGSTER-2B).
+
+``partitions_with_a_run_in_flight`` is exercised against a real ephemeral
+instance with real run records rather than a stub, because the parts most likely
+to be wrong are which statuses count as "still going" and whether the partition
+tag is where we think it is.
+"""
+
+from collections.abc import Iterator
+from types import SimpleNamespace
+
+import dagster as dg
+import pytest
+from canvas.lib.canvas import fetch_canvas_course_ids_from_google_sheet
+from canvas.sensors.canvas import (
+    PARTITION_NAME_TAG,
+    PENDING_RUN_STATUSES,
+    partition_changes,
+    partitions_with_a_run_in_flight,
+)
+from dagster import DagsterRunStatus
+from dagster._core.test_utils import create_run_for_test
+
+EXISTING = {"1001", "1002", "1003"}
+
+
+@pytest.fixture
+def instance() -> Iterator[dg.DagsterInstance]:
+    with dg.DagsterInstance.ephemeral() as ephemeral:
+        yield ephemeral
+
+
+def start_run_for(
+    instance: dg.DagsterInstance,
+    partition: str,
+    status: DagsterRunStatus = DagsterRunStatus.STARTED,
+) -> None:
+    """Put a real run record in the instance, tagged with its partition."""
+    create_run_for_test(
+        instance,
+        job_name="canvas_course_export_job",
+        status=status,
+        tags={PARTITION_NAME_TAG: partition},
+    )
+
+
+# ── partition_changes ─────────────────────────────────────────────────────────
+
+
+def test_a_partition_with_a_run_in_flight_is_not_deleted() -> None:
+    """DAGSTER-2B.
+
+    Deleting the partition does not stop the run. It completes the export, then
+    fails in get_output_context resolving the key range against a partitions
+    definition that no longer contains it -- "Partition range 33842 to 33842 is
+    not a valid range" -- and the finished work is discarded.
+    """
+    _, to_delete = partition_changes(
+        sheet_course_ids={"1001"},
+        existing_partitions=EXISTING,
+        in_flight={"1002"},
+    )
+
+    assert "1002" not in to_delete, "a run is still using this partition"
+    assert "1003" in to_delete, "the idle one is still cleaned up"
+
+
+def test_a_deferred_deletion_happens_once_the_run_ends() -> None:
+    """Deferral must not become permanent.
+
+    The diff is recomputed from the live partition set every tick, so the same
+    inputs minus the in-flight run delete it -- no bookkeeping required.
+    """
+    _, while_running = partition_changes({"1001"}, EXISTING, in_flight={"1002"})
+    assert "1002" not in while_running
+
+    _, once_finished = partition_changes({"1001"}, EXISTING, in_flight=set())
+
+    assert "1002" in once_finished
+
+
+def test_an_empty_sheet_deletes_everything_idle() -> None:
+    """A genuinely empty sheet must still clean up.
+
+    This is why a failed read has to be distinguishable from an empty one at the
+    source rather than guarded here -- see the sheet-read tests below.
+    """
+    _, to_delete = partition_changes(set(), EXISTING, in_flight=set())
+
+    assert to_delete == EXISTING
+
+
+def test_new_course_ids_are_added() -> None:
+    to_add, to_delete = partition_changes(
+        EXISTING | {"2001"}, EXISTING, in_flight=set()
+    )
+
+    assert to_add == {"2001"}
+    assert to_delete == set()
+
+
+def test_an_in_flight_run_does_not_block_additions() -> None:
+    """The in-flight check guards deletion only; adding is always safe."""
+    to_add, _ = partition_changes(
+        EXISTING | {"2001"}, EXISTING, in_flight={"2001", "1002"}
+    )
+
+    assert to_add == {"2001"}
+
+
+def test_no_changes_yields_nothing() -> None:
+    to_add, to_delete = partition_changes(EXISTING, EXISTING, in_flight=set())
+
+    assert (to_add, to_delete) == (set(), set())
+
+
+# ── partitions_with_a_run_in_flight ───────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "status",
+    [
+        DagsterRunStatus.NOT_STARTED,
+        DagsterRunStatus.STARTING,
+        DagsterRunStatus.STARTED,
+        DagsterRunStatus.CANCELING,
+    ],
+)
+def test_every_pending_status_counts_as_in_flight(instance, status) -> None:
+    """A run that has not started yet still intends to.
+
+    dagster's own IN_PROGRESS_RUN_STATUSES omits NOT_STARTED; a run whose
+    partition is deleted before it starts fails exactly the same way as one
+    already executing.
+    """
+    start_run_for(instance, "1002", status=status)
+    context = dg.build_sensor_context(instance=instance)
+
+    assert partitions_with_a_run_in_flight(context) == {"1002"}
+
+
+def test_queued_is_covered_by_the_filter() -> None:
+    """QUEUED is the status this most needs to cover, and the one the test
+    harness cannot construct.
+
+    ``create_run_for_test`` requires a RemoteJobOrigin for a queued run, which
+    needs a loaded code location. Asserting on the filter is weaker than
+    exercising it, but a queued run sitting behind a concurrency limit is
+    exactly the window in which the sheet sensor ticks and deletes its
+    partition, so leaving it uncovered entirely would be worse.
+    """
+    assert DagsterRunStatus.QUEUED in PENDING_RUN_STATUSES
+
+
+@pytest.mark.parametrize(
+    "status",
+    [DagsterRunStatus.SUCCESS, DagsterRunStatus.FAILURE, DagsterRunStatus.CANCELED],
+)
+def test_a_terminal_run_is_not_in_flight(instance, status) -> None:
+    """Nothing is using the partition any more, so cleanup must proceed."""
+    start_run_for(instance, "1002", status=status)
+    context = dg.build_sensor_context(instance=instance)
+
+    assert partitions_with_a_run_in_flight(context) == set()
+
+
+def test_an_untagged_run_contributes_nothing(instance) -> None:
+    """An unpartitioned run has no partition tag to read."""
+    create_run_for_test(
+        instance, job_name="some_other_job", status=DagsterRunStatus.STARTED
+    )
+    context = dg.build_sensor_context(instance=instance)
+
+    assert partitions_with_a_run_in_flight(context) == set()
+
+
+def test_no_runs_at_all(instance) -> None:
+    context = dg.build_sensor_context(instance=instance)
+
+    assert partitions_with_a_run_in_flight(context) == set()
+
+
+# ── fetch_canvas_course_ids_from_google_sheet ─────────────────────────────────
+
+
+def _sheet_context(service_account_json):
+    return SimpleNamespace(
+        resources=SimpleNamespace(
+            google_sheet_config=SimpleNamespace(
+                service_account_json=service_account_json,
+                sheet_id="sheet-1",
+                worksheet_id=0,
+            )
+        ),
+        log=SimpleNamespace(error=lambda *_args: None),
+    )
+
+
+def test_missing_credentials_reads_as_failure_not_as_an_empty_sheet() -> None:
+    """The sharpest form of the bug.
+
+    This used to return set(). The sensor could not tell that from a genuinely
+    empty sheet, so a transient Vault problem diffed every partition into the
+    delete set and wiped the entire Canvas partition definition -- taking any
+    in-flight export down with it.
+    """
+    assert fetch_canvas_course_ids_from_google_sheet(_sheet_context(None)) is None

--- a/dg_projects/data_loading/data_loading/defs/ingestion/assets.py
+++ b/dg_projects/data_loading/data_loading/defs/ingestion/assets.py
@@ -22,7 +22,7 @@ from ol_dlt.sources import (
     podcast_rss,
 )
 from ol_orchestrate.lib.constants import EDXORG_DB_TABLES
-from ol_orchestrate.lib.sentry import with_sentry_hooks
+from ol_orchestrate.lib.failures import with_failure_hooks
 
 from data_loading.defs.ingestion.translators import (
     EdxorgDltTranslator,
@@ -132,7 +132,7 @@ edxorg_s3_table_assets = [
 
 
 defs = Definitions(
-    assets=with_sentry_hooks(
+    assets=with_failure_hooks(
         [
             oll_assets,
             mitpe_assets,

--- a/dg_projects/data_platform/data_platform/definitions.py
+++ b/dg_projects/data_platform/data_platform/definitions.py
@@ -11,6 +11,7 @@ into something you can actually go and look up.
 
 import re
 from collections.abc import Sequence
+from datetime import UTC, datetime
 from typing import Any
 
 import sentry_sdk
@@ -27,7 +28,11 @@ from dagster import (
     sensor,
 )
 from ol_orchestrate.lib.constants import DAGSTER_ENV, VAULT_ADDRESS
-from ol_orchestrate.lib.sentry import failure_fingerprint, init_sentry
+from ol_orchestrate.lib.sentry import (
+    INTERRUPTION_ERRORS,
+    failure_fingerprint,
+    init_sentry,
+)
 from ol_orchestrate.lib.utils import authenticate_vault
 from slack_sdk import WebClient
 
@@ -226,6 +231,27 @@ def sentry_fingerprint(context: RunFailureSensorContext) -> list[str]:
     return failure_fingerprint(location, failure.step_key, error_type)
 
 
+def is_an_interrupted_worker(context: RunFailureSensorContext) -> bool:
+    """Whether this run died because its process was taken away.
+
+    The ``drop_interruptions`` before_send in ol_orchestrate.lib.sentry reads
+    ``exception.values``, which only an exception event carries. This sensor
+    reports through ``capture_message``, so its events have no exception at all
+    and sail straight past that filter -- meaning a SIGTERM'd worker was
+    dropped on the hook path and reported on this one.
+
+    The serialized step error is where the type survives, so the check has to
+    happen here rather than in the shared filter.
+    """
+    step_failures = context.get_step_failure_events()
+    if not step_failures:
+        return False
+    error = getattr(step_failures[0].event_specific_data, "error", None)
+    if error is None:
+        return False
+    return user_code_error_type(error) in INTERRUPTION_ERRORS
+
+
 def capture_run_failure_to_sentry(context: RunFailureSensorContext) -> str | None:
     """Report a run failure to Sentry and return the event ID.
 
@@ -408,13 +434,21 @@ def repeats_to_announce(
     once" and "this failed four thousand times" are different situations and the
     unbatched stream rendered them identically.
 
+    Deliberately does NOT open a new window; ``record_announcement`` does that,
+    after Slack has accepted the message. Opening it here would mean a Vault
+    outage or a Slack 5xx -- which fails the tick on purpose -- left a record
+    behind saying the failure had been announced, so the retry suppressed it and
+    every later occurrence stayed hidden for the rest of the window.
+
+    Suppressions *are* recorded here, because that path posts nothing and so has
+    nothing to fail.
+
     State lives in the run storage KV table rather than the sensor cursor:
     ``RunFailureSensorContext`` is invoked once per failed run and exposes no
     cursor to carry counts between those invocations.
     """
     record = instance.run_storage.get_cursor_values({key}).get(key)
     if not record:
-        instance.run_storage.set_cursor_values({key: f"{now}:0"})
         return 0
 
     announced_at, _, count = record.partition(":")
@@ -426,8 +460,17 @@ def repeats_to_announce(
         )
         return None
 
-    instance.run_storage.set_cursor_values({key: f"{now}:0"})
     return suppressed
+
+
+def record_announcement(instance: Any, key: str, now: float) -> None:
+    """Open a fresh rate-limit window, having actually announced something.
+
+    Separate from ``repeats_to_announce`` so the window only starts once the
+    message is out. Also clears the suppressed count, which the message just
+    reported.
+    """
+    instance.run_storage.set_cursor_values({key: f"{now}:0"})
 
 
 def get_slack_token() -> str:
@@ -467,17 +510,28 @@ def run_failure_notification_sensor(context: RunFailureSensorContext) -> None:
         )
         return
 
+    if is_an_interrupted_worker(context):
+        context.log.info(
+            "Skipping notification for run %s: its worker was terminated "
+            "(deploy, eviction or drain) rather than failing.",
+            run.run_id,
+        )
+        return
+
     fingerprint = sentry_fingerprint(context)
     sentry_event_id = capture_run_failure_to_sentry(context)
 
     # Sentry still receives every failure -- it aggregates, and the count is the
     # signal. Slack does not aggregate, so the same failure repeating is rate
     # limited to one message per window with a count of what it swallowed.
-    repeats = repeats_to_announce(
-        context.instance,
-        slack_announcement_key(fingerprint),
-        context.dagster_run.create_timestamp.timestamp(),
-    )
+    #
+    # The window is measured in wall-clock time rather than the run's creation
+    # time: a backlog of old failures drained in one tick carries creation
+    # timestamps hours apart and out of order, which would both let several
+    # messages through at once and suppress newer failures behind older ones.
+    announced_at = datetime.now(tz=UTC).timestamp()
+    announcement_key = slack_announcement_key(fingerprint)
+    repeats = repeats_to_announce(context.instance, announcement_key, announced_at)
     if repeats is None:
         context.log.info(
             "Suppressing Slack notification for run %s: %s was already "
@@ -490,13 +544,16 @@ def run_failure_notification_sensor(context: RunFailureSensorContext) -> None:
 
     # Deliberately unguarded. A failure here fails the sensor tick, which
     # surfaces in the Dagster UI and in Sentry -- the alternative is alerting
-    # that has quietly stopped working and nobody knowing.
+    # that has quietly stopped working and nobody knowing. The window is opened
+    # only after the post succeeds, so a failed tick retries rather than
+    # silencing the next thirty minutes.
     client = WebClient(token=get_slack_token())
     client.chat_postMessage(
         channel=slack_channel,
         blocks=error_message(context, sentry_event_id, repeats),
         text=f"Dagster {DAGSTER_ENV} run failure: {run.job_name}",
     )
+    record_announcement(context.instance, announcement_key, announced_at)
 
 
 def is_reported_by_the_run_failure_sensor(evaluation: Any) -> bool:

--- a/dg_projects/data_platform/data_platform/definitions.py
+++ b/dg_projects/data_platform/data_platform/definitions.py
@@ -27,7 +27,7 @@ from dagster import (
     sensor,
 )
 from ol_orchestrate.lib.constants import DAGSTER_ENV, VAULT_ADDRESS
-from ol_orchestrate.lib.sentry import init_sentry
+from ol_orchestrate.lib.sentry import failure_fingerprint, init_sentry
 from ol_orchestrate.lib.utils import authenticate_vault
 from slack_sdk import WebClient
 
@@ -186,13 +186,26 @@ def user_code_error_type(error: Any) -> str:
     return error.cls_name
 
 
+def code_location_of(run: DagsterRun) -> str | None:
+    """Which code location launched ``run``.
+
+    This sensor monitors every code location, so the location cannot be a
+    constant here the way it can inside a run worker. It used to be tagged as
+    "data_platform" for every run regardless of origin, which named the sensor's
+    own location rather than the one that broke.
+    """
+    if run.remote_job_origin is None:
+        return None
+    return run.remote_job_origin.repository_origin.code_location_origin.location_name
+
+
 def sentry_fingerprint(context: RunFailureSensorContext) -> list[str]:
     """Build a fingerprint matching the one the in-process hook uses.
 
-    ol_orchestrate.lib.sentry fingerprints a step failure as
-    ``[job_name, step_key, <exception class name>]``. This has to produce the
-    identical triple for the same failure, or the two reporting paths raise two
-    Sentry issues for every failure instead of collapsing into one.
+    Both paths delegate to ol_orchestrate.lib.sentry.failure_fingerprint. They
+    have to produce the identical list for the same failure, or the two
+    reporting paths raise two Sentry issues for every failure instead of
+    collapsing into one.
 
     A run that died without any step failure event -- OOM, eviction, a run
     monitoring timeout -- has no exception class and no step, and the hook
@@ -200,16 +213,17 @@ def sentry_fingerprint(context: RunFailureSensorContext) -> list[str]:
     grouping instead.
     """
     run = context.dagster_run
+    location = code_location_of(run)
     step_failures = context.get_step_failure_events()
     if not step_failures:
-        return [run.job_name, "run", "run_failure"]
+        return failure_fingerprint(location, "run", "run_failure")
 
     failure = step_failures[0]
     error = getattr(failure.event_specific_data, "error", None)
     error_type = (
         user_code_error_type(error) if error is not None else None
     ) or "run_failure"
-    return [run.job_name, failure.step_key, error_type]
+    return failure_fingerprint(location, failure.step_key, error_type)
 
 
 def capture_run_failure_to_sentry(context: RunFailureSensorContext) -> str | None:
@@ -231,7 +245,7 @@ def capture_run_failure_to_sentry(context: RunFailureSensorContext) -> str | Non
         scope.set_tag("dagster_job", run.job_name)
         scope.set_tag("dagster_step", step_key)
         scope.set_tag("dagster_run_id", run.run_id)
-        scope.set_tag("dagster_code_location", "data_platform")
+        scope.set_tag("dagster_code_location", code_location_of(run) or "unknown")
         scope.set_tag("captured_by", "sensor")
         scope.set_context(
             "dagster_run",
@@ -255,6 +269,7 @@ def capture_run_failure_to_sentry(context: RunFailureSensorContext) -> str | Non
 def error_message(
     context: RunFailureSensorContext,
     sentry_event_id: str | None = None,
+    suppressed_repeats: int = 0,
 ) -> list[dict[str, Any]]:
     """Format error message for Slack notification."""
 
@@ -323,6 +338,23 @@ def error_message(
         *error_details,
     ]
 
+    # The count is the difference between "an asset broke" and "an asset has
+    # been breaking on a loop since the last message", which the unbatched
+    # stream could not express except by posting thousands of times.
+    if suppressed_repeats:
+        blocks.append(
+            {
+                "type": "section",
+                "text": {
+                    "type": "mrkdwn",
+                    "text": (
+                        f":repeat: *{suppressed_repeats} further failures* of "
+                        "this same step were suppressed since the last message."
+                    ),
+                },
+            }
+        )
+
     if sentry_event_id:
         blocks.append(
             {
@@ -348,6 +380,56 @@ def error_message(
     return blocks
 
 
+# How long one distinct failure stays announced before it is announced again.
+# The sensor fires per failed run with no ceiling, so a single broken asset on
+# the automation treadmill posted ~27,900 messages in fourteen days -- past the
+# first few, every one of them said exactly what the one before it said.
+SLACK_REPEAT_WINDOW_SECONDS = 30 * 60
+
+# Namespaced so these cannot collide with Dagster's own cursor keys in the same
+# table.
+SLACK_ANNOUNCEMENT_KEY_PREFIX = "ol/slack_failure_announced/"
+
+
+def slack_announcement_key(fingerprint: Sequence[str]) -> str:
+    """Build the rate-limit key for a failure, keyed the way Sentry groups it."""
+    return SLACK_ANNOUNCEMENT_KEY_PREFIX + "|".join(fingerprint)
+
+
+def repeats_to_announce(
+    instance: Any,
+    key: str,
+    now: float,
+) -> int | None:
+    """Whether to post, and how many repeats were swallowed since last time.
+
+    Returns None to stay quiet, or the number of occurrences suppressed since
+    the previous message -- which is the part worth saying, because "this failed
+    once" and "this failed four thousand times" are different situations and the
+    unbatched stream rendered them identically.
+
+    State lives in the run storage KV table rather than the sensor cursor:
+    ``RunFailureSensorContext`` is invoked once per failed run and exposes no
+    cursor to carry counts between those invocations.
+    """
+    record = instance.run_storage.get_cursor_values({key}).get(key)
+    if not record:
+        instance.run_storage.set_cursor_values({key: f"{now}:0"})
+        return 0
+
+    announced_at, _, count = record.partition(":")
+    last_announced, suppressed = float(announced_at), int(count)
+
+    if now - last_announced < SLACK_REPEAT_WINDOW_SECONDS:
+        instance.run_storage.set_cursor_values(
+            {key: f"{last_announced}:{suppressed + 1}"}
+        )
+        return None
+
+    instance.run_storage.set_cursor_values({key: f"{now}:0"})
+    return suppressed
+
+
 def get_slack_token() -> str:
     """Read the Slack bot token from Vault.
 
@@ -368,7 +450,8 @@ def get_slack_token() -> str:
     description=(
         "Reports run failures across all code locations to Sentry and Slack. "
         "Reports the first failed attempt and suppresses its automatic retries, "
-        "so a failure is announced once whether or not a retry clears it."
+        "so a failure is announced once whether or not a retry clears it. "
+        "Slack is rate-limited per distinct failure; Sentry gets every one."
     ),
 )
 def run_failure_notification_sensor(context: RunFailureSensorContext) -> None:
@@ -384,7 +467,26 @@ def run_failure_notification_sensor(context: RunFailureSensorContext) -> None:
         )
         return
 
+    fingerprint = sentry_fingerprint(context)
     sentry_event_id = capture_run_failure_to_sentry(context)
+
+    # Sentry still receives every failure -- it aggregates, and the count is the
+    # signal. Slack does not aggregate, so the same failure repeating is rate
+    # limited to one message per window with a count of what it swallowed.
+    repeats = repeats_to_announce(
+        context.instance,
+        slack_announcement_key(fingerprint),
+        context.dagster_run.create_timestamp.timestamp(),
+    )
+    if repeats is None:
+        context.log.info(
+            "Suppressing Slack notification for run %s: %s was already "
+            "announced within the last %d minutes.",
+            run.run_id,
+            "|".join(fingerprint),
+            SLACK_REPEAT_WINDOW_SECONDS // 60,
+        )
+        return
 
     # Deliberately unguarded. A failure here fails the sensor tick, which
     # surfaces in the Dagster UI and in Sentry -- the alternative is alerting
@@ -392,7 +494,7 @@ def run_failure_notification_sensor(context: RunFailureSensorContext) -> None:
     client = WebClient(token=get_slack_token())
     client.chat_postMessage(
         channel=slack_channel,
-        blocks=error_message(context, sentry_event_id),
+        blocks=error_message(context, sentry_event_id, repeats),
         text=f"Dagster {DAGSTER_ENV} run failure: {run.job_name}",
     )
 

--- a/dg_projects/data_platform/data_platform_tests/test_definitions.py
+++ b/dg_projects/data_platform/data_platform_tests/test_definitions.py
@@ -16,8 +16,10 @@ from data_platform.definitions import (
     defs,
     error_message,
     get_exception,
+    is_an_interrupted_worker,
     is_reported_by_the_run_failure_sensor,
     is_retry_of_a_reported_failure,
+    record_announcement,
     repeats_to_announce,
     sentry_fingerprint,
     truncate_text,
@@ -362,6 +364,64 @@ def test_sensor_fingerprint_matches_a_real_dagster_step_failure(
     ]
 
 
+# ── Interrupted workers ───────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "cls_name", ["DagsterExecutionInterruptedError", "KeyboardInterrupt"]
+)
+def test_a_terminated_worker_is_not_reported_by_the_sensor(cls_name: str) -> None:
+    """The before_send filter cannot catch this path.
+
+    ol_orchestrate.lib.sentry.drop_interruptions reads exception.values, which
+    only an exception event has. This sensor reports through capture_message, so
+    its events carry no exception and sail past the filter -- a SIGTERM'd worker
+    was dropped on the hook path and reported on this one (DAGSTER-1R/1S/1T).
+    """
+    context = _context([_step_failure("some_model", "boom", cls_name=cls_name)])
+
+    assert is_an_interrupted_worker(context) is True
+
+
+def test_an_interruption_wrapped_by_dagster_is_still_caught() -> None:
+    """The serialized error is Dagster's wrapper with the real type below it."""
+    context = _context(
+        [
+            _step_failure(
+                "some_model",
+                "boom",
+                cls_name="DagsterExecutionStepExecutionError",
+                cause=SimpleNamespace(
+                    cls_name="DagsterExecutionInterruptedError", cause=None
+                ),
+            )
+        ]
+    )
+
+    assert is_an_interrupted_worker(context) is True
+
+
+def test_an_ordinary_failure_is_still_reported() -> None:
+    context = _context([_step_failure("some_model", "boom", cls_name="ValueError")])
+
+    assert is_an_interrupted_worker(context) is False
+
+
+def test_a_run_with_no_step_failure_is_still_reported() -> None:
+    """An OOM kill or a run-monitoring reap has no step error to inspect, and is
+    exactly the case this sensor exists to catch.
+    """
+    assert is_an_interrupted_worker(_context([])) is False
+
+
+def test_a_step_failure_with_no_error_payload_is_still_reported() -> None:
+    failure = SimpleNamespace(
+        step_key="some_model", event_specific_data=SimpleNamespace()
+    )
+
+    assert is_an_interrupted_worker(_context([failure])) is False
+
+
 # ── Slack rate limiting ───────────────────────────────────────────────────────
 
 
@@ -382,17 +442,24 @@ def _instance() -> Any:
     return SimpleNamespace(run_storage=FakeKeyValueStore())
 
 
+def announce(instance: Any, key: str, now: float) -> int | None:
+    """Perform a full successful announcement: decide, then commit the window."""
+    repeats = repeats_to_announce(instance, key, now)
+    if repeats is not None:
+        record_announcement(instance, key, now)
+    return repeats
+
+
 def test_a_failure_nobody_has_seen_is_announced() -> None:
     instance = _instance()
 
-    assert repeats_to_announce(instance, "k", now := 1_000.0) == 0
-    assert instance.run_storage.values["k"] == f"{now}:0"
+    assert repeats_to_announce(instance, "k", 1_000.0) == 0
 
 
 def test_the_same_failure_repeating_is_not_announced_again() -> None:
     """~27,900 Slack messages for DAGSTER-3 alone, every one of them identical."""
     instance = _instance()
-    repeats_to_announce(instance, "k", 1_000.0)
+    announce(instance, "k", 1_000.0)
 
     assert repeats_to_announce(instance, "k", 1_060.0) is None
     assert repeats_to_announce(instance, "k", 1_120.0) is None
@@ -401,29 +468,69 @@ def test_the_same_failure_repeating_is_not_announced_again() -> None:
 def test_the_next_announcement_carries_what_it_swallowed() -> None:
     """One failure and four thousand failures are different situations."""
     instance = _instance()
-    repeats_to_announce(instance, "k", 1_000.0)
+    announce(instance, "k", 1_000.0)
     for tick in range(4):
         repeats_to_announce(instance, "k", 1_100.0 + tick)
 
-    assert repeats_to_announce(instance, "k", 1_000.0 + 31 * 60) == 4
+    assert announce(instance, "k", 1_000.0 + 31 * 60) == 4
 
 
 def test_the_count_resets_after_it_is_reported() -> None:
     instance = _instance()
-    repeats_to_announce(instance, "k", 1_000.0)
+    announce(instance, "k", 1_000.0)
     repeats_to_announce(instance, "k", 1_100.0)
     later = 1_000.0 + 31 * 60
-    repeats_to_announce(instance, "k", later)
+    announce(instance, "k", later)
 
-    assert repeats_to_announce(instance, "k", later + 31 * 60) == 0
+    assert announce(instance, "k", later + 31 * 60) == 0
 
 
 def test_distinct_failures_do_not_silence_each_other() -> None:
     """The key is the Sentry fingerprint, so two defects are two rate limits."""
     instance = _instance()
-    repeats_to_announce(instance, "one", 1_000.0)
+    announce(instance, "one", 1_000.0)
 
     assert repeats_to_announce(instance, "two", 1_000.0) == 0
+
+
+def test_deciding_to_announce_does_not_itself_open_the_window() -> None:
+    """A Slack or Vault failure must not silence the next thirty minutes.
+
+    The post is deliberately unguarded so a broken alerting path fails the tick
+    loudly. If the window opened before the post, that tick's retry would find a
+    record saying the failure had already been announced and suppress it -- and
+    every later occurrence with it, until the window expired.
+    """
+    instance = _instance()
+
+    assert repeats_to_announce(instance, "k", 1_000.0) == 0
+    assert instance.run_storage.values == {}, "nothing committed before the post"
+
+    # The tick failed and Dagster retried it.
+    assert repeats_to_announce(instance, "k", 1_060.0) == 0, "still announces"
+
+
+def test_a_failed_post_does_not_lose_the_suppressed_count() -> None:
+    """The count survives a failed retry rather than resetting to zero."""
+    instance = _instance()
+    announce(instance, "k", 1_000.0)
+    for tick in range(3):
+        repeats_to_announce(instance, "k", 1_100.0 + tick)
+
+    later = 1_000.0 + 31 * 60
+    assert repeats_to_announce(instance, "k", later) == 3, "post fails here"
+
+    assert repeats_to_announce(instance, "k", later + 60) == 3, "retry still has it"
+
+
+def test_suppressions_are_recorded_even_though_announcements_are_not() -> None:
+    """The suppress path posts nothing, so it has nothing to fail after."""
+    instance = _instance()
+    announce(instance, "k", 1_000.0)
+
+    repeats_to_announce(instance, "k", 1_060.0)
+
+    assert instance.run_storage.values["k"] == "1000.0:1"
 
 
 def test_a_suppressed_repeat_is_named_in_the_next_message() -> None:

--- a/dg_projects/data_platform/data_platform_tests/test_definitions.py
+++ b/dg_projects/data_platform/data_platform_tests/test_definitions.py
@@ -18,27 +18,46 @@ from data_platform.definitions import (
     get_exception,
     is_reported_by_the_run_failure_sensor,
     is_retry_of_a_reported_failure,
+    repeats_to_announce,
     sentry_fingerprint,
     truncate_text,
 )
+from ol_orchestrate.lib.constants import DAGSTER_ENV
 
 ERROR = AssetCheckSeverity.ERROR
 WARN = AssetCheckSeverity.WARN
+CODE_LOCATION = "edxorg"
 
 # ── Helpers ───────────────────────────────────────────────────────────────────
 
 
-def _run(**tags: str) -> Any:
+def _origin(location_name: str | None) -> Any:
+    """Build the nesting the sensor reads a run's code location out of."""
+    if location_name is None:
+        return None
+    return SimpleNamespace(
+        repository_origin=SimpleNamespace(
+            code_location_origin=SimpleNamespace(location_name=location_name)
+        )
+    )
+
+
+def _run(location: str | None = CODE_LOCATION, **tags: str) -> Any:
     return SimpleNamespace(
         tags=tags,
         run_id="0123abcd-4567-89ef-0123-456789abcdef",
         job_name="a_job",
+        remote_job_origin=_origin(location),
     )
 
 
-def _context(step_failure_events: list[Any], failure_message: str = "") -> Any:
+def _context(
+    step_failure_events: list[Any],
+    failure_message: str = "",
+    location: str | None = CODE_LOCATION,
+) -> Any:
     return SimpleNamespace(
-        dagster_run=_run(),
+        dagster_run=_run(location=location),
         get_step_failure_events=lambda: step_failure_events,
         failure_event=SimpleNamespace(message=failure_message),
     )
@@ -150,20 +169,56 @@ def test_error_message_always_links_back_to_the_run() -> None:
 def test_sensor_fingerprint_matches_the_in_process_hook() -> None:
     """The two reporting paths must group into one Sentry issue, not two.
 
-    ol_orchestrate.lib.sentry's hook uses
-    ``[job_name, step_key, type(exception).__name__]``; a mismatch here raises a
-    duplicate issue for every single failure.
+    Both build it through ol_orchestrate.lib.sentry.failure_fingerprint; a
+    mismatch here raises a duplicate issue for every single failure.
     """
     context = _context([_step_failure("some_model", "boom", cls_name="ValueError")])
 
-    assert sentry_fingerprint(context) == ["a_job", "some_model", "ValueError"]
+    assert sentry_fingerprint(context) == [
+        DAGSTER_ENV,
+        CODE_LOCATION,
+        "some_model",
+        "ValueError",
+    ]
+
+
+def test_sensor_fingerprint_does_not_group_on_the_launch_path() -> None:
+    """DAGSTER-2C and DAGSTER-29 were one OVS failure wearing two issue numbers.
+
+    The triple used to lead with ``job_name``, so the same defect split in two
+    when one run came from the automation sensor's ``__ASSET_JOB`` and the other
+    from ``ovs_videos_webhook_job``. How a run was launched is not a property of
+    what broke.
+    """
+    context = _context([_step_failure("ovs_videos", "boom")])
+
+    assert context.dagster_run.job_name not in sentry_fingerprint(context)
+
+
+def test_sensor_fingerprint_names_the_location_that_broke() -> None:
+    """The location tag was hardcoded to this sensor's own code location."""
+    context = _context([_step_failure("some_model", "boom")], location="lakehouse")
+
+    assert sentry_fingerprint(context)[1] == "lakehouse"
+
+
+def test_sensor_fingerprint_tolerates_a_run_with_no_origin() -> None:
+    """A run submitted without a remote origin still has to group somewhere."""
+    context = _context([_step_failure("some_model", "boom")], location=None)
+
+    assert sentry_fingerprint(context)[1] == "unknown"
 
 
 def test_sensor_fingerprint_groups_process_deaths_separately() -> None:
     """No step failure means the hook never ran, so there is nothing to match."""
     context = _context([])
 
-    assert sentry_fingerprint(context) == ["a_job", "run", "run_failure"]
+    assert sentry_fingerprint(context) == [
+        DAGSTER_ENV,
+        CODE_LOCATION,
+        "run",
+        "run_failure",
+    ]
 
 
 def test_sensor_fingerprint_survives_a_missing_error_payload() -> None:
@@ -172,7 +227,12 @@ def test_sensor_fingerprint_survives_a_missing_error_payload() -> None:
     )
     context = _context([failure])
 
-    assert sentry_fingerprint(context) == ["a_job", "some_model", "run_failure"]
+    assert sentry_fingerprint(context) == [
+        DAGSTER_ENV,
+        CODE_LOCATION,
+        "some_model",
+        "run_failure",
+    ]
 
 
 def test_sensor_fingerprint_unwraps_dagsters_user_code_wrapper() -> None:
@@ -197,7 +257,8 @@ def test_sensor_fingerprint_unwraps_dagsters_user_code_wrapper() -> None:
     )
 
     assert sentry_fingerprint(context) == [
-        "a_job",
+        DAGSTER_ENV,
+        CODE_LOCATION,
         "extract_edxorg_courserun_metadata",
         "FileNotFoundError",
     ]
@@ -224,7 +285,7 @@ def test_sensor_fingerprint_unwraps_only_the_dagster_layer() -> None:
         ]
     )
 
-    assert sentry_fingerprint(context)[2] == "FileNotFoundError"
+    assert sentry_fingerprint(context)[3] == "FileNotFoundError"
 
 
 def test_sensor_fingerprint_keeps_a_wrapper_with_no_cause() -> None:
@@ -237,7 +298,7 @@ def test_sensor_fingerprint_keeps_a_wrapper_with_no_cause() -> None:
         ]
     )
 
-    assert sentry_fingerprint(context)[2] == "DagsterExecutionStepExecutionError"
+    assert sentry_fingerprint(context)[3] == "DagsterExecutionStepExecutionError"
 
 
 @pytest.mark.parametrize(
@@ -292,8 +353,91 @@ def test_sensor_fingerprint_matches_a_real_dagster_step_failure(
     ]
     fingerprint = sentry_fingerprint(_context(step_failures))
 
-    assert fingerprint[2] == hook_recorded["raises_file_not_found"]
-    assert fingerprint == ["a_job", "raises_file_not_found", "FileNotFoundError"]
+    assert fingerprint[3] == hook_recorded["raises_file_not_found"]
+    assert fingerprint == [
+        DAGSTER_ENV,
+        CODE_LOCATION,
+        "raises_file_not_found",
+        "FileNotFoundError",
+    ]
+
+
+# ── Slack rate limiting ───────────────────────────────────────────────────────
+
+
+class FakeKeyValueStore:
+    """The two run-storage cursor calls the rate limiter uses."""
+
+    def __init__(self) -> None:
+        self.values: dict[str, str] = {}
+
+    def get_cursor_values(self, keys: set[str]) -> dict[str, str]:
+        return {key: self.values[key] for key in keys if key in self.values}
+
+    def set_cursor_values(self, pairs: dict[str, str]) -> None:
+        self.values.update(pairs)
+
+
+def _instance() -> Any:
+    return SimpleNamespace(run_storage=FakeKeyValueStore())
+
+
+def test_a_failure_nobody_has_seen_is_announced() -> None:
+    instance = _instance()
+
+    assert repeats_to_announce(instance, "k", now := 1_000.0) == 0
+    assert instance.run_storage.values["k"] == f"{now}:0"
+
+
+def test_the_same_failure_repeating_is_not_announced_again() -> None:
+    """~27,900 Slack messages for DAGSTER-3 alone, every one of them identical."""
+    instance = _instance()
+    repeats_to_announce(instance, "k", 1_000.0)
+
+    assert repeats_to_announce(instance, "k", 1_060.0) is None
+    assert repeats_to_announce(instance, "k", 1_120.0) is None
+
+
+def test_the_next_announcement_carries_what_it_swallowed() -> None:
+    """One failure and four thousand failures are different situations."""
+    instance = _instance()
+    repeats_to_announce(instance, "k", 1_000.0)
+    for tick in range(4):
+        repeats_to_announce(instance, "k", 1_100.0 + tick)
+
+    assert repeats_to_announce(instance, "k", 1_000.0 + 31 * 60) == 4
+
+
+def test_the_count_resets_after_it_is_reported() -> None:
+    instance = _instance()
+    repeats_to_announce(instance, "k", 1_000.0)
+    repeats_to_announce(instance, "k", 1_100.0)
+    later = 1_000.0 + 31 * 60
+    repeats_to_announce(instance, "k", later)
+
+    assert repeats_to_announce(instance, "k", later + 31 * 60) == 0
+
+
+def test_distinct_failures_do_not_silence_each_other() -> None:
+    """The key is the Sentry fingerprint, so two defects are two rate limits."""
+    instance = _instance()
+    repeats_to_announce(instance, "one", 1_000.0)
+
+    assert repeats_to_announce(instance, "two", 1_000.0) == 0
+
+
+def test_a_suppressed_repeat_is_named_in_the_next_message() -> None:
+    blocks = error_message(
+        _context([_step_failure("some_model", "boom")]), None, suppressed_repeats=4_000
+    )
+
+    assert "4000 further failures" in _block_text(blocks)
+
+
+def test_no_repeat_block_when_there_was_nothing_to_suppress() -> None:
+    blocks = error_message(_context([_step_failure("some_model", "boom")]))
+
+    assert "further failures" not in _block_text(blocks)
 
 
 # ── dbt error extraction ──────────────────────────────────────────────────────

--- a/dg_projects/edxorg/edxorg/assets/openedx_course_archives.py
+++ b/dg_projects/edxorg/edxorg/assets/openedx_course_archives.py
@@ -21,6 +21,7 @@ from dagster._core.definitions.partitions.utils.multi import (
     MULTIPARTITION_KEY_DELIMITER,
 )
 from ol_orchestrate.lib.automation_policies import upstream_or_code_changes
+from ol_orchestrate.lib.http_errors import http_failure
 from ol_orchestrate.lib.openedx import (
     process_course_xml,
     process_course_xml_blocks,
@@ -353,9 +354,18 @@ def edxorg_course_content_webhook(
         )
 
     except httpx.HTTPStatusError as error:
-        error_message = (
-            f"Learn API webhook notification failed for course_id={course_id} "
-            f"with status code {error.response.status_code} and error: {error!s}"
+        context.log.exception(
+            "Learn API webhook notification failed for course_id=%s with status %s",
+            course_id,
+            error.response.status_code,
         )
-        context.log.exception(error_message)
-        raise Exception(error_message) from error  # noqa: TRY002
+        # A 405 here means the endpoint does not accept the method we send, and
+        # no number of reruns changes that -- this one was retried 5,363 times
+        # over six days before anyone noticed (DAGSTER-13). http_failure sorts
+        # that from the 5xx worth another attempt, and puts the course id in
+        # metadata rather than in the issue title.
+        raise http_failure(
+            error,
+            "Learn API webhook notification failed",
+            metadata={"course_id": course_id, "source": "mit_edx"},
+        ) from error

--- a/dg_projects/edxorg/edxorg/definitions.py
+++ b/dg_projects/edxorg/edxorg/definitions.py
@@ -26,7 +26,8 @@ from ol_orchestrate.io_managers.filepath import (
 )
 from ol_orchestrate.lib.constants import DAGSTER_ENV, VAULT_ADDRESS
 from ol_orchestrate.lib.dagster_helpers import default_io_manager
-from ol_orchestrate.lib.sentry import init_sentry, with_sentry_hooks
+from ol_orchestrate.lib.failures import with_failure_hooks
+from ol_orchestrate.lib.sentry import init_sentry
 from ol_orchestrate.lib.utils import authenticate_vault, unauthenticated_vault
 from ol_orchestrate.resources.api_client_factory import ApiClientFactory
 from ol_orchestrate.resources.gcp_gcs import GCSConnection
@@ -280,7 +281,7 @@ defs = Definitions(
         sync_edxorg_program_reports,
         gcs_sync_job,
     ],
-    assets=with_sentry_hooks(
+    assets=with_failure_hooks(
         [
             edxorg_raw_data_archive.to_source_asset(),
             edxorg_raw_tracking_logs.to_source_asset(),

--- a/dg_projects/lakehouse/lakehouse/assets/iceberg_maintenance.py
+++ b/dg_projects/lakehouse/lakehouse/assets/iceberg_maintenance.py
@@ -4,7 +4,10 @@ Two assets run on staggered nightly schedules:
 
 ``iceberg_dbt_layer_maintenance`` (02:00 UTC)
     Processes all dbt-managed tables discovered from ``manifest.json`` plus the
-    non-dbt singleton tables listed in ``NON_DBT_SINGLETON_TABLES``.
+    non-dbt singleton tables from ``non_dbt_singleton_tables()``. Both are
+    scoped to ``WAREHOUSE_ENV``: the manifest is compiled against production and
+    baked into an image that ships to every environment, so its resolved schemas
+    have to be re-pointed at the environment actually running.
 
     For each table it runs:
     - OPTIMIZE  (Trino)   — compact small files; triggered when materialization
@@ -48,14 +51,15 @@ from dagster import (
 )
 from ol_orchestrate.lib.constants import DAGSTER_ENV
 from ol_orchestrate.lib.iceberg_maintenance import (
-    NON_DBT_SINGLETON_TABLES,
     TableMaintenanceConfig,
     expire_snapshots,
     get_glue_catalog,
     load_maintenance_configs_from_manifest,
     load_raw_layer_maintenance_work,
+    non_dbt_singleton_tables,
     raw_config_for_table,
     remove_orphan_files,
+    warehouse_env_for,
 )
 from ol_orchestrate.resources.trino_maintenance import TrinoMaintenanceResource
 from pyiceberg.catalog.glue import GlueCatalog
@@ -65,18 +69,11 @@ from lakehouse.assets.lakehouse.dbt import dbt_project
 log = logging.getLogger(__name__)
 
 # Each environment runs maintenance only against its own catalog and schema set.
-# dev uses production because DAGSTER_ENV="dev" targets the production dbt profile
-# (dev_production), meaning developers run against real production Iceberg tables.
-_RAW_GLUE_DATABASE_MAP: dict[str, str] = {
-    "production": "ol_warehouse_production_raw",
-    "qa": "ol_warehouse_qa_raw",
-    "dev": "ol_warehouse_production_raw",
-    "ci": "ol_warehouse_qa_raw",
-}
-
-RAW_GLUE_DATABASE = _RAW_GLUE_DATABASE_MAP.get(
-    DAGSTER_ENV, "ol_warehouse_production_raw"
-)
+# The mapping lives in ol_orchestrate.lib.iceberg_maintenance so the raw layer
+# and the dbt layer cannot drift apart -- the dbt layer used to have no mapping
+# at all, and pointed QA at production.
+WAREHOUSE_ENV = warehouse_env_for(DAGSTER_ENV)
+RAW_GLUE_DATABASE = f"ol_warehouse_{WAREHOUSE_ENV}_raw"
 # Parallelism for raw layer: enough to be fast across 1,300+ tables without
 # hitting Glue API rate limits (default per-account limit is ~200 req/s).
 RAW_LAYER_WORKERS = 8
@@ -246,13 +243,16 @@ def iceberg_dbt_layer_maintenance(
     """Run Iceberg maintenance for all dbt-managed tables and non-dbt singletons."""
     configs = load_maintenance_configs_from_manifest(
         manifest_path=dbt_project.manifest_path,
+        warehouse_env=WAREHOUSE_ENV,
     )
-    all_configs = [*configs, *NON_DBT_SINGLETON_TABLES]
+    singletons = non_dbt_singleton_tables(WAREHOUSE_ENV)
+    all_configs = [*configs, *singletons]
     context.log.info(
-        "Loaded %d table configs (%d dbt, %d singleton)",
+        "Loaded %d table configs (%d dbt, %d singleton) for the %s warehouse",
         len(all_configs),
         len(configs),
-        len(NON_DBT_SINGLETON_TABLES),
+        len(singletons),
+        WAREHOUSE_ENV,
     )
 
     # Cursor of the previous maintenance run — used to count dbt materializations
@@ -272,10 +272,18 @@ def iceberg_dbt_layer_maintenance(
     snapshots_expired = 0
     orphans_removed = 0
     failures: list[str] = []
+    # Counted separately from `failures`, which holds one entry per failed
+    # *operation* -- OPTIMIZE and ANALYZE and EXPIRE can each fail for the same
+    # table. Comparing that count against a count of tables is what produced
+    # "failed for 1256/628 tables".
+    failed_tables: set[str] = set()
+    tables_attempted = 0
 
     for cfg in all_configs:
         if not cfg.enabled:
             continue
+        table = f"{cfg.schema_name}.{cfg.model_name}"
+        tables_attempted += 1
         try:
             result = _run_table_maintenance(
                 cfg, context.instance, last_cursor, trino_maintenance, catalog
@@ -287,41 +295,48 @@ def iceberg_dbt_layer_maintenance(
                 tables_analyzed += 1
             snapshots_expired += result["snapshots_expired"]
             orphans_removed += result["orphans_removed"]
-            failures.extend(
-                f"{cfg.schema_name}.{cfg.model_name}: {err}" for err in result["errors"]
-            )
+            if result["errors"]:
+                failed_tables.add(table)
+            failures.extend(f"{table}: {err}" for err in result["errors"])
         except Exception as exc:  # noqa: BLE001
-            log.warning(
-                "Maintenance failed for %s.%s: %s", cfg.schema_name, cfg.model_name, exc
-            )
-            failures.append(f"{cfg.schema_name}.{cfg.model_name}: {exc}")
+            log.warning("Maintenance failed for %s: %s", table, exc)
+            failed_tables.add(table)
+            failures.append(f"{table}: {exc}")
 
     context.log.info(
         "dbt layer maintenance complete: %d tables processed, %d optimized, "
-        "%d analyzed, %d snapshot batches expired, %d failures",
+        "%d analyzed, %d snapshot batches expired, %d failed operations across "
+        "%d tables",
         tables_processed,
         tables_optimized,
         tables_analyzed,
         snapshots_expired,
         len(failures),
+        len(failed_tables),
     )
 
-    # Fail the asset if maintenance failures exceed 5% of tables processed.
-    # This surfaces systemic failures (broken Trino credentials, Glue outage)
-    # that would otherwise accumulate silently in metadata while Dagster marks
-    # the run SUCCESS, advancing the cursor and blocking retries.
+    # Fail the asset if maintenance failed for more than 5% of tables. This
+    # surfaces systemic failures (broken Trino credentials, Glue outage) that
+    # would otherwise accumulate silently in metadata while Dagster marks the
+    # run SUCCESS, advancing the cursor and blocking retries.
+    #
+    # A table that failed every operation is one table, not three: the ratio is
+    # only meaningful if both sides count the same thing. The denominator is
+    # tables attempted rather than `tables_processed`, which excludes the ones
+    # that raised outright -- under a total outage that is zero, and a threshold
+    # against zero never trips.
     if failures:
-        failure_threshold = max(1, int(tables_processed * 0.05))
-        if len(failures) >= failure_threshold:
+        failure_threshold = max(1, int(tables_attempted * 0.05))
+        if len(failed_tables) >= failure_threshold:
             context.log.error(
                 "Maintenance failed for %d/%d tables (threshold: %d). Failing asset.",
-                len(failures),
-                tables_processed,
+                len(failed_tables),
+                tables_attempted,
                 failure_threshold,
             )
             msg = (
                 f"Iceberg maintenance failed for "
-                f"{len(failures)}/{tables_processed} "
+                f"{len(failed_tables)}/{tables_attempted} "
                 f"tables (threshold {failure_threshold}). "
                 f"First failures: {failures[:5]}"
             )
@@ -330,11 +345,14 @@ def iceberg_dbt_layer_maintenance(
     return Output(
         value=None,
         metadata={
+            "warehouse_env": MetadataValue.text(WAREHOUSE_ENV),
+            "tables_attempted": MetadataValue.int(tables_attempted),
             "tables_processed": MetadataValue.int(tables_processed),
             "tables_optimized": MetadataValue.int(tables_optimized),
             "tables_analyzed": MetadataValue.int(tables_analyzed),
             "snapshots_expired": MetadataValue.int(snapshots_expired),
             "orphans_removed": MetadataValue.int(orphans_removed),
+            "failed_tables": MetadataValue.int(len(failed_tables)),
             "failure_count": MetadataValue.int(len(failures)),
             # Cap at 20 entries so the Dagster UI doesn't time out rendering
             "failure_details": MetadataValue.json(failures[:20]),

--- a/dg_projects/lakehouse/lakehouse/assets/iceberg_maintenance.py
+++ b/dg_projects/lakehouse/lakehouse/assets/iceberg_maintenance.py
@@ -56,6 +56,7 @@ from ol_orchestrate.lib.iceberg_maintenance import (
     get_glue_catalog,
     load_maintenance_configs_from_manifest,
     load_raw_layer_maintenance_work,
+    maintenance_failure_threshold,
     non_dbt_singleton_tables,
     raw_config_for_table,
     remove_orphan_files,
@@ -326,7 +327,7 @@ def iceberg_dbt_layer_maintenance(
     # that raised outright -- under a total outage that is zero, and a threshold
     # against zero never trips.
     if failures:
-        failure_threshold = max(1, int(tables_attempted * 0.05))
+        failure_threshold = maintenance_failure_threshold(tables_attempted)
         if len(failed_tables) >= failure_threshold:
             context.log.error(
                 "Maintenance failed for %d/%d tables (threshold: %d). Failing asset.",

--- a/dg_projects/lakehouse/lakehouse/definitions.py
+++ b/dg_projects/lakehouse/lakehouse/definitions.py
@@ -27,7 +27,8 @@ from dagster_dbt import (
     DbtCliResource,
 )
 from ol_orchestrate.lib.constants import DAGSTER_ENV, VAULT_ADDRESS
-from ol_orchestrate.lib.sentry import init_sentry, with_sentry_hooks
+from ol_orchestrate.lib.failures import with_failure_hooks
+from ol_orchestrate.lib.sentry import init_sentry
 from ol_orchestrate.lib.utils import authenticate_vault, unauthenticated_vault
 from ol_orchestrate.resources.github import GithubApiClientFactory
 from ol_orchestrate.resources.trino_maintenance import TrinoMaintenanceResource
@@ -455,7 +456,7 @@ dbt_layer_freshness_sensor = build_sensor_for_freshness_checks(
 )
 
 defs = Definitions(
-    assets=with_sentry_hooks(
+    assets=with_failure_hooks(
         [
             *with_source_code_references([full_dbt_project]),
             *with_source_code_references([starrocks_dbt_assets]),

--- a/dg_projects/lakehouse/lakehouse/definitions.py
+++ b/dg_projects/lakehouse/lakehouse/definitions.py
@@ -149,6 +149,12 @@ airbyte_workspace = (
             else "mock_password"
         ),
         request_timeout=60,  # Allow up to a minute for Airbyte requests
+        # Attach to a sync that is already in flight rather than raising. The
+        # automation condition and Airbyte's own scheduler both launch syncs, so
+        # a tick landing on top of a running sync is routine, not exceptional --
+        # left at the library default of False it raised "Found sync job for
+        # connection_id=... already running" across ten connections.
+        poll_previous_running_sync=True,
     )
     if not SKIP_AIRBYTE
     else None

--- a/dg_projects/lakehouse/lakehouse/resources/airbyte.py
+++ b/dg_projects/lakehouse/lakehouse/resources/airbyte.py
@@ -172,15 +172,30 @@ class AirbyteOSSWorkspace(AirbyteWorkspace):
 
     @cached_method
     def get_client(self) -> AirbyteClient:
+        """Build the OSS client, carrying every setting the base class carries.
+
+        The polling four -- poll_interval, poll_timeout, cancel_on_termination
+        and poll_previous_running_sync -- were missing from this list, so
+        configuring them on the workspace set a field the client never saw and
+        every sync silently ran on the library defaults. That is why
+        ``poll_previous_running_sync`` did not take effect and ten connections
+        raised "already running" instead of waiting (DAGSTER-D, S, V, W, Y, Z,
+        11, 12, 19, 1W).
+        """
         return AirbyteOSSClient(
             api_server=self.api_server,
             username=self.username,
             password=self.password,
             client_id=self.client_id,
             client_secret=self.client_secret,
+            workspace_id=self.workspace_id,
             request_max_retries=self.request_max_retries,
             request_retry_delay=self.request_retry_delay,
             request_timeout=self.request_timeout,
+            poll_interval=self.poll_interval,
+            poll_timeout=self.poll_timeout,
+            cancel_on_termination=self.cancel_on_termination,
+            poll_previous_running_sync=self.poll_previous_running_sync,
             rest_api_base_url=self.rest_api_base_url
             or f"{self.api_server}/api/public/{AIRBYTE_REST_API_VERSION}",
             configuration_api_base_url=self.configuration_api_base_url

--- a/dg_projects/lakehouse/lakehouse/sensors.py
+++ b/dg_projects/lakehouse/lakehouse/sensors.py
@@ -8,6 +8,8 @@ import logging
 
 from dagster import (
     DefaultSensorStatus,
+    Failure,
+    MetadataValue,
     RunRequest,
     SensorEvaluationContext,
     SensorResult,
@@ -103,10 +105,18 @@ def repair_lagging_snapshot_pointers(context):
             )
 
     if failed:
-        raise Exception(  # noqa: TRY002
-            f"Snapshot pointer repair failed for {len(failed)} table(s): "
-            + ", ".join(failed)
-            + " — check the run logs for details."
+        # The table names go in metadata rather than the message: they were
+        # making every occurrence a differently-titled Sentry issue for what is
+        # one recurring problem.
+        raise Failure(
+            description=(
+                f"Snapshot pointer repair failed for {len(failed)} table(s) -- "
+                "check the run logs for details."
+            ),
+            metadata={
+                "failed_table_count": len(failed),
+                "failed_tables": MetadataValue.json(sorted(failed)),
+            },
         )
 
 

--- a/dg_projects/lakehouse/lakehouse_tests/test_airbyte_resource.py
+++ b/dg_projects/lakehouse/lakehouse_tests/test_airbyte_resource.py
@@ -1,0 +1,82 @@
+"""Tests for the Airbyte Community Edition workspace override.
+
+AirbyteOSSWorkspace.get_client() re-implements the base class's constructor call
+with an explicit argument list, which means any setting the base class grows --
+or that we simply forgot -- is silently dropped rather than failing loudly. That
+is not hypothetical: the four polling settings were missing, so configuring
+poll_previous_running_sync on the workspace set a field the client never read.
+"""
+
+import pytest
+from lakehouse.resources.airbyte import AirbyteOSSWorkspace
+
+# Non-default values throughout, so a setting that fails to propagate shows up
+# as the library default rather than coincidentally matching.
+WORKSPACE_SETTINGS = {
+    "api_server": "https://airbyte.example.invalid",
+    "username": "dagster",
+    "password": "not-a-real-password",  # pragma: allowlist secret
+    "workspace_id": "workspace-1",
+    "request_max_retries": 7,
+    "request_retry_delay": 1.5,
+    "request_timeout": 60,
+    "poll_interval": 17.0,
+    "poll_timeout": 1234.0,
+    "cancel_on_termination": False,
+    "poll_previous_running_sync": True,
+}
+
+
+@pytest.fixture
+def client():
+    return AirbyteOSSWorkspace(**WORKSPACE_SETTINGS).get_client()
+
+
+@pytest.mark.parametrize(
+    ("setting", "expected"),
+    [
+        # The polling four -- all of these were dropped.
+        ("poll_previous_running_sync", True),
+        ("poll_interval", 17.0),
+        ("poll_timeout", 1234.0),
+        ("cancel_on_termination", False),
+        # And the rest, so a future edit to the argument list cannot quietly
+        # drop one of these either.
+        ("workspace_id", "workspace-1"),
+        ("username", "dagster"),
+        ("request_max_retries", 7),
+        ("request_retry_delay", 1.5),
+        ("request_timeout", 60),
+    ],
+)
+def test_workspace_settings_reach_the_client(client, setting, expected) -> None:
+    assert getattr(client, setting) == expected
+
+
+def test_poll_previous_running_sync_is_what_stops_the_already_running_failure(
+    client,
+) -> None:
+    """The setting that turns ten Sentry issues into a wait.
+
+    dagster_airbyte.sync_and_poll raises `Failure: Found sync job for
+    connection_id=... already running` when it finds an in-flight sync and this
+    is False. The connection id is in the message, so each connection became its
+    own issue: DAGSTER-D, S, V, W, Y, Z, 11, 12, 19, 1W.
+    """
+    assert client.poll_previous_running_sync is True
+
+
+def test_the_api_base_urls_are_derived_from_the_api_server(client) -> None:
+    assert client.rest_api_base_url == "https://airbyte.example.invalid/api/public/v1"
+    assert client.configuration_api_base_url == "https://airbyte.example.invalid/api/v1"
+
+
+def test_explicit_base_urls_win_over_the_derived_ones() -> None:
+    client = AirbyteOSSWorkspace(
+        **WORKSPACE_SETTINGS,
+        rest_api_base_url="https://proxy.example.invalid/public",
+        configuration_api_base_url="https://proxy.example.invalid/config",
+    ).get_client()
+
+    assert client.rest_api_base_url == "https://proxy.example.invalid/public"
+    assert client.configuration_api_base_url == "https://proxy.example.invalid/config"

--- a/dg_projects/learning_resources/learning_resources/definitions.py
+++ b/dg_projects/learning_resources/learning_resources/definitions.py
@@ -19,7 +19,8 @@ from dagster_aws.s3 import S3Resource
 from ol_orchestrate.io_managers.filepath import S3FileObjectIOManager
 from ol_orchestrate.lib.constants import DAGSTER_ENV, VAULT_ADDRESS
 from ol_orchestrate.lib.dagster_helpers import default_io_manager
-from ol_orchestrate.lib.sentry import init_sentry, with_sentry_hooks
+from ol_orchestrate.lib.failures import with_failure_hooks
+from ol_orchestrate.lib.sentry import init_sentry
 from ol_orchestrate.lib.utils import (
     authenticate_vault,
     s3_uploads_bucket,
@@ -147,7 +148,7 @@ defs = Definitions(
             vault=vault,
         ),
     },
-    assets=with_sentry_hooks(
+    assets=with_failure_hooks(
         [
             sloan_course_metadata,
             video_api,

--- a/dg_projects/openedx/openedx/assets/openedx.py
+++ b/dg_projects/openedx/openedx/assets/openedx.py
@@ -24,6 +24,7 @@ from dagster import (
     AssetOut,
     DataVersion,
     DataVersionsByPartition,
+    MetadataValue,
     OpExecutionContext,
     Output,
     PartitionsDefinition,
@@ -35,6 +36,7 @@ from dagster import (
 from flatten_dict import flatten
 from flatten_dict.reducers import make_reducer
 from ol_orchestrate.lib.automation_policies import upstream_or_code_changes
+from ol_orchestrate.lib.failures import permanent_failure
 from ol_orchestrate.lib.http_errors import http_failure
 from ol_orchestrate.lib.openedx import (
     CourseExportOutcome,
@@ -433,11 +435,23 @@ def course_xml(context: AssetExecutionContext):
                 course: last_seen_status.get(course)
                 for course in sorted(failed_exports)
             }
+            # Studio reporting Failed is a terminal answer about this version of
+            # the course, not a hiccup -- re-asking returns the same thing until
+            # the course itself changes. Raised as a bare Exception it was never
+            # classified at all, so run_retries and the automation condition both
+            # kept re-running it: 2,587 events on DAGSTER-6.
             errmsg = (
-                f"Unable to export the course XML for {course_key}. "
-                f"Studio reported: {reported}"
+                f"Studio could not export the course XML for {course_key}, and "
+                "reported a terminal failure state. Rerunning will not change "
+                "that; the course itself has to be fixed or republished."
             )
-            raise Exception(errmsg)  # noqa: TRY002
+            raise permanent_failure(
+                errmsg,
+                metadata={
+                    "course_key": str(course_key),
+                    "studio_status": MetadataValue.json(reported),
+                },
+            )
         s3_location = exported_courses["upload_urls"][course_key]
         context.log.debug("Attempting to download the course XML from %s", s3_location)
         s3_path = urlparse(s3_location)

--- a/dg_projects/openedx/openedx/definitions.py
+++ b/dg_projects/openedx/openedx/definitions.py
@@ -18,7 +18,8 @@ from ol_orchestrate.lib.dagster_helpers import (
     default_file_object_io_manager,
     default_io_manager,
 )
-from ol_orchestrate.lib.sentry import init_sentry, with_sentry_hooks
+from ol_orchestrate.lib.failures import with_failure_hooks
+from ol_orchestrate.lib.sentry import init_sentry
 from ol_orchestrate.lib.utils import authenticate_vault, unauthenticated_vault
 from ol_orchestrate.resources.api_client_factory import ApiClientFactory
 
@@ -205,7 +206,7 @@ def _create_deployment_repository(
 
     return create_repository_using_definitions_args(
         name=f"{deployment_name}_openedx",
-        assets=with_sentry_hooks(deployment_defs.assets or []),
+        assets=with_failure_hooks(deployment_defs.assets or []),
         sensors=deployment_defs.sensors,
         resources=deployment_defs.resources,
     )

--- a/dg_projects/student_risk_probability/student_risk_probability/definitions.py
+++ b/dg_projects/student_risk_probability/student_risk_probability/definitions.py
@@ -11,7 +11,8 @@ from ol_orchestrate.lib.constants import DAGSTER_ENV, VAULT_ADDRESS
 from ol_orchestrate.lib.dagster_helpers import (
     default_file_object_io_manager,
 )
-from ol_orchestrate.lib.sentry import init_sentry, with_sentry_hooks
+from ol_orchestrate.lib.failures import with_failure_hooks
+from ol_orchestrate.lib.sentry import init_sentry
 from ol_orchestrate.lib.utils import (
     authenticate_vault,
     s3_uploads_bucket,
@@ -77,6 +78,6 @@ defs = Definitions(
         "vault": vault,
         "s3": S3Resource(),
     },
-    assets=with_sentry_hooks([student_risk_probability]),
+    assets=with_failure_hooks([student_risk_probability]),
     jobs=[data_export_job],
 )

--- a/packages/ol-orchestrate-lib/src/ol_orchestrate/io_managers/filepath.py
+++ b/packages/ol-orchestrate-lib/src/ol_orchestrate/io_managers/filepath.py
@@ -5,6 +5,7 @@ from dagster import (
     ConfigurableIOManager,
     DagsterEventType,
     EventRecordsFilter,
+    Failure,
     InputContext,
     MetadataValue,
     OutputContext,
@@ -18,6 +19,17 @@ from upath import UPath
 from ol_orchestrate.resources.secrets.vault import Vault
 
 
+class UpstreamObjectUnavailable(Failure):
+    """The upstream materialization does not point at a readable object.
+
+    A distinct class rather than a bare ``Failure`` so the three ways this
+    happens -- no materialization, no path in its metadata, a path whose object
+    is gone -- group as one Sentry issue naming the key, instead of dissolving
+    into whatever the reader raised downstream. Nothing a rerun does changes
+    any of them, which is why they carry ``allow_retries=False``.
+    """
+
+
 class FileObjectIOManager(ConfigurableIOManager):
     path_prefix: str | None = None
     gcs_credentials: str | None = None
@@ -28,6 +40,15 @@ class FileObjectIOManager(ConfigurableIOManager):
     _s3_fs: S3FileSystem = PrivateAttr(default=None)
 
     def load_input(self, context: InputContext) -> UPath:
+        """Resolve the upstream materialization to a path that actually exists.
+
+        The materialization record is a claim about the object store, not the
+        object store. Trusting it unconditionally is what turned one missing S3
+        key into ~368,000 failed runs: the manager handed back a path to nothing,
+        the reader raised NoSuchKey deep in whatever library opened it, and the
+        automation condition asked for the same run again. Checking here fails
+        once, permanently, and names the key.
+        """
         asset_dep = context.instance.get_event_records(
             event_records_filter=EventRecordsFilter(
                 asset_key=context.asset_key,
@@ -35,13 +56,51 @@ class FileObjectIOManager(ConfigurableIOManager):
                 asset_partitions=[context.partition_key],
             ),
             limit=1,
-        )[0]
+        )
+        target = f"{context.asset_key.to_user_string()} / {context.partition_key}"
+        if not asset_dep:
+            raise UpstreamObjectUnavailable(
+                description=(
+                    f"No materialization recorded for {target}, so there is no "
+                    "path to load. The upstream needs to run before this asset "
+                    "can."
+                ),
+                metadata={"asset_key": context.asset_key.to_user_string()},
+                allow_retries=False,
+            )
 
-        asset_path = UPath(asset_dep.asset_materialization.metadata["path"].value)
-        return UPath(
+        path_metadata = asset_dep[0].asset_materialization.metadata.get("path")
+        if path_metadata is None:
+            raise UpstreamObjectUnavailable(
+                description=(
+                    f"The latest materialization of {target} recorded no 'path' "
+                    "metadata. Whatever wrote it did not go through this IO "
+                    "manager's handle_output."
+                ),
+                metadata={"asset_key": context.asset_key.to_user_string()},
+                allow_retries=False,
+            )
+
+        asset_path = UPath(path_metadata.value)
+        resolved_path = UPath(
             asset_path,
             **self.configure_path_fs(asset_path.protocol).storage_options,
         )
+        if not resolved_path.exists():
+            raise UpstreamObjectUnavailable(
+                description=(
+                    f"{target} recorded a path to an object that is not there: "
+                    f"{resolved_path}. The materialization outlived the object -- "
+                    "expired by a lifecycle rule, deleted, or written to a "
+                    "different bucket than the one recorded."
+                ),
+                metadata={
+                    "asset_key": context.asset_key.to_user_string(),
+                    "missing_path": MetadataValue.text(str(resolved_path)),
+                },
+                allow_retries=False,
+            )
+        return resolved_path
 
     def handle_output(self, context: OutputContext, obj: tuple[Path, str]) -> None:
         context.log.info("Writing contents of %s to %s", *obj)

--- a/packages/ol-orchestrate-lib/src/ol_orchestrate/io_managers/filepath.py
+++ b/packages/ol-orchestrate-lib/src/ol_orchestrate/io_managers/filepath.py
@@ -5,7 +5,6 @@ from dagster import (
     ConfigurableIOManager,
     DagsterEventType,
     EventRecordsFilter,
-    Failure,
     InputContext,
     MetadataValue,
     OutputContext,
@@ -16,17 +15,19 @@ from pydantic import PrivateAttr
 from s3fs import S3FileSystem
 from upath import UPath
 
+from ol_orchestrate.lib.failures import PermanentFailure
 from ol_orchestrate.resources.secrets.vault import Vault
 
 
-class UpstreamObjectUnavailable(Failure):
+class UpstreamObjectUnavailable(PermanentFailure):
     """The upstream materialization does not point at a readable object.
 
-    A distinct class rather than a bare ``Failure`` so the three ways this
-    happens -- no materialization, no path in its metadata, a path whose object
-    is gone -- group as one Sentry issue naming the key, instead of dissolving
-    into whatever the reader raised downstream. Nothing a rerun does changes
-    any of them, which is why they carry ``allow_retries=False``.
+    A distinct class rather than a bare ``PermanentFailure`` so the three ways
+    this happens -- no materialization, no path in its metadata, a path whose
+    object is gone -- group as one Sentry issue naming the key, instead of
+    dissolving into whatever the reader raised downstream. Nothing a rerun does
+    changes any of them, which is why they carry ``allow_retries=False`` and
+    stop ``run_retries`` via the ``stop_run_retries`` hook.
     """
 
 

--- a/packages/ol-orchestrate-lib/src/ol_orchestrate/lib/automation_policies.py
+++ b/packages/ol-orchestrate-lib/src/ol_orchestrate/lib/automation_policies.py
@@ -11,8 +11,17 @@ def upstream_or_code_changes() -> AutomationCondition:
     indefinitely on stale data while every tick reports nothing to do.
 
     ``execution_failed`` is level-triggered -- true for as long as the latest
-    execution of the target is a failure -- so it keeps asking until a run
-    succeeds and goes quiet the moment one does. That covers the run that fails.
+    execution of the target is a failure. Used bare that is unbounded: a
+    partition that can never succeed is re-requested on every tick forever, and
+    ``run_retries.max_retries`` multiplies each request. That is how a single
+    broken asset produced ~368,000 failed runs in fourteen days.
+
+    ``.newly_true()`` converts it to an edge. It fires on the tick where the
+    latest execution first becomes a failure and not again, because the level
+    never drops back to false while the retry is in flight or after it also
+    fails. One failure therefore buys exactly one re-request; a success clears
+    the level, so the next genuine failure fires again. That covers the run that
+    fails without covering the run that can never succeed.
 
     The upstream signal is latched on top of it, because failure is not the only
     way the edge gets lost. ``~in_progress()`` gates the whole conjunction, so an
@@ -40,6 +49,13 @@ def upstream_or_code_changes() -> AutomationCondition:
     backfill -- no longer clears a pending upstream change, so one automation run
     can follow it. That is the conservative direction to err in, and it settles
     after that single run.
+
+    Deploy note: ``NewlyTrueCondition`` diffs against the previous tick's true
+    subset held in its cursor, and there is no cursor on the first evaluation.
+    Every partition that is *already* failed therefore reads as newly true once,
+    and fires one request each on a single tick. Against a large standing set of
+    failures that is a stampede -- so clear the failed set, or roll this out a
+    code location at a time, before deploying it.
     """
     not_in_progress = ~AutomationCondition.in_progress()
     no_upstream_dependencies_in_process = ~AutomationCondition.any_deps_in_progress()
@@ -53,7 +69,7 @@ def upstream_or_code_changes() -> AutomationCondition:
     )
     has_code_changes = AutomationCondition.code_version_changed()
     newly_missing = AutomationCondition.newly_missing()
-    latest_execution_failed = AutomationCondition.execution_failed()
+    execution_newly_failed = AutomationCondition.execution_failed().newly_true()
     all_upstream_dependencies_present = ~AutomationCondition.any_deps_missing()
     return (
         not_in_progress
@@ -62,7 +78,7 @@ def upstream_or_code_changes() -> AutomationCondition:
             has_upstream_changes
             | has_code_changes
             | newly_missing
-            | latest_execution_failed
+            | execution_newly_failed
         )
         & all_upstream_dependencies_present
     )

--- a/packages/ol-orchestrate-lib/src/ol_orchestrate/lib/failures.py
+++ b/packages/ol-orchestrate-lib/src/ol_orchestrate/lib/failures.py
@@ -1,0 +1,111 @@
+"""Failures a rerun cannot clear, and the wiring that makes that mean something.
+
+Dagster has three independent retry mechanisms and ``Failure(allow_retries=False)``
+only speaks to one of them:
+
+- an op's ``RetryPolicy`` -- honours ``allow_retries`` (see
+  ``dagster._core.execution.plan.utils.op_execution_error_boundary``);
+- the run-level auto-reexecution daemon -- decides purely from run status, the
+  ``dagster/max_retries`` and ``dagster/retry_on_asset_or_op_failure`` run tags,
+  and the run group size. It never looks at the exception;
+- an ``AutomationCondition`` -- sees only that the latest execution failed.
+
+So a failure raised as permanent was still re-run by ``run_retries`` and still
+re-requested by the automation condition. The Learn API 405 on Canvas course
+2198 was correctly classified as unretryable and then retried 5,363 times over
+six days.
+
+``stop_run_retries`` closes the second gap: it stamps the run so the daemon
+declines to retry it. Attach it, with the Sentry hook, via ``with_failure_hooks``.
+
+The third gap stays open by construction. Declarative automation exposes no
+primitive for "the failure was permanent" -- ``execution_failed()`` is the only
+failure signal and it is untyped. ``upstream_or_code_changes()`` bounds it to one
+re-request per failure edge instead (see ``automation_policies``), so a permanent
+failure now costs two runs rather than an unbounded stream of them.
+"""
+
+from collections.abc import Sequence
+from typing import Any
+
+from dagster import AssetsDefinition, Failure, HookContext, failure_hook
+
+from ol_orchestrate.lib.sentry import capture_exception_to_sentry
+
+# Dagster's own run tag, read by the auto-reexecution daemon in
+# dagster._daemon.auto_run_reexecution. Hardcoded rather than imported: the
+# constant lives in the private dagster._core.storage.tags, but the tag string
+# is stable and documented.
+RETRY_ON_ASSET_OR_OP_FAILURE_TAG = "dagster/retry_on_asset_or_op_failure"
+
+
+class PermanentFailure(Failure):
+    """A failure a rerun cannot change.
+
+    Subclass it rather than raising it directly when the *kind* of permanence is
+    worth its own Sentry issue -- both capture paths fingerprint on the
+    exception's class name, so everything raised as a bare ``PermanentFailure``
+    from one step collapses into a single issue no matter what went wrong.
+    """
+
+
+def permanent_failure(
+    description: str,
+    metadata: dict[str, Any] | None = None,
+) -> PermanentFailure:
+    """Build a failure for something a rerun cannot fix, outside HTTP.
+
+    ``description`` should say what the caller was trying to do and why another
+    attempt will not help, in terms a reader of the Sentry issue can act on.
+
+    Returned rather than raised so the call site keeps ``raise ... from error``
+    where there is a cause, and the original traceback survives. Mirrors
+    ``http_errors.http_failure``.
+    """
+    return PermanentFailure(
+        description=description,
+        metadata={
+            "retryable": False,
+            **(metadata or {}),
+        },
+        allow_retries=False,
+    )
+
+
+@failure_hook(name="stop_run_retries")
+def stop_run_retries(context: HookContext) -> None:
+    """Stop ``run_retries`` re-running a step that failed permanently.
+
+    The daemon reads ``dagster/retry_on_asset_or_op_failure`` off the run when it
+    processes the failure, which is after this hook has run in the run worker, so
+    stamping it here is in time to be seen.
+
+    A hook rather than a call at each raise site: the tag has to be set for every
+    permanent failure or the guarantee is only as good as whoever remembered, and
+    the raise sites do not all have an op context to hand.
+    """
+    if not isinstance(context.op_exception, PermanentFailure):
+        return
+
+    context.instance.add_run_tags(
+        context.run_id, {RETRY_ON_ASSET_OR_OP_FAILURE_TAG: "false"}
+    )
+
+
+def with_failure_hooks(assets: Sequence[Any]) -> list[Any]:
+    """Attach the failure hooks to every AssetsDefinition in ``assets``.
+
+    Hooks are attached to the asset rather than to a job on purpose. Job-level
+    hooks only fire for runs launched from a job, which would miss everything
+    materialized by an AutomationConditionSensorDefinition -- that is how the
+    whole dbt project runs.
+
+    Entries that are not AssetsDefinitions (AssetSpec, for instance) are passed
+    through untouched; they have no ops to hook.
+    """
+    return [
+        asset.with_hooks({capture_exception_to_sentry, stop_run_retries})
+        if isinstance(asset, AssetsDefinition)
+        else asset
+        for asset in assets
+    ]

--- a/packages/ol-orchestrate-lib/src/ol_orchestrate/lib/http_errors.py
+++ b/packages/ol-orchestrate-lib/src/ol_orchestrate/lib/http_errors.py
@@ -12,15 +12,21 @@ consults it only when the op or asset carries a ``RetryPolicy`` (see
 ``dagster._core.execution.plan.utils.op_execution_error_boundary``). It has no
 effect on the run-level auto-reexecution daemon, which decides purely from run
 status, the ``dagster/max_retries`` and
-``dagster/retry_on_asset_or_op_failure`` tags, and the run group size. So a
-permanent failure raised here is still re-run by ``run_retries`` unless that is
-suppressed at the run or instance level.
+``dagster/retry_on_asset_or_op_failure`` tags, and the run group size.
+
+``PermanentHTTPFailure`` is a ``PermanentFailure``, so the ``stop_run_retries``
+hook in ``ol_orchestrate.lib.failures`` stamps that run tag when one is raised
+and the daemon declines to retry. Without that inheritance the classification
+here is inert against ``run_retries`` -- which is how a Learn API 405 was
+correctly identified as unretryable and then retried 5,363 times.
 """
 
 from typing import Any
 
 from dagster import Failure, MetadataValue
 from httpx2 import HTTPStatusError
+
+from ol_orchestrate.lib.failures import PermanentFailure
 
 HTTP_SERVER_ERROR_FLOOR = 500
 HTTP_SERVER_ERROR_CEILING = 600
@@ -30,14 +36,14 @@ HTTP_SERVER_ERROR_CEILING = 600
 RETRYABLE_CLIENT_ERRORS = frozenset({408, 429})
 
 
-class PermanentHTTPFailure(Failure):
+class PermanentHTTPFailure(PermanentFailure):
     """A response a rerun cannot change: the request itself is being rejected.
 
-    A distinct class rather than a plain ``Failure`` so Sentry can separate it
-    from the transient case. Both the in-process hook and the run failure
-    sensor fingerprint on the exception's class name, so every ``Failure``
-    raised from one step used to collapse into a single issue no matter which
-    status produced it.
+    A distinct class rather than a plain ``PermanentFailure`` so Sentry can
+    separate it from the transient case. Both the in-process hook and the run
+    failure sensor fingerprint on the exception's class name, so every
+    ``Failure`` raised from one step used to collapse into a single issue no
+    matter which status produced it.
     """
 
 

--- a/packages/ol-orchestrate-lib/src/ol_orchestrate/lib/iceberg_maintenance.py
+++ b/packages/ol-orchestrate-lib/src/ol_orchestrate/lib/iceberg_maintenance.py
@@ -12,7 +12,7 @@ a natural authoritative registry, and we use each one directly:
 
 - dbt-managed tables  → ``manifest.json`` + Dagster materialization event log
 - Raw / Airbyte tables → Glue catalog live scan + Iceberg snapshot timestamps
-- Non-dbt singletons  → ``NON_DBT_SINGLETON_TABLES`` module-level constant
+- Non-dbt singletons  → ``non_dbt_singleton_tables()``
 
 The Airbyte layer cannot use the Dagster event log for timing because
 ``OLAirbyteTranslator`` prefixes asset keys with ``ol_warehouse_raw_data`` and
@@ -27,6 +27,7 @@ from __future__ import annotations
 
 import datetime
 import logging
+import re
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
@@ -128,22 +129,75 @@ RAW_LAYER_GROUP_CONFIGS: dict[str, RawLayerGroupConfig] = {
     "_default": RawLayerGroupConfig(snapshot_retention_days=7),
 }
 
-# Tables written outside dbt and Airbyte that still need Iceberg maintenance.
-# Add new entries here as additional inference pipelines or ad-hoc writers land.
-NON_DBT_SINGLETON_TABLES: list[TableMaintenanceConfig] = [
-    TableMaintenanceConfig(
-        model_name="student_risk_probability",
-        schema_name="ol_warehouse_production_reporting",
-        materialized="table",
-        # Asset key matches the Dagster asset in the student_risk_probability
-        # code location.
-        asset_key=["reporting", "student_risk_probability"],
-        snapshot_retention_days=7,
-        orphan_retention_days=7,
-        optimize_after_every_n_runs=1,
-        analyze_after_every_n_runs=7,
-    ),
-]
+# Which warehouse environment each Dagster environment maintains. dev maps to
+# production because DAGSTER_ENV="dev" targets the production dbt profile
+# (dev_production), so a developer is already reading real production tables.
+WAREHOUSE_ENV_BY_DAGSTER_ENV: dict[str, str] = {
+    "production": "production",
+    "qa": "qa",
+    "dev": "production",
+    "ci": "qa",
+}
+
+# Warehouse schemas are ``ol_warehouse_<env>_<layer>``. The env segment is a
+# single token, so the layer -- which may itself contain underscores -- is
+# whatever follows it.
+_WAREHOUSE_SCHEMA = re.compile(r"^ol_warehouse_(?P<env>[a-z]+)_(?P<layer>.+)$")
+
+
+def warehouse_env_for(dagster_env: str) -> str:
+    """Return the warehouse environment ``dagster_env`` is allowed to maintain."""
+    return WAREHOUSE_ENV_BY_DAGSTER_ENV.get(dagster_env, "qa")
+
+
+def scope_schema_to_env(schema_name: str, warehouse_env: str) -> str:
+    """Rewrite ``schema_name``'s environment segment to ``warehouse_env``.
+
+    One image ships to every environment carrying one ``manifest.json``, and
+    that manifest is compiled against production -- so its ``node['schema']``
+    reads ``ol_warehouse_production_intermediate`` whichever environment loads
+    it. QA maintenance was therefore issuing OPTIMIZE and ANALYZE against
+    production schemas, and the only thing stopping it was
+    ``data-lake-query-engine-role-qa`` lacking ``glue:GetTable``. An IAM denial
+    is not a scoping mechanism; it is a safety net that would disappear the
+    moment someone widened that role for an unrelated reason.
+
+    A schema that is not ``ol_warehouse_<env>_<layer>`` cannot be proven to
+    belong to any environment, so it raises rather than being passed through --
+    the failure this exists to prevent is silent cross-environment writes.
+    """
+    match = _WAREHOUSE_SCHEMA.match(schema_name)
+    if match is None:
+        msg = (
+            f"Cannot scope {schema_name!r} to the {warehouse_env} warehouse: it "
+            "is not of the form ol_warehouse_<env>_<layer>, so which "
+            "environment it belongs to is unknowable."
+        )
+        raise ValueError(msg)
+    return f"ol_warehouse_{warehouse_env}_{match['layer']}"
+
+
+def non_dbt_singleton_tables(warehouse_env: str) -> list[TableMaintenanceConfig]:
+    """Tables written outside dbt and Airbyte that still need maintenance.
+
+    A function rather than a constant so the schemas are scoped to the calling
+    environment for the same reason the dbt-derived ones are. Add new entries
+    here as additional inference pipelines or ad-hoc writers land.
+    """
+    return [
+        TableMaintenanceConfig(
+            model_name="student_risk_probability",
+            schema_name=f"ol_warehouse_{warehouse_env}_reporting",
+            materialized="table",
+            # Asset key matches the Dagster asset in the student_risk_probability
+            # code location.
+            asset_key=["reporting", "student_risk_probability"],
+            snapshot_retention_days=7,
+            orphan_retention_days=7,
+            optimize_after_every_n_runs=1,
+            analyze_after_every_n_runs=7,
+        ),
+    ]
 
 
 # ── Catalog Factory ───────────────────────────────────────────────────────────
@@ -311,6 +365,7 @@ def _pyiceberg_version() -> str:
 
 def load_maintenance_configs_from_manifest(
     manifest_path: str | Path,
+    warehouse_env: str,
 ) -> list[TableMaintenanceConfig]:
     """Parse dbt ``manifest.json`` and return a ``TableMaintenanceConfig`` per model.
 
@@ -320,11 +375,11 @@ def load_maintenance_configs_from_manifest(
     skipped rather than having Python-side defaults applied silently, which
     would diverge from the dbt config over time.
 
-    The Glue/Trino schema name is read directly from ``node['schema']``, which
-    dbt fully resolves at compile time (e.g. ``ol_warehouse_production_mart``).
-    Using the resolved value is safer than reconstructing it from
-    ``config.schema`` + an env prefix, because it reflects the actual target
-    the manifest was compiled against.
+    ``node['schema']`` is the schema dbt resolved *at compile time*, and the
+    manifest is compiled once against production and then baked into an image
+    that ships everywhere. Taking it at face value is what pointed QA's
+    maintenance at production schemas, so ``warehouse_env`` rewrites the
+    environment segment of every schema and rejects any that does not carry one.
 
     The Dagster AssetKey path is ``[config.schema, model_name]`` to match
     ``DbtAutomationTranslator.get_group_name``, which returns ``config.schema``
@@ -344,12 +399,13 @@ def load_maintenance_configs_from_manifest(
         if materialized not in ("table", "incremental"):
             continue  # skip view, ephemeral, seed-backed models
 
-        # Use the fully-resolved schema from the manifest node (e.g.
-        # "ol_warehouse_production_mart"), not config.schema (bare suffix).
-        schema_name = node.get("schema", "")
-        if not schema_name:
+        # The manifest's resolved schema (e.g. "ol_warehouse_production_mart"),
+        # re-pointed at this environment. config.schema is only the bare suffix.
+        compiled_schema = node.get("schema", "")
+        if not compiled_schema:
             log.debug("Skipping %s — no schema on manifest node", unique_id)
             continue
+        schema_name = scope_schema_to_env(compiled_schema, warehouse_env)
 
         # config.schema is the bare suffix (e.g. "mart") used as the Dagster
         # asset group name by DbtAutomationTranslator.get_group_name.

--- a/packages/ol-orchestrate-lib/src/ol_orchestrate/lib/iceberg_maintenance.py
+++ b/packages/ol-orchestrate-lib/src/ol_orchestrate/lib/iceberg_maintenance.py
@@ -145,6 +145,24 @@ WAREHOUSE_ENV_BY_DAGSTER_ENV: dict[str, str] = {
 _WAREHOUSE_SCHEMA = re.compile(r"^ol_warehouse_(?P<env>[a-z]+)_(?P<layer>.+)$")
 
 
+# Share of tables that may fail before the nightly maintenance asset itself
+# fails. Above this it is a systemic problem -- broken Trino credentials, a Glue
+# outage -- rather than a handful of awkward tables.
+MAINTENANCE_FAILURE_RATE = 0.05
+
+
+def maintenance_failure_threshold(tables_attempted: int) -> int:
+    """Return how many failed tables it takes to fail the maintenance asset.
+
+    ``floor(5%) + 1`` is the first count that is genuinely *more* than 5%.
+    ``max(1, int(5%))`` was not: at 21 tables it tripped on a single failure
+    (4.8%) and at 100 it tripped on exactly 5. The ``+ 1`` also makes the floor
+    of one fall out naturally, since a single failure out of twenty or fewer is
+    already over the line.
+    """
+    return int(tables_attempted * MAINTENANCE_FAILURE_RATE) + 1
+
+
 def warehouse_env_for(dagster_env: str) -> str:
     """Return the warehouse environment ``dagster_env`` is allowed to maintain."""
     return WAREHOUSE_ENV_BY_DAGSTER_ENV.get(dagster_env, "qa")

--- a/packages/ol-orchestrate-lib/src/ol_orchestrate/lib/sentry.py
+++ b/packages/ol-orchestrate-lib/src/ol_orchestrate/lib/sentry.py
@@ -36,6 +36,47 @@ SENTRY_FLUSH_TIMEOUT_SECONDS = 5.0
 # still re-tags -- see init_sentry.
 _initialized_location: str | None = None
 
+# A run worker that receives SIGTERM -- a deploy rolling the deployment, a node
+# draining, a pod evicted -- raises this on its way out. It is the process being
+# taken away, not the code being wrong, and there is nothing in the traceback
+# for anyone to act on.
+INTERRUPTION_ERRORS = frozenset(
+    {
+        "DagsterExecutionInterruptedError",
+        "KeyboardInterrupt",
+    }
+)
+
+
+def exception_type_of(event: dict[str, Any]) -> str | None:
+    """Return the type name of the exception an event carries, if it has one."""
+    values = (event.get("exception") or {}).get("values") or []
+    return values[-1].get("type") if values else None
+
+
+def drop_interruptions(
+    event: dict[str, Any],
+    hint: dict[str, Any],  # noqa: ARG001
+) -> dict[str, Any] | None:
+    """``before_send``: suppress events that only report a terminated process.
+
+    Deliberately narrow. Connection-class transients -- pgbouncer churn, httpx
+    timeouts, DNS -- are handled by giving the assets that touch the database
+    and external HTTP a ``RetryPolicy`` instead of by filtering here: a step
+    failure hook fires only once a RetryPolicy is exhausted, so a connection
+    error that still reaches Sentry is one that survived its retries and is
+    worth reading. Filtering those at the transport would hide the sustained
+    outage along with the blip.
+    """
+    if exception_type_of(event) in INTERRUPTION_ERRORS:
+        return None
+    return event
+
+
+def current_code_location() -> str | None:
+    """Return the code location this process was initialized for, if any."""
+    return _initialized_location
+
 
 def init_sentry(code_location: str) -> bool:
     """Initialize the Sentry SDK for a Dagster code location.
@@ -67,6 +108,7 @@ def init_sentry(code_location: str) -> bool:
             # run failure sensor, so a step failure is reported once rather
             # than once per logger that happens to shout about it.
             integrations=[LoggingIntegration(level=logging.INFO, event_level=None)],
+            before_send=drop_interruptions,
         )
         # Dagster logs the full failure of every step through its own logger.
         # Left alone it floods the breadcrumb trail with the same traceback we
@@ -81,6 +123,30 @@ def init_sentry(code_location: str) -> bool:
     sentry_sdk.set_tag("dagster_code_location", code_location)
     _initialized_location = code_location
     return True
+
+
+def failure_fingerprint(
+    code_location: str | None,
+    step_key: str | None,
+    exception_type: str,
+) -> list[str]:
+    """Build the grouping key for a step failure, shared by both capture paths.
+
+    ``step_key`` identifies the asset that broke. ``job_name`` -- which this
+    triple used to lead with -- identifies how the run was *launched*, which is
+    not a property of the defect: the same OVS webhook failure arrived as two
+    separate issues because one run came from the automation sensor's
+    ``__ASSET_JOB`` and the other from ``ovs_videos_webhook_job``.
+
+    The environment leads instead. QA and production share one Sentry project,
+    so without it a QA-only defect and a production outage merge into a single
+    issue and become indistinguishable in the list.
+
+    Both capture paths must build this identically or every failure raises two
+    issues rather than one, which is why they call this rather than each
+    assembling their own list.
+    """
+    return [DAGSTER_ENV, code_location or "unknown", step_key or "run", exception_type]
 
 
 @failure_hook(name="capture_exception_to_sentry")
@@ -102,11 +168,11 @@ def capture_exception_to_sentry(context: HookContext) -> None:
         scope.set_tag("captured_by", "hook")
         # Group by the step that broke rather than by traceback text, so a
         # recurring failure of one dbt model stays a single issue.
-        scope.fingerprint = [
-            context.job_name,
+        scope.fingerprint = failure_fingerprint(
+            current_code_location(),
             context.step_key,
             type(exception).__name__,
-        ]
+        )
         sentry_sdk.capture_exception(exception)
 
     sentry_sdk.flush(timeout=SENTRY_FLUSH_TIMEOUT_SECONDS)

--- a/packages/ol-orchestrate-lib/src/ol_orchestrate/lib/sentry.py
+++ b/packages/ol-orchestrate-lib/src/ol_orchestrate/lib/sentry.py
@@ -179,7 +179,12 @@ def capture_exception_to_sentry(context: HookContext) -> None:
 
 
 def with_sentry_hooks(assets: Sequence[Any]) -> list[Any]:
-    """Attach the Sentry failure hook to every AssetsDefinition in ``assets``.
+    """Attach only the Sentry failure hook to every AssetsDefinition.
+
+    Prefer ``ol_orchestrate.lib.failures.with_failure_hooks``, which attaches
+    this alongside the hook that stops ``run_retries`` re-running a permanent
+    failure. This narrower form exists for assets that deliberately want
+    reporting without that retry behaviour.
 
     Hooks are attached to the asset rather than to a job on purpose. Job-level
     hooks only fire for runs launched from a job, which would miss everything

--- a/packages/ol-orchestrate-lib/src/ol_orchestrate/resources/oauth.py
+++ b/packages/ol-orchestrate-lib/src/ol_orchestrate/resources/oauth.py
@@ -147,7 +147,12 @@ class OAuthApiClient(ConfigurableResource):
                 error_response.response.status_code == TOO_MANY_REQUESTS
                 and rate_limit_retries > 0
             ):
-                retry_after = error_response.response.headers.get("Retry-After", 60)
+                # Default as a string: the fallback used to be the int 60, and
+                # `.isdigit()` on it raised AttributeError -- so a 429 with no
+                # Retry-After header crashed the retry path that exists to
+                # handle 429s, and the traceback named the int rather than the
+                # rate limit (DAGSTER-E).
+                retry_after = error_response.response.headers.get("Retry-After", "60")
                 delay = int(retry_after) if retry_after.isdigit() else 60
                 time.sleep(delay)
                 return self.fetch_with_auth(

--- a/packages/ol-orchestrate-lib/src/ol_orchestrate/resources/openedx.py
+++ b/packages/ol-orchestrate-lib/src/ol_orchestrate/resources/openedx.py
@@ -1,8 +1,8 @@
 # mypy: disable-error-code="call-overload,union-attr,misc"
 from collections.abc import Generator
 from contextlib import contextmanager
-from typing import Self
-from urllib.parse import parse_qs
+from typing import Any, Self
+from urllib.parse import parse_qs, urlparse
 
 from dagster import ConfigurableResource, InitResourceContext, ResourceDependency
 from httpx2 import HTTPStatusError
@@ -10,6 +10,28 @@ from pydantic import Field, PrivateAttr
 
 from ol_orchestrate.resources.oauth import OAuthApiClient
 from ol_orchestrate.resources.secrets.vault import Vault
+
+
+def next_page_params(next_page: Any) -> dict[str, list[str]]:
+    """Extract the query parameters from a paginated API's ``next`` URL.
+
+    Typed ``Any`` because it is handed a value straight out of a JSON body, and
+    ``fetch_with_auth`` is declared as returning a union that keeps mypy from
+    narrowing it. ``urlparse`` accepts anything str-like and a non-string here
+    would be a server contract change, not something to branch on.
+
+    ``next`` is an absolute URL, and ``parse_qs`` applied to one of those parses
+    the whole thing as a single ``key=value`` pair: everything up to the first
+    ``=`` becomes the key. So ``https://host/courses/?page=2`` yielded
+    ``{"https://host/courses/?page": ["2"]}``, and that key was then sent as a
+    query parameter *name*.
+
+    Each page compounded it, since the server echoed the mangled parameters back
+    into the next ``next``, until the request URL was the base URL nested inside
+    itself twenty-five times over and the API answered 429 (DAGSTER-E). Parsing
+    only the query component is the fix.
+    """
+    return parse_qs(urlparse(next_page).query)
 
 
 class OpenEdxApiClient(OAuthApiClient):
@@ -37,7 +59,9 @@ class OpenEdxApiClient(OAuthApiClient):
         yield course_data
         while next_page:
             response_data = self.fetch_with_auth(
-                request_url, page_size=page_size, extra_params=parse_qs(next_page)
+                request_url,
+                page_size=page_size,
+                extra_params=next_page_params(next_page),
             )
             next_page = response_data["pagination"].get("next")
             yield response_data["results"]
@@ -134,7 +158,7 @@ class OpenEdxApiClient(OAuthApiClient):
         yield count, results
         while next_page:
             response_data = self.fetch_with_auth(
-                request_url, extra_params=parse_qs(next_page)
+                request_url, extra_params=next_page_params(next_page)
             )
             next_page = response_data["next"]
             yield response_data["results"]
@@ -154,7 +178,7 @@ class OpenEdxApiClient(OAuthApiClient):
         yield count, results
         while next_page:
             response_data = self.fetch_with_auth(
-                course_catalog_url, extra_params=parse_qs(next_page)
+                course_catalog_url, extra_params=next_page_params(next_page)
             )
             next_page = response_data["next"]
             yield response_data["results"]

--- a/packages/ol-orchestrate-lib/tests/io_managers/test_filepath.py
+++ b/packages/ol-orchestrate-lib/tests/io_managers/test_filepath.py
@@ -1,0 +1,103 @@
+"""Tests for FileObjectIOManager.load_input.
+
+The manager's job is to turn a materialization record into a path a downstream
+step can open. The record is a claim about the object store, and these pin what
+happens when the claim is wrong -- which is the whole of Group A: one S3 key
+that was recorded but never present, re-run ~368,000 times in fourteen days
+because every attempt failed somewhere downstream of here.
+"""
+
+from pathlib import Path
+
+import pytest
+from dagster import AssetKey, MetadataValue
+from ol_orchestrate.io_managers.filepath import (
+    FileObjectIOManager,
+    UpstreamObjectUnavailable,
+)
+
+ASSET_KEY = AssetKey(["edxorg", "raw_data", "course_xml"])
+PARTITION = "course-v1:MITx+6.002x+2T2024"
+
+
+class FakeMaterialization:
+    def __init__(self, metadata) -> None:
+        self.metadata = metadata
+
+
+class FakeRecord:
+    def __init__(self, metadata) -> None:
+        self.asset_materialization = FakeMaterialization(metadata)
+
+
+class FakeInstance:
+    def __init__(self, records) -> None:
+        self._records = records
+
+    def get_event_records(self, event_records_filter, limit):  # noqa: ARG002
+        return self._records
+
+
+class FakeInputContext:
+    """The three attributes load_input reads, and nothing else."""
+
+    def __init__(self, records) -> None:
+        self.instance = FakeInstance(records)
+        self.asset_key = ASSET_KEY
+        self.partition_key = PARTITION
+
+
+def context_for(metadata) -> FakeInputContext:
+    return FakeInputContext([FakeRecord(metadata)])
+
+
+def test_an_existing_object_resolves_to_its_path(tmp_path: Path) -> None:
+    """The happy path: a recorded path whose object is there comes back."""
+    archive = tmp_path / "course.tar.gz"
+    archive.write_bytes(b"course")
+    context = context_for({"path": MetadataValue.path(f"file://{archive}")})
+
+    resolved = FileObjectIOManager().load_input(context)
+
+    assert str(resolved) == f"file://{archive}"
+    assert resolved.read_bytes() == b"course"
+
+
+def test_a_missing_object_fails_permanently_and_names_the_key(
+    tmp_path: Path,
+) -> None:
+    """The Group A failure: a recorded path pointing at nothing.
+
+    Handing this path back left the NoSuchKey to surface deep inside whichever
+    library opened it, with nothing in the error saying which object was gone.
+    """
+    missing = tmp_path / "never-written.tar.gz"
+    context = context_for({"path": MetadataValue.path(f"file://{missing}")})
+
+    with pytest.raises(UpstreamObjectUnavailable) as raised:
+        FileObjectIOManager().load_input(context)
+
+    assert str(missing) in raised.value.description
+    assert raised.value.allow_retries is False
+
+
+def test_a_materialization_without_path_metadata_fails_permanently() -> None:
+    """DAGSTER-1 and DAGSTER-2: KeyError: 'path' out of a bare dict lookup."""
+    context = context_for({"size": MetadataValue.int(0)})
+
+    with pytest.raises(UpstreamObjectUnavailable) as raised:
+        FileObjectIOManager().load_input(context)
+
+    assert "path" in raised.value.description
+    assert raised.value.allow_retries is False
+
+
+def test_no_materialization_at_all_fails_permanently() -> None:
+    """An IndexError off ``[0]`` said nothing about the missing upstream."""
+    context = FakeInputContext([])
+
+    with pytest.raises(UpstreamObjectUnavailable) as raised:
+        FileObjectIOManager().load_input(context)
+
+    assert ASSET_KEY.to_user_string() in raised.value.description
+    assert raised.value.allow_retries is False

--- a/packages/ol-orchestrate-lib/tests/lib/test_automation_policies.py
+++ b/packages/ol-orchestrate-lib/tests/lib/test_automation_policies.py
@@ -214,11 +214,34 @@ def test_update_is_retried_after_a_failed_run(harness, behaviour) -> None:
     harness.execute_downstream()
 
     assert harness.tick() == [PARTITION]
-    assert harness.tick() == [PARTITION]
+
+
+def test_the_failure_retry_is_one_run_not_a_treadmill(harness, behaviour) -> None:
+    """A failure that keeps failing must stop asking.
+
+    execution_failed is level-triggered, so used bare it stays true for as long
+    as the latest execution is a failure -- a partition that can never succeed
+    is re-requested on every tick forever, and run_retries multiplies each
+    request. That is the mechanism behind ~368,000 failed runs from one asset in
+    fourteen days. .newly_true() spends the failure on a single re-request.
+    """
+    harness.reach_steady_state(behaviour)
+    harness.observe("v2")
+    harness.tick()
+
+    behaviour.mode = DownstreamBehaviour.FAIL
+    harness.execute_downstream()
+    assert harness.tick() == [PARTITION], "one retry for the failure"
+
+    assert harness.tick() == [], "and not a second one for the same failure"
+
+    harness.execute_downstream()
+    assert harness.tick() == [], "nor for the retry that failed the same way"
+    assert harness.tick() == []
 
 
 def test_retrying_stops_once_a_run_succeeds(harness, behaviour) -> None:
-    """The retry is level-triggered, so a success clears it."""
+    """A success clears the failure, so nothing is outstanding."""
     harness.reach_steady_state(behaviour)
     harness.observe("v2")
     harness.tick()
@@ -230,6 +253,31 @@ def test_retrying_stops_once_a_run_succeeds(harness, behaviour) -> None:
     harness.execute_downstream()
 
     assert harness.tick() == []
+
+
+def test_a_later_failure_gets_its_own_retry(harness, behaviour) -> None:
+    """Bounding the retry must not spend it permanently.
+
+    execution_failed falls back to false when a run succeeds, so the next
+    genuine failure is a fresh edge and earns its own re-request. Without that
+    the bound would silently downgrade to "one retry per asset, ever".
+    """
+    harness.reach_steady_state(behaviour)
+    harness.observe("v2")
+    harness.tick()
+    behaviour.mode = DownstreamBehaviour.FAIL
+    harness.execute_downstream()
+    assert harness.tick() == [PARTITION]
+    behaviour.mode = DownstreamBehaviour.SUCCEED
+    harness.execute_downstream()
+    assert harness.tick() == []
+
+    harness.observe("v3")
+    assert harness.tick() == [PARTITION]
+    behaviour.mode = DownstreamBehaviour.FAIL
+    harness.execute_downstream()
+
+    assert harness.tick() == [PARTITION]
 
 
 def test_update_survives_a_run_that_was_already_in_flight(harness, behaviour) -> None:

--- a/packages/ol-orchestrate-lib/tests/lib/test_failures.py
+++ b/packages/ol-orchestrate-lib/tests/lib/test_failures.py
@@ -1,0 +1,130 @@
+"""Tests for ol_orchestrate.lib.failures.
+
+The thing under test is not the exception classes, it is whether calling
+something "permanent" actually stops it being re-run. `Failure(allow_retries=
+False)` binds only an op's RetryPolicy; the run-level auto-reexecution daemon
+reads run tags and never looks at the exception. So these drive real runs and
+assert on the tag the daemon reads.
+"""
+
+import dagster as dg
+import pytest
+from dagster import AssetSpec, Failure, asset
+from ol_orchestrate.lib.failures import (
+    RETRY_ON_ASSET_OR_OP_FAILURE_TAG,
+    PermanentFailure,
+    permanent_failure,
+    with_failure_hooks,
+)
+from ol_orchestrate.lib.http_errors import PermanentHTTPFailure, TransientHTTPFailure
+
+
+def test_a_permanent_failure_refuses_op_level_retries() -> None:
+    failure = permanent_failure("the course is gone")
+
+    assert failure.allow_retries is False
+    assert failure.metadata["retryable"].value is False
+
+
+def test_permanent_http_failure_is_a_permanent_failure() -> None:
+    """Otherwise http_failure's classification never reaches the retry hook."""
+    assert issubclass(PermanentHTTPFailure, PermanentFailure)
+
+
+def test_a_transient_http_failure_is_not_permanent() -> None:
+    """A 502 must stay retryable -- the hook keys off the class."""
+    assert not issubclass(TransientHTTPFailure, PermanentFailure)
+
+
+def _run_failing_asset(exception: BaseException) -> dg.DagsterInstance:
+    """Materialize an asset that raises ``exception``, hooks attached."""
+
+    @asset(name="doomed")
+    def doomed() -> None:
+        raise exception
+
+    (hooked,) = with_failure_hooks([doomed])
+    instance = dg.DagsterInstance.ephemeral()
+    dg.materialize([hooked], instance=instance, raise_on_error=False)
+    return instance
+
+
+def _tags_of_the_only_run(instance: dg.DagsterInstance) -> dict[str, str]:
+    (run,) = instance.get_runs()
+    return dict(run.tags)
+
+
+def test_a_permanent_failure_stops_run_retries() -> None:
+    """The whole point of the task.
+
+    Dagster's auto-reexecution daemon decides purely from run status and the
+    dagster/retry_on_asset_or_op_failure tag -- it never inspects the exception.
+    A Learn API 405 was correctly classified as unretryable and then retried
+    5,363 times over six days because nothing wrote that tag.
+    """
+    instance = _run_failing_asset(permanent_failure("the endpoint is gone"))
+
+    tags = _tags_of_the_only_run(instance)
+    assert tags[RETRY_ON_ASSET_OR_OP_FAILURE_TAG] == "false"
+
+
+def test_a_permanent_http_failure_stops_run_retries() -> None:
+    """The subclass has to carry the behaviour, not just the name."""
+    instance = _run_failing_asset(
+        PermanentHTTPFailure(description="HTTP 405", allow_retries=False)
+    )
+
+    assert _tags_of_the_only_run(instance)[RETRY_ON_ASSET_OR_OP_FAILURE_TAG] == "false"
+
+
+@pytest.mark.parametrize(
+    "exception",
+    [
+        Failure(description="a plain failure"),
+        TransientHTTPFailure(description="HTTP 502"),
+        RuntimeError("something transient"),
+    ],
+    ids=["failure", "transient_http", "runtime_error"],
+)
+def test_a_failure_that_is_not_permanent_leaves_run_retries_alone(
+    exception: BaseException,
+) -> None:
+    """Over-tagging would silently disable retries for every ordinary failure."""
+    instance = _run_failing_asset(exception)
+
+    assert RETRY_ON_ASSET_OR_OP_FAILURE_TAG not in _tags_of_the_only_run(instance)
+
+
+def test_a_successful_run_is_not_tagged() -> None:
+    @asset(name="calm")
+    def calm() -> int:
+        return 1
+
+    (hooked,) = with_failure_hooks([calm])
+    instance = dg.DagsterInstance.ephemeral()
+    result = dg.materialize([hooked], instance=instance)
+
+    assert result.success
+    assert RETRY_ON_ASSET_OR_OP_FAILURE_TAG not in _tags_of_the_only_run(instance)
+
+
+def test_with_failure_hooks_attaches_both_hooks() -> None:
+    @asset
+    def some_asset() -> int:
+        return 1
+
+    (hooked,) = with_failure_hooks([some_asset])
+
+    assert {hook.name for hook in hooked.hook_defs} == {
+        "capture_exception_to_sentry",
+        "stop_run_retries",
+    }
+
+
+def test_with_failure_hooks_passes_through_non_assets_definitions() -> None:
+    """AssetSpec has no ops to hook and must survive untouched."""
+    spec = AssetSpec("an_external_asset")
+
+    (passed_through,) = with_failure_hooks([spec])
+
+    assert passed_through is spec

--- a/packages/ol-orchestrate-lib/tests/lib/test_iceberg_maintenance.py
+++ b/packages/ol-orchestrate-lib/tests/lib/test_iceberg_maintenance.py
@@ -5,10 +5,14 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
+import pytest
 from ol_orchestrate.lib.iceberg_maintenance import (
     RAW_LAYER_GROUP_CONFIGS,
     load_maintenance_configs_from_manifest,
+    non_dbt_singleton_tables,
     raw_config_for_table,
+    scope_schema_to_env,
+    warehouse_env_for,
 )
 
 # ── Helpers ───────────────────────────────────────────────────────────────────
@@ -84,7 +88,9 @@ class TestLoadMaintenanceConfigsFromManifest:
         manifest_path = tmp_path / "manifest.json"
         manifest_path.write_text(json.dumps(manifest))
 
-        configs = load_maintenance_configs_from_manifest(manifest_path)
+        configs = load_maintenance_configs_from_manifest(
+            manifest_path, warehouse_env="production"
+        )
 
         assert len(configs) == 1
         cfg = configs[0]
@@ -96,10 +102,10 @@ class TestLoadMaintenanceConfigsFromManifest:
         assert cfg.analyze_after_every_n_runs == 7
         assert cfg.asset_key == ["mart", "mart__revenue"]
 
-    def test_schema_name_from_node_schema_not_config_schema(
+    def test_layer_comes_from_node_schema_not_config_schema(
         self, tmp_path: Path
     ) -> None:
-        """node['schema'] is used directly; config.schema is not reconstructed."""
+        """The layer is taken from node['schema'], not rebuilt from config.schema."""
         manifest = _make_manifest(
             {
                 "model.proj.dim_user": _model_node(
@@ -115,10 +121,40 @@ class TestLoadMaintenanceConfigsFromManifest:
         manifest_path = tmp_path / "manifest.json"
         manifest_path.write_text(json.dumps(manifest))
 
-        configs = load_maintenance_configs_from_manifest(manifest_path)
+        configs = load_maintenance_configs_from_manifest(
+            manifest_path, warehouse_env="production"
+        )
 
         assert len(configs) == 1
         assert configs[0].schema_name == "ol_warehouse_production_dimensional"
+
+    def test_a_qa_load_never_returns_a_production_schema(self, tmp_path: Path) -> None:
+        """The DAGSTER-R bug: one manifest, compiled against production, shipped
+        to every environment.
+
+        QA read ``ol_warehouse_production_intermediate`` straight out of the
+        manifest and issued OPTIMIZE and ANALYZE against it. The only thing that
+        stopped it was data-lake-query-engine-role-qa lacking glue:GetTable --
+        an IAM denial standing in for a scoping rule that was never written.
+        """
+        manifest = _make_manifest(
+            {
+                "model.proj.int_enrollments": _model_node(
+                    "model.proj.int_enrollments",
+                    schema="ol_warehouse_production_intermediate",
+                    config_schema="intermediate",
+                    iceberg_meta=_iceberg_meta(),
+                )
+            }
+        )
+        manifest_path = tmp_path / "manifest.json"
+        manifest_path.write_text(json.dumps(manifest))
+
+        configs = load_maintenance_configs_from_manifest(
+            manifest_path, warehouse_env="qa"
+        )
+
+        assert configs[0].schema_name == "ol_warehouse_qa_intermediate"
 
     def test_model_without_iceberg_meta_is_skipped(self, tmp_path: Path) -> None:
         """Models without iceberg_maintenance in compiled meta are excluded."""
@@ -135,7 +171,9 @@ class TestLoadMaintenanceConfigsFromManifest:
         manifest_path = tmp_path / "manifest.json"
         manifest_path.write_text(json.dumps(manifest))
 
-        configs = load_maintenance_configs_from_manifest(manifest_path)
+        configs = load_maintenance_configs_from_manifest(
+            manifest_path, warehouse_env="production"
+        )
 
         assert configs == []
 
@@ -152,7 +190,9 @@ class TestLoadMaintenanceConfigsFromManifest:
         manifest_path = tmp_path / "manifest.json"
         manifest_path.write_text(json.dumps(manifest))
 
-        configs = load_maintenance_configs_from_manifest(manifest_path)
+        configs = load_maintenance_configs_from_manifest(
+            manifest_path, warehouse_env="production"
+        )
 
         assert configs == []
 
@@ -175,7 +215,9 @@ class TestLoadMaintenanceConfigsFromManifest:
         manifest_path = tmp_path / "manifest.json"
         manifest_path.write_text(json.dumps(manifest))
 
-        configs = load_maintenance_configs_from_manifest(manifest_path)
+        configs = load_maintenance_configs_from_manifest(
+            manifest_path, warehouse_env="production"
+        )
 
         assert configs == []
 
@@ -197,7 +239,9 @@ class TestLoadMaintenanceConfigsFromManifest:
         manifest_path = tmp_path / "manifest.json"
         manifest_path.write_text(json.dumps(manifest))
 
-        configs = load_maintenance_configs_from_manifest(manifest_path)
+        configs = load_maintenance_configs_from_manifest(
+            manifest_path, warehouse_env="production"
+        )
 
         assert len(configs) == 1
         assert configs[0].materialized == "incremental"
@@ -229,7 +273,9 @@ class TestLoadMaintenanceConfigsFromManifest:
         manifest_path = tmp_path / "manifest.json"
         manifest_path.write_text(json.dumps(manifest))
 
-        configs = load_maintenance_configs_from_manifest(manifest_path)
+        configs = load_maintenance_configs_from_manifest(
+            manifest_path, warehouse_env="production"
+        )
 
         assert configs == []
 
@@ -252,7 +298,9 @@ class TestLoadMaintenanceConfigsFromManifest:
         manifest_path = tmp_path / "manifest.json"
         manifest_path.write_text(json.dumps(manifest))
 
-        configs = load_maintenance_configs_from_manifest(manifest_path)
+        configs = load_maintenance_configs_from_manifest(
+            manifest_path, warehouse_env="production"
+        )
 
         assert configs[0].asset_key == ["mart", "fct_enrollments"]
 
@@ -306,3 +354,56 @@ class TestRawConfigForTable:
         default = RAW_LAYER_GROUP_CONFIGS["_default"]
         assert default.snapshot_retention_days == 7
         assert default.orphan_retention_days == 7
+
+
+# ── Environment scoping ───────────────────────────────────────────────────────
+
+
+class TestEnvironmentScoping:
+    """Which warehouse a given Dagster environment is allowed to touch."""
+
+    @pytest.mark.parametrize(
+        ("dagster_env", "warehouse_env"),
+        [
+            ("production", "production"),
+            ("qa", "qa"),
+            # dev targets the dev_production dbt profile, so a developer is
+            # already reading real production tables.
+            ("dev", "production"),
+            ("ci", "qa"),
+        ],
+    )
+    def test_known_environments_map_to_their_warehouse(
+        self, dagster_env: str, warehouse_env: str
+    ) -> None:
+        assert warehouse_env_for(dagster_env) == warehouse_env
+
+    def test_an_unknown_environment_falls_back_to_qa(self) -> None:
+        """A typo'd or new DAGSTER_ENV must not inherit production."""
+        assert warehouse_env_for("staging") == "qa"
+
+    @pytest.mark.parametrize(
+        ("schema", "expected"),
+        [
+            ("ol_warehouse_production_intermediate", "ol_warehouse_qa_intermediate"),
+            ("ol_warehouse_production_mart", "ol_warehouse_qa_mart"),
+            ("ol_warehouse_qa_raw", "ol_warehouse_qa_raw"),
+            # The layer keeps its own underscores.
+            ("ol_warehouse_production_raw_data", "ol_warehouse_qa_raw_data"),
+        ],
+    )
+    def test_the_env_segment_is_rewritten_and_the_layer_kept(
+        self, schema: str, expected: str
+    ) -> None:
+        assert scope_schema_to_env(schema, "qa") == expected
+
+    def test_a_schema_with_no_env_segment_is_rejected(self) -> None:
+        """Passing it through would be a silent cross-environment write."""
+        with pytest.raises(ValueError, match="ol_warehouse_<env>_<layer>"):
+            scope_schema_to_env("information_schema", "qa")
+
+    def test_singletons_are_scoped_to_the_calling_environment(self) -> None:
+        """The hand-written list hardcoded production for every environment."""
+        assert [t.schema_name for t in non_dbt_singleton_tables("qa")] == [
+            "ol_warehouse_qa_reporting"
+        ]

--- a/packages/ol-orchestrate-lib/tests/lib/test_iceberg_maintenance.py
+++ b/packages/ol-orchestrate-lib/tests/lib/test_iceberg_maintenance.py
@@ -9,6 +9,7 @@ import pytest
 from ol_orchestrate.lib.iceberg_maintenance import (
     RAW_LAYER_GROUP_CONFIGS,
     load_maintenance_configs_from_manifest,
+    maintenance_failure_threshold,
     non_dbt_singleton_tables,
     raw_config_for_table,
     scope_schema_to_env,
@@ -407,3 +408,53 @@ class TestEnvironmentScoping:
         assert [t.schema_name for t in non_dbt_singleton_tables("qa")] == [
             "ol_warehouse_qa_reporting"
         ]
+
+
+# ── Failure threshold ─────────────────────────────────────────────────────────
+
+
+class TestMaintenanceFailureThreshold:
+    """The asset's contract is "fail if more than 5% of tables failed".
+
+    Getting that boundary wrong in the tripping direction turns nightly
+    maintenance into a nightly false alarm, which is how an alerting channel
+    stops being read.
+    """
+
+    @pytest.mark.parametrize(
+        ("tables_attempted", "expected"),
+        [
+            # The two boundaries that were wrong under max(1, int(5%)): one
+            # failure in 21 is 4.8%, and exactly five in 100 is 5% -- neither is
+            # *more* than 5%.
+            (21, 2),
+            (100, 6),
+            # A single failure is over the line for any small set.
+            (1, 1),
+            (20, 2),
+            # The real fleet size.
+            (628, 32),
+        ],
+    )
+    def test_the_first_count_over_five_percent(
+        self, tables_attempted: int, expected: int
+    ) -> None:
+        assert maintenance_failure_threshold(tables_attempted) == expected
+
+    @pytest.mark.parametrize("tables_attempted", [1, 20, 21, 99, 100, 628, 1300])
+    def test_the_threshold_is_always_genuinely_over_five_percent(
+        self, tables_attempted: int
+    ) -> None:
+        """The property behind the table above, stated directly."""
+        threshold = maintenance_failure_threshold(tables_attempted)
+
+        assert threshold / tables_attempted > 0.05
+        assert (threshold - 1) / tables_attempted <= 0.05, (
+            "and it is the *first* such count"
+        )
+
+    def test_a_single_failure_never_slips_through(self) -> None:
+        """The floor of one is load-bearing: an empty run must not report a
+        threshold of zero and fail on nothing.
+        """
+        assert maintenance_failure_threshold(0) == 1

--- a/packages/ol-orchestrate-lib/tests/lib/test_sentry.py
+++ b/packages/ol-orchestrate-lib/tests/lib/test_sentry.py
@@ -8,6 +8,7 @@ import pytest
 import sentry_sdk
 from dagster import AssetSpec, Definitions, asset, materialize
 from ol_orchestrate.lib import sentry as sentry_lib
+from ol_orchestrate.lib.constants import DAGSTER_ENV
 from sentry_sdk.transport import Transport
 
 # ── Helpers ───────────────────────────────────────────────────────────────────
@@ -158,10 +159,43 @@ def test_failing_asset_reports_real_exception_to_sentry(
     assert event["tags"]["captured_by"] == "hook"
     assert event["tags"]["dagster_step"] == "exploding_asset"
     assert event["fingerprint"] == [
-        job.name,
+        DAGSTER_ENV,
+        # No init_sentry() in this fixture, so no location has been recorded.
+        "unknown",
         "exploding_asset",
         "ValueError",
     ]
+    assert job.name not in event["fingerprint"], (
+        "job_name describes the launch path, not the defect"
+    )
+
+
+def test_qa_and_production_do_not_share_an_issue(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """One Sentry project holds both, so the environment has to group them apart.
+
+    Without it a QA-only defect and a production outage merge into one issue and
+    the list cannot tell you which you are looking at.
+    """
+    production = sentry_lib.failure_fingerprint("lakehouse", "dbt_build", "Failure")
+    monkeypatch.setattr(sentry_lib, "DAGSTER_ENV", "qa")
+    qa = sentry_lib.failure_fingerprint("lakehouse", "dbt_build", "Failure")
+
+    assert production != qa
+
+
+def test_a_terminated_run_worker_is_not_reported() -> None:
+    """SIGTERM during a deploy or an eviction is not a defect (DAGSTER-1R/1S/1T)."""
+    event = {"exception": {"values": [{"type": "DagsterExecutionInterruptedError"}]}}
+
+    assert sentry_lib.drop_interruptions(event, {}) is None
+
+
+def test_a_real_exception_still_gets_through() -> None:
+    event = {"exception": {"values": [{"type": "ValueError"}]}}
+
+    assert sentry_lib.drop_interruptions(event, {}) is event
 
 
 def test_successful_asset_reports_nothing(

--- a/packages/ol-orchestrate-lib/tests/lib/test_sentry.py
+++ b/packages/ol-orchestrate-lib/tests/lib/test_sentry.py
@@ -178,10 +178,16 @@ def test_qa_and_production_do_not_share_an_issue(
     Without it a QA-only defect and a production outage merge into one issue and
     the list cannot tell you which you are looking at.
     """
+    # Both environments set explicitly. Letting the first one inherit the
+    # process's DAGSTER_ENV makes the test a tautology when that is `ci` or
+    # `dev`, and an outright failure when it is `qa`.
+    monkeypatch.setattr(sentry_lib, "DAGSTER_ENV", "production")
     production = sentry_lib.failure_fingerprint("lakehouse", "dbt_build", "Failure")
     monkeypatch.setattr(sentry_lib, "DAGSTER_ENV", "qa")
     qa = sentry_lib.failure_fingerprint("lakehouse", "dbt_build", "Failure")
 
+    assert production[0] == "production"
+    assert qa[0] == "qa"
     assert production != qa
 
 

--- a/packages/ol-orchestrate-lib/tests/resources/test_oauth.py
+++ b/packages/ol-orchestrate-lib/tests/resources/test_oauth.py
@@ -142,3 +142,76 @@ def test_username_lookup_honours_the_configured_token_type() -> None:
     http_client = client._http_client
     assert http_client is not None
     assert http_client.headers[0]["Authorization"] == "Bearer token"
+
+
+class _ThrottlingClientWithoutRetryAfter(_ThrottlingClient):
+    """Answers 429 with no Retry-After header at all.
+
+    Which is the ordinary case: the header is optional, and the edX courses API
+    frequently omits it.
+    """
+
+    def get(self, *args, **kwargs) -> httpx.Response:  # noqa: ARG002
+        self.gets += 1
+        request = httpx.Request("GET", "https://lms.example.com/api/thing/")
+        return httpx.Response(429, request=request)
+
+
+def test_a_429_without_retry_after_still_retries(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """DAGSTER-E: the retry path for 429s crashed on a 429.
+
+    The header default was the int 60, so ``retry_after.isdigit()`` raised
+    AttributeError -- and the traceback then named an int rather than the rate
+    limit that actually caused it.
+    """
+    slept: list[float] = []
+    monkeypatch.setattr(
+        "ol_orchestrate.resources.oauth.time.sleep",
+        slept.append,
+    )
+    client = _build_client()
+    throttling = _ThrottlingClientWithoutRetryAfter()
+    client._http_client = throttling
+    client._cached_username = "svc-account"
+
+    with pytest.raises(httpx.HTTPStatusError):
+        client.fetch_with_auth(
+            "https://lms.example.com/api/thing/", rate_limit_retries=2
+        )
+
+    assert throttling.gets == 3, "the retry path ran rather than raising AttributeError"
+    assert slept == [60, 60], "and fell back to the documented 60 second wait"
+
+
+def test_a_non_numeric_retry_after_falls_back(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Retry-After may be an HTTP-date rather than a delta-seconds count."""
+    slept: list[float] = []
+    monkeypatch.setattr(
+        "ol_orchestrate.resources.oauth.time.sleep",
+        slept.append,
+    )
+
+    class _HttpDateRetryAfter(_ThrottlingClient):
+        def get(self, *args, **kwargs) -> httpx.Response:  # noqa: ARG002
+            self.gets += 1
+            request = httpx.Request("GET", "https://lms.example.com/api/thing/")
+            return httpx.Response(
+                429,
+                request=request,
+                headers={"Retry-After": "Wed, 21 Oct 2026 07:28:00 GMT"},
+            )
+
+    client = _build_client()
+    client._http_client = _HttpDateRetryAfter()
+    client._cached_username = "svc-account"
+
+    with pytest.raises(httpx.HTTPStatusError):
+        client.fetch_with_auth(
+            "https://lms.example.com/api/thing/", rate_limit_retries=1
+        )
+
+    assert slept == [60]

--- a/packages/ol-orchestrate-lib/tests/resources/test_openedx.py
+++ b/packages/ol-orchestrate-lib/tests/resources/test_openedx.py
@@ -1,0 +1,47 @@
+"""Tests for ol_orchestrate.resources.openedx.
+
+Focused on pagination, which is where the subtle bug was: the ``next`` URL was
+parsed as though it were a bare query string, so the whole URL became a query
+parameter *name* and each page nested it one level deeper.
+"""
+
+from ol_orchestrate.resources.openedx import next_page_params
+
+COURSES = "https://courses.learn.mit.edu/api/courses/v1/courses/"
+
+
+def test_only_the_query_component_becomes_parameters() -> None:
+    assert next_page_params(f"{COURSES}?page=2") == {"page": ["2"]}
+
+
+def test_the_url_itself_never_becomes_a_parameter_name() -> None:
+    """The DAGSTER-E mechanism.
+
+    ``parse_qs`` on a full URL takes everything before the first ``=`` as the
+    key, so this used to return
+    ``{"https://courses.learn.mit.edu/api/courses/v1/courses/?page": ["2"]}``
+    and that key was sent as a query parameter name. The server echoed the
+    mangled parameters into the next ``next``, so each page nested the base URL
+    one level deeper until the request 429'd.
+    """
+    params = next_page_params(f"{COURSES}?page=2")
+
+    assert not any(key.startswith("http") for key in params), (
+        f"a URL leaked into the parameter names: {list(params)}"
+    )
+
+
+def test_several_parameters_all_survive() -> None:
+    params = next_page_params(f"{COURSES}?page=3&page_size=100&username=svc")
+
+    assert params == {"page": ["3"], "page_size": ["100"], "username": ["svc"]}
+
+
+def test_a_next_url_with_no_query_yields_nothing() -> None:
+    """The last page can hand back a bare URL; that must not invent a filter."""
+    assert next_page_params(COURSES) == {}
+
+
+def test_a_relative_next_url_is_handled() -> None:
+    """Some DRF configurations return a path rather than an absolute URL."""
+    assert next_page_params("/api/courses/v1/courses/?page=4") == {"page": ["4"]}

--- a/src/ol_dlt/ol_dlt/sources/edxorg_s3/__init__.py
+++ b/src/ol_dlt/ol_dlt/sources/edxorg_s3/__init__.py
@@ -17,14 +17,15 @@ Run standalone:
 
 import hashlib
 import logging
-from collections.abc import Generator
+from collections.abc import Generator, Iterable, Iterator
 from typing import Any
 
 import dlt
 import pyarrow as pa
 import s3fs
 from dlt.sources import incremental
-from dlt.sources.filesystem import filesystem, read_csv_duckdb
+from dlt.sources.filesystem import FileItemDict, filesystem
+from dlt.sources.filesystem.helpers import fetch_arrow
 
 from ol_dlt import config
 
@@ -76,6 +77,60 @@ _CSV_READER_OPTIONS: dict[str, Any] = {
     # files). dbt casts downstream.
     "all_varchar": True,
 }
+
+
+class EdxorgTSVUnreadableError(Exception):
+    """DuckDB could not read one edxorg TSV, named in the message."""
+
+
+@dlt.transformer(standalone=True)
+def read_edxorg_tsv(
+    items: Iterable[FileItemDict],
+    chunk_size: int = 5000,
+    **duckdb_kwargs: Any,
+) -> Iterator[Any]:
+    """Read edxorg TSVs, naming the file when DuckDB cannot read one.
+
+    Same work as ``dlt.sources.filesystem.read_csv_duckdb`` with
+    ``use_pyarrow=True``, wrapped for two reasons.
+
+    First, diagnosability. ``duckdb.from_csv_auto`` is handed an open file
+    object, so the file it names in an error is DuckDB's internal handle --
+    ``DUCKDB_INTERNAL_OBJECTSTORE://e3d60147029d6cb5``. Eleven Sentry issues
+    (DAGSTER-1C and friends) reported a sniffing failure against a content hash
+    that maps to nothing anyone can open. The S3 URL is right here; putting it in
+    the exception is the difference between a reproducible bug and a shrug.
+
+    Second, empty files. ``from_csv_auto`` cannot infer a dialect from zero
+    bytes and fails with the same "not possible to automatically detect the CSV
+    parsing dialect" message as a genuinely malformed file. An empty export is
+    not an error -- there is simply nothing in it -- so it is skipped and logged
+    rather than failing the whole table.
+
+    Note that pinning the dialect does not remove the sniffer: DuckDB still runs
+    it to find the header and column count. The delimiter, quote and escape are
+    already pinned in ``_CSV_READER_OPTIONS`` and these failures happened anyway.
+    """
+    import duckdb  # noqa: PLC0415
+
+    for item in items:
+        if not item.get("size_in_bytes"):
+            logger.warning(
+                "Skipping empty edxorg TSV %s -- nothing to read.", item["file_url"]
+            )
+            continue
+
+        with item.open() as file_handle:
+            try:
+                file_data = duckdb.from_csv_auto(file_handle, **duckdb_kwargs)
+                batches = list(fetch_arrow(file_data, chunk_size))
+            except duckdb.Error as error:
+                msg = (
+                    f"DuckDB could not read the edxorg TSV {item['file_url']} "
+                    f"({item.get('size_in_bytes')} bytes): {error}"
+                )
+                raise EdxorgTSVUnreadableError(msg) from error
+        yield from batches
 
 
 def _make_deduplicator():  # noqa: ANN202
@@ -215,7 +270,7 @@ def edxorg_s3_source(
         # *returns* another DltResource would replace the outer resource and
         # discard its name/hints; applying hints on the pipe avoids that.
         yield (
-            (files | read_csv_duckdb(use_pyarrow=True, **_CSV_READER_OPTIONS))
+            (files | read_edxorg_tsv(**_CSV_READER_OPTIONS))
             .with_name(resource_name)
             # Drop rows whose (row_hash, extracted_course_key) was already seen
             # earlier in this run (see _make_deduplicator docstring).

--- a/src/ol_dlt/tests/sources/test_edxorg_s3.py
+++ b/src/ol_dlt/tests/sources/test_edxorg_s3.py
@@ -227,3 +227,73 @@ def test_pipeline_for_shares_destination_with_singleton_pipeline() -> None:
         == singleton.destination.config_params["bucket_url"]
     )
     assert per_table.dataset_name == singleton.dataset_name
+
+
+# ── read_edxorg_tsv ───────────────────────────────────────────────────────────
+
+
+class _FakeFileItem(dict[str, Any]):
+    """The three FileItemDict members the reader touches."""
+
+    def __init__(self, url: str, content: bytes) -> None:
+        super().__init__(
+            file_url=url, file_name=url.rsplit("/", 1)[-1], size_in_bytes=len(content)
+        )
+        self._content = content
+
+    def open(self):  # noqa: ANN201
+        return io.BytesIO(self._content)
+
+
+def _read(items: list[_FakeFileItem]) -> list[pa.Table]:
+    """Drive the reader's generator directly, past dlt's transformer wrapper."""
+    return list(
+        edxorg_s3.read_edxorg_tsv._pipe.gen(  # noqa: SLF001
+            items, **edxorg_s3._CSV_READER_OPTIONS
+        )
+    )
+
+
+def test_reader_returns_rows_for_a_well_formed_file() -> None:
+    batches = _read([_FakeFileItem("s3://bucket/clean.tsv", _CLEAN_TSV)])
+
+    rows = [row for batch in batches for row in batch.to_pylist()]
+    assert [r["id"] for r in rows] == ["1", "2"]
+
+
+def test_reader_skips_an_empty_file_instead_of_failing_the_table() -> None:
+    """from_csv_auto cannot infer a dialect from zero bytes, and reports it in
+    the same words as a genuinely malformed file.
+
+    An empty export is not an error -- there is nothing in it -- so it must not
+    take the whole table's load down with it.
+    """
+    batches = _read(
+        [
+            _FakeFileItem("s3://bucket/empty.tsv", b""),
+            _FakeFileItem("s3://bucket/clean.tsv", _CLEAN_TSV),
+        ]
+    )
+
+    rows = [row for batch in batches for row in batch.to_pylist()]
+    assert [r["id"] for r in rows] == ["1", "2"], "the readable file still loads"
+
+
+def test_reader_names_the_s3_object_it_could_not_read() -> None:
+    """DAGSTER-1C..1V reported a sniffing failure against
+    ``DUCKDB_INTERNAL_OBJECTSTORE://e3d60147029d6cb5`` -- DuckDB's handle for
+    the open file object, which maps to nothing anyone can go and look at.
+
+    Whatever the underlying cause turns out to be, the error has to say which
+    object it was or nobody can reproduce it.
+    """
+    # Two header fields, a data row with far more -- unreadable under the pinned
+    # dialect with strict mode off and null padding deliberately unset.
+    unreadable = b'id\tname\n1\t"unterminated quote\n'
+
+    with pytest.raises(edxorg_s3.EdxorgTSVUnreadableError) as raised:
+        _read(
+            [_FakeFileItem("s3://bucket/db_table/auth_user/prod/x/bad.tsv", unreadable)]
+        )
+
+    assert "s3://bucket/db_table/auth_user/prod/x/bad.tsv" in str(raised.value)


### PR DESCRIPTION
## What are the relevant tickets?

Advances `wp-dagster-failure-semantics-sentry-signal-quality-f52032`. Closes six tasks:

- `tk-bound-the-failure-retry-term-in-upstream-or-code-3097b0` (p0) — M1
- `tk-give-permanent-failure-teeth-at-the-run-level-5454f8` (p0) — M2
- `tk-make-fileobjectiomanager-verify-an-object-exists-42bee5` (p1)
- `tk-scope-iceberg-maintenance-to-dagster-env-qa-is-t-5ba48f` (p1)
- `tk-have-the-airbyte-assets-check-for-an-in-flight-s-3ce4c0` (p2)
- `tk-make-the-sentry-pipeline-report-defects-not-laun-985529` (p1, 3 of 4 parts — see below)

Fixes DAGSTER-E. Partially addresses DAGSTER-1C..1V, DAGSTER-6, DAGSTER-13, DAGSTER-R, and the ten Airbyte "already running" issues.

## Description (What does it do?)

A permanent failure had no way to stop being re-run, and the reporting pipeline could not tell you that was happening. ~368,000 failed runs from one asset in fourteen days, reported as 27.9k Slack messages nobody could read.

### M1 — unbounded failure retry

`upstream_or_code_changes()` ORed in a bare `AutomationCondition.execution_failed()`. That term is level-triggered — true for as long as the latest execution is a failure — so a partition that can never succeed was re-requested on every sensor tick forever, and `run_retries.max_retries: 3` multiplied each request by four. `.newly_true()` spends one failure on one re-request: the level never drops back to false while the retry is in flight or after it also fails, and a success clears it so the next genuine failure earns its own. One function, every code location — this caps Group A (395,895 events) and Group B (8,180) together.

I checked `.since(newly_requested())` first, which the task suggested: it does not bound anything. `SinceCondition` computes `previous_true ∪ trigger_true − reset_true`, so a level-triggered trigger re-adds itself every tick after the reset clears. The edge has to come first.

### M2 — "permanent" never reached the rerun layer

Dagster has three independent retry mechanisms and `Failure(allow_retries=False)` speaks to exactly one. An op's `RetryPolicy` honours it; the run-level auto-reexecution daemon decides purely from run status and the `dagster/retry_on_asset_or_op_failure` tag and never inspects the exception; an `AutomationCondition` sees only that the latest execution failed. `http_errors.py` documented this gap and nothing closed it, so the Learn API 405 was correctly classified as unretryable and then retried 5,363 times over six days.

New `ol_orchestrate.lib.failures` carries a `PermanentFailure` base and a `stop_run_retries` failure hook that stamps the tag the daemon reads. `PermanentHTTPFailure` and `UpstreamObjectUnavailable` inherit from it. `with_sentry_hooks` is superseded by `with_failure_hooks`, which attaches both; all eight code locations move over and were import-checked individually.

A hook rather than a call at each raise site: the tag has to be set for every permanent failure or the guarantee is only as good as whoever remembered, and the raise sites do not all have an op context to hand.

**The third gap stays open by construction**, and the module docstring says so. Declarative automation exposes no primitive for "the failure was permanent" — `execution_failed()` is the only failure signal and it is untyped. The M1 bound is what covers it: a permanent failure now costs two runs rather than an unbounded stream.

Bare `raise Exception` sites migrated, which were never classified at all:

- edxorg Learn API webhook → `http_failure()`, so a 405 is permanent and a 502 still retries; the course id moves out of the message into metadata.
- openedx Studio export reporting `Failed` → `permanent_failure()` (DAGSTER-6, 2,587 events).
- canvas export in `failed`/`error` state → `permanent_failure()`.
- canvas export timeout → a plain `Failure`, **deliberately not permanent**. A slow export can genuinely succeed later; DAGSTER-7's problem was that the retry was unbounded, not that it retried. Claiming permanence here would suppress a real retry.
- lakehouse snapshot repair → `Failure` with the table list in metadata rather than the message, where it was making each occurrence its own issue title.

### Group A's actual defect

`FileObjectIOManager.load_input` trusted the materialization record unconditionally: it indexed `[0]` into the event records, read `metadata["path"]` with no guard, and handed back a path to an object that was not in S3. The `NoSuchKey` then surfaced deep inside whatever library opened it, naming nothing. It now checks the record exists, carries `path` metadata, and points at something present, and raises a non-retryable `UpstreamObjectUnavailable` naming the missing key.

### DAGSTER-R — Iceberg maintenance scoping

`load_maintenance_configs_from_manifest` read `node["schema"]` out of a manifest compiled against production and baked into an image that ships to every environment, so QA was issuing `OPTIMIZE`/`ANALYZE` against `ol_warehouse_production_intermediate`. The only thing stopping it was `data-lake-query-engine-role-qa` lacking `glue:GetTable`. Schemas are now re-pointed at `DAGSTER_ENV`'s warehouse, and a schema that is not `ol_warehouse_<env>_<layer>` raises rather than passing through. The raw-layer map and the hand-written singleton list both moved onto the same mapping so they cannot drift.

To be fair to the IAM policy: that denial is deliberate, not accidental. Both identities that reach Glue — the Starburst cross-account role and the Dagster pod IRSA role — scope resources to `arn:aws:glue:*:*:database/*{env_suffix}*` in Pulumi, and have since 2022. IAM is a working backstop here. It is still the wrong layer to be relying on, because it tells you "access denied" rather than "this should never have been attempted", and because the pattern is a substring match (see below).

Also fixed the arithmetically impossible threshold message — `failures` counted operations while `tables_processed` counted tables, producing "failed for 1256/628 tables". Both sides now count tables, and the denominator is tables *attempted* so a total outage does not divide by zero and silently never trip.

### M3 — the reporting pipeline

The Sentry fingerprint led with `job_name`, which describes how a run was launched rather than what broke: DAGSTER-2C and DAGSTER-29 were one OVS webhook failure split only because one run came from `__ASSET_JOB` and the other from `ovs_videos_webhook_job`. It is now `[environment, code_location, step_key, exception_type]`, built by one shared `failure_fingerprint()` so the in-process hook and the run failure sensor cannot drift apart. The environment leads because QA and production share a Sentry project. The sensor was also tagging every run's code location as `"data_platform"` regardless of origin; it now reads the run's actual origin.

Slack gets one message per distinct failure per 30 minutes, carrying a count of what it swallowed. Sentry still gets every event — it aggregates, and the count there is the signal. Rate-limit state lives in the run storage KV table because `RunFailureSensorContext` is invoked once per failed run and exposes no cursor.

`DagsterExecutionInterruptedError` and `KeyboardInterrupt` are dropped in a `before_send` (DAGSTER-1R/1S/1T).

### Two defects that turned out to be different from their descriptions

**Airbyte** — the cause was not a missing in-flight check. `dagster_airbyte.sync_and_poll` already checks, and has a `poll_previous_running_sync` flag to attach to a running sync instead of raising. The real bug is that `AirbyteOSSWorkspace.get_client()` re-implements the base class's constructor call with an explicit argument list, and four settings were missing from it: `poll_interval`, `poll_timeout`, `cancel_on_termination` and `poll_previous_running_sync` (plus `workspace_id`). Configuring any of them on the workspace set a field the client never read, so every sync ran on library defaults — and the flag defaults to False, hence ten connections raising "already running". Fixed by passing them through and turning the flag on.

**edxorg CSV** — the dialect is already pinned; that is not the fix. `delimiter`, `quotechar`, `escapechar`, `strict_mode` and `all_varchar` all landed in #2492 on 2026-07-30. The DAGSTER-1C..1V events are 2026-08-13 to 08-16 on release 2b127d70, and the Sentry error text shows the pinned dialect in use (`Delimiter Candidates: '\t'`, `Quote/Escape Candidates: ['"','"']`). Pinning the dialect does not remove the sniffer — DuckDB still runs it to find the header and column count.

What actually blocks diagnosis is that `from_csv_auto` is handed an open file object, so the file it names is DuckDB's internal handle, `DUCKDB_INTERNAL_OBJECTSTORE://e3d60147029d6cb5`, which maps to nothing anyone can open. `read_edxorg_tsv` does the same work wrapped to put the S3 URL in the exception, and to skip zero-byte files, which fail the sniffer with the identical message despite not being errors. **This does not close the underlying bug** — it makes the next occurrence reproducible.

### DAGSTER-E — two bugs in one traceback

The reported one: `headers.get("Retry-After", 60)` defaults to an *int*, so `retry_after.isdigit()` raised `AttributeError` and the 429 retry path crashed on a 429.

The one underneath it, visible in the URL that got rate limited: `parse_qs` was applied to the API's absolute `next` URL. `parse_qs` on a full URL takes everything up to the first `=` as a key, so `https://host/courses/?page=2` parsed to `{"https://host/courses/?page": ["2"]}` — and that key was sent as a query parameter *name*. The server echoed the mangled parameters back into the next `next`, so each page nested the base URL one level deeper; by page 27 the request contained its own base URL twenty-five times over and edX answered 429. That was not the rate limit doing its job, it was one client hammering an endpoint with a URL that grew every round. Three pagination loops had it.

## Deploy note — read before rolling this out

`NewlyTrueCondition` diffs the child's true subset against the previous tick's subset held in its cursor. On the first evaluation after deploy there is no cursor, so **every currently-failed partition reads as newly true and fires one request each, on one tick**. Against the ~368k standing failed partitions that is the exact stampede this change exists to prevent, once.

`initial_evaluation()` does not guard against this — I checked the implementation; it keys off whether a previous requested subset exists for the root key (and off `PartitionsDefinition` changes), not off the condition tree changing, so it is already false for any asset evaluated before. There is no in-condition defence; the constraint is a deployment one.

Land the edxorg backfill stop and clear the failed set first, or roll this out one code location at a time starting with small partition counts. This is documented in the function's docstring as well.

## How can this be tested?

All green: `packages/ol-orchestrate-lib` 156 passed / 80 skipped, `data_platform` 52, `lakehouse` 78, `openedx` 25, `data_loading` 18, `ol_dlt` 90. `pre-commit run` clean including mypy. All eight code locations import-checked individually after the `with_failure_hooks` migration.

New coverage worth looking at specifically:

- `test_the_failure_retry_is_one_run_not_a_treadmill` and `test_a_later_failure_gets_its_own_retry` — the bound holds *and* does not degrade to "one retry per asset, ever". The existing `test_update_is_retried_after_a_failed_run` (the mitodl/hq#12739 regression) still passes, so the property the docstring was protecting survives.
- `tests/lib/test_failures.py` — drives real runs and asserts on the run tag the daemon reads, including that plain `Failure`, `TransientHTTPFailure` and `RuntimeError` are **not** tagged. Over-tagging would silently disable retries for every ordinary failure.
- `tests/io_managers/test_filepath.py` — all three IO manager failure modes against a real local filesystem.
- `test_a_qa_load_never_returns_a_production_schema` — the DAGSTER-R bug directly.
- `lakehouse_tests/test_airbyte_resource.py` — pins every workspace setting individually, so the next edit to that argument list cannot quietly drop another.
- `test_sensor_fingerprint_matches_a_real_dagster_step_failure` still executes a real job and compares against what the actual hook records, so the two paths cannot drift silently.

## Additional context

Left for follow-up, deliberately, and **not** closed:

- **Identifiers in exception messages** (M3 part 4). Partially done — the edxorg course id, the Canvas course id, the Studio status map and the lakehouse table list all moved to metadata — but `load_id=...`, video ids and Airbyte connection ids remain in message text elsewhere.
- **Why the sensor reported only 27.9k of 368k failures.** Retry-dedup accounts for at most 75%; the sensor appears to be falling behind its own tick. Untouched.
- **`RetryPolicy` on the DB/HTTP-touching assets.** The `before_send` here is deliberately narrow: it drops terminated workers only. Connection-class transients should be *retried*, not filtered — a step failure hook fires only once a `RetryPolicy` is exhausted, so a connection error that still reaches Sentry is one that survived its retries and is worth reading.
- **The edxorg CSV sniffing bug itself**, per above.
- **DAGSTER-9, DAGSTER-M, DAGSTER-F** — the three remaining low-volume defects.

**Checked, so no longer an open question:** the QA role never had broader Glue access. It has been environment-scoped since it was created in 2022 (mitodl/ol-infrastructure#869), originally as a suffix match `database/*qa`, widened to the substring form `database/*qa*` on 2022-09-28 (`5c2886030`) so dbt's `ol_warehouse_qa_<layer>` names — which carry the env in the middle — would match. The only later change added a userDefinedFunction ARN.

**A separate finding, now fixed in mitodl/ol-infrastructure#5472.** That substring match means `*qa*` reaches any database whose name contains "qa" anywhere, and five in the production namespace do: `ol_warehouse_production_qa_{external,intermediate,mart,staging}` and `ol_warehouse_mitx_qa`. `ol_warehouse_production_qa_mart` is registered at `s3://ol-data-lake-staging-production/...`. All five are vestigial dbt developer schemas from 2023-07-28 with zero tables, so nothing is exposed today — but the granted actions include `glue:DeleteTable` and `glue:DeleteDatabase`, and this becomes real the moment a production schema containing "qa" holds data. The S3 grant is scoped tighter (`ol-data-lake-*-{env_suffix}`, a trailing match), so the exposure is metadata-only. mitodl/ol-infrastructure#5472 anchors the pattern to the real naming conventions and adds an explicit Deny on the production namespace for the non-production stacks; it is strictly narrowing, verified against the live catalog, and previews clean on all six affected stacks.

The pgbouncer churn underneath Group H is a symptom already scoped under `wp-dagster-pgbouncer-observability-and-pool-tuning-cce725` and is not re-scoped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PK9Bt1uMHXLysq6KuenDUR
