### PR TITLE
fix(dagster): declare per environment which cron schedules may register

### DIFF
--- a/dg_projects/lakehouse/lakehouse/definitions.py
+++ b/dg_projects/lakehouse/lakehouse/definitions.py
@@ -221,12 +221,12 @@ except Exception as e:  # noqa: BLE001
 # those tables. The eager auto materialize policy will then take effect for any
 # downstream dbt models that are dependent on those staging models being completed.
 #
-# That last sentence now holds only where DBT_AUTOMATION_MAP says "on". Where it
-# does not, nothing downstream carries an AutomationCondition, so one of these
+# That last sentence now holds only in DBT_AUTOMATION_ENVIRONMENTS. Outside it,
+# nothing downstream carries an AutomationCondition, so one of these
 # runs builds its staging models and stops -- deliberately, since a QA build of a
 # union model emits data that looks fine while silently dropping rows. It also
 # means starting one of these in QA cannot walk the graph to a full build; RFC
-# 12711 step 8 is what flips `qa` to "on".
+# 12711 step 8 is what adds `qa` to DBT_AUTOMATION_ENVIRONMENTS.
 group_names: set[str] = set()
 for assets_def in airbyte_assets:
     group_names.update(g for g in assets_def.group_names_by_key.values())

--- a/dg_projects/lakehouse/lakehouse/definitions.py
+++ b/dg_projects/lakehouse/lakehouse/definitions.py
@@ -54,6 +54,7 @@ from lakehouse.assets.lakehouse.dbt_starrocks import (
 from lakehouse.assets.starrocks_mv_refresh import refresh_starrocks_analytics_mvs
 from lakehouse.assets.superset import create_superset_asset
 from lakehouse.lib.dbt_environment import DBT_AUTOMATION_ENABLED
+from lakehouse.lib.scheduled_automation import schedules_for_environment
 from lakehouse.resources.airbyte import AirbyteOSSWorkspace
 from lakehouse.resources.dbt_s3_artifacts import DbtS3ArtifactsResource
 from lakehouse.resources.starrocks import StarRocksResource
@@ -219,6 +220,13 @@ except Exception as e:  # noqa: BLE001
 # materialize the tables for that connection and any associated dbt staging models for
 # those tables. The eager auto materialize policy will then take effect for any
 # downstream dbt models that are dependent on those staging models being completed.
+#
+# That last sentence now holds only where DBT_AUTOMATION_MAP says "on". Where it
+# does not, nothing downstream carries an AutomationCondition, so one of these
+# runs builds its staging models and stops -- deliberately, since a QA build of a
+# union model emits data that looks fine while silently dropping rows. It also
+# means starting one of these in QA cannot walk the graph to a full build; RFC
+# 12711 step 8 is what flips `qa` to "on".
 group_names: set[str] = set()
 for assets_def in airbyte_assets:
     group_names.update(g for g in assets_def.group_names_by_key.values())
@@ -522,12 +530,20 @@ defs = Definitions(
         iceberg_snapshot_pointer_repair_job,
         dbt_docs_artifacts_job,
     ],
-    schedules=[
-        *airbyte_update_schedules,
-        instructor_onboarding_schedule,
-        iceberg_dbt_maintenance_schedule,
-        iceberg_raw_maintenance_schedule,
-        dbt_docs_artifacts_schedule,
-        b2b_analytics_starrocks_schedule,
-    ],
+    # Registration is the gate. `default_status=DefaultScheduleStatus.STOPPED`
+    # on each of these only seeds the instance's instigator state on first
+    # deploy; a UI toggle overrides it forever after, which is how a QA code
+    # location came to run `dbt docs generate` against the production warehouse
+    # without anything in this file saying it could. A schedule this filter
+    # drops is not stopped, it is absent -- there is nothing left to toggle.
+    schedules=schedules_for_environment(
+        [
+            *(("daily_sync_and_stage", s) for s in airbyte_update_schedules),
+            ("instructor_onboarding_daily_schedule", instructor_onboarding_schedule),
+            ("iceberg_dbt_maintenance_nightly", iceberg_dbt_maintenance_schedule),
+            ("iceberg_raw_maintenance_nightly", iceberg_raw_maintenance_schedule),
+            ("dbt_docs_artifacts_daily", dbt_docs_artifacts_schedule),
+            ("b2b_analytics_starrocks_nightly", b2b_analytics_starrocks_schedule),
+        ]
+    ),
 )

--- a/dg_projects/lakehouse/lakehouse/definitions.py
+++ b/dg_projects/lakehouse/lakehouse/definitions.py
@@ -532,10 +532,12 @@ defs = Definitions(
     ],
     # Registration is the gate. `default_status=DefaultScheduleStatus.STOPPED`
     # on each of these only seeds the instance's instigator state on first
-    # deploy; a UI toggle overrides it forever after, which is how a QA code
-    # location came to run `dbt docs generate` against the production warehouse
-    # without anything in this file saying it could. A schedule this filter
-    # drops is not stopped, it is absent -- there is nothing left to toggle.
+    # deploy; a UI toggle overrides it forever after, so whether one of these
+    # ticked in QA was instance state nothing in this file had a say in. A
+    # schedule this filter drops is not stopped, it is absent -- there is
+    # nothing left to toggle. Note it also drops the job for the four that
+    # build one inline; see scheduled_automation for what that does and does
+    # not cost.
     schedules=schedules_for_environment(
         [
             *(("daily_sync_and_stage", s) for s in airbyte_update_schedules),

--- a/dg_projects/lakehouse/lakehouse/lib/dbt_environment.py
+++ b/dg_projects/lakehouse/lakehouse/lib/dbt_environment.py
@@ -120,15 +120,12 @@ STARROCKS_DBT_TARGET_MAP: Mapping[str, str] = {
 #
 # SCOPE, so the name is not read for more than it does: this covers the
 # AutomationCondition path only. The cron ScheduleDefinitions in definitions.py
-# -- b2b_analytics_starrocks_nightly (which builds the tag:starrocks models),
-# dbt_docs_artifacts_daily, and the two iceberg maintenance schedules -- are
-# registered in every environment and gated only by
-# ``default_status=DefaultScheduleStatus.STOPPED``, which is the same
-# seed-once-then-the-instance-wins setting this declaration replaces for
-# sensors. Whether any of them is running in QA is instance state the repo
-# cannot see -- the same blind spot, one layer over.
-# Left open for RFC 12711 (https://github.com/mitodl/hq/discussions/12711):
-# whether those schedules join this declaration, and
+# are the other way this code location starts work unattended, and they are
+# declared separately in ``lakehouse.lib.scheduled_automation`` -- per schedule
+# rather than per environment, because they disagree with each other about QA
+# (the ingestion family belongs there, the dbt and GitHub-writing ones do not).
+# Read the two together for the whole answer to "what may run here on its own".
+# Still open for RFC 12711 (https://github.com/mitodl/hq/discussions/12711):
 # whether production's synthesized default_automation_condition_sensor over
 # staging (see dbt_automation_sensor's target in definitions.py) should be closed
 # by dropping staging's condition rather than only excluding it from the target.

--- a/dg_projects/lakehouse/lakehouse/lib/dbt_environment.py
+++ b/dg_projects/lakehouse/lakehouse/lib/dbt_environment.py
@@ -121,8 +121,9 @@ STARROCKS_DBT_TARGET_MAP: Mapping[str, str] = {
 # SCOPE, so the name is not read for more than it does: this covers the
 # AutomationCondition path only. The cron ScheduleDefinitions in definitions.py
 # are the other way this code location starts work unattended, and they are
-# declared separately in ``lakehouse.lib.scheduled_automation`` -- per schedule
-# rather than per environment, because they disagree with each other about QA
+# declared separately in ``lakehouse.lib.scheduled_automation`` -- each with its
+# own environment set rather than one answer covering all of them, because they
+# disagree with each other about QA
 # (the ingestion family belongs there, the dbt and GitHub-writing ones do not).
 # Read the two together for the whole answer to "what may run here on its own".
 # Still open for RFC 12711 (https://github.com/mitodl/hq/discussions/12711):

--- a/dg_projects/lakehouse/lakehouse/lib/scheduled_automation.py
+++ b/dg_projects/lakehouse/lakehouse/lib/scheduled_automation.py
@@ -22,16 +22,40 @@ rewrites Iceberg metadata, and instructor onboarding pushes a commit to a GitHub
 repository. "May dbt materialize itself here" is the wrong question to ask of
 those, and answering it for them would have hidden the more interesting one.
 
+What is and is not known to have fired
+-------------------------------------
+No schedule is. QA's artifacts bucket holds 13 ``docs generate`` results, every
+one ``args.target = "production"`` (the newest, 2026-07-01, is 5.2 MB over 4370
+nodes, filed under the prefix QA's OpenMetadata reads -- so QA metadata was
+describing production). Those are launches of ``dbt_docs_artifacts_job``, NOT
+ticks of ``dbt_docs_artifacts_daily``: they land between 18:56 and 23:47 UTC,
+and twice in a day on 2026-05-11 and 2026-05-21, which fits neither its
+``0 4 * * *`` cron nor any daily one. The job stays registered in every
+environment, so this module does not close that path -- #2508 already did, by
+fixing the target it ran against.
+
+What this closes is the path nobody can see. A schedule toggled on in the UI
+ticks by itself, indefinitely, and until now the repo had no say in whether it
+could. Same argument ``DBT_AUTOMATION_MAP`` makes about the sensor: nothing said
+these were allowed to run in QA, and that they apparently did not was luck.
+
 Why it is per schedule rather than per environment
 --------------------------------------------------
 Because the schedules disagree. ``daily_sync_and_stage_*`` is the ingestion path
-QA needs *more* of -- RFC 12711 step 8 revives it -- while
-``dbt_docs_artifacts_daily`` is the schedule measurably observed running from the
-QA code location against the PRODUCTION warehouse (a 5.2 MB ``docs generate``
-artifact, ``args.target = "production"``, 4370 nodes, filed under QA's prefix on
-2026-07-01, which is where QA's OpenMetadata reads from -- so QA metadata was
-describing production). A single per-environment switch would have to be wrong
-about one of them.
+QA needs *more* of -- RFC 12711 step 8 revives it -- while a QA tick of
+``b2b_analytics_starrocks_nightly`` would publish silently partial B2B data. A
+single per-environment switch would have to be wrong about one of them.
+
+What omission also takes with it
+--------------------------------
+Four of these six build their job inline with ``define_asset_job`` inside the
+``ScheduleDefinition``, so dropping the schedule drops that job from the code
+location too -- ``iceberg_dbt_maintenance_job``, ``iceberg_raw_maintenance_job``,
+``b2b_analytics_starrocks_job`` and ``instructor_onboarding_daily_job`` are not
+manually launchable outside production. Their ASSETS stay registered everywhere
+and can still be materialized by hand from the asset graph, so nothing becomes
+unreachable; only the pre-built job disappears. ``dbt_docs_artifacts_daily`` is
+the exception -- its job is registered separately in ``jobs`` and is unaffected.
 
 Adding a schedule
 -----------------
@@ -77,10 +101,12 @@ SCHEDULE_ENVIRONMENTS: Mapping[str, frozenset[str]] = {
     # tidiness here.
     "iceberg_dbt_maintenance_nightly": frozenset({"production"}),
     "iceberg_raw_maintenance_nightly": frozenset({"production"}),
-    # `dbt docs generate` for OpenMetadata. The one that demonstrably fired from
-    # QA against production (see the module docstring). Production-only; the job
-    # stays registered everywhere, so a deliberate, attended QA run is still one
-    # click away, which is what step 8 needs.
+    # `dbt docs generate` for OpenMetadata. Its JOB is the one that demonstrably
+    # ran from QA against production -- by hand, not on this cron (see above).
+    # Production-only here, but note that leaves the path that actually fired
+    # open: dbt_docs_artifacts_job is registered in `jobs` in every environment
+    # and stays one click away, which is also what a deliberate QA run under
+    # step 8 needs.
     "dbt_docs_artifacts_daily": frozenset({"production"}),
     # Builds the tag:starrocks models, then refreshes their downstream MVs.
     # Always target-correct via STARROCKS_DBT_TARGET, but a QA run reads the

--- a/dg_projects/lakehouse/lakehouse/lib/scheduled_automation.py
+++ b/dg_projects/lakehouse/lakehouse/lib/scheduled_automation.py
@@ -1,13 +1,16 @@
 """Which environments may register each cron schedule in this code location.
 
-The companion to ``DBT_AUTOMATION_MAP`` in :mod:`lakehouse.lib.dbt_environment`,
-covering the path that map deliberately excluded. Between them, every unattended
-run this code location can start is now declared in the repo.
+The companion to ``DBT_AUTOMATION_ENVIRONMENTS`` in
+:mod:`lakehouse.lib.dbt_environment`, covering the path that declaration
+deliberately excluded. Between them, every unattended run this code location can
+start is now declared in the repo, and both are opt-in for the same reason: the
+omitted answer is "does not run", which is the safe one.
 
 Why a second mechanism rather than one flag
 -------------------------------------------
-``DBT_AUTOMATION_MAP`` enforces itself by withholding the ``AutomationCondition``
-from the assets, so a sensor someone starts by hand evaluates to nothing. A
+``DBT_AUTOMATION_ENVIRONMENTS`` enforces itself by withholding the
+``AutomationCondition`` from the assets, so a sensor someone starts by hand
+evaluates to nothing. A
 ``ScheduleDefinition`` has no equivalent inner switch: ``default_status`` only
 seeds the instance's instigator state on first deploy, and any later UI toggle
 wins forever. So the enforcing move here is *registration* -- a schedule left out
@@ -36,8 +39,9 @@ fixing the target it ran against.
 
 What this closes is the path nobody can see. A schedule toggled on in the UI
 ticks by itself, indefinitely, and until now the repo had no say in whether it
-could. Same argument ``DBT_AUTOMATION_MAP`` makes about the sensor: nothing said
-these were allowed to run in QA, and that they apparently did not was luck.
+could. Same argument ``DBT_AUTOMATION_ENVIRONMENTS`` makes about the sensor:
+nothing said these were allowed to run in QA, and that they apparently did not
+was luck.
 
 Why it is per schedule rather than per environment
 --------------------------------------------------
@@ -86,10 +90,11 @@ SCHEDULE_ENVIRONMENTS: Mapping[str, frozenset[str]] = {
     # dev/ci, where SKIP_AIRBYTE leaves the workspace empty and the loop that
     # builds these produces nothing to register.
     #
-    # Note this reaches less far than it did before DBT_AUTOMATION_MAP: the
-    # downstream handoff it was written for is severed where automation is off,
-    # so a QA run of one of these builds staging and stops. Intended -- step 8
-    # flips `qa` to "on" once the QA lake can actually fill the models.
+    # Note this reaches less far than it did before the automation declaration:
+    # the downstream handoff it was written for is severed outside
+    # DBT_AUTOMATION_ENVIRONMENTS, so a QA run of one of these builds staging
+    # and stops. Intended -- step 8 adds `qa` to DBT_AUTOMATION_ENVIRONMENTS
+    # once the QA lake can actually fill the models.
     "daily_sync_and_stage": frozenset({"qa", "production"}),
     # Both rewrite Iceberg metadata -- expire snapshots, compact manifests.
     # They resolve through trino_host_map/trino_catalog_map, which have always

--- a/dg_projects/lakehouse/lakehouse/lib/scheduled_automation.py
+++ b/dg_projects/lakehouse/lakehouse/lib/scheduled_automation.py
@@ -1,0 +1,143 @@
+"""Which environments may register each cron schedule in this code location.
+
+The companion to ``DBT_AUTOMATION_MAP`` in :mod:`lakehouse.lib.dbt_environment`,
+covering the path that map deliberately excluded. Between them, every unattended
+run this code location can start is now declared in the repo.
+
+Why a second mechanism rather than one flag
+-------------------------------------------
+``DBT_AUTOMATION_MAP`` enforces itself by withholding the ``AutomationCondition``
+from the assets, so a sensor someone starts by hand evaluates to nothing. A
+``ScheduleDefinition`` has no equivalent inner switch: ``default_status`` only
+seeds the instance's instigator state on first deploy, and any later UI toggle
+wins forever. So the enforcing move here is *registration* -- a schedule left out
+of ``Definitions.schedules`` is not stopped, it is absent, and nothing in the
+Dagster UI can start it. Dagster synthesizes sensors it was not given
+(``get_default_automation_condition_sensor``) but never schedules, so omission is
+final in a way that stopping is not.
+
+That difference is also why this is not one boolean shared with the dbt map.
+Only three of these six schedules run dbt at all; the iceberg maintenance pair
+rewrites Iceberg metadata, and instructor onboarding pushes a commit to a GitHub
+repository. "May dbt materialize itself here" is the wrong question to ask of
+those, and answering it for them would have hidden the more interesting one.
+
+Why it is per schedule rather than per environment
+--------------------------------------------------
+Because the schedules disagree. ``daily_sync_and_stage_*`` is the ingestion path
+QA needs *more* of -- RFC 12711 step 8 revives it -- while
+``dbt_docs_artifacts_daily`` is the schedule measurably observed running from the
+QA code location against the PRODUCTION warehouse (a 5.2 MB ``docs generate``
+artifact, ``args.target = "production"``, 4370 nodes, filed under QA's prefix on
+2026-07-01, which is where QA's OpenMetadata reads from -- so QA metadata was
+describing production). A single per-environment switch would have to be wrong
+about one of them.
+
+Adding a schedule
+-----------------
+Add its id below. There is no fallback, and that is the whole point: a new
+``ScheduleDefinition`` handed to :func:`schedules_for_environment` without an
+entry raises at import, in every environment, rather than quietly inheriting a
+default someone would then have to discover from instance state.
+"""
+
+from collections.abc import Iterable, Mapping
+
+from ol_orchestrate.lib.constants import DAGSTER_ENV, VALID_DAGSTER_ENVS
+
+# Keys are schedule ids, not necessarily schedule names: the sync_and_stage
+# family is generated one-per-Airbyte-connection-group from the LIVE workspace,
+# so its members' names are not knowable from the repo. Its id names the family.
+#
+# Every entry today is the environment set that matches observed intent, so
+# registering this map is not meant to change behaviour anywhere. Its value is
+# that the answer now lives in the repo: before this, whether any of these ran
+# in QA was instance state nothing here could see, and one of them had been
+# running against the wrong warehouse for months without leaving a trace in the
+# repo that it was even allowed to.
+SCHEDULE_ENVIRONMENTS: Mapping[str, frozenset[str]] = {
+    # Airbyte sync plus the dbt staging models at depth=1, one schedule per
+    # connection group. QA as well as production: this is ingestion, and a QA
+    # lake that is never fed is the problem RFC 12711 exists to fix. Harmless in
+    # dev/ci, where SKIP_AIRBYTE leaves the workspace empty and the loop that
+    # builds these produces nothing to register.
+    #
+    # Note this reaches less far than it did before DBT_AUTOMATION_MAP: the
+    # downstream handoff it was written for is severed where automation is off,
+    # so a QA run of one of these builds staging and stops. Intended -- step 8
+    # flips `qa` to "on" once the QA lake can actually fill the models.
+    "daily_sync_and_stage": frozenset({"qa", "production"}),
+    # Both rewrite Iceberg metadata -- expire snapshots, compact manifests.
+    # They resolve through trino_host_map/trino_catalog_map, which have always
+    # been environment-correct, so unlike the dbt schedules these were never
+    # misrouted. Production-only for two different reasons: expiring snapshots
+    # under a QA lake being rebuilt would fight step 8 rather than help it, and
+    # `dev` maps to the PRODUCTION catalog, so a tick on a laptop would expire
+    # production's snapshots. That second one is why "off in dev" is not merely
+    # tidiness here.
+    "iceberg_dbt_maintenance_nightly": frozenset({"production"}),
+    "iceberg_raw_maintenance_nightly": frozenset({"production"}),
+    # `dbt docs generate` for OpenMetadata. The one that demonstrably fired from
+    # QA against production (see the module docstring). Production-only; the job
+    # stays registered everywhere, so a deliberate, attended QA run is still one
+    # click away, which is what step 8 needs.
+    "dbt_docs_artifacts_daily": frozenset({"production"}),
+    # Builds the tag:starrocks models, then refreshes their downstream MVs.
+    # Always target-correct via STARROCKS_DBT_TARGET, but a QA run reads the
+    # empty QA lake and publishes a B2B dashboard's worth of silently partial
+    # data -- the exact failure mode RFC 12711 is about. Step 8's call to flip.
+    "b2b_analytics_starrocks_nightly": frozenset({"production"}),
+    # Not a data-platform schedule at all: it pushes a commit to the access
+    # forge GitHub repository. There is one of those, not one per environment,
+    # so a QA tick would write the real repo. This one was gated only by
+    # `ScheduleDefinition`'s implicit STOPPED default -- it passed no
+    # default_status at all.
+    "instructor_onboarding_daily_schedule": frozenset({"production"}),
+}
+
+_UNDECLARED_ENVIRONMENTS = {
+    schedule_id: sorted(environments - set(VALID_DAGSTER_ENVS))
+    for schedule_id, environments in SCHEDULE_ENVIRONMENTS.items()
+    if environments - set(VALID_DAGSTER_ENVS)
+}
+if _UNDECLARED_ENVIRONMENTS:
+    # A typo'd environment name here fails open -- the schedule simply never
+    # registers anywhere, which looks exactly like a deliberate decision to
+    # disable it. Caught at import instead.
+    msg = (
+        f"SCHEDULE_ENVIRONMENTS names environments that do not exist: "
+        f"{_UNDECLARED_ENVIRONMENTS}. Known environments: "
+        f"{sorted(VALID_DAGSTER_ENVS)}."
+    )
+    raise ValueError(msg)
+
+
+def schedules_for_environment[T](
+    candidates: Iterable[tuple[str, T]], *, environment: str = DAGSTER_ENV
+) -> list[T]:
+    """Keep the schedules *environment* is declared to run, drop the rest.
+
+    *candidates* pairs each schedule with its id in
+    :data:`SCHEDULE_ENVIRONMENTS`. The id is passed rather than read off the
+    schedule because the sync_and_stage family's names are generated from the
+    live Airbyte workspace and so cannot be enumerated here.
+
+    Raises KeyError for an id with no entry, which is the same no-fallback rule
+    :func:`lakehouse.lib.dbt_environment.resolve_for_environment` applies to
+    environments.
+    """
+    kept = []
+    for schedule_id, schedule in candidates:
+        try:
+            environments = SCHEDULE_ENVIRONMENTS[schedule_id]
+        except KeyError:
+            msg = (
+                f"No environments declared for schedule {schedule_id!r} "
+                f"(known: {sorted(SCHEDULE_ENVIRONMENTS)}). Add an explicit "
+                f"entry to SCHEDULE_ENVIRONMENTS -- defaulting here would let a "
+                f"new schedule start itself in an environment nobody chose."
+            )
+            raise KeyError(msg) from None
+        if environment in environments:
+            kept.append(schedule)
+    return kept

--- a/dg_projects/lakehouse/lakehouse_tests/test_definitions_schedule_ids.py
+++ b/dg_projects/lakehouse/lakehouse_tests/test_definitions_schedule_ids.py
@@ -1,0 +1,46 @@
+"""The call site's schedule ids must match the declaration.
+
+Split out from test_scheduled_automation.py because it tests definitions.py
+rather than the library: `schedules_for_environment` raises on an unknown id,
+but nothing in CI imports the code location -- that import needs /opt/dbt and a
+parsed manifest, which only the container has. So a typo'd id at the call site
+would first surface as a failed deploy. Reading the call site statically closes
+that, which is the same argument the module itself makes about instance state:
+if the repo can check it, the repo should.
+"""
+
+import ast
+from pathlib import Path
+
+import lakehouse
+from lakehouse.lib.scheduled_automation import SCHEDULE_ENVIRONMENTS
+
+
+def _schedule_ids_passed_at_the_call_site() -> set[str]:
+    source = Path(lakehouse.__file__).parent.joinpath("definitions.py").read_text()
+    calls = [
+        node
+        for node in ast.walk(ast.parse(source))
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Name)
+        and node.func.id == "schedules_for_environment"
+    ]
+    assert len(calls) == 1, "expected exactly one call site to read ids from"
+    return {
+        node.elts[0].value
+        for node in ast.walk(calls[0])
+        if isinstance(node, ast.Tuple)
+        and node.elts
+        and isinstance(node.elts[0], ast.Constant)
+        and isinstance(node.elts[0].value, str)
+    }
+
+
+def test_call_site_and_declaration_agree():
+    """Both directions.
+
+    An id passed but not declared fails the deploy; an id declared but never
+    passed is worse in its way -- it reads as a live gate on a schedule that no
+    longer exists, so someone editing it thinks they changed something.
+    """
+    assert _schedule_ids_passed_at_the_call_site() == set(SCHEDULE_ENVIRONMENTS)

--- a/dg_projects/lakehouse/lakehouse_tests/test_scheduled_automation.py
+++ b/dg_projects/lakehouse/lakehouse_tests/test_scheduled_automation.py
@@ -1,0 +1,126 @@
+"""Tests for the per-schedule environment declaration.
+
+The companion to test_dbt_environment.py, and the assertions have the same
+shape for the same reason: what is being locked down is not any one schedule's
+environment set -- those are judgement calls RFC 12711 step 8 will revisit --
+but that every schedule has to state one, and that stating it is what decides
+whether Dagster ever sees the schedule at all.
+"""
+
+import pytest
+from lakehouse.lib.scheduled_automation import (
+    SCHEDULE_ENVIRONMENTS,
+    schedules_for_environment,
+)
+from ol_orchestrate.lib.constants import VALID_DAGSTER_ENVS
+
+# The tuples are (id, schedule); nothing in schedules_for_environment inspects
+# the second element, so a string stands in for a ScheduleDefinition and these
+# tests need neither a dbt manifest nor a live Airbyte workspace.
+ALL_CANDIDATES = [(schedule_id, schedule_id) for schedule_id in SCHEDULE_ENVIRONMENTS]
+
+
+def test_every_declared_environment_exists():
+    """A typo'd environment fails open -- the schedule never registers anywhere.
+
+    Which is indistinguishable from a deliberate decision to disable it, so the
+    module raises at import. This asserts the shipped map is clean.
+    """
+    for schedule_id, environments in SCHEDULE_ENVIRONMENTS.items():
+        assert environments <= set(VALID_DAGSTER_ENVS), schedule_id
+
+
+def test_undeclared_schedule_raises():
+    """The no-fallback rule, one layer over from resolve_for_environment.
+
+    A new ScheduleDefinition wired into Definitions without an entry must fail
+    the code location's import in every environment, rather than picking up a
+    default nobody chose and then only being visible as instance state.
+    """
+    with pytest.raises(KeyError, match="brand_new_nightly"):
+        schedules_for_environment(
+            [("brand_new_nightly", object())], environment="production"
+        )
+
+
+@pytest.mark.parametrize("environment", VALID_DAGSTER_ENVS)
+def test_filter_keeps_exactly_what_is_declared(environment):
+    kept = schedules_for_environment(ALL_CANDIDATES, environment=environment)
+    expected = [
+        schedule_id
+        for schedule_id, environments in SCHEDULE_ENVIRONMENTS.items()
+        if environment in environments
+    ]
+    assert kept == expected
+
+
+def test_dev_and_ci_register_no_schedules():
+    """Neither reaches a warehouse worth writing on a timer.
+
+    `dev` is a laptop and `ci` is ephemeral; a cron tick in either would be a
+    surprise, and for the schedules that push to GitHub or rewrite Iceberg
+    metadata it would be a surprise with external side effects.
+    """
+    for environment in ("dev", "ci"):
+        assert schedules_for_environment(ALL_CANDIDATES, environment=environment) == []
+
+
+def test_only_ingestion_is_allowed_in_qa():
+    """QA gets fed, but does not build or publish on its own.
+
+    The distinction RFC 12711 turns on: a QA build of a union model whose
+    branches are missing emits a partial result that looks like working data.
+    Ingestion has no such failure mode -- more of it is strictly better -- so
+    the sync_and_stage family runs in QA while the dbt schedules do not.
+    """
+    assert schedules_for_environment(ALL_CANDIDATES, environment="qa") == [
+        "daily_sync_and_stage"
+    ]
+
+
+def test_qa_cannot_run_dbt_docs_generate_on_a_timer():
+    """The one that measurably fired the wrong way.
+
+    A 2026-07-01 `docs generate` ran from the QA code location against the
+    production warehouse and filed production's catalog under QA's artifacts
+    prefix, which QA's OpenMetadata ingests. #2508 fixed the target; this is
+    what stops the schedule.
+    """
+    assert "qa" not in SCHEDULE_ENVIRONMENTS["dbt_docs_artifacts_daily"]
+
+
+def test_instructor_onboarding_is_production_only():
+    """There is one access forge repository, not one per environment.
+
+    So a tick outside production would push a commit to the real one. This
+    schedule passed no default_status at all, relying on ScheduleDefinition's
+    implicit STOPPED -- the weakest form of the gate this replaces.
+    """
+    assert SCHEDULE_ENVIRONMENTS["instructor_onboarding_daily_schedule"] == frozenset(
+        {"production"}
+    )
+
+
+def test_production_registers_every_schedule():
+    """Nothing is dropped where the map is meant to be a no-op.
+
+    This change is a declaration, not a behaviour change: production's set is
+    what it registered before, so a green deploy there proves the mechanism
+    without proving anything about the environments it now excludes.
+    """
+    kept = schedules_for_environment(ALL_CANDIDATES, environment="production")
+    assert kept == list(SCHEDULE_ENVIRONMENTS)
+
+
+def test_family_id_covers_every_generated_member():
+    """The sync_and_stage schedules are named from the live Airbyte workspace.
+
+    How many exist in a given environment depends on that workspace, not on
+    this repo, so they cannot be declared by name. One family id decides all of
+    them, and the filter must not care how many there are.
+    """
+    generated = [
+        ("daily_sync_and_stage", f"daily_sync_and_stage_{i}") for i in range(5)
+    ]
+    assert len(schedules_for_environment(generated, environment="qa")) == len(generated)
+    assert schedules_for_environment(generated, environment="dev") == []

--- a/dg_projects/lakehouse/lakehouse_tests/test_scheduled_automation.py
+++ b/dg_projects/lakehouse/lakehouse_tests/test_scheduled_automation.py
@@ -79,12 +79,14 @@ def test_only_ingestion_is_allowed_in_qa():
 
 
 def test_qa_cannot_run_dbt_docs_generate_on_a_timer():
-    """The one that measurably fired the wrong way.
+    """The nearest thing to a measured incident, and what it does not show.
 
     A 2026-07-01 `docs generate` ran from the QA code location against the
     production warehouse and filed production's catalog under QA's artifacts
-    prefix, which QA's OpenMetadata ingests. #2508 fixed the target; this is
-    what stops the schedule.
+    prefix, which QA's OpenMetadata ingests. It was a launch of the JOB, not a
+    tick of this schedule -- the hours fit no daily cron. #2508 fixed the
+    target it ran against; this only stops the timer, which is the half that
+    could have run unattended.
     """
     assert "qa" not in SCHEDULE_ENVIRONMENTS["dbt_docs_artifacts_daily"]
 


### PR DESCRIPTION
### What are the relevant tickets?

RFC https://github.com/mitodl/hq/discussions/12711. Follows #2573 (merged as 26b2ffe9), whose `SCOPE` comment this updates; rebased onto `main` and no longer stacked.

### Description (What does it do?)

#2508 fixed *where* a QA dbt build writes. #2573 fixed *whether* one starts itself via an `AutomationCondition`. This fixes the other way this code location starts work on its own: the cron schedules.

Both halves had the same defect. `default_status=DefaultScheduleStatus.STOPPED` only seeds the instance's instigator state on first deploy; after any UI toggle the instance wins forever. So the repo could not see — let alone decide — whether a schedule was ticking in QA.

**Correcting the premise this task was filed on, because I checked it rather than restating it.** The note behind this work said `dbt_docs_artifacts_daily` had demonstrably fired in QA against production. It had not. QA's artifacts bucket does hold 13 `docs generate` results, every one `args.target = "production"` (`aws s3 cp` of the 2026-07-01 object: `invocation_command: "dbt docs generate --target production"`, 4370 nodes, filed under the prefix QA's OpenMetadata ingests — so QA metadata *was* describing production). But their hours are 18:56–23:47 UTC, and two land on 2026-05-11 and two on 2026-05-21. That fits neither the `0 4 * * *` cron nor any daily one. They are launches of `dbt_docs_artifacts_job`, not ticks of its schedule.

So this lands in the same place #2573 did: **no schedule is known to have fired in QA, and this closes a path that happened never to be taken.** Two things follow, and both are now in the code rather than only here:

- This PR does **not** close the path that actually ran. `dbt_docs_artifacts_job` is registered in `jobs=[…]` in every environment and stays that way — a deliberate QA run is still one click away, which is what step 8 needs. #2508 already fixed the target it ran against.
- What it closes is the half that could run *unattended*. A schedule toggled on in the UI ticks by itself, indefinitely, and nothing in the repo had a say. That is worth closing on its own terms; nothing said these were allowed to run in QA, and that they apparently did not was luck.

**The enforcing move differs from #2573's, and that is the design.** A schedule has no `AutomationCondition` to withhold, so what holds it closed is *registration*: `schedules_for_environment` omits it from `Definitions.schedules`, and a schedule that is absent is not merely stopped — there is nothing left for the UI to toggle. Checked before relying on it: Dagster synthesizes sensors it was not given (`get_default_automation_condition_sensor`, the finding that shaped #2573) but has no schedule analogue — nothing in `definitions_class.py` or `repository_definition/` constructs a `ScheduleDefinition`. Omission is final in a way stopping is not.

**Per schedule, not per environment**, because the six disagree about QA — a single switch would have to be wrong about one of them:

| schedule | declared | why |
| --- | --- | --- |
| `daily_sync_and_stage_*` | `qa`, `production` | Ingestion. A QA lake that is never fed is the problem RFC 12711 exists to fix; step 8 wants *more* of this, not less. |
| `iceberg_dbt_maintenance_nightly`, `iceberg_raw_maintenance_nightly` | `production` | These write — expire snapshots, compact manifests. Never misrouted (they resolve via `trino_host_map`/`trino_catalog_map`, always env-correct), but `dev` maps to the **production** catalog, so a tick on a laptop would expire production's snapshots. |
| `dbt_docs_artifacts_daily` | `production` | Its job is the one that ran the wrong way, by hand; the timer is the half worth removing. |
| `b2b_analytics_starrocks_nightly` | `production` | Always target-correct via `STARROCKS_DBT_TARGET`, but a QA run reads the empty QA lake and publishes a B2B dashboard's worth of silently partial data — the exact failure RFC 12711 is about. |
| `instructor_onboarding_daily_schedule` | `production` | Not a data-platform schedule: it pushes a commit to the access forge GitHub repo. There is one of those, not one per environment. It passed **no** `default_status` at all — the weakest form of the gate. |

The family id exists because `daily_sync_and_stage_*` members are generated one-per-connection-group from the **live** Airbyte workspace, so their names are not knowable from the repo. That is why ids are passed alongside the schedules rather than read off `.name`.

**What omission also takes with it**, since it is not obvious from the diff: four of the six build their job inline with `define_asset_job` inside the `ScheduleDefinition`, so dropping the schedule drops that job from the code location too — `iceberg_dbt_maintenance_job`, `iceberg_raw_maintenance_job`, `b2b_analytics_starrocks_job` and `instructor_onboarding_daily_job` are not manually launchable outside production. Their *assets* stay registered everywhere and can still be materialized by hand from the asset graph, so nothing becomes unreachable; only the pre-built job goes. `dbt_docs_artifacts_daily` is the exception — its job is registered separately.

Also stated, because #2573 caused it: the comment above the sync_and_stage loop says the eager policy "will then take effect for any downstream dbt models". That handoff is now severed where automation is off — a QA run of one of these builds staging and stops. Intended, but it means starting one in QA cannot walk the graph to a full build; step 8 is what adds `qa` to `DBT_AUTOMATION_ENVIRONMENTS`.

### How can this be tested?

No warehouse credentials needed:

```
cd dg_projects/lakehouse && uv run pytest lakehouse_tests/
```

What was run: full lakehouse suite, **98 passed** (85 on `main` after #2573, 13 new across `test_scheduled_automation.py` and `test_definitions_schedule_ids.py`). `pre-commit` clean, ruff and mypy included.

One of those tests deserves a note. `schedules_for_environment` raises on an undeclared id, but **nothing in CI imports the code location** — that import needs `/opt/dbt` and a parsed manifest, which only the container has (I tried; it fails at `DbtProject(project_dir=Path("/opt/dbt"))`). So a typo'd id at the call site would first surface as a failed deploy. `test_definitions_schedule_ids.py` reads the call site with `ast` and asserts the ids match the declaration in both directions — an orphaned declaration fails too, since it reads as a live gate on a schedule that no longer exists.

No live Dagster run was made, so the deployed effect is unverified. What to check after deploy:

- **Production**: all six still present in the Schedules tab, statuses unchanged. Production's declared set is exactly what it registered before, so this should be a no-op there — if a production schedule disappears, that is this PR.
- **QA**: only `daily_sync_and_stage_*` remain; the other four are gone from the UI, not merely stopped.

### Additional Context

**A declaration, not a behaviour change — with one caveat I cannot close from the repo.** Every entry matches observed intent. But whether one of the four now-omitted schedules was *actually running* in QA is precisely the instance state this PR exists because nobody can see. If one was, this stops it. The artifact evidence points the other way — nothing has been written to QA's bucket since 2026-08-11 (re-checked today), and the docs-generate results stop at 2026-07-01 — but a glance at QA's Schedules tab before merge would settle it.

Out of scope, same class, worth naming rather than leaving implicit: `iceberg_snapshot_pointer_lag_sensor` and `dbt_layer_freshness_sensor` are still gated only by `DefaultSensorStatus.STOPPED`. Neither writes a warehouse — one alerts, one runs freshness checks — so they are a much smaller blast radius than the schedules, but they are the remaining undeclared automation in this code location.

Still open on `DBT_AUTOMATION_ENVIRONMENTS` and unchanged here: whether production's synthesized `default_automation_condition_sensor` over staging should be closed by dropping staging's condition rather than only excluding it from the sensor's target. That changes production behaviour, so it belongs to RFC 12711, not to this PR.
