### PR TITLE
fix(dagster): keep instance identifiers out of Sentry issue titles

### DIFF
--- a/dg_projects/canvas/canvas/assets/canvas.py
+++ b/dg_projects/canvas/canvas/assets/canvas.py
@@ -315,6 +315,6 @@ def course_content_metadata(
         )
         raise http_failure(
             error,
-            f"Learn API webhook notification failed for course_id={course_id}",
+            "Learn API webhook notification failed",
             metadata={"course_id": course_id},
         ) from error

--- a/dg_projects/learning_resources/learning_resources/assets/ovs_videos.py
+++ b/dg_projects/learning_resources/learning_resources/assets/ovs_videos.py
@@ -22,6 +22,7 @@ from dagster import (
     asset,
 )
 from ol_orchestrate.lib.automation_policies import upstream_or_code_changes
+from ol_orchestrate.lib.http_errors import http_failure
 from ol_orchestrate.lib.utils import fetch_all_drf_pages
 from ol_orchestrate.resources.api_client_factory import ApiClientFactory
 
@@ -167,12 +168,16 @@ def video_webhook(
             response_data,
         )
     except httpx.HTTPStatusError as error:
-        error_message = (
-            f"OVS webhook failed for video_id={video_id} "
-            f"with status code {error.response.status_code}: {error}"
+        context.log.exception(
+            "OVS webhook failed for video_id=%s with status code %s",
+            video_id,
+            error.response.status_code,
         )
-        context.log.exception(error_message)
-        raise RuntimeError(error_message) from error
+        raise http_failure(
+            error,
+            "OVS video webhook notification failed",
+            metadata={"video_id": video_id},
+        ) from error
     else:
         context.add_output_metadata(
             {
@@ -217,12 +222,16 @@ def video_delete_webhook(
         response_data = learn_api.client.notify_ovs_video(payload)
         context.log.info("OVS delete webhook sent for partition: %s", video_id)
     except httpx.HTTPStatusError as error:
-        error_message = (
-            f"OVS delete webhook failed for video_id={video_id} "
-            f"with status code {error.response.status_code}: {error}"
+        context.log.exception(
+            "OVS delete webhook failed for video_id=%s with status code %s",
+            video_id,
+            error.response.status_code,
         )
-        context.log.exception(error_message)
-        raise RuntimeError(error_message) from error
+        raise http_failure(
+            error,
+            "OVS video delete webhook notification failed",
+            metadata={"video_id": video_id},
+        ) from error
     else:
         context.add_output_metadata({"video_id": video_id, "webhook_status": "success"})
         return {

--- a/dg_projects/openedx/openedx/assets/openedx.py
+++ b/dg_projects/openedx/openedx/assets/openedx.py
@@ -399,10 +399,21 @@ def course_xml(context: AssetExecutionContext):
                 datetime.now(tz=UTC) - start_time
                 > COURSE_EXPORT_GET_TASKS_STATUS_TIMEOUT
             ):
+                # Which course timed out and what Studio last said are logged
+                # rather than interpolated into the message: Sentry titles the
+                # event from the message, so a course key in there gives every
+                # timeout a different title. The course key is already on the
+                # event as the dagster_partition tag.
+                context.log.error(
+                    "Course export timed out for %s after %s. Last status "
+                    "reported by Studio: %s",
+                    course_key,
+                    COURSE_EXPORT_GET_TASKS_STATUS_TIMEOUT,
+                    last_seen_status or "none",
+                )
                 err_msg = (
-                    f"Course export timed out for {course_key} after "
-                    f"{COURSE_EXPORT_GET_TASKS_STATUS_TIMEOUT}. Last status "
-                    f"reported by Studio: {last_seen_status or 'none'}"
+                    "Course export timed out waiting for Studio after "
+                    f"{COURSE_EXPORT_GET_TASKS_STATUS_TIMEOUT}."
                 )
                 raise TimeoutError(err_msg)
             time.sleep(timedelta(seconds=20).seconds)
@@ -440,10 +451,13 @@ def course_xml(context: AssetExecutionContext):
             # the course itself changes. Raised as a bare Exception it was never
             # classified at all, so run_retries and the automation condition both
             # kept re-running it: 2,587 events on DAGSTER-6.
+            # The course key stays out of the message and in the metadata
+            # below, so every occurrence of this defect carries the same Sentry
+            # title instead of one title per course.
             errmsg = (
-                f"Studio could not export the course XML for {course_key}, and "
-                "reported a terminal failure state. Rerunning will not change "
-                "that; the course itself has to be fixed or republished."
+                "Studio could not export the course XML, and reported a "
+                "terminal failure state. Rerunning will not change that; the "
+                "course itself has to be fixed or republished."
             )
             raise permanent_failure(
                 errmsg,
@@ -747,6 +761,6 @@ def openedx_course_content_webhook(
         )
         raise http_failure(
             error,
-            f"Learn API webhook notification failed for course_id={course_id}",
+            "Learn API webhook notification failed",
             metadata={"course_id": course_id, "source": source},
         ) from error

--- a/packages/ol-orchestrate-lib/src/ol_orchestrate/io_managers/filepath.py
+++ b/packages/ol-orchestrate-lib/src/ol_orchestrate/io_managers/filepath.py
@@ -24,10 +24,17 @@ class UpstreamObjectUnavailable(PermanentFailure):
 
     A distinct class rather than a bare ``PermanentFailure`` so the three ways
     this happens -- no materialization, no path in its metadata, a path whose
-    object is gone -- group as one Sentry issue naming the key, instead of
-    dissolving into whatever the reader raised downstream. Nothing a rerun does
-    changes any of them, which is why they carry ``allow_retries=False`` and
-    stop ``run_retries`` via the ``stop_run_retries`` hook.
+    object is gone -- group as one Sentry issue, instead of dissolving into
+    whatever the reader raised downstream. Nothing a rerun does changes any of
+    them, which is why they carry ``allow_retries=False`` and stop
+    ``run_retries`` via the ``stop_run_retries`` hook.
+
+    Which asset and partition broke goes in ``metadata``, never in the
+    description. Sentry titles an event from the exception message, so an
+    interpolated partition key or S3 path gives every occurrence a different
+    title and the issue shows whichever one arrived last -- the asset key and
+    partition are already on the event as ``dagster_step`` and
+    ``dagster_partition`` tags.
     """
 
 
@@ -58,15 +65,18 @@ class FileObjectIOManager(ConfigurableIOManager):
             ),
             limit=1,
         )
-        target = f"{context.asset_key.to_user_string()} / {context.partition_key}"
+        location = {
+            "asset_key": context.asset_key.to_user_string(),
+            "partition": context.partition_key,
+        }
         if not asset_dep:
             raise UpstreamObjectUnavailable(
                 description=(
-                    f"No materialization recorded for {target}, so there is no "
-                    "path to load. The upstream needs to run before this asset "
-                    "can."
+                    "No materialization recorded for the upstream partition, so "
+                    "there is no path to load. The upstream needs to run before "
+                    "this asset can."
                 ),
-                metadata={"asset_key": context.asset_key.to_user_string()},
+                metadata=location,
                 allow_retries=False,
             )
 
@@ -74,11 +84,11 @@ class FileObjectIOManager(ConfigurableIOManager):
         if path_metadata is None:
             raise UpstreamObjectUnavailable(
                 description=(
-                    f"The latest materialization of {target} recorded no 'path' "
-                    "metadata. Whatever wrote it did not go through this IO "
-                    "manager's handle_output."
+                    "The latest materialization of the upstream partition "
+                    "recorded no 'path' metadata. Whatever wrote it did not go "
+                    "through this IO manager's handle_output."
                 ),
-                metadata={"asset_key": context.asset_key.to_user_string()},
+                metadata=location,
                 allow_retries=False,
             )
 
@@ -90,13 +100,13 @@ class FileObjectIOManager(ConfigurableIOManager):
         if not resolved_path.exists():
             raise UpstreamObjectUnavailable(
                 description=(
-                    f"{target} recorded a path to an object that is not there: "
-                    f"{resolved_path}. The materialization outlived the object -- "
+                    "The upstream partition recorded a path to an object that is "
+                    "not there. The materialization outlived the object -- "
                     "expired by a lifecycle rule, deleted, or written to a "
                     "different bucket than the one recorded."
                 ),
                 metadata={
-                    "asset_key": context.asset_key.to_user_string(),
+                    **location,
                     "missing_path": MetadataValue.text(str(resolved_path)),
                 },
                 allow_retries=False,

--- a/packages/ol-orchestrate-lib/src/ol_orchestrate/lib/openedx.py
+++ b/packages/ol-orchestrate-lib/src/ol_orchestrate/lib/openedx.py
@@ -50,7 +50,25 @@ def classify_course_export_state(state: str | None) -> CourseExportOutcome:
 
 
 class CourseExportNotQueuedError(Exception):
-    """Studio accepted the export request but queued no task for the course."""
+    """Studio accepted the export request but queued no task for the course.
+
+    ``course_key`` and Studio's raw ``response`` are attributes rather than
+    parts of the message. Sentry titles an event from the message, so a course
+    key interpolated into it gives every occurrence its own title and the issue
+    shows whichever arrived last; the caller is partitioned by course, so the
+    key is already on the event as the ``dagster_partition`` tag.
+    """
+
+    def __init__(
+        self,
+        message: str,
+        course_key: str,
+        response: dict[str, Any] | None = None,
+    ) -> None:
+        """Record which course failed alongside the stable ``message``."""
+        super().__init__(message)
+        self.course_key = course_key
+        self.response = response
 
 
 def course_export_task_id(course_key: str, export_response: dict[str, Any]) -> str:
@@ -68,18 +86,15 @@ def course_export_task_id(course_key: str, export_response: dict[str, Any]) -> s
     failed_uploads = export_response.get("failed_uploads") or {}
     if course_key in failed_uploads:
         msg = (
-            f"Studio declined to queue an export for {course_key}: "
+            "Studio declined to queue an export for the course: "
             f"{failed_uploads[course_key]}"
         )
-        raise CourseExportNotQueuedError(msg)
+        raise CourseExportNotQueuedError(msg, course_key, export_response)
 
     task_id = (export_response.get("upload_task_ids") or {}).get(course_key)
     if not task_id:
-        msg = (
-            f"Studio returned no export task for {course_key} and did not say "
-            f"why. Full response: {export_response}"
-        )
-        raise CourseExportNotQueuedError(msg)
+        msg = "Studio returned no export task for the course and did not say why."
+        raise CourseExportNotQueuedError(msg, course_key, export_response)
     return task_id
 
 

--- a/packages/ol-orchestrate-lib/tests/io_managers/test_filepath.py
+++ b/packages/ol-orchestrate-lib/tests/io_managers/test_filepath.py
@@ -70,6 +70,10 @@ def test_a_missing_object_fails_permanently_and_names_the_key(
 
     Handing this path back left the NoSuchKey to surface deep inside whichever
     library opened it, with nothing in the error saying which object was gone.
+
+    The path is named in metadata, not in the description: Sentry titles an
+    event from the exception message, and an S3 key with a content hash in it
+    gave DAGSTER-2H a different title for every occurrence.
     """
     missing = tmp_path / "never-written.tar.gz"
     context = context_for({"path": MetadataValue.path(f"file://{missing}")})
@@ -77,7 +81,9 @@ def test_a_missing_object_fails_permanently_and_names_the_key(
     with pytest.raises(UpstreamObjectUnavailable) as raised:
         FileObjectIOManager().load_input(context)
 
-    assert str(missing) in raised.value.description
+    assert str(missing) in raised.value.metadata["missing_path"].value
+    assert raised.value.metadata["partition"].value == PARTITION
+    assert str(missing) not in raised.value.description
     assert raised.value.allow_retries is False
 
 
@@ -99,5 +105,6 @@ def test_no_materialization_at_all_fails_permanently() -> None:
     with pytest.raises(UpstreamObjectUnavailable) as raised:
         FileObjectIOManager().load_input(context)
 
-    assert ASSET_KEY.to_user_string() in raised.value.description
+    assert raised.value.metadata["asset_key"].value == ASSET_KEY.to_user_string()
+    assert ASSET_KEY.to_user_string() not in raised.value.description
     assert raised.value.allow_retries is False

--- a/packages/ol-orchestrate-lib/tests/lib/test_openedx.py
+++ b/packages/ol-orchestrate-lib/tests/lib/test_openedx.py
@@ -476,8 +476,12 @@ def test_course_export_task_id_surfaces_studios_queue_failure() -> None:
     with pytest.raises(CourseExportNotQueuedError) as exc_info:
         course_export_task_id(COURSE_KEY, response)
 
-    assert COURSE_KEY in str(exc_info.value)
+    # Studio's explanation describes the defect and stays in the message; the
+    # course key identifies the instance and moves to an attribute, so every
+    # occurrence groups under one Sentry title.
     assert "Course not found" in str(exc_info.value)
+    assert COURSE_KEY not in str(exc_info.value)
+    assert exc_info.value.course_key == COURSE_KEY
 
 
 @pytest.mark.parametrize(
@@ -498,7 +502,9 @@ def test_course_export_task_id_rejects_a_response_with_no_task(
     with pytest.raises(CourseExportNotQueuedError) as exc_info:
         course_export_task_id(COURSE_KEY, response)
 
-    assert COURSE_KEY in str(exc_info.value)
+    assert COURSE_KEY not in str(exc_info.value)
+    assert exc_info.value.course_key == COURSE_KEY
+    assert exc_info.value.response == response
 
 
 def _block(category: str, children: list[str], display_name: str = "Block"):


### PR DESCRIPTION
## What

Move course ids, video ids, partition keys and S3 paths out of exception messages and into failure metadata, so one defect gets one readable Sentry title.

Closes part 4 of the "make the Sentry pipeline report defects, not launch paths" work. Parts 1-3 landed in #2564.

## Why

Sentry titles an event from the exception message. Grouping is already correct after #2564, but the *title* comes from the last event to arrive, so an identifier in the message makes the issue list unreadable.

Measured over the 7 days to 2026-08-24, `captured_by:hook`:

| Issue | Title today |
|---|---|
| DAGSTER-2H | `UpstreamObjectUnavailable: edxorg/raw_data/course_xml / MITx-18.033x-1T2021\|prod recorded a path to an object that is not there: s3://.../b42df13ce00411b1ebe6977ce7b40051e5d470fc2c44d44c0da486372...` |
| DAGSTER-2C / 2M | `RuntimeError: OVS webhook failed for video_id=a6edd29aa49b43c09dd47b9d398c4308 with status code 400: ...` |
| DAGSTER-2K | `PermanentHTTPFailure: Learn API webhook notification failed for course_id=155: ...` |

DAGSTER-2H is a single issue (id 7677264240) with a different title per event, each truncated mid content-hash.

The identifiers are not lost. They move to the failure `metadata`, which Dagster surfaces on the failed step, and the asset and partition are already on every event as the `dagster_step` and `dagster_partition` tags.

`edxorg`'s webhook already did exactly this and its comment states the convention; this brings canvas, openedx, the OVS webhooks and the IO manager in line.

## Also fixed: OVS retry classification

Both OVS webhook assets were raising a bare `RuntimeError`, and both carry a `RetryPolicy(max_retries=3)`. In `dagster/_core/execution/plan/utils.py`, `allow_retries` is only consulted inside `if retry_policy:`, and only for a `Failure`:

```python
if retry_policy:
    # if Failure with allow_retries set to false, disregard retry policy and raise
    if isinstance(e, Failure) and not e.allow_retries:
        raise e
    raise RetryRequestedFromPolicy(...)
```

A bare `RuntimeError` is not a `Failure`, so it fell straight through to `RetryRequestedFromPolicy` and a permanent 400 was retried three times before failing. Permanent and transient failures also shared one exception type and therefore one issue. Routing them through `http_failure` fixes the classification along with the title.

## What is deliberately unchanged

Exception types. The fingerprint is `[environment, code_location, step_key, exception_type]`, so changing a type re-homes a defect into a new issue and silently splits its history. That is not hypothetical: wrapping an httpx error in `PermanentHTTPFailure` in #2564 moved the Learn API 405 from DAGSTER-13 to DAGSTER-2K, whose first event (2026-08-17T21:37:46Z) lands 80 seconds after DAGSTER-13's last (2026-08-17T21:36:26Z). That reads as "fixed on Aug 17", but gateway logs show POST 405s on that endpoint continuing until mit-learn #3776 deployed on Aug 18/19.

The one exception is the OVS `RuntimeError`, where the split is the point.

## Testing

- `packages/ol-orchestrate-lib`: 208 passed, 80 skipped
- `dg_projects/openedx` (own env): 25 passed
- `dg_projects/canvas` + `dg_projects/learning_resources`: 21 passed
- pre-commit (ruff format, ruff check, mypy, detect-secrets): all pass

The two tests that asserted the identifier appears in the message now assert the inverse: it is in metadata and *not* in the description, which pins the property this PR is about.

`dg_projects/edxorg` tests could not be collected (`ModuleNotFoundError: duckdb` in that project's env). Pre-existing and unrelated: no file under `dg_projects/edxorg` is touched by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0137aMRH4447yktgAhYnaiiy