### PR TITLE
test(orchestrate): cover the pooled Postgres storages, and fix what that exposed

### DIFF
--- a/packages/ol-orchestrate-lib/pyproject.toml
+++ b/packages/ol-orchestrate-lib/pyproject.toml
@@ -14,6 +14,7 @@ dependencies = [
     "boto3 ~=1.43.0",
     "dagster ~= 1.11",
     "dagster-aws ~=0.29.0",
+    "dagster-postgres ~=0.29.0",
     "fsspec (>=2026.0.0,<2027.0.0)",
     "gcsfs (>=2026.0.0,<2027.0.0)",
     "httpx2 >= 2.2.0",

--- a/packages/ol-orchestrate-lib/src/ol_orchestrate/lib/postgres/event_log.py
+++ b/packages/ol-orchestrate-lib/src/ol_orchestrate/lib/postgres/event_log.py
@@ -139,6 +139,13 @@ class PooledPostgresEventLogStorage(PostgresEventLogStorage):
         if existing_options:
             kwargs["connect_args"] = {"options": existing_options}
 
+        # QueuePool keeps its checked-in connections open until the engine is
+        # disposed, and rebuilding below drops the only reference to the old
+        # one. Without this the replaced pool's connections stay open for the
+        # life of the process, pinning PgBouncer server connections that nothing
+        # can ever check out again.
+        self._engine.dispose()
+
         self._engine = create_engine(self.postgres_url, **kwargs)
         event.listen(
             self._engine,
@@ -174,8 +181,11 @@ class PooledPostgresEventLogStorage(PostgresEventLogStorage):
             "pool_timeout": Field(
                 IntSource,
                 is_required=False,
-                default_value=3600,
-                description="Recycle connections after N seconds",
+                default_value=30,
+                description=(
+                    "Seconds to wait for a connection from a saturated pool "
+                    "before raising"
+                ),
             ),
         }
 

--- a/packages/ol-orchestrate-lib/src/ol_orchestrate/lib/postgres/run_storage.py
+++ b/packages/ol-orchestrate-lib/src/ol_orchestrate/lib/postgres/run_storage.py
@@ -133,6 +133,13 @@ class PooledPostgresRunStorage(PostgresRunStorage):
         if existing_options:
             kwargs["connect_args"] = {"options": existing_options}
 
+        # QueuePool keeps its checked-in connections open until the engine is
+        # disposed, and rebuilding below drops the only reference to the old
+        # one. Without this the replaced pool's connections stay open for the
+        # life of the process, pinning PgBouncer server connections that nothing
+        # can ever check out again.
+        self._engine.dispose()
+
         self._engine = create_engine(self.postgres_url, **kwargs)
         event.listen(
             self._engine,

--- a/packages/ol-orchestrate-lib/src/ol_orchestrate/lib/postgres/schedule_storage.py
+++ b/packages/ol-orchestrate-lib/src/ol_orchestrate/lib/postgres/schedule_storage.py
@@ -132,6 +132,13 @@ class PooledPostgresScheduleStorage(PostgresScheduleStorage):
         if existing_options:
             kwargs["connect_args"] = {"options": existing_options}
 
+        # QueuePool keeps its checked-in connections open until the engine is
+        # disposed, and rebuilding below drops the only reference to the old
+        # one. Without this the replaced pool's connections stay open for the
+        # life of the process, pinning PgBouncer server connections that nothing
+        # can ever check out again.
+        self._engine.dispose()
+
         self._engine = create_engine(self.postgres_url, **kwargs)
         event.listen(
             self._engine,
@@ -167,8 +174,11 @@ class PooledPostgresScheduleStorage(PostgresScheduleStorage):
             "pool_timeout": Field(
                 IntSource,
                 is_required=False,
-                default_value=3600,
-                description="Recycle connections after N seconds",
+                default_value=30,
+                description=(
+                    "Seconds to wait for a connection from a saturated pool "
+                    "before raising"
+                ),
             ),
         }
 

--- a/packages/ol-orchestrate-lib/tests/lib/test_postgres.py
+++ b/packages/ol-orchestrate-lib/tests/lib/test_postgres.py
@@ -1,0 +1,185 @@
+"""Tests for ol_orchestrate.lib.postgres.
+
+These subclasses exist for one reason: dagster_postgres builds every engine with
+NullPool, so a process opens and closes a TCP connection per operation with no
+reuse and no upper bound. On 2026-08-18 the data-production daemon sustained 331
+connects/second that way and consumed all 28232 ephemeral ports in its network
+namespace, after which psycopg2 failed every new connection with "Cannot assign
+requested address" -- which reads as if PgBouncer were down, but is raised by
+bind() before a packet leaves the pod.
+
+So the property worth pinning is not storage behaviour, which is
+dagster_postgres' own concern and is covered upstream. It is that each storage
+ends up on a QueuePool whose retained size is the configured one, because
+connections above pool_size are closed when returned rather than kept, and a
+pool_size below a process's real concurrency reintroduces exactly the churn
+these classes exist to remove.
+
+Nothing here touches a database. SQLAlchemy creates engines lazily, so with
+should_autocreate_tables=False the pool can be inspected without a connection
+ever being opened.
+"""
+
+from unittest import mock
+
+import pytest
+from ol_orchestrate.lib.postgres import (
+    PooledPostgresEventLogStorage,
+    PooledPostgresRunStorage,
+    PooledPostgresScheduleStorage,
+)
+from sqlalchemy.pool import QueuePool
+
+POSTGRES_URL = (
+    "postgresql://dagster:dagster@localhost:5432/dagster"  # pragma: allowlist secret
+)
+
+STORAGE_CLASSES = [
+    PooledPostgresEventLogStorage,
+    PooledPostgresRunStorage,
+    PooledPostgresScheduleStorage,
+]
+
+# The three classes are configured from one dagster.yaml and are deployed
+# together, so every property below is asserted against all three. A pooled
+# event log next to a NullPool run storage would leave the churn in place.
+parametrize_storages = pytest.mark.parametrize(
+    "storage_class", STORAGE_CLASSES, ids=lambda cls: cls.__name__
+)
+
+
+def build_storage(storage_class, **pool_kwargs):
+    """Construct a storage without letting it reach a database."""
+    return storage_class(
+        postgres_url=POSTGRES_URL,
+        should_autocreate_tables=False,
+        **pool_kwargs,
+    )
+
+
+@parametrize_storages
+def test_storage_pools_connections_instead_of_reopening_them(storage_class) -> None:
+    """The whole point: NullPool reconnects per operation, QueuePool reuses."""
+    storage = build_storage(storage_class)
+
+    assert isinstance(storage._engine.pool, QueuePool)
+
+
+@parametrize_storages
+def test_configured_pool_size_is_the_number_of_connections_retained(
+    storage_class,
+) -> None:
+    """Connections above pool_size are closed on return, so this is the knob
+    that decides how much churn survives -- it has to be what was asked for.
+    """
+    storage = build_storage(storage_class, pool_size=7, max_overflow=3)
+
+    assert storage._engine.pool.size() == 7
+    assert storage._engine.pool._max_overflow == 3
+
+
+@parametrize_storages
+def test_pool_recycle_and_timeout_reach_the_pool(storage_class) -> None:
+    """pool_recycle bounds how long a connection outlives a PgBouncer restart;
+    pool_timeout bounds how long a caller blocks on a saturated pool.
+    """
+    storage = build_storage(storage_class, pool_recycle=900, pool_timeout=15)
+
+    assert storage._engine.pool._recycle == 900
+    assert storage._engine.pool._timeout == 15
+
+
+@parametrize_storages
+def test_pool_timeout_defaults_to_failing_fast(storage_class) -> None:
+    """A saturated pool has to raise in seconds. The config schema's default and
+    the from_config_value fallback are written in two different places, and a
+    disagreement between them is invisible until a pool actually saturates --
+    at which point the wrong value turns a fast error into a process that hangs.
+    """
+    schema_default = storage_class.config_type()["pool_timeout"].default_value
+
+    assert schema_default == 30
+    assert build_storage(storage_class)._engine.pool._timeout == 30
+
+
+@parametrize_storages
+def test_config_schema_defaults_match_the_constructor_defaults(storage_class) -> None:
+    """Dagster materializes schema defaults before from_config_value sees them,
+    so the schema is what actually ships. Divergence means the documented
+    default and the deployed one are different numbers.
+    """
+    config_type = storage_class.config_type()
+    storage = build_storage(storage_class)
+
+    assert config_type["pool_size"].default_value == storage._engine.pool.size()
+    assert (
+        config_type["max_overflow"].default_value == storage._engine.pool._max_overflow
+    )
+    assert config_type["pool_recycle"].default_value == storage._engine.pool._recycle
+
+
+@parametrize_storages
+def test_pool_settings_survive_loading_from_dagster_yaml(storage_class) -> None:
+    """The deployed path is from_config_value, not the constructor -- a class
+    whose __init__ pools correctly but drops the config on the floor would look
+    fine everywhere except production.
+    """
+    storage = storage_class.from_config_value(
+        None,
+        {
+            "postgres_db": {
+                "username": "dagster",
+                "password": "dagster",  # pragma: allowlist secret
+                "hostname": "localhost",
+                "db_name": "dagster",
+                "port": 5432,
+            },
+            "should_autocreate_tables": False,
+            "pool_size": 4,
+            "max_overflow": 6,
+            "pool_recycle": 120,
+            "pool_timeout": 5,
+        },
+    )
+
+    assert storage._engine.pool.size() == 4
+    assert storage._engine.pool._max_overflow == 6
+    assert storage._engine.pool._recycle == 120
+    assert storage._engine.pool._timeout == 5
+
+
+@parametrize_storages
+def test_optimize_for_webserver_keeps_pooling(storage_class) -> None:
+    """The webserver rebuilds the engine at startup to apply a statement
+    timeout. It must not land back on the unpooled default.
+    """
+    storage = build_storage(storage_class, pool_size=6)
+
+    storage.optimize_for_webserver(
+        statement_timeout=5000, pool_recycle=60, max_overflow=2
+    )
+
+    assert isinstance(storage._engine.pool, QueuePool)
+    assert storage._engine.pool.size() == 6
+    assert storage._engine.pool._max_overflow == 2
+
+
+@parametrize_storages
+def test_optimize_for_webserver_disposes_the_engine_it_replaces(storage_class) -> None:
+    """Rebuilding the engine drops the reference to the old one. Under NullPool
+    that costs nothing because it holds no connections, but a QueuePool that is
+    never disposed keeps its checked-in connections open for the life of the
+    process -- pinning PgBouncer server connections nothing will ever use again.
+    """
+    storage = build_storage(storage_class)
+    replaced_engine = storage._engine
+
+    with mock.patch.object(
+        replaced_engine, "dispose", wraps=replaced_engine.dispose
+    ) as dispose:
+        storage.optimize_for_webserver(
+            statement_timeout=5000, pool_recycle=60, max_overflow=2
+        )
+
+    dispose.assert_called_once()
+    assert storage._engine is not replaced_engine

--- a/uv.lock
+++ b/uv.lock
@@ -877,6 +877,19 @@ wheels = [
 ]
 
 [[package]]
+name = "dagster-postgres"
+version = "0.29.18"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "dagster" },
+    { name = "psycopg2-binary" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/68/00/55e53d046eae360d1e7475ec93e8ca185dd82346b79011ea14f05a06fde2/dagster_postgres-0.29.18.tar.gz", hash = "sha256:bdba1b9860c524b558b70a11b4cccf1836006058ecc6051700829e5d4f1ad824", size = 406346, upload-time = "2026-08-14T19:23:56.662Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/af/14/fa410bf40917d68a8400b73f7577347261b4bca28e470427578f6fd28999/dagster_postgres-0.29.18-py3-none-any.whl", hash = "sha256:9fdb27984fcc20566d1f3e731e1b039c58593a40d7f764fdcf2da139f9f5f146", size = 25559, upload-time = "2026-08-14T19:23:55.496Z" },
+]
+
+[[package]]
 name = "dagster-rest-resources"
 version = "0.29.18"
 source = { registry = "https://pypi.org/simple" }
@@ -2580,6 +2593,7 @@ dependencies = [
     { name = "boto3" },
     { name = "dagster" },
     { name = "dagster-aws" },
+    { name = "dagster-postgres" },
     { name = "fsspec" },
     { name = "gcsfs" },
     { name = "httpx2" },
@@ -2603,6 +2617,7 @@ requires-dist = [
     { name = "boto3", specifier = "~=1.43.0" },
     { name = "dagster", specifier = "~=1.11" },
     { name = "dagster-aws", specifier = "~=0.29.0" },
+    { name = "dagster-postgres", specifier = "~=0.29.0" },
     { name = "fsspec", specifier = ">=2026.0.0,<2027.0.0" },
     { name = "gcsfs", specifier = ">=2026.0.0,<2027.0.0" },
     { name = "httpx2", specifier = ">=2.2.0" },


### PR DESCRIPTION
### What are the relevant tickets?
N/A — prompted by a live failure on `data-production`.

### Description (What does it do?)

`PooledPostgresEventLogStorage`, `PooledPostgresRunStorage` and `PooledPostgresScheduleStorage` had no tests. They are being switched on in production in https://github.com/mitodl/ol-infrastructure/pull/5490, after the Dagster daemon consumed all 28,232 ephemeral ports in its network namespace — `NullPool` reconnects per operation, and 331 connects/sec against a single ClusterIP is more than a 60s `TIME_WAIT` can absorb. The control plane's connection behaviour now rests on these classes, so the properties they promise are worth pinning.

Adds `tests/lib/test_postgres.py` — 8 tests, parametrized across all three classes. They assert the pool is a `QueuePool`, that `pool_size`/`max_overflow`/`pool_recycle`/`pool_timeout` reach it from both the constructor and `from_config_value`, and that `optimize_for_webserver` neither loses pooling nor leaks the engine it replaces. Nothing touches a database: SQLAlchemy creates engines lazily, so with `should_autocreate_tables=False` the pool is inspectable without a connection ever being opened.

Writing them turned up three defects, each fixed here:

- **`dagster_postgres` was imported but never declared.** `ol-orchestrate-lib` imports it in all three modules and it is absent from `pyproject.toml`. It resolved only because something else in the environment pulled it in — the tests failed to collect with `ModuleNotFoundError: No module named 'dagster_postgres'` until it was added.
- **`optimize_for_webserver` never disposed the engine it replaced.** It rebuilds `self._engine` and drops the only reference to the old one. Harmless under `NullPool`, which holds nothing; a `QueuePool` keeps its checked-in connections open for the life of the process, pinning PgBouncer server connections nothing can ever check out again.
- **`pool_timeout`'s schema default was 3600 in the event log and schedule storages, 30 in the run storage.** Dagster materializes schema defaults before `from_config_value` sees them, so the schema is what ships — two of the three would block for an hour on a saturated pool instead of failing fast. Their `description` was also a copy-paste of `pool_recycle`'s. Nothing in production depended on the wrong value; the deployed `dagster.yaml` sets `pool_timeout` explicitly.

### How can this be tested?

```
uv sync --all-extras
uv run pytest packages/ol-orchestrate-lib/tests/lib/test_postgres.py -v
```

24 pass (8 tests × 3 classes) in ~1s, no database required.

To confirm the tests are not vacuous, stash the source fixes and rerun — 5 fail, exactly the ones covering the two behavioural defects:

```
git stash push packages/ol-orchestrate-lib/src/ol_orchestrate/lib/postgres/
uv run pytest packages/ol-orchestrate-lib/tests/lib/test_postgres.py -q
# 5 failed, 19 passed
#   test_pool_timeout_defaults_to_failing_fast[PooledPostgresEventLogStorage]
#   test_pool_timeout_defaults_to_failing_fast[PooledPostgresScheduleStorage]
#   test_optimize_for_webserver_disposes_the_engine_it_replaces[all three]
git stash pop
```

`pre-commit run --files ...` is clean on every changed file. `mypy` reports 19 pre-existing errors in these modules (`int()` over `object` in `from_config_value`); the count is identical before and after this change and is left alone.

### Additional Context

The `optimize_for_webserver` fix matters more than it looks now that pooling is on: the webserver calls it at startup to apply a statement timeout, so without the `dispose()` every webserver pod would strand a full pool's worth of connections for its entire lifetime.
