### PR TITLE
feat(dagster): render asset check metadata in the Slack failure notification

### DIFF
--- a/dg_projects/data_platform/data_platform/definitions.py
+++ b/dg_projects/data_platform/data_platform/definitions.py
@@ -660,7 +660,13 @@ def asset_check_failure_message(
         metadata_text = format_check_metadata(getattr(evaluation, "metadata", None))
         if metadata_text:
             lines.append(metadata_text)
-        return "\n".join(lines)
+        # Per-field limits (MAX_DESCRIPTION_LENGTH, MAX_METADATA_VALUE_LENGTH)
+        # bound each piece, but not an unbounded metadata *key* or the sum of
+        # several fields together. A section block over Slack's 3000-character
+        # text limit fails the whole chat.postMessage call -- and by then the
+        # sensor has already advanced its cursor past this batch, permanently
+        # dropping it. This is the backstop for that.
+        return truncate_text("\n".join(lines))
 
     detail_blocks = [
         {

--- a/dg_projects/data_platform/data_platform/definitions.py
+++ b/dg_projects/data_platform/data_platform/definitions.py
@@ -10,20 +10,28 @@ into something you can actually go and look up.
 """
 
 import re
-from collections.abc import Sequence
+from collections.abc import Mapping, Sequence
 from datetime import UTC, datetime
 from typing import Any
 
 import sentry_sdk
 from dagster import (
     AssetCheckSeverity,
+    BoolMetadataValue,
     DagsterEventType,
     DagsterRun,
     DefaultSensorStatus,
     Definitions,
     EventRecordsFilter,
+    FloatMetadataValue,
+    IntMetadataValue,
+    MarkdownMetadataValue,
+    MetadataValue,
     RunFailureSensorContext,
     SensorEvaluationContext,
+    TextMetadataValue,
+    TimestampMetadataValue,
+    UrlMetadataValue,
     run_failure_sensor,
     sensor,
 )
@@ -579,23 +587,87 @@ def is_reported_by_the_run_failure_sensor(evaluation: Any) -> bool:
     return set(evaluation.metadata or {}) >= DBT_PROVENANCE_KEYS
 
 
+# Bounds on the substance appended to each failure's detail block. Kept small
+# on purpose: this appends to the block's existing text rather than adding a
+# block per failure, which is what keeps the 1-header-plus-1-block-per-failure
+# arithmetic behind MAX_CHECK_EVALUATIONS_PER_TICK intact.
+MAX_METADATA_ENTRIES_PER_FAILURE = 3
+MAX_METADATA_VALUE_LENGTH = 200
+MAX_DESCRIPTION_LENGTH = 300
+
+# Metadata types rendered inline. All are scalars a human can read at a
+# glance -- JSON, tables and other structured metadata are left for the
+# Dagster UI, which is one click away via the "View run" button, rather than
+# dumped into the notification unbounded.
+_RENDERABLE_METADATA_TYPES = (
+    BoolMetadataValue,
+    FloatMetadataValue,
+    IntMetadataValue,
+    MarkdownMetadataValue,
+    TextMetadataValue,
+    TimestampMetadataValue,
+    UrlMetadataValue,
+)
+
+
+def _render_metadata_value(value: MetadataValue) -> str:
+    if isinstance(value, TimestampMetadataValue):
+        return datetime.fromtimestamp(value.value, tz=UTC).isoformat(timespec="seconds")
+    return str(value.value)
+
+
+def format_check_metadata(metadata: Mapping[str, Any] | None) -> str:
+    """Render a bounded, human-readable subset of a check's metadata.
+
+    Only the first MAX_METADATA_ENTRIES_PER_FAILURE scalar-valued keys render,
+    in metadata's own (insertion) order -- a check author who wants something
+    seen puts it first. Everything else, structured or overflow, stays in the
+    UI rather than turning the notification into a dump of the mapping.
+    """
+    lines = []
+    for key, value in (metadata or {}).items():
+        if not isinstance(value, _RENDERABLE_METADATA_TYPES):
+            continue
+        rendered = truncate_text(
+            _render_metadata_value(value), MAX_METADATA_VALUE_LENGTH
+        )
+        lines.append(f"• *{key}:* {rendered}")
+        if len(lines) == MAX_METADATA_ENTRIES_PER_FAILURE:
+            break
+    return "\n".join(lines)
+
+
 def asset_check_failure_message(
     failures: Sequence[tuple[str, Any]],
 ) -> list[dict[str, Any]]:
     """Format a batch of failed asset check evaluations for Slack.
 
     Each failure links to the run that produced it rather than a shared link,
-    since a single batch can span multiple runs.
+    since a single batch can span multiple runs. Beneath the check name, each
+    detail block also carries the check's own description (freshness checks
+    write one) and a bounded slice of its metadata -- see
+    format_check_metadata -- so the substance a check computed does not
+    require a click into the UI to see.
     """
+
+    def _detail_text(evaluation: Any) -> str:
+        lines = [
+            f"*{evaluation.asset_key.to_user_string()}* -- `{evaluation.check_name}`"
+        ]
+        description = getattr(evaluation, "description", None)
+        if description:
+            lines.append(truncate_text(description, MAX_DESCRIPTION_LENGTH))
+        metadata_text = format_check_metadata(getattr(evaluation, "metadata", None))
+        if metadata_text:
+            lines.append(metadata_text)
+        return "\n".join(lines)
+
     detail_blocks = [
         {
             "type": "section",
             "text": {
                 "type": "mrkdwn",
-                "text": (
-                    f"*{evaluation.asset_key.to_user_string()}* -- "
-                    f"`{evaluation.check_name}`"
-                ),
+                "text": _detail_text(evaluation),
             },
             "accessory": {
                 "type": "button",

--- a/dg_projects/data_platform/data_platform_tests/test_definitions.py
+++ b/dg_projects/data_platform/data_platform_tests/test_definitions.py
@@ -10,6 +10,7 @@ from dagster import AssetCheckSeverity, MetadataValue, RetryPolicy
 from data_platform.definitions import (
     MAX_CHECK_EVALUATIONS_PER_TICK,
     MAX_METADATA_ENTRIES_PER_FAILURE,
+    MAX_SLACK_TEXT_LENGTH,
     RETRY_NUMBER_TAG,
     asset_check_failure_message,
     collect_new_check_failures,
@@ -1000,3 +1001,29 @@ def test_format_check_metadata_renders_a_timestamp_as_an_iso_datetime() -> None:
 def test_format_check_metadata_handles_no_metadata() -> None:
     assert format_check_metadata(None) == ""
     assert format_check_metadata({}) == ""
+
+
+def test_asset_check_failure_message_caps_the_composed_detail_text() -> None:
+    """Regression (Copilot, PR #2568): per-field limits bound each value, but
+    not an unbounded metadata *key* or the sum of several fields together. A
+    section block over Slack's 3,000-character text limit fails the whole
+    chat.postMessage call -- and by then the sensor has already advanced its
+    cursor past the batch, permanently dropping it.
+    """
+    failures = [
+        _check_failure(
+            "run-1",
+            "mart/enrollments",
+            description="x" * MAX_SLACK_TEXT_LENGTH,
+            metadata={
+                "a" * 500: MetadataValue.text("x" * 500),
+                "b" * 500: MetadataValue.text("x" * 500),
+                "c" * 500: MetadataValue.text("x" * 500),
+            },
+        )
+    ]
+
+    blocks = asset_check_failure_message(failures)
+
+    detail_block = next(b for b in blocks if b["type"] == "section")
+    assert len(detail_block["text"]["text"]) <= MAX_SLACK_TEXT_LENGTH

--- a/dg_projects/data_platform/data_platform_tests/test_definitions.py
+++ b/dg_projects/data_platform/data_platform_tests/test_definitions.py
@@ -6,15 +6,17 @@ from types import SimpleNamespace
 from typing import Any
 
 import pytest
-from dagster import AssetCheckSeverity, RetryPolicy
+from dagster import AssetCheckSeverity, MetadataValue, RetryPolicy
 from data_platform.definitions import (
     MAX_CHECK_EVALUATIONS_PER_TICK,
+    MAX_METADATA_ENTRIES_PER_FAILURE,
     RETRY_NUMBER_TAG,
     asset_check_failure_message,
     collect_new_check_failures,
     dagster_url,
     defs,
     error_message,
+    format_check_metadata,
     get_exception,
     is_an_interrupted_worker,
     is_reported_by_the_run_failure_sensor,
@@ -770,6 +772,7 @@ def _check_failure(
     asset: str,
     metadata: dict[str, Any] | None = None,
     check_name: str = "freshness_check",
+    description: str | None = None,
 ) -> tuple[str, Any]:
     return (
         run_id,
@@ -777,6 +780,7 @@ def _check_failure(
             asset_key=SimpleNamespace(to_user_string=lambda: asset),
             check_name=check_name,
             metadata=metadata or {},
+            description=description,
         ),
     )
 
@@ -908,3 +912,91 @@ def test_asset_check_failure_message_links_each_check_to_its_own_run() -> None:
         f"{dagster_url}/runs/run-1",
         f"{dagster_url}/runs/run-2",
     ]
+
+
+# ── Metadata rendering ────────────────────────────────────────────────────────
+
+
+def test_asset_check_failure_message_renders_the_checks_description() -> None:
+    """Regression: a freshness check's own summary -- e.g. how overdue an
+    asset is -- named nothing but the check, leaving the substance a click
+    away.
+    """
+    failures = [
+        _check_failure(
+            "run-1",
+            "mart/enrollments",
+            description="Asset is overdue for an update. The last update was "
+            "3 days ago, which is past the allowed distance of 1 day ago.",
+        )
+    ]
+
+    blocks = asset_check_failure_message(failures)
+
+    assert "overdue for an update" in _block_text(blocks)
+
+
+def test_asset_check_failure_message_renders_a_bounded_slice_of_metadata() -> None:
+    """Scalar metadata a check computed -- the substance Copilot's PR #2565
+    review flagged as unreachable from Slack -- renders inline.
+    """
+    failures = [
+        _check_failure(
+            "run-1",
+            "mart/enrollments",
+            metadata={
+                "failed_partitions": MetadataValue.int(42),
+                "recovery": MetadataValue.md("Re-materialize the failed keys."),
+            },
+        )
+    ]
+
+    blocks = asset_check_failure_message(failures)
+
+    text = _block_text(blocks)
+    assert "failed_partitions" in text
+    assert "42" in text
+    assert "Re-materialize the failed keys." in text
+
+
+def test_format_check_metadata_skips_structured_values() -> None:
+    """JSON and other structured metadata stays in the UI -- rendering it
+    inline is how a notification for 49 failures becomes unreadable.
+    """
+    text = format_check_metadata(
+        {
+            "sample": MetadataValue.json(["p1", "p2", "p3"]),
+            "sample_truncated": MetadataValue.bool(True),
+        }
+    )
+
+    assert "sample_truncated" in text
+    assert "p1" not in text
+
+
+def test_format_check_metadata_bounds_entry_count() -> None:
+    """A check with many scalar metadata keys still gets a bounded message,
+    not the whole mapping.
+    """
+    metadata = {
+        f"key_{i}": MetadataValue.int(i)
+        for i in range(MAX_METADATA_ENTRIES_PER_FAILURE + 5)
+    }
+
+    text = format_check_metadata(metadata)
+
+    assert len(text.splitlines()) == MAX_METADATA_ENTRIES_PER_FAILURE
+
+
+def test_format_check_metadata_renders_a_timestamp_as_an_iso_datetime() -> None:
+    """Freshness checks report timing as unix timestamps; a raw float reads
+    as noise next to the run link, so it renders as a readable datetime.
+    """
+    text = format_check_metadata({"dagster/fresh_until": MetadataValue.timestamp(0.0)})
+
+    assert "1970-01-01" in text
+
+
+def test_format_check_metadata_handles_no_metadata() -> None:
+    assert format_check_metadata(None) == ""
+    assert format_check_metadata({}) == ""


### PR DESCRIPTION
### What are the relevant tickets?
Addresses task `tk-render-asset-check-metadata-in-the-slack-failure-432463` (raised by Copilot review on #2565).

### Description (What does it do?)
`asset_check_failure_message` in `dg_projects/data_platform/data_platform/definitions.py` used to render only the asset name, the check name and a "View run" button -- nothing from the evaluation. A check that computed something worth reading (a failed-partition count and recovery guidance, a freshness lag) announced only that it went red.

- Each detail block now also appends the check's own `description` (freshness checks write a human summary, e.g. "Asset is overdue for an update...") when present.
- It also appends a bounded slice (at most 3 entries) of the check's scalar metadata -- text, numbers, booleans, timestamps, URLs -- rendered inline as `key: value` lines. Structured metadata (JSON, tables) is deliberately skipped and stays one click away in the Dagster UI, so a check like the failed-partition inventory (which carries a `sample` list) doesn't dump 20 partition keys into Slack.
- Timestamps render as ISO datetimes rather than raw unix floats.
- This appends to the existing per-failure section block's text rather than adding a new block per failure, so the 1-header-plus-1-block-per-failure arithmetic behind `MAX_CHECK_EVALUATIONS_PER_TICK` (49, to stay under Slack's 50-block `chat.postMessage` limit) is unchanged.

### How can this be tested?
- `uv run pytest data_platform_tests/test_definitions.py -q` in `dg_projects/data_platform` -- 48 tests pass, including 6 new ones covering description rendering, bounded metadata rendering, structured-value skipping, entry-count bounding, timestamp formatting, and the no-metadata case.
- `uv run ruff check` / `uv run ruff format --check` / `uv run mypy` all pass on the changed files (via `pre-commit run`).
- Manually verified against `dagster`'s real `MetadataValue` types (`MetadataValue.int`, `.md`, `.json`, `.bool`, `.timestamp`) rather than only mocks, so the isinstance-based type dispatch is exercised against production types.

### Additional Context
- Scoped deliberately: this changes the shared formatter used by every asset check (freshness checks included), which is why the earlier PR (#2565) corrected the claim instead of touching this file as a side effect.
- Metadata worth surfacing was chosen by type (scalar vs. structured), not by hardcoding specific key names, so it generalizes across checks rather than special-casing the failed-partition inventory.
