### PR TITLE
fix(b2b_analytics): publish the cohort behind certificates_earned

### DIFF
--- a/src/ol_dbt/models/b2b_analytics/_b2b_analytics__models.yml
+++ b/src/ol_dbt/models/b2b_analytics/_b2b_analytics__models.yml
@@ -277,7 +277,12 @@ models:
   - name: certificates_earned
     description: >
       Certificates earned, all-time -- an EVENT count (learner x course run), so
-      it is not a learner cohort and cannot floor itself.
+      it is not a learner cohort. Floor it via certified_learners.
+  - name: certified_learners
+    description: >
+      Distinct learners who earned at least one certificate -- the cohort
+      certificates_earned is attributable to, and a strict subset of
+      engaged_learners.
 
 - name: mv_b2b_mit_admin_contract_health
   description: >
@@ -495,6 +500,10 @@ models:
     description: chatbot_users as a percentage of total_enrolled_learners.
   - name: certificates_earned
     description: >
-      Certificates earned in this course run -- an EVENT count. This view emits
-      no certified-learner cohort, so ol-analytics-api floors it as a count of
-      itself, which is weaker than flooring a cohort.
+      Certificates earned in this course run -- an EVENT count. Floor it via
+      certified_learners.
+  - name: certified_learners
+    description: >
+      Distinct learners who earned at least one certificate in this course run
+      -- the cohort certificates_earned is attributable to, and a strict subset
+      of engaged_learners.

--- a/src/ol_dbt/models/b2b_analytics/mv_b2b_content_engagement_depth.sql
+++ b/src/ol_dbt/models/b2b_analytics/mv_b2b_content_engagement_depth.sql
@@ -16,8 +16,9 @@
 -- (active_count is 1 on ANY activity -- see organization_administration_report).
 -- ol-analytics-api can only apply its k-anonymity floor to a cohort this view
 -- emits, so each such sum publishes its own contributing cohort count
--- (video_watchers, problem_attempters, chatbot_users) alongside it. Do not add
--- an activity aggregate without also emitting the cohort it is attributable to.
+-- (video_watchers, problem_attempters, chatbot_users, certified_learners)
+-- alongside it. Do not add an activity aggregate without also emitting the
+-- cohort it is attributable to.
 select
     oar.organization_key,
     org.sso_organization_id,
@@ -47,7 +48,8 @@ select
     round(100.0 * count(distinct case when oar.chatbot_used_count > 0
         then oar.user_email end)
         / nullif(count(distinct oar.user_email), 0), 1)                         as chatbot_adoption_pct,
-    sum(oar.certificate_count)                                                  as certificates_earned
+    sum(oar.certificate_count)                                                  as certificates_earned,
+    count(distinct case when oar.certificate_count > 0 then oar.user_email end) as certified_learners
 from {{ source('reporting', 'organization_administration_report') }} oar
 -- Dedupe to one row per organization_key so this join can never fan out and
 -- inflate the aggregates. organization_key is unique per mitxonline org today

--- a/src/ol_dbt/models/b2b_analytics/mv_b2b_contract_content_engagement_depth.sql
+++ b/src/ol_dbt/models/b2b_analytics/mv_b2b_contract_content_engagement_depth.sql
@@ -27,8 +27,9 @@
 -- (active_count is 1 on ANY activity -- see organization_administration_report).
 -- ol-analytics-api can only apply its k-anonymity floor to a cohort this view
 -- emits, so each such sum publishes its own contributing cohort count
--- (video_watchers, problem_attempters, chatbot_users) alongside it. Do not add
--- an activity aggregate without also emitting the cohort it is attributable to.
+-- (video_watchers, problem_attempters, chatbot_users, certified_learners)
+-- alongside it. Do not add an activity aggregate without also emitting the
+-- cohort it is attributable to.
 with contract_courseruns as (
     select
         cr.courserun_readable_id,
@@ -82,7 +83,8 @@ select
     round(100.0 * count(distinct case when oar.chatbot_used_count > 0
         then oar.user_email end)
         / nullif(count(distinct oar.user_email), 0), 1)                         as chatbot_adoption_pct,
-    sum(oar.certificate_count)                                                  as certificates_earned
+    sum(oar.certificate_count)                                                  as certificates_earned,
+    count(distinct case when oar.certificate_count > 0 then oar.user_email end) as certified_learners
 from {{ source('reporting', 'organization_administration_report') }} oar
 -- Inner join for the same reason as the contract-scoped trend view: a report
 -- row whose course run resolves to no contract has no row to sit under.


### PR DESCRIPTION
### What are the relevant tickets?
N/A

### Description (What does it do?)
Adds `certified_learners` to the two content-engagement views, so `certificates_earned` can be floored through the cohort that produced it.

- #2520 gave every activity aggregate on these views its contributing distinct-learner cohort, and ol-analytics-api #33 consumed them. `certificates_earned` was left out of that pass and is the last aggregate on these views still floored as a count of itself.
- It is `sum(certificate_count)` at learner x course-run grain, so five certificates can come from one learner and clear a floor of five. The schema YAML already said so: *"not a learner cohort and cannot floor itself."*
- Both monthly views already emit `certified_learners` from the same source column. This is that line applied to `mv_b2b_content_engagement_depth` and `mv_b2b_contract_content_engagement_depth`, plus the cohort list in each header comment and the `columns:` entries in `_b2b_analytics__models.yml`.

The YAML edit is not just docs: per the `b2b_analytics` note in `dbt_project.yml`, the Dagster asset compares each MV's live columns against the manifest's `columns:` to decide whether to escalate to `--full-refresh`, which is what makes a column add actually land.

Additive — no renames, and nothing breaks before ol-analytics-api maps the new cohort: its `build_select` projects `model_cls.model_fields` rather than `SELECT *`, so a column dbt adds that the model doesn't mirror is simply not selected.

### How can this be tested?
Run from the repo root, having done `dbt deps` in `src/ol_dbt` first:

```
# b2b_analytics models are only enabled when target.type == 'starrocks',
# so parse against a starrocks target or the validator skips them entirely.
cd src/ol_dbt && dbt parse --target starrocks_qa
cd ../.. && ol-dbt validate
```

`ol-dbt validate` reports **0 errors**. The 8 warnings are untouched by this PR — 4 staging models with no YAML definition, 4 dimensional/fact models with no enforced primary key, none in `b2b_analytics`. Its `yaml_sql_sync` check is the relevant one here: it holds the YAML `columns:` to the SQL SELECT in both directions.

I confirmed that check actually covers these models rather than passing vacuously. `dbt compile --target dev_local` reports both as "does not match any enabled nodes", so a manifest parsed there would not carry them; re-parsed against `starrocks_qa`, both appear with `certified_learners`. Then, as a negative control, I deleted the new SQL column while leaving the YAML entry and re-ran: `ERROR mv_b2b_content_engagement_depth: Columns in YAML but missing from SQL`, 1 error. Restored, back to 0.

`pre-commit run` on the three changed files passes, including `sqlfluff-lint` (jinja templater, trino dialect).

Not run: the models themselves. Building them needs StarRocks credentials I don't have, so the new column has not been executed against data — the SQL is parsed and linted, not run.

### Additional Context
Deploy ordering, from the `dbt_project.yml` comment: a consumer that projects a new column must deploy **after** the MV rebuild, or its `SELECT` errors on an unknown column. So this wants to land and rebuild before ol-analytics-api starts selecting `certified_learners`.

Follow-on work, not in this PR:

- **ol-analytics-api**: map `certificates_earned` to `("certified_learners",)` in both content-engagement `cohort_policy.derived` blocks, add `certified_learners` to `secondary` and to the model fields, and drop the `ContentEngagementDepth` docstring paragraph that calls this out as unclosed.
- **mit-learn**: `ContentEngagementDepth` in `frontends/api/src/analytics/types.ts` gains the field once the API returns it. The new content-engagement panel already prints each activity total with its cohort ("103 learners, 4,820 watched"), so the certificates cell can match — mitodl/mit-learn#3806.
