### PR TITLE
docs(dagster): record the run status sensor's throughput ceiling

### DIFF
--- a/dg_projects/data_platform/data_platform/definitions.py
+++ b/dg_projects/data_platform/data_platform/definitions.py
@@ -608,7 +608,28 @@ def get_slack_token() -> str:
     ),
 )
 def run_failure_notification_sensor(context: RunFailureSensorContext) -> None:
-    """Report a failed run to Sentry, then announce it in Slack."""
+    """Report a failed run to Sentry, then announce it in Slack.
+
+    THROUGHPUT CEILING -- read this before trusting any timestamp this sensor
+    produces. A run status sensor processes at most
+    ``DAGSTER_RUN_STATUS_SENSOR_PROCESS_LIMIT`` runs per tick, which defaults to
+    5, and ``monitor_all_code_locations=True`` pins the fetch limit to the same
+    number (dagster ``_core/definitions/run_status_sensor_definition.py``,
+    ``_get_run_status_sensor_fetch_limit``). At the default 30 second tick
+    (``DEFAULT_SENSOR_DAEMON_INTERVAL``) that is 5 * 2880 = 14,400 runs per day,
+    for every code location combined.
+
+    Production failures have run at ~12,000/day, 84% of that ceiling, so the
+    sensor has no room to recover from a backlog: on 2026-08-25 it was reporting
+    runs that had executed on 2026-08-13, a twelve day lag. An event's timestamp
+    is when this sensor reached the run, never when the run failed, and an issue
+    that looks live may describe something already fixed.
+
+    Raising the ceiling is a daemon environment change, not a code change --
+    there is no argument here that moves it. Draining a large backlog also
+    replays every one of those failures into Sentry and Slack, so fast-forwarding
+    the cursor is usually the better answer than turning the limit up and waiting.
+    """
     run = context.dagster_run
 
     if is_retry_of_a_reported_failure(run):


### PR DESCRIPTION
## What

A docstring on `run_failure_notification_sensor` recording the throughput limit that governs it. No behaviour change.

## Why

We spent a while treating the Dagster Sentry project as a live signal. It isn't, and the reason is a Dagster default that is invisible from this repo.

A run status sensor processes at most `DAGSTER_RUN_STATUS_SENSOR_PROCESS_LIMIT` runs per tick — **default 5** — and `monitor_all_code_locations=True` pins the *fetch* limit to the same number:

```python
def _get_run_status_sensor_fetch_limit(monitor_all_code_locations: bool) -> int:
    if monitor_all_code_locations:
        # No need to overfetch if we are going to process everything
        return _get_run_status_sensor_process_limit()
    return int(os.getenv("DAGSTER_RUN_STATUS_SENSOR_FETCH_LIMIT", "25"))

def _get_run_status_sensor_process_limit() -> int:
    return int(os.getenv("DAGSTER_RUN_STATUS_SENSOR_PROCESS_LIMIT", "5"))
```

`DEFAULT_SENSOR_DAEMON_INTERVAL` is 30 seconds and this sensor sets no `minimum_interval_seconds`, so the ceiling is:

> 5 runs × 2,880 ticks/day = **14,400 runs per day, across every code location combined**

Production failures have been arriving at ~12,000/day (12,075 sensor dispatches in the 24h to 2026-08-25), which is 84% of that. There is no headroom to recover from a backlog.

## What that has cost

Run `cfe0c460-d2c2-4a0c-ad2d-efffd3b91322` executed **2026-08-13 08:13:53** (retried twice on the 14th, once on the 15th) and was reported to Sentry **2026-08-25 18:33:03** — a **twelve day lag**, confirmed in the run's own event log.

So a `captured_by: sensor` event's timestamp is when the sensor reached the run, never when the run failed. Concretely:

- `lastSeen` on any sensor-captured issue is ~12 days stale.
- A failure today surfaces in Slack and Sentry in ~12 days.
- An issue that looks live may describe something already fixed. DAGSTER-2K's Learn API 405s are exactly this — the gateway shows 100% 200s on that endpoint today, because the bug was fixed on 2026-08-18/19 and Sentry is still replaying the pre-fix backlog.

## Why only a docstring

The ceiling is a daemon environment variable. No argument to `run_failure_sensor` moves it, so there is nothing to change in application code — the fix is a daemon env change in ol-infrastructure plus an operational decision about the existing backlog. Draining it replays every one of those failures into Sentry and Slack, so fast-forwarding the sensor cursor is likely better than raising the limit and waiting.

That reasoning is the part worth not rediscovering, which is why it goes next to the sensor rather than only in a ticket.

## Testing

`dg_projects/data_platform` (own env): 78 passed. pre-commit (ruff format, ruff check, mypy, detect-secrets) all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0137aMRH4447yktgAhYnaiiy