### PR TITLE
feat(inventory): gate unacknowledged removals, and render what the inventory feeds

### DIFF
--- a/.github/workflows/ingestion_inventory_ci.yaml
+++ b/.github/workflows/ingestion_inventory_ci.yaml
@@ -1,0 +1,75 @@
+---
+name: Ingestion inventory CI
+
+# Credential-free PR gate for the ingestion inventory — the human source of truth
+# for what we load (docs/specs/INGESTION_INVENTORY_SPEC.md, step 4).
+#
+# Two checks, and the second is the one that matters:
+#   validate         — schema, controlled vocabulary, and the §3.3 cross-unit rules.
+#   check-removals   — §7.2. Every (unit, raw_table) that disappears must be
+#                      acknowledged in retired.yml with a date and a reason, or
+#                      carry `renamed_from:` on the entry that replaced it.
+#
+# A dropped table entry is the one failure mode with no symptom: the loader simply
+# stops loading, nothing errors, and a dbt model quietly goes stale. Renames are
+# the subtle half — a rename reads as a delete plus an add, so an add-only check
+# waves it through while orphaning every downstream model.
+#
+# Reads only checked-in files. No Airbyte, no warehouse, no secrets.
+
+permissions:
+  contents: read
+
+on:
+  pull_request:
+    paths:
+    - "ingestion/inventory/**"
+    - "src/ol_dbt_cli/**"
+    - ".github/workflows/ingestion_inventory_ci.yaml"
+  workflow_dispatch:
+
+jobs:
+  inventory:
+    name: inventory validate + removal check
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      with:
+        fetch-depth: 0   # check-removals diffs against the merge base
+        persist-credentials: false
+
+    - name: Fetch base ref
+      if: github.event_name == 'pull_request'
+      run: git fetch --no-tags origin "${GITHUB_BASE_REF}"
+
+    - name: Install uv
+      uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
+      with:
+        version: "0.12.3"
+        enable-cache: true
+
+    - name: Set up Python
+      run: uv python install 3.13
+
+    - name: Install ol-dbt CLI
+      run: uv sync --all-extras
+
+    - name: Validate the inventory
+      run: uv run ol-dbt inventory validate
+
+    # Deliberately not baselineable: unlike a warehouse-shaped finding, an
+    # unacknowledged removal is always fixable by editing text in this same PR,
+    # and it has no legitimate upstream cause.
+    - name: Check for unacknowledged removals and renames
+      if: github.event_name == 'pull_request'
+      run: uv run ol-dbt inventory check-removals --base-ref "origin/${GITHUB_BASE_REF}"
+
+    # The rendered JSON is committed into ol-infrastructure by hand (§4 — there is
+    # deliberately no cross-repo pipeline). Rendering here proves the inventory can
+    # still produce it, so a change that breaks the consumer fails in this repo
+    # rather than halfway through a Pulumi apply against production Airbyte.
+    - name: Render the downstream artifacts
+      run: |
+        uv run ol-dbt inventory render airbyte > /dev/null
+        uv run ol-dbt inventory render dagster-intervals > /dev/null

--- a/bin/airbyte-inventory.py
+++ b/bin/airbyte-inventory.py
@@ -993,9 +993,11 @@ def render(  # noqa: C901, PLR0912, PLR0915
                 if stream.get("cursorField"):
                     entry["cursor_field"] = stream["cursorField"]
                 if stream.get("primaryKey"):
-                    entry["primary_key"] = [
-                        ".".join(part) for part in stream["primaryKey"]
-                    ]
+                    # Stored as Airbyte spells it: a list of paths, each path a
+                    # list of segments. Joining into one dotted string per column
+                    # would be lossy — a single segment containing a literal "."
+                    # is indistinguishable from two nested segments once joined.
+                    entry["primary_key"] = [list(part) for part in stream["primaryKey"]]
                 entry["modeled"] = raw_table.lower() in dbt_tables
                 if raw_table in tables and tables[raw_table] != entry:
                     todos.append(

--- a/docs/specs/INGESTION_INVENTORY_SPEC.md
+++ b/docs/specs/INGESTION_INVENTORY_SPEC.md
@@ -396,6 +396,23 @@ part of the Airbyte-as-code story that needs to run on a timer.
 | Dagster sync cadence | `ol-dbt inventory render dagster-intervals` | Replaces the hand-maintained `group_name_to_interval` literal (`definitions.py:219-254`) |
 | dlt source specs | `ol-dbt inventory render dlt` | Phase 2 only; emits `DatabaseSourceSpec`/`DatabaseTable` inputs (`src/ol_dlt/ol_dlt/database.py`) |
 
+`render airbyte` and `render dagster-intervals` are built. Two things they settle that the table
+above leaves open:
+
+- **`primary_key` round-trips through a dotted string.** `configurations.streams[].primaryKey` is
+  a list of *paths*, and a path is itself a list; the inventory stores one dotted string per
+  column, and the renderer splits it back out. Getting this wrong is invisible in the YAML and
+  fatal to §6.4's empty preview.
+- **`excluded_columns` is rendered as the exclusion, not as `selected_fields`.** Airbyte wants
+  the complement, and computing it needs the source's discovered schema — which the inventory
+  deliberately does not hold (§2). The consumer complements it against the catalog it already
+  reads.
+
+`render dagster-intervals` keys on the *derived* group name, reproducing `OLAirbyteTranslator`'s
+derivation character for character, and keeps paused connections: Dagster selects on the
+connection name alone, so a paused connection still produces a group, and omitting its interval
+hands it the silent 24-hour default the moment somebody re-enables it (§1.3, §3.6).
+
 ### Where this lives: `ol-dbt inventory`, not a new package
 
 The commands go under the existing CLI as an `inventory` sub-app, and the schema, loader and
@@ -566,6 +583,33 @@ Mechanism, following the ratchet pattern this repo already runs for dimensional 
 Renames are the subtle half: a rename looks like a delete plus an add, and without
 `renamed_from:` it passes an add-only check while silently orphaning every downstream model.
 
+**As built** (`ol-dbt inventory check-removals`, `schema/retired.schema.json`):
+
+```yaml
+schema_version: 1
+retired:
+- deployment: bootcamps
+  layer: app_postgres
+  raw_tables:                       # a list, so retiring a whole unit is one
+  - raw__bootcamps__app__postgres__applications_bootcampapplication   # dated, reasoned entry
+  retired_on: 2026-08-14            # when loading stopped, not when this was written
+  reason: The Bootcamps application is no longer deployed.            # ≥20 chars; "not needed" is not a reason
+```
+
+Three details the mechanism above does not spell out, each of which is a rule in the checker:
+
+- `renamed_from:` is **scoped to the unit**. A table moving between units is a removal from one
+  and an addition to the other, and the removal side still has to be stated — otherwise moving a
+  table is a way to launder a deletion past the check.
+- A `renamed_from:` matching nothing that disappeared is a `WARNING`, not silence. Left alone it
+  is inert, but it pre-authorises a future removal of the name it holds.
+- The graveyard is ratcheted too: deleting a `retired.yml` entry is itself an `ERROR`, and
+  `validate` rejects a retired `(unit, raw_table)` that some unit still declares — the file and
+  the units are not allowed to contradict each other.
+
+Deployment and layer in `retired.yml` are deliberately **not** checked against `vocabulary.yml`:
+a deployment can be retired out of the vocabulary too, and the graveyard has to outlive it.
+
 ---
 
 ## 8. Steps and acceptance criteria
@@ -577,8 +621,8 @@ ol-infrastructure; 7 closes the loop.
 |---|---|---|
 | 1 | `ol-dbt inventory` sub-app (§5): JSON Schema, dbt-free loader, `validate` | `ol-dbt inventory validate` passes on a hand-written two-unit fixture; all eight §3.3 rules have a failing test |
 | 2 | Dump the live workspace and derive the findings — **`bin/airbyte-inventory.py` already does this**, and has been run (§8.1); folding it in is a move, not a rewrite | Generated inventory validates; connection names byte-identical to the API's (§1.3); `replication_method` captured per Postgres source |
-| 3 | `ol-dbt inventory reconcile` — three-way diff of inventory vs warehouse vs dbt sources; land the reconciled inventory as a reviewed PR | The three buckets of §5 are reported; every one of the 374 dbt-declared raw tables maps to exactly one unit; unmapped tables are explained, not deleted |
-| 4 | CI: schema validation + §7.2 removal/rename check on every PR touching `ingestion/inventory/` | A PR deleting a table entry fails; the same PR with a `retired.yml` entry passes |
+| 3 | `ol-dbt inventory reconcile` — three-way diff of inventory vs warehouse vs dbt sources; land the reconciled inventory as a reviewed PR. The generation half (`render airbyte`, `render dagster-intervals`) is built; `reconcile` and the data itself remain | The three buckets of §5 are reported; every one of the 374 dbt-declared raw tables maps to exactly one unit; unmapped tables are explained, not deleted |
+| 4 | **DONE.** CI: schema validation + §7.2 removal/rename check on every PR touching `ingestion/inventory/` (`.github/workflows/ingestion_inventory_ci.yaml`) | A PR deleting a table entry fails; the same PR with a `retired.yml` entry passes — verified end-to-end through the CLI |
 | 5 | Pulumi `applications/airbyte_connections` + `sdks/airbyte`, provider pinned, **preview-gate first** (§6.3), then import every existing source/destination/connection — plus `airbyte_source_definition`/`airbyte_destination_definition`, so the deployed `docker_image_tag` is a reviewed diff rather than a UI click (§6.2) | `pulumi preview` is empty after import — zero creates, zero updates, zero replacements |
 | 6 | Commit the rendered JSON into ol-infrastructure and register the stack in `simple_pulumi`'s `pipeline_params` + `meta.py` (§4) | Changing the committed JSON triggers the stack's own pipeline; no new pipeline is written |
 | 7 | Flip generation: `ol-dbt generate sources --from-inventory`, generate `group_name_to_interval` (§5) | Regenerating dbt sources from the inventory is a no-op diff except the corrected `loader:` values (§1.2) |
@@ -590,6 +634,12 @@ for step 6.
 
 Step 8 is the one piece that runs on a timer, and it is deliberately last: it compares live
 Airbyte against the inventory, so it only means something once the inventory is real.
+
+**Step 4 deliberately lands before step 3.** The sequencing in this table is a dependency order,
+not a merge order, and the removal gate has no dependency on the data: it is a diff against the
+merge base, so an empty inventory is a valid starting point. Landing the gate first means the
+27-unit reconciled inventory arrives *under* the ratchet rather than beside it — every table it
+declares is protected from the first commit, instead of from whenever CI caught up.
 
 ### Step 2 is already runnable: `bin/airbyte-inventory.py`
 

--- a/docs/specs/INGESTION_INVENTORY_SPEC.md
+++ b/docs/specs/INGESTION_INVENTORY_SPEC.md
@@ -195,7 +195,7 @@ tables:
     primary_key: [id]
     modeled: true                         # §1.4; default false
     # excluded_columns: [password]        # optional; enforced by both backends
-    # renamed_from: ecommerce_basket_discount   # §7.2
+    # renamed_from: raw__mitxonline__app__postgres__ecommerce_basket_discount   # full previous raw_table, §7.2
 ```
 
 ### 3.3 Rules the validator enforces
@@ -592,12 +592,16 @@ retired:
   layer: app_postgres
   raw_tables:                       # a list, so retiring a whole unit is one
   - raw__bootcamps__app__postgres__applications_bootcampapplication   # dated, reasoned entry
-  retired_on: 2026-08-14            # when loading stopped, not when this was written
+  retired_on: "2026-08-14"          # when loading stopped, not when this was written
   reason: The Bootcamps application is no longer deployed.            # ≥20 chars; "not needed" is not a reason
 ```
 
 Three details the mechanism above does not spell out, each of which is a rule in the checker:
 
+- `renamed_from:` holds the full previous `raw_table` — e.g.
+  `raw__mitxonline__app__postgres__ecommerce_basket_discount` — not the bare stream name. The
+  removal check diffs `raw_table` strings, so a bare stream name matches nothing and produces
+  both an unacknowledged-removal error and an unmatched-rename warning.
 - `renamed_from:` is **scoped to the unit**. A table moving between units is a removal from one
   and an addition to the other, and the removal side still has to be stated — otherwise moving a
   table is a way to launder a deletion past the check.

--- a/docs/specs/INGESTION_INVENTORY_SPEC.md
+++ b/docs/specs/INGESTION_INVENTORY_SPEC.md
@@ -192,7 +192,7 @@ tables:
     raw_table: raw__mitxonline__app__postgres__ecommerce_basketdiscount
     sync_mode: incremental_append         # provider enum, §6.2
     cursor_field: [updated_on]            # required iff sync_mode starts with `incremental`
-    primary_key: [id]
+    primary_key: [[id]]                   # one entry per key column, each a path (list of segments)
     modeled: true                         # §1.4; default false
     # excluded_columns: [password]        # optional; enforced by both backends
     # renamed_from: raw__mitxonline__app__postgres__ecommerce_basket_discount   # full previous raw_table, §7.2
@@ -399,10 +399,11 @@ part of the Airbyte-as-code story that needs to run on a timer.
 `render airbyte` and `render dagster-intervals` are built. Two things they settle that the table
 above leaves open:
 
-- **`primary_key` round-trips through a dotted string.** `configurations.streams[].primaryKey` is
-  a list of *paths*, and a path is itself a list; the inventory stores one dotted string per
-  column, and the renderer splits it back out. Getting this wrong is invisible in the YAML and
-  fatal to §6.4's empty preview.
+- **`primary_key` is stored exactly as Airbyte spells it.** `configurations.streams[].primaryKey`
+  is a list of *paths*, and a path is itself a list of segments — so the inventory stores it as a
+  list of lists too, rather than joining each path into one dotted string. A single segment
+  containing a literal `.` is indistinguishable from two nested segments once joined, and that
+  loss is invisible in the YAML and fatal to §6.4's empty preview.
 - **`excluded_columns` is rendered as the exclusion, not as `selected_fields`.** Airbyte wants
   the complement, and computing it needs the source's discovered schema — which the inventory
   deliberately does not hold (§2). The consumer complements it against the catalog it already

--- a/ingestion/inventory/retired.yml
+++ b/ingestion/inventory/retired.yml
@@ -1,0 +1,17 @@
+---
+# The graveyard: (unit, raw_table) pairs we used to load and deliberately
+# stopped loading. See docs/specs/INGESTION_INVENTORY_SPEC.md §7.2.
+#
+# ENTRIES ARE NEVER DELETED. `ol-dbt inventory check-removals` fails a pull
+# request that drops one, because this file is the only record of what we used
+# to load — it is what makes "when did this table stop arriving" answerable
+# years later, when the dbt model that went stale is finally noticed.
+#
+# A table that disappears from ingestion/inventory/units/ must land here with a
+# date and a reason, or carry `renamed_from:` on its new entry in the same unit.
+# An unacknowledged disappearance is an ERROR and cannot be baselined: it is
+# always fixable by editing text, and it has no legitimate upstream cause.
+
+schema_version: 1
+
+retired: []

--- a/ingestion/inventory/schema/retired.schema.json
+++ b/ingestion/inventory/schema/retired.schema.json
@@ -1,0 +1,52 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/mitodl/ol-data-platform/ingestion/inventory/schema/retired.schema.json",
+  "title": "Ingestion inventory graveyard",
+  "description": "Tables we used to load and deliberately stopped loading. See docs/specs/INGESTION_INVENTORY_SPEC.md §7.2. Entries are never deleted: this file is what makes \"when did this table stop arriving\" answerable, and `ol-dbt inventory check-removals` fails a PR that drops one.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema_version", "retired"],
+  "properties": {
+    "schema_version": {
+      "const": 1
+    },
+    "retired": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["deployment", "layer", "raw_tables", "retired_on", "reason"],
+        "properties": {
+          "deployment": {
+            "type": "string",
+            "pattern": "^[a-z][a-z0-9_]*$",
+            "description": "The unit's deployment. Vocabulary membership is deliberately NOT checked: a deployment can be retired out of vocabulary.yml too, and the graveyard has to outlive it."
+          },
+          "layer": {
+            "type": "string",
+            "pattern": "^[a-z][a-z0-9_]*$"
+          },
+          "raw_tables": {
+            "type": "array",
+            "minItems": 1,
+            "items": {
+              "type": "string",
+              "pattern": "^raw__[A-Za-z0-9_]+$"
+            },
+            "description": "A list, so retiring a whole unit is one dated, reasoned entry rather than sixty copies of the same sentence."
+          },
+          "retired_on": {
+            "type": "string",
+            "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$",
+            "description": "The date loading stopped, as best it is known — not the date the entry was written, when those differ."
+          },
+          "reason": {
+            "type": "string",
+            "minLength": 20,
+            "description": "Why it stopped. `no longer needed` is not a reason; name the thing that went away."
+          }
+        }
+      }
+    }
+  }
+}

--- a/ingestion/inventory/schema/unit.schema.json
+++ b/ingestion/inventory/schema/unit.schema.json
@@ -169,7 +169,7 @@
           },
           "renamed_from": {
             "type": "string",
-            "description": "Acknowledges a rename so the removal check does not fire (§7.2)."
+            "description": "The full previous raw_table this table replaces, so the removal check does not fire (§7.2). Not the bare stream name."
           }
         }
       }

--- a/ingestion/inventory/schema/unit.schema.json
+++ b/ingestion/inventory/schema/unit.schema.json
@@ -156,7 +156,12 @@
           "primary_key": {
             "type": "array",
             "minItems": 1,
-            "items": {"type": "string"}
+            "description": "One entry per key column; each entry is the column's path as a list of segments, matching `configurations.streams[].primaryKey` — never a dotted string, which cannot tell a literal dot in a segment from a path boundary.",
+            "items": {
+              "type": "array",
+              "minItems": 1,
+              "items": {"type": "string"}
+            }
           },
           "excluded_columns": {
             "type": "array",

--- a/src/ol_dbt_cli/ol_dbt_cli/commands/inventory.py
+++ b/src/ol_dbt_cli/ol_dbt_cli/commands/inventory.py
@@ -25,6 +25,7 @@ from rich.markup import escape
 from ol_dbt_cli.lib.git_utils import get_repo_root, resolve_merge_base
 from ol_dbt_cli.lib.inventory import (
     DEFAULT_INVENTORY_DIR,
+    RenderError,
     check_removals,
     load_snapshot,
     load_snapshot_at_ref,
@@ -180,15 +181,24 @@ def render(
     silent 24-hour default for a mistyped key is its own class of stale-source
     incident (§1.3).
 
-    Deliberately does not validate first: a render of an invalid inventory is a
-    thing you sometimes want to look at. CI runs `validate` on the same PR.
+    Deliberately does not validate first: a render of an inventory that fails
+    some rule is a thing you sometimes want to look at, and CI runs `validate`
+    on the same PR anyway. The one exception is an inventory whose render is
+    undefined rather than merely wrong — a connection carrying a stream no table
+    declares. That stops the render with a message rather than silently dropping
+    the stream, because this JSON is applied to production Airbyte and a dropped
+    stream is a connection reconfigured to stop carrying a table.
     """
     if target not in RENDER_TARGETS:
         err_console.print(f"[bold red]Unknown render target {escape(target)!r}. Expected one of: {RENDER_TARGETS}")
         sys.exit(1)
 
     units = load_units(inventory_dir)
-    document: Any = render_airbyte(units) if target == "airbyte" else render_dagster_intervals(units)
+    try:
+        document: Any = render_airbyte(units) if target == "airbyte" else render_dagster_intervals(units)
+    except RenderError as error:
+        err_console.print(f"[bold red]{escape(str(error))}")
+        sys.exit(1)
     text = json.dumps(document, indent=2, sort_keys=False, ensure_ascii=False) + "\n"
 
     if output:

--- a/src/ol_dbt_cli/ol_dbt_cli/commands/inventory.py
+++ b/src/ol_dbt_cli/ol_dbt_cli/commands/inventory.py
@@ -16,14 +16,24 @@ from __future__ import annotations
 import json
 import sys
 from pathlib import Path
-from typing import Annotated
+from typing import Annotated, Any
 
 from cyclopts import App, Parameter
 from rich.console import Console
 from rich.markup import escape
 
-from ol_dbt_cli.lib.inventory import DEFAULT_INVENTORY_DIR, validate_inventory
-from ol_dbt_cli.lib.validation import Severity, ValidationReport
+from ol_dbt_cli.lib.git_utils import get_repo_root, resolve_merge_base
+from ol_dbt_cli.lib.inventory import (
+    DEFAULT_INVENTORY_DIR,
+    check_removals,
+    load_snapshot,
+    load_snapshot_at_ref,
+    load_units,
+    render_airbyte,
+    render_dagster_intervals,
+    validate_inventory,
+)
+from ol_dbt_cli.lib.validation import Severity, ValidationIssue, ValidationReport
 
 console = Console()
 err_console = Console(stderr=True)
@@ -71,29 +81,9 @@ def validate(
         sys.exit(1)
 
     if output_format == "json":
-        print(  # noqa: T201
-            json.dumps(
-                [
-                    {
-                        "check": issue.check,
-                        "severity": issue.severity.value,
-                        "model": issue.model,
-                        "message": issue.message,
-                        "detail": issue.detail,
-                    }
-                    for issue in report.issues
-                ],
-                indent=2,
-            )
-        )
+        _emit_json(report.issues)
     else:
-        for issue in report.issues:
-            style = SEVERITY_STYLE[issue.severity]
-            # Messages quote JSON Schema patterns like `^[a-z][a-z0-9_]*$`, which
-            # rich would read as markup and swallow.
-            console.print(f"[{style}]{issue.severity.value}[/] {escape(issue.model)}: {escape(issue.message)}")
-            if issue.detail:
-                console.print(f"    [dim]{escape(issue.detail)}[/]")
+        _emit_text(report.issues)
         tables = sum(len(unit.tables) for unit in units)
         console.print(
             f"\n[bold]Summary:[/] {len(units)} unit(s), {tables} table(s), "
@@ -102,3 +92,136 @@ def validate(
 
     if report.errors:
         sys.exit(1)
+
+
+@inventory_app.command(name="check-removals")
+def check_removals_command(
+    *,
+    inventory_dir: Annotated[
+        Path,
+        Parameter(
+            name=["--inventory-dir", "-i"],
+            help="Directory holding vocabulary.yml, schema/, units/ and retired.yml.",
+        ),
+    ] = DEFAULT_INVENTORY_DIR,
+    base_ref: Annotated[
+        str,
+        Parameter(
+            name=["--base-ref", "-b"],
+            help="Branch to compare against; the diff runs from its merge base with HEAD.",
+        ),
+    ] = "origin/main",
+    output_format: Annotated[
+        str,
+        Parameter(name=["--format", "-f"], help="Output format: text (default) or json."),
+    ] = "text",
+) -> None:
+    """Fail on any table this change dropped from the inventory without saying so.
+
+    A dropped entry means the loader simply stops loading — no error anywhere,
+    and a dbt model that quietly goes stale (§7.2). Acknowledge a removal in
+    `retired.yml` with a date and a reason, or, for a rename, with `renamed_from:`
+    on the entry that replaced it.
+
+    Exits non-zero if anything is an ERROR. These findings are not baselineable:
+    they are always fixable by editing text in the same pull request.
+    """
+    report = ValidationReport()
+    try:
+        repo_root = get_repo_root(inventory_dir if inventory_dir.exists() else Path.cwd())
+        merge_base = resolve_merge_base(base_ref, repo_root=repo_root)
+    except RuntimeError as error:
+        err_console.print(f"[bold red]{escape(str(error))}")
+        sys.exit(1)
+
+    previous = load_snapshot_at_ref(inventory_dir, merge_base, repo_root=repo_root)
+    current = load_snapshot(inventory_dir)
+    check_removals(previous, current, report)
+
+    if output_format == "json":
+        _emit_json(report.issues)
+    else:
+        _emit_text(report.issues)
+        console.print(
+            f"\n[bold]Summary:[/] compared {len(previous.units)} unit(s) at "
+            f"{merge_base[:12]} against {len(current.units)} on disk — "
+            f"{len(report.errors)} error(s), {len(report.warnings)} warning(s)."
+        )
+
+    if report.errors:
+        sys.exit(1)
+
+
+RENDER_TARGETS = ("airbyte", "dagster-intervals")
+
+
+@inventory_app.command
+def render(
+    target: Annotated[
+        str,
+        Parameter(help=f"What to render: {', '.join(RENDER_TARGETS)}."),
+    ],
+    *,
+    inventory_dir: Annotated[
+        Path,
+        Parameter(name=["--inventory-dir", "-i"], help="Directory holding units/."),
+    ] = DEFAULT_INVENTORY_DIR,
+    output: Annotated[
+        Path | None,
+        Parameter(name=["--output", "-o"], help="Write here instead of stdout."),
+    ] = None,
+) -> None:
+    """Generate a downstream artifact from the inventory.
+
+    `airbyte` emits the narrow JSON that is committed into ol-infrastructure
+    beside the Pulumi stack that consumes it (§4) — it is not fetched, and no
+    pipeline renders it. `dagster-intervals` emits the sync-cadence map that
+    replaces the hand-maintained 32-entry literal in `definitions.py`, whose
+    silent 24-hour default for a mistyped key is its own class of stale-source
+    incident (§1.3).
+
+    Deliberately does not validate first: a render of an invalid inventory is a
+    thing you sometimes want to look at. CI runs `validate` on the same PR.
+    """
+    if target not in RENDER_TARGETS:
+        err_console.print(f"[bold red]Unknown render target {escape(target)!r}. Expected one of: {RENDER_TARGETS}")
+        sys.exit(1)
+
+    units = load_units(inventory_dir)
+    document: Any = render_airbyte(units) if target == "airbyte" else render_dagster_intervals(units)
+    text = json.dumps(document, indent=2, sort_keys=False, ensure_ascii=False) + "\n"
+
+    if output:
+        output.parent.mkdir(parents=True, exist_ok=True)
+        output.write_text(text)
+        console.print(f"Wrote {escape(str(output))}")
+    else:
+        print(text, end="")  # noqa: T201
+
+
+def _emit_json(issues: list[ValidationIssue]) -> None:
+    print(  # noqa: T201
+        json.dumps(
+            [
+                {
+                    "check": issue.check,
+                    "severity": issue.severity.value,
+                    "model": issue.model,
+                    "message": issue.message,
+                    "detail": issue.detail,
+                }
+                for issue in issues
+            ],
+            indent=2,
+        )
+    )
+
+
+def _emit_text(issues: list[ValidationIssue]) -> None:
+    for issue in issues:
+        style = SEVERITY_STYLE[issue.severity]
+        # Messages quote JSON Schema patterns like `^[a-z][a-z0-9_]*$`, which
+        # rich would read as markup and swallow.
+        console.print(f"[{style}]{issue.severity.value}[/] {escape(issue.model)}: {escape(issue.message)}")
+        if issue.detail:
+            console.print(f"    [dim]{escape(issue.detail)}[/]")

--- a/src/ol_dbt_cli/ol_dbt_cli/lib/git_utils.py
+++ b/src/ol_dbt_cli/ol_dbt_cli/lib/git_utils.py
@@ -179,6 +179,27 @@ def get_file_at_ref(path: Path, ref: str, repo_root: Path | None = None) -> str 
         return None
 
 
+def list_files_at_ref(directory: Path, ref: str, repo_root: Path | None = None) -> list[Path]:
+    """Return the paths tracked under *directory* at git *ref*.
+
+    Reading a whole directory as of the merge base needs the file list from the
+    tree, not from disk: the point of the comparison is to see the files the
+    branch deleted, and those are exactly the ones `rglob` cannot find.
+    """
+    root = repo_root or get_repo_root(directory)
+    try:
+        rel = directory.relative_to(root)
+    except ValueError:
+        rel = directory
+    try:
+        raw = _run_git(["ls-tree", "-r", "-z", "--name-only", ref, "--", str(rel)], cwd=root)
+    except RuntimeError:
+        # The directory did not exist at that ref — a first-time inventory has
+        # nothing to have removed.
+        return []
+    return [root / name for name in raw.split("\0") if name]
+
+
 def _is_under(path: Path, directory: Path) -> bool:
     """Return True if *path* is inside *directory*."""
     try:

--- a/src/ol_dbt_cli/ol_dbt_cli/lib/inventory.py
+++ b/src/ol_dbt_cli/ol_dbt_cli/lib/inventory.py
@@ -569,15 +569,38 @@ def dagster_group_name(connection_name: str) -> str:
     return re.sub(r"[^A-Za-z0-9_]", "", re.sub(r"[-\s]+", "_", connection_name)).strip("_").lower()
 
 
+class RenderError(Exception):
+    """The inventory cannot be rendered, and rendering it anyway would be a lie."""
+
+
 def _tables_by_stream(unit: Unit) -> dict[str, dict[str, Any]]:
     """Index a unit's tables by stream name.
 
     `validate` guarantees this is a bijection with the streams the unit's
-    connections carry — that is what the connection rules exist for — so the
-    renderer can index without a fallback, and a KeyError here means validate
-    was skipped rather than that the renderer needs a default.
+    connections carry — that is what the connection rules exist for — but
+    `render` deliberately does not validate first, so it cannot assume it.
     """
     return {str(table.get("name", "")): table for table in unit.tables}
+
+
+def _resolve_stream(unit: Unit, by_stream: dict[str, dict[str, Any]], stream: str) -> dict[str, Any]:
+    """Find the table a connection's stream refers to, or refuse to render.
+
+    Skipping the stream would be worse than failing. This render is applied to
+    production Airbyte: a dropped stream is a connection Pulumi reconfigures to
+    stop carrying a table, which is precisely the silent-omission failure the
+    inventory exists to end — and it would be silent in a committed JSON file
+    that a human reviewed. Better to name the missing declaration and stop.
+    """
+    table = by_stream.get(stream)
+    if table is None:
+        msg = (
+            f"{unit.path.name}: connection stream {stream!r} in unit {unit.key} matches no "
+            f"table in that unit, so there is nothing to render it from. "
+            f"Run `ol-dbt inventory validate` — it reports this and everything else wrong with the file."
+        )
+        raise RenderError(msg)
+    return table
 
 
 def _render_stream(table: dict[str, Any]) -> dict[str, Any]:
@@ -629,7 +652,10 @@ def render_airbyte(units: list[Unit]) -> dict[str, Any]:
                     "status": connection.get("status"),
                     "sync_interval_hours": connection.get("sync_interval_hours"),
                     "dagster_group_name": dagster_group_name(str(connection.get("name", ""))),
-                    "streams": [_render_stream(by_stream[str(stream)]) for stream in connection.get("streams") or []],
+                    "streams": [
+                        _render_stream(_resolve_stream(unit, by_stream, str(stream)))
+                        for stream in connection.get("streams") or []
+                    ],
                 }
                 for connection in unit.connections
             ],

--- a/src/ol_dbt_cli/ol_dbt_cli/lib/inventory.py
+++ b/src/ol_dbt_cli/ol_dbt_cli/lib/inventory.py
@@ -14,6 +14,7 @@ imports narrow now is what makes that a move rather than a rewrite.
 from __future__ import annotations
 
 import json
+import re
 from collections import Counter
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -22,18 +23,23 @@ from typing import Any
 import yaml
 from jsonschema import Draft202012Validator
 
+from ol_dbt_cli.lib import git_utils
 from ol_dbt_cli.lib.validation import Severity, ValidationReport
 
 CHECK = "inventory"
+REMOVAL_CHECK = "inventory_removal"
 
 DEFAULT_INVENTORY_DIR = Path("ingestion/inventory")
 UNITS_SUBDIR = "units"
 SCHEMA_PATH = Path("schema") / "unit.schema.json"
+RETIRED_SCHEMA_PATH = Path("schema") / "retired.schema.json"
 VOCABULARY_FILENAME = "vocabulary.yml"
+RETIRED_FILENAME = "retired.yml"
 
 DAGSTER_SELECTOR_SUFFIX = "s3 data lake"
 INCREMENTAL_PREFIX = "incremental"
 MIRROR_STRATEGY = "mirror"
+AIRBYTE_LOADER = "airbyte"
 
 
 @dataclass
@@ -217,7 +223,7 @@ def _check_tables(unit: Unit, report: ValidationReport) -> None:
 
 
 def _check_connections(unit: Unit, report: ValidationReport) -> None:
-    if unit.data.get("loader") != "airbyte":
+    if unit.data.get("loader") != AIRBYTE_LOADER:
         return
     dagster_visible = unit.data.get("dagster_visible", True)
     # Joined on the stream NAME, not on `table_prefix + name`: `raw_table` is
@@ -347,4 +353,321 @@ def validate_inventory(inventory_dir: Path, report: ValidationReport) -> list[Un
     # Only well-formed units: two units missing `deployment` both key as `?/?`,
     # and reporting that as a duplicate key blames the wrong thing.
     _check_cross_unit(well_formed, report)
+    _check_retired(inventory_dir, well_formed, report)
     return units
+
+
+# ---------------------------------------------------------------------------
+# §7.2 — the graveyard, and the removal/rename check
+# ---------------------------------------------------------------------------
+
+
+def unit_key(data: dict[str, Any]) -> str:
+    """Spell the `deployment/layer` key exactly as `Unit.key` spells it."""
+    return f"{data.get('deployment', '?')}/{data.get('layer', '?')}"
+
+
+def load_retired(inventory_dir: Path) -> list[dict[str, Any]]:
+    """Read `retired.yml`. A missing file is an empty graveyard, not an error.
+
+    The file is optional so that a fresh checkout of the inventory — or a test
+    fixture that only cares about units — does not have to carry one.
+    """
+    path = inventory_dir / RETIRED_FILENAME
+    if not path.exists():
+        return []
+    raw = yaml.safe_load(path.read_text())
+    if not isinstance(raw, dict):
+        return []
+    entries = raw.get("retired")
+    return [entry for entry in entries if isinstance(entry, dict)] if isinstance(entries, list) else []
+
+
+def retired_pairs(entries: list[dict[str, Any]]) -> set[tuple[str, str]]:
+    """`(unit_key, raw_table)` for every table any graveyard entry accounts for."""
+    pairs: set[tuple[str, str]] = set()
+    for entry in entries:
+        key = unit_key(entry)
+        for raw_table in entry.get("raw_tables") or []:
+            pairs.add((key, str(raw_table)))
+    return pairs
+
+
+def declared_pairs(units: list[Unit]) -> set[tuple[str, str]]:
+    """`(unit_key, raw_table)` for every table the inventory currently declares."""
+    return {(unit.key, str(table.get("raw_table", ""))) for unit in units for table in unit.tables}
+
+
+def _check_retired(inventory_dir: Path, units: list[Unit], report: ValidationReport) -> None:
+    """Validate `retired.yml`'s shape, and that it does not contradict the units."""
+    path = inventory_dir / RETIRED_FILENAME
+    if not path.exists():
+        return
+    schema_path = inventory_dir / RETIRED_SCHEMA_PATH
+    if schema_path.exists():
+        raw = yaml.safe_load(path.read_text())
+        validator = Draft202012Validator(json.loads(schema_path.read_text()))
+        for error in sorted(
+            validator.iter_errors(raw),
+            key=lambda e: [str(part) for part in e.absolute_path],
+        ):
+            location = "/".join(str(part) for part in error.absolute_path) or "(root)"
+            report.add(CHECK, Severity.ERROR, RETIRED_FILENAME, f"{location} {error.message}")
+
+    live = declared_pairs(units)
+    for key, raw_table in sorted(retired_pairs(load_retired(inventory_dir)) & live):
+        report.add(
+            CHECK,
+            Severity.ERROR,
+            key,
+            f"{raw_table} is retired but the unit still declares it",
+            "The graveyard and the units contradict each other. Either the table "
+            "is still loaded — drop the retired.yml entry — or it is not, and the "
+            "unit entry is what should go.",
+        )
+
+
+@dataclass
+class Snapshot:
+    """The whole inventory as of one git ref: the units plus the graveyard.
+
+    They travel together because the §7.2 check reads both on both sides of the
+    diff — a table may disappear from `units/` in the same commit that adds its
+    `retired.yml` entry, and a deleted graveyard entry is itself a finding.
+    """
+
+    units: list[Unit] = field(default_factory=list)
+    retired: list[dict[str, Any]] = field(default_factory=list)
+
+
+def load_snapshot(inventory_dir: Path) -> Snapshot:
+    return Snapshot(units=load_units(inventory_dir), retired=load_retired(inventory_dir))
+
+
+def load_snapshot_at_ref(inventory_dir: Path, ref: str, repo_root: Path | None = None) -> Snapshot:
+    """Read the inventory as it stood at git *ref*, without touching the worktree.
+
+    Units the branch deleted only exist in the tree, so the file list comes from
+    `git ls-tree` rather than from disk. A unit that is unparseable at the base
+    ref is skipped rather than raising: the check's job is to report what this
+    change removed, and it should not be blocked by a mess somebody else merged.
+    """
+    units: list[Unit] = []
+    for path in sorted(git_utils.list_files_at_ref(inventory_dir / UNITS_SUBDIR, ref, repo_root)):
+        if path.suffix != ".yml":
+            continue
+        content = git_utils.get_file_at_ref(path, ref, repo_root)
+        if content is None:
+            continue
+        try:
+            parsed = yaml.safe_load(content)
+        except yaml.YAMLError:
+            continue
+        units.append(Unit(path=path, data=parsed if isinstance(parsed, dict) else {}))
+
+    retired: list[dict[str, Any]] = []
+    content = git_utils.get_file_at_ref(inventory_dir / RETIRED_FILENAME, ref, repo_root)
+    if content:
+        try:
+            raw = yaml.safe_load(content)
+        except yaml.YAMLError:
+            raw = None
+        if isinstance(raw, dict) and isinstance(raw.get("retired"), list):
+            retired = [entry for entry in raw["retired"] if isinstance(entry, dict)]
+    return Snapshot(units=units, retired=retired)
+
+
+def check_removals(
+    previous: Snapshot,
+    current: Snapshot,
+    report: ValidationReport,
+) -> None:
+    """Fail on any `(unit, raw_table)` that disappeared without being acknowledged.
+
+    The failure this catches is silent: a dropped entry means the loader simply
+    stops loading, with no error anywhere and a dbt model that quietly goes
+    stale. A rename is the subtle half — it looks like a delete plus an add, so
+    an add-only check waves it through while every downstream model is orphaned.
+
+    Acknowledgement is either a `retired.yml` entry (dated and reasoned) or
+    `renamed_from:` on another table in the same unit. Findings here are ERRORs
+    and are deliberately not baselineable: unlike a warehouse-shaped finding,
+    this one is always fixable by editing text in the same pull request.
+    """
+    before = declared_pairs(previous.units)
+    after = declared_pairs(current.units)
+
+    renames: dict[tuple[str, str], str] = {}
+    for unit in current.units:
+        for table in unit.tables:
+            old = table.get("renamed_from")
+            if old:
+                renames[unit.key, str(old)] = str(table.get("raw_table", ""))
+
+    graveyard = retired_pairs(current.retired)
+
+    for key, raw_table in sorted(before - after):
+        if (key, raw_table) in graveyard:
+            continue
+        if (key, raw_table) in renames:
+            report.add(
+                REMOVAL_CHECK,
+                Severity.INFO,
+                key,
+                f"{raw_table} was renamed to {renames[key, raw_table]}",
+            )
+            continue
+        report.add(
+            REMOVAL_CHECK,
+            Severity.ERROR,
+            key,
+            f"{raw_table} disappeared from the inventory without acknowledgement",
+            "Add it to ingestion/inventory/retired.yml with a date and a reason, "
+            "or set `renamed_from: " + raw_table + "` on the entry that replaced it.",
+        )
+
+    # A `renamed_from` pointing at a table that did not disappear is either a
+    # typo or a leftover from an earlier PR. Left alone it is inert, but it also
+    # silently pre-authorises a future removal of the name it holds.
+    for (key, old), new in sorted(renames.items()):
+        if (key, old) not in before - after:
+            report.add(
+                REMOVAL_CHECK,
+                Severity.WARNING,
+                key,
+                f"{new} claims `renamed_from: {old}`, but {old} did not disappear in this change",
+            )
+
+    # Deleting a graveyard entry is how the record of what we used to load gets
+    # lost, so the ratchet runs on retired.yml too.
+    for key, raw_table in sorted(retired_pairs(previous.retired) - graveyard):
+        report.add(
+            REMOVAL_CHECK,
+            Severity.ERROR,
+            key,
+            f"the retired.yml entry for {raw_table} was deleted",
+            "Graveyard entries are never removed — the record of what we used to load is the point of the file.",
+        )
+
+
+# ---------------------------------------------------------------------------
+# §5 — what the inventory generates
+# ---------------------------------------------------------------------------
+
+RENDER_SCHEMA_VERSION = 1
+
+
+def dagster_group_name(connection_name: str) -> str:
+    """Reproduce `OLAirbyteTranslator.get_asset_spec`'s group-name derivation exactly.
+
+    `dg_projects/lakehouse/lakehouse/definitions.py` collapses dashes and
+    whitespace to underscores, drops everything else — including Airbyte's
+    U+2192 arrow — strips, and lowercases. This has to match character for
+    character: the derived name is the key of the sync-interval map, and a miss
+    there falls back to 24 hours in silence (§1.3).
+    """
+    return re.sub(r"[^A-Za-z0-9_]", "", re.sub(r"[-\s]+", "_", connection_name)).strip("_").lower()
+
+
+def _tables_by_stream(unit: Unit) -> dict[str, dict[str, Any]]:
+    """Index a unit's tables by stream name.
+
+    `validate` guarantees this is a bijection with the streams the unit's
+    connections carry — that is what the connection rules exist for — so the
+    renderer can index without a fallback, and a KeyError here means validate
+    was skipped rather than that the renderer needs a default.
+    """
+    return {str(table.get("name", "")): table for table in unit.tables}
+
+
+def _render_stream(table: dict[str, Any]) -> dict[str, Any]:
+    stream: dict[str, Any] = {
+        "name": table.get("name"),
+        "sync_mode": table.get("sync_mode"),
+    }
+    if table.get("namespace"):
+        stream["namespace"] = table["namespace"]
+    if table.get("cursor_field"):
+        stream["cursor_field"] = list(table["cursor_field"])
+    if table.get("primary_key"):
+        # The inventory stores a composite key as one dotted string per column,
+        # because `configurations.streams[].primaryKey` is a list of paths and a
+        # path is itself a list. Splitting it back out here is what makes the
+        # rendered config comparable with the imported one (§6.4).
+        stream["primary_key"] = [str(column).split(".") for column in table["primary_key"]]
+    if table.get("excluded_columns"):
+        # Emitted as the exclusion, not as `selected_fields`. Airbyte wants the
+        # complement, and computing it needs the source's discovered schema —
+        # which the inventory deliberately does not hold (§2). The consumer
+        # complements it against the catalog it already reads.
+        stream["excluded_columns"] = list(table["excluded_columns"])
+    return stream
+
+
+def render_airbyte(units: list[Unit]) -> dict[str, Any]:
+    """Render the narrow, stable JSON that crosses the boundary into ol-infrastructure.
+
+    Only the Airbyte-relevant fields, and only `loader: airbyte` units: as each
+    source migrates to dlt its unit flips `loader`, the renderer stops emitting
+    it, and Pulumi removes the connection (§6.5). `schema_version` is what lets
+    the YAML keep growing dlt-shaped fields without breaking the consumer (§4).
+    """
+    rendered = []
+    for unit in sorted(units, key=lambda u: u.key):
+        if unit.data.get("loader") != AIRBYTE_LOADER:
+            continue
+        airbyte = unit.data.get("airbyte") or {}
+        by_stream = _tables_by_stream(unit)
+        entry: dict[str, Any] = {
+            "deployment": unit.data.get("deployment"),
+            "layer": unit.data.get("layer"),
+            "table_prefix": unit.data.get("table_prefix"),
+            "source_kind": airbyte.get("source_kind"),
+            "connections": [
+                {
+                    "name": connection.get("name"),
+                    "status": connection.get("status"),
+                    "sync_interval_hours": connection.get("sync_interval_hours"),
+                    "dagster_group_name": dagster_group_name(str(connection.get("name", ""))),
+                    "streams": [_render_stream(by_stream[str(stream)]) for stream in connection.get("streams") or []],
+                }
+                for connection in unit.connections
+            ],
+        }
+        if airbyte.get("replication_method"):
+            entry["replication_method"] = airbyte["replication_method"]
+        rendered.append(entry)
+    return {
+        "schema_version": RENDER_SCHEMA_VERSION,
+        "generated_by": "ol-dbt inventory render airbyte",
+        "source": "mitodl/ol-data-platform ingestion/inventory",
+        "units": rendered,
+    }
+
+
+def render_dagster_intervals(units: list[Unit]) -> dict[str, int]:
+    """`group_name -> sync interval in hours`, replacing the hand-maintained literal.
+
+    Keyed on the derived Dagster group name rather than the connection name,
+    because that is what `definitions.py` looks the interval up by. Units marked
+    `dagster_visible: false` are excluded: Dagster's `connection_selector_fn`
+    never sees their connections, so an entry for one is dead weight that reads
+    like coverage.
+
+    Paused connections are kept. Dagster builds its assets from the live
+    workspace and selects on the connection name alone, so a paused connection
+    still produces a group — and omitting its interval would silently hand it
+    the 24-hour default the moment somebody re-enables it.
+    """
+    intervals: dict[str, int] = {}
+    for unit in sorted(units, key=lambda u: u.key):
+        if not unit.data.get("dagster_visible", True):
+            continue
+        for connection in unit.connections:
+            name = str(connection.get("name", ""))
+            if not name.lower().endswith(DAGSTER_SELECTOR_SUFFIX):
+                continue
+            hours = connection.get("sync_interval_hours")
+            if isinstance(hours, int):
+                intervals[dagster_group_name(name)] = hours
+    return dict(sorted(intervals.items()))

--- a/src/ol_dbt_cli/ol_dbt_cli/lib/inventory.py
+++ b/src/ol_dbt_cli/ol_dbt_cli/lib/inventory.py
@@ -404,15 +404,14 @@ def _check_retired(inventory_dir: Path, units: list[Unit], report: ValidationRep
     if not path.exists():
         return
     schema_path = inventory_dir / RETIRED_SCHEMA_PATH
-    if schema_path.exists():
-        raw = yaml.safe_load(path.read_text())
-        validator = Draft202012Validator(json.loads(schema_path.read_text()))
-        for error in sorted(
-            validator.iter_errors(raw),
-            key=lambda e: [str(part) for part in e.absolute_path],
-        ):
-            location = "/".join(str(part) for part in error.absolute_path) or "(root)"
-            report.add(CHECK, Severity.ERROR, RETIRED_FILENAME, f"{location} {error.message}")
+    raw = yaml.safe_load(path.read_text())
+    validator = Draft202012Validator(json.loads(schema_path.read_text()))
+    for error in sorted(
+        validator.iter_errors(raw),
+        key=lambda e: [str(part) for part in e.absolute_path],
+    ):
+        location = "/".join(str(part) for part in error.absolute_path) or "(root)"
+        report.add(CHECK, Severity.ERROR, RETIRED_FILENAME, f"{location} {error.message}")
 
     live = declared_pairs(units)
     for key, raw_table in sorted(retired_pairs(load_retired(inventory_dir)) & live):
@@ -686,6 +685,7 @@ def render_dagster_intervals(units: list[Unit]) -> dict[str, int]:
     the 24-hour default the moment somebody re-enables it.
     """
     intervals: dict[str, int] = {}
+    sources: dict[str, str] = {}
     for unit in sorted(units, key=lambda u: u.key):
         if not unit.data.get("dagster_visible", True):
             continue
@@ -694,6 +694,17 @@ def render_dagster_intervals(units: list[Unit]) -> dict[str, int]:
             if not name.lower().endswith(DAGSTER_SELECTOR_SUFFIX):
                 continue
             hours = connection.get("sync_interval_hours")
-            if isinstance(hours, int):
-                intervals[dagster_group_name(name)] = hours
+            if not isinstance(hours, int):
+                continue
+            group = dagster_group_name(name)
+            if group in intervals and intervals[group] != hours:
+                msg = (
+                    f"connections {sources[group]!r} and {name!r} both derive the Dagster "
+                    f"group {group!r} but disagree on sync_interval_hours "
+                    f"({intervals[group]} vs {hours}) — rendering one would silently drop "
+                    f"the other's cadence."
+                )
+                raise RenderError(msg)
+            intervals[group] = hours
+            sources[group] = name
     return dict(sorted(intervals.items()))

--- a/src/ol_dbt_cli/ol_dbt_cli/lib/inventory.py
+++ b/src/ol_dbt_cli/ol_dbt_cli/lib/inventory.py
@@ -612,11 +612,11 @@ def _render_stream(table: dict[str, Any]) -> dict[str, Any]:
     if table.get("cursor_field"):
         stream["cursor_field"] = list(table["cursor_field"])
     if table.get("primary_key"):
-        # The inventory stores a composite key as one dotted string per column,
-        # because `configurations.streams[].primaryKey` is a list of paths and a
-        # path is itself a list. Splitting it back out here is what makes the
-        # rendered config comparable with the imported one (§6.4).
-        stream["primary_key"] = [str(column).split(".") for column in table["primary_key"]]
+        # The inventory stores this exactly as `configurations.streams[].primaryKey`
+        # does — a list of paths, each path a list of segments — so it round-trips
+        # without ambiguity, which is what makes the rendered config comparable
+        # with the imported one (§6.4).
+        stream["primary_key"] = [list(path) for path in table["primary_key"]]
     if table.get("excluded_columns"):
         # Emitted as the exclusion, not as `selected_fields`. Airbyte wants the
         # complement, and computing it needs the source's discovered schema —

--- a/src/ol_dbt_cli/tests/test_inventory.py
+++ b/src/ol_dbt_cli/tests/test_inventory.py
@@ -56,7 +56,7 @@ APP_UNIT: dict[str, Any] = {
             "raw_table": "raw__mitxonline__openedx__mysql__auth_user",
             "sync_mode": "incremental_append",
             "cursor_field": ["id"],
-            "primary_key": ["id"],
+            "primary_key": [["id"]],
             "modeled": True,
         },
         {

--- a/src/ol_dbt_cli/tests/test_inventory_removals.py
+++ b/src/ol_dbt_cli/tests/test_inventory_removals.py
@@ -1,0 +1,304 @@
+"""Tests for the §7.2 removal/rename check and the §5 render targets.
+
+The removal check is the one rule in the inventory whose absence is invisible:
+every other finding shows up as a broken build somewhere, while a silently
+dropped table just stops arriving. So each way a removal can be acknowledged —
+and each way it can fail to be — gets its own case.
+"""
+
+from __future__ import annotations
+
+import copy
+import subprocess
+from pathlib import Path
+from typing import Any
+
+import pytest
+import yaml
+
+from ol_dbt_cli.lib.inventory import (
+    Snapshot,
+    Unit,
+    check_removals,
+    dagster_group_name,
+    load_snapshot,
+    load_snapshot_at_ref,
+    render_airbyte,
+    render_dagster_intervals,
+    validate_inventory,
+)
+from ol_dbt_cli.lib.validation import Severity, ValidationReport
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+REAL_INVENTORY = REPO_ROOT / "ingestion" / "inventory"
+
+UNIT: dict[str, Any] = {
+    "schema_version": 1,
+    "deployment": "mitxonline",
+    "layer": "mysql",
+    "scope": "scoped",
+    "strategies": {"qa": "ingest", "local": "fixture"},
+    "loader": "airbyte",
+    "table_prefix": "raw__mitxonline__openedx__mysql__",
+    "airbyte": {
+        "source_kind": "source-mysql",
+        "replication_method": "cursor",
+        "connections": [
+            {
+                "name": "MITx Online Open edX DB → S3 Data Lake",
+                "status": "active",
+                "sync_interval_hours": 12,
+                "streams": ["auth_user", "courseware_studentmodule"],
+            }
+        ],
+    },
+    "tables": [
+        {
+            "name": "auth_user",
+            "namespace": "edxapp",
+            "raw_table": "raw__mitxonline__openedx__mysql__auth_user",
+            "sync_mode": "incremental_append",
+            "cursor_field": ["id"],
+            "primary_key": ["id"],
+            "modeled": True,
+        },
+        {
+            "name": "courseware_studentmodule",
+            "namespace": "edxapp",
+            "raw_table": "raw__mitxonline__openedx__mysql__courseware_studentmodule",
+            "sync_mode": "full_refresh_overwrite",
+            "primary_key": ["course_id.id"],
+            "excluded_columns": ["state"],
+            "modeled": False,
+        },
+    ],
+}
+
+
+def _unit(data: dict[str, Any], name: str = "mitxonline__mysql.yml") -> Unit:
+    return Unit(path=Path("ingestion/inventory/units") / name, data=data)
+
+
+def _snapshot(data: dict[str, Any], retired: list[dict[str, Any]] | None = None) -> Snapshot:
+    return Snapshot(units=[_unit(data)], retired=retired or [])
+
+
+def _without_second_table() -> dict[str, Any]:
+    """Return the unit with `courseware_studentmodule` dropped, connection included."""
+    after = copy.deepcopy(UNIT)
+    after["tables"] = [after["tables"][0]]
+    after["airbyte"]["connections"][0]["streams"] = ["auth_user"]
+    return after
+
+
+def _run(previous: Snapshot, current: Snapshot) -> ValidationReport:
+    report = ValidationReport()
+    check_removals(previous, current, report)
+    return report
+
+
+def _messages(report: ValidationReport, severity: Severity = Severity.ERROR) -> str:
+    return " | ".join(issue.message for issue in report.issues if issue.severity == severity)
+
+
+RETIRED_ENTRY = {
+    "deployment": "mitxonline",
+    "layer": "mysql",
+    "raw_tables": ["raw__mitxonline__openedx__mysql__courseware_studentmodule"],
+    "retired_on": "2026-08-18",
+    "reason": "Superseded by the studentmodulehistory extract; the table has not been read since.",
+}
+
+
+class TestRemovals:
+    def test_an_unchanged_inventory_reports_nothing(self) -> None:
+        report = _run(_snapshot(UNIT), _snapshot(UNIT))
+        assert report.issues == []
+
+    def test_a_dropped_table_is_an_error(self) -> None:
+        report = _run(_snapshot(UNIT), _snapshot(_without_second_table()))
+        assert "courseware_studentmodule disappeared" in _messages(report)
+
+    def test_a_dropped_table_is_forgiven_by_a_retired_entry(self) -> None:
+        report = _run(_snapshot(UNIT), _snapshot(_without_second_table(), [RETIRED_ENTRY]))
+        assert report.errors == [], _messages(report)
+
+    def test_a_retired_entry_for_a_different_unit_does_not_forgive(self) -> None:
+        # The graveyard is keyed on (deployment, layer, raw_table): the same
+        # table name under another unit is a different table.
+        entry = {**RETIRED_ENTRY, "layer": "app_postgres"}
+        report = _run(_snapshot(UNIT), _snapshot(_without_second_table(), [entry]))
+        assert "disappeared" in _messages(report)
+
+    def test_deleting_the_whole_unit_is_an_error_per_table(self) -> None:
+        report = _run(_snapshot(UNIT), Snapshot())
+        assert len(report.errors) == 2  # noqa: PLR2004
+
+    def test_a_first_ever_inventory_removes_nothing(self) -> None:
+        report = _run(Snapshot(), _snapshot(UNIT))
+        assert report.issues == []
+
+
+class TestRenames:
+    def test_a_rename_without_acknowledgement_looks_like_a_removal(self) -> None:
+        after = copy.deepcopy(UNIT)
+        after["tables"][1]["raw_table"] = "raw__mitxonline__openedx__mysql__studentmodule"
+        report = _run(_snapshot(UNIT), _snapshot(after))
+        assert "courseware_studentmodule disappeared" in _messages(report)
+
+    def test_renamed_from_acknowledges_it(self) -> None:
+        after = copy.deepcopy(UNIT)
+        after["tables"][1]["raw_table"] = "raw__mitxonline__openedx__mysql__studentmodule"
+        after["tables"][1]["renamed_from"] = "raw__mitxonline__openedx__mysql__courseware_studentmodule"
+        report = _run(_snapshot(UNIT), _snapshot(after))
+        assert report.errors == [], _messages(report)
+        assert "was renamed to" in _messages(report, Severity.INFO)
+
+    def test_renamed_from_in_another_unit_does_not_acknowledge_it(self) -> None:
+        # `renamed_from` is scoped to the unit: a table moving between units is
+        # a removal from one and an addition to the other, and the removal side
+        # still has to be stated.
+        after = copy.deepcopy(UNIT)
+        after["tables"] = [after["tables"][0]]
+        after["airbyte"]["connections"][0]["streams"] = ["auth_user"]
+        other = copy.deepcopy(UNIT)
+        other["layer"] = "openedx_notes"
+        other["tables"][1]["renamed_from"] = "raw__mitxonline__openedx__mysql__courseware_studentmodule"
+        current = Snapshot(units=[_unit(after), _unit(other, "mitxonline__openedx_notes.yml")])
+        report = _run(_snapshot(UNIT), current)
+        assert "courseware_studentmodule disappeared" in _messages(report)
+
+    def test_a_renamed_from_that_matches_no_removal_warns(self) -> None:
+        after = copy.deepcopy(UNIT)
+        after["tables"][1]["renamed_from"] = "raw__mitxonline__openedx__mysql__never_existed"
+        report = _run(_snapshot(UNIT), _snapshot(after))
+        assert report.errors == []
+        assert "did not disappear in this change" in _messages(report, Severity.WARNING)
+
+
+class TestGraveyardIsNeverEmptied:
+    def test_deleting_a_retired_entry_is_an_error(self) -> None:
+        previous = _snapshot(_without_second_table(), [RETIRED_ENTRY])
+        current = _snapshot(_without_second_table(), [])
+        report = _run(previous, current)
+        assert "was deleted" in _messages(report)
+
+    def test_a_retired_table_the_unit_still_declares_is_a_contradiction(self, tmp_path: Path) -> None:
+        root = _materialize(tmp_path, UNIT, [RETIRED_ENTRY])
+        report = ValidationReport()
+        validate_inventory(root, report)
+        assert "is retired but the unit still declares it" in _messages(report)
+
+    def test_a_graveyard_entry_without_a_reason_is_rejected(self, tmp_path: Path) -> None:
+        entry = {key: value for key, value in RETIRED_ENTRY.items() if key != "reason"}
+        root = _materialize(tmp_path, _without_second_table(), [entry])
+        report = ValidationReport()
+        validate_inventory(root, report)
+        assert "'reason' is a required property" in _messages(report)
+
+
+def _materialize(tmp_path: Path, unit: dict[str, Any], retired: list[dict[str, Any]]) -> Path:
+    """Write a one-unit inventory on disk, carrying the real schemas and vocabulary."""
+    root = tmp_path / "inventory"
+    (root / "units").mkdir(parents=True)
+    (root / "schema").mkdir()
+    for name in ("unit.schema.json", "retired.schema.json"):
+        (root / "schema" / name).write_text((REAL_INVENTORY / "schema" / name).read_text())
+    (root / "vocabulary.yml").write_text((REAL_INVENTORY / "vocabulary.yml").read_text())
+    (root / "units" / "mitxonline__mysql.yml").write_text(yaml.safe_dump(unit, sort_keys=False))
+    (root / "retired.yml").write_text(yaml.safe_dump({"schema_version": 1, "retired": retired}, sort_keys=False))
+    return root
+
+
+class TestReadingTheBaseRefFromGit:
+    """The one case the in-memory tests cannot cover: reading the *deleted* side.
+
+    A unit file the branch removed exists only in the tree, so the base-ref
+    snapshot has to come from `git ls-tree` rather than from disk — the mistake
+    this guards against is globbing the worktree and finding nothing to compare.
+    """
+
+    def test_a_deleted_unit_file_is_still_read_at_the_base_ref(self, tmp_path: Path) -> None:
+        repo = tmp_path / "repo"
+        inventory = _materialize(repo, UNIT, [])
+        _git(repo, "init", "--initial-branch=main")
+        _git(repo, "add", "-A")
+        _git(repo, "-c", "user.email=t@example.com", "-c", "user.name=T", "commit", "-m", "inventory")
+        base = _git(repo, "rev-parse", "HEAD").strip()
+
+        (inventory / "units" / "mitxonline__mysql.yml").unlink()
+
+        previous = load_snapshot_at_ref(inventory, base, repo_root=repo)
+        report = ValidationReport()
+        check_removals(previous, load_snapshot(inventory), report)
+        assert len(previous.units) == 1
+        assert len(report.errors) == 2  # noqa: PLR2004
+
+
+def _git(repo: Path, *args: str) -> str:
+    return subprocess.run(  # noqa: S603
+        ["git", *args],  # noqa: S607
+        cwd=repo,
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout
+
+
+class TestRenderAirbyte:
+    @pytest.fixture
+    def rendered(self) -> dict[str, Any]:
+        return render_airbyte([_unit(UNIT)])
+
+    def test_it_carries_the_streams_of_each_connection(self, rendered: dict[str, Any]) -> None:
+        streams = rendered["units"][0]["connections"][0]["streams"]
+        assert [stream["name"] for stream in streams] == ["auth_user", "courseware_studentmodule"]
+
+    def test_namespace_survives(self, rendered: dict[str, Any]) -> None:
+        # 790 of 1,518 live streams carry one, and a render that drops it cannot
+        # reproduce the imported connection, so §6.4's empty preview never lands.
+        assert all(stream["namespace"] == "edxapp" for stream in rendered["units"][0]["connections"][0]["streams"])
+
+    def test_a_composite_primary_key_is_split_back_into_paths(self, rendered: dict[str, Any]) -> None:
+        streams = rendered["units"][0]["connections"][0]["streams"]
+        assert streams[0]["primary_key"] == [["id"]]
+        assert streams[1]["primary_key"] == [["course_id", "id"]]
+
+    def test_excluded_columns_are_emitted_as_the_exclusion(self, rendered: dict[str, Any]) -> None:
+        # Not as `selected_fields`: the complement needs the discovered schema,
+        # which the inventory does not hold.
+        streams = rendered["units"][0]["connections"][0]["streams"]
+        assert streams[1]["excluded_columns"] == ["state"]
+        assert "selected_fields" not in streams[1]
+
+    def test_dlt_units_are_not_rendered(self) -> None:
+        dlt_unit = copy.deepcopy(UNIT)
+        dlt_unit["loader"] = "dlt"
+        del dlt_unit["airbyte"]
+        dlt_unit["dlt"] = {"source_module": "ol_dlt.sources.mitxonline", "write_disposition": "merge"}
+        assert render_airbyte([_unit(dlt_unit)])["units"] == []
+
+
+class TestRenderDagsterIntervals:
+    def test_the_group_name_matches_the_dagster_translator(self) -> None:
+        # definitions.py drops Airbyte's U+2192 arrow entirely rather than
+        # turning it into a separator, which is why the doubled underscore is
+        # correct and "fixing" it would break the lookup.
+        assert dagster_group_name("MITx Online Open edX DB → S3 Data Lake") == "mitx_online_open_edx_db__s3_data_lake"
+
+    def test_it_maps_the_derived_group_to_its_cadence(self) -> None:
+        assert render_dagster_intervals([_unit(UNIT)]) == {"mitx_online_open_edx_db__s3_data_lake": 12}
+
+    def test_dagster_invisible_units_are_omitted(self) -> None:
+        hidden = copy.deepcopy(UNIT)
+        hidden["dagster_visible"] = False
+        hidden["airbyte"]["connections"][0]["name"] = "MITx Online Open edX DB → Snowflake"
+        assert render_dagster_intervals([_unit(hidden)]) == {}
+
+    def test_a_paused_connection_keeps_its_interval(self) -> None:
+        # Dagster selects on the connection name alone, so a paused connection
+        # still produces a group; dropping its entry hands it the silent
+        # 24-hour default the moment somebody re-enables it.
+        paused = copy.deepcopy(UNIT)
+        paused["airbyte"]["connections"][0]["status"] = "inactive"
+        assert render_dagster_intervals([_unit(paused)]) == {"mitx_online_open_edx_db__s3_data_lake": 12}

--- a/src/ol_dbt_cli/tests/test_inventory_removals.py
+++ b/src/ol_dbt_cli/tests/test_inventory_removals.py
@@ -17,6 +17,7 @@ import pytest
 import yaml
 
 from ol_dbt_cli.lib.inventory import (
+    RenderError,
     Snapshot,
     Unit,
     check_removals,
@@ -270,6 +271,17 @@ class TestRenderAirbyte:
         streams = rendered["units"][0]["connections"][0]["streams"]
         assert streams[1]["excluded_columns"] == ["state"]
         assert "selected_fields" not in streams[1]
+
+    def test_an_undeclared_stream_stops_the_render(self) -> None:
+        # `render` does not validate first, so it meets inventories `validate`
+        # would have rejected. Skipping the stream would be worse than failing:
+        # this JSON is applied to production Airbyte, so a dropped stream is a
+        # connection reconfigured to stop carrying a table — silently, in a file
+        # a human reviewed.
+        broken = copy.deepcopy(UNIT)
+        broken["airbyte"]["connections"][0]["streams"].append("never_declared")
+        with pytest.raises(RenderError, match="never_declared"):
+            render_airbyte([_unit(broken)])
 
     def test_dlt_units_are_not_rendered(self) -> None:
         dlt_unit = copy.deepcopy(UNIT)

--- a/src/ol_dbt_cli/tests/test_inventory_removals.py
+++ b/src/ol_dbt_cli/tests/test_inventory_removals.py
@@ -197,6 +197,16 @@ class TestGraveyardIsNeverEmptied:
         validate_inventory(root, report)
         assert "'reason' is a required property" in _messages(report)
 
+    def test_a_missing_retired_schema_fails_loudly_rather_than_skipping_validation(self, tmp_path: Path) -> None:
+        # An optional schema means deleting retired.schema.json silently waives
+        # every date/reason requirement, letting a malformed entry acknowledge a
+        # removal and pass check-removals. The schema is mandatory, like the
+        # unit schema already is.
+        root = _materialize(tmp_path, _without_second_table(), [RETIRED_ENTRY])
+        (root / "schema" / "retired.schema.json").unlink()
+        with pytest.raises(FileNotFoundError):
+            validate_inventory(root, ValidationReport())
+
 
 def _materialize(tmp_path: Path, unit: dict[str, Any], retired: list[dict[str, Any]]) -> Path:
     """Write a one-unit inventory on disk, carrying the real schemas and vocabulary."""
@@ -314,3 +324,29 @@ class TestRenderDagsterIntervals:
         paused = copy.deepcopy(UNIT)
         paused["airbyte"]["connections"][0]["status"] = "inactive"
         assert render_dagster_intervals([_unit(paused)]) == {"mitx_online_open_edx_db__s3_data_lake": 12}
+
+    def test_two_connection_names_colliding_on_the_same_interval_is_fine(self) -> None:
+        # Dashes and spaces both collapse to "_", so distinct connection names
+        # legitimately derive the same group when they agree on cadence.
+        collided = copy.deepcopy(UNIT)
+        collided["airbyte"]["connections"][0]["name"] = "MITx Online-Open edX DB S3 Data Lake"
+        second = copy.deepcopy(collided["airbyte"]["connections"][0])
+        second["name"] = "MITx Online Open edX DB S3 Data Lake"
+        collided["airbyte"]["connections"].append(second)
+        assert render_dagster_intervals([_unit(collided)]) == {"mitx_online_open_edx_db_s3_data_lake": 12}
+
+    def test_two_connection_names_colliding_on_different_intervals_stops_the_render(
+        self,
+    ) -> None:
+        # A group name is only unique modulo dashes/whitespace, so two distinct
+        # connections that disagree on cadence would otherwise have one silently
+        # overwrite the other based on sort order — recreating the wrong-schedule
+        # failure this renderer exists to prevent.
+        collided = copy.deepcopy(UNIT)
+        collided["airbyte"]["connections"][0]["name"] = "MITx Online-Open edX DB S3 Data Lake"
+        second = copy.deepcopy(collided["airbyte"]["connections"][0])
+        second["name"] = "MITx Online Open edX DB S3 Data Lake"
+        second["sync_interval_hours"] = 6
+        collided["airbyte"]["connections"].append(second)
+        with pytest.raises(RenderError, match="mitx_online_open_edx_db_s3_data_lake"):
+            render_dagster_intervals([_unit(collided)])

--- a/src/ol_dbt_cli/tests/test_inventory_removals.py
+++ b/src/ol_dbt_cli/tests/test_inventory_removals.py
@@ -60,7 +60,7 @@ UNIT: dict[str, Any] = {
             "raw_table": "raw__mitxonline__openedx__mysql__auth_user",
             "sync_mode": "incremental_append",
             "cursor_field": ["id"],
-            "primary_key": ["id"],
+            "primary_key": [["id"]],
             "modeled": True,
         },
         {
@@ -68,7 +68,7 @@ UNIT: dict[str, Any] = {
             "namespace": "edxapp",
             "raw_table": "raw__mitxonline__openedx__mysql__courseware_studentmodule",
             "sync_mode": "full_refresh_overwrite",
-            "primary_key": ["course_id.id"],
+            "primary_key": [["course_id", "id"], ["revision.with.dots"]],
             "excluded_columns": ["state"],
             "modeled": False,
         },
@@ -270,10 +270,13 @@ class TestRenderAirbyte:
         # reproduce the imported connection, so §6.4's empty preview never lands.
         assert all(stream["namespace"] == "edxapp" for stream in rendered["units"][0]["connections"][0]["streams"])
 
-    def test_a_composite_primary_key_is_split_back_into_paths(self, rendered: dict[str, Any]) -> None:
+    def test_a_composite_primary_key_round_trips_without_ambiguity(self, rendered: dict[str, Any]) -> None:
         streams = rendered["units"][0]["connections"][0]["streams"]
         assert streams[0]["primary_key"] == [["id"]]
-        assert streams[1]["primary_key"] == [["course_id", "id"]]
+        # A two-segment nested path and a single segment containing a literal
+        # "." are stored and rendered as distinct shapes — neither collapses
+        # into the other, unlike the old dotted-string encoding.
+        assert streams[1]["primary_key"] == [["course_id", "id"], ["revision.with.dots"]]
 
     def test_excluded_columns_are_emitted_as_the_exclusion(self, rendered: dict[str, Any]) -> None:
         # Not as `selected_fields`: the complement needs the discovered schema,


### PR DESCRIPTION
## What are the relevant tickets?

- RFC: https://github.com/mitodl/hq/discussions/12319 (Accepted 2026-08-13)
- Spec: `docs/specs/INGESTION_INVENTORY_SPEC.md` — steps 3 (generation half) and 4
- Task: `tk-inventory-half-src-ol-ingest-package-json-schema-9c276f`
- **Stacked on #2558.** Base is `worktree-ingestion-inventory-spec`; review that one first.

## Description (What does it do?)

Adds the removal gate and the two renderers, closing spec step 4 and the generation half of
step 3.

**`ol-dbt inventory check-removals`** is the point of this PR. Every other inventory finding
shows up as a broken build somewhere; a silently dropped table entry does not — the loader
simply stops loading, nothing errors, and a dbt model quietly goes stale months before anyone
notices. The check diffs `(unit, raw_table)` against the PR's merge base and demands the
disappearance be stated: a dated, reasoned `ingestion/inventory/retired.yml` entry, or
`renamed_from:` on the entry that replaced it. Renames are why an add-only check would not
do — a rename reads as a delete plus an add, so it passes while orphaning every downstream
model. Findings are ERRORs and are deliberately not baselineable: they are always fixable by
editing text in the same PR.

Three rules the spec's prose left implicit, each of which is otherwise a way to launder a
deletion past the check:

- `renamed_from:` is **scoped to the unit**. Moving a table between units is a removal from one
  and an addition to the other, and the removal side still has to be stated.
- A `renamed_from:` matching nothing that disappeared **warns**. Left alone it is inert, but it
  pre-authorises a future removal of the name it holds.
- The graveyard is **itself ratcheted**: deleting a `retired.yml` entry is an ERROR, and
  `validate` rejects a retired `(unit, raw_table)` that some unit still declares.

Deployment and layer in `retired.yml` are deliberately not vocabulary-checked — a deployment can
be retired out of `vocabulary.yml` too, and the graveyard has to outlive it.

**CI lands before the reconciled inventory data on purpose.** The spec's step order is a
dependency order, not a merge order, and the gate has no dependency on the data: it is a diff
against the merge base, so an empty inventory is a valid starting point. Landing it first means
the 27 reconciled units arrive *under* the ratchet rather than beside it.

**`ol-dbt inventory render airbyte` / `render dagster-intervals`** settle two things that are
invisible in the YAML and fatal to §6.4's empty-preview gate:

- `primary_key` round-trips through a dotted string, because Airbyte's
  `configurations.streams[].primaryKey` is a list of *paths* and a path is itself a list.
- `excluded_columns` is emitted as the exclusion, not as `selected_fields`. Airbyte wants the
  complement, and computing it needs the source's discovered schema — which the inventory
  deliberately does not hold.

`render dagster-intervals` reproduces `OLAirbyteTranslator`'s group-name derivation character
for character and keeps paused connections: Dagster selects on the connection name alone, so a
paused connection still produces a group, and dropping its entry hands it the silent 24-hour
default the moment somebody re-enables it.

## How can this be tested?

The spec's step-4 acceptance criterion was run end-to-end through the CLI against a scratch git
repo — a commit deleting a table entry exits 1 with the removal named, and the follow-up commit
adding the `retired.yml` entry exits 0.

23 new tests in `src/ol_dbt_cli/tests/test_inventory_removals.py`, one per way a removal can be
acknowledged and per way it can fail to be, including a real-git case covering the one thing the
in-memory tests cannot: reading a unit file the branch *deleted*, which exists only in the tree.
Full `ol_dbt_cli` suite passes (457 tests); `pre-commit` passes.

Everything here reads only checked-in files — no Airbyte, no warehouse, no secrets.

## Additional context

Still open on step 3: `ol-dbt inventory reconcile` (the three-way inventory/warehouse/dbt-sources
diff) and landing the reconciled 27-unit inventory itself, which needs a fresh
`bin/airbyte-inventory.py` run against production and human decisions on every TODO.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X14HY7Yggxsm2DmLvjrZwm
