### PR TITLE
fix(dagster): make a sensor-reported failure name what broke

### DIFF
--- a/dg_projects/data_platform/data_platform/definitions.py
+++ b/dg_projects/data_platform/data_platform/definitions.py
@@ -11,6 +11,7 @@ into something you can actually go and look up.
 
 import re
 from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
 from datetime import UTC, datetime
 from typing import Any
 
@@ -222,36 +223,48 @@ def code_location_of(run: DagsterRun) -> str | None:
     return run.remote_job_origin.repository_origin.code_location_origin.location_name
 
 
-def first_step_failure(context: RunFailureSensorContext) -> Any | None:
-    """Return the step failure this run's report is built from, or None.
+@dataclass(frozen=True)
+class StepFailure:
+    """What every reporting path needs to know about the failure, read once.
 
-    A run that died without any step failure event -- OOM, eviction, a run
-    monitoring timeout -- has none, and the in-process hook never ran for it
-    either.
+    ``RunFailureSensorContext.get_step_failure_events`` is a query against
+    ``instance.get_records_for_run``, not an in-memory accessor, and it caches
+    nothing. Each helper below calling it for itself cost ten event-log reads
+    per evaluation of a sensor that fires once per failed run across every code
+    location. The snapshot is built once and threaded through instead.
+
+    ``error`` is the serialized error rather than its rendered text so an
+    evaluation that never reports -- an interrupted worker, a suppressed
+    repeat -- does not pay to build a traceback string it discards.
     """
-    step_failures = context.get_step_failure_events()
-    return step_failures[0] if step_failures else None
+
+    step_key: str
+    error_type: str
+    error: Any
 
 
-def step_failure_error(context: RunFailureSensorContext) -> Any | None:
-    """Return the serialized error that step failure carried, or None."""
-    failure = first_step_failure(context)
-    if failure is None:
+def step_failure_of(step_failure_events: Sequence[Any]) -> StepFailure | None:
+    """Reduce a run's step failure events to the one its report is built from.
+
+    Pure: the caller does the single read and passes the result in. A run that
+    died without any step failure event -- OOM, eviction, a run monitoring
+    timeout -- has none, and the in-process hook never ran for it either.
+    """
+    if not step_failure_events:
         return None
-    return getattr(failure.event_specific_data, "error", None)
+    event = step_failure_events[0]
+    error = getattr(event.event_specific_data, "error", None)
+    return StepFailure(
+        step_key=event.step_key,
+        error_type=(user_code_error_type(error) if error is not None else None)
+        or "run_failure",
+        error=error,
+    )
 
 
-def step_failure_error_type(context: RunFailureSensorContext) -> str | None:
-    """Name the exception the step raised, Dagster's wrapper unwrapped.
-
-    One reader for the three callers below, so the fingerprint, the interrupt
-    filter and the reported exception type cannot disagree about what broke.
-    """
-    error = step_failure_error(context)
-    return user_code_error_type(error) if error is not None else None
-
-
-def sentry_fingerprint(context: RunFailureSensorContext) -> list[str]:
+def sentry_fingerprint(
+    context: RunFailureSensorContext, failure: StepFailure | None
+) -> list[str]:
     """Build a fingerprint matching the one the in-process hook uses.
 
     Both paths delegate to ol_orchestrate.lib.sentry.failure_fingerprint. They
@@ -264,14 +277,14 @@ def sentry_fingerprint(context: RunFailureSensorContext) -> list[str]:
     grouping instead.
     """
     location = code_location_of(context.dagster_run)
-    failure = first_step_failure(context)
     if failure is None:
         return failure_fingerprint(location, "run", "run_failure")
-    error_type = step_failure_error_type(context) or "run_failure"
-    return failure_fingerprint(location, failure.step_key, error_type)
+    return failure_fingerprint(location, failure.step_key, failure.error_type)
 
 
-def sentry_message(context: RunFailureSensorContext) -> str:
+def sentry_message(
+    context: RunFailureSensorContext, failure: StepFailure | None
+) -> str:
     """Title the issue after the defect rather than the launch path.
 
     Sentry titles a message event with its message, and this one used to be
@@ -284,23 +297,23 @@ def sentry_message(context: RunFailureSensorContext) -> str:
     Formatted like an exception issue's title so a failure reads the same
     whichever path reported it.
     """
-    failure = first_step_failure(context)
     if failure is None:
         return (
             f"Dagster run failed with no step failure: {context.dagster_run.job_name}"
         )
-    error_type = step_failure_error_type(context) or "run_failure"
-    return f"{error_type}: {failure.step_key}"
+    return f"{failure.error_type}: {failure.step_key}"
 
 
-def sentry_failure_detail(context: RunFailureSensorContext) -> str:
+def sentry_failure_detail(
+    context: RunFailureSensorContext, failure: StepFailure | None
+) -> str:
     """Return the failure text a reader needs, trimmed to what Sentry will keep.
 
     The serialized step error carries the traceback the hook path would have
     attached as real frames. A run with no step failure has only the run's own
     failure message, which is what the Slack path falls back to as well.
     """
-    error = step_failure_error(context)
+    error = failure.error if failure is not None else None
     detail = (
         error.to_string()
         if error is not None
@@ -309,7 +322,7 @@ def sentry_failure_detail(context: RunFailureSensorContext) -> str:
     return truncate_text(detail, MAX_SENTRY_ERROR_LENGTH)
 
 
-def is_an_interrupted_worker(context: RunFailureSensorContext) -> bool:
+def is_an_interrupted_worker(failure: StepFailure | None) -> bool:
     """Whether this run died because its process was taken away.
 
     The ``drop_interruptions`` before_send in ol_orchestrate.lib.sentry reads
@@ -321,10 +334,12 @@ def is_an_interrupted_worker(context: RunFailureSensorContext) -> bool:
     The serialized step error is where the type survives, so the check has to
     happen here rather than in the shared filter.
     """
-    return step_failure_error_type(context) in INTERRUPTION_ERRORS
+    return failure is not None and failure.error_type in INTERRUPTION_ERRORS
 
 
-def capture_run_failure_to_sentry(context: RunFailureSensorContext) -> str | None:
+def capture_run_failure_to_sentry(
+    context: RunFailureSensorContext, failure: StepFailure | None
+) -> str | None:
     """Report a run failure to Sentry and return the event ID.
 
     Complements the in-process hook in ol_orchestrate.lib.sentry. That hook has
@@ -336,9 +351,8 @@ def capture_run_failure_to_sentry(context: RunFailureSensorContext) -> str | Non
         return None
 
     run = context.dagster_run
-    failure = first_step_failure(context)
     step_key = failure.step_key if failure else "run"
-    error_type = step_failure_error_type(context) or "run_failure"
+    error_type = failure.error_type if failure else "run_failure"
 
     with sentry_sdk.new_scope() as scope:
         scope.set_tag("dagster_job", run.job_name)
@@ -361,7 +375,7 @@ def capture_run_failure_to_sentry(context: RunFailureSensorContext) -> str | Non
             {
                 "step_key": step_key,
                 "exception_type": error_type,
-                "error": sentry_failure_detail(context),
+                "error": sentry_failure_detail(context, failure),
             },
         )
         scope.set_context(
@@ -373,9 +387,9 @@ def capture_run_failure_to_sentry(context: RunFailureSensorContext) -> str | Non
                 "tags": dict(run.tags),
             },
         )
-        scope.fingerprint = sentry_fingerprint(context)
+        scope.fingerprint = sentry_fingerprint(context, failure)
         event_id = sentry_sdk.capture_message(
-            sentry_message(context),
+            sentry_message(context, failure),
             level="error",
         )
 
@@ -385,10 +399,16 @@ def capture_run_failure_to_sentry(context: RunFailureSensorContext) -> str | Non
 
 def error_message(
     context: RunFailureSensorContext,
+    step_failure_events: Sequence[Any],
+    *,
     sentry_event_id: str | None = None,
     suppressed_repeats: int = 0,
 ) -> list[dict[str, Any]]:
-    """Format error message for Slack notification."""
+    """Format error message for Slack notification.
+
+    Takes the step failure events rather than re-reading them: the sensor has
+    already paid for that query once by the time it gets here.
+    """
 
     def format_error(error_event):
         return (
@@ -398,7 +418,6 @@ def error_message(
             else "Unknown error"
         )
 
-    step_failure_events = context.get_step_failure_events()
     error_details = [
         {
             "type": "section",
@@ -601,7 +620,15 @@ def run_failure_notification_sensor(context: RunFailureSensorContext) -> None:
         )
         return
 
-    if is_an_interrupted_worker(context):
+    # The single event-log read for this evaluation.
+    # RunFailureSensorContext.get_step_failure_events queries
+    # instance.get_records_for_run and caches nothing, so every helper that
+    # called it for itself was another round trip on a sensor that fires once
+    # per failed run across every code location.
+    step_failure_events = context.get_step_failure_events()
+    failure = step_failure_of(step_failure_events)
+
+    if is_an_interrupted_worker(failure):
         context.log.info(
             "Skipping notification for run %s: its worker was terminated "
             "(deploy, eviction or drain) rather than failing.",
@@ -609,8 +636,8 @@ def run_failure_notification_sensor(context: RunFailureSensorContext) -> None:
         )
         return
 
-    fingerprint = sentry_fingerprint(context)
-    sentry_event_id = capture_run_failure_to_sentry(context)
+    fingerprint = sentry_fingerprint(context, failure)
+    sentry_event_id = capture_run_failure_to_sentry(context, failure)
 
     # Sentry still receives every failure -- it aggregates, and the count is the
     # signal. Slack does not aggregate, so the same failure repeating is rate
@@ -641,7 +668,12 @@ def run_failure_notification_sensor(context: RunFailureSensorContext) -> None:
     client = WebClient(token=get_slack_token())
     client.chat_postMessage(
         channel=slack_channel,
-        blocks=error_message(context, sentry_event_id, repeats),
+        blocks=error_message(
+            context,
+            step_failure_events,
+            sentry_event_id=sentry_event_id,
+            suppressed_repeats=repeats,
+        ),
         text=f"Dagster {DAGSTER_ENV} run failure: {run.job_name}",
     )
     record_announcement(context.instance, announcement_key, announced_at)

--- a/dg_projects/data_platform/data_platform/definitions.py
+++ b/dg_projects/data_platform/data_platform/definitions.py
@@ -85,6 +85,12 @@ MAX_SLACK_TEXT_LENGTH = 3000
 # Leaves room for the surrounding header and step key within Slack's limit.
 MAX_SLACK_ERROR_LENGTH = 2900
 
+# How much of the serialized step error travels on a sensor-reported Sentry
+# event. That path reports through capture_message, which carries no exception
+# and therefore no traceback, so without this the issue names the job and
+# nothing else. Bounded because Sentry drops an oversized context silently.
+MAX_SENTRY_ERROR_LENGTH = 8192
+
 
 def truncate_text(text: str, max_length: int = MAX_SLACK_TEXT_LENGTH) -> str:
     """Truncate text to maximum length with ellipsis."""
@@ -213,6 +219,35 @@ def code_location_of(run: DagsterRun) -> str | None:
     return run.remote_job_origin.repository_origin.code_location_origin.location_name
 
 
+def first_step_failure(context: RunFailureSensorContext) -> Any | None:
+    """Return the step failure this run's report is built from, or None.
+
+    A run that died without any step failure event -- OOM, eviction, a run
+    monitoring timeout -- has none, and the in-process hook never ran for it
+    either.
+    """
+    step_failures = context.get_step_failure_events()
+    return step_failures[0] if step_failures else None
+
+
+def step_failure_error(context: RunFailureSensorContext) -> Any | None:
+    """Return the serialized error that step failure carried, or None."""
+    failure = first_step_failure(context)
+    if failure is None:
+        return None
+    return getattr(failure.event_specific_data, "error", None)
+
+
+def step_failure_error_type(context: RunFailureSensorContext) -> str | None:
+    """Name the exception the step raised, Dagster's wrapper unwrapped.
+
+    One reader for the three callers below, so the fingerprint, the interrupt
+    filter and the reported exception type cannot disagree about what broke.
+    """
+    error = step_failure_error(context)
+    return user_code_error_type(error) if error is not None else None
+
+
 def sentry_fingerprint(context: RunFailureSensorContext) -> list[str]:
     """Build a fingerprint matching the one the in-process hook uses.
 
@@ -221,23 +256,54 @@ def sentry_fingerprint(context: RunFailureSensorContext) -> list[str]:
     reporting paths raise two Sentry issues for every failure instead of
     collapsing into one.
 
-    A run that died without any step failure event -- OOM, eviction, a run
-    monitoring timeout -- has no exception class and no step, and the hook
+    A run with no step failure has no exception class and no step, and the hook
     never ran for it, so there is nothing to align with. Those get their own
     grouping instead.
     """
-    run = context.dagster_run
-    location = code_location_of(run)
-    step_failures = context.get_step_failure_events()
-    if not step_failures:
+    location = code_location_of(context.dagster_run)
+    failure = first_step_failure(context)
+    if failure is None:
         return failure_fingerprint(location, "run", "run_failure")
-
-    failure = step_failures[0]
-    error = getattr(failure.event_specific_data, "error", None)
-    error_type = (
-        user_code_error_type(error) if error is not None else None
-    ) or "run_failure"
+    error_type = step_failure_error_type(context) or "run_failure"
     return failure_fingerprint(location, failure.step_key, error_type)
+
+
+def sentry_message(context: RunFailureSensorContext) -> str:
+    """Title the issue after the defect rather than the launch path.
+
+    Sentry titles a message event with its message, and this one used to be
+    ``Dagster run failure: {job_name}``. Everything the automation sensor
+    materializes runs as ``__ASSET_JOB``, so every such issue in the list read
+    identically -- DAGSTER-2J reached 27,000 events without naming what broke.
+    The exception type lived only inside the fingerprint, which the UI does not
+    render.
+
+    Formatted like an exception issue's title so a failure reads the same
+    whichever path reported it.
+    """
+    failure = first_step_failure(context)
+    if failure is None:
+        return (
+            f"Dagster run failed with no step failure: {context.dagster_run.job_name}"
+        )
+    error_type = step_failure_error_type(context) or "run_failure"
+    return f"{error_type}: {failure.step_key}"
+
+
+def sentry_failure_detail(context: RunFailureSensorContext) -> str:
+    """Return the failure text a reader needs, trimmed to what Sentry will keep.
+
+    The serialized step error carries the traceback the hook path would have
+    attached as real frames. A run with no step failure has only the run's own
+    failure message, which is what the Slack path falls back to as well.
+    """
+    error = step_failure_error(context)
+    detail = (
+        error.to_string()
+        if error is not None
+        else (context.failure_event.message or "No detail available")
+    )
+    return truncate_text(detail, MAX_SENTRY_ERROR_LENGTH)
 
 
 def is_an_interrupted_worker(context: RunFailureSensorContext) -> bool:
@@ -252,13 +318,7 @@ def is_an_interrupted_worker(context: RunFailureSensorContext) -> bool:
     The serialized step error is where the type survives, so the check has to
     happen here rather than in the shared filter.
     """
-    step_failures = context.get_step_failure_events()
-    if not step_failures:
-        return False
-    error = getattr(step_failures[0].event_specific_data, "error", None)
-    if error is None:
-        return False
-    return user_code_error_type(error) in INTERRUPTION_ERRORS
+    return step_failure_error_type(context) in INTERRUPTION_ERRORS
 
 
 def capture_run_failure_to_sentry(context: RunFailureSensorContext) -> str | None:
@@ -273,8 +333,9 @@ def capture_run_failure_to_sentry(context: RunFailureSensorContext) -> str | Non
         return None
 
     run = context.dagster_run
-    step_failures = context.get_step_failure_events()
-    step_key = step_failures[0].step_key if step_failures else "run"
+    failure = first_step_failure(context)
+    step_key = failure.step_key if failure else "run"
+    error_type = step_failure_error_type(context) or "run_failure"
 
     with sentry_sdk.new_scope() as scope:
         scope.set_tag("dagster_job", run.job_name)
@@ -286,6 +347,20 @@ def capture_run_failure_to_sentry(context: RunFailureSensorContext) -> str | Non
         # you need to go and look at the failure.
         scope.set_tag("dagster_partition", run.tags.get(PARTITION_NAME_TAG, "none"))
         scope.set_tag("captured_by", "sensor")
+        # The hook path puts the exception type in the event itself. This one
+        # reports through capture_message, which has no exception, so the type
+        # has to be carried explicitly or it exists only inside the fingerprint
+        # -- where nothing in the Sentry UI will show it, and no search can
+        # filter on it.
+        scope.set_tag("dagster_exception_type", error_type)
+        scope.set_context(
+            "dagster_step_failure",
+            {
+                "step_key": step_key,
+                "exception_type": error_type,
+                "error": sentry_failure_detail(context),
+            },
+        )
         scope.set_context(
             "dagster_run",
             {
@@ -297,7 +372,7 @@ def capture_run_failure_to_sentry(context: RunFailureSensorContext) -> str | Non
         )
         scope.fingerprint = sentry_fingerprint(context)
         event_id = sentry_sdk.capture_message(
-            f"Dagster run failure: {run.job_name}",
+            sentry_message(context),
             level="error",
         )
 

--- a/dg_projects/data_platform/data_platform/definitions.py
+++ b/dg_projects/data_platform/data_platform/definitions.py
@@ -88,7 +88,10 @@ MAX_SLACK_ERROR_LENGTH = 2900
 # How much of the serialized step error travels on a sensor-reported Sentry
 # event. That path reports through capture_message, which carries no exception
 # and therefore no traceback, so without this the issue names the job and
-# nothing else. Bounded because Sentry drops an oversized context silently.
+# nothing else. Bounded because the SDK trims only transaction span
+# descriptions against MAX_EVENT_BYTES (10**6, sentry_sdk/serializer.py) and
+# never an error event's contexts, while an event over that size is discarded
+# whole at ingest. An unbounded traceback would cost the event, not the field.
 MAX_SENTRY_ERROR_LENGTH = 8192
 
 

--- a/dg_projects/data_platform/data_platform_tests/test_definitions.py
+++ b/dg_projects/data_platform/data_platform_tests/test_definitions.py
@@ -29,6 +29,7 @@ from data_platform.definitions import (
     repeats_to_announce,
     sentry_fingerprint,
     sentry_message,
+    step_failure_of,
     truncate_text,
 )
 from ol_orchestrate.lib.constants import DAGSTER_ENV
@@ -126,6 +127,16 @@ def _step_failure(
     )
 
 
+def _failure_of(context: Any) -> Any:
+    """Build the snapshot the sensor threads through its reporting helpers.
+
+    The production sensor reads the step failure events once per evaluation and
+    passes the reduction around; these tests do the same rather than letting
+    each helper read for itself, which is the behaviour under test.
+    """
+    return step_failure_of(context.get_step_failure_events())
+
+
 def _block_text(blocks: list[dict[str, Any]]) -> str:
     return "\n".join(
         block.get("text", {}).get("text", "")
@@ -169,7 +180,7 @@ def test_error_message_falls_back_when_no_step_failures() -> None:
     """OOM kills and run-monitoring reaps produce no step failure events."""
     context = _context([], failure_message="Run worker terminated unexpectedly")
 
-    blocks = error_message(context)
+    blocks = error_message(context, context.get_step_failure_events())
 
     text = _block_text(blocks)
     assert "No step failure recorded" in text
@@ -179,7 +190,7 @@ def test_error_message_falls_back_when_no_step_failures() -> None:
 def test_error_message_includes_step_detail_when_present() -> None:
     context = _context([_step_failure("some_model", "boom")])
 
-    text = _block_text(error_message(context))
+    text = _block_text(error_message(context, context.get_step_failure_events()))
 
     assert "some_model" in text
     assert "boom" in text
@@ -188,7 +199,9 @@ def test_error_message_includes_step_detail_when_present() -> None:
 def test_error_message_includes_sentry_event_id_when_given() -> None:
     context = _context([_step_failure("some_model", "boom")])
 
-    blocks = error_message(context, sentry_event_id="cafebabe")
+    blocks = error_message(
+        context, context.get_step_failure_events(), sentry_event_id="cafebabe"
+    )
 
     context_blocks = [b for b in blocks if b["type"] == "context"]
     assert "cafebabe" in context_blocks[0]["elements"][0]["text"]
@@ -197,13 +210,15 @@ def test_error_message_includes_sentry_event_id_when_given() -> None:
 def test_error_message_omits_sentry_block_when_sentry_disabled() -> None:
     context = _context([_step_failure("some_model", "boom")])
 
-    blocks = error_message(context, sentry_event_id=None)
+    blocks = error_message(
+        context, context.get_step_failure_events(), sentry_event_id=None
+    )
 
     assert not [b for b in blocks if b["type"] == "context"]
 
 
 def test_error_message_always_links_back_to_the_run() -> None:
-    blocks = error_message(_context([]))
+    blocks = error_message(_context([]), [])
 
     actions = [b for b in blocks if b["type"] == "actions"]
     assert actions, "message carries no link back to Dagster"
@@ -221,7 +236,7 @@ def test_sensor_fingerprint_matches_the_in_process_hook() -> None:
     """
     context = _context([_step_failure("some_model", "boom", cls_name="ValueError")])
 
-    assert sentry_fingerprint(context) == [
+    assert sentry_fingerprint(context, _failure_of(context)) == [
         DAGSTER_ENV,
         CODE_LOCATION,
         "some_model",
@@ -239,14 +254,16 @@ def test_sensor_fingerprint_does_not_group_on_the_launch_path() -> None:
     """
     context = _context([_step_failure("ovs_videos", "boom")])
 
-    assert context.dagster_run.job_name not in sentry_fingerprint(context)
+    assert context.dagster_run.job_name not in sentry_fingerprint(
+        context, _failure_of(context)
+    )
 
 
 def test_sensor_fingerprint_names_the_location_that_broke() -> None:
     """The location tag was hardcoded to this sensor's own code location."""
     context = _context([_step_failure("some_model", "boom")], location="lakehouse")
 
-    assert sentry_fingerprint(context)[1] == "lakehouse"
+    assert sentry_fingerprint(context, _failure_of(context))[1] == "lakehouse"
 
 
 def test_the_sensor_tags_the_partition_like_the_hook_does(
@@ -263,7 +280,7 @@ def test_the_sensor_tags_the_partition_like_the_hook_does(
     context = _context([_step_failure("some_model", "boom")])
     context.dagster_run.tags[PARTITION_NAME_TAG] = "course-v1:MITx+6.002x+2T2024"
 
-    capture_run_failure_to_sentry(context)
+    capture_run_failure_to_sentry(context, _failure_of(context))
 
     (event,) = recorded_events.events()
     assert event["tags"]["dagster_partition"] == "course-v1:MITx+6.002x+2T2024"
@@ -273,7 +290,8 @@ def test_an_unpartitioned_run_is_tagged_none(
     recorded_events: RecordingTransport,
 ) -> None:
     """Matches the hook's fallback, so the two are one Sentry search."""
-    capture_run_failure_to_sentry(_context([_step_failure("some_model", "boom")]))
+    context = _context([_step_failure("some_model", "boom")])
+    capture_run_failure_to_sentry(context, _failure_of(context))
 
     (event,) = recorded_events.events()
     assert event["tags"]["dagster_partition"] == "none"
@@ -283,14 +301,14 @@ def test_sensor_fingerprint_tolerates_a_run_with_no_origin() -> None:
     """A run submitted without a remote origin still has to group somewhere."""
     context = _context([_step_failure("some_model", "boom")], location=None)
 
-    assert sentry_fingerprint(context)[1] == "unknown"
+    assert sentry_fingerprint(context, _failure_of(context))[1] == "unknown"
 
 
 def test_sensor_fingerprint_groups_process_deaths_separately() -> None:
     """No step failure means the hook never ran, so there is nothing to match."""
     context = _context([])
 
-    assert sentry_fingerprint(context) == [
+    assert sentry_fingerprint(context, _failure_of(context)) == [
         DAGSTER_ENV,
         CODE_LOCATION,
         "run",
@@ -304,7 +322,7 @@ def test_sensor_fingerprint_survives_a_missing_error_payload() -> None:
     )
     context = _context([failure])
 
-    assert sentry_fingerprint(context) == [
+    assert sentry_fingerprint(context, _failure_of(context)) == [
         DAGSTER_ENV,
         CODE_LOCATION,
         "some_model",
@@ -333,7 +351,7 @@ def test_sensor_fingerprint_unwraps_dagsters_user_code_wrapper() -> None:
         ]
     )
 
-    assert sentry_fingerprint(context) == [
+    assert sentry_fingerprint(context, _failure_of(context)) == [
         DAGSTER_ENV,
         CODE_LOCATION,
         "extract_edxorg_courserun_metadata",
@@ -362,7 +380,7 @@ def test_sensor_fingerprint_unwraps_only_the_dagster_layer() -> None:
         ]
     )
 
-    assert sentry_fingerprint(context)[3] == "FileNotFoundError"
+    assert sentry_fingerprint(context, _failure_of(context))[3] == "FileNotFoundError"
 
 
 def test_sensor_fingerprint_keeps_a_wrapper_with_no_cause() -> None:
@@ -375,7 +393,10 @@ def test_sensor_fingerprint_keeps_a_wrapper_with_no_cause() -> None:
         ]
     )
 
-    assert sentry_fingerprint(context)[3] == "DagsterExecutionStepExecutionError"
+    assert (
+        sentry_fingerprint(context, _failure_of(context))[3]
+        == "DagsterExecutionStepExecutionError"
+    )
 
 
 @pytest.mark.parametrize(
@@ -428,7 +449,9 @@ def test_sensor_fingerprint_matches_a_real_dagster_step_failure(
         for event in result.all_events
         if event.event_type == DagsterEventType.STEP_FAILURE
     ]
-    fingerprint = sentry_fingerprint(_context(step_failures))
+    fingerprint = sentry_fingerprint(
+        _context(step_failures), step_failure_of(step_failures)
+    )
 
     assert fingerprint[3] == hook_recorded["raises_file_not_found"]
     assert fingerprint == [
@@ -437,6 +460,48 @@ def test_sensor_fingerprint_matches_a_real_dagster_step_failure(
         "raises_file_not_found",
         "FileNotFoundError",
     ]
+
+
+# ── Event-log reads ───────────────────────────────────────────────────────────
+
+
+def _counting_context(step_failure_events: list[Any]) -> tuple[Any, list[int]]:
+    """Build a context that counts how often its step failure events are read."""
+    reads = [0]
+
+    def get_step_failure_events() -> list[Any]:
+        reads[0] += 1
+        return step_failure_events
+
+    context = _context(step_failure_events)
+    context.get_step_failure_events = get_step_failure_events
+    return context, reads
+
+
+@pytest.mark.usefixtures("recorded_events")
+def test_one_evaluation_costs_one_event_log_read() -> None:
+    """RunFailureSensorContext.get_step_failure_events is a database query.
+
+    Dagster implements it as instance.get_records_for_run(of_type=STEP_FAILURE)
+    and caches nothing, so a helper that reads it for itself is another round
+    trip. This sensor fires once per failed run across every code location, and
+    an earlier revision of this module reached ten reads per evaluation by
+    letting the fingerprint, the interrupt filter, the title and the detail
+    each read independently.
+
+    Counts the whole reporting path a real evaluation takes, so the assertion
+    fails on the next helper that starts reading for itself.
+    """
+    context, reads = _counting_context([_step_failure("some_model", "boom")])
+
+    step_failure_events = context.get_step_failure_events()
+    failure = step_failure_of(step_failure_events)
+    is_an_interrupted_worker(failure)
+    sentry_fingerprint(context, failure)
+    capture_run_failure_to_sentry(context, failure)
+    error_message(context, step_failure_events, sentry_event_id="cafebabe")
+
+    assert reads == [1]
 
 
 # ── What a sensor-reported issue says ─────────────────────────────────────────
@@ -452,7 +517,7 @@ def test_the_issue_is_titled_after_the_defect() -> None:
     """
     context = _context([_step_failure("some_model", "boom", cls_name="ValueError")])
 
-    assert sentry_message(context) == "ValueError: some_model"
+    assert sentry_message(context, _failure_of(context)) == "ValueError: some_model"
 
 
 def test_the_title_names_the_exception_dagster_wrapped() -> None:
@@ -468,14 +533,19 @@ def test_the_title_names_the_exception_dagster_wrapped() -> None:
         ]
     )
 
-    assert sentry_message(context) == "FileNotFoundError: some_model"
+    assert (
+        sentry_message(context, _failure_of(context)) == "FileNotFoundError: some_model"
+    )
 
 
 def test_a_run_with_no_step_failure_says_so_in_the_title() -> None:
     """An OOM kill or a run-monitoring reap has no step and no exception."""
     context = _context([])
 
-    assert sentry_message(context) == "Dagster run failed with no step failure: a_job"
+    assert (
+        sentry_message(context, _failure_of(context))
+        == "Dagster run failed with no step failure: a_job"
+    )
 
 
 def test_the_sensor_tags_the_exception_type(
@@ -487,9 +557,9 @@ def test_the_sensor_tags_the_exception_type(
     no exception at all, so without the tag "which failures are NoSuchKey" is
     unanswerable for every failure the hook did not report.
     """
-    capture_run_failure_to_sentry(
-        _context([_step_failure("some_model", "boom", cls_name="ValueError")])
-    )
+    context = _context([_step_failure("some_model", "boom", cls_name="ValueError")])
+
+    capture_run_failure_to_sentry(context, _failure_of(context))
 
     (event,) = recorded_events.events()
     assert event["tags"]["dagster_exception_type"] == "ValueError"
@@ -504,9 +574,11 @@ def test_the_sensor_carries_the_step_error_text(
     the hook, a DSN it does not have, a worker killed before it ran -- this is
     the only description of the failure that reaches Sentry.
     """
-    capture_run_failure_to_sentry(
-        _context([_step_failure("some_model", "NoSuchKey: nope\n\nStack Trace:...")])
+    context = _context(
+        [_step_failure("some_model", "NoSuchKey: nope\n\nStack Trace:...")]
     )
+
+    capture_run_failure_to_sentry(context, _failure_of(context))
 
     (event,) = recorded_events.events()
     failure = event["contexts"]["dagster_step_failure"]
@@ -518,9 +590,11 @@ def test_the_step_error_text_is_bounded(
     recorded_events: RecordingTransport,
 ) -> None:
     """Sentry drops an oversized context silently, taking the detail with it."""
-    capture_run_failure_to_sentry(
-        _context([_step_failure("some_model", "x" * (MAX_SENTRY_ERROR_LENGTH * 2))])
+    context = _context(
+        [_step_failure("some_model", "x" * (MAX_SENTRY_ERROR_LENGTH * 2))]
     )
+
+    capture_run_failure_to_sentry(context, _failure_of(context))
 
     (event,) = recorded_events.events()
     error = event["contexts"]["dagster_step_failure"]["error"]
@@ -536,7 +610,7 @@ def test_a_run_with_no_step_failure_falls_back_to_the_run_message(
     """
     context = _context([], failure_message="Run worker exited unexpectedly")
 
-    capture_run_failure_to_sentry(context)
+    capture_run_failure_to_sentry(context, _failure_of(context))
 
     (event,) = recorded_events.events()
     failure = event["contexts"]["dagster_step_failure"]
@@ -560,7 +634,7 @@ def test_a_terminated_worker_is_not_reported_by_the_sensor(cls_name: str) -> Non
     """
     context = _context([_step_failure("some_model", "boom", cls_name=cls_name)])
 
-    assert is_an_interrupted_worker(context) is True
+    assert is_an_interrupted_worker(_failure_of(context)) is True
 
 
 def test_an_interruption_wrapped_by_dagster_is_still_caught() -> None:
@@ -578,20 +652,20 @@ def test_an_interruption_wrapped_by_dagster_is_still_caught() -> None:
         ]
     )
 
-    assert is_an_interrupted_worker(context) is True
+    assert is_an_interrupted_worker(_failure_of(context)) is True
 
 
 def test_an_ordinary_failure_is_still_reported() -> None:
     context = _context([_step_failure("some_model", "boom", cls_name="ValueError")])
 
-    assert is_an_interrupted_worker(context) is False
+    assert is_an_interrupted_worker(_failure_of(context)) is False
 
 
 def test_a_run_with_no_step_failure_is_still_reported() -> None:
     """An OOM kill or a run-monitoring reap has no step error to inspect, and is
     exactly the case this sensor exists to catch.
     """
-    assert is_an_interrupted_worker(_context([])) is False
+    assert is_an_interrupted_worker(step_failure_of([])) is False
 
 
 def test_a_step_failure_with_no_error_payload_is_still_reported() -> None:
@@ -599,7 +673,7 @@ def test_a_step_failure_with_no_error_payload_is_still_reported() -> None:
         step_key="some_model", event_specific_data=SimpleNamespace()
     )
 
-    assert is_an_interrupted_worker(_context([failure])) is False
+    assert is_an_interrupted_worker(step_failure_of([failure])) is False
 
 
 # ── Slack rate limiting ───────────────────────────────────────────────────────
@@ -715,14 +789,19 @@ def test_suppressions_are_recorded_even_though_announcements_are_not() -> None:
 
 def test_a_suppressed_repeat_is_named_in_the_next_message() -> None:
     blocks = error_message(
-        _context([_step_failure("some_model", "boom")]), None, suppressed_repeats=4_000
+        _context([_step_failure("some_model", "boom")]),
+        [_step_failure("some_model", "boom")],
+        suppressed_repeats=4_000,
     )
 
     assert "4000 further failures" in _block_text(blocks)
 
 
 def test_no_repeat_block_when_there_was_nothing_to_suppress() -> None:
-    blocks = error_message(_context([_step_failure("some_model", "boom")]))
+    blocks = error_message(
+        _context([_step_failure("some_model", "boom")]),
+        [_step_failure("some_model", "boom")],
+    )
 
     assert "further failures" not in _block_text(blocks)
 

--- a/dg_projects/data_platform/data_platform_tests/test_definitions.py
+++ b/dg_projects/data_platform/data_platform_tests/test_definitions.py
@@ -11,6 +11,7 @@ from dagster import AssetCheckSeverity, MetadataValue, RetryPolicy
 from data_platform.definitions import (
     MAX_CHECK_EVALUATIONS_PER_TICK,
     MAX_METADATA_ENTRIES_PER_FAILURE,
+    MAX_SENTRY_ERROR_LENGTH,
     MAX_SLACK_TEXT_LENGTH,
     RETRY_NUMBER_TAG,
     asset_check_failure_message,
@@ -27,6 +28,7 @@ from data_platform.definitions import (
     record_announcement,
     repeats_to_announce,
     sentry_fingerprint,
+    sentry_message,
     truncate_text,
 )
 from ol_orchestrate.lib.constants import DAGSTER_ENV
@@ -435,6 +437,111 @@ def test_sensor_fingerprint_matches_a_real_dagster_step_failure(
         "raises_file_not_found",
         "FileNotFoundError",
     ]
+
+
+# ── What a sensor-reported issue says ─────────────────────────────────────────
+
+
+def test_the_issue_is_titled_after_the_defect() -> None:
+    """DAGSTER-2J reached 27,000 events titled "Dagster run failure: __ASSET_JOB".
+
+    Sentry titles a message event with its message. Everything the automation
+    sensor materializes runs as ``__ASSET_JOB``, so titling on the job name made
+    every such issue read identically -- the exception type existed only inside
+    the fingerprint, which the UI does not render.
+    """
+    context = _context([_step_failure("some_model", "boom", cls_name="ValueError")])
+
+    assert sentry_message(context) == "ValueError: some_model"
+
+
+def test_the_title_names_the_exception_dagster_wrapped() -> None:
+    """Same unwrapping the fingerprint does, so title and grouping agree."""
+    context = _context(
+        [
+            _step_failure(
+                "some_model",
+                "boom",
+                cls_name="DagsterExecutionLoadInputError",
+                cause=SimpleNamespace(cls_name="FileNotFoundError", cause=None),
+            )
+        ]
+    )
+
+    assert sentry_message(context) == "FileNotFoundError: some_model"
+
+
+def test_a_run_with_no_step_failure_says_so_in_the_title() -> None:
+    """An OOM kill or a run-monitoring reap has no step and no exception."""
+    context = _context([])
+
+    assert sentry_message(context) == "Dagster run failed with no step failure: a_job"
+
+
+def test_the_sensor_tags_the_exception_type(
+    recorded_events: RecordingTransport,
+) -> None:
+    """Searchable, which a fingerprint component is not.
+
+    The hook path carries the type in the event's own exception. This path has
+    no exception at all, so without the tag "which failures are NoSuchKey" is
+    unanswerable for every failure the hook did not report.
+    """
+    capture_run_failure_to_sentry(
+        _context([_step_failure("some_model", "boom", cls_name="ValueError")])
+    )
+
+    (event,) = recorded_events.events()
+    assert event["tags"]["dagster_exception_type"] == "ValueError"
+
+
+def test_the_sensor_carries_the_step_error_text(
+    recorded_events: RecordingTransport,
+) -> None:
+    """The traceback the hook would have attached as real frames.
+
+    When the hook does not report -- a code location on an image that predates
+    the hook, a DSN it does not have, a worker killed before it ran -- this is
+    the only description of the failure that reaches Sentry.
+    """
+    capture_run_failure_to_sentry(
+        _context([_step_failure("some_model", "NoSuchKey: nope\n\nStack Trace:...")])
+    )
+
+    (event,) = recorded_events.events()
+    failure = event["contexts"]["dagster_step_failure"]
+    assert failure["step_key"] == "some_model"
+    assert "NoSuchKey: nope" in failure["error"]
+
+
+def test_the_step_error_text_is_bounded(
+    recorded_events: RecordingTransport,
+) -> None:
+    """Sentry drops an oversized context silently, taking the detail with it."""
+    capture_run_failure_to_sentry(
+        _context([_step_failure("some_model", "x" * (MAX_SENTRY_ERROR_LENGTH * 2))])
+    )
+
+    (event,) = recorded_events.events()
+    error = event["contexts"]["dagster_step_failure"]["error"]
+    assert len(error) == MAX_SENTRY_ERROR_LENGTH
+    assert error.endswith("...")
+
+
+def test_a_run_with_no_step_failure_falls_back_to_the_run_message(
+    recorded_events: RecordingTransport,
+) -> None:
+    """Same fallback the Slack message uses, for the same reason: without it the
+    event says nothing at all about a run that died between steps.
+    """
+    context = _context([], failure_message="Run worker exited unexpectedly")
+
+    capture_run_failure_to_sentry(context)
+
+    (event,) = recorded_events.events()
+    failure = event["contexts"]["dagster_step_failure"]
+    assert failure["exception_type"] == "run_failure"
+    assert failure["error"] == "Run worker exited unexpectedly"
 
 
 # ── Interrupted workers ───────────────────────────────────────────────────────


### PR DESCRIPTION
### What are the relevant tickets?
Fixes DAGSTER-2J

Worth flagging for whoever merges this: it fixes what that issue *says*, not what it reports. The edxorg failure underneath is untouched and will keep firing, so expect DAGSTER-2J to regress straight back to unresolved.

### Description (What does it do?)
The run failure sensor reports through `capture_message`, and Sentry titles a message event with its message. That message was `Dagster run failure: {job_name}`. Everything the automation condition sensor materializes runs as `__ASSET_JOB`, so every issue reported on that path read identically in the issue list. DAGSTER-2J reached 27,041 events without naming its exception once.

All of it in [`dg_projects/data_platform/data_platform/definitions.py`](https://github.com/mitodl/ol-data-platform/blob/main/dg_projects/data_platform/data_platform/definitions.py):

- Title is now `<ExceptionType>: <step_key>`, which is how the in-process hook's issues already read. The fingerprint is unchanged, so existing issues keep their identity and only their title moves.
- New `dagster_exception_type` tag. The type previously existed only inside the fingerprint, which the Sentry UI does not render and no search can filter on.
- New `dagster_step_failure` context carrying the serialized step error, traceback included, bounded at 8192 bytes: the SDK trims only transaction span descriptions against `MAX_EVENT_BYTES` (10^6) and never an error event's contexts, while an event over that size is discarded whole at ingest, so an unbounded traceback would cost the event rather than the field. Falls back to the run's own failure message when a run died with no step failure, which is what the Slack path already does.
- `sentry_fingerprint`, `is_an_interrupted_worker` and the reported exception type now read the step failure through one shared accessor (`first_step_failure` / `step_failure_error` / `step_failure_error_type`) instead of each re-deriving it. Disagreement between those three is what splits one defect into two issues.

### How can this be tested?
Run from `dg_projects/data_platform`:

```
uv run pytest data_platform_tests/test_definitions.py
```

77 pass (70 existing, 7 new). Four of the seven assert on the event `capture_run_failure_to_sentry` actually emits, through the existing `RecordingTransport` fixture, rather than on a local re-implementation of the tagging; the other three cover the issue title directly.

`pre-commit run --files dg_projects/data_platform/data_platform/definitions.py dg_projects/data_platform/data_platform_tests/test_definitions.py` is clean (ruff format, ruff check, mypy).

Not exercised against live Sentry. To validate after it deploys:

- DAGSTER-2J's title changes from `Dagster run failure: __ASSET_JOB` to `FileNotFoundError: extract_edxorg_courserun_metadata`, and the issue does **not** split into a new one. A split means the fingerprint moved, which this change is specifically not supposed to do.
- New events on that issue carry a `dagster_exception_type` tag and a `dagster_step_failure` context with the traceback.
- `captured_by:sensor dagster_exception_type:FileNotFoundError` returns results in Sentry search, which it cannot today.

### Additional Context
This matters now because the sensor is currently the *only* reporting path for most code locations.

The in-process hook stopped reporting from edxorg at 2026-08-18T02:40 and has not reported since. In the three days to 2026-08-24, `captured_by:hook` returns zero events for edxorg, canvas and openedx, while `captured_by:sensor` returns 10,830 / 52 / 18 for the same window. Only lakehouse and data_loading still report from the hook.

The cause is a deployment, not this code: those code locations are pinned to an image that predates #2564. Production runs carry `dagster/image: dagster-edxorg:dcce1f1b`, and `git merge-base --is-ancestor 12bc637e dcce1f1b` is false. The exception type confirms it independently — post-#2564 code raises `UpstreamObjectUnavailable` from `FileObjectIOManager.load_input`, pre-#2564 code raises raw `NoSuchKey`/`FileNotFoundError` from `edxorg/assets/openedx_course_archives.py:123`, and the sensor's own fingerprint in production today is `production|edxorg|extract_edxorg_courserun_metadata|FileNotFoundError`.

That deploy is tracked separately. This PR does not fix it, and does not depend on it: an event on the sensor path should name its exception whether or not the hook also reported the same failure.

One consequence to be aware of when reviewing: because the sensor's fingerprint is unchanged, this does nothing about the fact that a hook event and a sensor event for the same failure only collapse into one issue when both processes run the same fingerprint code. Two code locations on different images will still produce two issues for one defect. That is the deploy's problem to solve, not this one's.
