### PR TITLE
fix(dbt): drop a dead Trino-only regexp_replace from two edxorg models

### DIFF
--- a/src/ol_dbt/models/staging/edxorg/stg__edxorg__bigquery__mitx_person_course.sql
+++ b/src/ol_dbt/models/staging/edxorg/stg__edxorg__bigquery__mitx_person_course.sql
@@ -49,10 +49,7 @@ with source as (
         , certified as courseruncertificate_is_earned
         , cert_status as courseruncertificate_status
         , coalesce(is_active = 1, false) as courserunenrollment_is_active
-        --- trino doesn't have function to convert first letter to upper case
-        , regexp_replace( -- noqa: PRS
-            {{ transform_gender_value('gender') }}, '(^[a-z])(.)', x -> upper(x[1]) || x[2] -- noqa
-        ) as user_gender
+        , {{ transform_gender_value('gender') }} as user_gender
         ,{{ transform_education_value('loe') }} as user_highest_education
         ,{{ cast_timestamp_to_iso8601('start_time') }} as courserunenrollment_created_on
         ,{{ cast_timestamp_to_iso8601('verified_enroll_time') }} as courserunenrollment_enrolled_on

--- a/src/ol_dbt/models/staging/edxorg/stg__edxorg__bigquery__mitx_user_info_combo.sql
+++ b/src/ol_dbt/models/staging/edxorg/stg__edxorg__bigquery__mitx_user_info_combo.sql
@@ -36,10 +36,7 @@ with source as (
         , certificate_verify_uuid as courseruncertificate_verify_uuid
         , certificate_name as courseruncertificate_name
         , certificate_status as courseruncertificate_status
-        --- trino doesn't have function to convert first letter to upper case
-        , regexp_replace( -- noqa: PRS
-            {{ transform_gender_value('profile_gender') }}, '(^[a-z])(.)', x -> upper(x[1]) || x[2] -- noqa
-        ) as user_gender
+        , {{ transform_gender_value('profile_gender') }} as user_gender
         ,{{ transform_education_value('profile_level_of_education') }} as user_highest_education
         ,{{ cast_timestamp_to_iso8601('date_joined') }} as user_joined_on
         ,{{ cast_timestamp_to_iso8601('last_login') }} as user_last_login


### PR DESCRIPTION
## What are the relevant tickets?

Witan task `tk-two-edxorg-staging-models-use-trino-s-lambda-reg-19b118`. Part of the
StarRocks cross-database macro epic (#2375).

## Description (What does it do?)

Two edxorg staging models wrapped `transform_gender_value(...)` in a Trino-only
`regexp_replace` lambda to capitalise the first letter:

```sql
--- trino doesn't have function to convert first letter to upper case
, regexp_replace( -- noqa: PRS
    {{ transform_gender_value('gender') }}, '(^[a-z])(.)', x -> upper(x[1]) || x[2] -- noqa
) as user_gender
```

**The wrapper has been dead code since it was written.** `transform_gender_value`
(`macros/transform_code_to_readable_values.sql:1-11`) returns only these:

| input | output |
|---|---|
| `m` | `Male` |
| `f` | `Female` |
| `t` | `Transgender` |
| `b` | `Binary` |
| `nb` | `Non-binary/non-conforming` |
| `o` | `Other/Prefer Not to Say` |
| anything else | `NULL` |

Every one already starts with a capital, so `(^[a-z])` cannot match and `regexp_replace`
returns its input unchanged. `NULL` in, `NULL` out.

The git history explains how it got there, and it is a tidy accident. In the macro's first
version (47dc60cf, #1022) the fallback was `else {{ column_name }}` — it passed the **raw
source code through**, so an unmapped lowercase value like `xyz` really would have reached
the caller uncapitalised. That is what the wrapper was written for. But the commit that
added the wrapper, b8bf7d1c (#1130), is the *same* commit that changed the fallback to
`else null`. The wrapper was dead on arrival.

Two further signals it was a mistake rather than a subtlety: the **six other** call sites of
`transform_gender_value` (mitxpro, mitxonline, edxorg s3, residential, bootcamps,
micromasters) all invoke it bare, and the expression needed two `-- noqa` suppressions to
get past sqlfluff.

So this deletes the wrapper rather than adding the `capitalize_first()` dispatch macro the
task originally proposed. No caller would have used it, and a new cross-db macro is a
maintenance surface that buys nothing here.

### Why it matters beyond tidiness

The lambda overload of `regexp_replace` is Trino-only.

- **DuckDB rejects it outright**: `Binder Error: failed to bind function, either: This scalar
  function does not support lambdas! or: Referenced column "x" not found in FROM clause!`
  `stg__edxorg__bigquery__mitx_user_info_combo` is upstream of `dim_user`, so this single
  expression made `dim_user` unbuildable on the local DuckDB target — which is how it
  surfaced (while trying to verify #2597 against production data).
- **StarRocks has no lambda `regexp_replace` either** — its docs give a single signature,
  `VARCHAR regexp_replace(VARCHAR str, VARCHAR pattern, VARCHAR repl)`, where the
  replacement is a string and not a function. So this was also on the critical path for the
  StarRocks migration.

## How can this be tested?

- `dbt parse -t dev`: clean.
- `ol-dbt validate` on both models: **0 errors, 0 warnings** (the 3 INFO lines are
  pre-existing `SELECT *` notes).
- `ol-dbt impact --base-ref origin/main`: **0 breaking, 0 warnings, no column-level impact** —
  the column's values are unchanged, so nothing downstream shifts.
- **Both models now build on the `dev_local` DuckDB target against real production data**:
  `dbt run --select stg__edxorg__bigquery__mitx_user_info_combo
  stg__edxorg__bigquery__mitx_person_course` → `Completed successfully`, `PASS=3 WARN=0
  ERROR=0`. `mitx_user_info_combo` previously died in 2.65s with the binder error above.

The no-op claim is checkable by hand: run the six literals above against `(^[a-z])(.)` and
none match.

## Things to look at closely

Nothing subtle here, but the one thing worth a second pair of eyes is the claim that
`transform_gender_value` has no lowercase-returning branch — if a branch is ever added that
returns a lowercase literal, it must return the display form directly rather than relying on
a caller to capitalise it.

Out of scope: `models/migration/edxorg_to_mitxonline_enrollments.sql:93` uses a *different*
Trino lambda (`transform(..., x -> CAST(json_extract_scalar(x, '$.value') as integer))`).
That one does real work and needs an actual cross-db array-transform macro; it stays on the
StarRocks epic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QapG9XRweT7AWGXAforRbj
