### PR TITLE
fix(lakehouse): reconcile Iceberg maintenance targets against the live catalog

### DIFF
--- a/dg_projects/lakehouse/lakehouse/assets/iceberg_maintenance.py
+++ b/dg_projects/lakehouse/lakehouse/assets/iceberg_maintenance.py
@@ -58,6 +58,7 @@ from ol_orchestrate.lib.iceberg_maintenance import (
     load_raw_layer_maintenance_work,
     maintenance_failure_threshold,
     non_dbt_singleton_tables,
+    partition_by_catalog_presence,
     raw_config_for_table,
     remove_orphan_files,
     warehouse_env_for,
@@ -225,6 +226,62 @@ def _run_table_maintenance(
     return summary
 
 
+def _maintainable_dbt_layer_configs(
+    context: AssetExecutionContext,
+    trino_maintenance: TrinoMaintenanceResource,
+) -> tuple[list[TableMaintenanceConfig], list[str]]:
+    """Return the configs this environment can actually maintain, and the rest.
+
+    The manifest states what production builds; the engine states what this
+    environment holds. Where they disagree the relation is a view or missing,
+    and every maintenance operation on it fails -- 401 of 628 configs in one QA
+    run, on ``ALTER TABLE EXECUTE is not supported for views`` and
+    ``TABLE_NOT_FOUND``. Asking the engine first is what keeps the failure
+    ratio measuring engine failures rather than this asset's own assumptions
+    about a manifest compiled somewhere else.
+    """
+    configs = load_maintenance_configs_from_manifest(
+        manifest_path=dbt_project.manifest_path,
+        warehouse_env=WAREHOUSE_ENV,
+    )
+    singletons = non_dbt_singleton_tables(WAREHOUSE_ENV)
+    manifest_configs = [*configs, *singletons]
+    context.log.info(
+        "Loaded %d table configs (%d dbt, %d singleton) for the %s warehouse",
+        len(manifest_configs),
+        len(configs),
+        len(singletons),
+        WAREHOUSE_ENV,
+    )
+
+    base_tables = trino_maintenance.base_tables_in_schemas(
+        {cfg.schema_name for cfg in manifest_configs}
+    )
+    maintainable, unbacked = partition_by_catalog_presence(
+        manifest_configs, base_tables
+    )
+    if unbacked:
+        context.log.warning(
+            "Skipping %d of %d configs with no table in %s (view or absent): %s",
+            len(unbacked),
+            len(manifest_configs),
+            WAREHOUSE_ENV,
+            unbacked[:20],
+        )
+    # Filtering to nothing is not "no work to do" -- it means the manifest and
+    # the catalog share no name at all, which is a scoping or deployment fault.
+    # Left to run, the maintenance loop would do nothing, find no failures and
+    # report SUCCESS, the silent-staleness mode the threshold exists to stop.
+    if manifest_configs and not maintainable:
+        msg = (
+            f"No table in the {WAREHOUSE_ENV} catalog matches any of the "
+            f"{len(manifest_configs)} maintenance configs. Refusing to report "
+            "success for zero work."
+        )
+        raise RuntimeError(msg)
+    return maintainable, unbacked
+
+
 # ── Assets ────────────────────────────────────────────────────────────────────
 
 
@@ -242,19 +299,7 @@ def iceberg_dbt_layer_maintenance(
     trino_maintenance: TrinoMaintenanceResource,
 ) -> Output[None]:
     """Run Iceberg maintenance for all dbt-managed tables and non-dbt singletons."""
-    configs = load_maintenance_configs_from_manifest(
-        manifest_path=dbt_project.manifest_path,
-        warehouse_env=WAREHOUSE_ENV,
-    )
-    singletons = non_dbt_singleton_tables(WAREHOUSE_ENV)
-    all_configs = [*configs, *singletons]
-    context.log.info(
-        "Loaded %d table configs (%d dbt, %d singleton) for the %s warehouse",
-        len(all_configs),
-        len(configs),
-        len(singletons),
-        WAREHOUSE_ENV,
-    )
+    all_configs, unbacked = _maintainable_dbt_layer_configs(context, trino_maintenance)
 
     # Cursor of the previous maintenance run — used to count dbt materializations
     # that occurred since the last time this asset ran.
@@ -353,6 +398,8 @@ def iceberg_dbt_layer_maintenance(
             "tables_analyzed": MetadataValue.int(tables_analyzed),
             "snapshots_expired": MetadataValue.int(snapshots_expired),
             "orphans_removed": MetadataValue.int(orphans_removed),
+            "tables_unbacked": MetadataValue.int(len(unbacked)),
+            "unbacked_details": MetadataValue.json(unbacked[:20]),
             "failed_tables": MetadataValue.int(len(failed_tables)),
             "failure_count": MetadataValue.int(len(failures)),
             # Cap at 20 entries so the Dagster UI doesn't time out rendering

--- a/packages/ol-orchestrate-lib/src/ol_orchestrate/lib/iceberg_maintenance.py
+++ b/packages/ol-orchestrate-lib/src/ol_orchestrate/lib/iceberg_maintenance.py
@@ -483,6 +483,33 @@ def load_maintenance_configs_from_manifest(
     return configs
 
 
+def partition_by_catalog_presence(
+    configs: list[TableMaintenanceConfig],
+    base_tables: set[tuple[str, str]],
+) -> tuple[list[TableMaintenanceConfig], list[str]]:
+    """Split *configs* into those backed by a real table and those that are not.
+
+    ``manifest.json`` is compiled against production and shipped to every
+    environment, so it states what production builds rather than what the
+    target environment holds.  QA holds views under names the manifest calls
+    tables, and holds nothing at all under others.  Both are indistinguishable
+    from the manifest alone, and both are unmaintainable: OPTIMIZE and ANALYZE
+    reject views outright, and pyiceberg cannot load a table that is not there.
+
+    *base_tables* is the live ``(schema, table)`` set from the engine, so a
+    config is kept only when the engine agrees it is a table.  The second
+    return value names the rest as ``schema.table`` for reporting.
+    """
+    present: list[TableMaintenanceConfig] = []
+    unbacked: list[str] = []
+    for cfg in configs:
+        if (cfg.schema_name, cfg.model_name) in base_tables:
+            present.append(cfg)
+        else:
+            unbacked.append(f"{cfg.schema_name}.{cfg.model_name}")
+    return present, unbacked
+
+
 # ── Raw Layer ─────────────────────────────────────────────────────────────────
 
 

--- a/packages/ol-orchestrate-lib/src/ol_orchestrate/resources/trino_maintenance.py
+++ b/packages/ol-orchestrate-lib/src/ol_orchestrate/resources/trino_maintenance.py
@@ -107,12 +107,19 @@ class TrinoMaintenanceResource(ConfigurableResource[None]):
             )
         return self._connection
 
-    def execute(self, sql: str) -> list[Any]:
-        """Execute a SQL statement and return all rows."""
+    def execute(self, sql: str, params: tuple[Any, ...] | None = None) -> list[Any]:
+        """Execute a SQL statement and return all rows.
+
+        ``params`` binds ``?`` placeholders through the Trino driver rather than
+        interpolating into *sql*.
+        """
         conn = self._get_connection()
         cursor = conn.cursor()
         log.debug("Trino maintenance SQL: %.200s", sql)
-        cursor.execute(sql)
+        if params:
+            cursor.execute(sql, params)
+        else:
+            cursor.execute(sql)
         return cursor.fetchall()
 
     def optimize(
@@ -149,3 +156,29 @@ class TrinoMaintenanceResource(ConfigurableResource[None]):
         sql = f"ANALYZE {schema}.{table}"
         self.execute(sql)
         log.info("ANALYZE complete: %s.%s", schema, table)
+
+    def base_tables_in_schemas(self, schemas: set[str]) -> set[tuple[str, str]]:
+        """Return the ``(schema, table)`` pairs that exist as real tables.
+
+        The dbt ``manifest.json`` describes what production *builds*, not what
+        any given environment *has*. QA carries views under names the manifest
+        calls tables, and carries nothing at all under others, so issuing
+        OPTIMIZE and ANALYZE straight off the manifest produced 401 failures in
+        one run -- ``ALTER TABLE EXECUTE is not supported for views`` and
+        ``TABLE_NOT_FOUND``. Reconciling against the live catalog first is what
+        keeps maintenance reporting engine failures rather than its own
+        assumptions.
+
+        ``table_type = 'BASE TABLE'`` excludes views; a name absent from the
+        catalog is absent from the result.
+        """
+        if not schemas:
+            return set()
+        ordered = tuple(sorted(schemas))
+        placeholders = ", ".join("?" for _ in ordered)
+        sql = (
+            # Only the ? placeholders are interpolated; the values are bound.
+            "SELECT table_schema, table_name FROM information_schema.tables "  # noqa: S608
+            f"WHERE table_type = 'BASE TABLE' AND table_schema IN ({placeholders})"
+        )
+        return {(row[0], row[1]) for row in self.execute(sql, ordered)}

--- a/packages/ol-orchestrate-lib/tests/lib/test_iceberg_maintenance.py
+++ b/packages/ol-orchestrate-lib/tests/lib/test_iceberg_maintenance.py
@@ -8,9 +8,11 @@ from pathlib import Path
 import pytest
 from ol_orchestrate.lib.iceberg_maintenance import (
     RAW_LAYER_GROUP_CONFIGS,
+    TableMaintenanceConfig,
     load_maintenance_configs_from_manifest,
     maintenance_failure_threshold,
     non_dbt_singleton_tables,
+    partition_by_catalog_presence,
     raw_config_for_table,
     scope_schema_to_env,
     warehouse_env_for,
@@ -458,3 +460,76 @@ class TestMaintenanceFailureThreshold:
         threshold of zero and fail on nothing.
         """
         assert maintenance_failure_threshold(0) == 1
+
+
+# ── Catalog reconciliation ────────────────────────────────────────────────────
+
+
+class TestPartitionByCatalogPresence:
+    """The manifest is compiled against production and shipped everywhere.
+
+    QA holds views under names the manifest calls tables, and holds nothing at
+    all under others. Both are unmaintainable and both were being attempted:
+    401 of 628 configs failed in a single QA run on ``ALTER TABLE EXECUTE is
+    not supported for views`` and ``TABLE_NOT_FOUND``.
+    """
+
+    @staticmethod
+    def _cfg(schema: str, model: str) -> TableMaintenanceConfig:
+        return TableMaintenanceConfig(
+            model_name=model,
+            schema_name=schema,
+            materialized="table",
+            asset_key=[schema.rsplit("_", 1)[-1], model],
+        )
+
+    def test_a_config_the_catalog_calls_a_table_is_kept(self) -> None:
+        cfg = self._cfg("ol_warehouse_qa_intermediate", "int__mitx__enrollments")
+        present, unbacked = partition_by_catalog_presence(
+            [cfg], {("ol_warehouse_qa_intermediate", "int__mitx__enrollments")}
+        )
+        assert present == [cfg]
+        assert unbacked == []
+
+    def test_a_view_is_dropped_and_named(self) -> None:
+        """A view is in the catalog but not in the BASE TABLE set."""
+        cfg = self._cfg("ol_warehouse_qa_intermediate", "int__mitx__users")
+        present, unbacked = partition_by_catalog_presence([cfg], set())
+        assert present == []
+        assert unbacked == ["ol_warehouse_qa_intermediate.int__mitx__users"]
+
+    def test_a_table_missing_from_the_environment_is_dropped(self) -> None:
+        cfg = self._cfg("ol_warehouse_qa_intermediate", "int__mitx__courses")
+        present, unbacked = partition_by_catalog_presence(
+            [cfg], {("ol_warehouse_qa_intermediate", "something_else")}
+        )
+        assert present == []
+        assert unbacked == ["ol_warehouse_qa_intermediate.int__mitx__courses"]
+
+    def test_the_match_is_schema_qualified(self) -> None:
+        """A production table of the same name must not vouch for the QA one.
+
+        Matching on model name alone would let production's build satisfy QA's
+        config, which is the cross-environment confusion scope_schema_to_env
+        exists to prevent.
+        """
+        cfg = self._cfg("ol_warehouse_qa_intermediate", "int__mitx__users")
+        present, unbacked = partition_by_catalog_presence(
+            [cfg], {("ol_warehouse_production_intermediate", "int__mitx__users")}
+        )
+        assert present == []
+        assert unbacked == ["ol_warehouse_qa_intermediate.int__mitx__users"]
+
+    def test_order_is_preserved_for_the_kept_configs(self) -> None:
+        first = self._cfg("ol_warehouse_qa_mart", "a")
+        second = self._cfg("ol_warehouse_qa_mart", "b")
+        third = self._cfg("ol_warehouse_qa_mart", "c")
+        present, unbacked = partition_by_catalog_presence(
+            [first, second, third],
+            {("ol_warehouse_qa_mart", "a"), ("ol_warehouse_qa_mart", "c")},
+        )
+        assert present == [first, third]
+        assert unbacked == ["ol_warehouse_qa_mart.b"]
+
+    def test_an_empty_config_list_yields_nothing(self) -> None:
+        assert partition_by_catalog_presence([], {("s", "t")}) == ([], [])


### PR DESCRIPTION
### What are the relevant tickets?
Fixes DAGSTER-2V (Sentry, project `dagster`)

### Description (What does it do?)
`iceberg_dbt_layer_maintenance` built its target list from `manifest.json` alone. The manifest is compiled against production and baked into an image that ships everywhere, so it states what production *builds*, not what the target environment *holds*. QA holds views under names the manifest calls tables, and holds nothing at all under others. One QA run failed 401 of 628 configs — `ALTER TABLE EXECUTE is not supported for views`, `Analyzing views is not supported`, `TABLE_NOT_FOUND`.

The existing `materialized in ("table", "incremental")` filter cannot catch this: `int__mitx__users` is configured `table` in `dbt_project.yml` and is a view in the QA catalog. Only the engine knows.

- `TrinoMaintenanceResource.base_tables_in_schemas()` — one `information_schema.tables` query, `table_type = 'BASE TABLE'`, scoped to the schemas in the config set.
- `partition_by_catalog_presence()` — splits manifest configs into maintainable and unbacked. Matching is schema-qualified, so production's build cannot vouch for QA's config.
- The threshold now measures failures against relations maintenance can actually touch. `tables_attempted` falls out of the filtered list.
- Unbacked names land in asset metadata (`tables_unbacked`, `unbacked_details`) and a log warning rather than being discarded — a model the manifest declares but QA never built is a real signal, just not maintenance's failure.
- Filtering to *nothing* raises rather than reporting SUCCESS for zero work. No overlap between manifest and catalog is a scoping or deployment fault, and the loop would otherwise find no failures and advance the cursor.

`execute()` gained optional `?` parameter binding for the schema list.

### How can this be tested?
- `uv run pytest packages/ol-orchestrate-lib/tests -q` — 214 passed, 80 skipped. Six new cases cover `partition_by_catalog_presence`: table kept, view dropped, missing table dropped, schema-qualified matching, order preservation, empty input.
- `uv run mypy packages/ dg_projects/ --config-file=pyproject.toml` — no new errors on the changed files.
- `pre-commit run --files <changed>` — clean.

Not verified locally: the `information_schema.tables` query has not been run against a live Trino/Starburst catalog from this branch (no warehouse credentials here). Worth a reviewer running it once against QA before merge:

```sql
SELECT table_type, count(*)
FROM information_schema.tables
WHERE table_schema LIKE 'ol_warehouse_qa_%'
GROUP BY table_type
```

`iceberg_dbt_maintenance_nightly` runs at 02:00 UTC, so the real confirmation is the next `iceberg_dbt_maintenance_job` tick after deploy: `tables_unbacked` should be roughly 401 and DAGSTER-2V should stop recurring.

### Additional Context
This does not address *why* QA holds views under table names, or why ~400 intermediate models are missing from QA. That belongs to the QA/production data topology work (`docs/specs/QA_DATA_TOPOLOGY_SPEC.md`, RFC [mitodl/hq#12711](https://github.com/mitodl/hq/discussions/12711)). Maintenance should not be the thing that discovers it, and should not fail nightly because of it — but it now reports the count instead of swallowing it.

The `1256/628` count in the older DAGSTER-R was already fixed by #2564's `failed_tables` set; no change needed there.
