### PR TITLE
fix(feedback): update tfact_feedback to use dagster source table feedback_redacted

### DIFF
--- a/src/ol_dbt/models/dimensional/_feedback_facts.yml
+++ b/src/ol_dbt/models/dimensional/_feedback_facts.yml
@@ -114,11 +114,13 @@ models:
       so user_fk can be recomputed later without rebuilding this insert-only fact.
       Not for downstream consumption.
   - name: feedback_title
-    description: str, the redacted title. Null until the feedback_redacted Dagster
-      asset lands and this fact left-joins it in on (source_slug, source_record_id).
+    description: str, the redacted title, left-joined from the feedback_redacted Dagster
+      asset on (source_slug, source_record_id). Null where the asset has not yet processed
+      the row, or the source turn's title was null.
   - name: feedback_text
-    description: str, the redacted body text. Null until the feedback_redacted Dagster
-      asset lands and this fact left-joins it in on (source_slug, source_record_id).
+    description: str, the redacted body text, left-joined from the feedback_redacted
+      Dagster asset on (source_slug, source_record_id). Null where the asset has not
+      yet processed the row, or the source turn's text was null.
   - name: feedback_text_chars
     description: int, length of the text measured before masking, so the metric survives
       redaction.

--- a/src/ol_dbt/models/dimensional/tfact_feedback.sql
+++ b/src/ol_dbt/models/dimensional/tfact_feedback.sql
@@ -19,6 +19,10 @@ with unioned as (
     where email is not null
 )
 
+, redacted as (
+    select * from {{ source('feedback_intermediate', 'feedback_redacted') }}
+)
+
 select
     {{ dbt_utils.generate_surrogate_key(['unioned.source_slug', 'unioned.source_record_ref']) }}
         as feedback_pk
@@ -46,10 +50,8 @@ select
     , unioned.subject_url
     -- kept so user_fk can be re-resolved later without a rebuild
     , unioned.subject_user_ref
-    -- Stubs the redacted text. When the feedback_redacted Dagster asset lands, declare
-    -- it as a source and left join it on (source_slug, source_record_ref).
-    , cast(null as varchar) as feedback_title
-    , cast(null as varchar) as feedback_text
+    , redacted.title_redacted as feedback_title
+    , redacted.text_redacted as feedback_text
     , unioned.feedback_text_chars
     , unioned.explicit_rating
     , unioned.source_metadata
@@ -60,6 +62,9 @@ select
 from unioned
 left join users
     on lower(unioned.subject_user_ref) = users.email
+left join redacted
+    on unioned.source_slug = redacted.source_slug
+    and unioned.source_record_ref = redacted.source_record_ref
 {% if is_incremental() %}
     -- Watermark on the CONVERSATION's updated_at, not the turn's: a ticket that gains a
     -- rating, a status change or a late-syncing comment re-enters with all of its turns,

--- a/src/ol_dbt/models/intermediate/feedback/_feedback_sources.yml
+++ b/src/ol_dbt/models/intermediate/feedback/_feedback_sources.yml
@@ -1,0 +1,31 @@
+---
+version: 2
+
+sources:
+- name: feedback_intermediate
+  loader: dagster
+  database: '{{ target.database | default(none) }}'
+  schema: '{{ target.schema.replace(var("schema_suffix", ""), "").rstrip("_") }}_intermediate'
+  tables:
+  - name: feedback_redacted
+    description: Presidio-masked title/text for every feedback turn, materialized
+      by the feedback_redacted Dagster asset.
+    columns:
+    - name: source_slug
+      description: str, which source the turn came from.
+      tests:
+      - not_null
+    - name: source_record_ref
+      description: str, the source-native turn id.
+      tests:
+      - not_null
+    - name: title_redacted
+      description: str, PII-masked ticket subject/title. Null where the source turn's
+        title was null.
+    - name: text_redacted
+      description: str, PII-masked turn body. Null where the source turn's text was
+        null.
+    tests:
+    - dbt_expectations.expect_compound_columns_to_be_unique:
+        arguments:
+          column_list: ["source_slug", "source_record_ref"]


### PR DESCRIPTION
#### What are the relevant tickets?
Closes https://github.com/mitodl/ol-data-platform/issues/2541

### Description (What does it do?)
Completes the `feedback_redacted` left-join that #2541 scoped but #2592 didn't land — `tfact_feedback.feedback_title`/`feedback_text` were shipping as hardcoded `null` stubs even after the `feedback_redacted` Dagster asset merged.

- Declares `feedback_redacted` as a dbt source (output of https://github.com/mitodl/ol-data-platform/pull/2592)
- Updates `tfact_feedback` to use the redacted table `feedback_redacted`

Unblocks #2542 (conversation summarization) and #2543 (embedding) — both depend on `int__feedback__conversation.conversation_text`, which was null for every row until this join exists.

### How can this be tested?
```
cd src/ol_dbt
dbt build --target dev_production --vars 'schema_suffix: rlougee' --select tfact_feedback
```
Confirmed locally: full-refresh built 283,051 rows, with `feedback_text` non-null for 283,049 of them (the `feedback_redacted` asset had already run in this dev schema). All 22 existing `tfact_feedback` tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)