### PR TITLE
fix(lakehouse): attach to the newest in-flight Airbyte sync instead of failing

### DIFF
--- a/dg_projects/lakehouse/lakehouse/resources/airbyte.py
+++ b/dg_projects/lakehouse/lakehouse/resources/airbyte.py
@@ -1,15 +1,26 @@
 from collections.abc import Mapping, Sequence
+from datetime import datetime
 from typing import Any, Self
 from urllib.parse import urlparse, urlunparse
 
 from dagster._annotations import beta
 from dagster_airbyte.resources import AirbyteClient, AirbyteWorkspace
+from dagster_airbyte.translator import AirbyteJob, AirbyteJobStatusType
 from dagster_shared.utils.cached_method import cached_method
 from pydantic.fields import Field, PrivateAttr
 from pydantic.functional_validators import model_validator
 
 AIRBYTE_REST_API_VERSION = "v1"
 AIRBYTE_CONFIGURATION_API_VERSION = "v1"
+
+# The statuses ``AirbyteClient.sync_and_poll`` counts as "a sync is already
+# under way" when it decides whether to start a new job or attach to an
+# existing one.  Mirrored here so the collapse below keys off the same set.
+IN_FLIGHT_JOB_STATUSES = (
+    AirbyteJobStatusType.RUNNING,
+    AirbyteJobStatusType.PENDING,
+    AirbyteJobStatusType.INCOMPLETE,
+)
 
 
 @beta
@@ -77,6 +88,40 @@ class AirbyteOSSClient(AirbyteClient):
             ).get("data", [])
             self.__dict__["workspace_id"] = workspaces[0]["workspaceId"]
         return self
+
+    def get_jobs_for_connection(
+        self, connection_id: str, created_after: datetime | None = None
+    ) -> Sequence[AirbyteJob]:
+        """Return the connection's jobs with concurrent in-flight ones collapsed.
+
+        ``sync_and_poll`` attaches to a single in-flight job and raises
+        ``Found multiple running jobs`` on two or more.  That distinction does
+        not hold here: ``definitions.py`` sets ``poll_previous_running_sync``
+        precisely because the automation condition and Airbyte's own scheduler
+        both launch syncs into the same connection, so two in-flight jobs is
+        the same routine overlap as one, arriving twice.  Nine connections were
+        failing nightly on it, each amplified fourfold by run retries that
+        cannot succeed -- the condition is unchanged by re-running.
+
+        Attaching to the newest is what the one-job branch already does, and
+        Airbyte job ids increase monotonically, so the highest id is the most
+        recently created.  Older in-flight jobs are dropped from the returned
+        list; every terminal job is passed through untouched.
+
+        This overrides the accessor rather than ``sync_and_poll`` because the
+        library exposes no other seam: the decision is inline in a method too
+        large to fork safely, and this is its only caller in dagster-airbyte
+        0.29.
+        """
+        jobs = super().get_jobs_for_connection(
+            connection_id=connection_id, created_after=created_after
+        )
+        in_flight = [job for job in jobs if job.status in IN_FLIGHT_JOB_STATUSES]
+        if len(in_flight) <= 1:
+            return jobs
+        newest_id = max(job.id for job in in_flight)
+        superseded = {job.id for job in in_flight if job.id != newest_id}
+        return [job for job in jobs if job.id not in superseded]
 
     def _paginated_request(
         self,

--- a/dg_projects/lakehouse/lakehouse_tests/test_airbyte_resource.py
+++ b/dg_projects/lakehouse/lakehouse_tests/test_airbyte_resource.py
@@ -104,7 +104,7 @@ class TestConcurrentInFlightJobsAreCollapsed:
     That distinction does not survive contact with a connection that two
     schedulers launch into. Nine connections failed nightly on `Found multiple
     running jobs`, each amplified fourfold by run retries that cannot change
-    the condition (DAGSTER-2R, 3A, 3C, 3E, 3F, 3N, 3R, 33, 39).
+    the condition (DAGSTER-2Q, 33, 39, 3A, 3C, 3E, 3F, 3N, 3R).
     """
 
     def test_the_newest_in_flight_job_is_the_one_kept(

--- a/dg_projects/lakehouse/lakehouse_tests/test_airbyte_resource.py
+++ b/dg_projects/lakehouse/lakehouse_tests/test_airbyte_resource.py
@@ -8,6 +8,8 @@ poll_previous_running_sync on the workspace set a field the client never read.
 """
 
 import pytest
+from dagster_airbyte.resources import AirbyteClient
+from dagster_airbyte.translator import AirbyteJob, AirbyteJobStatusType
 from lakehouse.resources.airbyte import AirbyteOSSWorkspace
 
 # Non-default values throughout, so a setting that fails to propagate shows up
@@ -80,3 +82,87 @@ def test_explicit_base_urls_win_over_the_derived_ones() -> None:
 
     assert client.rest_api_base_url == "https://proxy.example.invalid/public"
     assert client.configuration_api_base_url == "https://proxy.example.invalid/config"
+
+
+def _job(job_id: int, status: AirbyteJobStatusType | str) -> AirbyteJob:
+    status_value = status.value if isinstance(status, AirbyteJobStatusType) else status
+    return AirbyteJob(id=job_id, status=status_value, type="sync")
+
+
+def _stub_super_jobs(monkeypatch, jobs):
+    """Make AirbyteClient.get_jobs_for_connection return *jobs* without HTTP."""
+    monkeypatch.setattr(
+        AirbyteClient,
+        "get_jobs_for_connection",
+        lambda self, connection_id, created_after=None: jobs,  # noqa: ARG005
+    )
+
+
+class TestConcurrentInFlightJobsAreCollapsed:
+    """sync_and_poll fails outright on two in-flight jobs; one it attaches to.
+
+    That distinction does not survive contact with a connection that two
+    schedulers launch into. Nine connections failed nightly on `Found multiple
+    running jobs`, each amplified fourfold by run retries that cannot change
+    the condition (DAGSTER-2R, 3A, 3C, 3E, 3F, 3N, 3R, 33, 39).
+    """
+
+    def test_the_newest_in_flight_job_is_the_one_kept(
+        self, client, monkeypatch
+    ) -> None:
+        _stub_super_jobs(
+            monkeypatch,
+            [
+                _job(10, AirbyteJobStatusType.RUNNING),
+                _job(12, AirbyteJobStatusType.PENDING),
+                _job(11, AirbyteJobStatusType.RUNNING),
+            ],
+        )
+        kept = client.get_jobs_for_connection(connection_id="c")
+        assert [job.id for job in kept] == [12]
+
+    def test_terminal_jobs_are_passed_through_untouched(
+        self, client, monkeypatch
+    ) -> None:
+        """Only the in-flight set is collapsed; history is not rewritten."""
+        _stub_super_jobs(
+            monkeypatch,
+            [
+                _job(1, AirbyteJobStatusType.SUCCEEDED),
+                _job(2, AirbyteJobStatusType.FAILED),
+                _job(3, AirbyteJobStatusType.RUNNING),
+                _job(4, AirbyteJobStatusType.RUNNING),
+                _job(5, AirbyteJobStatusType.CANCELLED),
+            ],
+        )
+        kept = client.get_jobs_for_connection(connection_id="c")
+        assert [job.id for job in kept] == [1, 2, 4, 5]
+
+    def test_incomplete_counts_as_in_flight(self, client, monkeypatch) -> None:
+        """sync_and_poll treats INCOMPLETE as in-flight, so this must agree.
+
+        Disagreeing would leave two jobs in the set sync_and_poll counts and
+        reproduce the failure this exists to remove.
+        """
+        _stub_super_jobs(
+            monkeypatch,
+            [
+                _job(7, AirbyteJobStatusType.INCOMPLETE),
+                _job(8, AirbyteJobStatusType.RUNNING),
+            ],
+        )
+        kept = client.get_jobs_for_connection(connection_id="c")
+        assert [job.id for job in kept] == [8]
+
+    def test_a_single_in_flight_job_is_left_alone(self, client, monkeypatch) -> None:
+        jobs = [
+            _job(1, AirbyteJobStatusType.SUCCEEDED),
+            _job(2, AirbyteJobStatusType.RUNNING),
+        ]
+        _stub_super_jobs(monkeypatch, jobs)
+        assert client.get_jobs_for_connection(connection_id="c") == jobs
+
+    def test_no_in_flight_job_is_left_alone(self, client, monkeypatch) -> None:
+        jobs = [_job(1, AirbyteJobStatusType.SUCCEEDED)]
+        _stub_super_jobs(monkeypatch, jobs)
+        assert client.get_jobs_for_connection(connection_id="c") == jobs


### PR DESCRIPTION
### What are the relevant tickets?
Fixes DAGSTER-2Q, DAGSTER-33, DAGSTER-39, DAGSTER-3A, DAGSTER-3C, DAGSTER-3E, DAGSTER-3F, DAGSTER-3N, DAGSTER-3R (Sentry, project `dagster`) — nine issue IDs for one behaviour, because `connection_id` is in the exception message.

### Description (What does it do?)
Two findings first, because they correct the premise this was filed under.

**The `poll_previous_running_sync` wiring did take.** `dagster_airbyte/resources.py:415` raises `Found multiple running jobs` only on the `poll_previous_running_sync=True` branch; the `False` branch raises `Found sync job for connection_id=... already running`. Every one of the nine issues carries the former text, so the flag is reaching the client at runtime exactly as intended.

**It is not several assets launched by one schedule tick.** Every event carries a distinct `dagster_run_id` with a single `dagster_step`, spaced 30–60s apart — four runs for `airbyte_edx_org_production_course_metadata_s3_data_lake` on 2026-08-24 (00:06:14, 00:08:11, 00:08:44, 00:09:17), four for `airbyte_irx_bigquery_email_opt_in_s3_data_lake` on 08-23, three for `airbyte_xpro_production_app_db_s3_data_lake` on 08-25. That is one real occurrence per connection per night, re-run by the run-retry daemon against a condition that re-running cannot change. (One initial run plus three retries matches `run_retries.max_retries: 3`, though that value lives outside this repo and is not verified here.)

What is left is the library's own rule: `sync_and_poll` attaches to **one** in-flight job and raises on **two or more**. `definitions.py:155-159` already records why that distinction does not hold here — "the automation condition and Airbyte's own scheduler both launch syncs" — so two in-flight jobs is the same routine overlap as one, arriving twice.

- `AirbyteOSSClient.get_jobs_for_connection()` now collapses concurrent in-flight jobs (`RUNNING`, `PENDING`, `INCOMPLETE` — the same set `sync_and_poll` counts) to the newest before returning. Airbyte job ids increase monotonically, so the highest id is the most recently created.
- Attaching to the newest is what the single-job branch already does, so this extends existing behaviour rather than inventing one.
- Terminal jobs are passed through untouched; job history is not rewritten.

The override sits on the accessor rather than on `sync_and_poll` because the library exposes no other seam: the decision is inline in a method too large to fork safely, and `get_jobs_for_connection` has exactly one caller in dagster-airbyte 0.29 (`resources.py:391`).

### How can this be tested?
- `cd dg_projects/lakehouse && uv run pytest lakehouse_tests -q` — 103 passed. Five new cases: newest in-flight kept, terminal jobs untouched, `INCOMPLETE` counted as in-flight, single in-flight left alone, no in-flight left alone.
- `pre-commit run --files <changed>` — ruff format, ruff check and mypy clean.

Not verified: nothing here has been run against the live Airbyte API (`api-airbyte.odl.mit.edu` needs credentials this session does not have). The confirming signal is the nightly window 00:06–00:15 UTC after deploy — `Found multiple running jobs` should stop, and the sync should log `Job N already running for connection_id=... Resume polling.` instead.

### Additional Context
Deliberately out of scope, and worth separate attention:

- **Why two jobs exist at all.** Establishing whether the second is an Airbyte-scheduler-initiated sync, a job left `RUNNING` by a Dagster run that died before its `cancel_on_termination` cleanup, or an `INCOMPLETE` attempt inside the 48-hour lookback needs the live Airbyte API. This PR makes the overlap survivable; it does not remove it.
- **The retry amplification.** A deterministic `Failure` being re-run three times at 30s intervals is the failure-semantics problem this project is scoped around, not an Airbyte defect.
- **Nine issue IDs for one behaviour.** The `connection_id` in the exception message splits the fingerprint. That belongs to the Sentry pipeline work.
- **DAGSTER-3V** (`Failure: Job was cancelled: 55609`, 4 events, first seen 2026-08-24) is a second face of the same overlap — one run's `cancel_on_termination` cleanup cancelling a job another run is polling. Attaching to the newest should reduce it; it is not directly addressed here.

`request_timeout` is 60s here (`definitions.py:153`), not the library default of 15s — relevant to the sibling DAGSTER-2R / DAGSTER-3Q "Max retries (3) exceeded" investigation, which this PR does not touch. Note that the task filed against this behaviour listed DAGSTER-2R among the "multiple running jobs" issues; 2R is in fact the "Max retries" issue, and 2Q is the ninth "multiple running jobs" one.
