### PR TITLE
feat(dagster): make outstanding permanent failures visible

### DIFF
--- a/dg_projects/data_platform/data_platform/definitions.py
+++ b/dg_projects/data_platform/data_platform/definitions.py
@@ -38,6 +38,7 @@ from dagster import (
 from ol_orchestrate.lib.constants import DAGSTER_ENV, VAULT_ADDRESS
 from ol_orchestrate.lib.sentry import (
     INTERRUPTION_ERRORS,
+    PARTITION_NAME_TAG,
     failure_fingerprint,
     init_sentry,
 )
@@ -280,6 +281,10 @@ def capture_run_failure_to_sentry(context: RunFailureSensorContext) -> str | Non
         scope.set_tag("dagster_step", step_key)
         scope.set_tag("dagster_run_id", run.run_id)
         scope.set_tag("dagster_code_location", code_location_of(run) or "unknown")
+        # Matches the hook's tag, which reads the same run tag. Without it a
+        # partitioned asset's issue names everything except the one identifier
+        # you need to go and look at the failure.
+        scope.set_tag("dagster_partition", run.tags.get(PARTITION_NAME_TAG, "none"))
         scope.set_tag("captured_by", "sensor")
         scope.set_context(
             "dagster_run",

--- a/dg_projects/data_platform/data_platform_tests/test_definitions.py
+++ b/dg_projects/data_platform/data_platform_tests/test_definitions.py
@@ -6,6 +6,7 @@ from types import SimpleNamespace
 from typing import Any
 
 import pytest
+import sentry_sdk
 from dagster import AssetCheckSeverity, MetadataValue, RetryPolicy
 from data_platform.definitions import (
     MAX_CHECK_EVALUATIONS_PER_TICK,
@@ -13,6 +14,7 @@ from data_platform.definitions import (
     MAX_SLACK_TEXT_LENGTH,
     RETRY_NUMBER_TAG,
     asset_check_failure_message,
+    capture_run_failure_to_sentry,
     collect_new_check_failures,
     dagster_url,
     defs,
@@ -29,12 +31,44 @@ from data_platform.definitions import (
 )
 from ol_orchestrate.lib.constants import DAGSTER_ENV
 from ol_orchestrate.lib.sentry import PARTITION_NAME_TAG
+from sentry_sdk.transport import Transport
 
 ERROR = AssetCheckSeverity.ERROR
 WARN = AssetCheckSeverity.WARN
 CODE_LOCATION = "edxorg"
 
 # ── Helpers ───────────────────────────────────────────────────────────────────
+
+
+class RecordingTransport(Transport):
+    """Stands in for the Sentry HTTP transport and keeps every event."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.envelopes: list[Any] = []
+
+    def capture_envelope(self, envelope: Any) -> None:
+        self.envelopes.append(envelope)
+
+    def events(self) -> list[dict[str, Any]]:
+        return [
+            item.payload.json
+            for envelope in self.envelopes
+            for item in envelope.items
+            if item.headers.get("type") == "event"
+        ]
+
+
+@pytest.fixture
+def recorded_events() -> RecordingTransport:
+    """Initialize Sentry against a recording transport for one test.
+
+    capture_run_failure_to_sentry no-ops unless a client is active, so the
+    tests that assert on its output have to give it one.
+    """
+    transport = RecordingTransport()
+    sentry_sdk.init(dsn="https://key@example.ingest.sentry.io/1", transport=transport)
+    return transport
 
 
 def _origin(location_name: str | None) -> Any:
@@ -213,18 +247,34 @@ def test_sensor_fingerprint_names_the_location_that_broke() -> None:
     assert sentry_fingerprint(context)[1] == "lakehouse"
 
 
-def test_the_sensor_tags_the_partition_like_the_hook_does() -> None:
+def test_the_sensor_tags_the_partition_like_the_hook_does(
+    recorded_events: RecordingTransport,
+) -> None:
     """Both paths read the same run tag, so a partitioned failure is findable
     whichever one reported it.
+
+    Asserts on the event capture_run_failure_to_sentry actually emitted. An
+    earlier version of this test called a local helper that re-implemented the
+    production tag lookup, so it would have passed with the tag removed
+    entirely.
     """
-    run = _run(**{PARTITION_NAME_TAG: "course-v1:MITx+6.002x+2T2024"})
+    context = _context([_step_failure("some_model", "boom")])
+    context.dagster_run.tags[PARTITION_NAME_TAG] = "course-v1:MITx+6.002x+2T2024"
 
-    assert _partition_of(run) == "course-v1:MITx+6.002x+2T2024"
+    capture_run_failure_to_sentry(context)
+
+    (event,) = recorded_events.events()
+    assert event["tags"]["dagster_partition"] == "course-v1:MITx+6.002x+2T2024"
 
 
-def test_an_unpartitioned_run_is_tagged_none() -> None:
+def test_an_unpartitioned_run_is_tagged_none(
+    recorded_events: RecordingTransport,
+) -> None:
     """Matches the hook's fallback, so the two are one Sentry search."""
-    assert _partition_of(_run()) == "none"
+    capture_run_failure_to_sentry(_context([_step_failure("some_model", "boom")]))
+
+    (event,) = recorded_events.events()
+    assert event["tags"]["dagster_partition"] == "none"
 
 
 def test_sensor_fingerprint_tolerates_a_run_with_no_origin() -> None:

--- a/dg_projects/data_platform/data_platform_tests/test_definitions.py
+++ b/dg_projects/data_platform/data_platform_tests/test_definitions.py
@@ -28,6 +28,7 @@ from data_platform.definitions import (
     truncate_text,
 )
 from ol_orchestrate.lib.constants import DAGSTER_ENV
+from ol_orchestrate.lib.sentry import PARTITION_NAME_TAG
 
 ERROR = AssetCheckSeverity.ERROR
 WARN = AssetCheckSeverity.WARN
@@ -54,6 +55,11 @@ def _run(location: str | None = CODE_LOCATION, **tags: str) -> Any:
         job_name="a_job",
         remote_job_origin=_origin(location),
     )
+
+
+def _partition_of(run: Any) -> str:
+    """Return what capture_run_failure_to_sentry tags as dagster_partition."""
+    return run.tags.get(PARTITION_NAME_TAG, "none")
 
 
 def _context(
@@ -205,6 +211,20 @@ def test_sensor_fingerprint_names_the_location_that_broke() -> None:
     context = _context([_step_failure("some_model", "boom")], location="lakehouse")
 
     assert sentry_fingerprint(context)[1] == "lakehouse"
+
+
+def test_the_sensor_tags_the_partition_like_the_hook_does() -> None:
+    """Both paths read the same run tag, so a partitioned failure is findable
+    whichever one reported it.
+    """
+    run = _run(**{PARTITION_NAME_TAG: "course-v1:MITx+6.002x+2T2024"})
+
+    assert _partition_of(run) == "course-v1:MITx+6.002x+2T2024"
+
+
+def test_an_unpartitioned_run_is_tagged_none() -> None:
+    """Matches the hook's fallback, so the two are one Sentry search."""
+    assert _partition_of(_run()) == "none"
 
 
 def test_sensor_fingerprint_tolerates_a_run_with_no_origin() -> None:

--- a/dg_projects/edxorg/edxorg/definitions.py
+++ b/dg_projects/edxorg/edxorg/definitions.py
@@ -26,6 +26,10 @@ from ol_orchestrate.io_managers.filepath import (
 )
 from ol_orchestrate.lib.constants import DAGSTER_ENV, VAULT_ADDRESS
 from ol_orchestrate.lib.dagster_helpers import default_io_manager
+from ol_orchestrate.lib.failed_partitions import (
+    build_failed_partition_checks,
+    failed_partition_check_schedule,
+)
 from ol_orchestrate.lib.failures import with_failure_hooks
 from ol_orchestrate.lib.sentry import init_sentry
 from ol_orchestrate.lib.utils import authenticate_vault, unauthenticated_vault
@@ -246,6 +250,17 @@ sensor_list = [
 ]
 
 # Create unified definitions
+# Group A lives here: these are the partitions that sit silently in a failed
+# state once the bounded retry has been spent, which is what the inventory
+# checks exist to surface.
+failed_partition_checks = build_failed_partition_checks(
+    [
+        extract_edxorg_courserun_metadata,
+        flatten_edxorg_course_structure,
+        edxorg_course_content_webhook,
+    ]
+)
+
 defs = Definitions(
     resources={
         "io_manager": FileObjectIOManager(
@@ -296,5 +311,9 @@ defs = Definitions(
             *edxorg_db_table_specs,
         ]
     ),
-    schedules=[edxorg_api_daily_schedule],
+    asset_checks=failed_partition_checks,
+    schedules=[
+        edxorg_api_daily_schedule,
+        failed_partition_check_schedule(failed_partition_checks),
+    ],
 )

--- a/packages/ol-orchestrate-lib/src/ol_orchestrate/lib/failed_partitions.py
+++ b/packages/ol-orchestrate-lib/src/ol_orchestrate/lib/failed_partitions.py
@@ -34,8 +34,13 @@ renders it against the asset it concerns, ``asset_check_failure_sensor`` in the
 data_platform code location already announces ERROR-severity check failures to
 Slack, and a check is evaluated on a schedule independent of materialization --
 which is what makes it a standing signal rather than another event.
+
+The Slack half of that is a notification, not a report: the existing formatter
+carries the asset, the check and a run link, so the failed keys live in the
+check metadata and the UI rather than in the message.
 """
 
+import heapq
 from collections.abc import Sequence
 
 from dagster import (
@@ -53,8 +58,14 @@ from dagster import (
     define_asset_job,
 )
 
-# Failed partition keys carried in the check metadata. Enough to start work from
-# the notification alone; the count is always exact, and the UI has the rest.
+# Failed partition keys carried in the check metadata, where the Dagster UI
+# renders them against the asset. The count is always exact; this only caps the
+# sample.
+#
+# Note that the Slack notification does NOT carry them: data_platform's
+# asset_check_failure_message renders the asset name, the check name and a link
+# to the run, and nothing from the evaluation's metadata. Slack tells you which
+# check went red; the keys are one click away, not in the message.
 MAX_REPORTED_PARTITION_KEYS = 20
 
 FAILED_PARTITION_CHECK_NAME = "no_partitions_left_failed"
@@ -87,6 +98,29 @@ def failed_partition_subset(instance, asset_key: AssetKey, partitions_def):
         # the chance to fail yet.
         return None
     return cache_value.deserialize_failed_partition_subsets(partitions_def)
+
+
+def _recovery_text(count: int, truncated: bool) -> str:  # noqa: FBT001
+    """Say what has to happen next, and over how many partitions.
+
+    The count matters as much as the procedure. Told to "re-materialize the
+    listed partitions" against a truncated sample, an operator fixes twenty of
+    them, sees the list they were given go green, and leaves the rest failed --
+    which is the same silent staleness these checks exist to end.
+    """
+    scope = (
+        f"all {count} failed partitions -- the sample below is the first "
+        f"{MAX_REPORTED_PARTITION_KEYS}, and the asset's partition view in the "
+        "Dagster UI has the rest"
+        if truncated
+        else "the partitions listed below"
+    )
+    return (
+        "Nothing retries these automatically -- the automation condition spent "
+        "its one retry when they first failed, and only an upstream change, a "
+        "code version change or a manual re-materialization will ask for them "
+        f"again. Fix the cause, then re-materialize {scope}."
+    )
 
 
 def build_failed_partition_checks(
@@ -127,23 +161,21 @@ def _check_for(asset_key: AssetKey, partitions_def) -> AssetChecksDefinition:
                 passed=True, metadata={"failed_partitions": MetadataValue.int(0)}
             )
 
-        keys = sorted(failed.get_partition_keys())
+        # nsmallest rather than sorted()[:n]: sorting the whole set to keep
+        # twenty of it would rebuild the very structure this function reads a
+        # subset to avoid, and at O(F log F) rather than O(F log 20).
+        truncated = count > MAX_REPORTED_PARTITION_KEYS
+        sample = heapq.nsmallest(
+            MAX_REPORTED_PARTITION_KEYS, failed.get_partition_keys()
+        )
         return AssetCheckResult(
             passed=False,
             severity=AssetCheckSeverity.ERROR,
             metadata={
                 "failed_partitions": MetadataValue.int(count),
-                "sample": MetadataValue.json(keys[:MAX_REPORTED_PARTITION_KEYS]),
-                "sample_truncated": MetadataValue.bool(
-                    count > MAX_REPORTED_PARTITION_KEYS
-                ),
-                "recovery": MetadataValue.md(
-                    "Nothing retries these automatically -- the automation "
-                    "condition spent its one retry when they first failed, and "
-                    "only an upstream change, a code version change or a manual "
-                    "re-materialization will ask for them again. Fix the cause, "
-                    "then re-materialize the listed partitions."
-                ),
+                "sample": MetadataValue.json(sample),
+                "sample_truncated": MetadataValue.bool(truncated),
+                "recovery": MetadataValue.md(_recovery_text(count, truncated)),
             },
         )
 

--- a/packages/ol-orchestrate-lib/src/ol_orchestrate/lib/failed_partitions.py
+++ b/packages/ol-orchestrate-lib/src/ol_orchestrate/lib/failed_partitions.py
@@ -1,0 +1,178 @@
+"""Surface partitions that are sitting in a failed state.
+
+``upstream_or_code_changes()`` bounds the failure retry to one attempt per
+failure edge, and ``stop_run_retries`` keeps ``run_retries`` off a permanent
+failure. Both are deliberate, and together they mean a partition that cannot
+succeed goes quiet after two runs rather than being re-requested forever.
+
+Quiet is the point, and quiet is also the danger. Nothing then re-requests that
+partition until its upstream changes, its code version changes, or a human
+re-materializes it -- and the Sentry issue that reported the original failure
+falls silent, which in a list of issues is indistinguishable from being fixed.
+Silent staleness is the failure mode that let one broken asset run undetected
+for six days; bounding the retry removed the noise without replacing the signal.
+
+These checks are that replacement. They answer "what is broken *right now*"
+rather than "what broke at 03:14", which is the question a standing inventory
+has to answer to be worth reading.
+
+Wire them into a code location alongside the assets they watch::
+
+    failed_partition_checks = build_failed_partition_checks(
+        [edxorg_course_xml, edxorg_course_structure]
+    )
+
+    defs = Definitions(
+        assets=with_failure_hooks([...]),
+        asset_checks=failed_partition_checks,
+        jobs=[failed_partition_check_job(failed_partition_checks)],
+        schedules=[failed_partition_check_schedule(failed_partition_checks)],
+    )
+
+An asset check rather than a bespoke sensor, for three reasons: the Dagster UI
+renders it against the asset it concerns, ``asset_check_failure_sensor`` in the
+data_platform code location already announces ERROR-severity check failures to
+Slack, and a check is evaluated on a schedule independent of materialization --
+which is what makes it a standing signal rather than another event.
+"""
+
+from collections.abc import Sequence
+
+from dagster import (
+    AssetCheckResult,
+    AssetChecksDefinition,
+    AssetCheckSeverity,
+    AssetKey,
+    AssetsDefinition,
+    AssetSelection,
+    DefaultScheduleStatus,
+    JobDefinition,
+    MetadataValue,
+    ScheduleDefinition,
+    asset_check,
+    define_asset_job,
+)
+
+# Failed partition keys carried in the check metadata. Enough to start work from
+# the notification alone; the count is always exact, and the UI has the rest.
+MAX_REPORTED_PARTITION_KEYS = 20
+
+FAILED_PARTITION_CHECK_NAME = "no_partitions_left_failed"
+FAILED_PARTITION_JOB_NAME = "failed_partition_inventory"
+
+# Daily rather than hourly. This reports a standing condition that a human has
+# to act on, so re-announcing it every hour would recreate the noise problem
+# that bounding the retry was meant to solve.
+FAILED_PARTITION_CRON = "0 13 * * *"
+
+
+def failed_partition_subset(instance, asset_key: AssetKey, partitions_def):
+    """Return the partitions of ``asset_key`` whose latest run failed.
+
+    Read from Dagster's partition status cache, which stores the failed set as
+    a serialized subset. Deliberately not ``instance.get_status_by_partition``,
+    which expands to a status-per-key mapping -- for the edxorg archives that is
+    a dict of several hundred thousand entries built to answer a question about
+    its length.
+    """
+    from dagster._core.storage.partition_status_cache import (  # noqa: PLC0415
+        get_and_update_asset_status_cache_value,
+    )
+
+    cache_value = get_and_update_asset_status_cache_value(
+        instance, asset_key, partitions_def
+    )
+    if cache_value is None:
+        # No materialization recorded for the asset at all, so nothing has had
+        # the chance to fail yet.
+        return None
+    return cache_value.deserialize_failed_partition_subsets(partitions_def)
+
+
+def build_failed_partition_checks(
+    assets: Sequence[AssetsDefinition],
+) -> list[AssetChecksDefinition]:
+    """Build one "no partitions left failed" check per partitioned asset.
+
+    Unpartitioned assets are skipped rather than raising: a run-level failure on
+    one of those is already visible as a failed run, and the check would have
+    nothing to count.
+    """
+    checks: list[AssetChecksDefinition] = []
+    for asset in assets:
+        partitions_def = asset.partitions_def
+        if partitions_def is None:
+            continue
+        checks.extend(_check_for(asset_key, partitions_def) for asset_key in asset.keys)
+    return checks
+
+
+def _check_for(asset_key: AssetKey, partitions_def) -> AssetChecksDefinition:
+    @asset_check(
+        asset=asset_key,
+        name=FAILED_PARTITION_CHECK_NAME,
+        blocking=False,
+        description=(
+            "Fails while any partition of this asset is sitting in a failed "
+            "state. The automation condition retries a failure once and then "
+            "goes quiet, so without this nothing reports that the partition is "
+            "still broken."
+        ),
+    )
+    def _check(context) -> AssetCheckResult:
+        failed = failed_partition_subset(context.instance, asset_key, partitions_def)
+        count = len(failed) if failed is not None else 0
+        if not count:
+            return AssetCheckResult(
+                passed=True, metadata={"failed_partitions": MetadataValue.int(0)}
+            )
+
+        keys = sorted(failed.get_partition_keys())
+        return AssetCheckResult(
+            passed=False,
+            severity=AssetCheckSeverity.ERROR,
+            metadata={
+                "failed_partitions": MetadataValue.int(count),
+                "sample": MetadataValue.json(keys[:MAX_REPORTED_PARTITION_KEYS]),
+                "sample_truncated": MetadataValue.bool(
+                    count > MAX_REPORTED_PARTITION_KEYS
+                ),
+                "recovery": MetadataValue.md(
+                    "Nothing retries these automatically -- the automation "
+                    "condition spent its one retry when they first failed, and "
+                    "only an upstream change, a code version change or a manual "
+                    "re-materialization will ask for them again. Fix the cause, "
+                    "then re-materialize the listed partitions."
+                ),
+            },
+        )
+
+    return _check
+
+
+def failed_partition_check_job(
+    checks: Sequence[AssetChecksDefinition],
+) -> JobDefinition:
+    """Build a job that evaluates the inventory checks and nothing else."""
+    return define_asset_job(
+        name=FAILED_PARTITION_JOB_NAME,
+        selection=AssetSelection.checks(*checks),
+        description=(
+            "Evaluates the failed-partition inventory checks. Runs on a schedule "
+            "rather than with each materialization, because the question is what "
+            "is still broken rather than what just broke."
+        ),
+    )
+
+
+def failed_partition_check_schedule(
+    checks: Sequence[AssetChecksDefinition],
+    cron_schedule: str = FAILED_PARTITION_CRON,
+) -> ScheduleDefinition:
+    """Evaluate the inventory once a day."""
+    return ScheduleDefinition(
+        name=f"{FAILED_PARTITION_JOB_NAME}_schedule",
+        job=failed_partition_check_job(checks),
+        cron_schedule=cron_schedule,
+        default_status=DefaultScheduleStatus.STOPPED,
+    )

--- a/packages/ol-orchestrate-lib/src/ol_orchestrate/lib/sentry.py
+++ b/packages/ol-orchestrate-lib/src/ol_orchestrate/lib/sentry.py
@@ -36,6 +36,11 @@ SENTRY_FLUSH_TIMEOUT_SECONDS = 5.0
 # still re-tags -- see init_sentry.
 _initialized_location: str | None = None
 
+# Dagster's own run tag. Hardcoded rather than imported: the constant lives in
+# the private dagster._core.storage.tags, but the tag string is stable and
+# documented.
+PARTITION_NAME_TAG = "dagster/partition"
+
 # A run worker that receives SIGTERM -- a deploy rolling the deployment, a node
 # draining, a pod evicted -- raises this on its way out. It is the process being
 # taken away, not the code being wrong, and there is nothing in the traceback
@@ -76,6 +81,24 @@ def drop_interruptions(
 def current_code_location() -> str | None:
     """Return the code location this process was initialized for, if any."""
     return _initialized_location
+
+
+def partition_key_of(context: HookContext) -> str:
+    """Return the partition this step ran for, or ``none``.
+
+    Deliberately a tag rather than context: for a partitioned asset "which
+    partitions are broken" is the whole question, and an issue naming the job,
+    the step and the run but not the partition cannot answer it without opening
+    runs one at a time.
+
+    ``HookContext`` exposes no partition of its own, so this reads the run tag
+    Dagster stamps on every partitioned run -- one extra instance read on a path
+    that is already about to write to Sentry and block on a flush.
+    """
+    run = context.instance.get_run_by_id(context.run_id)
+    if run is None:
+        return "unknown"
+    return run.tags.get(PARTITION_NAME_TAG, "none")
 
 
 def init_sentry(code_location: str) -> bool:
@@ -165,6 +188,7 @@ def capture_exception_to_sentry(context: HookContext) -> None:
         scope.set_tag("dagster_job", context.job_name)
         scope.set_tag("dagster_step", context.step_key)
         scope.set_tag("dagster_run_id", context.run_id)
+        scope.set_tag("dagster_partition", partition_key_of(context))
         scope.set_tag("captured_by", "hook")
         # Group by the step that broke rather than by traceback text, so a
         # recurring failure of one dbt model stays a single issue.

--- a/packages/ol-orchestrate-lib/tests/lib/test_failed_partitions.py
+++ b/packages/ol-orchestrate-lib/tests/lib/test_failed_partitions.py
@@ -14,6 +14,7 @@ from dagster import AssetCheckSeverity, StaticPartitionsDefinition, asset
 from ol_orchestrate.lib.failed_partitions import (
     FAILED_PARTITION_CHECK_NAME,
     MAX_REPORTED_PARTITION_KEYS,
+    _recovery_text,
     build_failed_partition_checks,
     failed_partition_check_schedule,
     failed_partition_subset,
@@ -195,3 +196,38 @@ def test_the_sample_is_capped_but_the_count_is_not(instance) -> None:
     assert evaluation.metadata["failed_partitions"].value == 40
     assert len(evaluation.metadata["sample"].value) == MAX_REPORTED_PARTITION_KEYS
     assert evaluation.metadata["sample_truncated"].value is True
+    # nsmallest, so the sample is still the lowest keys in order despite never
+    # sorting the whole set.
+    assert evaluation.metadata["sample"].value == [
+        f"p{index:03d}" for index in range(MAX_REPORTED_PARTITION_KEYS)
+    ]
+
+
+def test_a_truncated_sample_says_to_fix_all_of_them() -> None:
+    """Told to "re-materialize the listed partitions" against a truncated
+    sample, an operator fixes twenty, watches the list they were given go
+    green, and leaves the rest failed -- the same silent staleness these checks
+    exist to end.
+    """
+    text = _recovery_text(count=400, truncated=True)
+
+    assert "all 400 failed partitions" in text
+    assert "Dagster UI has the rest" in text
+
+
+def test_an_untruncated_sample_points_at_the_list() -> None:
+    text = _recovery_text(count=3, truncated=False)
+
+    assert "the partitions listed below" in text
+    assert "all 3" not in text
+
+
+@pytest.mark.parametrize("truncated", [True, False])
+def test_the_recovery_text_always_says_nothing_retries_automatically(
+    *, truncated: bool
+) -> None:
+    """The part an operator cannot infer from a red check on their own."""
+    text = _recovery_text(count=5, truncated=truncated)
+
+    assert "Nothing retries these automatically" in text
+    assert "re-materiali" in text

--- a/packages/ol-orchestrate-lib/tests/lib/test_failed_partitions.py
+++ b/packages/ol-orchestrate-lib/tests/lib/test_failed_partitions.py
@@ -1,0 +1,197 @@
+"""Tests for the failed-partition inventory checks.
+
+These drive real runs against an ephemeral instance rather than stubbing the
+partition status cache, because the thing being tested is whether Dagster
+considers a partition failed -- which is a property of the event log and the
+status cache, not of our arithmetic.
+"""
+
+from collections.abc import Iterator
+
+import dagster as dg
+import pytest
+from dagster import AssetCheckSeverity, StaticPartitionsDefinition, asset
+from ol_orchestrate.lib.failed_partitions import (
+    FAILED_PARTITION_CHECK_NAME,
+    MAX_REPORTED_PARTITION_KEYS,
+    build_failed_partition_checks,
+    failed_partition_check_schedule,
+    failed_partition_subset,
+)
+
+PARTITIONS = StaticPartitionsDefinition(["a", "b", "c"])
+
+
+class Behaviour:
+    """Controls whether the asset succeeds for a given partition."""
+
+    def __init__(self) -> None:
+        self.failing: set[str] = set()
+
+
+@pytest.fixture
+def behaviour() -> Behaviour:
+    return Behaviour()
+
+
+@pytest.fixture
+def instance() -> Iterator[dg.DagsterInstance]:
+    with dg.DagsterInstance.ephemeral() as ephemeral:
+        yield ephemeral
+
+
+@pytest.fixture
+def partitioned_asset(behaviour: Behaviour):
+    @asset(name="partitioned", partitions_def=PARTITIONS)
+    def partitioned(context) -> None:
+        if context.partition_key in behaviour.failing:
+            msg = f"{context.partition_key} is broken"
+            raise RuntimeError(msg)
+
+    return partitioned
+
+
+def materialize(asset_def, instance, partition_key: str) -> None:
+    dg.materialize(
+        [asset_def],
+        instance=instance,
+        partition_key=partition_key,
+        raise_on_error=False,
+    )
+
+
+def run_check(check_def, asset_def, instance):
+    """Execute the inventory check on its own and return its single evaluation."""
+    result = dg.materialize(
+        [asset_def, check_def],
+        instance=instance,
+        selection=dg.AssetSelection.checks(check_def),
+        raise_on_error=False,
+    )
+    (evaluation,) = result.get_asset_check_evaluations()
+    return evaluation
+
+
+def test_a_clean_asset_passes(partitioned_asset, instance) -> None:
+    for partition in ("a", "b", "c"):
+        materialize(partitioned_asset, instance, partition)
+    (check_def,) = build_failed_partition_checks([partitioned_asset])
+
+    evaluation = run_check(check_def, partitioned_asset, instance)
+
+    assert evaluation.passed is True
+    assert evaluation.metadata["failed_partitions"].value == 0
+
+
+def test_a_failed_partition_fails_the_check(
+    partitioned_asset, instance, behaviour
+) -> None:
+    """The signal the bounded retry removed.
+
+    After execution_failed().newly_true() spends its one retry, nothing
+    re-requests this partition and the Sentry issue falls silent -- which in a
+    list of issues is indistinguishable from being fixed.
+    """
+    behaviour.failing = {"b"}
+    for partition in ("a", "b", "c"):
+        materialize(partitioned_asset, instance, partition)
+    (check_def,) = build_failed_partition_checks([partitioned_asset])
+
+    evaluation = run_check(check_def, partitioned_asset, instance)
+
+    assert evaluation.passed is False
+    assert evaluation.severity == AssetCheckSeverity.ERROR
+    assert evaluation.metadata["failed_partitions"].value == 1
+    assert evaluation.metadata["sample"].value == ["b"]
+
+
+def test_the_check_names_which_partitions(
+    partitioned_asset, instance, behaviour
+) -> None:
+    """A count alone does not tell anyone where to start."""
+    behaviour.failing = {"a", "c"}
+    for partition in ("a", "b", "c"):
+        materialize(partitioned_asset, instance, partition)
+    (check_def,) = build_failed_partition_checks([partitioned_asset])
+
+    evaluation = run_check(check_def, partitioned_asset, instance)
+
+    assert evaluation.metadata["sample"].value == ["a", "c"]
+    assert evaluation.metadata["sample_truncated"].value is False
+
+
+def test_a_partition_that_recovers_stops_being_reported(
+    partitioned_asset, instance, behaviour
+) -> None:
+    """The inventory reports current state, not history.
+
+    Otherwise it becomes a permanent red mark that people learn to ignore --
+    the same fate as the alert stream this replaces.
+    """
+    behaviour.failing = {"b"}
+    materialize(partitioned_asset, instance, "b")
+    (check_def,) = build_failed_partition_checks([partitioned_asset])
+    assert run_check(check_def, partitioned_asset, instance).passed is False
+
+    behaviour.failing = set()
+    materialize(partitioned_asset, instance, "b")
+
+    assert run_check(check_def, partitioned_asset, instance).passed is True
+
+
+def test_an_asset_never_materialized_passes(instance) -> None:
+    """Nothing has had the chance to fail yet, so there is nothing to report."""
+
+    @asset(name="untouched", partitions_def=PARTITIONS)
+    def untouched() -> None: ...
+
+    assert failed_partition_subset(instance, untouched.key, PARTITIONS) is None
+
+
+def test_unpartitioned_assets_are_skipped() -> None:
+    """A run-level failure there is already visible as a failed run, and the
+    check would have nothing to count.
+    """
+
+    @asset(name="plain")
+    def plain() -> None: ...
+
+    assert build_failed_partition_checks([plain]) == []
+
+
+def test_every_partitioned_asset_key_gets_a_check(partitioned_asset) -> None:
+    (check_def,) = build_failed_partition_checks([partitioned_asset])
+
+    (check_key,) = check_def.check_keys
+    assert check_key.asset_key == partitioned_asset.key
+    assert check_key.name == FAILED_PARTITION_CHECK_NAME
+
+
+def test_the_schedule_is_stopped_by_default(partitioned_asset) -> None:
+    """Turning it on is a deliberate act, like every other sensor here."""
+    checks = build_failed_partition_checks([partitioned_asset])
+
+    schedule = failed_partition_check_schedule(checks)
+
+    assert schedule.default_status == dg.DefaultScheduleStatus.STOPPED
+    assert schedule.cron_schedule == "0 13 * * *"
+
+
+def test_the_sample_is_capped_but_the_count_is_not(instance) -> None:
+    """A Slack block and a Sentry issue both have limits; the count does not."""
+    many = StaticPartitionsDefinition([f"p{index:03d}" for index in range(40)])
+
+    @asset(name="many_partitions", partitions_def=many)
+    def many_partitions() -> None:
+        msg = "always broken"
+        raise RuntimeError(msg)
+
+    for partition in many.get_partition_keys():
+        materialize(many_partitions, instance, partition)
+    (check_def,) = build_failed_partition_checks([many_partitions])
+
+    evaluation = run_check(check_def, many_partitions, instance)
+
+    assert evaluation.metadata["failed_partitions"].value == 40
+    assert len(evaluation.metadata["sample"].value) == MAX_REPORTED_PARTITION_KEYS
+    assert evaluation.metadata["sample_truncated"].value is True

--- a/packages/ol-orchestrate-lib/tests/lib/test_sentry.py
+++ b/packages/ol-orchestrate-lib/tests/lib/test_sentry.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from typing import Any
 
+import dagster as dg
 import pytest
 import sentry_sdk
 from dagster import AssetSpec, Definitions, asset, materialize
@@ -189,6 +190,49 @@ def test_qa_and_production_do_not_share_an_issue(
     assert production[0] == "production"
     assert qa[0] == "qa"
     assert production != qa
+
+
+def test_a_partitioned_failure_names_its_partition(
+    recorded_events: RecordingTransport,
+) -> None:
+    """Without this the issue names the job, the step and the run -- everything
+    except the one identifier you need to go and look at the failure.
+    """
+    partitions = dg.StaticPartitionsDefinition(["run-a", "run-b"])
+
+    @asset(partitions_def=partitions)
+    def exploding_partition() -> None:
+        message = "the partition is on fire"
+        raise ValueError(message)
+
+    dg.materialize(
+        sentry_lib.with_sentry_hooks([exploding_partition]),
+        partition_key="run-b",
+        raise_on_error=False,
+    )
+
+    (event,) = recorded_events.events()
+    assert event["tags"]["dagster_partition"] == "run-b"
+
+
+def test_an_unpartitioned_failure_says_so(
+    recorded_events: RecordingTransport,
+) -> None:
+    """`none` rather than an absent tag, so the two cases are distinguishable in
+    a Sentry search.
+    """
+
+    @asset
+    def exploding_unpartitioned() -> None:
+        message = "no partitions here"
+        raise ValueError(message)
+
+    dg.materialize(
+        sentry_lib.with_sentry_hooks([exploding_unpartitioned]), raise_on_error=False
+    )
+
+    (event,) = recorded_events.events()
+    assert event["tags"]["dagster_partition"] == "none"
 
 
 def test_a_terminated_run_worker_is_not_reported() -> None:


### PR DESCRIPTION
## What are the relevant tickets?

Follow-up to #2564, tracked as `tk-make-outstanding-permanent-failures-visible-part-5e4312` on `wp-dagster-failure-semantics-sentry-signal-quality-f52032`.

## Description (What does it do?)

#2564 bounded the failure retry and stopped `run_retries` re-running a permanent failure. That fixed the noise and created a quieter problem, which is worth stating plainly: **a partition that cannot succeed now goes silent after two runs.**

Nothing re-requests it until its upstream changes, its code version changes, or a human re-materializes it — `execution_failed().newly_true()` spent its one edge and the level never returns to false. The Sentry issue that reported the original failure falls quiet too, and in a list of issues quiet is indistinguishable from fixed.

Silent staleness is the failure mode that let one broken asset run undetected for six days. Removing the noise without replacing the signal only changes where the six days come from.

### The Sentry events now name the partition

Both capture paths read the `dagster/partition` run tag — the hook via an instance lookup, since `HookContext` exposes no partition of its own, and the sensor off the run it already holds. An issue naming the job, the step and the run but not the partition cannot answer the only question that matters for a partitioned asset without opening runs one at a time.

Unpartitioned failures are tagged `none` rather than leaving the tag absent, so the two cases are one Sentry search rather than a search and an absence.

### A standing inventory of what is broken now

`ol_orchestrate.lib.failed_partitions` builds a `no_partitions_left_failed` check per partitioned asset, evaluated on a daily schedule rather than with each materialization — because the question is what is *still* broken, not what just broke. Wired into `edxorg` first, where Group A lives, covering `extract_edxorg_courserun_metadata`, `flatten_edxorg_course_structure` and `edxorg_course_content_webhook` (ten asset keys between them).

An asset check rather than a bespoke sensor, for three reasons:

- the Dagster UI renders it against the asset it concerns, so the state is visible where you'd look for it;
- `asset_check_failure_sensor` in `data_platform` already announces ERROR-severity check failures to Slack, so this needs no new notification path;
- scheduled evaluation is what makes it a standing signal rather than another event.

The check metadata carries the exact count, a capped sample of failed keys, and the recovery procedure. That last part is deliberate: **nothing retries these automatically**, and that is not obvious from the outside — someone finding a red check needs to be told that fixing the cause is not sufficient and the partitions must be re-materialized.

### One performance note

The failed set is read from the partition status cache's serialized subset, not `instance.get_status_by_partition`. The latter expands to a status-per-key mapping; for the edxorg archives that means building a dict of several hundred thousand entries to answer a question about its length. `len(subset)` is exact and cheap, and keys are only expanded for the capped sample.

## How can this be tested?

`packages/ol-orchestrate-lib` 180 passed / 80 skipped, `data_platform` 63, `edxorg` 34. `pre-commit run` clean including mypy. Rebased onto merged main and re-run there, not just against the pre-merge branch.

The inventory tests drive real materializations against an ephemeral instance rather than stubbing the status cache, because what is being tested is whether *Dagster* considers a partition failed — a property of the event log and the cache, not of our arithmetic. Worth looking at specifically:

- `test_a_failed_partition_fails_the_check` — the signal the bounded retry removed.
- `test_a_partition_that_recovers_stops_being_reported` — reports current state, not history. Without this it becomes a permanent red mark people learn to ignore, which is the fate of the alert stream it replaces.
- `test_the_sample_is_capped_but_the_count_is_not` — 40 failed partitions, exact count, 20 sampled, truncation flagged.
- `test_a_partitioned_failure_names_its_partition` — materializes a real partitioned asset through the hook and asserts on the recorded Sentry event.

## Additional context

The schedule ships `DefaultScheduleStatus.STOPPED`, like every other sensor and schedule here — turning it on is a deliberate act.

Scope deliberately limited to `edxorg`. The same two lines wire it into `openedx` and `canvas`, both of which have partitioned assets that fail this way, but I'd rather see one code location's checks running and calibrated (particularly the daily cadence and whether the Slack volume is right) before spreading it.

Two things from the task that are **not** in here:

- **No acknowledgement state.** A check that has been seen and deferred looks identical to one nobody has looked at. That wants a decision about where the state lives before it wants code.
- **No freshness coverage for these assets.** `build_last_update_freshness_checks` is still scoped to the dbt `mart`/`reporting`/`dimensional` groups. A failed-partition inventory answers "did it break"; freshness answers "did it silently stop running at all", and they are not the same question.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PK9Bt1uMHXLysq6KuenDUR
