### PR TITLE
docs(cohort-4): spec the ContentFile scoped-pull trigger contract

### DIFF
--- a/docs/design/contentfile_scoped_pull_contract.md
+++ b/docs/design/contentfile_scoped_pull_contract.md
@@ -93,10 +93,13 @@ created duplicate resources instead of updating them. **Verify the derivation on
 source before enabling.**
 
 **Canvas:** the sender computes `readable_id`, not Learn. Learn's own derivation is
-`f"{course_folder}-{course_code}"` (`learning_resources/etl/canvas.py:138`); the Dagster Canvas
-sender has `course_id` and `metadata["course_code"]` available but does not currently compose
-them into this form. The new Canvas sending asset must build `readable_id` this same way before
-sending, so it matches `LearningResource.readable_id` on receipt.
+`f"{course_folder}-{course_code}"` (`learning_resources/etl/canvas.py:138`), where `course_folder`
+is just `str(course_id)` — Learn's `canvas_course_folder()` derives it from the archive's S3 key,
+but its own docstring says that value *is* the Canvas course id, it's just reached via the archive
+path today. So the formula the new sender builds is `f"{course_id}-{course_code}"`, using the
+`course_id` and `metadata["course_code"]` it already has; it does not need `course_folder` as a
+separate lookup. The new Canvas sending asset must build `readable_id` this way before sending, so
+it matches `LearningResource.readable_id` on receipt.
 
 ## 3. Receiver behaviour
 

--- a/docs/design/contentfile_scoped_pull_contract.md
+++ b/docs/design/contentfile_scoped_pull_contract.md
@@ -250,6 +250,21 @@ in `dg_projects`, and no OCW dg project** — OCW's only Learn-facing model is t
 of anything above; it cannot ride the existing mechanism.
 Tracked by `tk-ocw-text-extraction-assets-integrations-learn-oc-8ff9b4`.
 
+**What triggers it, and what happens to the existing Learn-facing webhook.** Today Concourse
+notifies Learn directly when an OCW course publishes, and Learn downloads from S3 and extracts it
+itself; after this change the platform does the extraction, so the platform — not Learn — needs to
+learn a course published. Narrowed to two candidates, not yet decided between them:
+- Concourse's publish step calls a new platform-side endpoint instead of (or alongside) Learn's.
+- A Dagster sensor watches the OCW S3 bucket directly for new/changed course exports.
+
+(Polling OCW Studio's `publish_date` column already in the warehouse was considered and set aside
+— the two options above stay closer to the current push-based, low-latency model.)
+
+Whichever is chosen, it needs to account for **unpublish**, which the existing Learn-facing webhook
+also handles and which happens immediately today. If that webhook is retired outright, the platform
+side needs an equivalent immediate signal for a course being unpublished — the §7 daily
+reconciliation sweep is not a substitute for that latency. Not designed here.
+
 ## 9. Warehouse views the tasks read
 
 | Task | View |

--- a/docs/design/contentfile_scoped_pull_contract.md
+++ b/docs/design/contentfile_scoped_pull_contract.md
@@ -23,6 +23,12 @@ All three send a **pointer**: `{course_id, course_readable_id, content_path, sou
 MIT Learn fires `ingest_edx_run_archive` (or `ingest_canvas_course` for Canvas) — i.e. the message
 means *"a new archive is at this path, go extract it yourself."* **MIT Learn does the extraction.**
 
+**Known gap in the current Canvas sender:** `course_readable_id` is only set when Canvas's
+`sis_course_id` is truthy (`dg_projects/canvas/canvas/assets/canvas.py:283-286`) — Learn rejects a
+null value, so some Canvas courses never carry this field today. The new endpoint closes this gap
+rather than inheriting it: §2 has the Canvas sender compute `readable_id` itself from
+`course_id`/`course_code`, so it no longer depends on `sis_course_id` being set.
+
 Cohort 4 inverts that: the platform runs Tika extraction and publishes
 `integrations__learn__ocw_content_files` / `integrations__learn__content_files`, and MIT Learn
 *consumes* extracted text. The message has to change meaning from "go extract" to
@@ -86,6 +92,12 @@ where a dlt-derived id differed from MIT Learn's own derivation by a trailing sl
 created duplicate resources instead of updating them. **Verify the derivation on both sides per
 source before enabling.**
 
+**Canvas:** the sender computes `readable_id`, not Learn. Learn's own derivation is
+`f"{course_folder}-{course_code}"` (`learning_resources/etl/canvas.py:138`); the Dagster Canvas
+sender has `course_id` and `metadata["course_code"]` available but does not currently compose
+them into this form. The new Canvas sending asset must build `readable_id` this same way before
+sending, so it matches `LearningResource.readable_id` on receipt.
+
 ## 3. Receiver behaviour
 
 For each entry, enqueue a **scoped** pull rather than doing work in the request:
@@ -141,14 +153,25 @@ key for the receiver to filter on (see §9).
 
 This is the podcast full-sync hazard (`MIN_PODCASTS` / `MIN_EPISODES` in
 `assets/podcasts.py`) at a different granularity, and it deserves the same guard.
-`content_file_count` in the payload is that guard: the platform states how many rows it published,
-and the task **refuses to prune** if the warehouse returns materially fewer. A course legitimately
-going to zero files is rare enough to be worth an explicit override rather than a silent mass
-unpublish.
+`content_file_count` in the payload is that guard: the platform states how many rows it published
+for this course, and the task compares that against what it actually reads back from the warehouse
+view for the same scope key. Since both numbers come from the same publish event, any gap between
+them is a read-consistency skew (StarRocks/Iceberg catalog cache not yet refreshed, a dbt rebuild
+of the view in flight, etc.), not a legitimate content change — a course that really did shrink
+would already show the smaller count in `content_file_count` itself.
 
-**Open for the implementer:** whether `content_file_count` mismatch should abort the whole pull or
-merely skip pruning while still upserting. Skipping the prune is the safer default — it degrades
-to "stale extra files" rather than "missing files."
+**Decision: any mismatch, not just a "material" one, skips the prune** (still upserts the rows it
+did read). The task never aborts the pull outright on a count mismatch. This is the strict
+direction on purpose — the alternative (tolerating a small gap) risks unpublishing files that
+still exist but weren't visible yet in the read, which is exactly the podcast-migration failure
+mode above; the cost of being strict is that pruning stalls on any catalog-timing hiccup rather
+than clean-deleting the same run, so a lingering-stale-file backlog needs some other cleanup path
+(not designed here) rather than relying on this guard to eventually catch up.
+
+**Still open:** a course legitimately going to zero files has no explicit override path — as
+written, the strict-mismatch guard above also blocks that case (0 read vs. non-zero
+`content_file_count` is the largest possible "mismatch"), so a real empty-course prune needs its
+own signal, not decided here.
 
 ## 5. Cadence — per asset, not one global answer
 
@@ -237,9 +260,13 @@ Column names must match `learn_marts_contract.md` conventions.
 
 ## Open questions
 
-1. **Abort vs skip-prune on count mismatch** (§4). Recommend skip-prune.
+1. ~~Abort vs skip-prune on count mismatch~~ — decided (§4): any mismatch skips the prune, never
+   aborts.
 2. **Batch size ceiling** for the N-element form. Unbounded lists make one failed POST lose a whole
    sweep; a cap turns it into partial progress.
 3. **Does `expected_count` belong in the task signature or re-read from the view?** In the payload
    it is a cross-check between two systems; re-read from the view it only catches read failures,
    not publish failures.
+4. **Explicit override for a legitimate zero-file course** (§4). The strict count-mismatch guard
+   has no way to distinguish "real content lost" from "this course now legitimately has zero
+   files," so a genuine empty-course prune needs its own signal — not designed here.

--- a/docs/design/contentfile_scoped_pull_contract.md
+++ b/docs/design/contentfile_scoped_pull_contract.md
@@ -115,6 +115,14 @@ An entry naming an unknown/unsupported `source` is logged and skipped, not 500'd
 source cannot reject an otherwise-valid batch. (Same resilience rule the `learning_resources`
 handler uses.)
 
+**Per-run lock.** Two scoped pulls for the same `readable_id` can be in flight at once — a course
+exported twice in quick succession, or a retried POST. Without coordination, an
+earlier-started/later-finishing pull can prune based on a result set that predates a
+later-started/earlier-finishing pull's upserts, unpublishing files the other pull just added, with
+nothing to correct it until the next export. **Decision: serialize scoped pulls per `readable_id`**
+(a lock keyed on the scope key) rather than a staleness check against a payload timestamp — a
+second pull for a run already in flight waits rather than racing it.
+
 These tasks subclass `BaseWarehouseETLTask` from
 [mit-learn#3807](https://github.com/mitodl/mit-learn/pull/3807)
 (`learning_resources/lib/warehouse.py`), which already provides the StarRocks connection,
@@ -223,6 +231,16 @@ Both paths run simultaneously; each sender moves independently.
 
 Because Canvas migrates, the `ETLSource.canvas` branch in the current handler is transitional, not
 permanent.
+
+**Self-healing after cutover.** This design is purely event-driven — nothing else re-triggers a
+pull. mit-learn's `import_all_*_files` Celery beat sweeps currently provide a backstop against a
+dropped webhook POST by periodically re-pulling everything regardless of what triggered it; once
+those retire, a dropped POST would leave that run stale indefinitely with no automatic recovery.
+**Decision: a daily reconciliation sweep on the Learn side**, not a platform-side re-announce —
+now that the "ETL" on Learn's end is just a SQL pull against the warehouse view rather than
+downloading and parsing an archive, a full sweep is cheap enough to run on a schedule without the
+O(N²) hazard §5 warns about (that hazard is specific to re-triggering the *extraction* side, not
+reading an already-materialized view).
 
 ## 8. OCW has no sender at all
 

--- a/docs/design/contentfile_scoped_pull_contract.md
+++ b/docs/design/contentfile_scoped_pull_contract.md
@@ -257,12 +257,18 @@ Tracked by `tk-ocw-text-extraction-assets-integrations-learn-oc-8ff9b4`.
 | `SyncOCWContentFilesTask` | `integrations.integrations__learn__ocw_content_files` |
 | `SyncOpenEdXContentFilesTask` | `integrations.integrations__learn__content_files` |
 
-Neither model exists yet. Both must expose at minimum the scope key (`readable_id` of the owning
-course/run), `etl_source` (needed by the §4 prune predicate to disambiguate scope keys across
-sources), plus the `ContentFile` fields MIT Learn persists — `key`, `title`, `description`,
-`url`, `file_type`, `content`, `content_title`, `content_author`, `content_language`,
-`content_type`, `image_src`, `uid` — and a `last_modified` for the incremental (`since`) path.
-Column names must match `learn_marts_contract.md` conventions.
+Neither model exists yet. Both must expose at minimum the scope key, `etl_source` (needed by the
+§4 prune predicate to disambiguate scope keys across sources), plus the `ContentFile` fields MIT
+Learn persists — `key`, `title`, `description`, `url`, `file_type`, `content`, `content_title`,
+`content_author`, `content_language`, `content_type`, `image_src`, `uid`, `edx_module_id`,
+`source_path`, `file_extension`, `checksum` — and a `last_modified` for the incremental (`since`)
+path. Column names must match `learn_marts_contract.md` conventions.
+
+**Naming: `run_readable_id`, not `readable_id`.** This view is one row per file, so its own
+identity column is `key` (the `ContentFile` key). Calling the scope-key column `readable_id` here
+would clash with §2's `readable_id`, which is the payload's course/run-level field — despite both
+naming the same underlying value, this is one row per *file* using a column that reads like the
+row's own key. Name it `run_readable_id` to keep the two unambiguous.
 
 ## 10. Checklist before enabling any source
 

--- a/docs/design/contentfile_scoped_pull_contract.md
+++ b/docs/design/contentfile_scoped_pull_contract.md
@@ -15,8 +15,8 @@ Today three Dagster locations already POST to `/api/v1/webhooks/content_files/`:
 
 | Sender | Partitioned by |
 |---|---|
-| `dg_projects/openedx/openedx/assets/openedx.py:725` | `partitions_def` (per deployment, per course) |
-| `dg_projects/edxorg/edxorg/assets/openedx_course_archives.py:340` | `course_and_source_partitions` |
+| `dg_projects/openedx/openedx/assets/openedx.py:731` | `partitions_def` (per deployment, per course) |
+| `dg_projects/edxorg/edxorg/assets/openedx_course_archives.py:332` | `course_and_source_partitions` |
 | `dg_projects/canvas/canvas/assets/canvas.py:294` | `canvas_course_ids` (`DynamicPartitionsDefinition`) |
 
 All three send a **pointer**: `{course_id, course_readable_id, content_path, source}`. On receipt
@@ -76,12 +76,15 @@ one-element list, a batched/scheduled run sends N.
 **`content_path` is deliberately absent.** It points at a raw archive MIT Learn no longer reads.
 Carrying it would invite exactly the confusion this endpoint exists to remove.
 
-`readable_id` is the course/run identifier used as the pull's scope key, and must match the
-identifier in the corresponding `integrations__learn__*content_files` row. Getting this wrong is
-the failure mode from the podcast migration (`integrations__learn__podcasts`), where a dlt-derived
-id differed from MIT Learn's own derivation by a trailing slash and would have created duplicate
-resources instead of updating them. **Verify the derivation on both sides per source before
-enabling.**
+`readable_id` is the course/run identifier used as the pull's scope key, and must match
+`ContentFile.run.run_id` on the MIT Learn side — **not** `LearningResource.readable_id`, which is
+keyed at the course level and would unpublish every other run's files. This is what the existing
+webhook already sends as `course_readable_id` (`process_create_content_file_request` passes it
+straight through as `run_id=`), so the new payload keeps the same semantics under a new field name.
+Getting this wrong is the failure mode from the podcast migration (`integrations__learn__podcasts`),
+where a dlt-derived id differed from MIT Learn's own derivation by a trailing slash and would have
+created duplicate resources instead of updating them. **Verify the derivation on both sides per
+source before enabling.**
 
 ## 3. Receiver behaviour
 
@@ -101,9 +104,17 @@ source cannot reject an otherwise-valid batch. (Same resilience rule the `learni
 handler uses.)
 
 These tasks subclass `BaseWarehouseETLTask` from
-[mit-learn#3566](https://github.com/mitodl/mit-learn/pull/3566)
-(`learning_resources/lib/warehouse.py`), which already provides the Trino connection, `iter_rows`,
-and the watermark bookkeeping.
+[mit-learn#3807](https://github.com/mitodl/mit-learn/pull/3807)
+(`learning_resources/lib/warehouse.py`), which already provides the StarRocks connection,
+`iter_rows`, and the watermark bookkeeping (mit-learn#3566, the earlier Trino-backed version, was
+closed in favor of #3807's StarRocks rewrite).
+
+**Open for the implementer:** `iter_rows` currently only filters on `last_modified` (the
+incremental path) and `BaseWarehouseETLTask.run()` discards `**kwargs`, so neither supports a scope
+predicate yet. Landing the scoped pull needs new code on the mit-learn side: a scope predicate
+parameter on `iter_rows`, `run()` forwarding `source`/`readable_id` through to it, and confirming a
+scoped run does not advance the incremental watermark. Not designed here since it's mit-learn-side
+work.
 
 ## 4. The scoping problem — the part that needs new code
 
@@ -120,8 +131,13 @@ pruning globally from a single-course pull would unpublish the entire corpus.
 
 So the prune predicate must be scoped to the same key as the fetch:
 
-> prune content files whose `run.learning_resource.readable_id == readable_id` **and** which are
-> absent from this result set — never anything outside that course.
+> prune content files whose `run.run_id == readable_id` **and**
+> `run.learning_resource.etl_source == source` **and** which are absent from this result set —
+> never anything outside that course.
+
+Both fields are needed: `run_id` alone is not unique across sources (Open edX run keys and Canvas
+course/run pairs can collide), so the warehouse view must expose `etl_source` alongside the scope
+key for the receiver to filter on (see §9).
 
 This is the podcast full-sync hazard (`MIN_PODCASTS` / `MIN_EPISODES` in
 `assets/podcasts.py`) at a different granularity, and it deserves the same guard.
@@ -137,10 +153,11 @@ to "stale extra files" rather than "missing files."
 ## 5. Cadence — per asset, not one global answer
 
 Cadence is chosen per sending asset via Dagster automation conditions / freshness policies, not a
-hardcoded cron. All four senders are already partitioned per course, so per-partition triggering
-needs no restructuring.
+hardcoded cron. The three existing senders (openedx, edxorg, canvas) are already partitioned per
+course, so per-partition triggering needs no restructuring there; OCW's new sending asset (§8) will
+need this designed from scratch.
 
-**⚠ Constraint learned the hard way.** `dg_projects/openedx/openedx/assets/openedx.py:196`
+**⚠ Constraint learned the hard way.** `dg_projects/openedx/openedx/assets/openedx.py:194`
 documents an outage caused by exactly this:
 
 > Deliberately carries no `automation_condition`. An AutomationCondition is evaluated per
@@ -159,7 +176,7 @@ high-cardinality partitioned asset — this asset graph has already been taken d
 wrong.
 
 Existing pattern to build on: `_DBT_AUTOMATION_CONDITION = upstream_or_code_changes()` in
-`dg_projects/lakehouse/lakehouse/assets/lakehouse/dbt.py:36`.
+`dg_projects/lakehouse/lakehouse/assets/lakehouse/dbt.py:39`.
 
 ## 6. Deletes
 
@@ -200,7 +217,8 @@ Tracked by `tk-ocw-text-extraction-assets-integrations-learn-oc-8ff9b4`.
 | `SyncOpenEdXContentFilesTask` | `integrations.integrations__learn__content_files` |
 
 Neither model exists yet. Both must expose at minimum the scope key (`readable_id` of the owning
-course/run) plus the `ContentFile` fields MIT Learn persists — `key`, `title`, `description`,
+course/run), `etl_source` (needed by the §4 prune predicate to disambiguate scope keys across
+sources), plus the `ContentFile` fields MIT Learn persists — `key`, `title`, `description`,
 `url`, `file_type`, `content`, `content_title`, `content_author`, `content_language`,
 `content_type`, `image_src`, `uid` — and a `last_modified` for the incremental (`since`) path.
 Column names must match `learn_marts_contract.md` conventions.

--- a/docs/design/contentfile_scoped_pull_contract.md
+++ b/docs/design/contentfile_scoped_pull_contract.md
@@ -1,0 +1,227 @@
+# Cohort 4 — ContentFile Scoped-Pull Trigger Contract
+
+Status: **spec** · Project: `wp-mit-learn-etl-migration-to-data-platform-bad80f`
+Date: 2026-08-19 · Resolves `tk-define-contentfile-dagster-mit-learn-trigger-mec-8641eb`
+Companion to [`learn_marts_contract.md`](../learn_marts_contract.md).
+
+Spans two repos: the sender is `ol-data-platform`, the receiver is
+[`mitodl/mit-learn`](https://github.com/mitodl/mit-learn).
+
+---
+
+## 0. What this replaces, and why a new endpoint
+
+Today three Dagster locations already POST to `/api/v1/webhooks/content_files/`:
+
+| Sender | Partitioned by |
+|---|---|
+| `dg_projects/openedx/openedx/assets/openedx.py:725` | `partitions_def` (per deployment, per course) |
+| `dg_projects/edxorg/edxorg/assets/openedx_course_archives.py:340` | `course_and_source_partitions` |
+| `dg_projects/canvas/canvas/assets/canvas.py:294` | `canvas_course_ids` (`DynamicPartitionsDefinition`) |
+
+All three send a **pointer**: `{course_id, course_readable_id, content_path, source}`. On receipt
+MIT Learn fires `ingest_edx_run_archive` (or `ingest_canvas_course` for Canvas) — i.e. the message
+means *"a new archive is at this path, go extract it yourself."* **MIT Learn does the extraction.**
+
+Cohort 4 inverts that: the platform runs Tika extraction and publishes
+`integrations__learn__ocw_content_files` / `integrations__learn__content_files`, and MIT Learn
+*consumes* extracted text. The message has to change meaning from "go extract" to
+"extraction is done, come get it."
+
+**This is a new endpoint, not a reinterpretation of the existing one.** All three senders share
+one path, so changing what `process_create_content_file_request` does would flip openedx, edxorg
+and Canvas simultaneously — a big-bang cutover with no per-source rollback. Keeping them
+independent under the old path means branching the handler per `ETLSource`, which is the same
+dual-meaning problem in a different place. A new path lets sources migrate one at a time, with
+the old one still serving whatever has not moved, and makes the coexistence explicit in routing.
+
+Canvas migrates too, so the old path eventually retires rather than living on (§7).
+
+---
+
+## 1. Endpoint
+
+```
+POST /api/v1/webhooks/extracted_content_files/
+```
+
+Named for what it carries. `content_files/` stays live and unchanged until §7 retires it.
+
+Auth and transport are unchanged from the existing webhooks: subclass `BaseWebhookView`, so
+`require_POST` + `require_signature` (HMAC-SHA256 over the exact request body, header
+`X-MITLearn-Signature`, shared Vault secret `secret-global/shared_hmac` → `learn` → `token`) +
+`non_atomic_requests` + `csrf_exempt` all apply. Sender side is
+`ol_orchestrate.resources.learn_api.MITLearnApiClient._post_signed_webhook`, which already signs
+exactly the bytes it posts.
+
+## 2. Payload
+
+```jsonc
+{
+  "courses": [
+    {
+      "source": "mit_edx",                                  // required, ETLSource member
+      "readable_id": "course-v1:MITx+6.00.1x+2T2024",        // required
+      "content_file_count": 412,                             // required, see §4
+      "extracted_at": "2026-08-19T04:31:07+00:00"            // optional, provenance only
+    }
+  ]
+}
+```
+
+A **list**, always — even for one course. This is what lets §5's per-asset cadence choice be made
+on the platform side without a second payload shape: a per-partition condition sends a
+one-element list, a batched/scheduled run sends N.
+
+**`content_path` is deliberately absent.** It points at a raw archive MIT Learn no longer reads.
+Carrying it would invite exactly the confusion this endpoint exists to remove.
+
+`readable_id` is the course/run identifier used as the pull's scope key, and must match the
+identifier in the corresponding `integrations__learn__*content_files` row. Getting this wrong is
+the failure mode from the podcast migration (`integrations__learn__podcasts`), where a dlt-derived
+id differed from MIT Learn's own derivation by a trailing slash and would have created duplicate
+resources instead of updating them. **Verify the derivation on both sides per source before
+enabling.**
+
+## 3. Receiver behaviour
+
+For each entry, enqueue a **scoped** pull rather than doing work in the request:
+
+```python
+SyncOpenEdXContentFilesTask.apply_async(
+    kwargs={"source": source, "readable_id": readable_id, "expected_count": content_file_count},
+)
+```
+
+with `SyncOCWContentFilesTask` for `ocw`. Respond `200` once enqueued — the webhook acknowledges
+receipt, not completion, matching the existing handlers.
+
+An entry naming an unknown/unsupported `source` is logged and skipped, not 500'd, so one bad
+source cannot reject an otherwise-valid batch. (Same resilience rule the `learning_resources`
+handler uses.)
+
+These tasks subclass `BaseWarehouseETLTask` from
+[mit-learn#3566](https://github.com/mitodl/mit-learn/pull/3566)
+(`learning_resources/lib/warehouse.py`), which already provides the Trino connection, `iter_rows`,
+and the watermark bookkeeping.
+
+## 4. The scoping problem — the part that needs new code
+
+`BaseWarehouseETLTask` has exactly two modes, and **neither is what this needs**:
+
+| mode | `since` | prunes? |
+|---|---|---|
+| `full_refresh=True` | `None` | yes — "the only mode that ever sees deletes/unpublishes upstream" |
+| `full_refresh=False` | last watermark | **no** — "a partial pull must never be treated as the complete state of the source" |
+
+A per-course trigger needs a **third mode: scoped full refresh.** Within one course it *is* the
+complete state — a file removed from that course must be unpublished — but globally it is not, and
+pruning globally from a single-course pull would unpublish the entire corpus.
+
+So the prune predicate must be scoped to the same key as the fetch:
+
+> prune content files whose `run.learning_resource.readable_id == readable_id` **and** which are
+> absent from this result set — never anything outside that course.
+
+This is the podcast full-sync hazard (`MIN_PODCASTS` / `MIN_EPISODES` in
+`assets/podcasts.py`) at a different granularity, and it deserves the same guard.
+`content_file_count` in the payload is that guard: the platform states how many rows it published,
+and the task **refuses to prune** if the warehouse returns materially fewer. A course legitimately
+going to zero files is rare enough to be worth an explicit override rather than a silent mass
+unpublish.
+
+**Open for the implementer:** whether `content_file_count` mismatch should abort the whole pull or
+merely skip pruning while still upserting. Skipping the prune is the safer default — it degrades
+to "stale extra files" rather than "missing files."
+
+## 5. Cadence — per asset, not one global answer
+
+Cadence is chosen per sending asset via Dagster automation conditions / freshness policies, not a
+hardcoded cron. All four senders are already partitioned per course, so per-partition triggering
+needs no restructuring.
+
+**⚠ Constraint learned the hard way.** `dg_projects/openedx/openedx/assets/openedx.py:196`
+documents an outage caused by exactly this:
+
+> Deliberately carries no `automation_condition`. An AutomationCondition is evaluated per
+> *partition*, so an hourly cron on a 3,500-partition asset asks for 3,500 observation runs an
+> hour — and because the observe function sweeps the whole deployment regardless of which
+> partition its run was requested for, each of those runs re-fetched every course. That is O(N²)
+> against the LMS and it saturated the run queue to the point where no export ran at all.
+
+The mitigation was `courseware_observation_sensor`: one sweep per tick, reporting versions
+directly, with no run in between.
+
+**Rule:** a per-partition `AutomationCondition` is safe only where *evaluating* it is genuinely
+per-partition and cheap. Where evaluation sweeps globally, use a single sensor that batches into
+one N-element POST instead. Prove the evaluation cost before attaching a condition to a
+high-cardinality partitioned asset — this asset graph has already been taken down by getting it
+wrong.
+
+Existing pattern to build on: `_DBT_AUTOMATION_CONDITION = upstream_or_code_changes()` in
+`dg_projects/lakehouse/lakehouse/assets/lakehouse/dbt.py:36`.
+
+## 6. Deletes
+
+`/api/v1/webhooks/content_files/delete/` (`ContentFileDeleteWebhookView` →
+`process_delete_content_file_request`) deletes a whole `LearningResource` by `course_id` prefix.
+That is course-level and orthogonal to extracted-file sync, so **it is out of scope here and stays
+where it is.** Per-file removal within a still-live course is handled by §4's scoped prune, not by
+a delete webhook.
+
+## 7. Coexistence and retirement
+
+Both paths run simultaneously; each sender moves independently.
+
+1. Land the endpoint + the two pull tasks. No sender changes. Nothing happens yet.
+2. Move senders one at a time — swap `notify_course_export` for the new client method on that
+   asset. Rollback is reverting one asset.
+3. Once all four (openedx, edxorg, canvas, **and** OCW — see §8) are on the new path, delete
+   `ContentFileWebhookView`, `process_create_content_file_request`, the `ETLSource.canvas` branch,
+   and `notify_course_export`.
+4. `content_files/delete/` survives that retirement (§6).
+
+Because Canvas migrates, the `ETLSource.canvas` branch in the current handler is transitional, not
+permanent.
+
+## 8. OCW has no sender at all
+
+The three senders are openedx, edxorg and canvas. **There is no OCW content-file sender anywhere
+in `dg_projects`, and no OCW dg project** — OCW's only Learn-facing model is the course-level
+`integrations__learn__ocw_courses` (Cohort 1). So OCW needs a *new* sending asset built regardless
+of anything above; it cannot ride the existing mechanism.
+Tracked by `tk-ocw-text-extraction-assets-integrations-learn-oc-8ff9b4`.
+
+## 9. Warehouse views the tasks read
+
+| Task | View |
+|---|---|
+| `SyncOCWContentFilesTask` | `integrations.integrations__learn__ocw_content_files` |
+| `SyncOpenEdXContentFilesTask` | `integrations.integrations__learn__content_files` |
+
+Neither model exists yet. Both must expose at minimum the scope key (`readable_id` of the owning
+course/run) plus the `ContentFile` fields MIT Learn persists — `key`, `title`, `description`,
+`url`, `file_type`, `content`, `content_title`, `content_author`, `content_language`,
+`content_type`, `image_src`, `uid` — and a `last_modified` for the incremental (`since`) path.
+Column names must match `learn_marts_contract.md` conventions.
+
+## 10. Checklist before enabling any source
+
+- [ ] `readable_id` derivation verified identical on both sides for that source (§2)
+- [ ] Scoped prune proven to touch only the named course (§4)
+- [ ] `content_file_count` guard exercised against a deliberately short read (§4)
+- [ ] Evaluation cost of the chosen automation condition measured, not assumed (§5)
+- [ ] Parallel-validation diff between the Celery-extracted and platform-extracted text reviewed —
+      Tika output will not be byte-identical to whatever the legacy path produced, so agree what
+      counts as an acceptable delta *before* cutover rather than during it
+
+---
+
+## Open questions
+
+1. **Abort vs skip-prune on count mismatch** (§4). Recommend skip-prune.
+2. **Batch size ceiling** for the N-element form. Unbounded lists make one failed POST lose a whole
+   sweep; a cap turns it into partial progress.
+3. **Does `expected_count` belong in the task signature or re-read from the view?** In the payload
+   it is a cross-check between two systems; re-read from the view it only catches read failures,
+   not publish failures.


### PR DESCRIPTION
### What are the relevant tickets?

MIT Learn ETL → OL Data Platform migration, Cohort 4: https://github.com/mitodl/hq/issues/11513

Resolves the open design question tracked as `tk-define-contentfile-dagster-mit-learn-trigger-mec-8641eb`.

### Description (What does it do?)

Adds `docs/design/contentfile_scoped_pull_contract.md`, specifying how Dagster tells MIT Learn that extracted ContentFiles are ready, now that Cohort 4 moves Tika extraction to the platform. Docs only — no code.

**The question the task asked was already answered, but not the one that mattered.** It framed the decision as "(a) webhook from platform to Learn vs (b) Learn polls Dagster asset metadata". (a) shipped some time ago and runs in production from three Dagster locations:

| Sender | Partitioned by |
|---|---|
| `dg_projects/openedx/openedx/assets/openedx.py:725` | `partitions_def` |
| `dg_projects/edxorg/edxorg/assets/openedx_course_archives.py:340` | `course_and_source_partitions` |
| `dg_projects/canvas/canvas/assets/canvas.py:294` | `canvas_course_ids` (`DynamicPartitionsDefinition`) |

All three POST `{course_id, course_readable_id, content_path, source}` to `/api/v1/webhooks/content_files/`, and MIT Learn responds by firing `ingest_edx_run_archive` — i.e. *"go extract this archive yourself."* Cohort 4 inverts that. So the real question is what the message should mean once the platform does the extracting.

### Things worth a reviewer's attention

**New endpoint, not a reinterpretation.** All three senders share one path, so changing `process_create_content_file_request` would flip openedx, edxorg and Canvas simultaneously — no per-source rollback. Keeping them independent under the old path means branching per `ETLSource`, which is the same dual-meaning problem relocated. A new path lets sources migrate one at a time with the old one still serving whatever hasn't moved. Canvas migrates too, so the old path retires rather than living on.

**The part that needs genuinely new code is scoping, and it is the risky part.** `BaseWarehouseETLTask` (from mitodl/mit-learn#3566) has two modes and neither fits:

- `full_refresh=True` → prunes; "the only mode that ever sees deletes/unpublishes upstream"
- `full_refresh=False` → never prunes; "a partial pull must never be treated as the complete state of the source"

A per-course trigger is neither. Within one course it *is* the complete state — a removed file must be unpublished — but globally it is not, and pruning globally from a single-course pull would unpublish the entire corpus. §4 specifies a third mode whose prune predicate is scoped to the same key as the fetch, plus a published-row-count guard so a short read skips pruning instead of mass-unpublishing. This is the same full-sync hazard as `MIN_PODCASTS`/`MIN_EPISODES` in #2579, one level down.

**§5 records a constraint that has already caused an outage.** `openedx.py:196` documents it: per-partition `AutomationCondition` evaluation on a 3,500-partition asset produced O(N²) load against the LMS and saturated the run queue until no export ran at all. The spec turns that into a rule — per-partition conditions only where *evaluating* them is per-partition and cheap; otherwise one sweeping sensor batching into a single N-element POST. Hence the payload is a list even for one course.

**§8 flags a gap independent of the decision:** there is no OCW content-file sender anywhere in `dg_projects` and no OCW dg project. OCW's only Learn-facing model is the course-level `integrations__learn__ocw_courses`. Whatever is chosen above, OCW needs a new sending asset built.

### How can this be tested?

Not applicable — documentation only, no code paths. `pre-commit run --files docs/design/contentfile_scoped_pull_contract.md` passes: trailing-whitespace, end-of-files, added-large-files, merge-conflicts and detect-secrets all run on it and pass.

Every code reference in the doc was read from source at `origin/main` on 2026-08-19 rather than recalled: the three sender call sites and their `partitions_def`s, `learn_api.py:55`, `webhooks/urls.py`, `webhooks/views.py:162`/`:179`, the `BaseWarehouseETLTask` docstring, and the `openedx.py:196` note quoted verbatim in §5.

### Additional Context

Decisions this encodes, made by @tmacey: Option C (new endpoint, scoped pull), Canvas migrates with the others, and cadence is set per asset via automation conditions / freshness policies rather than a fixed cron.

Three questions are deliberately left open at the end of the doc rather than settled unilaterally — abort-vs-skip-prune on count mismatch, a batch-size ceiling, and whether the expected count belongs in the task signature or is re-read from the view.

Neither warehouse view (`integrations__learn__ocw_content_files`, `integrations__learn__content_files`) exists yet; §9 states the minimum columns they must expose.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VcWh3q3Bi2mxBmaiPCbBW9
