### PR TITLE
fix(canvas): omit course_readable_id from Learn webhook when Canvas has no SIS id  

### DIFF
--- a/dg_projects/canvas/canvas/assets/canvas.py
+++ b/dg_projects/canvas/canvas/assets/canvas.py
@@ -275,12 +275,15 @@ def course_content_metadata(
         "course_id": course_id,
         "course_name": metadata["name"],
         "course_code": metadata["course_code"],
-        "course_readable_id": metadata["sis_course_id"],
         "content_path": content_path,
         "metadata_path": metadata_path,
         "source": "canvas",
         "time": time.time(),
     }
+    # Learn rejects a null course_readable_id, which Canvas returns for any
+    # course with no SIS mapping.
+    if metadata["sis_course_id"]:
+        data["course_readable_id"] = metadata["sis_course_id"]
     context.log.info(
         "Sending webhook notification to Learn API for course_id=%s and data=%s",
         course_id,

--- a/dg_projects/canvas/canvas_tests/test_assets.py
+++ b/dg_projects/canvas/canvas_tests/test_assets.py
@@ -1,0 +1,73 @@
+"""Tests for the Canvas assets."""
+
+from types import SimpleNamespace
+from typing import Any
+
+import dagster as dg
+import pytest
+from canvas.assets.canvas import course_content_metadata
+
+COURSE_ID = "155"
+
+
+class _RecordingLearnClient:
+    """Capture the webhook payload instead of sending it."""
+
+    def __init__(self) -> None:
+        self.payloads: list[dict[str, Any]] = []
+
+    def notify_course_export(self, data: dict[str, Any]) -> dict[str, Any]:
+        self.payloads.append(data)
+        return {"status": "success", "message": "Webhook received"}
+
+
+def _send_webhook(sis_course_id: str | None) -> dict[str, Any]:
+    """Invoke the asset for one partition and return the payload it sent."""
+    learn_client = _RecordingLearnClient()
+    canvas_client = SimpleNamespace(
+        get_course=lambda course_id: {  # noqa: ARG005
+            "name": "MITx Test",
+            "course_code": "MITxTest01",
+            "sis_course_id": sis_course_id,
+        }
+    )
+    context = dg.build_asset_context(
+        partition_key=COURSE_ID,
+        resources={
+            "canvas_api": SimpleNamespace(client=canvas_client),
+            "learn_api": SimpleNamespace(client=learn_client),
+        },
+    )
+
+    course_content_metadata(
+        context,
+        f"canvas/course_content/{COURSE_ID}/abc.imscc",
+        f"canvas/course_content/{COURSE_ID}/abc.metadata.json",
+    )
+
+    assert len(learn_client.payloads) == 1
+    return learn_client.payloads[0]
+
+
+def test_null_sis_course_id_is_omitted_from_the_payload():
+    """Learn rejects a null course_readable_id, so the key must be absent."""
+    payload = _send_webhook(sis_course_id=None)
+    assert "course_readable_id" not in payload
+
+
+def test_a_real_sis_course_id_is_sent():
+    payload = _send_webhook(sis_course_id="2026SP:7.572")
+    assert payload["course_readable_id"] == "2026SP:7.572"
+
+
+@pytest.mark.parametrize("sis_course_id", [None, "2026SP:7.572"])
+def test_the_rest_of_the_payload_is_unchanged(sis_course_id):
+    """Omitting the key must not disturb the fields Learn actually uses."""
+    payload = _send_webhook(sis_course_id=sis_course_id)
+    assert payload["source"] == "canvas"
+    assert payload["course_id"] == int(COURSE_ID)
+    assert payload["content_path"] == f"canvas/course_content/{COURSE_ID}/abc.imscc"
+    assert (
+        payload["metadata_path"]
+        == f"canvas/course_content/{COURSE_ID}/abc.metadata.json"
+    )


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
NA
https://pipelines.odl.mit.edu/runs/b2a0382e-528c-46f7-a278-f86ae9af6184

### Description (What does it do?)
<!--- Describe your changes in detail -->
Canvas returns `sis_course_id: null` for courses with no SIS mapping. mitodl/mit-learn#2849 added `course_readable_id = serializers.CharField(required=False, allow_blank=True)` to Learn's webhook serializer,  and `CharField` rejects `None` unless `allow_null=True` — so those payloads now fail validation, and `handle_error`'s `@api_view()` (GET-only) reports that 400 as the 405 in the Dagster logs. 

  Omitting the key gets the pre #2849 outcome back — the field was undeclared then, so DRF discarded `required=False` accepts absence, and Learn's canvas code never reads the value. 

- [Succeeds](https://pipelines.odl.mit.edu/runs/f5754d8d-c078-4281-8d17-650b8a22fcae) — course with a course_readable_id
- [Fails with 405](https://pipelines.odl.mit.edu/runs/b2a0382e-528c-46f7-a278-f86ae9af6184) — course without one    


### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

cd dg_projects/canvas && uv run pytest canvas_tests/   

After deploy, re-materialize `canvas/course_content_metadata` for a course with no SIS id (155 or 2198). The log line should show no `course_readable_id` key, followed by `Webhook received`. Course 37046 (a real SIS id) should be unchanged.                                                                                                                                                                                 
                                      

### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->


<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
