### PR TITLE
Close the ContentFile parity gaps and route WebVTT to the transcript parser

### DIFF
--- a/dg_projects/openedx/openedx/assets/content_files.py
+++ b/dg_projects/openedx/openedx/assets/content_files.py
@@ -14,6 +14,17 @@ Data flow:
 Only documents Tika can parse are handled here. Video transcripts are a
 separate asset: they need no external service, and pairing them with Tika would
 mean a Tika outage also stopped transcript extraction.
+
+What counts as a document here is aligned to MIT Learn's VALID_TEXT_FILE_TYPES,
+but the two systems reach that set differently -- MIT Learn filters by file
+extension, this asset by MIME type -- so agreement is a property that has to be
+asserted rather than assumed. The tests parametrize over MIT Learn's list to
+enforce it.
+
+Note that Open edX course *problems* do not arrive here at all. `problem/` is a
+first-class OLX block-type directory, so problem documents are carried by the
+block path with their XML intact; a real 14.310x export has 782 of them. This
+asset covers the file-storage side of the archive, not the block side.
 """
 
 import hashlib
@@ -62,9 +73,18 @@ MIN_DOCUMENTS_FOR_RATE_CHECK = 5
 # this exclusion every one of the `.srt` would be extracted twice: once as
 # unusable timestamp-laden "text" here, and once properly by the transcript
 # asset. The transcript parser owns them.
+#
+# `.vtt` joins them for a different reason. `mimetypes` maps it to `text/vtt`,
+# which Tika would also accept and return verbatim -- which is exactly what MIT
+# Learn stores today, since its `_transform_content_by_type` has transformers
+# only for `.srt` and `.sjson`. WebVTT cue timings and speaker tags are noise to
+# every consumer of this text (search indexing, embedding, summarisation), so it
+# is routed to the transcript parser instead of being published as "document
+# text" that happens to be two-thirds timestamps.
 SRT_SUFFIX = ".srt"
 SJSON_SUFFIX = ".sjson"
-TRANSCRIPT_SUFFIXES = frozenset({SRT_SUFFIX, SJSON_SUFFIX})
+VTT_SUFFIX = ".vtt"
+TRANSCRIPT_SUFFIXES = frozenset({SRT_SUFFIX, SJSON_SUFFIX, VTT_SUFFIX})
 
 
 def is_transcript(relative_path: str) -> bool:
@@ -122,6 +142,19 @@ def open_bundle_members(
                 yield member.name, _read
 
         yield _members()
+
+
+def file_extension(relative_path: str) -> str:
+    """Return a bundle member's lowercased final suffix, or "" if it has none.
+
+    Published on every row for two reasons. It is a `ContentFile` field on MIT
+    Learn's side, carried through `documents_from_olx` metadata, so publishing it
+    saves the consumer re-deriving what this asset already knows. And MIT Learn
+    selects files by EXTENSION where this asset gates by MIME type, so a consumer
+    that needs to apply its own allowlist can do so directly rather than mapping
+    back from a MIME string.
+    """
+    return Path(relative_path).suffix.lower()
 
 
 def _content_type(relative_path: str) -> str:
@@ -265,6 +298,7 @@ def build_document_rows(
                     "course_id": course_id,
                     "source_system": source_system,
                     "file_path": relative_path,
+                    "file_extension": file_extension(relative_path),
                     "content_type": content_type,
                     "size_bytes": 0,
                     "content": None,
@@ -314,6 +348,7 @@ def build_document_rows(
                 "course_id": course_id,
                 "source_system": source_system,
                 "file_path": relative_path,
+                "file_extension": file_extension(relative_path),
                 "content_type": content_type,
                 "size_bytes": len(file_bytes),
                 "content": text or None,

--- a/dg_projects/openedx/openedx/assets/content_files.py
+++ b/dg_projects/openedx/openedx/assets/content_files.py
@@ -157,13 +157,25 @@ def file_extension(relative_path: str) -> str:
     return Path(relative_path).suffix.lower()
 
 
+# Pinned to Python's builtin table rather than the module-level lookup, which
+# reads /etc/mime.types when the host has one. That file is present on a dev
+# machine and on ubuntu-latest but absent from the python:3.14-slim runtime
+# image, so the same file resolved to different MIME types in dev and in
+# production: `.rtf` was `application/rtf` locally and `text/rtf` in the
+# cluster, and only one of those was in SUPPORTED_CONTENT_TYPES. Every RTF MIT
+# Learn extracts today would have been skipped in production with no row and no
+# error, while the parity test passed in the one environment nobody runs
+# production in.
+_MIMETYPES = mimetypes.MimeTypes(filenames=())
+
+
 def _content_type(relative_path: str) -> str:
     """Guess a document's MIME type from its path.
 
     The bundle manifest carries the same value, but it is a sibling S3 object;
     deriving it here keeps this asset dependent on the archive alone.
     """
-    mime_type, _ = mimetypes.guess_type(relative_path)
+    mime_type, _ = _MIMETYPES.guess_type(relative_path)
     return mime_type or "application/octet-stream"
 
 

--- a/dg_projects/openedx/openedx/assets/transcripts.py
+++ b/dg_projects/openedx/openedx/assets/transcripts.py
@@ -10,18 +10,26 @@ Data flow:
             -> openedx/processed_data/course_transcript_text  (JSONL in S3)
                 -> integrations__learn__content_files         (dbt)
 
-The two parsers below reproduce mit-learn's
+The SRT and SJSON parsers below reproduce mit-learn's
 ``learning_resources/etl/utils.py:text_from_srt_content`` and
 ``text_from_sjson_content`` exactly, including their quirks. Their test table is
 ported verbatim into this project's tests so the parity is enforced rather than
 asserted -- a cutover diff should show a difference in the data, never in how
 the two sides parse it.
+
+The WebVTT parser is the one deliberate exception. MIT Learn has no VTT
+transformer, so it stores whatever Tika returns for a `.vtt`: the `WEBVTT`
+header, every cue timing, and the speaker tags. That is not text anyone wants
+indexed, and no consumer reads the timings, so `.vtt` is routed here and parsed
+properly rather than published as document text. See `text_from_vtt_content` for
+the evidence behind that call.
 """
 
 import json
 import logging
 import re
 from collections.abc import Callable, Iterable
+from html import unescape
 from pathlib import Path
 from tempfile import NamedTemporaryFile
 from typing import Any
@@ -41,6 +49,8 @@ from upath import UPath
 from openedx.assets.content_files import (
     SJSON_SUFFIX,
     SRT_SUFFIX,
+    VTT_SUFFIX,
+    file_extension,
     is_transcript,
     open_bundle_members,
     output_digest,
@@ -105,6 +115,58 @@ def text_from_sjson_content(content: str) -> str | None:
     return " ".join(caption for caption in captions if isinstance(caption, str))
 
 
+_VTT_BLOCK_SEPARATOR = re.compile(r"\r?\n[ \t]*\r?\n")
+_VTT_TAG = re.compile(r"</?[^>]*>")
+
+
+def text_from_vtt_content(content: str) -> str:
+    """Extract the spoken text from WebVTT subtitle content.
+
+    Unlike the two parsers above, this one has no mit-learn counterpart to
+    reproduce. MIT Learn's ``_transform_content_by_type`` registers transformers
+    only for ``.srt`` and ``.sjson``, so a ``.vtt`` is handed to Tika and stored
+    exactly as it came out -- ``WEBVTT`` header, cue timings, speaker tags and
+    all. This is therefore a deliberate divergence, not a parity gap.
+
+    It is safe because no consumer reads the timings. Searching the mit-learn
+    codebase, the only occurrence of ``-->`` is the SRT stripping regex itself;
+    the three things that consume transcript text are OpenSearch indexing (as
+    an English-analysed text field), embedding (a plain recursive character
+    splitter, markdown-aware only), and LLM summarisation. None of them is
+    cue-aware, and MIT Learn already strips timings from SRT and SJSON, which is
+    100% of the transcripts in the archives sampled. A consumer that depended on
+    cue timings would already be broken for those.
+
+    Structure is handled by one rule: a block is a cue if and only if it
+    contains a ``-->`` line, and its text is the lines after that. The WebVTT
+    spec forbids ``-->`` in ``NOTE`` bodies, so headers, comments, ``STYLE`` and
+    ``REGION`` blocks are all excluded by the same rule rather than by matching
+    each keyword. Cue identifiers sit above the timing line and are dropped with
+    it. Inline tags (``<v Speaker>``, ``<i>``, ``<c.loud>``, and mid-cue
+    ``<00:00:01.000>`` timestamps) are stripped, then HTML entities are
+    unescaped -- in that order, so an escaped ``&lt;b&gt;`` in the caption text
+    survives as literal text rather than being re-read as a tag.
+    """
+    cues = []
+    for raw_block in _VTT_BLOCK_SEPARATOR.split(content.lstrip("﻿")):
+        block = raw_block.strip()
+        if not block:
+            continue
+        lines = block.splitlines()
+        timing_index = next(
+            (index for index, line in enumerate(lines) if "-->" in line), None
+        )
+        if timing_index is None:
+            continue
+        spoken = " ".join(
+            _VTT_TAG.sub("", line).strip() for line in lines[timing_index + 1 :]
+        )
+        spoken = unescape(spoken).strip()
+        if spoken:
+            cues.append(spoken)
+    return " ".join(cues)
+
+
 def transcript_text(relative_path: str, raw: bytes) -> str | None:
     """Parse one transcript file, dispatching on its suffix.
 
@@ -126,6 +188,8 @@ def transcript_text(relative_path: str, raw: bytes) -> str | None:
         return text_from_sjson_content(content)
     if suffix == SRT_SUFFIX:
         return text_from_srt_content(content)
+    if suffix == VTT_SUFFIX:
+        return text_from_vtt_content(content)
     return None
 
 
@@ -200,6 +264,11 @@ def build_transcript_rows(
                 "course_id": course_id,
                 "source_system": source_system,
                 "file_path": relative_path,
+                # Both row sources are unioned into one model downstream, so a
+                # field present on document rows and absent here is a schema
+                # inconsistency, not a harmless omission -- every
+                # transcript-derived row would read as a null extension.
+                "file_extension": file_extension(relative_path),
                 "content_type": (
                     "application/json"
                     if relative_path.lower().endswith(SJSON_SUFFIX)

--- a/dg_projects/openedx/openedx/assets/transcripts.py
+++ b/dg_projects/openedx/openedx/assets/transcripts.py
@@ -137,6 +137,12 @@ def text_from_vtt_content(content: str) -> str:
     100% of the transcripts in the archives sampled. A consumer that depended on
     cue timings would already be broken for those.
 
+    One consequence worth naming: this parser has no failure return. A garbage
+    ``.vtt`` yields no cues and records as ``empty``, where a malformed sjson
+    records as ``failed``. That asymmetry is deliberate -- there is no cheap
+    validity check for WebVTT, and "no ``-->`` anywhere" is indistinguishable
+    from a file that legitimately holds only headers and comments.
+
     Structure is handled by one rule: a block is a cue if and only if it
     contains a ``-->`` line, and its text is the lines after that. The WebVTT
     spec forbids ``-->`` in ``NOTE`` bodies, so headers, comments, ``STYLE`` and
@@ -193,6 +199,20 @@ def transcript_text(relative_path: str, raw: bytes) -> str | None:
     return None
 
 
+def _transcript_content_type(relative_path: str) -> str:
+    """Return the MIME type a transcript row publishes.
+
+    These rows are unioned with the document rows downstream, which derive
+    content_type from mimetypes, so the two have to agree on the spelling.
+    """
+    lowered = relative_path.lower()
+    if lowered.endswith(SJSON_SUFFIX):
+        return "application/json"
+    if lowered.endswith(VTT_SUFFIX):
+        return "text/vtt"
+    return "text/plain"
+
+
 def build_transcript_rows(
     members: Iterable[tuple[str, Callable[[], bytes]]],
     *,
@@ -232,11 +252,7 @@ def build_transcript_rows(
                     "course_id": course_id,
                     "source_system": source_system,
                     "file_path": relative_path,
-                    "content_type": (
-                        "application/json"
-                        if relative_path.lower().endswith(SJSON_SUFFIX)
-                        else "text/plain"
-                    ),
+                    "content_type": _transcript_content_type(relative_path),
                     "size_bytes": len(raw),
                     "content": None,
                     "extraction_status": "failed",
@@ -269,11 +285,10 @@ def build_transcript_rows(
                 # inconsistency, not a harmless omission -- every
                 # transcript-derived row would read as a null extension.
                 "file_extension": file_extension(relative_path),
-                "content_type": (
-                    "application/json"
-                    if relative_path.lower().endswith(SJSON_SUFFIX)
-                    else "text/plain"
-                ),
+                # Mirrors what the document asset derives from mimetypes, so
+                # the two row sources agree once they are unioned: .vtt is
+                # text/vtt in both the host and the builtin table.
+                "content_type": _transcript_content_type(relative_path),
                 "size_bytes": len(raw),
                 "content": text if has_text else None,
                 "extraction_status": status,

--- a/dg_projects/openedx/openedx_tests/test_content_files.py
+++ b/dg_projects/openedx/openedx_tests/test_content_files.py
@@ -10,21 +10,27 @@ from pathlib import Path
 
 import httpx2 as httpx
 import pytest
+from ol_orchestrate.resources.tika import SUPPORTED_CONTENT_TYPES
 from openedx.assets.content_files import (
     MIN_DOCUMENTS_FOR_RATE_CHECK,
     TikaUnavailableError,
+    _content_type,
     assert_extraction_healthy,
     build_document_rows,
+    file_extension,
     open_bundle_members,
     output_digest,
 )
 from upath import UPath
 
-SUPPORTED = {"application/pdf", "text/html", "text/plain"}
-
 
 def fake_is_supported(content_type):
-    return content_type in SUPPORTED
+    """Gate on the real supported set rather than a hand-picked subset.
+
+    A local subset would keep passing while the real one drifted, which is the
+    exact failure these tests exist to catch.
+    """
+    return content_type in SUPPORTED_CONTENT_TYPES
 
 
 def fake_extract(_file_bytes, _content_type):
@@ -464,3 +470,118 @@ def test_open_bundle_members_reads_a_real_tarball(tmp_path):
     assert len(temp_files) == 1, "the download must be registered for cleanup"
     for temp_file in temp_files:
         temp_file.unlink(missing_ok=True)
+
+
+# Verbatim from mit-learn learning_resources/constants.py. Reproduced rather
+# than imported because mit-learn is a separate deployment with no shared
+# package; these tests are what catches the two drifting apart.
+VALID_TEXT_FILE_TYPES = frozenset(
+    {
+        ".doc",
+        ".docx",
+        ".htm",
+        ".html",
+        ".json",
+        ".md",
+        ".pdf",
+        ".tex",
+        ".ppt",
+        ".pptx",
+        ".rtf",
+        ".sjson",
+        ".srt",
+        ".txt",
+        ".vtt",
+        ".xml",
+    }
+)
+
+# Subtitles belong to the sibling transcript asset, so they are expected NOT to
+# be Tika-supported here. `.vtt` is in that set deliberately: MIT Learn sends it
+# to Tika and stores the cue timings, and routing it to the parser instead is a
+# considered divergence rather than an oversight.
+_HANDLED_ELSEWHERE = {".srt", ".sjson", ".vtt"}
+
+
+@pytest.mark.parametrize(
+    "extension", sorted(VALID_TEXT_FILE_TYPES - _HANDLED_ELSEWHERE)
+)
+def test_every_extension_mit_learn_extracts_is_supported(extension):
+    """Nothing MIT Learn extracts today may be silently dropped by this asset.
+
+    The two systems filter by different mechanisms -- MIT Learn by extension,
+    this asset by MIME type -- so agreement between them is a coincidence
+    unless it is asserted. `.json` was genuinely lost before this check
+    existed: four files in a real course-v1:MITx+14.310x+3T2021 export. `.tex`
+    did not appear in the archives sampled, but maps to `application/x-tex`,
+    which was missing from the supported set for the same reason.
+    """
+    content_type = _content_type("problem_set" + extension)
+    assert content_type in SUPPORTED_CONTENT_TYPES, (
+        f"{extension} maps to {content_type}, which Tika will refuse; "
+        "MIT Learn extracts this extension, so the file would be lost"
+    )
+
+
+def test_csv_stays_out_of_the_document_set():
+    """`.csv` is excluded from VALID_TEXT_FILE_TYPES and must stay excluded.
+
+    It appears only in VALID_TUTOR_PROBLEM_FILE_TYPES, which exists because
+    Canvas needs an explicit mapping of which assets to process for tutor -- its
+    export is structurally different. Open edX problems are a first-class OLX
+    block type and are already carried as blocks, so nothing here needs `.csv`,
+    and extracting it would publish course data files as course text.
+    """
+    rows, counters = rows_for(
+        [("course/static/gradebook.csv", b"student,score\nalice,90\n")]
+    )
+
+    assert rows == []
+    assert counters["skipped"] == 1
+    assert counters["candidates"] == 0
+
+
+def test_vtt_stays_out_of_the_document_set():
+    """`.vtt` is a subtitle track; the transcript parser owns it.
+
+    MIT Learn sends it to Tika and stores the result verbatim, cue timings and
+    all, because it has no VTT transformer. Routing it to the parser is the
+    divergence this asset makes on purpose.
+    """
+    rows, counters = rows_for(
+        [
+            (
+                "course/static/lecture01.vtt",
+                b"WEBVTT\n\n00:00:01.000 --> 00:00:02.000\nhi",
+            )
+        ]
+    )
+
+    assert rows == []
+    assert counters["transcripts"] == 1
+    assert counters["candidates"] == 0
+
+
+def test_rows_carry_the_extension_consumers_filter_on():
+    """The extension is what lets one extraction serve both MIT Learn allowlists."""
+    rows, _ = rows_for(
+        [
+            ("course/static/syllabus.pdf", b"%PDF-fake"),
+            ("course/static/notes.tex", b"\\documentclass{article}"),
+            ("course/tabs/overview.html", b"<p>hi</p>"),
+        ]
+    )
+
+    by_path = {row["file_path"]: row["file_extension"] for row in rows}
+    assert by_path == {
+        "course/static/syllabus.pdf": ".pdf",
+        "course/static/notes.tex": ".tex",
+        "course/tabs/overview.html": ".html",
+    }
+    assert all(row["file_extension"] in VALID_TEXT_FILE_TYPES for row in rows)
+
+
+def test_extensionless_files_report_an_empty_extension():
+    """A bare `LICENSE` has no suffix; it must not become the whole filename."""
+    assert file_extension("course/static/LICENSE") == ""
+    assert file_extension("course/static/subs_abc.srt.sjson") == ".sjson"

--- a/dg_projects/openedx/openedx_tests/test_content_files.py
+++ b/dg_projects/openedx/openedx_tests/test_content_files.py
@@ -5,6 +5,7 @@ and the failure accounting -- without a Dagster context or a live Tika service.
 """
 
 import io
+import mimetypes
 import tarfile
 from pathlib import Path
 
@@ -502,9 +503,16 @@ VALID_TEXT_FILE_TYPES = frozenset(
 # considered divergence rather than an oversight.
 _HANDLED_ELSEWHERE = {".srt", ".sjson", ".vtt"}
 
+# `.xml` never reaches the MIME gate at all: process_course_xml_blocks collects
+# only non-XML members, so no XML file is in the bundle this asset reads. Course
+# XML travels as blocks with its raw_xml intact. Asserting a MIME type for it
+# here would be a check that cannot fail.
+_NEVER_IN_THE_BUNDLE = {".xml"}
+
 
 @pytest.mark.parametrize(
-    "extension", sorted(VALID_TEXT_FILE_TYPES - _HANDLED_ELSEWHERE)
+    "extension",
+    sorted(VALID_TEXT_FILE_TYPES - _HANDLED_ELSEWHERE - _NEVER_IN_THE_BUNDLE),
 )
 def test_every_extension_mit_learn_extracts_is_supported(extension):
     """Nothing MIT Learn extracts today may be silently dropped by this asset.
@@ -520,6 +528,22 @@ def test_every_extension_mit_learn_extracts_is_supported(extension):
     assert content_type in SUPPORTED_CONTENT_TYPES, (
         f"{extension} maps to {content_type}, which Tika will refuse; "
         "MIT Learn extracts this extension, so the file would be lost"
+    )
+
+
+def test_the_mime_lookup_does_not_depend_on_the_host():
+    """The parity check above is only worth anything if it runs prod's table.
+
+    `mimetypes.guess_type` reads /etc/mime.types when the host has one. A dev
+    machine and ubuntu-latest do; the python:3.14-slim runtime image does not.
+    `.rtf` is where that bit: the host table answers `application/rtf` and the
+    builtin answers `text/rtf`, so every RTF extracted in dev and was skipped in
+    production with no row and no error, while this test passed.
+    """
+    assert _content_type("notes.rtf") == "text/rtf"
+    assert (
+        _content_type("notes.rtf")
+        == mimetypes.MimeTypes(filenames=()).guess_type("notes.rtf")[0]
     )
 
 

--- a/dg_projects/openedx/openedx_tests/test_transcripts.py
+++ b/dg_projects/openedx/openedx_tests/test_transcripts.py
@@ -16,6 +16,7 @@ from openedx.assets.transcripts import (
     is_transcript,
     text_from_sjson_content,
     text_from_srt_content,
+    text_from_vtt_content,
     transcript_text,
 )
 
@@ -81,6 +82,8 @@ def test_srt_digit_only_caption_is_stripped():
         ("static/subs_abc123.srt.sjson", True),
         ("static/captions.srt", True),
         ("static/CAPTIONS.SRT", True),
+        ("static/captions.vtt", True),
+        ("static/CAPTIONS.VTT", True),
         ("static/syllabus.pdf", False),
         ("static/logo.png", False),
         ("html/content.html", False),
@@ -293,6 +296,24 @@ def test_whitespace_only_transcript_is_empty_with_null_content():
     assert rows[0]["content"] is None
 
 
+@pytest.mark.parametrize(
+    ("path", "expected"),
+    [
+        ("static/subs_x.srt.sjson", ".sjson"),
+        ("static/captions.srt", ".srt"),
+        ("static/captions.vtt", ".vtt"),
+    ],
+)
+def test_transcript_rows_carry_file_extension_like_document_rows(path, expected):
+    """A field on one row source and not the other is a schema inconsistency.
+
+    Both feed integrations__learn__content_files, so omitting file_extension
+    here made every transcript-derived row read as a null extension.
+    """
+    rows, _ = rows_for([(path, b'{"text": ["hi"]}')])
+    assert rows[0]["file_extension"] == expected
+
+
 def test_status_vocabulary_matches_the_document_asset():
     """Both row sources feed one model, so "parsed" vs "extracted" is a schema
     difference dressed up as a naming choice.
@@ -353,3 +374,110 @@ def test_srt_blank_lines_between_blocks_collapse_to_a_space():
     assert "First caption." in text
     assert "Second caption." in text
     assert "\n\n" not in text
+
+
+# --- WebVTT ----------------------------------------------------------------
+#
+# The one deliberate divergence from mit-learn, which has no VTT transformer
+# and stores Tika's verbatim output instead. These pin what "parsed properly"
+# means so the divergence stays intentional rather than drifting.
+
+REALISTIC_VTT = """WEBVTT Kind: captions; Language: en
+
+NOTE This transcript was auto-generated.
+
+intro-cue
+00:00:00.500 --> 00:00:03.910 line:90% align:middle
+But the problem is that as soon as you
+introduce many units,
+
+2
+00:00:03.910 --> 00:00:07.030
+you introduce many states of the world.
+
+3
+00:00:07.030 --> 00:00:11.765
+<v Instructor>Take <i>this</i> example.</v>
+"""
+
+
+def test_vtt_keeps_only_the_spoken_text():
+    text = text_from_vtt_content(REALISTIC_VTT)
+
+    assert text == (
+        "But the problem is that as soon as you introduce many units, "
+        "you introduce many states of the world. "
+        "Take this example."
+    )
+
+
+@pytest.mark.parametrize(
+    "noise",
+    ["WEBVTT", "-->", "line:90%", "align:middle", "<v ", "NOTE", "intro-cue"],
+)
+def test_vtt_structure_never_reaches_the_stored_text(noise):
+    """Every one of these survives in what MIT Learn stores for a `.vtt` today."""
+    assert noise not in text_from_vtt_content(REALISTIC_VTT)
+
+
+def test_vtt_cue_identifiers_are_dropped_not_spoken():
+    """A cue id sits above the timing line and is metadata, not caption text."""
+    vtt = "WEBVTT\n\nslide-14-intro\n00:00:01.000 --> 00:00:02.000\nHello there.\n"
+    assert text_from_vtt_content(vtt) == "Hello there."
+
+
+def test_vtt_style_and_region_blocks_are_excluded():
+    """Non-cue blocks carry no `-->`, which is the rule that excludes them."""
+    vtt = (
+        "WEBVTT\n\n"
+        "STYLE\n::cue { color: papayawhip; }\n\n"
+        "REGION\nid:fred width:40%\n\n"
+        "00:00:01.000 --> 00:00:02.000\nActual caption.\n"
+    )
+    assert text_from_vtt_content(vtt) == "Actual caption."
+
+
+def test_vtt_entities_are_unescaped_after_tags_are_stripped():
+    """Order matters: an escaped tag in the caption must survive as text."""
+    vtt = (
+        "WEBVTT\n\n"
+        "00:00:01.000 --> 00:00:02.000\n"
+        "Use &lt;b&gt; for bold &amp; &lt;i&gt; for italic.\n"
+    )
+    assert text_from_vtt_content(vtt) == "Use <b> for bold & <i> for italic."
+
+
+def test_vtt_inline_timestamps_are_stripped():
+    """Karaoke-style mid-cue timestamps are markup, not words."""
+    vtt = (
+        "WEBVTT\n\n"
+        "00:00:01.000 --> 00:00:05.000\n"
+        "<00:00:01.000>Now <00:00:02.000>hear <00:00:03.000>this.\n"
+    )
+    assert text_from_vtt_content(vtt) == "Now hear this."
+
+
+def test_vtt_with_no_cues_is_empty_not_an_error():
+    """A header-only file is an empty caption track, which is a fact."""
+    assert text_from_vtt_content("WEBVTT\n\nNOTE nothing here\n") == ""
+
+
+def test_vtt_handles_crlf_and_a_byte_order_mark():
+    """Studio exports are not guaranteed to be LF-only or BOM-free."""
+    vtt = "﻿WEBVTT\r\n\r\n00:00:01.000 --> 00:00:02.000\r\nHello there.\r\n"
+    assert text_from_vtt_content(vtt) == "Hello there."
+
+
+def test_vtt_dispatches_through_transcript_text():
+    text = transcript_text("static/captions.vtt", REALISTIC_VTT.encode())
+    assert text.startswith("But the problem is")
+
+
+def test_vtt_rows_are_built_like_any_other_transcript():
+    rows, counters = rows_for([("static/captions.vtt", REALISTIC_VTT.encode())])
+
+    assert counters["candidates"] == 1
+    assert counters["extracted"] == 1
+    assert counters["failed"] == 0
+    assert rows[0]["file_path"] == "static/captions.vtt"
+    assert "-->" not in rows[0]["content"]

--- a/dg_projects/openedx/openedx_tests/test_transcripts.py
+++ b/dg_projects/openedx/openedx_tests/test_transcripts.py
@@ -314,6 +314,25 @@ def test_transcript_rows_carry_file_extension_like_document_rows(path, expected)
     assert rows[0]["file_extension"] == expected
 
 
+@pytest.mark.parametrize(
+    ("path", "expected"),
+    [
+        ("static/subs_x.srt.sjson", "application/json"),
+        ("static/captions.srt", "text/plain"),
+        ("static/captions.vtt", "text/vtt"),
+    ],
+)
+def test_transcript_rows_use_the_same_content_type_spelling(path, expected):
+    """The union has to agree on the MIME string, not just the field name.
+
+    The document asset derives content_type from mimetypes, which answers
+    `text/vtt` for a `.vtt` in both the host and the builtin table. Publishing
+    `text/plain` for the same file put two conventions in one column.
+    """
+    rows, _ = rows_for([(path, b"WEBVTT\n\n00:00:01.000 --> 00:00:02.000\nhi")])
+    assert rows[0]["content_type"] == expected
+
+
 def test_status_vocabulary_matches_the_document_asset():
     """Both row sources feed one model, so "parsed" vs "extracted" is a schema
     difference dressed up as a naming choice.

--- a/packages/ol-orchestrate-lib/src/ol_orchestrate/resources/tika.py
+++ b/packages/ol-orchestrate-lib/src/ol_orchestrate/resources/tika.py
@@ -26,19 +26,24 @@ log = logging.getLogger(__name__)
 # MIME types Tika handles well via the /tika endpoint.
 # Anything outside this set is likely to return empty text or garbage.
 #
-# The last two were added to close a gap against MIT Learn, which filters by
+# The last four were added to close a gap against MIT Learn, which filters by
 # file EXTENSION against VALID_TEXT_FILE_TYPES rather than by MIME type. Files
 # it extracts today but whose MIME type was missing here would have been
-# silently dropped by any caller gating on this set. Both were confirmed
-# against a local Tika 3.2.2 to return usable text rather than an empty body:
+# silently dropped by any caller gating on this set:
 #
-#   application/json   .json
-#   application/x-tex  .tex  -- both spellings, because Python's mimetypes maps
-#   text/x-tex         .tex     `.tex` differently depending on the platform's
-#                               mime database: `application/x-tex` locally and
-#                               `text/x-tex` on CI. That divergence is itself
-#                               the argument for the parity test over MIT
-#                               Learn's extension list, which is what caught it.
+#   application/json   .json  -- confirmed against a local Tika 3.2.2 to return
+#   application/x-tex  .tex      usable text rather than an empty body.
+#   text/x-tex         .tex
+#   text/rtf           .rtf  -- what the builtin mimetypes table answers for
+#                               .rtf. `application/rtf` below is what a host
+#                               with an /etc/mime.types answers, and callers
+#                               that pin to the builtin table (as the Open edX
+#                               asset does) would otherwise skip every RTF in
+#                               production while extracting them in dev.
+#
+# Both `.tex` spellings stay for the same class of reason: a caller reading the
+# host mime database can produce either. That divergence is the argument for
+# the parity test over MIT Learn's extension list, which is what caught it.
 #
 # Deliberately absent:
 #   text/csv   -- excluded from VALID_TEXT_FILE_TYPES. It appears only in
@@ -61,6 +66,7 @@ SUPPORTED_CONTENT_TYPES: frozenset[str] = frozenset(
         "application/vnd.ms-excel",
         "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
         "application/rtf",
+        "text/rtf",
         "application/epub+zip",
         "application/xml",
         "text/xml",

--- a/packages/ol-orchestrate-lib/src/ol_orchestrate/resources/tika.py
+++ b/packages/ol-orchestrate-lib/src/ol_orchestrate/resources/tika.py
@@ -25,6 +25,29 @@ log = logging.getLogger(__name__)
 
 # MIME types Tika handles well via the /tika endpoint.
 # Anything outside this set is likely to return empty text or garbage.
+#
+# The last two were added to close a gap against MIT Learn, which filters by
+# file EXTENSION against VALID_TEXT_FILE_TYPES rather than by MIME type. Files
+# it extracts today but whose MIME type was missing here would have been
+# silently dropped by any caller gating on this set. Both were confirmed
+# against a local Tika 3.2.2 to return usable text rather than an empty body:
+#
+#   application/json   .json
+#   application/x-tex  .tex  -- both spellings, because Python's mimetypes maps
+#   text/x-tex         .tex     `.tex` differently depending on the platform's
+#                               mime database: `application/x-tex` locally and
+#                               `text/x-tex` on CI. That divergence is itself
+#                               the argument for the parity test over MIT
+#                               Learn's extension list, which is what caught it.
+#
+# Deliberately absent:
+#   text/csv   -- excluded from VALID_TEXT_FILE_TYPES. It appears only in
+#                 VALID_TUTOR_PROBLEM_FILE_TYPES, which is Canvas-specific:
+#                 Canvas needs an explicit folder mapping because its export is
+#                 structurally different. Open edX problems are a first-class
+#                 OLX block type and are already carried as blocks, so nothing
+#                 in the Open edX path needs `.csv`.
+#   text/vtt   -- subtitles, owned by the transcript parser rather than Tika.
 SUPPORTED_CONTENT_TYPES: frozenset[str] = frozenset(
     [
         "application/pdf",
@@ -41,6 +64,9 @@ SUPPORTED_CONTENT_TYPES: frozenset[str] = frozenset(
         "application/epub+zip",
         "application/xml",
         "text/xml",
+        "application/json",
+        "application/x-tex",
+        "text/x-tex",
     ]
 )
 


### PR DESCRIPTION
Fourth in the Cohort 4 Open edX extraction stack. Stacked on #2586.

Two fixes with the same root cause: this asset gates by **MIME type**, MIT Learn gates by **file extension**. The two agreeing was never a property, only a coincidence — and measured against real course exports, they didn't.

## 1. `.json` and `.tex` were being lost

`.json` maps to `application/json`, which was missing from Tika's supported set, so **four files in a real `MITx+14.310x+3T2021` export were extracted by MIT Learn and silently dropped here**. `.tex` maps to `application/x-tex` and would go the same way; it didn't appear in either archive sampled.

Both are now supported, and the tests parametrize over MIT Learn's `VALID_TEXT_FILE_TYPES` so the next divergence fails a test rather than losing files. `fake_is_supported` now gates on the real `SUPPORTED_CONTENT_TYPES` instead of a hand-picked subset that would have kept passing while the real set drifted.

## 2. WebVTT moves to the transcript parser

MIT Learn has no VTT transformer — `_transform_content_by_type` registers only `.srt` and `.sjson` — so a `.vtt` goes to Tika and is stored exactly as returned: `WEBVTT` header, cue timings, speaker tags and all.

Nothing reads those. The only `-->` anywhere in the mit-learn codebase is the SRT stripping regex, and the three consumers of transcript text — OpenSearch indexing (as an English-analysed text field), embedding (a plain recursive character splitter, markdown-aware only), and LLM summarisation — are none of them cue-aware. MIT Learn already strips timings from SRT and SJSON, which is **100% of the transcripts in both archives sampled**, so no consumer could have depended on cue timings.

This is a deliberate divergence rather than a parity fix, and is documented as one at both the module docstring and `text_from_vtt_content`.

The parser handles cue identifiers, `STYLE`/`REGION`/`NOTE` blocks, cue settings (`line:90% align:middle`), inline tags including mid-cue `<00:00:01.000>` timestamps, HTML entities, CRLF, and a BOM. Structure is excluded by one rule — a block is a cue iff it has a `-->` line — which works because the spec forbids `-->` in `NOTE` bodies.

## Correction from the previous revision of this PR

The first version also added `text/csv`, on the theory that Open edX needed it to serve tutor problems. **That was wrong.**

`.csv` appears only in `VALID_TUTOR_PROBLEM_FILE_TYPES`, which exists because Canvas requires an explicit mapping of which assets to process for tutor — its export is structurally different. Open edX was the *first* tutor target and needs no such mapping: `problem/` is a first-class OLX block-type directory, so problem documents are already carried by the block path with their XML intact.

Verified in both exports:

```
mitxonline MITx+14.310x+3T2021     782 problem blocks   (raw XML carries the question text)
xpro DEMO+SysEng1xDEMO             122 problem blocks
```

Extracting `.csv` here would have published course data files (gradebooks and the like) as course text for no consumer. It's now explicitly excluded, with a test pinning that.

## Coverage, measured end-to-end

The earlier revision compared only files inside the static-asset bundle, which structurally *cannot* reveal files the pipeline never collects. `documents_from_olx` walks the whole OLX tree with `os.walk`, so that was the wrong universe. Re-measured against it:

| | 14.310x | xpro SysEng1x |
|---|---|---|
| MIT Learn extracts (whole tree) | 3567 | 1530 |
| carried as blocks | 2028 | 756 |
| carried as transcripts | 1208 | 239 |
| carried as documents | 328 | 532 |
| **not carried** | **3** | **3** |

The three uncovered in each are `assets/assets.xml` (a manifest) and the two course metadata files, all handled by `process_course_xml()`. Transcripts we parse that MIT Learn skips: 0.

## Also

`file_extension` is now published on every document row. It's a `ContentFile` field on MIT Learn's side already, carried through `documents_from_olx` metadata, so publishing it saves the consumer re-deriving what this asset knows — and lets a consumer apply its own extension allowlist without mapping back from a MIME string.

## Tests

93 pass in `openedx_tests`. New coverage: the parametrized allowlist parity check, `.csv` and `.vtt` exclusion from the document set, and ten WebVTT cases pinning what "parsed properly" means so the divergence stays intentional rather than drifting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VcWh3q3Bi2mxBmaiPCbBW9
