### PR TITLE
 fix(feedback): left-join feedback_redacted (dagster source) onto tfact_feedback 

### DIFF
--- a/dg_projects/ml/ml/assets/feedback_redacted.py
+++ b/dg_projects/ml/ml/assets/feedback_redacted.py
@@ -22,8 +22,12 @@ from pydantic import Field
 from pyiceberg.exceptions import NoSuchTableError
 
 if DAGSTER_ENV == "dev":
+    # dev intentionally targets the production catalog under a personal schema
+    # suffix, matching the dev_production dbt target other assets build against.
     _schema_suffix = os.environ.get("DBT_SCHEMA_SUFFIX")
     database_name = f"ol_warehouse_production_{_schema_suffix}_intermediate"
+elif DAGSTER_ENV == "qa":
+    database_name = "ol_warehouse_qa_intermediate"
 else:
     database_name = "ol_warehouse_production_intermediate"
 

--- a/src/ol_dbt/models/dimensional/_feedback_facts.yml
+++ b/src/ol_dbt/models/dimensional/_feedback_facts.yml
@@ -114,11 +114,13 @@ models:
       so user_fk can be recomputed later without rebuilding this insert-only fact.
       Not for downstream consumption.
   - name: feedback_title
-    description: str, the redacted title. Null until the feedback_redacted Dagster
-      asset lands and this fact left-joins it in on (source_slug, source_record_id).
+    description: str, the redacted title, left-joined from the feedback_redacted Dagster
+      asset on (source_slug, source_record_id). Null where the asset has not yet processed
+      the row, or the source turn's title was null.
   - name: feedback_text
-    description: str, the redacted body text. Null until the feedback_redacted Dagster
-      asset lands and this fact left-joins it in on (source_slug, source_record_id).
+    description: str, the redacted body text, left-joined from the feedback_redacted
+      Dagster asset on (source_slug, source_record_id). Null where the asset has not
+      yet processed the row, or the source turn's text was null.
   - name: feedback_text_chars
     description: int, length of the text measured before masking, so the metric survives
       redaction.

--- a/src/ol_dbt/models/dimensional/_feedback_facts.yml
+++ b/src/ol_dbt/models/dimensional/_feedback_facts.yml
@@ -114,13 +114,11 @@ models:
       so user_fk can be recomputed later without rebuilding this insert-only fact.
       Not for downstream consumption.
   - name: feedback_title
-    description: str, the redacted title, left-joined from the feedback_redacted Dagster
-      asset on (source_slug, source_record_id). Null where the asset has not yet processed
-      the row, or the source turn's title was null.
+    description: str, the redacted title populated from the feedback_redacted Dagster
+      asset
   - name: feedback_text
-    description: str, the redacted body text, left-joined from the feedback_redacted
-      Dagster asset on (source_slug, source_record_id). Null where the asset has not
-      yet processed the row, or the source turn's text was null.
+    description: str, the redacted body text populated from the feedback_redacted
+      Dagster asset
   - name: feedback_text_chars
     description: int, length of the text measured before masking, so the metric survives
       redaction.

--- a/src/ol_dbt/models/dimensional/tfact_feedback.sql
+++ b/src/ol_dbt/models/dimensional/tfact_feedback.sql
@@ -19,6 +19,10 @@ with unioned as (
     where email is not null
 )
 
+, redacted as (
+    select * from {{ source('feedback_intermediate', 'feedback_redacted') }}
+)
+
 select
     {{ dbt_utils.generate_surrogate_key(['unioned.source_slug', 'unioned.source_record_ref']) }}
         as feedback_pk
@@ -46,10 +50,8 @@ select
     , unioned.subject_url
     -- kept so user_fk can be re-resolved later without a rebuild
     , unioned.subject_user_ref
-    -- Stubs the redacted text. When the feedback_redacted Dagster asset lands, declare
-    -- it as a source and left join it on (source_slug, source_record_ref).
-    , cast(null as varchar) as feedback_title
-    , cast(null as varchar) as feedback_text
+    , redacted.title_redacted as feedback_title
+    , redacted.text_redacted as feedback_text
     , unioned.feedback_text_chars
     , unioned.explicit_rating
     , unioned.source_metadata
@@ -60,6 +62,9 @@ select
 from unioned
 left join users
     on lower(unioned.subject_user_ref) = users.email
+left join redacted
+    on unioned.source_slug = redacted.source_slug
+    and unioned.source_record_ref = redacted.source_record_ref
 {% if is_incremental() %}
     -- Watermark on the CONVERSATION's updated_at, not the turn's: a ticket that gains a
     -- rating, a status change or a late-syncing comment re-enters with all of its turns,

--- a/src/ol_dbt/models/dimensional/tfact_feedback.sql
+++ b/src/ol_dbt/models/dimensional/tfact_feedback.sql
@@ -71,4 +71,17 @@ left join redacted
     -- so delete+insert replaces them together. Filtering to unseen turns instead would
     -- freeze the ticket-level columns and leave turn_index inconsistent.
     where unioned.updated_at > (select max(feedback_updated_at) from {{ this }})
+    -- Backfill: a row inserted before feedback_redacted existed carries the old
+    -- feedback_text = null stub forever under the watermark above alone, because
+    -- redaction landing does not bump the source ticket's updated_at. Reselect any
+    -- row still null in the fact where redaction has since produced real text.
+    or exists (
+        select 1
+        from {{ this }} as stale
+        inner join redacted
+            on stale.source_record_id = redacted.source_record_ref
+        where stale.source_record_id = unioned.source_record_ref
+            and stale.feedback_text is null
+            and redacted.text_redacted is not null
+    )
 {% endif %}

--- a/src/ol_dbt/models/dimensional/tfact_feedback.sql
+++ b/src/ol_dbt/models/dimensional/tfact_feedback.sql
@@ -80,7 +80,9 @@ left join redacted
         from {{ this }} as stale
         inner join redacted
             on stale.source_record_id = redacted.source_record_ref
+            and stale.feedback_source_fk = {{ dbt_utils.generate_surrogate_key(['redacted.source_slug']) }}
         where stale.source_record_id = unioned.source_record_ref
+            and stale.feedback_source_fk = {{ dbt_utils.generate_surrogate_key(['unioned.source_slug']) }}
             and stale.feedback_text is null
             and redacted.text_redacted is not null
     )

--- a/src/ol_dbt/models/intermediate/feedback/_feedback_sources.yml
+++ b/src/ol_dbt/models/intermediate/feedback/_feedback_sources.yml
@@ -2,6 +2,10 @@
 version: 2
 
 sources:
+# database/schema are target-derived, not literals, so they must keep resolving to
+# the same relation feedback_redacted.py's DAGSTER_ENV branch actually writes to
+# (dev -> production catalog + personal suffix, qa -> qa catalog, else -> production).
+# Verify both sides agree before changing either.
 - name: feedback_intermediate
   loader: dagster
   database: '{{ target.database | default(none) }}'

--- a/src/ol_dbt/models/intermediate/feedback/_feedback_sources.yml
+++ b/src/ol_dbt/models/intermediate/feedback/_feedback_sources.yml
@@ -1,0 +1,31 @@
+---
+version: 2
+
+sources:
+- name: feedback_intermediate
+  loader: dagster
+  database: '{{ target.database | default(none) }}'
+  schema: '{{ target.schema.replace(var("schema_suffix", ""), "").rstrip("_") }}_intermediate'
+  tables:
+  - name: feedback_redacted
+    description: Presidio-masked title/text for every feedback turn, materialized
+      by the feedback_redacted Dagster asset.
+    columns:
+    - name: source_slug
+      description: str, which source the turn came from.
+      tests:
+      - not_null
+    - name: source_record_ref
+      description: str, the source-native turn id.
+      tests:
+      - not_null
+    - name: title_redacted
+      description: str, PII-masked ticket subject/title. Null where the source turn's
+        title was null.
+    - name: text_redacted
+      description: str, PII-masked turn body. Null where the source turn's text was
+        null.
+    tests:
+    - dbt_expectations.expect_compound_columns_to_be_unique:
+        arguments:
+          column_list: ["source_slug", "source_record_ref"]


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
https://github.com/mitodl/ol-data-platform/issues/2541

### Description (What does it do?)
<!--- Describe your changes in detail -->

- Declares `feedback_redacted` as a dbt source (output of https://github.com/mitodl/ol-data-platform/pull/2592)
- Updates `tfact_feedback` to use the redacted table `feedback_redacted` instead of null placeholder since now we have data 


### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

 dbt build --target dev_production -select tfact_feedback  

Verify `feedback_title` and `feedback_text` are populated now, with PII data masked.

### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->


<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
