### PR TITLE
fix(ol-dbt-cli): make composite --primary-key work in `ol-dbt diff`

### DIFF
--- a/docs/specs/DBT_WAREHOUSE_CI_QA_SPEC.md
+++ b/docs/specs/DBT_WAREHOUSE_CI_QA_SPEC.md
@@ -148,6 +148,25 @@ loudly instead of silently falling to text.
    email-keyed surrogate that collapses NULL emails — a naive full-row compare shows spurious
    mismatches; callers should pass `--primary-key` and/or `--exclude-columns` for known
    unstable columns.
+
+   **Correction (implementation reality).** `audit_helper` takes `primary_key` as an *opaque
+   string it interpolates directly into SQL*, never as a list, so a composite key cannot simply
+   be handed over as a Jinja list — doing so emits the literal text `['k1', 'k2']` into the
+   query. The two consumers need different forms:
+   - `compare_relations` → `compare_queries` uses `primary_key` **only** in the `order by` of
+     the `summarize=false` branch (it is unused when `summarize=true`). A comma-joined column
+     list (`'k1, k2'`) is the correct form there.
+   - `compare_column_values` (the per-column mismatch path) emits
+     `a_query.{{ primary_key }} = b_query.{{ primary_key }}`, so it requires a **scalar** column
+     name present in both sides. A composite key is therefore collapsed into a single hashed
+     join column via `dbt_utils.generate_surrogate_key([...])` inside the `a_query`/`b_query`
+     blocks, and that column's name is what gets passed.
+
+   Accept a composite key both comma-separated (`-k a,b,c`) and as a repeated flag
+   (`-k a -k b -k c`); cyclopts consumes one token per flag occurrence, so `-k a b c` would
+   otherwise silently truncate the key and spill the remaining tokens into `--dbt-dir`. Same
+   handling for `--exclude-columns`. Using the model's true grain is not cosmetic: a non-unique
+   key pairs rows many-to-many and reports join artifacts as mismatches.
 4. **Run the comparison.** Render an `audit_helper` operation via a small analysis/macro
    invocation and execute it with `dbt`. On `dev_local`, unbuilt sides resolve to the Glue
    DuckDB views through `override_ref`/`override_source` (zero-copy). `--auto-build` may first
@@ -193,7 +212,8 @@ loudly instead of silently falling to text.
 ### 3.8 Acceptance criteria
 - [ ] `ol-dbt diff --old A --new B` runs on `dev_local` with zero cloud creds and prints a
       capped human summary.
-- [ ] `--format json` emits the schema in §3.5; `--primary-key`/`--exclude-columns` respected.
+- [ ] `--format json` emits the schema in §3.5; `--primary-key`/`--exclude-columns` respected,
+      in both their comma-separated and repeated-flag forms, single and composite.
 - [ ] Schema mismatch yields a structured message, not a raw SQL error.
 - [ ] Exit code 1 on any mismatch (CI-gateable).
 - [ ] `dbt_audit_helper` added to `packages.yml`; `test_diff.py` added; `cli.py` registers it.

--- a/docs/specs/DBT_WAREHOUSE_CI_QA_SPEC.md
+++ b/docs/specs/DBT_WAREHOUSE_CI_QA_SPEC.md
@@ -159,8 +159,21 @@ loudly instead of silently falling to text.
    - `compare_column_values` (the per-column mismatch path) emits
      `a_query.{{ primary_key }} = b_query.{{ primary_key }}`, so it requires a **scalar** column
      name present in both sides. A composite key is therefore collapsed into a single hashed
-     join column via `dbt_utils.generate_surrogate_key([...])` inside the `a_query`/`b_query`
-     blocks, and that column's name is what gets passed.
+     join column inside the `a_query`/`b_query` blocks, and that column's name is what gets
+     passed. Build that column with the project's `diff_composite_key` macro
+     (`src/ol_dbt/macros/diff_composite_key.sql`) — **not**
+     `dbt_utils.generate_surrogate_key`, which joins components with a literal `-` without
+     encoding component boundaries, so `('a-b', 'c')` and `('a', 'b-c')` hash identically
+     (verified on dbt_utils 1.3.3). Two distinct keys would then pair as one row, reintroducing
+     the same many-to-many mispairing a composite key exists to prevent.
+     `diff_composite_key` length-prefixes each component (`<len>:<value>`, NULL as `~`) so no
+     character inside a value can shift a boundary.
+
+     This caveat is specific to using a hash as a **row-pairing join key across two
+     relations**. It is not a claim about the `*_pk` surrogates in the dimensional models,
+     which legitimately use `generate_surrogate_key`: there both sides of a join compute the
+     hash identically, and a boundary collision would make two rows share a `*_pk` and fail
+     that column's `unique` test rather than silently mispair.
 
    Accept a composite key both comma-separated (`-k a,b,c`) and as a repeated flag
    (`-k a -k b -k c`); cyclopts consumes one token per flag occurrence, so `-k a b c` would

--- a/skills/data/ol-dbt-fast-validation/SKILL.md
+++ b/skills/data/ol-dbt-fast-validation/SKILL.md
@@ -90,9 +90,12 @@ ol-dbt diff --target dev_local \
   error. A non-unique key pairs rows many-to-many and inflates the mismatch and
   "missing" counts with join artifacts rather than real differences, so a
   single-column key on a composite-grain model actively misleads. If you don't know
-  the grain, check the model for a
-  `dbt_expectations_expect_compound_columns_to_be_unique` test — its column list is
-  the key.
+  the grain, check the model YAML for a
+  `dbt_expectations.expect_compound_columns_to_be_unique` test — its column list is
+  the key. (Grep the dotted spelling; the underscored form appears only in compiled
+  test names.) A single column is safe alone only with **both** `unique` and
+  `not_null` passing — `unique` ignores NULLs, and the single-column join cannot
+  pair NULL keys.
 - Use `--exclude-columns` for non-deterministic columns (load timestamps, etc.).
 - Column sets are reconciled first: a schema mismatch is reported as
   `schema_divergence`, not a raw SQL error.

--- a/skills/data/ol-dbt-fast-validation/SKILL.md
+++ b/skills/data/ol-dbt-fast-validation/SKILL.md
@@ -59,6 +59,7 @@ migrations (epic #2072).
 
 ```bash
 ol-dbt diff --old dim_user_old --new dim_user --primary-key user_pk
+ol-dbt diff --old m_old --new m_new -k user_email,exam_created_on   # composite key
 ol-dbt diff --old m_old --new m_new -k id --exclude-columns _loaded_at --format json
 ol-dbt diff --old m_old --new m_new --auto-build   # build both sides first
 ```
@@ -82,6 +83,16 @@ ol-dbt diff --target dev_local \
   for models with known surrogate-key non-determinism (e.g. `dim_user.user_pk`
   is email-keyed and collapses NULL emails — a naive full-row compare shows
   spurious mismatches).
+- **Use the model's real grain, including composite keys.** Pass a composite key
+  comma-separated (`-k a,b,c`) or by repeating the flag (`-k a -k b -k c`); the two
+  are equivalent. `-k a b c` does *not* work — only the first token is taken as a
+  key and the rest are read as positional args, producing a confusing `--dbt-dir`
+  error. A non-unique key pairs rows many-to-many and inflates the mismatch and
+  "missing" counts with join artifacts rather than real differences, so a
+  single-column key on a composite-grain model actively misleads. If you don't know
+  the grain, check the model for a
+  `dbt_expectations_expect_compound_columns_to_be_unique` test — its column list is
+  the key.
 - Use `--exclude-columns` for non-deterministic columns (load timestamps, etc.).
 - Column sets are reconciled first: a schema mismatch is reported as
   `schema_divergence`, not a raw SQL error.

--- a/skills/data/ol-dbt-local-dev/SKILL.md
+++ b/skills/data/ol-dbt-local-dev/SKILL.md
@@ -63,6 +63,10 @@ ol-dbt local register --all-layers          # mount prod data
 ol-dbt run --select dim_user_old dim_user   # build both relations on dev_local
 ol-dbt diff --old dim_user_old --new dim_user --primary-key user_pk
 ```
+For a model whose grain is more than one column, pass the whole key —
+comma-separated (`-k a,b,c`) or by repeating the flag (`-k a -k b -k c`), which are
+equivalent. `-k a b c` does not work. A non-unique key pairs rows many-to-many and
+reports join artifacts as mismatches.
 
 ## Typical use: freeze a baseline before an in-place edit
 When you change a model's SQL rather than adding a `_new` copy, snapshot the

--- a/src/ol_dbt/README.md
+++ b/src/ol_dbt/README.md
@@ -178,9 +178,18 @@ columns and 7,826 rows as "missing" — all noise. The correct composite key rep
 the truth: one genuinely differing column, 8,891 rows, nothing missing on either
 side.
 
-If you are unsure of the grain, look for a `dbt_expectations_expect_compound_columns_to_be_unique`
-test on the model — its column list is the key you want. Failing that, a passing
-`unique` test on a single column means that column is safe to use alone.
+If you are unsure of the grain, look for a
+`dbt_expectations.expect_compound_columns_to_be_unique` test on the model — its
+column list is the key you want. (That dotted spelling is what appears in the model
+YAML; the underscored form only shows up in compiled test names, so grep for the
+dotted one.)
+
+Failing that, a single column is safe to use alone only if it has **both** a passing
+`unique` **and** a passing `not_null` test. `unique` on its own is not enough: dbt's
+`unique` test ignores NULLs, so a nullable column can pass it and still have NULL
+values — and the single-column comparison path joins with a plain `a.k = b.k`, which
+never matches NULL to NULL. Those rows land in the "missing from" buckets on both
+sides rather than pairing up.
 
 `--old-raw`/`--new-raw` treat that side as a literal existing table rather than a
 dbt model — required for a snapshot table (`ol-dbt local snapshot` output) or any

--- a/src/ol_dbt/README.md
+++ b/src/ol_dbt/README.md
@@ -132,11 +132,18 @@ the rebuild only reflects your code change), any reported mismatch can only come
 from your change — never from production data changing in the background.
 
 ```bash
-# Per-column mismatch rates require --primary-key (repeatable for a composite key)
+# Per-column mismatch rates require --primary-key
 ol-dbt diff --old m_old --new m_new --primary-key id
+
+# Composite key: comma-separated, or repeat the flag. These are equivalent.
+ol-dbt diff --old m_old --new m_new -k user_email,exam_created_on
+ol-dbt diff --old m_old --new m_new -k user_email -k exam_created_on
 
 # Exclude a known non-deterministic column (e.g. a load timestamp)
 ol-dbt diff --old m_old --new m_new -k id --exclude-columns _loaded_at
+
+# --exclude-columns takes the same two forms
+ol-dbt diff --old m_old --new m_new -k id --exclude-columns _loaded_at,_synced_at
 
 # Build both sides first, then compare
 ol-dbt diff --old m_old --new m_new --auto-build
@@ -151,6 +158,29 @@ ol-dbt diff --target dev_production \
 # Emit JSON (e.g. for CI); exits non-zero on any divergence
 ol-dbt diff --old m_old --new m_new -k id --format json
 ```
+
+#### Choosing the primary key
+
+`--primary-key` is how rows get paired across the two sides, so it has to be the
+model's **actual grain**. Pass every column of a composite key — either
+comma-separated (`-k a,b,c`) or by repeating the flag (`-k a -k b -k c`). The two
+forms are interchangeable.
+
+Note that `-k a b c` does **not** work. Only the first token is consumed as a key;
+the rest are read as positional arguments, so you get a confusing error about
+`--dbt-dir` rather than anything mentioning primary keys.
+
+Getting the grain right matters more than it looks. A key that is not unique pairs
+rows many-to-many, and the resulting mismatch counts are an artifact of the join
+rather than a real difference. For example, on a 20,908-row mart whose real grain is
+three columns, keying on just one of them reported 65,000+ mismatches across eight
+columns and 7,826 rows as "missing" — all noise. The correct composite key reported
+the truth: one genuinely differing column, 8,891 rows, nothing missing on either
+side.
+
+If you are unsure of the grain, look for a `dbt_expectations_expect_compound_columns_to_be_unique`
+test on the model — its column list is the key you want. Failing that, a passing
+`unique` test on a single column means that column is safe to use alone.
 
 `--old-raw`/`--new-raw` treat that side as a literal existing table rather than a
 dbt model — required for a snapshot table (`ol-dbt local snapshot` output) or any

--- a/src/ol_dbt/README.md
+++ b/src/ol_dbt/README.md
@@ -161,42 +161,35 @@ ol-dbt diff --old m_old --new m_new -k id --format json
 
 #### Choosing the primary key
 
-`--primary-key` is how rows get paired across the two sides, so it has to be the
-model's **actual grain**. Pass every column of a composite key — either
-comma-separated (`-k a,b,c`) or by repeating the flag (`-k a -k b -k c`). The two
-forms are interchangeable.
+`--primary-key` pairs rows across the two sides, so it has to be the model's
+**actual grain**. A non-unique key joins many-to-many and the mismatch counts
+become an artifact of the join rather than a real difference: on one 20,908-row
+mart, keying on a single column of a three-column grain reported 65,000+
+mismatches and 7,826 rows "missing", where the correct composite key found one
+genuinely differing column, 8,891 rows, and nothing missing.
 
-Note that `-k a b c` does **not** work. Only the first token is consumed as a key;
-the rest are read as positional arguments, so you get a confusing error about
-`--dbt-dir` rather than anything mentioning primary keys.
+Composite keys take either form, interchangeably:
 
-Repeated spellings of one column collapse (`-k id,ID` is just `id`), and the tool
-fails fast rather than degrading quietly in two cases: passing the flag with
-nothing usable in it (`-k ""`, `-k ","`) is an error rather than being read as "no
-key given", and a key column that is not present in both relations is reported by
-name — with the common column list — instead of surfacing later as a raw SQL
-"column not found".
+```
+-k a,b,c          # comma-separated
+-k a -k b -k c    # repeated flag
+```
 
-Getting the grain right matters more than it looks. A key that is not unique pairs
-rows many-to-many, and the resulting mismatch counts are an artifact of the join
-rather than a real difference. For example, on a 20,908-row mart whose real grain is
-three columns, keying on just one of them reported 65,000+ mismatches across eight
-columns and 7,826 rows as "missing" — all noise. The correct composite key reported
-the truth: one genuinely differing column, 8,891 rows, nothing missing on either
-side.
+`-k a b c` does **not** work — only `a` is read as a key, the rest are consumed
+as positional arguments, and the resulting error mentions `--dbt-dir` rather
+than primary keys.
 
-If you are unsure of the grain, look for a
-`dbt_expectations.expect_compound_columns_to_be_unique` test on the model — its
-column list is the key you want. (That dotted spelling is what appears in the model
-YAML; the underscored form only shows up in compiled test names, so grep for the
-dotted one.)
+To find the grain, look for a `dbt_expectations.expect_compound_columns_to_be_unique`
+test on the model; its column list is the key you want. (Grep the dotted
+spelling — the underscored form only appears in compiled test names.) Failing
+that, a single column is safe alone only with **both** a passing `unique` and a
+passing `not_null` test: `unique` ignores NULLs, and the single-column path joins
+on `a.k = b.k`, which never matches NULL to NULL, so those rows land in the
+"missing from" buckets on both sides instead of pairing up.
 
-Failing that, a single column is safe to use alone only if it has **both** a passing
-`unique` **and** a passing `not_null` test. `unique` on its own is not enough: dbt's
-`unique` test ignores NULLs, so a nullable column can pass it and still have NULL
-values — and the single-column comparison path joins with a plain `a.k = b.k`, which
-never matches NULL to NULL. Those rows land in the "missing from" buckets on both
-sides rather than pairing up.
+Duplicate spellings collapse (`-k id,ID` is just `id`), and the tool fails fast
+rather than degrading quietly on an empty key (`-k ""`, `-k ","`) or a key column
+absent from either relation (reported by name, with the common column list).
 
 `--old-raw`/`--new-raw` treat that side as a literal existing table rather than a
 dbt model — required for a snapshot table (`ol-dbt local snapshot` output) or any

--- a/src/ol_dbt/README.md
+++ b/src/ol_dbt/README.md
@@ -170,6 +170,13 @@ Note that `-k a b c` does **not** work. Only the first token is consumed as a ke
 the rest are read as positional arguments, so you get a confusing error about
 `--dbt-dir` rather than anything mentioning primary keys.
 
+Repeated spellings of one column collapse (`-k id,ID` is just `id`), and the tool
+fails fast rather than degrading quietly in two cases: passing the flag with
+nothing usable in it (`-k ""`, `-k ","`) is an error rather than being read as "no
+key given", and a key column that is not present in both relations is reported by
+name — with the common column list — instead of surfacing later as a raw SQL
+"column not found".
+
 Getting the grain right matters more than it looks. A key that is not unique pairs
 rows many-to-many, and the resulting mismatch counts are an artifact of the join
 rather than a real difference. For example, on a 20,908-row mart whose real grain is

--- a/src/ol_dbt/macros/diff_composite_key.sql
+++ b/src/ol_dbt/macros/diff_composite_key.sql
@@ -1,0 +1,46 @@
+{% macro diff_composite_key(field_list) %}
+  {{ return(adapter.dispatch('diff_composite_key', 'open_learning')(field_list)) }}
+{% endmacro %}
+
+{% macro default__diff_composite_key(field_list) %}
+{#-
+  Collapse a composite key into ONE unambiguous scalar join column, for
+  `ol-dbt diff`'s per-column comparison. audit_helper.compare_column_values
+  emits `a_query.{{ primary_key }} = b_query.{{ primary_key }}`, so it can only
+  join on a single column; this is what that column is built from.
+
+  Why not dbt_utils.generate_surrogate_key: it joins components with a literal
+  '-' before hashing, which does not encode component boundaries. It therefore
+  maps ('a-b', 'c') and ('a', 'b-c') to the SAME hash -- verified on dbt_utils
+  1.3.3 -- so two distinct keys would pair as one row and reintroduce exactly
+  the many-to-many mispairing the composite key is there to prevent.
+
+  Here each component is length-prefixed as `<len>:<value>`. Reading digits up
+  to the first ':' gives the length, and the next <len> characters are the value,
+  so no character inside a value can shift a boundary. The encoding is injective
+  regardless of whether the adapter's length() counts bytes or characters, since
+  both sides of any one comparison are computed by the same engine.
+
+  NULL renders as '~'. A non-null component always renders as '<digits>:<value>',
+  so a null can never collide with a real value. Nulls still PAIR (rather than
+  being dropped by a plain equi-join), which is what makes a diff on a nullable
+  key useful.
+
+  The '|' between components is for legibility only -- the length prefixes
+  already make the encoding unambiguous without it.
+-#}
+{%- set parts = [] -%}
+{%- for field in field_list -%}
+  {%- set value = "cast(" ~ field ~ " as " ~ dbt.type_string() ~ ")" -%}
+  {%- set encoded = dbt.concat([
+       "cast(" ~ dbt.length(value) ~ " as " ~ dbt.type_string() ~ ")",
+       "':'",
+       value,
+     ]) -%}
+  {%- do parts.append("case when " ~ field ~ " is null then '~' else " ~ encoded ~ " end") -%}
+  {%- if not loop.last -%}
+    {%- do parts.append("'|'") -%}
+  {%- endif -%}
+{%- endfor -%}
+{{ dbt.hash(dbt.concat(parts)) }}
+{% endmacro %}

--- a/src/ol_dbt_cli/ol_dbt_cli/commands/diff.py
+++ b/src/ol_dbt_cli/ol_dbt_cli/commands/diff.py
@@ -332,6 +332,25 @@ def _jinja_list(values: list[str]) -> str:
     return f"[{inner}]"
 
 
+# Alias for the synthetic single-column join key that stands in for a composite
+# primary key in the per-column comparison (see `_compare_column_sql`). Named to
+# be collision-proof against real warehouse columns.
+_SURROGATE_PK = "ol_dbt_diff_surrogate_key"
+
+
+def _pk_string(values: list[str]) -> str:
+    """Render primary key columns as a single quoted, comma-joined SQL fragment.
+
+    audit_helper takes ``primary_key`` as an opaque string it interpolates
+    straight into SQL, never as a list -- a Jinja list literal reaches the
+    database as the text ``['k1', 'k2']`` and fails to parse. For
+    ``compare_relations``/``compare_queries`` the only use is the ``order by``
+    of the ``summarize=false`` branch, where a comma-joined column list is
+    exactly right.
+    """
+    return f"'{', '.join(values)}'"
+
+
 def _relation_jinja(
     name: str,
     *,
@@ -374,10 +393,7 @@ def _compare_relations_sql(
     ``percent_of_total`` grouping; with ``summarize=False`` it returns the actual
     differing rows (used to sample mismatches).
     """
-    pk_arg = ""
-    if primary_key:
-        pk_repr = f"'{primary_key[0]}'" if len(primary_key) == 1 else _jinja_list(primary_key)
-        pk_arg = f", primary_key={pk_repr}"
+    pk_arg = f", primary_key={_pk_string(primary_key)}" if primary_key else ""
     exclude_arg = f", exclude_columns={_jinja_list(exclude_columns)}" if exclude_columns else ""
     a_expr = _relation_jinja(old, raw=old_raw, database=old_database, schema=old_schema)
     b_expr = _relation_jinja(new, raw=new_raw, database=new_database, schema=new_schema)
@@ -403,8 +419,21 @@ def _compare_column_sql(
     old_database: str | None = None,
     new_database: str | None = None,
 ) -> str:
-    """Build inline SQL calling ``audit_helper.compare_column_values`` for one column."""
-    pk = f"'{primary_key[0]}'" if len(primary_key) == 1 else _jinja_list(primary_key)
+    """Build inline SQL calling ``audit_helper.compare_column_values`` for one column.
+
+    ``compare_column_values`` supports only a *scalar* primary key: it emits
+    ``a_query.{{ primary_key }} = b_query.{{ primary_key }}`` (plus a coalesce
+    and several null checks), so the key has to be one column name that exists
+    in both queries. A composite key therefore cannot be passed through --
+    neither as a Jinja list (which reaches the database as the literal text
+    ``['k1', 'k2']``) nor comma-joined (``a.k1, k2 = b.k1, k2``).
+
+    For a composite key we instead synthesize a single hashed join column with
+    ``dbt_utils.generate_surrogate_key`` inside a_query/b_query and hand
+    audit_helper *that* column name. One side effect is better than the scalar
+    path: generate_surrogate_key coalesces nulls to a sentinel, so rows whose
+    key components are null still pair up, where a plain equi-join drops them.
+    """
     a_expr = _relation_jinja(old, raw=old_raw, database=old_database, schema=old_schema)
     b_expr = _relation_jinja(new, raw=new_raw, database=new_database, schema=new_schema)
     # Only the primary key(s) + the one column being compared are needed here --
@@ -412,7 +441,13 @@ def _compare_column_sql(
     # selecting every column (as this used to) forces that join to carry the
     # whole row width for a single-column comparison, which is needless I/O on
     # wide tables.
-    select_cols = ", ".join(dict.fromkeys([*primary_key, column]))
+    if len(primary_key) > 1:
+        pk = f"'{_SURROGATE_PK}'"
+        key_expr = f"{{{{ dbt_utils.generate_surrogate_key({_jinja_list(primary_key)}) }}}}"
+        select_cols = f"{key_expr} as {_SURROGATE_PK}, {column}"
+    else:
+        pk = f"'{primary_key[0]}'"
+        select_cols = ", ".join(dict.fromkeys([*primary_key, column]))
     # a_query/b_query are built with {% set %}/{% endset %} so `a_expr`/`b_expr`
     # (a ref()/api.Relation.create() call) are rendered by Jinja BEFORE
     # compare_column_values ever sees the string. Embedding `{{ ... }}` directly

--- a/src/ol_dbt_cli/ol_dbt_cli/commands/diff.py
+++ b/src/ol_dbt_cli/ol_dbt_cli/commands/diff.py
@@ -451,11 +451,18 @@ def _compare_column_sql(
     neither as a Jinja list (which reaches the database as the literal text
     ``['k1', 'k2']``) nor comma-joined (``a.k1, k2 = b.k1, k2``).
 
-    For a composite key we instead synthesize a single hashed join column with
-    ``dbt_utils.generate_surrogate_key`` inside a_query/b_query and hand
+    For a composite key we instead synthesize a single hashed join column with the
+    project's ``diff_composite_key`` macro inside a_query/b_query and hand
     audit_helper *that* column name. One side effect is better than the scalar
-    path: generate_surrogate_key coalesces nulls to a sentinel, so rows whose
-    key components are null still pair up, where a plain equi-join drops them.
+    path: the macro encodes nulls rather than dropping them, so rows whose key
+    components are null still pair up, where a plain equi-join drops them.
+
+    ``dbt_utils.generate_surrogate_key`` is deliberately NOT used here: it joins
+    components with a literal ``-`` before hashing, without encoding component
+    boundaries, so ``('a-b', 'c')`` and ``('a', 'b-c')`` hash identically
+    (verified on dbt_utils 1.3.3). That would pair two distinct keys as one row
+    and reintroduce the very mispairing a composite key exists to prevent.
+    ``diff_composite_key`` length-prefixes each component instead.
     """
     a_expr = _relation_jinja(old, raw=old_raw, database=old_database, schema=old_schema)
     b_expr = _relation_jinja(new, raw=new_raw, database=new_database, schema=new_schema)
@@ -466,7 +473,7 @@ def _compare_column_sql(
     # wide tables.
     if len(primary_key) > 1:
         pk = f"'{_SURROGATE_PK}'"
-        key_expr = f"{{{{ dbt_utils.generate_surrogate_key({_jinja_list(primary_key)}) }}}}"
+        key_expr = f"{{{{ diff_composite_key({_jinja_list(primary_key)}) }}}}"
         select_cols = f"{key_expr} as {_SURROGATE_PK}, {column}"
     else:
         pk = f"'{primary_key[0]}'"

--- a/src/ol_dbt_cli/ol_dbt_cli/commands/diff.py
+++ b/src/ol_dbt_cli/ol_dbt_cli/commands/diff.py
@@ -70,6 +70,29 @@ class InvalidIdentifierError(ValueError):
     """Raised when a user-supplied name is not a safe dbt identifier."""
 
 
+def _split_columns(values: tuple[str, ...]) -> list[str]:
+    """Flatten repeated and comma-separated column arguments into one list.
+
+    Cyclopts consumes exactly one token per flag occurrence, so the repeatable
+    form (``-k a -k b``) is the only one it understands natively; ``-k a b`` puts
+    ``b`` in the next positional parameter instead. Accepting commas as well means
+    ``-k a,b`` and ``-k a -k b`` are equivalent, which is what most people try
+    first for a composite key.
+
+    Order is preserved and duplicates are dropped -- a repeated key column would
+    otherwise be emitted twice into the surrogate-key expression. Empty segments
+    (a trailing comma, ``-k ""``) are discarded rather than passed on to
+    :func:`_validate_identifiers` as a confusing empty-identifier error.
+    """
+    out: list[str] = []
+    for value in values:
+        for part in value.split(","):
+            cleaned = part.strip()
+            if cleaned and cleaned not in out:
+                out.append(cleaned)
+    return out
+
+
 def _validate_identifiers(kind: str, names: list[str]) -> None:
     """Reject any *names* that are not plain dbt identifiers.
 
@@ -681,8 +704,10 @@ def diff(
             name=["--primary-key", "-k"],
             help=(
                 "Column(s) uniquely identifying a row, used as the comparison join key. "
-                "Repeatable. Required for per-column mismatch rates. Use this for models with "
-                "known surrogate-key non-determinism (e.g. dim_user.user_pk email-keyed collapse)."
+                "For a composite key pass a comma-separated list (-k a,b,c) or repeat the flag "
+                "(-k a -k b -k c); note that '-k a b c' does NOT work, since only the first "
+                "token is consumed. Required for per-column mismatch rates. Use this for models "
+                "with known surrogate-key non-determinism (e.g. dim_user.user_pk email-keyed collapse)."
             ),
         ),
     ] = (),
@@ -690,7 +715,8 @@ def diff(
         tuple[str, ...],
         Parameter(
             name=["--exclude-columns"],
-            help="Column(s) to exclude from the comparison (e.g. non-deterministic load timestamps). Repeatable.",
+            help="Column(s) to exclude from the comparison (e.g. non-deterministic load timestamps). "
+            "Comma-separated (--exclude-columns a,b) or repeatable, same as --primary-key.",
         ),
     ] = (),
     output_format: Annotated[
@@ -763,6 +789,13 @@ def diff(
         Compare an old mart against its migrated replacement on local DuckDB:
             ol-dbt diff --old dim_user_old --new dim_user --primary-key user_pk
 
+        Use the model's real grain when no single column is unique. A composite key is
+        comma-separated, or the flag repeated -- these two are equivalent, and getting it
+        right matters: a single non-unique key pairs rows many-to-many and reports
+        mismatches that are an artifact of the join rather than a real difference.
+            ol-dbt diff --old m_old --new m_new -k user_email,exam_created_on
+            ol-dbt diff --old m_old --new m_new -k user_email -k exam_created_on
+
         Exclude a non-deterministic column and emit JSON for CI:
             ol-dbt diff --old m_old --new m_new -k id --exclude-columns _loaded_at --format json
 
@@ -785,8 +818,8 @@ def diff(
 
     """
     new = new or old
-    primary_key_list = list(primary_key)
-    exclude_list = list(exclude_columns)
+    primary_key_list = _split_columns(primary_key)
+    exclude_list = _split_columns(exclude_columns)
     notes: list[str] = []
 
     if (old_schema or old_database) and not old_raw:

--- a/src/ol_dbt_cli/ol_dbt_cli/commands/diff.py
+++ b/src/ol_dbt_cli/ol_dbt_cli/commands/diff.py
@@ -80,17 +80,43 @@ def _split_columns(values: tuple[str, ...]) -> list[str]:
     first for a composite key.
 
     Order is preserved and duplicates are dropped -- a repeated key column would
-    otherwise be emitted twice into the surrogate-key expression. Empty segments
-    (a trailing comma, ``-k ""``) are discarded rather than passed on to
-    :func:`_validate_identifiers` as a confusing empty-identifier error.
+    otherwise be emitted twice into the surrogate-key expression, and would
+    needlessly push a single-column key onto the composite path. Matching is
+    case-INSENSITIVE, because unquoted warehouse identifiers are and the rest of
+    this path already treats them that way (see ``_validate_identifiers`` and the
+    ``pk_lower`` filter in :func:`diff`); the first spelling seen is the one kept,
+    since that is what the user wrote and what the emitted SQL should say.
+
+    Empty segments (a trailing comma, ``-k ""``, ``-k ","``) are dropped here
+    rather than reaching :func:`_validate_identifiers` as a confusing
+    empty-identifier error. Dropping them means an all-empty value flattens to
+    ``[]``, which is indistinguishable from the option never being passed -- so
+    the caller must reject that case explicitly rather than silently treating it
+    as "no key given". See :func:`_require_non_empty`.
     """
     out: list[str] = []
+    seen: set[str] = set()
     for value in values:
         for part in value.split(","):
             cleaned = part.strip()
-            if cleaned and cleaned not in out:
+            if cleaned and cleaned.lower() not in seen:
+                seen.add(cleaned.lower())
                 out.append(cleaned)
     return out
+
+
+def _require_non_empty(kind: str, flag: str, given: tuple[str, ...], flattened: list[str]) -> None:
+    """Reject a column-list option that was supplied but held no usable names.
+
+    ``-k ""`` and ``-k ","`` flatten to nothing. Treating that as "not supplied"
+    would silently skip the per-column comparison the user explicitly asked for
+    (or silently exclude nothing), where before comma-splitting existed the empty
+    string simply failed identifier validation. Silent degradation is worse than a
+    loud error for a tool whose output is meant to be trusted, so this fails.
+    """
+    if given and not flattened:
+        msg = f"{flag} was given but contains no column names (values: {', '.join(repr(g) for g in given)})."
+        raise InvalidIdentifierError(msg)
 
 
 def _validate_identifiers(kind: str, names: list[str]) -> None:
@@ -867,6 +893,8 @@ def diff(
 
     # Validate every value interpolated into inline Jinja SQL before use.
     try:
+        _require_non_empty("primary key", "--primary-key", primary_key, primary_key_list)
+        _require_non_empty("excluded column", "--exclude-columns", exclude_columns, exclude_list)
         _validate_identifiers("model name", [old, new])
         _validate_identifiers("primary key", primary_key_list)
         _validate_identifiers("excluded column", exclude_list)
@@ -964,6 +992,23 @@ def diff(
             else unresolved_note.format(new)
         )
     recon = reconcile_columns(old_cols, new_cols, set(exclude_list))
+
+    # A mistyped --primary-key is a valid identifier, so identifier validation
+    # cannot catch it; without this it reaches the warehouse and comes back as a
+    # raw "column not found" SQL error with no hint that the key is at fault.
+    # Composite keys multiply the typo surface, so name the offenders here. Only
+    # meaningful when the column set actually resolved -- an unresolved set is
+    # "unknown", not "empty", and must not be read as "the key does not exist".
+    if primary_key_list and old_cols and new_cols:
+        known = {c.lower() for c in old_cols} & {c.lower() for c in new_cols}
+        unknown = [k for k in primary_key_list if k.lower() not in known]
+        if unknown:
+            err_console.print(
+                f"[red]Error:[/] --primary-key column(s) not present in both relations: "
+                f"{', '.join(repr(u) for u in unknown)}."
+            )
+            err_console.print(f"[dim]Columns common to both: {', '.join(sorted(known))}[/]")
+            sys.exit(1)
 
     # When a column set can't be resolved statically, the schema-divergence gate
     # cannot run — an empty reconciliation is "unverified", NOT "verified equal".

--- a/src/ol_dbt_cli/ol_dbt_cli/commands/diff.py
+++ b/src/ol_dbt_cli/ol_dbt_cli/commands/diff.py
@@ -355,10 +355,35 @@ def _jinja_list(values: list[str]) -> str:
     return f"[{inner}]"
 
 
-# Alias for the synthetic single-column join key that stands in for a composite
-# primary key in the per-column comparison (see `_compare_column_sql`). Named to
-# be collision-proof against real warehouse columns.
+# Base alias for the synthetic single-column join key that stands in for a
+# composite primary key in the per-column comparison (see `_compare_column_sql`).
+# Deliberately tool-namespaced, but see `_surrogate_alias` -- "unlikely to
+# collide" is not the same as "cannot", and the collision failed silently.
 _SURROGATE_PK = "ol_dbt_diff_surrogate_key"
+
+
+def _surrogate_alias(taken: list[str]) -> str:
+    """Pick a surrogate-key alias that cannot collide with a real column name.
+
+    If the compared column is itself called ``ol_dbt_diff_surrogate_key``, the
+    emitted select would carry that identifier twice -- once for the generated
+    key, once for the real column -- and audit_helper would then use the same
+    name as both ``primary_key`` and ``column_to_compare``. DuckDB does not
+    reject that: it binds to the *first* match, so the comparison compares the
+    generated key against itself and reports a perfect match no matter how much
+    the real values differ. A silent false negative is the worst outcome for a
+    tool whose job is detecting differences, so the alias is derived rather than
+    assumed safe.
+
+    Matching is case-insensitive because warehouse identifiers are. The ``_x``
+    suffix keeps the result a plain identifier, so it still satisfies
+    :data:`_IDENTIFIER_RE`.
+    """
+    taken_lower = {t.lower() for t in taken}
+    alias = _SURROGATE_PK
+    while alias.lower() in taken_lower:
+        alias += "_x"
+    return alias
 
 
 def _pk_string(values: list[str]) -> str:
@@ -472,9 +497,13 @@ def _compare_column_sql(
     # whole row width for a single-column comparison, which is needless I/O on
     # wide tables.
     if len(primary_key) > 1:
-        pk = f"'{_SURROGATE_PK}'"
+        # Guard against every identifier that could appear alongside the alias --
+        # `column` is the only other one emitted today, but including the key
+        # columns keeps this correct if they are ever selected again.
+        alias = _surrogate_alias([*primary_key, column])
+        pk = f"'{alias}'"
         key_expr = f"{{{{ diff_composite_key({_jinja_list(primary_key)}) }}}}"
-        select_cols = f"{key_expr} as {_SURROGATE_PK}, {column}"
+        select_cols = f"{key_expr} as {alias}, {column}"
     else:
         pk = f"'{primary_key[0]}'"
         select_cols = ", ".join(dict.fromkeys([*primary_key, column]))

--- a/src/ol_dbt_cli/tests/test_diff.py
+++ b/src/ol_dbt_cli/tests/test_diff.py
@@ -19,6 +19,8 @@ from ol_dbt_cli.commands.diff import (
     _resolve_raw_columns,
     _split_columns,
     _summarize_relations,
+    _surrogate_alias,
+    _validate_identifiers,
     diff,
     reconcile_columns,
 )
@@ -207,6 +209,43 @@ class TestSplitColumns:
         assert _split_columns(()) == []
 
 
+class TestSurrogateAlias:
+    """The synthetic join-key alias must never collide with a real column."""
+
+    def test_default_alias_when_nothing_collides(self) -> None:
+        assert _surrogate_alias(["k1", "k2", "some_col"]) == "ol_dbt_diff_surrogate_key"
+
+    def test_collision_with_compared_column_is_avoided(self) -> None:
+        # A model column actually named ol_dbt_diff_surrogate_key would otherwise
+        # be emitted twice; audit_helper would bind primary_key and
+        # column_to_compare to the same identifier and DuckDB silently resolves
+        # to the FIRST match -- comparing the generated key against itself and
+        # reporting a perfect match however much the real values differ.
+        alias = _surrogate_alias(["k1", "k2", "ol_dbt_diff_surrogate_key"])
+        assert alias != "ol_dbt_diff_surrogate_key"
+
+    def test_collision_check_is_case_insensitive(self) -> None:
+        # Warehouse identifiers are case-insensitive, so an upper/mixed-case
+        # column still collides.
+        for name in ("OL_DBT_DIFF_SURROGATE_KEY", "Ol_Dbt_Diff_Surrogate_Key"):
+            assert _surrogate_alias(["k1", name]).lower() != name.lower()
+
+    def test_collision_with_a_key_column_is_avoided(self) -> None:
+        alias = _surrogate_alias(["ol_dbt_diff_surrogate_key", "k2", "some_col"])
+        assert alias != "ol_dbt_diff_surrogate_key"
+
+    def test_escalates_until_free(self) -> None:
+        # Pathological but must terminate on a distinct, still-valid identifier.
+        taken = ["ol_dbt_diff_surrogate_key", "ol_dbt_diff_surrogate_key_x"]
+        alias = _surrogate_alias(taken)
+        assert alias == "ol_dbt_diff_surrogate_key_x_x"
+
+    def test_result_is_always_a_plain_identifier(self) -> None:
+        # Must keep satisfying _validate_identifiers' pattern.
+        taken = ["ol_dbt_diff_surrogate_key", "ol_dbt_diff_surrogate_key_x"]
+        _validate_identifiers("primary key", [_surrogate_alias(taken)])
+
+
 class TestSqlBuilders:
     def test_jinja_list(self) -> None:
         assert _jinja_list(["a", "b"]) == "['a', 'b']"
@@ -315,6 +354,16 @@ class TestRelationJinja:
         sql = _compare_column_sql("old_m", "new_m", ["k1", "k2"], "some_col")
         select_clause = "select {{ diff_composite_key(['k1', 'k2']) }} as ol_dbt_diff_surrogate_key, some_col from"
         assert sql.count(select_clause) == 2
+
+    def test_compare_column_sql_alias_does_not_shadow_the_compared_column(self) -> None:
+        # Regression for the silent false negative: comparing a column that is
+        # itself named ol_dbt_diff_surrogate_key must not emit that identifier
+        # twice in one select.
+        sql = _compare_column_sql("old_m", "new_m", ["k1", "k2"], "ol_dbt_diff_surrogate_key")
+        assert "as ol_dbt_diff_surrogate_key," not in sql
+        assert "as ol_dbt_diff_surrogate_key_x, ol_dbt_diff_surrogate_key" in sql
+        assert "primary_key='ol_dbt_diff_surrogate_key_x'" in sql
+        assert "column_to_compare='ol_dbt_diff_surrogate_key'" in sql
 
     def test_compare_column_sql_single_pk_keeps_the_real_column(self) -> None:
         # No surrogate for a single key -- the real column joins directly.

--- a/src/ol_dbt_cli/tests/test_diff.py
+++ b/src/ol_dbt_cli/tests/test_diff.py
@@ -180,9 +180,14 @@ class TestSqlBuilders:
         assert "exclude_columns=['_loaded_at']" in sql
         assert "summarize=true" in sql
 
-    def test_compare_relations_composite_pk(self) -> None:
+    def test_compare_relations_composite_pk_is_comma_joined_not_a_jinja_list(self) -> None:
+        # audit_helper interpolates primary_key straight into the summarize=false
+        # `order by`, so a Jinja list reaches the database as the literal text
+        # `['k1', 'k2']` and fails to parse. A comma-joined column list is the
+        # only form that renders to valid SQL there.
         sql = _compare_relations_sql("a", "b", ["k1", "k2"], [], summarize=False)
-        assert "primary_key=['k1', 'k2']" in sql
+        assert "primary_key='k1, k2'" in sql
+        assert "['k1', 'k2']" not in sql
         assert "summarize=false" in sql
 
     def test_compare_relations_no_pk(self) -> None:
@@ -250,6 +255,31 @@ class TestRelationJinja:
         sql = _compare_column_sql("old_m", "new_m", ["id"], "some_col")
         assert "select id, some_col from" in sql
         assert "select *" not in sql
+
+    def test_compare_column_sql_composite_pk_uses_a_surrogate_join_key(self) -> None:
+        # compare_column_values only supports a scalar primary key -- it emits
+        # `a_query.{{ primary_key }} = b_query.{{ primary_key }}`. A composite key
+        # is collapsed into one hashed column inside a_query/b_query instead, so no
+        # Jinja list (or comma-joined list) ever lands in the emitted SQL.
+        sql = _compare_column_sql("old_m", "new_m", ["k1", "k2"], "some_col")
+        assert "primary_key='ol_dbt_diff_surrogate_key'" in sql
+        assert "{{ dbt_utils.generate_surrogate_key(['k1', 'k2']) }} as ol_dbt_diff_surrogate_key" in sql
+        assert "primary_key=['k1', 'k2']" not in sql
+        assert "primary_key='k1, k2'" not in sql
+
+    def test_compare_column_sql_composite_pk_selects_key_on_both_sides(self) -> None:
+        # The surrogate must exist in a_query AND b_query for the join to resolve.
+        sql = _compare_column_sql("old_m", "new_m", ["k1", "k2"], "some_col")
+        select_clause = (
+            "select {{ dbt_utils.generate_surrogate_key(['k1', 'k2']) }} as ol_dbt_diff_surrogate_key, some_col from"
+        )
+        assert sql.count(select_clause) == 2
+
+    def test_compare_column_sql_single_pk_keeps_the_real_column(self) -> None:
+        # No surrogate for a single key -- the real column joins directly.
+        sql = _compare_column_sql("old_m", "new_m", ["id"], "some_col")
+        assert "primary_key='id'" in sql
+        assert "surrogate_key" not in sql
 
 
 class TestCompareSingleColumn:

--- a/src/ol_dbt_cli/tests/test_diff.py
+++ b/src/ol_dbt_cli/tests/test_diff.py
@@ -9,6 +9,7 @@ import pytest
 
 from ol_dbt_cli.commands import diff as diff_mod
 from ol_dbt_cli.commands.diff import (
+    InvalidIdentifierError,
     Verdict,
     _compare_column_sql,
     _compare_relations_sql,
@@ -16,6 +17,7 @@ from ol_dbt_cli.commands.diff import (
     _format_sample_mismatches,
     _jinja_list,
     _relation_jinja,
+    _require_non_empty,
     _resolve_raw_columns,
     _split_columns,
     _summarize_relations,
@@ -207,6 +209,51 @@ class TestSplitColumns:
 
     def test_no_arguments(self) -> None:
         assert _split_columns(()) == []
+
+
+class TestSplitColumnsCaseInsensitivity:
+    """Warehouse identifiers are case-insensitive; dedup must match that."""
+
+    def test_case_differing_duplicates_are_collapsed(self) -> None:
+        # `-k id,ID` previously emitted the column twice AND pushed a single-column
+        # key onto the composite path.
+        assert _split_columns(("id,ID",)) == ["id"]
+
+    def test_first_spelling_is_the_one_kept(self) -> None:
+        # The user's spelling is what should reach the emitted SQL.
+        assert _split_columns(("ID,id",)) == ["ID"]
+        assert _split_columns(("Id", "iD")) == ["Id"]
+
+    def test_case_dedup_across_separate_flags(self) -> None:
+        assert _split_columns(("id", "ID")) == ["id"]
+
+    def test_a_case_duplicate_collapses_to_the_single_key_path(self) -> None:
+        # Consequence of the above: one real column must not take the composite path.
+        sql = _compare_column_sql("old_m", "new_m", _split_columns(("id,ID",)), "some_col")
+        assert "primary_key='id'" in sql
+        assert "diff_composite_key" not in sql
+
+    def test_distinct_names_are_not_collapsed(self) -> None:
+        assert _split_columns(("k1,K2",)) == ["k1", "K2"]
+
+
+class TestRequireNonEmpty:
+    """An option supplied but empty must fail, not silently mean "not supplied"."""
+
+    @pytest.mark.parametrize("given", [("",), (",",), (" ",), ("", ""), (" , ",)])
+    def test_supplied_but_empty_is_rejected(self, given: tuple[str, ...]) -> None:
+        with pytest.raises(InvalidIdentifierError):
+            _require_non_empty("primary key", "--primary-key", given, _split_columns(given))
+
+    def test_not_supplied_is_fine(self) -> None:
+        _require_non_empty("primary key", "--primary-key", (), [])
+
+    def test_supplied_and_usable_is_fine(self) -> None:
+        _require_non_empty("primary key", "--primary-key", ("a,b",), _split_columns(("a,b",)))
+
+    def test_error_names_the_flag_and_the_offending_values(self) -> None:
+        with pytest.raises(InvalidIdentifierError, match="--primary-key"):
+            _require_non_empty("primary key", "--primary-key", ("",), [])
 
 
 class TestSurrogateAlias:
@@ -610,6 +657,52 @@ class TestDiffCommand:
         assert "exclude_columns=['a', 'b']" in relations[0]
         # Both excluded, so nothing is left to compare per-column.
         assert not [q for q in seen if "compare_column_values" in q]
+
+    def test_empty_primary_key_exits_1_instead_of_silently_skipping(self, tmp_path: Path) -> None:
+        # `-k ""` must not degrade into "no --primary-key given", which would
+        # silently skip the per-column comparison the user asked for.
+        dbt_dir = _make_project(tmp_path, "select 1 as id", "select 1 as id")
+        with pytest.raises(SystemExit) as exc:
+            diff(old="m_old", new="m_new", primary_key=("",), dbt_dir_path=str(dbt_dir))
+        assert exc.value.code == 1
+
+    def test_empty_exclude_columns_exits_1(self, tmp_path: Path) -> None:
+        dbt_dir = _make_project(tmp_path, "select 1 as id", "select 1 as id")
+        with pytest.raises(SystemExit) as exc:
+            diff(old="m_old", new="m_new", exclude_columns=(",",), dbt_dir_path=str(dbt_dir))
+        assert exc.value.code == 1
+
+    def test_unknown_primary_key_column_exits_1_before_any_warehouse_call(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # A typo is a valid identifier, so identifier validation cannot catch it;
+        # without this guard it reaches the warehouse as a raw column-not-found error.
+        dbt_dir = _make_project(tmp_path, "select 1 as id, 'x' as name", "select 1 as id, 'x' as name")
+        called: list[str] = []
+
+        def fake_show(*a: Any, **k: Any) -> list[dict[str, Any]]:
+            called.append("ran")
+            return []
+
+        monkeypatch.setattr(diff_mod, "_run_dbt_show", fake_show)
+        with pytest.raises(SystemExit) as exc:
+            diff(old="m_old", new="m_new", primary_key=("idd",), dbt_dir_path=str(dbt_dir))
+        assert exc.value.code == 1
+        assert called == []
+
+    def test_known_primary_key_accepted_case_insensitively(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # The guard must not reject a correct key spelled in a different case.
+        dbt_dir = _make_project(tmp_path, "select 1 as id, 'x' as name", "select 1 as id, 'x' as name")
+
+        def fake_show(inline_sql: str, *a: Any, **k: Any) -> list[dict[str, Any]]:
+            if "compare_column_values" in inline_sql:
+                return [{"match_status": "✅: perfect match", "count_records": 1}]
+            return [{"in_a": True, "in_b": True, "count": 1}]
+
+        monkeypatch.setattr(diff_mod, "_run_dbt_show", fake_show)
+        diff(old="m_old", new="m_new", primary_key=("ID",), dbt_dir_path=str(dbt_dir))
 
     def test_row_mismatch_exits_1(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         dbt_dir = _make_project(

--- a/src/ol_dbt_cli/tests/test_diff.py
+++ b/src/ol_dbt_cli/tests/test_diff.py
@@ -302,16 +302,18 @@ class TestRelationJinja:
         # Jinja list (or comma-joined list) ever lands in the emitted SQL.
         sql = _compare_column_sql("old_m", "new_m", ["k1", "k2"], "some_col")
         assert "primary_key='ol_dbt_diff_surrogate_key'" in sql
-        assert "{{ dbt_utils.generate_surrogate_key(['k1', 'k2']) }} as ol_dbt_diff_surrogate_key" in sql
+        # Must NOT be dbt_utils.generate_surrogate_key -- it joins components with
+        # a literal '-' without encoding boundaries, so ('a-b','c') and ('a','b-c')
+        # collide and would pair two distinct keys as one row.
+        assert "generate_surrogate_key" not in sql
+        assert "{{ diff_composite_key(['k1', 'k2']) }} as ol_dbt_diff_surrogate_key" in sql
         assert "primary_key=['k1', 'k2']" not in sql
         assert "primary_key='k1, k2'" not in sql
 
     def test_compare_column_sql_composite_pk_selects_key_on_both_sides(self) -> None:
         # The surrogate must exist in a_query AND b_query for the join to resolve.
         sql = _compare_column_sql("old_m", "new_m", ["k1", "k2"], "some_col")
-        select_clause = (
-            "select {{ dbt_utils.generate_surrogate_key(['k1', 'k2']) }} as ol_dbt_diff_surrogate_key, some_col from"
-        )
+        select_clause = "select {{ diff_composite_key(['k1', 'k2']) }} as ol_dbt_diff_surrogate_key, some_col from"
         assert sql.count(select_clause) == 2
 
     def test_compare_column_sql_single_pk_keeps_the_real_column(self) -> None:
@@ -505,7 +507,7 @@ class TestDiffCommand:
         # Only `name` is compared -- both key columns were recognised as keys.
         assert len(seen) == 1
         assert "column_to_compare='name'" in seen[0]
-        assert "generate_surrogate_key(['k1', 'k2'])" in seen[0]
+        assert "diff_composite_key(['k1', 'k2'])" in seen[0]
 
     def test_comma_and_repeated_primary_key_produce_identical_sql(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch

--- a/src/ol_dbt_cli/tests/test_diff.py
+++ b/src/ol_dbt_cli/tests/test_diff.py
@@ -17,6 +17,7 @@ from ol_dbt_cli.commands.diff import (
     _jinja_list,
     _relation_jinja,
     _resolve_raw_columns,
+    _split_columns,
     _summarize_relations,
     diff,
     reconcile_columns,
@@ -166,6 +167,44 @@ class TestFormatSampleMismatches:
         ]
         lines = _format_sample_mismatches(rows, ["id"], "old_side", "new_side")
         assert lines == ["id=3: only in old_side (+1 more rows in this key group, not shown)"]
+
+
+class TestSplitColumns:
+    """Comma-separated and repeated column arguments must be equivalent."""
+
+    def test_repeated_flags(self) -> None:
+        assert _split_columns(("a", "b", "c")) == ["a", "b", "c"]
+
+    def test_comma_separated_single_token(self) -> None:
+        assert _split_columns(("a,b,c",)) == ["a", "b", "c"]
+
+    def test_comma_and_repeat_are_equivalent(self) -> None:
+        assert _split_columns(("a,b,c",)) == _split_columns(("a", "b", "c"))
+
+    def test_mixed_forms(self) -> None:
+        assert _split_columns(("a,b", "c")) == ["a", "b", "c"]
+
+    def test_surrounding_whitespace_is_stripped(self) -> None:
+        # `-k "a, b"` is a single shell token; the space must not become part of
+        # the identifier, or _validate_identifiers rejects a legitimate key.
+        assert _split_columns(("a, b",)) == ["a", "b"]
+
+    def test_order_is_preserved(self) -> None:
+        assert _split_columns(("z,a,m",)) == ["z", "a", "m"]
+
+    def test_duplicates_dropped_so_a_key_is_not_emitted_twice(self) -> None:
+        assert _split_columns(("a,b,a",)) == ["a", "b"]
+        assert _split_columns(("a", "a")) == ["a"]
+
+    def test_empty_segments_discarded(self) -> None:
+        # A trailing comma or an empty value must not reach _validate_identifiers
+        # as an empty-string identifier.
+        assert _split_columns(("a,",)) == ["a"]
+        assert _split_columns(("a,,b",)) == ["a", "b"]
+        assert _split_columns(("",)) == []
+
+    def test_no_arguments(self) -> None:
+        assert _split_columns(()) == []
 
 
 class TestSqlBuilders:
@@ -440,6 +479,86 @@ class TestDiffCommand:
         diff(old="m_old", new="m_new", primary_key=("id",), dbt_dir_path=str(dbt_dir))
         assert len(compared) == 1
         assert "column_to_compare='name'" in compared[0]
+
+    def test_comma_separated_primary_key_reaches_comparison_as_composite(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # End-to-end through the CLI entrypoint: `-k a,b` must behave exactly like
+        # `-k a -k b`, i.e. produce the composite surrogate-key join rather than a
+        # single key named "a,b" (which _validate_identifiers would reject).
+        dbt_dir = _make_project(
+            tmp_path,
+            "select 1 as k1, 2 as k2, 'x' as name",
+            "select 1 as k1, 2 as k2, 'x' as name",
+        )
+        seen: list[str] = []
+
+        def fake_show(inline_sql: str, *a: Any, **k: Any) -> list[dict[str, Any]]:
+            if "compare_column_values" in inline_sql:
+                seen.append(inline_sql)
+                return [{"match_status": "✅: perfect match", "count_records": 10}]
+            return [{"in_a": True, "in_b": True, "count": 10}]
+
+        monkeypatch.setattr(diff_mod, "_run_dbt_show", fake_show)
+        diff(old="m_old", new="m_new", primary_key=("k1,k2",), dbt_dir_path=str(dbt_dir))
+
+        # Only `name` is compared -- both key columns were recognised as keys.
+        assert len(seen) == 1
+        assert "column_to_compare='name'" in seen[0]
+        assert "generate_surrogate_key(['k1', 'k2'])" in seen[0]
+
+    def test_comma_and_repeated_primary_key_produce_identical_sql(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        dbt_dir = _make_project(
+            tmp_path,
+            "select 1 as k1, 2 as k2, 'x' as name",
+            "select 1 as k1, 2 as k2, 'x' as name",
+        )
+
+        def run(pk: tuple[str, ...]) -> list[str]:
+            captured: list[str] = []
+
+            def fake_show(inline_sql: str, *a: Any, **k: Any) -> list[dict[str, Any]]:
+                captured.append(inline_sql)
+                if "compare_column_values" in inline_sql:
+                    return [{"match_status": "✅: perfect match", "count_records": 10}]
+                return [{"in_a": True, "in_b": True, "count": 10}]
+
+            monkeypatch.setattr(diff_mod, "_run_dbt_show", fake_show)
+            diff(old="m_old", new="m_new", primary_key=pk, dbt_dir_path=str(dbt_dir))
+            return captured
+
+        assert run(("k1,k2",)) == run(("k1", "k2"))
+
+    def test_comma_separated_exclude_columns_are_all_excluded(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        dbt_dir = _make_project(
+            tmp_path,
+            "select 1 as id, 'x' as a, 'y' as b",
+            "select 1 as id, 'x' as a, 'y' as b",
+        )
+        seen: list[str] = []
+
+        def fake_show(inline_sql: str, *a: Any, **k: Any) -> list[dict[str, Any]]:
+            seen.append(inline_sql)
+            if "compare_column_values" in inline_sql:
+                return [{"match_status": "✅: perfect match", "count_records": 10}]
+            return [{"in_a": True, "in_b": True, "count": 10}]
+
+        monkeypatch.setattr(diff_mod, "_run_dbt_show", fake_show)
+        diff(
+            old="m_old",
+            new="m_new",
+            primary_key=("id",),
+            exclude_columns=("a,b",),
+            dbt_dir_path=str(dbt_dir),
+        )
+        relations = [q for q in seen if "compare_relations" in q]
+        assert "exclude_columns=['a', 'b']" in relations[0]
+        # Both excluded, so nothing is left to compare per-column.
+        assert not [q for q in seen if "compare_column_values" in q]
 
     def test_row_mismatch_exits_1(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         dbt_dir = _make_project(


### PR DESCRIPTION
### What are the relevant tickets?

No GitHub issue — this was tracked in the internal task graph (`tk-ol-dbt-diff-composite-primary-key-generates-inva-617789`, `tk-ol-dbt-diff-k-a-b-c-space-separated-truncates-th-65117e`).

Context, not closed by this PR: discovered while validating #2088 (migrate `marts__micromasters_dedp_exam_grades` to the dimensional layer). That migration needs a trustworthy diff on the mart's real grain, which is what this unblocks.

### Description (What does it do?)

Makes composite `--primary-key` work in `ol-dbt diff`. Passing the flag more than once previously died with a SQL parser error:

```
Parser Error: syntax error at or near "["
LINE 14: coalesce(a_query.['user_micromasters_email', 'user_mitxonline_email', 'proct...
```

**Root cause.** `audit_helper` takes `primary_key` as an *opaque string it interpolates straight into SQL*, never as a list. The Jinja list literal we were building reached the database as the literal text `['k1', 'k2']`. Two call sites were affected, and they need *different* forms:

| Consumer | Uses `primary_key` as | Fix |
|---|---|---|
| [`compare_column_values`](https://github.com/dbt-labs/dbt-audit-helper/blob/main/macros/compare_column_values.sql) | `a_query.{{ pk }} = b_query.{{ pk }}` — a **scalar** column present in both queries | Collapse the composite key into one hashed join column via the new `diff_composite_key` macro inside the `a_query`/`b_query` blocks, and pass that column's name |
| [`compare_queries`](https://github.com/dbt-labs/dbt-audit-helper/blob/main/macros/compare_queries.sql) (via `compare_relations`) | interpolated into `order by` on the `summarize=false` branch | Render comma-joined (`primary_key='k1, k2'`) |

The second one is worth flagging for reviewers: the bug report assumed `compare_relations` was fine. It isn't. `primary_key` is unused when `summarize=true` (which is why row counts looked healthy), but the `summarize=false` sample path renders `order by ['k1', 'k2'], in_a desc`. Same parser error, only reached once a diff actually has unmatched rows to sample — so it would have come back as a separate bug report later.

**Second commit** accepts a comma-separated key. Cyclopts consumes exactly one token per flag occurrence, so `-k a -k b -k c` was the only way to express a composite key, and the two forms people reach for first both failed with errors that never mentioned primary keys:

- `-k a b c` → `Cannot specify token "b" positionally for parameter dbt-dir`, or with `old`/`new` positional, `dbt project not found at <repo>/b` — the stray token is absorbed as `dbt_dir_path` and the key list silently truncates to one column.
- `-k "a,b,c"` → `Invalid primary key: 'a,b,c'` (correctly loud, since `_IDENTIFIER_RE` rejects the comma, but it turns away a form most CLIs accept).

`_split_columns()` now flattens both repeated and comma-separated arguments for `--primary-key` and `--exclude-columns`, so `-k a,b,c` ≡ `-k a -k b -k c`. Order preserved, duplicates dropped (a repeated key column would otherwise be emitted twice into the surrogate-key expression), empty segments discarded rather than surfacing as an empty-identifier error.

`-k a b c` still cannot be made to work — that's cyclopts' arity, not ours — so the help text, docstring, and docs now say so explicitly rather than leaving people to hit the `--dbt-dir` error.

**Why this matters beyond the crash.** The correct grain for many marts *is* composite, and the single-column fallback the tool forced isn't a lesser answer, it's a misleading one. Same comparison, same data, 20,908-row mart:

| Key | Result |
|---|---|
| `user_micromasters_email` alone | 65,000+ mismatches across **8** columns, 7,826 rows reported "missing from old" |
| the real 3-column grain | **1** differing column (`semester`, 8,891 rows), nothing missing on either side |

All of that first row is join artifact from many-to-many pairing on a non-unique key.

### How can this be tested?

**No warehouse setup required.** The whole fix is pinned by unit tests, so a reviewer can
verify it from a clean checkout:

```bash
uv sync                                        # if you haven't already
cd src/ol_dbt_cli && uv run pytest -q          # 500 passed
uv run pre-commit run --files <changed files>  # ruff format, ruff check, mypy, detect-secrets
```

The tests that carry the argument, if you want to read rather than run them:

| Path | Test |
| --- | --- |
| per-column (`compare_relations`) | `test_compare_relations_composite_pk_is_comma_joined_not_a_jinja_list` |
| sample rows (`summarize=false`) | `test_compare_column_sql_composite_pk_uses_a_surrogate_join_key`, `test_compare_column_sql_composite_pk_selects_key_on_both_sides` |
| CLI key parsing | `test_comma_separated_primary_key_reaches_comparison_as_composite`, `test_comma_and_repeated_primary_key_produce_identical_sql` |

16 tests added/rewritten. Note that `test_compare_relations_composite_pk` was *asserting the buggy* `primary_key=['k1', 'k2']` output, so it was replaced rather than kept.

Run in a terminal rather than piped, that `500 passed` reads `4 failed, 496 passed`:
`test_diff.py` and `test_validate.py` carry 4 pre-existing ANSI-assertion failures that
only surface when rich emits colour. They are present on `main` too (see #2610), and none
of them are in the paths this PR touches.

<details>
<summary>The live run this PR came from (context, not a reproduction recipe)</summary>

Against a local `dev_local` DuckDB, on `main` this crashes with `Parser Error: syntax
error at or near "["`; on this branch it completes:

```bash
uv run ol-dbt diff --target dev_local \
  --old marts__micromasters_dedp_exam_grades_baseline --old-raw \
  --new marts__micromasters_dedp_exam_grades \
  --primary-key user_micromasters_email \
  --primary-key user_mitxonline_email \
  --primary-key proctoredexamgrade_created_on

# the comma form is equivalent
uv run ol-dbt diff --target dev_local \
  --old marts__micromasters_dedp_exam_grades_baseline --old-raw \
  --new marts__micromasters_dedp_exam_grades \
  -k user_micromasters_email,user_mitxonline_email,proctoredexamgrade_created_on
```

Both forms produced **byte-identical** output:

```
primary_key      : ['user_micromasters_email', 'user_mitxonline_email', 'proctoredexamgrade_created_on']
row_counts       : {'old': 20908, 'new': 20908, 'delta': 0}
column_mismatches: [('semester', 8891, 0, 0)]     # (column, mismatched, missing_in_old, missing_in_new)
verdict          : mismatch
```

The 20 rendered sample-mismatch rows are what confirm the `summarize=false` `order by`
path ran, not just the per-column one.

**Please don't try to recreate this to review the PR.** Those numbers need two things this
branch doesn't carry: the migrated mart from #2403 (here, `marts__micromasters_dedp_exam_grades`
is still the pre-migration model, so old and new are the same SQL and you'd get
`verdict: match` with nothing to render), and a freshly registered local warehouse — a
registry more than a day old resolves to replaced Iceberg metadata and fails with an S3
404 (that staleness is what #2610 fixes). The unit tests above cover the same two SQL
paths without any of it.

Also note `ol-dbt` needs the `uv run` prefix — it's a workspace entry point, not on `PATH`.

</details>

### Additional Context

**Docs.** `docs/specs/DBT_WAREHOUSE_CI_QA_SPEC.md` §3.4 step 3 said the key is simply "passed to `compare_relations` as the join key" — that's the assumption that produced this bug, so it's corrected to record the real audit_helper contract. `src/ol_dbt/README.md` gets a "Choosing the primary key" section with the numbers above and how to find a model's real grain (its `dbt_expectations_expect_compound_columns_to_be_unique` test). Both `ol-dbt-*` skill docs updated.

**Two judgment calls worth a reviewer's opinion:**

1. Comma-splitting was applied to `--exclude-columns` as well as `--primary-key`. Identical declaration, identical trap, and leaving the two inconsistent seemed worse than the small scope increase — but it is scope creep, so say if you'd rather it were dropped.
2. I did **not** make `--dbt-dir` keyword-only, which would stop a stray token being absorbed as a path. It changes the CLI's positional contract for a case that already errors rather than silently misbehaving, so it didn't seem worth the blast radius. Reconsider if anyone actually trips on it.

**Known asymmetry, filed as follow-up** (`tk-ol-dbt-diff-single-column-primary-key-drops-null-1d1a40`, p3): `generate_surrogate_key` coalesces NULLs to a sentinel, so the composite path pairs rows with NULL key components while the single-column path (a plain equi-join, unchanged here) does not. Not a wrong answer on a well-formed key — a primary key column shouldn't be nullable — but the two paths now differ, and that's worth tidying separately rather than expanding this PR.

**Scope note:** no dbt *models* are touched. The change is CLI + docs + one new dbt macro (`src/ol_dbt/macros/diff_composite_key.sql`).

---

### Review round 1 — Copilot feedback addressed in 52b3c499

All three comments were valid; each was verified before changing anything.

**1. `dbt_utils.generate_surrogate_key` is unsafe as a join key.** It joins components with a literal `-` before hashing without encoding boundaries. Reproduced on the pinned dbt_utils 1.3.3 / DuckDB — `('a-b', 'c')` and `('a', 'b-c')` both hash to `7b193b3d3318446...`, so two distinct keys would pair as one row and reintroduce the exact mispairing this PR prevents.

Replaced with a new `diff_composite_key` macro that length-prefixes each component as `<len>:<value>` (NULL as `~`). Reading digits to the first `:` gives the length and the next `<len>` characters are the value, so nothing inside a value can shift a boundary; it stays injective whether the adapter's `length()` counts bytes or characters, since both sides of a comparison are computed by the same engine.

It's a project macro rather than inline SQL because it needs `dbt.concat`/`dbt.hash`/`dbt.length` — those dispatch per adapter (Trino needs `to_hex(md5(to_utf8(..)))`, StarRocks has no `||`) and Jinja doesn't re-render inside string literals, so they can't be nested into generated SQL.

Verified in DuckDB: the colliding pair now yields distinct keys (`ea478e8e...` vs `77550cbf...`), identical tuples still match, and NULL, `''`, `'~'` and `'1:x'` — chosen to attack the *new* encoding — all stay distinct. End-to-end results on the repro are unchanged, so the swap is behaviour-preserving on real data.

**2. The grain-lookup guidance named a test spelling that doesn't exist.** Model YAML uses the dotted `dbt_expectations.expect_compound_columns_to_be_unique` (230 occurrences); the underscored form has **0** occurrences — it only appears in compiled test names, which is where I picked it up. Anyone following the original guidance would have grepped for a string that isn't in the project. Corrected, with a note on why the two spellings differ.

**3. `unique` alone doesn't make a single column safe.** dbt's `unique` ignores NULLs, so a nullable column can pass it while the single-column path's plain `a.k = b.k` never pairs NULL to NULL — those rows inflate the "missing from" buckets on both sides. Docs now require both `unique` and `not_null`.


