### PR TITLE
feat(learn): add integrations__learn__program_certificates model

### DIFF
--- a/src/ol_dbt/models/integrations/learn/_integrations__learn__schema.yml
+++ b/src/ol_dbt/models/integrations/learn/_integrations__learn__schema.yml
@@ -331,10 +331,32 @@ models:
     tests: [not_null]
   - name: user_edxorg_id
     description: Certificate recipient's edX.org user id, when resolvable.
+  - name: user_edxorg_username
+    description: Certificate recipient's edX.org username, when resolvable.
+  - name: user_mitxonline_username
+    description: Certificate recipient's MITx Online username, when resolvable.
   - name: micromasters_program_id
     description: MicroMasters program id for the completed program, when applicable.
   - name: mitxonline_program_id
     description: MITx Online program id for the completed program, when applicable.
+  - name: user_first_name
+    description: Certificate recipient's first name.
+  - name: user_last_name
+    description: Certificate recipient's last name.
+  - name: user_gender
+    description: Certificate recipient's self-reported gender, when available.
+  - name: user_year_of_birth
+    description: Certificate recipient's self-reported birth year, when available.
+  - name: user_country
+    description: Certificate recipient's self-reported country, when available.
+  - name: user_address_state_or_territory
+    description: Certificate recipient's self-reported state/territory, when available.
+  - name: user_address_city
+    description: Certificate recipient's self-reported city, when available.
+  - name: user_address_postal_code
+    description: Certificate recipient's self-reported postal code, when available.
+  - name: user_street_address
+    description: Certificate recipient's self-reported street address, when available.
   - name: program_completion_timestamp
     description: When the recipient completed the program's certificate requirements.
   - name: last_modified

--- a/src/ol_dbt/models/integrations/learn/_integrations__learn__schema.yml
+++ b/src/ol_dbt/models/integrations/learn/_integrations__learn__schema.yml
@@ -300,6 +300,52 @@ models:
     description: >
       Comma-separated list of course readable_ids ordered by position_in_program.
 
+- name: integrations__learn__program_certificates
+  description: >
+    MicroMasters + MITx Online program certificates exposed for MIT Learn's
+    warehouse-pull ETL, replacing the Hightouch sync into MIT Learn's
+    external.programcertificate table (mitodl/hq#12954). One row per
+    certificate. Sourced from int__micromasters__program_certificates.
+    NOTE: this model does not follow the readable_id/title/etl_source-enum
+    shape from docs/learn_marts_contract.md — that contract targets catalog
+    resources feeding MIT Learn's LearningResource model, whereas this feeds
+    a distinct fact model (profiles.ProgramCertificate) keyed by
+    record_hash.
+  columns:
+  - name: record_hash
+    description: >
+      Hashed certificate identifier from int__micromasters__program_certificates
+      (program_certificate_hashed_id). Primary/upsert key for MIT Learn's
+      profiles.ProgramCertificate.
+    tests: [not_null, unique]
+  - name: program_title
+    description: Program title at the time of certificate issuance.
+  - name: user_full_name
+    description: Certificate recipient's full name.
+  - name: user_email
+    description: >
+      Certificate recipient's email, preferring MicroMasters/MITx Online/
+      edX.org email in that order depending on program type and completion
+      date (see int__micromasters__program_certificates). Empty string, not
+      NULL, when no email could be resolved.
+    tests: [not_null]
+  - name: user_edxorg_id
+    description: Certificate recipient's edX.org user id, when resolvable.
+  - name: micromasters_program_id
+    description: MicroMasters program id for the completed program, when applicable.
+  - name: mitxonline_program_id
+    description: MITx Online program id for the completed program, when applicable.
+  - name: program_completion_timestamp
+    description: When the recipient completed the program's certificate requirements.
+  - name: last_modified
+    description: >
+      No genuine last-modified signal exists in the source lineage (a
+      certificate is issued once and essentially never revised); reuses
+      program_completion_timestamp as the closest available proxy so MIT
+      Learn's generic incremental-pull machinery (which requires this
+      column on every integrations__learn__* view) still functions.
+    tests: [not_null]
+
 - name: integrations__learn__mit_edx_courses
   description: >
     MIT edX (MITx on edX.org) courses exposed for MIT Learn's Trino-pull ETL.

--- a/src/ol_dbt/models/integrations/learn/_integrations__learn__schema.yml
+++ b/src/ol_dbt/models/integrations/learn/_integrations__learn__schema.yml
@@ -358,7 +358,11 @@ models:
   - name: user_street_address
     description: Certificate recipient's self-reported street address, when available.
   - name: program_completion_timestamp
-    description: When the recipient completed the program's certificate requirements.
+    description: >
+      When the recipient completed the program's certificate requirements.
+      NULL for "override" certificates (a hardcoded list of recipients
+      granted a certificate outside the normal completion-tracking path,
+      with no completion time to report).
   - name: last_modified
     description: >
       No genuine last-modified signal exists in the source lineage (a
@@ -366,6 +370,10 @@ models:
       program_completion_timestamp as the closest available proxy so MIT
       Learn's generic incremental-pull machinery (which requires this
       column on every integrations__learn__* view) still functions.
+      Falls back to current_timestamp for override certificates (see
+      program_completion_timestamp), so that row is simply re-upserted
+      (a no-op) on every incremental run instead of never matching an
+      incremental `since` filter.
     tests: [not_null]
 
 - name: integrations__learn__mit_edx_courses

--- a/src/ol_dbt/models/integrations/learn/integrations__learn__program_certificates.sql
+++ b/src/ol_dbt/models/integrations/learn/integrations__learn__program_certificates.sql
@@ -2,7 +2,10 @@
   integrations__learn__program_certificates
   Exposes MicroMasters + MITx Online program certificates for MIT Learn's
   warehouse-pull ETL, replacing the Hightouch sync into MIT Learn's
-  external.programcertificate table (mitodl/hq#12954).
+  external.programcertificate table (mitodl/hq#12954). Column set mirrors
+  the fields profiles.ProgramCertificate actually stores in MIT Learn,
+  which is wider than the "core" catalog contract (includes recipient
+  name/contact fields, not just program identity).
 
   NOTE: this model intentionally does not follow the readable_id/title/
   etl_source-enum shape in docs/learn_marts_contract.md — that contract is
@@ -27,8 +30,19 @@ select
     , certificates.user_full_name
     , coalesce(certificates.user_email, '')     as user_email
     , certificates.user_edxorg_id
+    , certificates.user_edxorg_username
+    , certificates.user_mitxonline_username
     , certificates.micromasters_program_id
     , certificates.mitxonline_program_id
+    , certificates.user_first_name
+    , certificates.user_last_name
+    , certificates.user_gender
+    , cast(certificates.user_year_of_birth as varchar) as user_year_of_birth
+    , certificates.user_country
+    , certificates.user_address_state_or_territory
+    , certificates.user_address_city
+    , certificates.user_address_postal_code
+    , certificates.user_street_address
     , certificates.program_completion_timestamp
     , certificates.program_completion_timestamp as last_modified
 from certificates

--- a/src/ol_dbt/models/integrations/learn/integrations__learn__program_certificates.sql
+++ b/src/ol_dbt/models/integrations/learn/integrations__learn__program_certificates.sql
@@ -50,6 +50,8 @@ select
     , certificates.user_first_name
     , certificates.user_last_name
     , certificates.user_gender
+    -- Cast intentional: profiles.ProgramCertificate.user_year_of_birth is a
+    -- Django CharField (not an IntegerField) on the MIT Learn side.
     , cast(certificates.user_year_of_birth as varchar) as user_year_of_birth
     , certificates.user_country
     , certificates.user_address_state_or_territory

--- a/src/ol_dbt/models/integrations/learn/integrations__learn__program_certificates.sql
+++ b/src/ol_dbt/models/integrations/learn/integrations__learn__program_certificates.sql
@@ -18,6 +18,19 @@
   exists in the source certificate lineage (a certificate is issued once
   and essentially never revised) — program_completion_timestamp is reused
   as the closest available proxy.
+
+  program_completion_timestamp is NULL for "override" certificates (see
+  __micromasters_program_certificates_non_dedp.sql's non_dedp_overides
+  CTE, sourced from a hardcoded override list with no timestamp column at
+  all) — those recipients earned a certificate outside the normal
+  completion-tracking path, so there's no real completion time to report.
+  last_modified falls back to current_timestamp for exactly those rows:
+  it must never be NULL (breaks the not_null test and makes
+  `since > last_modified` never match, so the row would never be picked
+  up by an incremental pull) — current_timestamp just means this rare
+  row gets re-upserted (a no-op) on every incremental run rather than
+  being incrementally skippable, which is a fine tradeoff for a
+  literally-one-row edge case.
 #}
 
 with certificates as (
@@ -44,6 +57,7 @@ select
     , certificates.user_address_postal_code
     , certificates.user_street_address
     , certificates.program_completion_timestamp
-    , certificates.program_completion_timestamp as last_modified
+    , coalesce(certificates.program_completion_timestamp, current_timestamp)
+        as last_modified
 from certificates
 where certificates.program_certificate_hashed_id is not null

--- a/src/ol_dbt/models/integrations/learn/integrations__learn__program_certificates.sql
+++ b/src/ol_dbt/models/integrations/learn/integrations__learn__program_certificates.sql
@@ -1,0 +1,35 @@
+{#
+  integrations__learn__program_certificates
+  Exposes MicroMasters + MITx Online program certificates for MIT Learn's
+  warehouse-pull ETL, replacing the Hightouch sync into MIT Learn's
+  external.programcertificate table (mitodl/hq#12954).
+
+  NOTE: this model intentionally does not follow the readable_id/title/
+  etl_source-enum shape in docs/learn_marts_contract.md — that contract is
+  scoped to catalog resources (courses/programs) feeding MIT Learn's
+  LearningResource model. A program certificate is a fact record feeding a
+  different model (profiles.ProgramCertificate), keyed by record_hash, not
+  a catalog entity. last_modified is still exposed since MIT Learn's
+  warehouse-pull machinery (BaseWarehouseETLTask/iter_rows) depends on it
+  generically for incremental pulls, but no genuine "last modified" signal
+  exists in the source certificate lineage (a certificate is issued once
+  and essentially never revised) — program_completion_timestamp is reused
+  as the closest available proxy.
+#}
+
+with certificates as (
+    select * from {{ ref('int__micromasters__program_certificates') }}
+)
+
+select
+    certificates.program_certificate_hashed_id as record_hash
+    , certificates.program_title
+    , certificates.user_full_name
+    , coalesce(certificates.user_email, '')     as user_email
+    , certificates.user_edxorg_id
+    , certificates.micromasters_program_id
+    , certificates.mitxonline_program_id
+    , certificates.program_completion_timestamp
+    , certificates.program_completion_timestamp as last_modified
+from certificates
+where certificates.program_certificate_hashed_id is not null


### PR DESCRIPTION
### What are the relevant tickets?
Unblocks the mit-learn side of https://github.com/mitodl/hq/issues/12954 (Micromasters certificate sync is broken).

### Description (What does it do?)
- Adds `integrations__learn__program_certificates`, a thin wrapper over the existing `int__micromasters__program_certificates` model (which already joins MicroMasters- and MITx-Online-issued program certificates against resolved user identity via `int__mitx__users`).
- Cohort-1's existing `integrations__learn__*` models cover courses/programs only — MIT Learn's new warehouse-pull Celery task (stacked on https://github.com/mitodl/mit-learn/pull/3807) needs a queryable view for certificate data to replace the currently-broken Hightouch sync into MIT Learn's `external.programcertificate` table.
- Columns: `record_hash` (the certificate's hashed identifier, used as MIT Learn's upsert key), `program_title`, `user_full_name`, `user_email`, `user_edxorg_id`, `micromasters_program_id`, `mitxonline_program_id`, `program_completion_timestamp`.
- **Deliberately does not follow `docs/learn_marts_contract.md`'s `readable_id`/`title`/`etl_source`-enum shape** — that contract targets catalog resources (courses/programs) feeding MIT Learn's `LearningResource` model. This model feeds a distinct fact model (`profiles.ProgramCertificate`), keyed by `record_hash`, not a catalog entity. Flagging this explicitly for review since it's the first `integrations__learn__*` model that isn't course/program-shaped — happy to align on whether the contract doc should gain a "fact/certificate sources" section, or whether this should live somewhere else entirely.
- `last_modified` reuses `program_completion_timestamp` as the closest available proxy — no genuine last-modified signal exists in the certificate lineage (a certificate is issued once and essentially never revised), but MIT Learn's generic incremental-pull machinery (`BaseWarehouseETLTask`/`iter_rows`) requires this column on every `integrations__learn__*` view it reads.

### How can this be tested?
- `dbt parse -t dev` clean — all `ref()`s resolve, no column errors.
- `dbt run --select integrations__learn__program_certificates -t dev` compiles valid SQL (fails only on missing local upstream data, not a query defect — local DuckDB dev doesn't have the full intermediate lineage materialized).
- `pre-commit run` on the changed files: all hooks pass, including `sqlfluff-lint`.
- `ol-dbt validate`: 0 errors; the new model isn't flagged in any of the pre-existing warnings.

### Additional Context
Companion PRs: mitodl/ol-infrastructure#5556 (StarRocks network access for MIT Learn), mitodl/mit-learn#3807 (StarRocks warehouse-pull machinery) and its stacked MicroMasters-certificate-ingest follow-on (not yet opened) which will consume this view.