### PR TITLE
feat(cohort-3): deliver podcasts to MIT Learn via webhook

### DIFF
--- a/dg_projects/lakehouse/lakehouse/definitions.py
+++ b/dg_projects/lakehouse/lakehouse/definitions.py
@@ -6,6 +6,7 @@ from datetime import timedelta
 
 from dagster import (
     AssetCheckSeverity,
+    AssetKey,
     AssetSelection,
     AssetSpec,
     AutomationConditionSensorDefinition,
@@ -399,6 +400,60 @@ b2b_analytics_starrocks_schedule = ScheduleDefinition(
     default_status=DefaultScheduleStatus.STOPPED,
 )
 
+# MIT Learn delivery chain: refresh the dbt models the mit_learn_delivery
+# webhook assets read, between the dlt ingests and the delivery POSTs.
+#
+# Without this the delivery assets POST whatever was last materialized. The gap
+# is not obvious from any one file, so, concretely: the dlt ingest schedules in
+# the data_loading location materialize ONLY the raw tables (03:00-04:00 UTC);
+# `dbt_automation_sensor` below covers the integrations models but explicitly
+# excludes the `staging` group; and the `sync_and_stage_*` jobs that are meant
+# to cover staging are built from the Airbyte source groups, so they never touch
+# these dlt-sourced staging models. That leaves stg__mit_climate__*,
+# stg__mitpe__*, stg__oll__*, stg__edxorg__discovery__api__programs and
+# stg__podcast__rss__* with no scheduled materialization at all, and the
+# integrations models above them reading yesterday's staging.
+#
+# These live in the lakehouse location because a Dagster job cannot span code
+# locations -- the delivery assets are in `learning_resources` and cannot
+# materialize dbt assets defined here, so the refresh has to be driven from
+# this side rather than by widening the delivery schedules.
+#
+# Keys are listed explicitly rather than selected by group: `integrations` and
+# `staging` both hold many models unrelated to MIT Learn, and `.upstream()`
+# from the integrations models would pull in the whole edxorg lineage.
+LEARN_DELIVERY_MODEL_KEYS = [
+    # staging
+    AssetKey(["staging", "mit_climate", "stg__mit_climate__api__articles"]),
+    AssetKey(["staging", "mitpe", "stg__mitpe__api__courses"]),
+    AssetKey(["staging", "oll", "stg__oll__google_sheets__courses"]),
+    AssetKey(["staging", "edxorg", "stg__edxorg__discovery__api__programs"]),
+    AssetKey(["staging", "podcast", "stg__podcast__rss__channels"]),
+    AssetKey(["staging", "podcast", "stg__podcast__rss__episodes"]),
+    # integrations
+    AssetKey(["integrations", "learn", "integrations__learn__mit_climate_articles"]),
+    AssetKey(["integrations", "learn", "integrations__learn__mitpe_courses"]),
+    AssetKey(["integrations", "learn", "integrations__learn__oll_courses"]),
+    AssetKey(["integrations", "learn", "integrations__learn__mit_edx_programs"]),
+    AssetKey(["integrations", "learn", "integrations__learn__podcasts"]),
+    AssetKey(["integrations", "learn", "integrations__learn__podcast_episodes"]),
+]
+
+# 05:00 UTC sits after the last dlt ingest (podcast_rss at 04:00) and before the
+# first delivery POST (mit_climate at 06:00). STOPPED by default, matching the
+# delivery schedules it feeds -- enabling this without enabling those is safe
+# and is the right order to turn them on.
+learn_delivery_models_schedule = ScheduleDefinition(
+    name="learn_delivery_models_daily",
+    job=define_asset_job(
+        name="learn_delivery_models_job",
+        selection=AssetSelection.assets(*LEARN_DELIVERY_MODEL_KEYS),
+    ),
+    cron_schedule="0 5 * * *",
+    execution_timezone="UTC",
+    default_status=DefaultScheduleStatus.STOPPED,
+)
+
 # Instructor onboarding schedule
 instructor_onboarding_schedule = ScheduleDefinition(
     name="instructor_onboarding_daily_schedule",
@@ -546,6 +601,7 @@ defs = Definitions(
             ("iceberg_raw_maintenance_nightly", iceberg_raw_maintenance_schedule),
             ("dbt_docs_artifacts_daily", dbt_docs_artifacts_schedule),
             ("b2b_analytics_starrocks_nightly", b2b_analytics_starrocks_schedule),
+            ("learn_delivery_models_daily", learn_delivery_models_schedule),
         ]
     ),
 )

--- a/dg_projects/lakehouse/lakehouse/lib/scheduled_automation.py
+++ b/dg_projects/lakehouse/lakehouse/lib/scheduled_automation.py
@@ -20,7 +20,7 @@ Dagster UI can start it. Dagster synthesizes sensors it was not given
 final in a way that stopping is not.
 
 That difference is also why this is not one boolean shared with the dbt map.
-Only three of these six schedules run dbt at all; the iceberg maintenance pair
+Only four of these seven schedules run dbt at all; the iceberg maintenance pair
 rewrites Iceberg metadata, and instructor onboarding pushes a commit to a GitHub
 repository. "May dbt materialize itself here" is the wrong question to ask of
 those, and answering it for them would have hidden the more interesting one.
@@ -52,12 +52,13 @@ single per-environment switch would have to be wrong about one of them.
 
 What omission also takes with it
 --------------------------------
-Four of these six build their job inline with ``define_asset_job`` inside the
+Five of these seven build their job inline with ``define_asset_job`` inside the
 ``ScheduleDefinition``, so dropping the schedule drops that job from the code
 location too -- ``iceberg_dbt_maintenance_job``, ``iceberg_raw_maintenance_job``,
-``b2b_analytics_starrocks_job`` and ``instructor_onboarding_daily_job`` are not
-manually launchable outside production. Their ASSETS stay registered everywhere
-and can still be materialized by hand from the asset graph, so nothing becomes
+``b2b_analytics_starrocks_job``, ``instructor_onboarding_daily_job`` and
+``learn_delivery_models_job`` are not manually launchable outside production.
+Their ASSETS stay registered everywhere and can still be materialized by hand
+from the asset graph, so nothing becomes
 unreachable; only the pre-built job disappears. ``dbt_docs_artifacts_daily`` is
 the exception -- its job is registered separately in ``jobs`` and is unaffected.
 
@@ -124,6 +125,13 @@ SCHEDULE_ENVIRONMENTS: Mapping[str, frozenset[str]] = {
     # `ScheduleDefinition`'s implicit STOPPED default -- it passed no
     # default_status at all.
     "instructor_onboarding_daily_schedule": frozenset({"production"}),
+    # Builds the integrations__learn__* models the MIT Learn delivery assets
+    # POST from. A dbt build, so it takes the same answer as the other dbt
+    # entries rather than the ingestion one: QA gets fed, it does not build.
+    # Its job is defined inline and therefore absent outside production too;
+    # the Cohort 3 QA validation this schedule was written for materializes the
+    # models from the asset graph, which stays available everywhere.
+    "learn_delivery_models_daily": frozenset({"production"}),
 }
 
 _UNDECLARED_ENVIRONMENTS = {

--- a/dg_projects/learning_resources/learning_resources/assets/podcasts.py
+++ b/dg_projects/learning_resources/learning_resources/assets/podcasts.py
@@ -21,8 +21,12 @@ model fields -- an unexpected key is a hard error, not an ignored extra.
 FULL-SYNC HAZARD: ``load_podcasts()`` unpublishes every podcast and every
 episode that is absent from the delivered batch. A partial read -- an empty
 Iceberg table, a half-written dbt run -- would therefore unpublish the live
-catalog. ``MIN_PODCASTS`` below is the floor that guards against that; the
-asset raises rather than delivering a suspiciously small batch.
+catalog. ``assert_deliverable`` guards both tables against that, raising
+rather than delivering a suspiciously small batch. The two floors are
+separate because the two models materialize independently: healthy channels
+plus an empty episode table empties every delivered podcast while leaving the
+podcasts themselves published, which is the failure that looks most like a
+success.
 
 Scheduling: daily at 07:00 UTC. Configured in definitions.py.
 """
@@ -34,6 +38,7 @@ from email.utils import parsedate_to_datetime
 from typing import Any, cast
 
 import httpx2 as httpx
+import nh3
 import polars as pl
 from dagster import (
     AssetExecutionContext,
@@ -63,43 +68,77 @@ _EPISODES_TABLE = "integrations__learn__podcast_episodes"
 # individual feed that fails to fetch or parse, and a handful of dead feeds is
 # normal. Single digits, though, means the read is wrong -- not the catalog.
 MIN_PODCASTS = 5
+# Companion floor for the episode table, which materializes independently of
+# the channel table. Deliberately far below the real episode count (thousands
+# across 38 feeds) for the same reason MIN_PODCASTS is loose -- this catches an
+# empty or truncated read, not natural variation. A per-podcast coverage
+# assertion would be stricter, but a podcast whose feed legitimately yields no
+# usable <item> (all entries missing <enclosure>) is a real, non-broken state,
+# so a coverage rule would block valid deliveries.
+MIN_EPISODES = 50
 
-_HHMMSS = re.compile(r"^(?:(\d+):)?(\d{1,2}):(\d{2})$")
+# "HH:MM:SS" or "MM:SS". The minute and hour groups are deliberately unbounded:
+# mit-learn accepts "72:59" and normalizes it to PT1H12M59S rather than
+# rejecting it or emitting PT72M59S, so every clock form is summed to seconds
+# below and re-split, instead of being mapped component-for-component.
+_CLOCK = re.compile(r"^(?:(\d+):)?(\d+):(\d{1,2})$")
+# Strict ISO-8601 duration. Django's parse_duration -- which mit-learn's
+# iso8601_duration delegates to -- REJECTS a malformed value like "PTBarnum"
+# and returns None. A `startswith("PT")` passthrough would forward that string
+# to PodcastEpisode.duration unvalidated, so the shape is matched properly.
+_ISO = re.compile(r"^P(?!$)(?:(\d+)D)?(?:T(?!$)(?:(\d+)H)?(?:(\d+)M)?(?:(\d+)S)?)?$")
+
+
+def _duration_seconds(raw: str) -> int | None:
+    """Reduce any accepted duration spelling to a total number of seconds."""
+    clock = _CLOCK.match(raw)
+    if clock:
+        hours, minutes, seconds = (int(g or 0) for g in clock.groups())
+        return hours * 3600 + minutes * 60 + seconds
+
+    iso = _ISO.match(raw)
+    if iso and any(group is not None for group in iso.groups()):
+        days, hours, minutes, seconds = (int(g or 0) for g in iso.groups())
+        return days * 86400 + hours * 3600 + minutes * 60 + seconds
+
+    if raw.isdigit():
+        return int(raw)
+
+    return None
 
 
 def _iso8601_duration(duration: str | None) -> str | None:
     """Normalize a raw itunes:duration to an ISO-8601 duration string.
 
-    Mirrors ``learning_resources/etl/utils.py:iso8601_duration`` in mit-learn.
-    Accepts "HH:MM:SS", "MM:SS", or a bare seconds count; returns None when the
-    value is absent or unparseable, matching the Celery ETL's behaviour.
+    Mirrors ``learning_resources/etl/utils.py:iso8601_duration`` in mit-learn,
+    whose behaviour is pinned by the parametrized table in
+    ``learning_resources/etl/utils_test.py`` -- that table is ported verbatim
+    into this project's tests, so parity is proven rather than asserted.
 
-    Parity with that function is deliberate down to its rough edge: zero
-    components are omitted, so most values stay short, but an episode of 10+
-    hours with non-zero minutes and seconds yields 11 characters
-    ("PT10H30M15S") and overflows ``PodcastEpisode.duration``'s 10-character
-    column. The Celery ETL has the same latent failure, so this is not a new
-    divergence -- keeping the two byte-identical matters more during parallel
-    validation than papering over it here would.
+    Accepts "HH:MM:SS", "MM:SS", a bare seconds count, or an ISO-8601 duration;
+    returns None (and warns) when a non-empty value cannot be parsed.
+
+    Everything is reduced to total seconds and re-split, because mit-learn
+    normalizes overflow: "72:59" is 1h12m59s, not 72 minutes.
+
+    Parity is deliberate down to one rough edge: zero components are omitted,
+    so most values stay short, but an episode of 10+ hours with non-zero
+    minutes and seconds yields 11 characters ("PT10H30M15S") and overflows
+    ``PodcastEpisode.duration``'s 10-character column. The Celery ETL has the
+    same latent failure, so this is not a new divergence -- keeping the two
+    byte-identical matters more during parallel validation than papering over
+    it here would.
     """
     if not duration:
         return None
-    raw = duration.strip()
-    if raw.startswith("PT"):
-        return raw
 
-    match = _HHMMSS.match(raw)
-    if match:
-        hours = int(match.group(1) or 0)
-        minutes = int(match.group(2))
-        seconds = int(match.group(3))
-    elif raw.isdigit():
-        total = int(raw)
-        hours, remainder = divmod(total, 3600)
-        minutes, seconds = divmod(remainder, 60)
-    else:
-        log.warning("Could not parse duration string %s", raw)
+    total = _duration_seconds(duration.strip())
+    if total is None:
+        log.warning("Could not parse duration string %s", duration)
         return None
+
+    hours, remainder = divmod(total, 3600)
+    minutes, seconds = divmod(remainder, 60)
 
     if not (hours or minutes or seconds):
         return "PT0S"
@@ -120,6 +159,60 @@ def _parse_pub_date(pub_date: str | None) -> str | None:
     except (TypeError, ValueError):
         log.warning("Could not parse pubDate %s", pub_date)
         return None
+
+
+# Mirrors main/constants.py in mit-learn: ALLOWED_HTML_TAGS plus "a", and
+# ALLOWED_HTML_ATTRIBUTES_WITH_LINKS. The Celery ETL sanitizes podcast titles
+# and descriptions with exactly this allowlist before they reach the database;
+# the webhook path has to do the same, because the loader passes these fields
+# straight to LearningResource and would otherwise persist raw third-party RSS
+# HTML unchanged.
+#
+# Duplicated rather than imported -- there is no shared package between the two
+# repos. If MIT Learn changes its allowlist, this must change with it; a drift
+# here is a sanitization difference, not a formatting one.
+_ALLOWED_HTML_TAGS = {
+    "a",
+    "b",
+    "blockquote",
+    "br",
+    "caption",
+    "center",
+    "cite",
+    "code",
+    "div",
+    "em",
+    "hr",
+    "i",
+    "li",
+    "ol",
+    "p",
+    "pre",
+    "q",
+    "small",
+    "span",
+    "strike",
+    "strong",
+    "sub",
+    "sup",
+    "u",
+    "ul",
+}
+_ALLOWED_HTML_ATTRIBUTES = {"a": {"href", "title"}}
+
+
+def _clean(value: str | None) -> str | None:
+    """Strip disallowed HTML, mirroring mit-learn's clean_data().
+
+    mit-learn's clean_data returns "" for a falsy input; None is preserved here
+    instead, so an absent field stays absent in the payload rather than being
+    delivered as an empty string that would overwrite a populated value.
+    """
+    if not value:
+        return value
+    return nh3.clean(
+        value, tags=_ALLOWED_HTML_TAGS, attributes=_ALLOWED_HTML_ATTRIBUTES
+    )
 
 
 def _topics(raw: str | None) -> list[dict[str, str]]:
@@ -159,7 +252,7 @@ def _episode_to_resource(
         "resource_type": "podcast_episode",
         "title": row.get("title"),
         "offered_by": offered_by,
-        "description": row.get("description"),
+        "description": _clean(row.get("description")),
         "url": row.get("url"),
         "image": _image(row.get("image_url")) or parent_image,
         "last_modified": _parse_pub_date(row.get("published_on_raw")),
@@ -188,7 +281,7 @@ def _podcast_to_resource(
         "etl_source": "podcast",
         "resource_type": "podcast",
         "offered_by": offered_by,
-        "description": row.get("description"),
+        "description": _clean(row.get("description")),
         "image": image,
         "published": True,
         "url": row.get("url"),
@@ -204,6 +297,35 @@ def _podcast_to_resource(
         },
         "availability": "anytime",
     }
+
+
+def assert_deliverable(podcast_count: int, episode_count: int) -> None:
+    """Refuse to deliver a batch too small to be a real full sync.
+
+    MIT Learn unpublishes every podcast and every episode absent from the
+    delivered batch, so a short read is a catalog-wide outage rather than a
+    small delivery. Both tables are checked independently: they materialize
+    separately, so the episode table can be empty or half-written while the
+    channel table looks entirely healthy. That combination empties every
+    delivered podcast while the podcasts themselves survive -- the failure
+    mode that looks most like a success.
+    """
+    if podcast_count < MIN_PODCASTS:
+        msg = (
+            f"Refusing to deliver {podcast_count} podcasts (floor is "
+            f"{MIN_PODCASTS}): MIT Learn full-syncs this batch and would "
+            "unpublish every podcast and episode not included."
+        )
+        raise RuntimeError(msg)
+
+    if episode_count < MIN_EPISODES:
+        msg = (
+            f"Refusing to deliver {episode_count} episodes across "
+            f"{podcast_count} podcasts (floor is {MIN_EPISODES}): MIT Learn "
+            "unpublishes every episode absent from this batch, so a short "
+            "episode read silently empties the podcasts it does deliver."
+        )
+        raise RuntimeError(msg)
 
 
 def build_podcast_resources(
@@ -261,16 +383,7 @@ def podcast_webhook(
         len(episodes_df),
     )
 
-    # Full-sync guard -- see the module docstring. MIT Learn unpublishes every
-    # podcast and episode missing from this batch, so a short read is a
-    # catalog-wide outage, not a small delivery.
-    if len(podcasts_df) < MIN_PODCASTS:
-        msg = (
-            f"Refusing to deliver {len(podcasts_df)} podcasts (floor is "
-            f"{MIN_PODCASTS}): MIT Learn full-syncs this batch and would "
-            "unpublish every podcast and episode not included."
-        )
-        raise RuntimeError(msg)
+    assert_deliverable(len(podcasts_df), len(episodes_df))
 
     resources = build_podcast_resources(
         list(podcasts_df.iter_rows(named=True)),

--- a/dg_projects/learning_resources/learning_resources/assets/podcasts.py
+++ b/dg_projects/learning_resources/learning_resources/assets/podcasts.py
@@ -204,9 +204,18 @@ _ALLOWED_HTML_ATTRIBUTES = {"a": {"href", "title"}}
 def _clean(value: str | None) -> str | None:
     """Strip disallowed HTML, mirroring mit-learn's clean_data().
 
-    mit-learn's clean_data returns "" for a falsy input; None is preserved here
-    instead, so an absent field stays absent in the payload rather than being
-    delivered as an empty string that would overwrite a populated value.
+    mit-learn's clean_data returns "" for a falsy input; the falsy value is
+    preserved here instead, so the delivered payload matches the source row
+    exactly.
+
+    Note this is NOT protection against clobbering an existing description.
+    The "description" key is always present in the payload and
+    ``LearningResource.description`` is ``TextField(null=True, blank=True)``,
+    so ``update_or_create(defaults=...)`` writes whatever we send -- None
+    replaces a populated value just as "" would. The reason to preserve it is
+    fidelity: coercing None to "" would flip a NULL description to an empty
+    string on every delivery, which is a diff the Celery ETL would not produce
+    and therefore noise during parallel validation.
     """
     if not value:
         return value

--- a/dg_projects/learning_resources/learning_resources/assets/podcasts.py
+++ b/dg_projects/learning_resources/learning_resources/assets/podcasts.py
@@ -1,0 +1,307 @@
+"""MIT podcast webhook delivery asset.
+
+Reads pre-transformed podcast channels and episodes from the
+``integrations__learn__podcasts`` / ``integrations__learn__podcast_episodes``
+Iceberg tables (produced by dbt from the podcast_rss dlt pipeline), nests each
+podcast's episodes inside it, and delivers the batch to MIT Learn via a single
+signed webhook POST.
+
+Data flow:
+    raw__podcast__rss__channels  (Iceberg, via dlt)
+    raw__podcast__rss__episodes  (Iceberg, via dlt)
+        -> integrations__learn__podcasts          (dbt)
+        -> integrations__learn__podcast_episodes  (dbt)
+            -> MIT Learn webhook (this asset)
+
+The payload shape mirrors ``learning_resources/etl/podcast.py:transform()`` in
+mit-learn exactly, because MIT Learn's ``load_podcasts()`` pops a fixed set of
+keys and passes whatever remains straight through as ``LearningResource``
+model fields -- an unexpected key is a hard error, not an ignored extra.
+
+FULL-SYNC HAZARD: ``load_podcasts()`` unpublishes every podcast and every
+episode that is absent from the delivered batch. A partial read -- an empty
+Iceberg table, a half-written dbt run -- would therefore unpublish the live
+catalog. ``MIN_PODCASTS`` below is the floor that guards against that; the
+asset raises rather than delivering a suspiciously small batch.
+
+Scheduling: daily at 07:00 UTC. Configured in definitions.py.
+"""
+
+import logging
+import re
+from collections import defaultdict
+from email.utils import parsedate_to_datetime
+from typing import Any, cast
+
+import httpx2 as httpx
+import polars as pl
+from dagster import (
+    AssetExecutionContext,
+    AssetKey,
+    MetadataValue,
+    RetryPolicy,
+    asset,
+)
+from ol_orchestrate.lib.constants import DAGSTER_ENV
+from ol_orchestrate.lib.glue_helper import get_dbt_model_as_dataframe
+from ol_orchestrate.resources.api_client_factory import ApiClientFactory
+from ol_orchestrate.resources.learn_api import MITLearnApiClient
+
+log = logging.getLogger(__name__)
+
+_GLUE_DB = (
+    f"ol_warehouse_{DAGSTER_ENV}_integrations"
+    if DAGSTER_ENV in ("qa", "production")
+    else "ol_warehouse_production_integrations"
+)
+_PODCASTS_TABLE = "integrations__learn__podcasts"
+_EPISODES_TABLE = "integrations__learn__podcast_episodes"
+
+# Floor for the full-sync guard described in the module docstring. There are 38
+# podcasts configured in mitodl/open-podcast-data as of 2026-08-19, so this is a
+# deliberately loose floor rather than a close one: the dlt source skips any
+# individual feed that fails to fetch or parse, and a handful of dead feeds is
+# normal. Single digits, though, means the read is wrong -- not the catalog.
+MIN_PODCASTS = 5
+
+_HHMMSS = re.compile(r"^(?:(\d+):)?(\d{1,2}):(\d{2})$")
+
+
+def _iso8601_duration(duration: str | None) -> str | None:
+    """Normalize a raw itunes:duration to an ISO-8601 duration string.
+
+    Mirrors ``learning_resources/etl/utils.py:iso8601_duration`` in mit-learn.
+    Accepts "HH:MM:SS", "MM:SS", or a bare seconds count; returns None when the
+    value is absent or unparseable, matching the Celery ETL's behaviour.
+
+    Parity with that function is deliberate down to its rough edge: zero
+    components are omitted, so most values stay short, but an episode of 10+
+    hours with non-zero minutes and seconds yields 11 characters
+    ("PT10H30M15S") and overflows ``PodcastEpisode.duration``'s 10-character
+    column. The Celery ETL has the same latent failure, so this is not a new
+    divergence -- keeping the two byte-identical matters more during parallel
+    validation than papering over it here would.
+    """
+    if not duration:
+        return None
+    raw = duration.strip()
+    if raw.startswith("PT"):
+        return raw
+
+    match = _HHMMSS.match(raw)
+    if match:
+        hours = int(match.group(1) or 0)
+        minutes = int(match.group(2))
+        seconds = int(match.group(3))
+    elif raw.isdigit():
+        total = int(raw)
+        hours, remainder = divmod(total, 3600)
+        minutes, seconds = divmod(remainder, 60)
+    else:
+        log.warning("Could not parse duration string %s", raw)
+        return None
+
+    if not (hours or minutes or seconds):
+        return "PT0S"
+    return (
+        "PT"
+        f"{f'{hours}H' if hours else ''}"
+        f"{f'{minutes}M' if minutes else ''}"
+        f"{f'{seconds}S' if seconds else ''}"
+    )
+
+
+def _parse_pub_date(pub_date: str | None) -> str | None:
+    """Parse an RFC 2822 <pubDate> into an ISO-8601 timestamp string."""
+    if not pub_date:
+        return None
+    try:
+        return parsedate_to_datetime(pub_date).isoformat()
+    except (TypeError, ValueError):
+        log.warning("Could not parse pubDate %s", pub_date)
+        return None
+
+
+def _topics(raw: str | None) -> list[dict[str, str]]:
+    """Split the comma-separated topics column into MIT Learn's topic dicts."""
+    if not raw:
+        return []
+    return [{"name": topic.strip()} for topic in raw.split(",") if topic.strip()]
+
+
+def _offered_by(raw: str | None) -> dict[str, str] | None:
+    """Wrap the offered_by name, or None when the config omits it."""
+    return {"name": raw} if raw else None
+
+
+def _image(url: str | None) -> dict[str, str] | None:
+    """Wrap an image URL, or None when the feed exposes none."""
+    return {"url": url} if url else None
+
+
+def _episode_to_resource(
+    row: dict[str, Any],
+    topics: list[dict[str, str]],
+    offered_by: dict[str, str] | None,
+    parent_image: dict[str, str] | None,
+) -> dict[str, Any]:
+    """Map an episodes row to MIT Learn's podcast_episode payload shape.
+
+    ``podcast_episode.rss`` (the raw <item> XML the Celery ETL stores) is
+    deliberately omitted: the dlt source does not capture per-item XML, and
+    the field is nullable. Omitting it leaves any existing value intact,
+    because ``load_podcast_episode`` passes this dict as ``defaults=`` to
+    ``update_or_create`` -- absent keys are not written.
+    """
+    return {
+        "readable_id": row["readable_id"],
+        "etl_source": "podcast",
+        "resource_type": "podcast_episode",
+        "title": row.get("title"),
+        "offered_by": offered_by,
+        "description": row.get("description"),
+        "url": row.get("url"),
+        "image": _image(row.get("image_url")) or parent_image,
+        "last_modified": _parse_pub_date(row.get("published_on_raw")),
+        "published": True,
+        "topics": topics,
+        "podcast_episode": {
+            "audio_url": row["audio_url"],
+            "episode_link": row.get("episode_link"),
+            "duration": _iso8601_duration(row.get("duration_raw")),
+        },
+        "availability": "anytime",
+    }
+
+
+def _podcast_to_resource(
+    row: dict[str, Any], episode_rows: list[dict[str, Any]]
+) -> dict[str, Any]:
+    """Map a podcasts row plus its episodes to MIT Learn's podcast payload."""
+    topics = _topics(row.get("topics"))
+    offered_by = _offered_by(row.get("offered_by"))
+    image = _image(row.get("image_url"))
+
+    return {
+        "readable_id": row["readable_id"],
+        "title": row["title"],
+        "etl_source": "podcast",
+        "resource_type": "podcast",
+        "offered_by": offered_by,
+        "description": row.get("description"),
+        "image": image,
+        "published": True,
+        "url": row.get("url"),
+        "topics": topics,
+        "episodes": [
+            _episode_to_resource(episode, topics, offered_by, image)
+            for episode in episode_rows
+        ],
+        "podcast": {
+            "apple_podcasts_url": row.get("apple_podcasts_url"),
+            "google_podcasts_url": row.get("google_podcasts_url"),
+            "rss_url": row.get("rss_url"),
+        },
+        "availability": "anytime",
+    }
+
+
+def build_podcast_resources(
+    podcasts: list[dict[str, Any]], episodes: list[dict[str, Any]]
+) -> list[dict[str, Any]]:
+    """Join episodes onto their podcasts and build the webhook payload."""
+    episodes_by_podcast: dict[str, list[dict[str, Any]]] = defaultdict(list)
+    for episode in episodes:
+        episodes_by_podcast[episode["podcast_readable_id"]].append(episode)
+
+    return [
+        _podcast_to_resource(
+            podcast, episodes_by_podcast.get(podcast["readable_id"], [])
+        )
+        for podcast in podcasts
+    ]
+
+
+@asset(
+    key=AssetKey(["mit_learn_delivery", "podcast_webhook"]),
+    group_name="mit_learn_delivery",
+    description=(
+        "Read MIT podcast channels and episodes from the "
+        "integrations__learn__podcasts / integrations__learn__podcast_episodes "
+        "Iceberg tables and POST as a signed webhook batch to MIT Learn."
+    ),
+    deps=[
+        AssetKey(["integrations", "learn", "integrations__learn__podcasts"]),
+        AssetKey(["integrations", "learn", "integrations__learn__podcast_episodes"]),
+    ],
+    retry_policy=RetryPolicy(max_retries=3, delay=5.0),
+)
+def podcast_webhook(
+    context: AssetExecutionContext,
+    learn_api: ApiClientFactory,
+) -> dict[str, Any]:
+    """Deliver MIT podcasts (with nested episodes) to MIT Learn via webhook."""
+    context.log.info(
+        "Reading %s and %s from Glue database %s",
+        _PODCASTS_TABLE,
+        _EPISODES_TABLE,
+        _GLUE_DB,
+    )
+    podcasts_df: pl.DataFrame = get_dbt_model_as_dataframe(
+        database_name=_GLUE_DB,
+        table_name=_PODCASTS_TABLE,
+    ).collect()
+    episodes_df: pl.DataFrame = get_dbt_model_as_dataframe(
+        database_name=_GLUE_DB,
+        table_name=_EPISODES_TABLE,
+    ).collect()
+    context.log.info(
+        "Loaded %d podcasts and %d episodes from Iceberg",
+        len(podcasts_df),
+        len(episodes_df),
+    )
+
+    # Full-sync guard -- see the module docstring. MIT Learn unpublishes every
+    # podcast and episode missing from this batch, so a short read is a
+    # catalog-wide outage, not a small delivery.
+    if len(podcasts_df) < MIN_PODCASTS:
+        msg = (
+            f"Refusing to deliver {len(podcasts_df)} podcasts (floor is "
+            f"{MIN_PODCASTS}): MIT Learn full-syncs this batch and would "
+            "unpublish every podcast and episode not included."
+        )
+        raise RuntimeError(msg)
+
+    resources = build_podcast_resources(
+        list(podcasts_df.iter_rows(named=True)),
+        list(episodes_df.iter_rows(named=True)),
+    )
+    episode_count = sum(len(resource["episodes"]) for resource in resources)
+
+    context.log.info(
+        "Delivering %d podcasts (%d episodes) to MIT Learn webhook",
+        len(resources),
+        episode_count,
+    )
+    try:
+        response = cast(MITLearnApiClient, learn_api.client).notify_learning_resources(
+            resources
+        )
+    except httpx.HTTPStatusError as exc:
+        msg = f"Podcast webhook failed with status {exc.response.status_code}: {exc}"
+        context.log.exception(msg)
+        raise RuntimeError(msg) from exc
+
+    context.add_output_metadata(
+        {
+            "resource_count": len(resources),
+            "episode_count": episode_count,
+            "webhook_status": "success",
+            "response": MetadataValue.json(response),
+        }
+    )
+    return {
+        "resource_count": len(resources),
+        "episode_count": episode_count,
+        "webhook_status": "success",
+    }

--- a/dg_projects/learning_resources/learning_resources/assets/podcasts.py
+++ b/dg_projects/learning_resources/learning_resources/assets/podcasts.py
@@ -38,7 +38,6 @@ from email.utils import parsedate_to_datetime
 from typing import Any, cast
 
 import httpx2 as httpx
-import nh3
 import polars as pl
 from dagster import (
     AssetExecutionContext,
@@ -51,6 +50,12 @@ from ol_orchestrate.lib.constants import DAGSTER_ENV
 from ol_orchestrate.lib.glue_helper import get_dbt_model_as_dataframe
 from ol_orchestrate.resources.api_client_factory import ApiClientFactory
 from ol_orchestrate.resources.learn_api import MITLearnApiClient
+
+from learning_resources.lib.sanitize import (
+    ALLOWED_HTML_ATTRIBUTES_WITH_LINKS,
+    ALLOWED_HTML_TAGS_WITH_LINKS,
+    clean_html,
+)
 
 log = logging.getLogger(__name__)
 
@@ -161,66 +166,27 @@ def _parse_pub_date(pub_date: str | None) -> str | None:
         return None
 
 
-# Mirrors main/constants.py in mit-learn: ALLOWED_HTML_TAGS plus "a", and
-# ALLOWED_HTML_ATTRIBUTES_WITH_LINKS. The Celery ETL sanitizes podcast titles
-# and descriptions with exactly this allowlist before they reach the database;
-# the webhook path has to do the same, because the loader passes these fields
-# straight to LearningResource and would otherwise persist raw third-party RSS
-# HTML unchanged.
-#
-# Duplicated rather than imported -- there is no shared package between the two
-# repos. If MIT Learn changes its allowlist, this must change with it; a drift
-# here is a sanitization difference, not a formatting one.
-_ALLOWED_HTML_TAGS = {
-    "a",
-    "b",
-    "blockquote",
-    "br",
-    "caption",
-    "center",
-    "cite",
-    "code",
-    "div",
-    "em",
-    "hr",
-    "i",
-    "li",
-    "ol",
-    "p",
-    "pre",
-    "q",
-    "small",
-    "span",
-    "strike",
-    "strong",
-    "sub",
-    "sup",
-    "u",
-    "ul",
-}
-_ALLOWED_HTML_ATTRIBUTES = {"a": {"href", "title"}}
-
-
+# mit-learn's podcast ETL is the one caller that passes the _WITH_LINKS
+# allowlists (learning_resources/etl/podcast.py:205,275): RSS show notes carry
+# resource links worth keeping, unlike the MIT PE descriptions clean_html
+# sanitizes by default. Bound once here so both payload builders below cannot
+# drift apart.
 def _clean(value: str | None) -> str | None:
-    """Strip disallowed HTML, mirroring mit-learn's clean_data().
+    """Sanitize an RSS field the way mit-learn's podcast ETL does.
 
-    mit-learn's clean_data returns "" for a falsy input; the falsy value is
-    preserved here instead, so the delivered payload matches the source row
-    exactly.
-
-    Note this is NOT protection against clobbering an existing description.
-    The "description" key is always present in the payload and
-    ``LearningResource.description`` is ``TextField(null=True, blank=True)``,
-    so ``update_or_create(defaults=...)`` writes whatever we send -- None
-    replaces a populated value just as "" would. The reason to preserve it is
-    fidelity: coercing None to "" would flip a NULL description to an empty
-    string on every delivery, which is a diff the Celery ETL would not produce
-    and therefore noise during parallel validation.
+    A falsy value is delivered unchanged rather than coerced to "" the way
+    ``clean_data`` does. Not protection against clobbering: the "description"
+    key is always present and ``LearningResource.description`` is
+    ``TextField(null=True, blank=True)``, so ``update_or_create(defaults=...)``
+    writes whatever we send -- None replaces a populated value just as "" would.
+    The reason to preserve it is fidelity. Coercing None to "" would flip a NULL
+    description to an empty string on every delivery, a diff the Celery ETL
+    would not produce and therefore noise during parallel validation.
     """
-    if not value:
-        return value
-    return nh3.clean(
-        value, tags=_ALLOWED_HTML_TAGS, attributes=_ALLOWED_HTML_ATTRIBUTES
+    return clean_html(
+        value,
+        tags=ALLOWED_HTML_TAGS_WITH_LINKS,
+        attributes=ALLOWED_HTML_ATTRIBUTES_WITH_LINKS,
     )
 
 

--- a/dg_projects/learning_resources/learning_resources/definitions.py
+++ b/dg_projects/learning_resources/learning_resources/definitions.py
@@ -39,6 +39,7 @@ from learning_resources.assets.ovs_videos import (
     video_metadata,
     video_webhook,
 )
+from learning_resources.assets.podcasts import podcast_webhook
 from learning_resources.assets.sloan_api import sloan_course_metadata
 from learning_resources.sensors.ovs_videos import (
     ovs_videos_delete_job,
@@ -91,6 +92,15 @@ mit_edx_programs_schedule = ScheduleDefinition(
     name="mit_edx_programs_schedule",
     target=AssetSelection.assets(mit_edx_programs_webhook),
     cron_schedule="45 6 * * *",
+    execution_timezone="Etc/UTC",
+)
+
+# Cohort 3 media/feed delivery. Podcasts deliver a nested channel+episode
+# payload, so this runs after the Cohort 2 slots rather than sharing one.
+podcast_schedule = ScheduleDefinition(
+    name="podcast_schedule",
+    target=AssetSelection.assets(podcast_webhook),
+    cron_schedule="0 7 * * *",
     execution_timezone="Etc/UTC",
 )
 
@@ -160,6 +170,8 @@ defs = Definitions(
             mitpe_webhook,
             oll_webhook,
             mit_edx_programs_webhook,
+            # Media/feed webhook delivery
+            podcast_webhook,
         ]
     ),
     schedules=[
@@ -169,6 +181,7 @@ defs = Definitions(
         mitpe_schedule,
         oll_schedule,
         mit_edx_programs_schedule,
+        podcast_schedule,
     ],
     sensors=[
         ovs_videos_discovery_sensor,

--- a/dg_projects/learning_resources/learning_resources_tests/test_podcasts.py
+++ b/dg_projects/learning_resources/learning_resources_tests/test_podcasts.py
@@ -10,9 +10,12 @@ assertions below are exact.
 
 import pytest
 from learning_resources.assets.podcasts import (
+    MIN_EPISODES,
+    MIN_PODCASTS,
     _iso8601_duration,
     _parse_pub_date,
     _topics,
+    assert_deliverable,
     build_podcast_resources,
 )
 
@@ -82,22 +85,54 @@ def episode_row():
     }
 
 
+# Ported VERBATIM from mit-learn's learning_resources/etl/utils_test.py
+# ::test_parse_duration. This is the parity contract: the webhook path and the
+# Celery ETL must agree on every one of these, or a cutover diff shows a
+# difference that is ours rather than the data's. Do not edit a case here to
+# make this implementation pass -- fix the implementation, or change both
+# repos together.
+MIT_LEARN_DURATION_CASES = [
+    ("1:00:00", "PT1H"),
+    ("1:30:04", "PT1H30M4S"),
+    ("00:00", "PT0S"),
+    ("00:00:00", "PT0S"),
+    ("00:01:00", "PT1M"),
+    ("01:00:00", "PT1H"),
+    ("00:00:01", "PT1S"),
+    ("02:59", "PT2M59S"),
+    ("72:59", "PT1H12M59S"),
+    ("3675", "PT1H1M15S"),
+    ("5", "PT5S"),
+    ("PT1H30M4S", "PT1H30M4S"),
+    ("", None),
+    (None, None),
+    ("bad_duration", None),
+    ("PTBarnum", None),
+]
+
+
+@pytest.mark.parametrize(("raw", "expected"), MIT_LEARN_DURATION_CASES)
+def test_iso8601_duration_matches_mit_learn(raw, expected):
+    """Durations normalize exactly as mit-learn's iso8601_duration does."""
+    assert _iso8601_duration(raw) == expected
+
+
 @pytest.mark.parametrize(
     ("raw", "expected"),
     [
         ("1:02:03", "PT1H2M3S"),
-        ("02:03", "PT2M3S"),
         ("3600", "PT1H"),
         ("0", "PT0S"),
-        ("0:00:00", "PT0S"),
-        ("PT1H30M", "PT1H30M"),
-        ("", None),
-        (None, None),
+        # Overflow in the minutes field is summed, not passed through.
+        ("90:00", "PT1H30M"),
+        # A malformed ISO value is rejected rather than forwarded verbatim to
+        # PodcastEpisode.duration.
+        ("PT", None),
+        ("PTnonsense", None),
         ("not a duration", None),
     ],
 )
 def test_iso8601_duration(raw, expected):
-    """Durations normalize the way mit-learn's iso8601_duration does."""
     assert _iso8601_duration(raw) == expected
 
 
@@ -149,6 +184,75 @@ def test_parse_pub_date(raw, expected):
 )
 def test_topics(raw, expected):
     assert _topics(raw) == expected
+
+
+def test_assert_deliverable_accepts_a_healthy_batch():
+    """A batch exactly at both floors passes -- the floors are inclusive."""
+    assert_deliverable(MIN_PODCASTS, MIN_EPISODES)
+
+
+def test_assert_deliverable_rejects_a_short_podcast_read():
+    with pytest.raises(RuntimeError, match="Refusing to deliver"):
+        assert_deliverable(MIN_PODCASTS - 1, MIN_EPISODES)
+
+
+def test_assert_deliverable_rejects_a_short_episode_read():
+    """Healthy channels + an empty episode table is the dangerous combination.
+
+    It empties every delivered podcast while the podcasts themselves survive,
+    so nothing about the run looks wrong.
+    """
+    with pytest.raises(RuntimeError, match="episodes"):
+        assert_deliverable(38, 0)
+
+
+def test_assert_deliverable_rejects_a_truncated_episode_read():
+    with pytest.raises(RuntimeError, match="episodes"):
+        assert_deliverable(38, MIN_EPISODES - 1)
+
+
+def test_descriptions_are_sanitized(podcast_row, episode_row):
+    """Third-party RSS HTML is stripped the way mit-learn's clean_data does.
+
+    The loader passes description straight to LearningResource, so an unstripped
+    <script> from a feed would be persisted verbatim.
+    """
+    hostile = '<p>Real text</p><script>alert("xss")</script><img src=x onerror=1>'
+    podcast_row["description"] = hostile
+    episode_row["description"] = hostile
+
+    [podcast] = build_podcast_resources([podcast_row], [episode_row])
+
+    for description in (podcast["description"], podcast["episodes"][0]["description"]):
+        assert "<script>" not in description
+        assert "onerror" not in description
+        assert "<img" not in description
+        assert "<p>Real text</p>" in description
+
+
+def test_sanitization_keeps_show_note_links(podcast_row, episode_row):
+    """<a href> survives — podcast show notes are mostly resource links.
+
+    mit-learn uses ALLOWED_HTML_TAGS_WITH_LINKS for exactly this reason.
+    """
+    episode_row["description"] = '<a href="https://mit.edu" title="MIT">MIT</a>'
+    [podcast] = build_podcast_resources([podcast_row], [episode_row])
+
+    description = podcast["episodes"][0]["description"]
+    assert 'href="https://mit.edu"' in description
+    assert 'title="MIT"' in description
+
+
+@pytest.mark.parametrize("empty", ["", None])
+def test_sanitization_preserves_absent_descriptions(podcast_row, episode_row, empty):
+    """An absent description stays absent rather than becoming "".
+
+    mit-learn's clean_data returns "" for falsy input; delivering "" would
+    overwrite a populated description on the resource.
+    """
+    podcast_row["description"] = empty
+    [podcast] = build_podcast_resources([podcast_row], [episode_row])
+    assert podcast["description"] == empty
 
 
 def test_podcast_payload_shape(podcast_row, episode_row):

--- a/dg_projects/learning_resources/learning_resources_tests/test_podcasts.py
+++ b/dg_projects/learning_resources/learning_resources_tests/test_podcasts.py
@@ -245,10 +245,14 @@ def test_sanitization_keeps_show_note_links(podcast_row, episode_row):
 
 @pytest.mark.parametrize("empty", ["", None])
 def test_sanitization_preserves_absent_descriptions(podcast_row, episode_row, empty):
-    """An absent description stays absent rather than becoming "".
+    """A falsy description is delivered as-is rather than coerced to "".
 
-    mit-learn's clean_data returns "" for falsy input; delivering "" would
-    overwrite a populated description on the resource.
+    mit-learn's clean_data returns "" for falsy input. Preserving the value is
+    about payload fidelity, not about protecting an existing description: the
+    key is always present and description is nullable, so update_or_create
+    writes whatever we send either way. Coercing None to "" would flip a NULL
+    description to an empty string on every delivery — a diff the Celery ETL
+    never produces, and therefore noise during parallel validation.
     """
     podcast_row["description"] = empty
     [podcast] = build_podcast_resources([podcast_row], [episode_row])

--- a/dg_projects/learning_resources/learning_resources_tests/test_podcasts.py
+++ b/dg_projects/learning_resources/learning_resources_tests/test_podcasts.py
@@ -1,0 +1,268 @@
+"""Tests for the podcast webhook delivery payload construction.
+
+These cover the pure transform half of ``assets/podcasts.py`` -- the part that
+has to match ``learning_resources/etl/podcast.py`` in mit-learn key for key,
+because MIT Learn's ``load_podcast``/``load_podcast_episode`` pop a fixed set
+of keys and pass the remainder straight to ``LearningResource`` as model
+fields. An extra key there is an error, not an ignored extra, so the shape
+assertions below are exact.
+"""
+
+import pytest
+from learning_resources.assets.podcasts import (
+    _iso8601_duration,
+    _parse_pub_date,
+    _topics,
+    build_podcast_resources,
+)
+
+# Keys mit-learn's load_podcast() pops, plus the LearningResource fields it
+# forwards. Anything outside this set would blow up update_or_create().
+PODCAST_KEYS = {
+    "readable_id",
+    "title",
+    "etl_source",
+    "resource_type",
+    "offered_by",
+    "description",
+    "image",
+    "published",
+    "url",
+    "topics",
+    "episodes",
+    "podcast",
+    "availability",
+}
+EPISODE_KEYS = {
+    "readable_id",
+    "etl_source",
+    "resource_type",
+    "title",
+    "offered_by",
+    "description",
+    "url",
+    "image",
+    "last_modified",
+    "published",
+    "topics",
+    "podcast_episode",
+    "availability",
+}
+
+
+@pytest.fixture
+def podcast_row():
+    return {
+        "readable_id": "feeds.example.com/mit-podcast/",
+        "title": "MIT Podcast",
+        "description": "A podcast about MIT.",
+        "url": "https://example.com/mit-podcast",
+        "image_url": "https://example.com/cover.png",
+        "topics": "Science, Engineering",
+        "offered_by": "MIT Open Learning",
+        "rss_url": "https://feeds.example.com/mit-podcast/",
+        "apple_podcasts_url": "https://podcasts.apple.com/mit",
+        "google_podcasts_url": None,
+    }
+
+
+@pytest.fixture
+def episode_row():
+    return {
+        "readable_id": "episode-guid-1",
+        "podcast_readable_id": "feeds.example.com/mit-podcast/",
+        "title": "Episode 1",
+        "description": "The first episode.",
+        "url": "https://example.com/ep1",
+        "audio_url": "https://example.com/ep1.mp3",
+        "episode_link": "https://example.com/ep1",
+        "image_url": None,
+        "duration_raw": "1:02:03",
+        "published_on_raw": "Wed, 02 Oct 2002 13:00:00 GMT",
+    }
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        ("1:02:03", "PT1H2M3S"),
+        ("02:03", "PT2M3S"),
+        ("3600", "PT1H"),
+        ("0", "PT0S"),
+        ("0:00:00", "PT0S"),
+        ("PT1H30M", "PT1H30M"),
+        ("", None),
+        (None, None),
+        ("not a duration", None),
+    ],
+)
+def test_iso8601_duration(raw, expected):
+    """Durations normalize the way mit-learn's iso8601_duration does."""
+    assert _iso8601_duration(raw) == expected
+
+
+def test_iso8601_duration_fits_the_column_under_ten_hours():
+    """Durations up to 9h59m59s fit PodcastEpisode.duration (a 10-char column)."""
+    max_duration_length = 10
+    assert len(_iso8601_duration("9:59:59")) == max_duration_length
+
+
+def test_iso8601_duration_overflows_the_column_past_ten_hours():
+    """A >=10h episode with non-zero minutes AND seconds overflows the column.
+
+    Zero components are omitted, so "10:00:00" stays short ("PT10H"); it takes
+    all three parts being non-zero to reach 11 characters.
+
+    This is NOT a divergence introduced here -- mit-learn's own
+    iso8601_duration() emits the identical string, so the Celery ETL has the
+    same latent failure. It is asserted rather than worked around so the two
+    paths stay byte-identical during parallel validation; deviating would make
+    a cutover diff that is noise rather than signal.
+    """
+    max_duration_length = 10
+    assert _iso8601_duration("10:00:00") == "PT10H"
+    assert len(_iso8601_duration("10:30:15")) > max_duration_length
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        ("Wed, 02 Oct 2002 13:00:00 GMT", "2002-10-02T13:00:00+00:00"),
+        ("", None),
+        (None, None),
+        ("yesterday", None),
+    ],
+)
+def test_parse_pub_date(raw, expected):
+    assert _parse_pub_date(raw) == expected
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        ("Science, Engineering", [{"name": "Science"}, {"name": "Engineering"}]),
+        ("Science", [{"name": "Science"}]),
+        ("Science, , Engineering", [{"name": "Science"}, {"name": "Engineering"}]),
+        ("", []),
+        (None, []),
+    ],
+)
+def test_topics(raw, expected):
+    assert _topics(raw) == expected
+
+
+def test_podcast_payload_shape(podcast_row, episode_row):
+    """The podcast payload carries exactly the keys load_podcast() expects."""
+    [podcast] = build_podcast_resources([podcast_row], [episode_row])
+
+    assert set(podcast) == PODCAST_KEYS
+    assert podcast["readable_id"] == "feeds.example.com/mit-podcast/"
+    assert podcast["etl_source"] == "podcast"
+    assert podcast["resource_type"] == "podcast"
+    assert podcast["availability"] == "anytime"
+    assert podcast["published"] is True
+    assert podcast["offered_by"] == {"name": "MIT Open Learning"}
+    assert podcast["image"] == {"url": "https://example.com/cover.png"}
+    assert podcast["topics"] == [{"name": "Science"}, {"name": "Engineering"}]
+    assert podcast["podcast"] == {
+        "apple_podcasts_url": "https://podcasts.apple.com/mit",
+        "google_podcasts_url": None,
+        "rss_url": "https://feeds.example.com/mit-podcast/",
+    }
+
+
+def test_episode_payload_shape(podcast_row, episode_row):
+    """The episode payload carries exactly the keys load_podcast_episode() expects."""
+    [podcast] = build_podcast_resources([podcast_row], [episode_row])
+    [episode] = podcast["episodes"]
+
+    assert set(episode) == EPISODE_KEYS
+    assert episode["readable_id"] == "episode-guid-1"
+    assert episode["resource_type"] == "podcast_episode"
+    assert episode["last_modified"] == "2002-10-02T13:00:00+00:00"
+    assert episode["podcast_episode"] == {
+        "audio_url": "https://example.com/ep1.mp3",
+        "episode_link": "https://example.com/ep1",
+        "duration": "PT1H2M3S",
+    }
+
+
+def test_episode_omits_rss(podcast_row, episode_row):
+    """`rss` is left out so update_or_create does not blank an existing value."""
+    [podcast] = build_podcast_resources([podcast_row], [episode_row])
+    assert "rss" not in podcast["episodes"][0]["podcast_episode"]
+
+
+def test_episode_inherits_channel_topics_and_offered_by(podcast_row, episode_row):
+    """Episodes inherit topics/offered_by from their channel, as transform_episode."""
+    [podcast] = build_podcast_resources([podcast_row], [episode_row])
+    [episode] = podcast["episodes"]
+
+    assert episode["topics"] == podcast["topics"]
+    assert episode["offered_by"] == podcast["offered_by"]
+
+
+def test_episode_falls_back_to_channel_image(podcast_row, episode_row):
+    """An episode with no image of its own uses the channel's cover art."""
+    [podcast] = build_podcast_resources([podcast_row], [episode_row])
+    assert podcast["episodes"][0]["image"] == {"url": "https://example.com/cover.png"}
+
+
+def test_episode_prefers_its_own_image(podcast_row, episode_row):
+    episode_row["image_url"] = "https://example.com/ep1.png"
+    [podcast] = build_podcast_resources([podcast_row], [episode_row])
+    assert podcast["episodes"][0]["image"] == {"url": "https://example.com/ep1.png"}
+
+
+def test_episodes_group_by_podcast(podcast_row, episode_row):
+    """Episodes attach to their own podcast and nowhere else."""
+    other_podcast = {**podcast_row, "readable_id": "feeds.example.com/other/"}
+    other_episode = {
+        **episode_row,
+        "readable_id": "episode-guid-2",
+        "podcast_readable_id": "feeds.example.com/other/",
+    }
+
+    resources = build_podcast_resources(
+        [podcast_row, other_podcast], [episode_row, other_episode]
+    )
+
+    by_id = {resource["readable_id"]: resource for resource in resources}
+    assert [
+        episode["readable_id"]
+        for episode in by_id["feeds.example.com/mit-podcast/"]["episodes"]
+    ] == ["episode-guid-1"]
+    assert [
+        episode["readable_id"]
+        for episode in by_id["feeds.example.com/other/"]["episodes"]
+    ] == ["episode-guid-2"]
+
+
+def test_podcast_with_no_episodes(podcast_row):
+    """A podcast whose feed yielded no usable items still delivers, with no episodes."""
+    [podcast] = build_podcast_resources([podcast_row], [])
+    assert podcast["episodes"] == []
+
+
+def test_orphan_episode_is_dropped(podcast_row, episode_row):
+    """An episode whose podcast is absent is not smuggled into another one."""
+    orphan = {**episode_row, "podcast_readable_id": "feeds.example.com/gone/"}
+    [podcast] = build_podcast_resources([podcast_row], [orphan])
+    assert podcast["episodes"] == []
+
+
+def test_missing_offered_by_is_none(podcast_row, episode_row):
+    """offered_by is None rather than {"name": None} when the config omits it."""
+    podcast_row["offered_by"] = None
+    [podcast] = build_podcast_resources([podcast_row], [episode_row])
+
+    assert podcast["offered_by"] is None
+    assert podcast["episodes"][0]["offered_by"] is None
+
+
+def test_missing_image_is_none(podcast_row, episode_row):
+    podcast_row["image_url"] = None
+    [podcast] = build_podcast_resources([podcast_row], [episode_row])
+
+    assert podcast["image"] is None
+    assert podcast["episodes"][0]["image"] is None

--- a/dg_projects/learning_resources/pyproject.toml
+++ b/dg_projects/learning_resources/pyproject.toml
@@ -9,6 +9,8 @@ dependencies = [
     "dagster-postgres>=0.27.13",
     "httpx2 >= 2.2.0",
     "jsonlines ~= 4.0.0",
+    # Same sanitizer MIT Learn's clean_data() uses, so the webhook path strips
+    # third-party RSS HTML exactly the way the Celery ETL does.
     "nh3 >= 0.2.0",
     "ol-orchestrate-lib",
     "pygsheets>=2.0.6",

--- a/src/ol_dbt/models/integrations/learn/_integrations__learn__cohort3__schema.yml
+++ b/src/ol_dbt/models/integrations/learn/_integrations__learn__cohort3__schema.yml
@@ -1,0 +1,131 @@
+---
+# MIT Learn integration layer — Cohort 3 media & feed sources
+# Sits above marts, exposes stable application-level contracts for ETL consumption.
+# Naming: integrations__learn__<entity>
+# See: docs/learn_marts_contract.md for the full schema contract.
+#
+# Unlike the Cohort 2 sources, podcasts deliver as a NESTED payload: MIT Learn's
+# load_podcasts() expects each podcast to carry its episodes inline under an
+# "episodes" key. The two models here stay flat and relational; the
+# mit_learn_delivery/podcast_webhook asset joins them into that nested shape.
+
+version: 2
+
+models:
+- name: integrations__learn__podcasts
+  description: >
+    MIT podcast channels exposed for MIT Learn's ETL. One row per podcast
+    configured in mitodl/open-podcast-data. Sourced from
+    stg__podcast__rss__channels via the podcast_rss dlt pipeline.
+    NOTE: RSS exposes only <lastBuildDate> (RFC 2822, not Trino-parseable
+    without a per-feed format string), so last_modified is current_timestamp.
+  columns:
+  - name: readable_id
+    description: >
+      The RSS feed URL with the scheme stripped, recomputed from rss_url to
+      match MIT Learn's parse_readable_id_from_url (which, unlike the dlt
+      source, preserves a trailing slash). Used for upsert matching.
+    tests: [not_null, unique]
+  - name: title
+    description: >
+      Podcast title — the YAML config's podcast_title when set, otherwise the
+      RSS channel title.
+    tests: [not_null]
+  - name: description
+    description: Podcast description from the RSS channel.
+  - name: url
+    description: The podcast's website URL from its YAML config.
+  - name: image_url
+    description: Cover art URL, or NULL if the feed exposes none.
+  - name: topics
+    description: Comma-separated topic labels from the YAML config.
+  - name: offered_by
+    description: Offering department name from the YAML config, or NULL.
+  - name: rss_url
+    description: >
+      The podcast's RSS feed URL. Delivered to MIT Learn inside the nested
+      "podcast" detail object, not as a top-level resource field.
+    tests: [not_null]
+  - name: apple_podcasts_url
+    description: Apple Podcasts listing URL from the YAML config, or NULL.
+  - name: google_podcasts_url
+    description: Google Podcasts listing URL from the YAML config, or NULL.
+  - name: last_modified
+    description: >
+      current_timestamp — see the model-level note on <lastBuildDate>.
+    tests: [not_null]
+  - name: etl_source
+    description: Always 'podcast'.
+    tests: [not_null]
+  - name: platform
+    description: Always 'podcast', matches etl_source.
+  - name: resource_type
+    description: Always 'podcast'.
+  - name: availability
+    description: Always 'anytime'.
+  - name: published
+    description: >
+      Always true; a podcast that stops being configured simply stops
+      appearing, and MIT Learn's load_podcasts() unpublishes it.
+
+- name: integrations__learn__podcast_episodes
+  description: >
+    MIT podcast episodes exposed for MIT Learn's ETL. One row per episode
+    across all configured podcasts. Sourced from stg__podcast__rss__episodes,
+    joined to its channel for the inherited topics/offered_by values.
+    Episodes with no <enclosure> (no audio file) are dropped at ingest.
+    NOTE: duration_raw and published_on_raw are deliberately un-normalized —
+    both are free-form/RFC 2822 strings that the delivery asset parses in
+    Python, mirroring the Celery ETL's iso8601_duration() and dateutil parse.
+  columns:
+  - name: readable_id
+    description: >
+      The episode <guid> when present, otherwise the episode link (or audio
+      URL) with the scheme stripped. Used for upsert matching.
+    tests: [not_null, unique]
+  - name: podcast_readable_id
+    description: >
+      readable_id of the parent podcast in integrations__learn__podcasts.
+      The delivery asset groups episodes by this column.
+    tests: [not_null]
+  - name: title
+    description: Episode title.
+  - name: description
+    description: Episode description from the RSS item.
+  - name: url
+    description: The episode link when present, otherwise the audio URL.
+  - name: audio_url
+    description: >
+      The audio file URL from the RSS <enclosure>. Required — MIT Learn's
+      PodcastEpisode.audio_url is NOT NULL.
+    tests: [not_null]
+  - name: episode_link
+    description: The RSS <link> for the episode, or NULL.
+  - name: image_url
+    description: >
+      Episode cover art — the episode's own itunes:image when present,
+      otherwise the parent channel's image URL.
+  - name: duration_raw
+    description: >
+      Raw itunes:duration text ("HH:MM:SS", "MM:SS", or a seconds count).
+      Normalized to an ISO-8601 duration by the delivery asset.
+  - name: published_on_raw
+    description: >
+      Raw RFC 2822 <pubDate>. Parsed into the resource's last_modified by the
+      delivery asset.
+  - name: topics
+    description: >
+      Comma-separated topic labels inherited from the parent podcast.
+  - name: offered_by
+    description: Offering department name inherited from the parent podcast.
+  - name: etl_source
+    description: Always 'podcast'.
+    tests: [not_null]
+  - name: platform
+    description: Always 'podcast', matches etl_source.
+  - name: resource_type
+    description: Always 'podcast_episode'.
+  - name: availability
+    description: Always 'anytime'.
+  - name: published
+    description: Always true.

--- a/src/ol_dbt/models/integrations/learn/_integrations__learn__cohort3__schema.yml
+++ b/src/ol_dbt/models/integrations/learn/_integrations__learn__cohort3__schema.yml
@@ -77,11 +77,23 @@ models:
   description: >
     MIT podcast episodes exposed for MIT Learn's ETL. One row per episode
     across all configured podcasts. Sourced from stg__podcast__rss__episodes,
-    joined to its channel for the inherited topics/offered_by values.
+    joined to integrations__learn__podcasts for the inherited topics and
+    offered_by values.
     Episodes with no <enclosure> (no audio file) are dropped at ingest.
     NOTE: duration_raw and published_on_raw are deliberately un-normalized —
     both are free-form/RFC 2822 strings that the delivery asset parses in
     Python, mirroring the Celery ETL's iso8601_duration() and dateutil parse.
+    NOTE: filtered by the same dlt-load grace window as
+    integrations__learn__podcasts, but on each episode's OWN load recency — a
+    feed can drop one old episode while the channel keeps refreshing daily.
+    NOTE: the parent is read from integrations__learn__podcasts rather than
+    from staging. Joining grace-filtered episodes to the UNFILTERED staging
+    channels would let an episode still inside its window attach to a channel
+    that had already aged out, producing rows no delivered podcast claims.
+    The delivery asset drops those, so the payload stayed correct — but they
+    would inflate the row count MIN_EPISODES uses to detect a short read, and
+    the two tables rank recency over independent _dlt_load_id universes, so
+    "3 loads ago" need not mean the same instant in each.
   columns:
   - name: readable_id
     description: >
@@ -91,8 +103,14 @@ models:
   - name: podcast_readable_id
     description: >
       readable_id of the parent podcast in integrations__learn__podcasts.
-      The delivery asset groups episodes by this column.
-    tests: [not_null]
+      The delivery asset groups episodes by this column. Read from that model
+      directly, so an episode cannot reference a podcast that does not ship —
+      the relationships test below pins that guarantee.
+    tests:
+    - not_null
+    - relationships:
+        to: ref('integrations__learn__podcasts')
+        field: readable_id
   - name: title
     description: Episode title.
   - name: description

--- a/src/ol_dbt/models/integrations/learn/_integrations__learn__cohort3__schema.yml
+++ b/src/ol_dbt/models/integrations/learn/_integrations__learn__cohort3__schema.yml
@@ -19,6 +19,11 @@ models:
     stg__podcast__rss__channels via the podcast_rss dlt pipeline.
     NOTE: RSS exposes only <lastBuildDate> (RFC 2822, not Trino-parseable
     without a per-feed format string), so last_modified is current_timestamp.
+    NOTE: the raw table is merge-loaded, so a podcast removed from the config
+    is never deleted. Rows are filtered to those seen in the last N dlt loads
+    (var podcast_absence_grace_loads, default 3) so removals eventually reach
+    MIT Learn, while a transient RSS fetch failure -- which makes the dlt
+    source skip that feed for one run -- does not unpublish a live podcast.
   columns:
   - name: readable_id
     description: >

--- a/src/ol_dbt/models/integrations/learn/integrations__learn__podcast_episodes.sql
+++ b/src/ol_dbt/models/integrations/learn/integrations__learn__podcast_episodes.sql
@@ -1,0 +1,47 @@
+{#
+  integrations__learn__podcast_episodes
+  Exposes MIT podcast episodes for MIT Learn's ETL (webhook delivery).
+  Contract: docs/learn_marts_contract.md
+  Joined to integrations__learn__podcasts on podcast_readable_id = readable_id.
+#}
+
+with episodes as (
+    select * from {{ ref('stg__podcast__rss__episodes') }}
+)
+
+, channels as (
+    select * from {{ ref('stg__podcast__rss__channels') }}
+)
+
+select
+    -- The dlt source already derives the episode identifier the way MIT Learn
+    -- does (<guid>, else the link/audio URL with the scheme stripped), so this
+    -- one passes through unchanged -- unlike the channel identifier.
+    episodes.episode_readable_id                             as readable_id
+    -- Recomputed from the channel's rss_url for the same reason as in
+    -- integrations__learn__podcasts: MIT Learn keeps the trailing slash.
+    , regexp_replace(channels.podcast_rss_url, '^.*//', '')  as podcast_readable_id
+    , episodes.episode_title                                 as title
+    , episodes.episode_description                           as description
+    , episodes.episode_url                                   as url
+    , episodes.episode_audio_url                             as audio_url
+    , episodes.episode_link                                  as episode_link
+    , episodes.episode_image_url                             as image_url
+    -- Free-form itunes:duration text; normalized to ISO-8601 by the delivery
+    -- asset, mirroring learning_resources/etl/utils.py:iso8601_duration.
+    , episodes.episode_duration_raw                          as duration_raw
+    -- RFC 2822 <pubDate>; parsed by the delivery asset into last_modified.
+    , episodes.episode_published_on_raw                      as published_on_raw
+    -- Topics and offered_by are inherited from the parent channel, matching
+    -- transform_episode() in learning_resources/etl/podcast.py.
+    , channels.podcast_topics_raw                            as topics
+    , channels.podcast_offered_by                            as offered_by
+    , 'podcast'                                              as etl_source
+    , 'podcast'                                              as platform
+    , 'podcast_episode'                                      as resource_type
+    , 'anytime'                                              as availability
+    , true                                                   as published
+from episodes
+inner join channels
+    on episodes.podcast_dlt_readable_id = channels.podcast_dlt_readable_id
+where channels.podcast_rss_url is not null

--- a/src/ol_dbt/models/integrations/learn/integrations__learn__podcast_episodes.sql
+++ b/src/ol_dbt/models/integrations/learn/integrations__learn__podcast_episodes.sql
@@ -10,14 +10,27 @@
   could never retire it. Episodes are filtered on their OWN load recency, not
   their channel's: a feed can drop a single old episode while the channel
   itself keeps being refreshed every day.
+
+  Channel attributes come from integrations__learn__podcasts rather than from
+  stg__podcast__rss__channels, and that is deliberate. Joining the filtered
+  episodes to the UNFILTERED staging table would let an episode still inside
+  its grace window attach to a channel that had already aged out of the
+  podcasts model -- producing rows whose podcast_readable_id matches no
+  delivered podcast. The delivery asset drops those, so the payload stayed
+  correct, but the row count did not: MIN_EPISODES counts rows in this model,
+  so orphans would inflate the very number that guards against a short read.
+  The two tables also rank recency over independent _dlt_load_id universes, so
+  "3 loads ago" does not necessarily mean the same instant in each. Reading the
+  parent from the podcasts model makes referential integrity structural instead
+  of coincidental -- an episode can only exist here if its podcast ships.
 #}
 
 with episodes as (
     select * from {{ ref('stg__podcast__rss__episodes') }}
 )
 
-, channels as (
-    select * from {{ ref('stg__podcast__rss__channels') }}
+, podcasts as (
+    select * from {{ ref('integrations__learn__podcasts') }}
 )
 
 -- rank 1 = most recent load; see integrations__learn__podcasts for why a
@@ -41,9 +54,7 @@ select
     -- does (<guid>, else the link/audio URL with the scheme stripped), so this
     -- one passes through unchanged -- unlike the channel identifier.
     current_episodes.episode_readable_id                     as readable_id
-    -- Recomputed from the channel's rss_url for the same reason as in
-    -- integrations__learn__podcasts: MIT Learn keeps the trailing slash.
-    , regexp_replace(channels.podcast_rss_url, '^.*//', '')  as podcast_readable_id
+    , podcasts.readable_id                                   as podcast_readable_id
     , current_episodes.episode_title                         as title
     , current_episodes.episode_description                   as description
     , current_episodes.episode_url                           as url
@@ -55,16 +66,19 @@ select
     , current_episodes.episode_duration_raw                  as duration_raw
     -- RFC 2822 <pubDate>; parsed by the delivery asset into last_modified.
     , current_episodes.episode_published_on_raw              as published_on_raw
-    -- Topics and offered_by are inherited from the parent channel, matching
+    -- Topics and offered_by are inherited from the parent podcast, matching
     -- transform_episode() in learning_resources/etl/podcast.py.
-    , channels.podcast_topics_raw                            as topics
-    , channels.podcast_offered_by                            as offered_by
+    , podcasts.topics                                        as topics
+    , podcasts.offered_by                                    as offered_by
     , 'podcast'                                              as etl_source
     , 'podcast'                                              as platform
     , 'podcast_episode'                                      as resource_type
     , 'anytime'                                              as availability
     , true                                                   as published
 from current_episodes
-inner join channels
-    on current_episodes.podcast_dlt_readable_id = channels.podcast_dlt_readable_id
-where channels.podcast_rss_url is not null
+-- The episode carries its channel's feed URL, so the parent is resolved the
+-- same way integrations__learn__podcasts derives its own readable_id, keeping
+-- the two in lockstep by construction.
+inner join podcasts
+    on regexp_replace(current_episodes.podcast_rss_url, '^.*//', '')
+    = podcasts.readable_id

--- a/src/ol_dbt/models/integrations/learn/integrations__learn__podcast_episodes.sql
+++ b/src/ol_dbt/models/integrations/learn/integrations__learn__podcast_episodes.sql
@@ -3,6 +3,13 @@
   Exposes MIT podcast episodes for MIT Learn's ETL (webhook delivery).
   Contract: docs/learn_marts_contract.md
   Joined to integrations__learn__podcasts on podcast_readable_id = readable_id.
+
+  STALENESS: same merge-load problem as integrations__learn__podcasts, and the
+  same fix. An episode dropped from a feed is left un-upserted rather than
+  deleted, so without filtering it would be redelivered forever and MIT Learn
+  could never retire it. Episodes are filtered on their OWN load recency, not
+  their channel's: a feed can drop a single old episode while the channel
+  itself keeps being refreshed every day.
 #}
 
 with episodes as (
@@ -13,25 +20,41 @@ with episodes as (
     select * from {{ ref('stg__podcast__rss__channels') }}
 )
 
+-- rank 1 = most recent load; see integrations__learn__podcasts for why a
+-- grace window is used instead of "most recent load only".
+, loads as (
+    select
+        episode_dlt_load_id
+        , row_number() over (order by episode_dlt_load_id desc) as loads_ago
+    from (select distinct episode_dlt_load_id from episodes)
+)
+
+, current_episodes as (
+    select episodes.*
+    from episodes
+    inner join loads on episodes.episode_dlt_load_id = loads.episode_dlt_load_id
+    where loads.loads_ago <= {{ var('podcast_absence_grace_loads', 3) }}
+)
+
 select
     -- The dlt source already derives the episode identifier the way MIT Learn
     -- does (<guid>, else the link/audio URL with the scheme stripped), so this
     -- one passes through unchanged -- unlike the channel identifier.
-    episodes.episode_readable_id                             as readable_id
+    current_episodes.episode_readable_id                     as readable_id
     -- Recomputed from the channel's rss_url for the same reason as in
     -- integrations__learn__podcasts: MIT Learn keeps the trailing slash.
     , regexp_replace(channels.podcast_rss_url, '^.*//', '')  as podcast_readable_id
-    , episodes.episode_title                                 as title
-    , episodes.episode_description                           as description
-    , episodes.episode_url                                   as url
-    , episodes.episode_audio_url                             as audio_url
-    , episodes.episode_link                                  as episode_link
-    , episodes.episode_image_url                             as image_url
+    , current_episodes.episode_title                         as title
+    , current_episodes.episode_description                   as description
+    , current_episodes.episode_url                           as url
+    , current_episodes.episode_audio_url                     as audio_url
+    , current_episodes.episode_link                          as episode_link
+    , current_episodes.episode_image_url                     as image_url
     -- Free-form itunes:duration text; normalized to ISO-8601 by the delivery
     -- asset, mirroring learning_resources/etl/utils.py:iso8601_duration.
-    , episodes.episode_duration_raw                          as duration_raw
+    , current_episodes.episode_duration_raw                  as duration_raw
     -- RFC 2822 <pubDate>; parsed by the delivery asset into last_modified.
-    , episodes.episode_published_on_raw                      as published_on_raw
+    , current_episodes.episode_published_on_raw              as published_on_raw
     -- Topics and offered_by are inherited from the parent channel, matching
     -- transform_episode() in learning_resources/etl/podcast.py.
     , channels.podcast_topics_raw                            as topics
@@ -41,7 +64,7 @@ select
     , 'podcast_episode'                                      as resource_type
     , 'anytime'                                              as availability
     , true                                                   as published
-from episodes
+from current_episodes
 inner join channels
-    on episodes.podcast_dlt_readable_id = channels.podcast_dlt_readable_id
+    on current_episodes.podcast_dlt_readable_id = channels.podcast_dlt_readable_id
 where channels.podcast_rss_url is not null

--- a/src/ol_dbt/models/integrations/learn/integrations__learn__podcasts.sql
+++ b/src/ol_dbt/models/integrations/learn/integrations__learn__podcasts.sql
@@ -1,0 +1,38 @@
+{#
+  integrations__learn__podcasts
+  Exposes MIT podcast channels for MIT Learn's ETL (webhook delivery).
+  Contract: docs/learn_marts_contract.md
+  Episodes live in integrations__learn__podcast_episodes, joined on readable_id.
+#}
+
+with channels as (
+    select * from {{ ref('stg__podcast__rss__channels') }}
+)
+
+select
+    -- MIT Learn derives a podcast's readable_id as rss_url.split("//")[-1]
+    -- (learning_resources/etl/podcast.py:parse_readable_id_from_url), which
+    -- keeps any trailing slash. The dlt source strips it, so recompute here
+    -- from rss_url instead of reusing the raw readable_id -- otherwise the
+    -- webhook would create a second resource alongside the Celery ETL's.
+    regexp_replace(podcast_rss_url, '^.*//', '')             as readable_id
+    , podcast_title                                          as title
+    , podcast_description                                    as description
+    , podcast_website                                        as url
+    , podcast_image_url                                      as image_url
+    , podcast_topics_raw                                     as topics
+    , podcast_offered_by                                     as offered_by
+    , podcast_rss_url                                        as rss_url
+    , podcast_apple_podcasts_url                             as apple_podcasts_url
+    , podcast_google_podcasts_url                            as google_podcasts_url
+    -- The RSS <lastBuildDate> is RFC 2822, which Trino cannot parse without a
+    -- format string that varies by feed; current_timestamp is the same
+    -- conservative fallback mitpe/oll use.
+    , {{ cast_timestamp_to_iso8601('current_timestamp') }}   as last_modified
+    , 'podcast'                                              as etl_source
+    , 'podcast'                                              as platform
+    , 'podcast'                                              as resource_type
+    , 'anytime'                                              as availability
+    , true                                                   as published
+from channels
+where podcast_rss_url is not null and podcast_title is not null

--- a/src/ol_dbt/models/integrations/learn/integrations__learn__podcasts.sql
+++ b/src/ol_dbt/models/integrations/learn/integrations__learn__podcasts.sql
@@ -3,10 +3,41 @@
   Exposes MIT podcast channels for MIT Learn's ETL (webhook delivery).
   Contract: docs/learn_marts_contract.md
   Episodes live in integrations__learn__podcast_episodes, joined on readable_id.
+
+  STALENESS: raw__podcast__rss__channels is loaded with write_disposition=
+  "merge", so a podcast removed from mitodl/open-podcast-data is never deleted
+  -- it is left un-upserted, and its _dlt_load_id stays behind at the last load
+  that saw it. A plain full-table read would therefore keep delivering removed
+  podcasts forever, and MIT Learn (which unpublishes only what is ABSENT from
+  the batch) could never retire one.
+
+  Rows are filtered to those seen in the last {{ var('podcast_absence_grace_loads', 3) }}
+  loads rather than only the most recent one. The grace period exists because
+  the dlt source SKIPS a feed it cannot fetch or parse: with a strict
+  most-recent-load filter, one transient RSS outage would drop that podcast
+  from the batch and unpublish a live podcast and all its episodes. At a daily
+  ingest cadence a podcast must be missing three consecutive days before it is
+  treated as removed.
 #}
 
 with channels as (
     select * from {{ ref('stg__podcast__rss__channels') }}
+)
+
+-- Rank the distinct load ids so recency can be expressed in "loads ago"
+-- rather than by comparing opaque load-id strings. rank 1 = most recent load.
+, loads as (
+    select
+        podcast_dlt_load_id
+        , row_number() over (order by podcast_dlt_load_id desc) as loads_ago
+    from (select distinct podcast_dlt_load_id from channels)
+)
+
+, current_channels as (
+    select channels.*
+    from channels
+    inner join loads on channels.podcast_dlt_load_id = loads.podcast_dlt_load_id
+    where loads.loads_ago <= {{ var('podcast_absence_grace_loads', 3) }}
 )
 
 select
@@ -34,5 +65,5 @@ select
     , 'podcast'                                              as resource_type
     , 'anytime'                                              as availability
     , true                                                   as published
-from channels
+from current_channels
 where podcast_rss_url is not null and podcast_title is not null

--- a/src/ol_dbt/models/staging/podcast/_podcast__sources.yml
+++ b/src/ol_dbt/models/staging/podcast/_podcast__sources.yml
@@ -1,0 +1,86 @@
+---
+version: 2
+
+sources:
+- name: ol_warehouse_raw_data
+  loader: dlt
+  database: '{{ target.database | default(none) }}'
+  schema: '{{ target.schema.replace(var("schema_suffix", ""), "").rstrip("_") }}_raw'
+  tables:
+  - name: raw__podcast__rss__channels
+    description: >
+      One row per podcast channel configured in mitodl/open-podcast-data,
+      parsed from that podcast's RSS <channel> element by the podcast_rss dlt
+      pipeline. Merged on readable_id.
+    columns:
+    - name: readable_id
+      description: >
+        str, dlt-side channel identifier (rss_url with the scheme stripped and
+        any trailing slash removed). NOTE: MIT Learn's own convention does NOT
+        strip the trailing slash, so downstream integrations models recompute
+        the identifier from rss_url rather than reusing this column.
+    - name: rss_url
+      description: str, the podcast's RSS feed URL (from the YAML config)
+    - name: website
+      description: str, the podcast's website URL (from the YAML config)
+    - name: title
+      description: >
+        str, podcast title — the YAML config's podcast_title when set,
+        otherwise the RSS <channel><title>
+    - name: description
+      description: str, RSS <channel><description>
+    - name: language
+      description: str, RSS <channel><language>
+    - name: last_build_date
+      description: str, RSS <channel><lastBuildDate>, an RFC 2822 timestamp
+    - name: image_url
+      description: >
+        str, cover art URL — itunes:image/@href when present, otherwise
+        <image><url>
+    - name: offered_by
+      description: str, offering department name from the YAML config
+    - name: topics
+      description: str, comma-separated topic labels from the YAML config
+    - name: apple_podcasts_url
+      description: str, Apple Podcasts listing URL from the YAML config
+    - name: google_podcasts_url
+      description: str, Google Podcasts listing URL from the YAML config
+    - name: etl_source
+      description: str, always 'podcast'
+
+  - name: raw__podcast__rss__episodes
+    description: >
+      One row per episode across all configured podcasts, parsed from each
+      feed's RSS <item> elements by the podcast_rss dlt pipeline. Items with no
+      <enclosure> (no audio file) are dropped at ingest. Merged on readable_id.
+    columns:
+    - name: readable_id
+      description: >
+        str, the episode <guid> when present, otherwise the episode link (or
+        audio URL) with the scheme stripped. Matches MIT Learn's convention.
+    - name: channel_readable_id
+      description: str, the dlt-side readable_id of the parent channel
+    - name: channel_rss_url
+      description: str, the parent channel's RSS feed URL
+    - name: title
+      description: str, RSS <item><title>
+    - name: description
+      description: str, RSS <item><description>
+    - name: url
+      description: str, the episode link when present, otherwise the audio URL
+    - name: audio_url
+      description: str, RSS <item><enclosure>/@url — the audio file
+    - name: episode_link
+      description: str, RSS <item><link>
+    - name: duration
+      description: >
+        str, raw itunes:duration text. Free-form — may be "HH:MM:SS", "MM:SS",
+        or a plain seconds count. Normalized to ISO-8601 downstream.
+    - name: pub_date
+      description: str, RSS <item><pubDate>, an RFC 2822 timestamp
+    - name: image_url
+      description: >
+        str, episode cover art — itunes:image/@href when present, otherwise the
+        parent channel's image URL
+    - name: etl_source
+      description: str, always 'podcast'

--- a/src/ol_dbt/models/staging/podcast/_stg_podcast__models.yml
+++ b/src/ol_dbt/models/staging/podcast/_stg_podcast__models.yml
@@ -1,0 +1,94 @@
+---
+version: 2
+
+models:
+- name: stg__podcast__rss__channels
+  description: >
+    One row per podcast channel configured in mitodl/open-podcast-data, as
+    parsed from that podcast's RSS <channel> element by the podcast_rss dlt
+    pipeline. Rows with no rss_url are dropped -- the feed URL is the podcast's
+    identity, and the ingest cannot have produced a channel without one.
+  columns:
+  - name: podcast_dlt_readable_id
+    description: >
+      str, the dlt-side channel identifier (rss_url with the scheme stripped
+      and any trailing slash removed). Used only to join episodes to channels.
+      NOT the identifier delivered to MIT Learn -- see
+      integrations__learn__podcasts, which recomputes it from rss_url because
+      MIT Learn's convention preserves the trailing slash.
+    tests: [not_null, unique]
+  - name: podcast_rss_url
+    description: str, the podcast's RSS feed URL, from its YAML config
+    tests: [not_null]
+  - name: podcast_website
+    description: str, the podcast's website URL, from its YAML config
+  - name: podcast_title
+    description: >
+      str, podcast title -- the YAML config's podcast_title when set, otherwise
+      the RSS channel title
+  - name: podcast_description
+    description: str, podcast description from the RSS channel
+  - name: podcast_language
+    description: str, RSS <channel><language>
+  - name: podcast_last_build_date_raw
+    description: >
+      str, RSS <channel><lastBuildDate> as an unparsed RFC 2822 timestamp.
+      Left raw because the format varies by feed and Trino has no RFC 2822
+      parser; no downstream model currently consumes it.
+  - name: podcast_image_url
+    description: >
+      str, cover art URL -- itunes:image/@href when present, otherwise
+      <image><url>
+  - name: podcast_offered_by
+    description: str, offering department name from the YAML config
+  - name: podcast_topics_raw
+    description: str, comma-separated topic labels from the YAML config
+  - name: podcast_apple_podcasts_url
+    description: str, Apple Podcasts listing URL from the YAML config
+  - name: podcast_google_podcasts_url
+    description: str, Google Podcasts listing URL from the YAML config
+
+- name: stg__podcast__rss__episodes
+  description: >
+    One row per episode across all configured podcasts, as parsed from each
+    feed's RSS <item> elements by the podcast_rss dlt pipeline. Items with no
+    <enclosure> are already dropped at ingest; the audio_url filter here is a
+    second guard, because MIT Learn's PodcastEpisode.audio_url is NOT NULL.
+  columns:
+  - name: episode_readable_id
+    description: >
+      str, the episode <guid> when present, otherwise the episode link (or
+      audio URL) with the scheme stripped. Matches MIT Learn's convention and
+      passes through to the integrations layer unchanged.
+    tests: [not_null, unique]
+  - name: podcast_dlt_readable_id
+    description: >
+      str, the dlt-side readable_id of the parent channel. Joins to
+      stg__podcast__rss__channels.
+    tests: [not_null]
+  - name: podcast_rss_url
+    description: str, the parent channel's RSS feed URL
+  - name: episode_title
+    description: str, RSS <item><title>
+  - name: episode_description
+    description: str, RSS <item><description>
+  - name: episode_url
+    description: str, the episode link when present, otherwise the audio URL
+  - name: episode_audio_url
+    description: str, RSS <item><enclosure>/@url -- the audio file
+    tests: [not_null]
+  - name: episode_link
+    description: str, RSS <item><link>
+  - name: episode_duration_raw
+    description: >
+      str, raw itunes:duration text. Free-form -- may be "HH:MM:SS", "MM:SS",
+      or a plain seconds count. Normalized to ISO-8601 by the delivery asset
+      rather than in SQL, to mirror mit-learn's iso8601_duration() exactly.
+  - name: episode_published_on_raw
+    description: >
+      str, RSS <item><pubDate> as an unparsed RFC 2822 timestamp. Parsed by the
+      delivery asset, for the same reason as episode_duration_raw.
+  - name: episode_image_url
+    description: >
+      str, episode cover art -- the episode's own itunes:image when present,
+      otherwise the parent channel's image URL

--- a/src/ol_dbt/models/staging/podcast/_stg_podcast__models.yml
+++ b/src/ol_dbt/models/staging/podcast/_stg_podcast__models.yml
@@ -47,6 +47,14 @@ models:
     description: str, Apple Podcasts listing URL from the YAML config
   - name: podcast_google_podcasts_url
     description: str, Google Podcasts listing URL from the YAML config
+  - name: podcast_dlt_load_id
+    description: >
+      str, the dlt load that most recently upserted this row. The raw table is
+      merge-loaded, so a podcast dropped from the config is left behind rather
+      than deleted and this value stops advancing.
+      integrations__learn__podcasts uses it to distinguish "still configured"
+      from "merge left this behind".
+    tests: [not_null]
 
 - name: stg__podcast__rss__episodes
   description: >
@@ -92,3 +100,10 @@ models:
     description: >
       str, episode cover art -- the episode's own itunes:image when present,
       otherwise the parent channel's image URL
+  - name: episode_dlt_load_id
+    description: >
+      str, the dlt load that most recently upserted this episode. Merge-loaded
+      like the channels table, so a dropped episode stops advancing rather than
+      disappearing. Used by integrations__learn__podcast_episodes to retire
+      episodes a feed no longer lists.
+    tests: [not_null]

--- a/src/ol_dbt/models/staging/podcast/stg__podcast__rss__channels.sql
+++ b/src/ol_dbt/models/staging/podcast/stg__podcast__rss__channels.sql
@@ -1,0 +1,19 @@
+with source as (
+    select * from {{ source('ol_warehouse_raw_data', 'raw__podcast__rss__channels') }}
+)
+
+select
+    readable_id                                 as podcast_dlt_readable_id
+    , rss_url                                   as podcast_rss_url
+    , website                                   as podcast_website
+    , title                                     as podcast_title
+    , description                               as podcast_description
+    , language                                  as podcast_language
+    , last_build_date                           as podcast_last_build_date_raw
+    , image_url                                 as podcast_image_url
+    , offered_by                                as podcast_offered_by
+    , topics                                    as podcast_topics_raw
+    , apple_podcasts_url                        as podcast_apple_podcasts_url
+    , google_podcasts_url                       as podcast_google_podcasts_url
+from source
+where rss_url is not null

--- a/src/ol_dbt/models/staging/podcast/stg__podcast__rss__channels.sql
+++ b/src/ol_dbt/models/staging/podcast/stg__podcast__rss__channels.sql
@@ -15,5 +15,12 @@ select
     , topics                                    as podcast_topics_raw
     , apple_podcasts_url                        as podcast_apple_podcasts_url
     , google_podcasts_url                       as podcast_google_podcasts_url
+    -- The raw table is loaded with write_disposition="merge", so a podcast
+    -- dropped from mitodl/open-podcast-data is never deleted -- it is simply
+    -- left un-upserted and its _dlt_load_id stays behind at the last load that
+    -- saw it. Carried through so the integrations layer can tell "still
+    -- configured" from "merge left this behind". See
+    -- integrations__learn__podcasts.
+    , _dlt_load_id                              as podcast_dlt_load_id
 from source
 where rss_url is not null

--- a/src/ol_dbt/models/staging/podcast/stg__podcast__rss__episodes.sql
+++ b/src/ol_dbt/models/staging/podcast/stg__podcast__rss__episodes.sql
@@ -1,0 +1,18 @@
+with source as (
+    select * from {{ source('ol_warehouse_raw_data', 'raw__podcast__rss__episodes') }}
+)
+
+select
+    readable_id                                 as episode_readable_id
+    , channel_readable_id                       as podcast_dlt_readable_id
+    , channel_rss_url                           as podcast_rss_url
+    , title                                     as episode_title
+    , description                               as episode_description
+    , url                                       as episode_url
+    , audio_url                                 as episode_audio_url
+    , episode_link                              as episode_link
+    , duration                                  as episode_duration_raw
+    , pub_date                                  as episode_published_on_raw
+    , image_url                                 as episode_image_url
+from source
+where readable_id is not null and audio_url is not null

--- a/src/ol_dbt/models/staging/podcast/stg__podcast__rss__episodes.sql
+++ b/src/ol_dbt/models/staging/podcast/stg__podcast__rss__episodes.sql
@@ -14,5 +14,9 @@ select
     , duration                                  as episode_duration_raw
     , pub_date                                  as episode_published_on_raw
     , image_url                                 as episode_image_url
+    -- Merge-loaded like the channels table: an episode dropped from a feed is
+    -- left un-upserted rather than deleted, so its _dlt_load_id marks the last
+    -- load that saw it. See integrations__learn__podcast_episodes.
+    , _dlt_load_id                              as episode_dlt_load_id
 from source
 where readable_id is not null and audio_url is not null


### PR DESCRIPTION
### What are the relevant tickets?

MIT Learn ETL → OL Data Platform migration, Cohort 3 (media & feed sources): https://github.com/mitodl/hq/issues/11511

### Description (What does it do?)

The `podcast_rss` dlt ingest has been landing `raw__podcast__rss__channels` / `raw__podcast__rss__episodes` for a while, but nothing consumed them — Cohort 3 had no delivery path at all. This adds the whole platform-side chain so podcasts can cut over as soon as MIT Learn's generic webhook endpoint (mitodl/mit-learn#3557) merges. Nothing here waits on that PR; the assets and models stand on their own.

```
raw__podcast__rss__channels ─┐
raw__podcast__rss__episodes ─┴→ stg__podcast__rss__* → integrations__learn__podcasts
                                                     → integrations__learn__podcast_episodes
                                                            → mit_learn_delivery/podcast_webhook → MIT Learn
```

- **dbt staging** — `stg__podcast__rss__channels`, `stg__podcast__rss__episodes` (+ sources and model docs).
- **dbt integrations** — `integrations__learn__podcasts`, `integrations__learn__podcast_episodes`, documented in a new `_integrations__learn__cohort3__schema.yml`.
- **Delivery asset** — `mit_learn_delivery/podcast_webhook`, on a daily 07:00 UTC schedule (after the Cohort 2 slots, which run 06:00–06:45).

### Things worth a reviewer's attention

**Podcasts are the first nested payload.** Every Cohort 2 source delivers a flat list; MIT Learn's `load_podcasts()` instead expects each channel to carry its episodes inline under an `episodes` key. The two integrations models stay flat and relational, and the delivery asset does the join and nesting — the SQL stays reviewable and the nesting stays unit-testable.

**The payload shape is exact, not approximate.** `load_podcast` / `load_podcast_episode` pop a fixed set of keys and pass whatever remains straight to `LearningResource.objects.update_or_create(defaults=...)`. An unexpected key is a hard error, not an ignored extra, so the tests assert the key set exactly against `learning_resources/etl/podcast.py`.

**The channel `readable_id` is recomputed from `rss_url` rather than reused.** The dlt source does `rss_url.split("//")[-1].rstrip("/")`; MIT Learn's `parse_readable_id_from_url` does **not** strip the trailing slash. Reusing the stored value would have upserted against a key the Celery ETL never writes — creating a second resource per podcast instead of updating the existing one. Episodes don't have this problem (the source already derives them MIT Learn's way), so those pass through unchanged.

**Two transforms stay in Python on purpose.** The free-form `itunes:duration` normalization and the RFC 2822 `<pubDate>` parse both have to match mit-learn byte for byte, and Trino expresses neither cleanly. They live in the asset next to tests that pin them, rather than in SQL.

**Full-sync guard.** `load_podcasts()` unpublishes every podcast *and every episode* absent from the delivered batch, so a short read — an empty Iceberg table, a half-written dbt run — would unpublish the live catalog rather than deliver a small update. The asset raises below `MIN_PODCASTS` instead of POSTing. The floor is deliberately loose (5, against 38 podcasts configured in `mitodl/open-podcast-data` as of 2026-08-19) because the dlt source skips any individual feed that fails to fetch or parse, so a handful of dead feeds is normal — single digits is not.

**One known rough edge, deliberately preserved.** `_iso8601_duration` reproduces mit-learn's `iso8601_duration` including its overflow: an episode of 10+ hours with non-zero minutes *and* seconds yields 11 characters (`PT10H30M15S`), one past `PodcastEpisode.duration`'s 10-char column. The Celery ETL has the identical latent failure, so this is not a new divergence — the two are kept byte-identical so parallel validation produces signal rather than noise. It is asserted in a test rather than left implicit. Worth fixing in mit-learn, but not by making the two paths differ mid-migration.

`podcast_episode.rss` (the raw `<item>` XML the Celery ETL stores) is omitted — the dlt source doesn't capture per-item XML and the field is nullable. Because the dict is passed as `defaults=`, omitting it leaves any existing value intact rather than blanking it.

### How can this be tested?

Automated (added here): `dg_projects/learning_resources/learning_resources_tests/test_podcasts.py` — 31 tests covering duration/pubDate/topic parsing, exact payload key sets for both channel and episode, episode→channel grouping, orphan episodes, image and offered_by fallbacks, and the omitted `rss` field.

```
cd dg_projects/learning_resources && uv run --with pytest-cov pytest learning_resources_tests/ -q
```

Results on this branch:
- pytest: **31 passed**
- `dbt parse -t dev`: clean; manifest lineage confirmed (`integrations__learn__podcast_episodes` → both staging models, staging → the two dlt sources)
- `ol-dbt validate --changed-only --skip dimensional_layering`: `[]`
- pre-commit (ruff, ruff-format, mypy, sqlfluff, yamllint, detect-secrets): all pass

Not yet run against real data — the models have never been built in a warehouse, so the first QA `dbt build` is the real check on the SQL. The delivery asset's schedule follows the Cohort 2 precedent of shipping without `default_status`, so it lands **stopped** (confirmed by resolving the definitions: `podcast_schedule` and all four Cohort 2 schedules report `DefaultScheduleStatus.STOPPED`); enabling it is a deliberate follow-up, gated on the same full-sync review as the Cohort 2 schedules.

### Additional Context

The `uv.lock` hunk is an unrelated but correct resync: `ol-orchestrate-lib` already declares `dagster-postgres` on main, and this project's lock had simply not been re-resolved to include it.

Delivery depends on MIT Learn's generic endpoint, mitodl/mit-learn#3557 (`POST /api/v1/webhooks/learning_resources/`), which already routes `resource_type: podcast` to `load_podcasts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VcWh3q3Bi2mxBmaiPCbBW9
