### PR TITLE
feat(ingestion): strike the Pulumi steps, add ol-dbt inventory drift

### DIFF
--- a/dg_projects/lakehouse/lakehouse/assets/airbyte_drift.py
+++ b/dg_projects/lakehouse/lakehouse/assets/airbyte_drift.py
@@ -1,0 +1,147 @@
+"""Report where the live Airbyte workspace has drifted from the ingestion inventory.
+
+INGESTION_INVENTORY_SPEC steps 5 and 6 were struck (§6.0), so nothing applies
+the inventory to Airbyte and its configuration is edited by hand. That makes
+this the only thing that notices when the file stops describing reality —
+§4 calls it "the only part of the Airbyte-as-code story that needs to run on a
+timer", and the acceptance criterion is that a connection edited in the UI is
+reported within a day.
+
+It runs here rather than in Concourse because Dagster already holds the
+Airbyte basic-auth credential it needs, and because a failing run already
+routes to Sentry through the existing run-failure sensor — so an ERROR
+finding needs no reporting plumbing of its own.
+
+The comparison itself lives in `ol_dbt_cli.lib.inventory`, which imports
+neither dbt nor duckdb precisely so a Dagster code location can read the
+inventory (spec §5). This module only fetches and adapts.
+"""
+
+from pathlib import Path
+from typing import Any
+
+from dagster import AssetExecutionContext, Failure, MetadataValue, Output, asset
+from ol_dbt_cli.lib.inventory import check_drift, load_units
+from ol_dbt_cli.lib.validation import Severity, ValidationReport
+
+from lakehouse.resources.airbyte import AirbyteOSSWorkspace
+
+# The image copies the repo to /opt/dagster/code and sets it as WORKDIR
+# (dockerfiles/orchestrate/Dockerfile.global), so the inventory ships with the
+# code location and the relative path resolves. Anchored on this file rather
+# than the process's cwd, which a run launcher is free to change.
+INVENTORY_DIR = Path(__file__).resolve().parents[4] / "ingestion" / "inventory"
+
+
+def _fetch_workspace(workspace: AirbyteOSSWorkspace) -> dict[str, list[dict[str, Any]]]:
+    """Read the connections and sources the drift check compares against.
+
+    Deliberately raw API responses rather than `fetch_airbyte_workspace_data`:
+    dagster-airbyte's `AirbyteConnection` carries only id, name, stream_prefix
+    and stream names. It has no status, no schedule, no `sourceId`, and no
+    per-stream sync mode or cursor — which is most of what drift means here.
+    """
+    client = workspace.get_client()
+    common = {
+        "workspaceIds": workspace.workspace_id,
+        "limit": workspace.request_page_size,
+    }
+
+    connections = list(
+        client._paginated_request(  # noqa: SLF001
+            method="GET",
+            url=f"{client.rest_api_base_url}/connections",
+            params=dict(common),
+        )
+    )
+    sources = list(
+        client._paginated_request(  # noqa: SLF001
+            method="GET", url=f"{client.rest_api_base_url}/sources", params=dict(common)
+        )
+    )
+
+    # Some server versions omit stream configs from the list response; the same
+    # re-fetch `bin/airbyte-inventory.py` does. A connection left without one is
+    # NOT treated as having no streams — `check_drift` reports the gap as an
+    # unusable snapshot rather than as every declared stream being dropped.
+    for connection in connections:
+        if not (connection.get("configurations") or {}).get("streams"):
+            detail = client._single_request(  # noqa: SLF001
+                method="GET",
+                url=f"{client.rest_api_base_url}/connections/{connection['connectionId']}",
+            )
+            if detail:
+                connection["configurations"] = detail.get("configurations", {})
+
+    return {"connections": connections, "sources": sources}
+
+
+@asset(
+    name="airbyte_inventory_drift",
+    group_name="ingestion_inventory",
+    description=(
+        "Diff the live Airbyte workspace against ingestion/inventory. Fails the "
+        "run when the inventory is wrong about something it declares."
+    ),
+    compute_kind="airbyte",
+)
+def airbyte_inventory_drift(
+    context: AssetExecutionContext, airbyte: AirbyteOSSWorkspace
+) -> Output[dict[str, int]]:
+    """Fail when Airbyte no longer matches what the inventory declares."""
+    workspace = _fetch_workspace(airbyte)
+    units = load_units(INVENTORY_DIR)
+
+    # An empty fetch is not a workspace with no connections — it is a read that
+    # did not work, and reporting it as drift would claim every declared
+    # connection had been deleted. Same refusal as an incomplete snapshot.
+    if not workspace["connections"]:
+        msg = (
+            "Airbyte returned no connections. Refusing to report drift against an "
+            "empty read, which would say every declared connection has been deleted."
+        )
+        raise Failure(description=msg)
+    if not units:
+        msg = f"No inventory units found under {INVENTORY_DIR}."
+        raise Failure(description=msg)
+
+    report = ValidationReport()
+    check_drift(workspace, units, report)
+
+    for issue in report.issues:
+        line = f"{issue.model}: {issue.message}"
+        if issue.severity is Severity.ERROR:
+            context.log.error(line)
+        else:
+            context.log.warning(line)
+
+    counts = {
+        "live_connections": len(workspace["connections"]),
+        "units": len(units),
+        "errors": len(report.errors),
+        "warnings": len(report.warnings),
+    }
+    metadata = {
+        **{key: MetadataValue.int(value) for key, value in counts.items()},
+        "findings": MetadataValue.md(
+            "\n".join(
+                f"- **{i.severity.value}** {i.model}: {i.message}"
+                for i in report.issues
+            )
+            or "No drift."
+        ),
+    }
+
+    if report.errors:
+        # Failing the run is the report: the existing run-failure sensor routes
+        # it to Sentry, so an ERROR needs no notification path of its own.
+        # Warnings do not fail — a connection we have not declared yet costs
+        # nothing until something depends on it, and paging on it would train
+        # people to ignore this.
+        msg = (
+            f"{len(report.errors)} way(s) in which the inventory no longer describes "
+            f"Airbyte. See the run logs, and INGESTION_INVENTORY_SPEC §4."
+        )
+        raise Failure(description=msg, metadata=metadata)
+
+    return Output(counts, metadata=metadata)

--- a/dg_projects/lakehouse/lakehouse/definitions.py
+++ b/dg_projects/lakehouse/lakehouse/definitions.py
@@ -33,6 +33,7 @@ from ol_orchestrate.lib.utils import authenticate_vault, unauthenticated_vault
 from ol_orchestrate.resources.github import GithubApiClientFactory
 from ol_orchestrate.resources.trino_maintenance import TrinoMaintenanceResource
 
+from lakehouse.assets.airbyte_drift import airbyte_inventory_drift
 from lakehouse.assets.iceberg_maintenance import (
     iceberg_dbt_layer_maintenance,
     iceberg_raw_layer_maintenance,
@@ -399,6 +400,34 @@ b2b_analytics_starrocks_schedule = ScheduleDefinition(
     default_status=DefaultScheduleStatus.STOPPED,
 )
 
+# Airbyte inventory drift. Daily, which is exactly step 8's acceptance
+# criterion — "a connection edited in the UI is reported within a day". Runs
+# ahead of the ingestion schedules, so a report describes the workspace as it
+# was configured for the day's syncs.
+#
+# Gated on SKIP_AIRBYTE with the assets above: the asset requires the `airbyte`
+# resource, which is not registered when that flag is set, and a definition
+# asking for an absent resource fails the whole code location at load.
+airbyte_drift_assets = [] if SKIP_AIRBYTE else [airbyte_inventory_drift]
+airbyte_drift_schedules = (
+    []
+    if SKIP_AIRBYTE
+    else [
+        (
+            "airbyte_inventory_drift_daily",
+            ScheduleDefinition(
+                name="airbyte_inventory_drift_daily_schedule",
+                job=define_asset_job(
+                    name="airbyte_inventory_drift_daily_job",
+                    selection=AssetSelection.assets(airbyte_inventory_drift),
+                ),
+                cron_schedule="0 3 * * *",
+                execution_timezone="UTC",
+            ),
+        )
+    ]
+)
+
 # Instructor onboarding schedule
 instructor_onboarding_schedule = ScheduleDefinition(
     name="instructor_onboarding_daily_schedule",
@@ -483,6 +512,7 @@ defs = Definitions(
             iceberg_dbt_layer_maintenance,
             iceberg_raw_layer_maintenance,
             refresh_starrocks_analytics_mvs,
+            *airbyte_drift_assets,
         ]
     ),
     asset_checks=dbt_layer_freshness_checks,
@@ -546,6 +576,7 @@ defs = Definitions(
             ("iceberg_raw_maintenance_nightly", iceberg_raw_maintenance_schedule),
             ("dbt_docs_artifacts_daily", dbt_docs_artifacts_schedule),
             ("b2b_analytics_starrocks_nightly", b2b_analytics_starrocks_schedule),
+            *airbyte_drift_schedules,
         ]
     ),
 )

--- a/dg_projects/lakehouse/lakehouse_tests/test_airbyte_drift.py
+++ b/dg_projects/lakehouse/lakehouse_tests/test_airbyte_drift.py
@@ -1,0 +1,203 @@
+"""Tests for the Airbyte inventory drift asset.
+
+The comparison itself is tested in `src/ol_dbt_cli/tests/test_inventory_drift.py`.
+What is worth testing here is the part that only exists in Dagster: that the
+raw workspace read is adapted into the shape the check expects, that a failed
+read is refused rather than reported as mass drift, and that an ERROR fails the
+run while a warning does not.
+"""
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+from dagster import Failure, build_asset_context
+from lakehouse.assets.airbyte_drift import _fetch_workspace, airbyte_inventory_drift
+
+PREFIX = "raw__mitxonline__openedx__mysql__"
+CONNECTION_NAME = "MITx Online Open edX DB → S3 Data Lake"
+
+UNIT = f"""
+schema_version: 1
+deployment: mitxonline
+layer: mysql
+scope: scoped
+strategies:
+  qa: omit
+  local: fixture
+loader: airbyte
+table_prefix: {PREFIX}
+airbyte:
+  source_kind: source-mysql
+  replication_method: cursor
+  connections:
+  - name: {CONNECTION_NAME}
+    status: active
+    sync_interval_hours: 12
+    streams:
+    - auth_user
+tables:
+- name: auth_user
+  raw_table: {PREFIX}auth_user
+  sync_mode: incremental_append
+  cursor_field:
+  - id
+  modeled: true
+"""
+
+
+class FakeClient:
+    """Stands in for AirbyteOSSWorkspace.get_client()."""
+
+    rest_api_base_url = "https://airbyte.example.invalid/api/public/v1"
+
+    def __init__(
+        self,
+        connections: list[dict[str, Any]],
+        sources: list[dict[str, Any]],
+        detail: dict[str, Any] | None = None,
+    ) -> None:
+        self._connections = connections
+        self._sources = sources
+        self._detail = detail
+        self.detail_calls = 0
+
+    # Both are called with keyword arguments, so the ones this fake ignores are
+    # absorbed rather than named and silenced.
+    def _paginated_request(self, url: str, **_: Any) -> list[dict[str, Any]]:
+        return self._sources if url.endswith("/sources") else self._connections
+
+    def _single_request(self, **_: Any) -> dict[str, Any]:
+        self.detail_calls += 1
+        return self._detail or {}
+
+
+class FakeWorkspace:
+    workspace_id = "workspace-1"
+    request_page_size = 15
+
+    def __init__(self, client: FakeClient) -> None:
+        self._client = client
+
+    def get_client(self) -> FakeClient:
+        return self._client
+
+
+def connection(**overrides: Any) -> dict[str, Any]:
+    base = {
+        "connectionId": "conn-1",
+        "name": CONNECTION_NAME,
+        "status": "active",
+        "prefix": PREFIX,
+        "sourceId": "src-1",
+        "schedule": {"scheduleType": "manual"},
+        "configurations": {
+            "streams": [
+                {
+                    "name": "auth_user",
+                    "syncMode": "incremental_append",
+                    "cursorField": ["id"],
+                    "primaryKey": [],
+                }
+            ]
+        },
+    }
+    base.update(overrides)
+    return base
+
+
+SOURCE = {
+    "sourceId": "src-1",
+    "sourceType": "mysql",
+    "configuration": {"replication_method": {"method": "STANDARD"}},
+}
+
+
+@pytest.fixture
+def inventory(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    root = tmp_path / "inventory"
+    (root / "units").mkdir(parents=True)
+    (root / "units" / "mitxonline__mysql.yml").write_text(UNIT)
+    monkeypatch.setattr("lakehouse.assets.airbyte_drift.INVENTORY_DIR", root)
+    return root
+
+
+def _materialise(client: FakeClient) -> Any:
+    return airbyte_inventory_drift(build_asset_context(), FakeWorkspace(client))
+
+
+class TestFetchAdaptation:
+    def test_streams_missing_from_the_list_response_are_re_fetched(self) -> None:
+        # Mirrors bin/airbyte-inventory.py: some server versions omit stream
+        # configs from the list response.
+        bare = connection(configurations={})
+        detail = {
+            "configurations": {
+                "streams": [{"name": "auth_user", "syncMode": "incremental_append"}]
+            }
+        }
+        client = FakeClient([bare], [SOURCE], detail=detail)
+        fetched = _fetch_workspace(FakeWorkspace(client))
+
+        assert client.detail_calls == 1
+        assert (
+            fetched["connections"][0]["configurations"]["streams"][0]["name"]
+            == "auth_user"
+        )
+
+    def test_a_complete_list_response_is_not_re_fetched(self) -> None:
+        client = FakeClient([connection()], [SOURCE])
+        _fetch_workspace(FakeWorkspace(client))
+        assert client.detail_calls == 0
+
+
+class TestRefusals:
+    @pytest.mark.usefixtures("inventory")
+    def test_an_empty_read_is_refused_rather_than_reported_as_drift(self) -> None:
+        # Every declared connection would otherwise be reported as deleted,
+        # which is a page-worthy alarm produced by a failed read.
+        with pytest.raises(
+            Failure, match="Refusing to report drift against an empty read"
+        ):
+            _materialise(FakeClient([], [SOURCE]))
+
+    def test_an_empty_inventory_is_refused(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        empty = tmp_path / "inventory"
+        (empty / "units").mkdir(parents=True)
+        monkeypatch.setattr("lakehouse.assets.airbyte_drift.INVENTORY_DIR", empty)
+        with pytest.raises(Failure, match="No inventory units"):
+            _materialise(FakeClient([connection()], [SOURCE]))
+
+
+class TestOutcome:
+    @pytest.mark.usefixtures("inventory")
+    def test_agreement_returns_counts_and_does_not_fail(self) -> None:
+        result = _materialise(FakeClient([connection()], [SOURCE]))
+        assert result.value == {
+            "live_connections": 1,
+            "units": 1,
+            "errors": 0,
+            "warnings": 0,
+        }
+
+    @pytest.mark.usefixtures("inventory")
+    def test_an_error_fails_the_run(self) -> None:
+        # A paused connection the inventory declares active: the run failing is
+        # the report, since the existing run-failure sensor routes it onward.
+        with pytest.raises(Failure, match="no longer describes"):
+            _materialise(FakeClient([connection(status="inactive")], [SOURCE]))
+
+    @pytest.mark.usefixtures("inventory")
+    def test_a_warning_alone_does_not_fail(self) -> None:
+        # An undeclared connection is usually config nobody deleted. Paging on
+        # it would train people to ignore this.
+        extra = connection(
+            connectionId="conn-2",
+            name="Something From The UI",
+            configurations={"streams": []},
+        )
+        result = _materialise(FakeClient([connection(), extra], [SOURCE]))
+        assert result.value["errors"] == 0
+        assert result.value["warnings"] == 1

--- a/dg_projects/lakehouse/pyproject.toml
+++ b/dg_projects/lakehouse/pyproject.toml
@@ -12,6 +12,10 @@ dependencies = [
     "dbt-starrocks>=1.9.0",
     "dbt-trino >=1.10.0",
     "httpx2 >= 2.2.0",
+    # For ol_dbt_cli.lib.inventory, which the drift asset reads the inventory
+    # with. That module imports neither dbt nor duckdb precisely so a Dagster
+    # code location can use it (INGESTION_INVENTORY_SPEC §5).
+    "ol-dbt-cli",
     "ol-orchestrate-lib",
     "pygithub>=2.8.1",
     "pyiceberg>=0.8.0",
@@ -49,6 +53,7 @@ root_module = "lakehouse"
 exclude=["lakehouse_tests"]
 
 [tool.uv.sources]
+ol-dbt-cli = { path = "../../src/ol_dbt_cli", editable = true }
 ol-orchestrate-lib = { path = "../../packages/ol-orchestrate-lib", editable = true }
 
 # Pin grpcio-health-checking below 1.82.0: that release bundles health_pb2.py

--- a/dg_projects/lakehouse/uv.lock
+++ b/dg_projects/lakehouse/uv.lock
@@ -396,6 +396,21 @@ wheels = [
 ]
 
 [[package]]
+name = "cyclopts"
+version = "4.23.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "docstring-parser" },
+    { name = "rich" },
+    { name = "rich-rst" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/fc/db/becc1331b1eefe8e3370281a2fd7b9685ae6a10dbdd54c7e44ea05bf2ed6/cyclopts-4.23.2.tar.gz", hash = "sha256:1c9de7f245394d3ef9344fc6c976fc373fe1f2ce929b27f08ad4ea8499c13461", size = 196127, upload-time = "2026-08-22T19:20:49.534Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/35/40/c17d731af4ddbf6dede1f1acb09e6335c2587e8b73b3d4742f3f9c6996d3/cyclopts-4.23.2-py3-none-any.whl", hash = "sha256:eb95b6f221ec8e62ba64f879beb27dff779408a320db730fc184427c463a3695", size = 236258, upload-time = "2026-08-22T19:20:48.106Z" },
+]
+
+[[package]]
 name = "daff"
 version = "1.4.2"
 source = { registry = "https://pypi.org/simple" }
@@ -1434,6 +1449,11 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/55/33/71e45a6bd6875f44a26f99da31c63b6840123e88bedf2c0b1ce429b8be12/hvac-2.4.0-py3-none-any.whl", hash = "sha256:008db5efd8c2f77bd37d2368ea5f713edceae1c65f11fd608393179478649e0f", size = 155921, upload-time = "2025-10-30T12:57:46.253Z" },
 ]
 
+[package.optional-dependencies]
+parser = [
+    { name = "pyhcl" },
+]
+
 [[package]]
 name = "idna"
 version = "3.18"
@@ -1556,6 +1576,7 @@ dependencies = [
     { name = "dbt-starrocks" },
     { name = "dbt-trino" },
     { name = "httpx2" },
+    { name = "ol-dbt-cli" },
     { name = "ol-orchestrate-lib" },
     { name = "pygithub" },
     { name = "pyiceberg" },
@@ -1580,6 +1601,7 @@ requires-dist = [
     { name = "dbt-starrocks", specifier = ">=1.9.0" },
     { name = "dbt-trino", specifier = ">=1.10.0" },
     { name = "httpx2", specifier = ">=2.2.0" },
+    { name = "ol-dbt-cli", editable = "../../src/ol_dbt_cli" },
     { name = "ol-orchestrate-lib", editable = "../../packages/ol-orchestrate-lib" },
     { name = "pygithub", specifier = ">=2.8.1" },
     { name = "pyiceberg", specifier = ">=0.8.0" },
@@ -1866,6 +1888,39 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/0b/5f/19930f824ffeb0ad4372da4812c50edbd1434f678c90c2733e1188edfc63/oauthlib-3.3.1.tar.gz", hash = "sha256:0f0f8aa759826a193cf66c12ea1af1637f87b9b4622d46e866952bb022e538c9", size = 185918, upload-time = "2025-06-19T22:48:08.269Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/be/9c/92789c596b8df838baa98fa71844d84283302f7604ed565dafe5a6b5041a/oauthlib-3.3.1-py3-none-any.whl", hash = "sha256:88119c938d2b8fb88561af5f6ee0eec8cc8d552b7bb1f712743136eb7523b7a1", size = 160065, upload-time = "2025-06-19T22:48:06.508Z" },
+]
+
+[[package]]
+name = "ol-dbt-cli"
+version = "0.1.0"
+source = { editable = "../../src/ol_dbt_cli" }
+dependencies = [
+    { name = "boto3" },
+    { name = "cyclopts" },
+    { name = "duckdb" },
+    { name = "hvac", extra = ["parser"] },
+    { name = "jinja2" },
+    { name = "jsonschema" },
+    { name = "markupsafe" },
+    { name = "pyyaml" },
+    { name = "rich" },
+    { name = "sqlglot" },
+    { name = "trino" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "boto3", specifier = ">=1.35" },
+    { name = "cyclopts", specifier = ">=4.0" },
+    { name = "duckdb", specifier = ">=1.0,!=1.5.0,!=1.5.1" },
+    { name = "hvac", extras = ["parser"], specifier = ">=2.0.0,<3" },
+    { name = "jinja2", specifier = ">=3.1" },
+    { name = "jsonschema", specifier = ">=4.0" },
+    { name = "markupsafe", specifier = ">=2.1" },
+    { name = "pyyaml", specifier = ">=6.0" },
+    { name = "rich", specifier = ">=13.0" },
+    { name = "sqlglot", specifier = ">=25.26" },
+    { name = "trino", specifier = ">=0.329" },
 ]
 
 [[package]]
@@ -2316,6 +2371,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pyhcl"
+version = "0.4.5"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/20/b9/ff5019eef43b613f49a4695253d8814f8a7012745ae570158e5b64967200/pyhcl-0.4.5.tar.gz", hash = "sha256:c47293a51ccdd25e18bb5c8c0ab0ffe355b37c87f8d6f9d3280dc41efd4740bc", size = 61772, upload-time = "2023-09-01T05:25:16.788Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a8/b4/b766fd33774b55cc15f240916219c4ce9c1bd7bef4acd997ad36ff3622d0/pyhcl-0.4.5-py3-none-any.whl", hash = "sha256:30ee337d330d1f90c9f5ed8f49c468f66c8e6e43192bdc7c6ece1420beb3070c", size = 50160, upload-time = "2023-09-01T05:25:15.237Z" },
+]
+
+[[package]]
 name = "pyiceberg"
 version = "0.11.1"
 source = { registry = "https://pypi.org/simple" }
@@ -2604,6 +2668,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/e9/67/cae617f1351490c25a4b8ac3b8b63a4dda609295d8222bad12242dfdc629/rich-14.3.4.tar.gz", hash = "sha256:817e02727f2b25b40ef56f5aa2217f400c8489f79ca8f46ea2b70dd5e14558a9", size = 230524, upload-time = "2026-04-11T02:57:45.419Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b3/76/6d163cfac87b632216f71879e6b2cf17163f773ff59c00b5ff4900a80fa3/rich-14.3.4-py3-none-any.whl", hash = "sha256:07e7adb4690f68864777b1450859253bed81a99a31ac321ac1817b2313558952", size = 310480, upload-time = "2026-04-11T02:57:47.484Z" },
+]
+
+[[package]]
+name = "rich-rst"
+version = "2.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pygments" },
+    { name = "rich" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e2/d6/d0b9fafc73b65767200da027acab1db1bdb1048f4fea5ebf659df01c700e/rich_rst-2.1.0.tar.gz", hash = "sha256:f4d117b49697f338769759fa5cacf5197da4888b347b9fda2e50aef5cd8d93bd", size = 302732, upload-time = "2026-07-05T02:59:44.308Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/68/1fc93dd759605b5d00fc98b50200739e41ed32bd22d6ba35ca6c3932371b/rich_rst-2.1.0-py3-none-any.whl", hash = "sha256:7ecd1343ee12c879d0e7ae74c3eb6d263b023d2929c6d114212eb1fd91057255", size = 272987, upload-time = "2026-07-05T02:59:42.792Z" },
 ]
 
 [[package]]

--- a/docs/specs/INGESTION_INVENTORY_SPEC.md
+++ b/docs/specs/INGESTION_INVENTORY_SPEC.md
@@ -772,7 +772,7 @@ ol-infrastructure; 7 closes the loop.
 | ~~5~~ | ~~Pulumi `applications/airbyte_connections` + `sdks/airbyte`, import every source/destination/connection~~ | **STRUCK 2026-08-25 — §6.0** |
 | ~~6~~ | ~~Commit the rendered JSON into ol-infrastructure, register the stack in `simple_pulumi`~~ | **STRUCK 2026-08-25 — §6.0** |
 | 7 | Flip generation: `ol-dbt generate sources --from-inventory`, generate `group_name_to_interval` (§5) | Regenerating dbt sources from the inventory is a no-op diff except the corrected `loader:` values (§1.2) |
-| 8 | Scheduled drift check: dump the live workspace, diff against the inventory, report differences (§4) | A connection edited in the UI is reported within a day |
+| 8 | Scheduled drift check: dump the live workspace, diff against the inventory, report differences (§4). **`ol-dbt inventory drift` is built**; what remains is scheduling it and choosing how it reports. Promoted to the load-bearing check by §6.0 — with the config hand-managed it is the only thing that notices a UI edit | A connection edited in the UI is reported within a day. Baseline 2026-08-25: **0 errors, 5 warnings**, all five deliberate — 3 connections pending deletion, 2 paused ones carrying an Airbyte schedule |
 
 Steps 1–4 unblock `tk-step-2-extend-the-rfc-12319-ingestion-inventory--5a2841` (RFC 12711's
 critical path) — that step needs the schema and the file, not the Pulumi half. Do not hold it
@@ -839,7 +839,7 @@ reproduce, and several of them changed this spec (§1.1, §3.4–§3.7).
 | Sources on `xmin` | 11, covering 560 streams |
 | Incremental streams with no explicit cursor | 514 — i.e. riding xmin |
 | Distinct explicit cursor fields | 22, dominated by Salesforce's `SystemModstamp` (1,176) |
-| Connections carrying their own Airbyte cron | **0** — Dagster is the sole trigger, as assumed |
+| Connections carrying their own Airbyte cron | **0 active** — Dagster is the sole trigger, as assumed. **Corrected 2026-08-25:** three *paused* connections do carry `scheduleType: basic` (Mailgun legacy, GitHub, HubSpot Bootcamps). Nothing runs twice while they are paused, but resuming one double-schedules it. Step 8's drift check reports them, at warning rather than error, for that reason. |
 
 Findings that are work items rather than schema changes:
 

--- a/docs/specs/INGESTION_INVENTORY_SPEC.md
+++ b/docs/specs/INGESTION_INVENTORY_SPEC.md
@@ -419,6 +419,13 @@ disabled connection still records the streams someone once wanted in QA.
 
 ## 4. Crossing the repo boundary: a committed, generated JSON
 
+> **The consumer changed (2026-08-25, §6.0).** This section was written for a Pulumi stack in
+> ol-infrastructure applying the rendered JSON. That stack is not being built. The render
+> survives as the *expected state* step 8's drift check diffs live Airbyte against, so the
+> reasoning below about committing a generated artifact rather than fetching it still applies —
+> it is simply read by a check rather than by an apply, and nothing crosses the repo boundary
+> any more.
+
 The Pulumi program in ol-infrastructure must not import a Python package from ol-data-platform,
 and Pulumi must not parse the YAML dialect directly. The contract between the repos is a
 **rendered JSON document**, produced by `ol-dbt inventory render airbyte`, carrying
@@ -477,7 +484,7 @@ part of the Airbyte-as-code story that needs to run on a timer.
 | Target | Command | Notes |
 |---|---|---|
 | dbt sources YAML | `ol-dbt generate sources --from-inventory` | Merges into existing files; emits `loader` from the unit (§1.2); only `modeled: true` tables (§1.4) |
-| Airbyte config | `ol-dbt inventory render airbyte` → committed JSON → Pulumi | §4, §6 |
+| Airbyte config | `ol-dbt inventory render airbyte` → the expected state step 8's drift check compares against | §4, §6.0 — no longer applied by Pulumi |
 | Dagster sync cadence | `ol-dbt inventory render dagster-intervals` | Replaces the hand-maintained `group_name_to_interval` literal (`definitions.py:219-254`) |
 | dlt source specs | `ol-dbt inventory render dlt` | Phase 2 only; emits `DatabaseSourceSpec`/`DatabaseTable` inputs (`src/ol_dlt/ol_dlt/database.py`) |
 
@@ -546,6 +553,45 @@ incident.
 ---
 
 ## 6. Airbyte-as-code mechanics
+
+### 6.0 Not being built — decided 2026-08-25
+
+**Steps 5 and 6 are struck. Airbyte's configuration stays hand-managed until Airbyte is
+retired.** The rest of §6 is kept as the record of why, and would be the starting point if the
+decision is ever revisited — none of it was wrong, it just buys less than it costs.
+
+Three measurements taken while starting the work moved the balance:
+
+1. **Airbyte's API masks connector secrets server-side.** An imported source reads the mask
+   into Pulumi state while the declared configuration holds the real value, so the two can
+   never match. §6.4's acceptance test — "after importing, `pulumi preview` shows zero changes
+   of any kind" — is unreachable for **33 of 50 sources**. It survives only for the 17
+   secret-free sources, the 4 destinations, and the connections.
+2. **The database sources authenticate with Vault *dynamic* roles**, which mint a new
+   credential on every read. Declaring one rotates the database user on every apply and
+   guarantees a dirty preview, so `tk-switch-source-read-replica-creds-from-vault-dyna-812a53`
+   would have had to land first.
+3. **Managing the configuration and rotating the credential are the same lever, and masking
+   takes it away.** The way round (1) is `ignore_changes` on `configuration` — after which
+   Pulumi can no longer push a rotated password into Airbyte either. The one benefit that
+   would have justified the stack on its own is the one the workaround removes.
+
+Against that: every connection here is scheduled to be deleted. The stack was always designed
+to be destroyed unit by unit as sources move to dlt (§6.5), so the work is an investment in a
+shrinking asset, and the migration itself is the thing that retires the risk.
+
+**What still holds, and is worth more than the stack was.** The inventory keeps all three of
+its other consumers — dbt source generation (step 7), the Dagster interval map (§5), and the
+drift check (step 8). **Step 8 gets more important, not less**: with the configuration
+hand-managed, a scheduled diff of live Airbyte against the inventory is the only thing that
+notices a UI edit, and `ol-dbt inventory render airbyte` is already the shape to compare
+against. The apply gate §6.3 describes has no preview to gate and is not needed.
+
+One loose end deliberately left alone: `SENSITIVE_KEY_MARKERS` in `bin/airbyte-inventory.py`
+contains a bare `auth`, which over-redacts `auth_type`, `database_config.auth_source` and
+`entra_service_principal_auth` — ordinary configuration, not credentials. It was worth fixing
+when a Pulumi artifact needed those values verbatim. With no consumer reading them, the
+conservative redaction is the better default; narrow the marker if something ever needs them.
 
 ### 6.1 Provider, edition, auth
 
@@ -723,8 +769,8 @@ ol-infrastructure; 7 closes the loop.
 | 2 | Dump the live workspace and derive the findings — **`bin/airbyte-inventory.py` already does this**, and has been run (§8.1); folding it in is a move, not a rewrite | Generated inventory validates; connection names byte-identical to the API's (§1.3); `replication_method` captured per Postgres source |
 | 3 | `ol-dbt inventory reconcile` — three-way diff of inventory vs warehouse vs dbt sources; land the reconciled inventory as a reviewed PR. **Command and data both landed** (§8.2); the acceptance criterion is not yet met — see below | The three buckets of §5 are reported ✅; unmapped tables are explained, not deleted ✅; every one of the 374 dbt-declared raw tables maps to exactly one unit — **348/374**, the remaining 26 explained and tracked, not resolved |
 | 4 | **DONE.** CI: schema validation + §7.2 removal/rename check on every PR touching `ingestion/inventory/` (`.github/workflows/ingestion_inventory_ci.yaml`) | A PR deleting a table entry fails; the same PR with a `retired.yml` entry passes — verified end-to-end through the CLI |
-| 5 | Pulumi `applications/airbyte_connections` + `sdks/airbyte`, provider pinned, **preview-gate first** (§6.3), then import every existing source/destination/connection — plus `airbyte_source_definition`/`airbyte_destination_definition`, so the deployed `docker_image_tag` is a reviewed diff rather than a UI click (§6.2) | `pulumi preview` is empty after import — zero creates, zero updates, zero replacements |
-| 6 | Commit the rendered JSON into ol-infrastructure and register the stack in `simple_pulumi`'s `pipeline_params` + `meta.py` (§4) | Changing the committed JSON triggers the stack's own pipeline; no new pipeline is written |
+| ~~5~~ | ~~Pulumi `applications/airbyte_connections` + `sdks/airbyte`, import every source/destination/connection~~ | **STRUCK 2026-08-25 — §6.0** |
+| ~~6~~ | ~~Commit the rendered JSON into ol-infrastructure, register the stack in `simple_pulumi`~~ | **STRUCK 2026-08-25 — §6.0** |
 | 7 | Flip generation: `ol-dbt generate sources --from-inventory`, generate `group_name_to_interval` (§5) | Regenerating dbt sources from the inventory is a no-op diff except the corrected `loader:` values (§1.2) |
 | 8 | Scheduled drift check: dump the live workspace, diff against the inventory, report differences (§4) | A connection edited in the UI is reported within a day |
 

--- a/ingestion/inventory/units/edxorg__google_sheets.yml
+++ b/ingestion/inventory/units/edxorg__google_sheets.yml
@@ -24,4 +24,7 @@ tables:
 - name: raw__edxorg__program_entitlement
   raw_table: raw__edxorg__program_entitlement
   sync_mode: full_refresh_overwrite
+  primary_key:
+  - - Email
+  - - Program Title
   modeled: true

--- a/ingestion/inventory/units/edxorg__s3.yml
+++ b/ingestion/inventory/units/edxorg__s3.yml
@@ -38,25 +38,37 @@ airbyte:
 tables:
 - name: raw__edxorg__s3__course_blocks
   raw_table: raw__edxorg__s3__course_blocks
-  sync_mode: full_refresh_overwrite
+  sync_mode: incremental_append
+  cursor_field:
+  - _ab_source_file_last_modified
   modeled: true
 - name: raw__edxorg__s3__mitx_course
   raw_table: raw__edxorg__s3__mitx_course
-  sync_mode: full_refresh_overwrite
+  sync_mode: incremental_append
+  cursor_field:
+  - _ab_source_file_last_modified
   modeled: true
 - name: raw__edxorg__s3__mitx_course_run
   raw_table: raw__edxorg__s3__mitx_course_run
-  sync_mode: full_refresh_overwrite
+  sync_mode: incremental_append
+  cursor_field:
+  - _ab_source_file_last_modified
   modeled: true
 - name: raw__edxorg__s3__program
   raw_table: raw__edxorg__s3__program
-  sync_mode: full_refresh_overwrite
+  sync_mode: incremental_append
+  cursor_field:
+  - _ab_source_file_last_modified
   modeled: true
 - name: raw__edxorg__s3__program_course
   raw_table: raw__edxorg__s3__program_course
-  sync_mode: full_refresh_overwrite
+  sync_mode: incremental_append
+  cursor_field:
+  - _ab_source_file_last_modified
   modeled: true
 - name: raw__edxorg__program_learner_report
   raw_table: raw__edxorg__program_learner_report
-  sync_mode: full_refresh_overwrite
+  sync_mode: incremental_append
+  cursor_field:
+  - _ab_source_file_last_modified
   modeled: true

--- a/ingestion/inventory/units/edxorg__tracking_logs.yml
+++ b/ingestion/inventory/units/edxorg__tracking_logs.yml
@@ -23,5 +23,7 @@ airbyte:
 tables:
 - name: raw__edxorg__s3__tracking_logs
   raw_table: raw__edxorg__s3__tracking_logs
-  sync_mode: full_refresh_overwrite
+  sync_mode: incremental_append
+  cursor_field:
+  - _ab_source_file_last_modified
   modeled: true

--- a/src/ol_dbt_cli/ol_dbt_cli/commands/inventory.py
+++ b/src/ol_dbt_cli/ol_dbt_cli/commands/inventory.py
@@ -380,7 +380,8 @@ def drift(
 
     report = ValidationReport()
     try:
-        check_drift(json.loads(snapshot.read_text()), units, report)
+        workspace = json.loads(snapshot.read_text())
+        check_drift(workspace, units, report)
     except (json.JSONDecodeError, RenderError) as error:
         err_console.print(f"[bold red]{escape(str(error))}")
         sys.exit(1)
@@ -389,10 +390,14 @@ def drift(
         _emit_json(report.issues)
     else:
         _emit_text(report.issues)
-        live = len(json.loads(snapshot.read_text()).get("connections") or [])
+        live = len(workspace.get("connections") or [])
+        # Connections, not units: `render airbyte` skips the dlt and Dagster
+        # units, so counting all 43 would put 43 against 43 and read as
+        # agreement while three live connections went undeclared.
+        rendered = sum(len(unit.get("connections") or []) for unit in render_airbyte(units).get("units") or [])
         console.print(
             f"\n[bold]Summary:[/] compared {live} live connection(s) against "
-            f"{len(units)} unit(s) — {len(report.errors)} error(s), "
+            f"{rendered} declared — {len(report.errors)} error(s), "
             f"{len(report.warnings)} warning(s)."
         )
 

--- a/src/ol_dbt_cli/ol_dbt_cli/commands/inventory.py
+++ b/src/ol_dbt_cli/ol_dbt_cli/commands/inventory.py
@@ -29,6 +29,7 @@ from ol_dbt_cli.lib.inventory import (
     DEFAULT_INVENTORY_DIR,
     RenderError,
     Unit,
+    check_drift,
     check_removals,
     load_snapshot,
     load_snapshot_at_ref,
@@ -331,6 +332,69 @@ def reconcile(
                 f"{len(warehouse_result.observed_not_declared)} present but undeclared."
             )
         console.print(f"[bold]Summary:[/] {len(report.errors)} error(s), {len(report.warnings)} warning(s).")
+
+    if report.errors:
+        sys.exit(1)
+
+
+@inventory_app.command
+def drift(
+    *,
+    snapshot: Annotated[
+        Path,
+        Parameter(
+            name=["--snapshot", "-s"],
+            help="A workspace dump from `bin/airbyte-inventory.py dump`.",
+        ),
+    ] = Path("airbyte-snapshot.json"),
+    inventory_dir: Annotated[
+        Path,
+        Parameter(name=["--inventory-dir", "-i"], help="Directory holding units/."),
+    ] = DEFAULT_INVENTORY_DIR,
+    output_format: Annotated[
+        str,
+        Parameter(name=["--format", "-f"], help="Output format: text (default) or json."),
+    ] = "text",
+) -> None:
+    """Report every way the live Airbyte workspace differs from the inventory.
+
+    Steps 5 and 6 were struck (§6.0), so Airbyte's configuration is
+    hand-managed and nothing applies the inventory to it. This is what keeps
+    the file honest in between: on a schedule, dump the workspace and diff it,
+    because the divergence nothing else can catch is somebody editing a
+    connection in the UI (§4).
+
+    Takes a dump rather than reading the API, so the credentialed step stays
+    separate and a drift report can be re-derived offline from a saved
+    snapshot. Exits non-zero when the inventory is wrong about something it
+    declares; a live connection or stream the inventory merely does not cover
+    is a warning.
+    """
+    units = load_units(inventory_dir)
+    if not snapshot.exists():
+        err_console.print(
+            f"[bold red]No snapshot at {escape(str(snapshot))}. Produce one with:\n"
+            "  uv run python bin/airbyte-inventory.py dump --username dagster"
+        )
+        sys.exit(1)
+
+    report = ValidationReport()
+    try:
+        check_drift(json.loads(snapshot.read_text()), units, report)
+    except (json.JSONDecodeError, RenderError) as error:
+        err_console.print(f"[bold red]{escape(str(error))}")
+        sys.exit(1)
+
+    if output_format == "json":
+        _emit_json(report.issues)
+    else:
+        _emit_text(report.issues)
+        live = len(json.loads(snapshot.read_text()).get("connections") or [])
+        console.print(
+            f"\n[bold]Summary:[/] compared {live} live connection(s) against "
+            f"{len(units)} unit(s) — {len(report.errors)} error(s), "
+            f"{len(report.warnings)} warning(s)."
+        )
 
     if report.errors:
         sys.exit(1)

--- a/src/ol_dbt_cli/ol_dbt_cli/lib/inventory.py
+++ b/src/ol_dbt_cli/ol_dbt_cli/lib/inventory.py
@@ -967,6 +967,25 @@ DRIFT_CHECK = "inventory_drift"
 
 MANUAL_SCHEDULE = "manual"
 
+# How Airbyte spells a Postgres replication method, mapped to the inventory's
+# vocabulary. Mirrors `bin/airbyte-inventory.py`, which cannot be imported from
+# here — it is a script, not a package.
+REPLICATION_METHODS = {"xmin": "xmin", "standard": "cursor", "cursor": "cursor", "cdc": "cdc"}
+
+
+def _live_replication_method(configuration: dict[str, Any] | None) -> str:
+    """Read a source's replication method out of its configuration, whatever shape it takes."""
+    if not isinstance(configuration, dict):
+        return "n/a"
+    method = configuration.get("replication_method")
+    if isinstance(method, dict):
+        raw = str(method.get("method") or method.get("replication_slot") or "unknown")
+    elif isinstance(method, str):
+        raw = method
+    else:
+        return "n/a"
+    return REPLICATION_METHODS.get(raw.lower(), "n/a")
+
 
 def _live_connections(snapshot: dict[str, Any]) -> dict[str, dict[str, Any]]:
     return {str(c.get("name", "")): c for c in snapshot.get("connections") or []}
@@ -981,8 +1000,19 @@ def _declared_connections(rendered: dict[str, Any]) -> dict[str, tuple[dict[str,
     }
 
 
-def _live_streams(connection: dict[str, Any]) -> dict[str, dict[str, Any]]:
-    configurations = connection.get("configurations") or {}
+def _live_streams(connection: dict[str, Any]) -> dict[str, dict[str, Any]] | None:
+    """Index a connection's live streams, or None if the snapshot never captured them.
+
+    An explicitly empty list means every stream really was deselected, which is
+    drift worth shouting about. A *missing* `configurations.streams` means the
+    dump failed to read them: the dumper re-fetches a connection whose list
+    response omitted its streams, but leaves the key absent when that GET also
+    fails. Collapsing the two into `[]` would turn one transient API failure
+    into "every declared stream has been dropped" across the whole workspace.
+    """
+    configurations = connection.get("configurations")
+    if not isinstance(configurations, dict) or "streams" not in configurations:
+        return None
     return {str(s.get("name", "")): s for s in configurations.get("streams") or []}
 
 
@@ -1027,6 +1057,18 @@ def check_drift(snapshot: dict[str, Any], units: list[Unit], report: ValidationR
     rendered = render_airbyte(units)
     live = _live_connections(snapshot)
     declared = _declared_connections(rendered)
+    # The render carries stream names, not the raw tables they land in — that
+    # stays on the unit (§2). Keyed per connection, never globally: a stream
+    # name is only unique within its unit, and `users` alone belongs to three
+    # Mongo forums and to Zendesk.
+    raw_tables = {
+        str(connection.get("name", "")): {
+            str(table.get("name", "")): str(table.get("raw_table", "")) for table in unit.tables
+        }
+        for unit in units
+        for connection in unit.connections
+    }
+    live_sources = {str(s.get("sourceId", "")): s for s in snapshot.get("sources") or []}
 
     for name in sorted(set(declared) - set(live)):
         _, unit = declared[name]
@@ -1053,7 +1095,64 @@ def check_drift(snapshot: dict[str, Any], units: list[Unit], report: ValidationR
         )
 
     for name in sorted(set(live) & set(declared)):
-        _compare_connection(name, live[name], *declared[name], report)
+        connection, unit = declared[name]
+        _compare_connection(
+            name,
+            live[name],
+            connection,
+            unit,
+            raw_tables.get(name, {}),
+            live_sources,
+            report,
+        )
+
+
+def _compare_source(  # noqa: PLR0913
+    name: str,
+    live: dict[str, Any],
+    unit: dict[str, Any],
+    live_sources: dict[str, dict[str, Any]],
+    report: ValidationReport,
+    key: str,
+) -> None:
+    """Compare the source behind a connection, which the streams do not describe.
+
+    `replication_method` is recorded deliberately and is not decorative (§3.4):
+    it is what `tk-determine-per-source-incremental-cursor-viabilit-51f299`
+    reads to decide which connections need a replacement cursor before dlt can
+    take over. A source flipped from xmin to a cursor column changes nothing
+    about the streams, so comparing streams alone would report no drift while
+    that answer silently went wrong.
+    """
+    source = live_sources.get(str(live.get("sourceId", "")))
+    if source is None:
+        return
+
+    # The inventory spells a connector `source-postgres`; the API says
+    # `postgres`.
+    live_kind = f"source-{source.get('sourceType')}" if source.get("sourceType") else None
+    if live_kind and live_kind != unit.get("source_kind"):
+        report.add(
+            DRIFT_CHECK,
+            Severity.ERROR,
+            key,
+            f"connection {name!r} now uses connector {live_kind!r}, unit declares {unit.get('source_kind')!r}",
+            "A different connector reads the source differently, so the unit's "
+            "sync modes and cursors describe a pipeline that no longer exists.",
+        )
+
+    live_method = _live_replication_method(source.get("configuration"))
+    declared_method = unit.get("replication_method")
+    if declared_method and live_method != declared_method:
+        report.add(
+            DRIFT_CHECK,
+            Severity.ERROR,
+            key,
+            f"connection {name!r} replicates by {live_method!r}, unit declares {declared_method!r}",
+            "§3.4 records this so `rg replication_method: xmin` answers which "
+            "connections need a replacement cursor before dlt can take them. A "
+            "stale value makes that answer wrong without changing any stream.",
+        )
 
 
 def _compare_connection(  # noqa: PLR0913
@@ -1061,9 +1160,12 @@ def _compare_connection(  # noqa: PLR0913
     live: dict[str, Any],
     declared: dict[str, Any],
     unit: dict[str, Any],
+    raw_tables: dict[str, str],
+    live_sources: dict[str, dict[str, Any]],
     report: ValidationReport,
 ) -> None:
     key = f"{unit['deployment']}/{unit['layer']}"
+    _compare_source(name, live, unit, live_sources, report, key)
 
     if (live_status := live.get("status")) != declared.get("status"):
         report.add(
@@ -1093,27 +1195,21 @@ def _compare_connection(  # noqa: PLR0913
             "would double-schedule it against Dagster (§6.4).",
         )
 
-    # `startswith`, not equality: `table_prefix` is declared documentation that
-    # covers a unit's tables (§1.1), not a copy of the literal string Airbyte
-    # prepends. The mongodb units legitimately declare
-    # `raw__<dep>__openedx__mongodb__` while Airbyte writes `…mongodb__forum_`.
-    # What would be drift is a live prefix the declared one no longer covers,
-    # because then the unit's raw_table values name tables that stop arriving.
-    live_prefix = live.get("prefix")
-    declared_prefix = unit.get("table_prefix") or ""
-    if live_prefix and not live_prefix.startswith(declared_prefix):
+    live_streams = _live_streams(live)
+    declared_streams = {str(s.get("name", "")): s for s in declared.get("streams") or []}
+
+    if live_streams is None:
         report.add(
             DRIFT_CHECK,
             Severity.ERROR,
             key,
-            f"connection {name!r} writes prefix {live_prefix!r}, outside the unit's declared {declared_prefix!r}",
-            "Every raw table this connection lands is named from the live "
-            "prefix, so the unit's tables are describing names that no longer "
-            "arrive.",
+            f"the snapshot holds no stream configuration for connection {name!r}",
+            "The dump could not read them, so this says nothing about drift. "
+            "Re-dump before trusting the report — an absent configuration is "
+            "not an empty one, and treating it as empty would claim every "
+            "declared stream had been dropped.",
         )
-
-    live_streams = _live_streams(live)
-    declared_streams = {str(s.get("name", "")): s for s in declared.get("streams") or []}
+        return
 
     for stream in sorted(set(declared_streams) - set(live_streams)):
         report.add(
@@ -1134,7 +1230,30 @@ def _compare_connection(  # noqa: PLR0913
             "It is being loaded and nothing records that it is.",
         )
 
+    # Where a raw table actually lands, rather than whether the unit's
+    # documentation prefix still looks plausible. Comparing `table_prefix`
+    # against Airbyte's `prefix` cannot work in either direction: the mongodb
+    # units legitimately declare `…__mongodb__` while Airbyte writes
+    # `…__mongodb__forum_`, and 12 connections carry no prefix at all because
+    # their stream names are already whole raw table names. `prefix + stream`
+    # is what Airbyte lands, and it reproduces all 949 declared raw tables
+    # exactly — so clearing a prefix, which the earlier check skipped as
+    # falsey, now shows up as every table in that connection moving.
+    live_prefix = live.get("prefix") or ""
     for stream in sorted(set(live_streams) & set(declared_streams)):
+        landed = f"{live_prefix}{stream}"
+        expected = raw_tables.get(stream)
+        if expected and landed != expected:
+            report.add(
+                DRIFT_CHECK,
+                Severity.ERROR,
+                key,
+                f"{name!r} stream {stream!r} now lands in {landed!r}, not the declared {expected!r}",
+                "The connection's prefix changed, so the table the unit "
+                "declares stops being written and anything modelling it goes "
+                "stale against whatever it last held.",
+            )
+
         want = _normalise_declared_stream(declared_streams[stream])
         got = _normalise_live_stream(live_streams[stream])
         for attribute in sorted(set(want) | set(got)):

--- a/src/ol_dbt_cli/ol_dbt_cli/lib/inventory.py
+++ b/src/ol_dbt_cli/ol_dbt_cli/lib/inventory.py
@@ -950,3 +950,199 @@ def reconcile_dbt(
         )
 
     return result
+
+
+# ---------------------------------------------------------------------------
+# Drift (§4, step 8): the inventory against the live Airbyte workspace
+# ---------------------------------------------------------------------------
+#
+# The failure this project exists to end is a static file that quietly stops
+# describing reality, and the divergence nothing else can catch is somebody
+# editing a connection in the Airbyte UI. Steps 5-6 were struck (§6.0), so
+# Airbyte's configuration is hand-managed and this check is the only thing that
+# notices. It compares against `render_airbyte`, which is already the inventory
+# expressed in Airbyte's own shape.
+
+DRIFT_CHECK = "inventory_drift"
+
+MANUAL_SCHEDULE = "manual"
+
+
+def _live_connections(snapshot: dict[str, Any]) -> dict[str, dict[str, Any]]:
+    return {str(c.get("name", "")): c for c in snapshot.get("connections") or []}
+
+
+def _declared_connections(rendered: dict[str, Any]) -> dict[str, tuple[dict[str, Any], dict[str, Any]]]:
+    """Map connection name to (connection, its unit), as the render emits them."""
+    return {
+        str(connection.get("name", "")): (connection, unit)
+        for unit in rendered.get("units") or []
+        for connection in unit.get("connections") or []
+    }
+
+
+def _live_streams(connection: dict[str, Any]) -> dict[str, dict[str, Any]]:
+    configurations = connection.get("configurations") or {}
+    return {str(s.get("name", "")): s for s in configurations.get("streams") or []}
+
+
+def _normalise_live_stream(stream: dict[str, Any]) -> dict[str, Any]:
+    """Put a live stream in the render's vocabulary, dropping empty values.
+
+    The render omits a field it has nothing to say about; Airbyte returns `[]`.
+    Comparing those raw would report drift on every stream that simply has no
+    cursor, which is most of them.
+    """
+    normalised: dict[str, Any] = {"sync_mode": stream.get("syncMode")}
+    if stream.get("namespace"):
+        normalised["namespace"] = stream["namespace"]
+    if stream.get("cursorField"):
+        normalised["cursor_field"] = list(stream["cursorField"])
+    if stream.get("primaryKey"):
+        normalised["primary_key"] = [list(path) for path in stream["primaryKey"]]
+    return normalised
+
+
+def _normalise_declared_stream(stream: dict[str, Any]) -> dict[str, Any]:
+    """Take the same view of a rendered stream, minus what Airbyte cannot be asked for.
+
+    `excluded_columns` is dropped rather than compared: Airbyte holds the
+    complement (`selectedFields`), and computing it needs the source's
+    discovered schema, which the inventory deliberately does not hold (§2).
+    Comparing an exclusion against a selection would report drift on every
+    stream that has one.
+    """
+    return {key: value for key, value in stream.items() if key not in {"name", "excluded_columns"}}
+
+
+def check_drift(snapshot: dict[str, Any], units: list[Unit], report: ValidationReport) -> None:
+    """Report every way the live workspace differs from what the inventory declares.
+
+    Severity follows what the finding says about the inventory. A declaration
+    the workspace does not honour means the inventory is *wrong* — a model may
+    be reading a table nothing loads — and is an ERROR. Something live the
+    inventory does not cover is a WARNING: it is usually config that should
+    have been deleted, and it costs nothing until somebody depends on it.
+    """
+    rendered = render_airbyte(units)
+    live = _live_connections(snapshot)
+    declared = _declared_connections(rendered)
+
+    for name in sorted(set(declared) - set(live)):
+        _, unit = declared[name]
+        report.add(
+            DRIFT_CHECK,
+            Severity.ERROR,
+            f"{unit['deployment']}/{unit['layer']}",
+            f"connection {name!r} is declared but no longer exists in Airbyte",
+            "Either it was deleted in the UI and the tables it loaded have "
+            "stopped arriving, or it was renamed — and a rename also breaks "
+            "Dagster's selector and its interval map, which key on this exact "
+            "string (§1.3).",
+        )
+
+    for name in sorted(set(live) - set(declared)):
+        report.add(
+            DRIFT_CHECK,
+            Severity.WARNING,
+            "(undeclared)",
+            f"connection {name!r} exists in Airbyte but no unit declares it",
+            "Either it was created in the UI, or it is config we meant to "
+            "delete and did not. Retiring a connection means deleting it in "
+            "Airbyte as well as recording its tables in retired.yml.",
+        )
+
+    for name in sorted(set(live) & set(declared)):
+        _compare_connection(name, live[name], *declared[name], report)
+
+
+def _compare_connection(  # noqa: PLR0913
+    name: str,
+    live: dict[str, Any],
+    declared: dict[str, Any],
+    unit: dict[str, Any],
+    report: ValidationReport,
+) -> None:
+    key = f"{unit['deployment']}/{unit['layer']}"
+
+    if (live_status := live.get("status")) != declared.get("status"):
+        report.add(
+            DRIFT_CHECK,
+            Severity.ERROR,
+            key,
+            f"connection {name!r} is {live_status!r} in Airbyte but declared {declared.get('status')!r}",
+            "A connection paused in the UI stops loading silently; one resumed "
+            "without the inventory saying so is loading tables nothing declares.",
+        )
+
+    schedule_type = (live.get("schedule") or {}).get("scheduleType")
+    if schedule_type and schedule_type != MANUAL_SCHEDULE:
+        # A paused connection cannot double-schedule anything, so this is a
+        # warning until somebody resumes it — at which point it runs on both
+        # Airbyte's timer and Dagster's.
+        running = live_status == "active"
+        report.add(
+            DRIFT_CHECK,
+            Severity.ERROR if running else Severity.WARNING,
+            key,
+            f"connection {name!r} carries its own Airbyte schedule ({schedule_type!r})",
+            "Dagster is meant to be the sole trigger, so this is double-scheduled "
+            "and `sync_interval_hours` describes only half of what runs (§6.4)."
+            if running
+            else "It is paused, so nothing runs twice today — but resuming it "
+            "would double-schedule it against Dagster (§6.4).",
+        )
+
+    # `startswith`, not equality: `table_prefix` is declared documentation that
+    # covers a unit's tables (§1.1), not a copy of the literal string Airbyte
+    # prepends. The mongodb units legitimately declare
+    # `raw__<dep>__openedx__mongodb__` while Airbyte writes `…mongodb__forum_`.
+    # What would be drift is a live prefix the declared one no longer covers,
+    # because then the unit's raw_table values name tables that stop arriving.
+    live_prefix = live.get("prefix")
+    declared_prefix = unit.get("table_prefix") or ""
+    if live_prefix and not live_prefix.startswith(declared_prefix):
+        report.add(
+            DRIFT_CHECK,
+            Severity.ERROR,
+            key,
+            f"connection {name!r} writes prefix {live_prefix!r}, outside the unit's declared {declared_prefix!r}",
+            "Every raw table this connection lands is named from the live "
+            "prefix, so the unit's tables are describing names that no longer "
+            "arrive.",
+        )
+
+    live_streams = _live_streams(live)
+    declared_streams = {str(s.get("name", "")): s for s in declared.get("streams") or []}
+
+    for stream in sorted(set(declared_streams) - set(live_streams)):
+        report.add(
+            DRIFT_CHECK,
+            Severity.ERROR,
+            key,
+            f"connection {name!r} no longer carries declared stream {stream!r}",
+            "The unit still declares a table for it, so anything modelling that "
+            "table is going stale. Retire it, or re-select the stream.",
+        )
+
+    for stream in sorted(set(live_streams) - set(declared_streams)):
+        report.add(
+            DRIFT_CHECK,
+            Severity.WARNING,
+            key,
+            f"connection {name!r} carries stream {stream!r}, which the unit does not declare",
+            "It is being loaded and nothing records that it is.",
+        )
+
+    for stream in sorted(set(live_streams) & set(declared_streams)):
+        want = _normalise_declared_stream(declared_streams[stream])
+        got = _normalise_live_stream(live_streams[stream])
+        for attribute in sorted(set(want) | set(got)):
+            if want.get(attribute) != got.get(attribute):
+                report.add(
+                    DRIFT_CHECK,
+                    Severity.ERROR,
+                    key,
+                    f"{name!r} stream {stream!r}: {attribute} is {got.get(attribute)!r} in Airbyte, "
+                    f"declared {want.get(attribute)!r}",
+                )

--- a/src/ol_dbt_cli/tests/test_inventory_drift.py
+++ b/src/ol_dbt_cli/tests/test_inventory_drift.py
@@ -1,0 +1,188 @@
+"""Tests for `ol-dbt inventory drift` (INGESTION_INVENTORY_SPEC §4, step 8).
+
+Steps 5 and 6 were struck (§6.0), so nothing applies the inventory to Airbyte
+and this check is the only thing that notices a UI edit. Its first run against
+production found a real error in the hand-written edxorg units, which is the
+argument for the cases below: each one is a way the file can quietly stop
+describing reality.
+"""
+
+from __future__ import annotations
+
+import copy
+from pathlib import Path
+from typing import Any
+
+import pytest
+import yaml
+
+from ol_dbt_cli.lib.inventory import check_drift, load_units
+from ol_dbt_cli.lib.validation import Severity, ValidationReport
+
+PREFIX = "raw__mitxonline__openedx__mysql__"
+
+UNIT: dict[str, Any] = {
+    "schema_version": 1,
+    "deployment": "mitxonline",
+    "layer": "mysql",
+    "scope": "scoped",
+    "strategies": {"qa": "omit", "local": "fixture"},
+    "loader": "airbyte",
+    "table_prefix": PREFIX,
+    "airbyte": {
+        "source_kind": "source-mysql",
+        "replication_method": "cursor",
+        "connections": [
+            {
+                "name": "MITx Online Open edX DB → S3 Data Lake",
+                "status": "active",
+                "sync_interval_hours": 12,
+                "streams": ["auth_user"],
+            }
+        ],
+    },
+    "tables": [
+        {
+            "name": "auth_user",
+            "raw_table": f"{PREFIX}auth_user",
+            "sync_mode": "incremental_append",
+            "cursor_field": ["id"],
+            "modeled": True,
+        }
+    ],
+}
+
+CONNECTION_NAME = "MITx Online Open edX DB → S3 Data Lake"
+
+
+def live(**overrides: Any) -> dict[str, Any]:
+    """Build a snapshot that agrees with UNIT, before overrides are applied."""
+    connection = {
+        "name": CONNECTION_NAME,
+        "status": "active",
+        "prefix": PREFIX,
+        "schedule": {"scheduleType": "manual"},
+        "configurations": {
+            "streams": [
+                {
+                    "name": "auth_user",
+                    "syncMode": "incremental_append",
+                    "cursorField": ["id"],
+                    "primaryKey": [],
+                    "selectedFields": [],
+                }
+            ]
+        },
+    }
+    connection.update(overrides)
+    return {"connections": [connection]}
+
+
+@pytest.fixture
+def units(tmp_path: Path) -> list[Any]:
+    root = tmp_path / "inventory"
+    (root / "units").mkdir(parents=True)
+    (root / "units" / "mitxonline__mysql.yml").write_text(yaml.safe_dump(UNIT, sort_keys=False))
+    return load_units(root)
+
+
+def _run(snapshot: dict[str, Any], units: list[Any]) -> ValidationReport:
+    report = ValidationReport()
+    check_drift(snapshot, units, report)
+    return report
+
+
+def _messages(report: ValidationReport, severity: Severity) -> list[str]:
+    return [i.message for i in report.issues if i.severity == severity]
+
+
+class TestAgreement:
+    def test_a_workspace_matching_the_inventory_is_silent(self, units: list[Any]) -> None:
+        assert _run(live(), units).issues == []
+
+    def test_an_empty_cursor_matches_an_undeclared_one(self, units: list[Any]) -> None:
+        # Airbyte returns `[]` where the render omits the field. Comparing those
+        # raw would report drift on nearly every stream, since most have no
+        # primary key.
+        no_key = copy.deepcopy(UNIT)
+        del no_key["tables"][0]["cursor_field"]
+        snapshot = live()
+        snapshot["connections"][0]["configurations"]["streams"][0]["cursorField"] = []
+        report = ValidationReport()
+        check_drift(snapshot, [type(units[0])(path=Path("u.yml"), data=no_key)], report)
+        assert report.issues == []
+
+
+class TestConnectionDrift:
+    def test_a_declared_connection_missing_from_airbyte_is_an_error(self, units: list[Any]) -> None:
+        report = _run({"connections": []}, units)
+        assert "is declared but no longer exists in Airbyte" in _messages(report, Severity.ERROR)[0]
+
+    def test_an_undeclared_live_connection_is_a_warning(self, units: list[Any]) -> None:
+        # Usually config someone forgot to delete, and it costs nothing until
+        # something depends on it — unlike a declaration that has gone missing.
+        snapshot = live()
+        snapshot["connections"].append({"name": "Something Someone Made In The UI", "configurations": {}})
+        report = _run(snapshot, units)
+        assert report.errors == []
+        assert "no unit declares it" in _messages(report, Severity.WARNING)[0]
+
+    def test_a_paused_connection_is_reported(self, units: list[Any]) -> None:
+        report = _run(live(status="inactive"), units)
+        assert "'inactive' in Airbyte but declared 'active'" in _messages(report, Severity.ERROR)[0]
+
+
+class TestScheduleDrift:
+    def test_an_active_connection_with_its_own_schedule_is_an_error(self, units: list[Any]) -> None:
+        report = _run(live(schedule={"scheduleType": "basic"}), units)
+        assert "carries its own Airbyte schedule" in _messages(report, Severity.ERROR)[0]
+
+    def test_a_paused_one_is_only_a_warning(self, units: list[Any]) -> None:
+        # It cannot double-schedule anything while paused; resuming it would.
+        report = _run(live(status="inactive", schedule={"scheduleType": "basic"}), units)
+        schedule = [m for m in _messages(report, Severity.WARNING) if "schedule" in m]
+        assert schedule, _messages(report, Severity.WARNING)
+
+
+class TestPrefixDrift:
+    def test_a_narrower_live_prefix_is_not_drift(self, units: list[Any]) -> None:
+        # Real case: the mongodb units declare `…__mongodb__` while Airbyte
+        # writes `…__mongodb__forum_`. `table_prefix` is declared documentation
+        # covering a unit's tables (§1.1), not a copy of Airbyte's literal.
+        report = _run(live(prefix=f"{PREFIX}forum_"), units)
+        assert [m for m in _messages(report, Severity.ERROR) if "prefix" in m] == []
+
+    def test_a_live_prefix_outside_the_declared_one_is_an_error(self, units: list[Any]) -> None:
+        report = _run(live(prefix="raw__somewhere__else__"), units)
+        assert "outside the unit's declared" in [m for m in _messages(report, Severity.ERROR) if "prefix" in m][0]
+
+
+class TestStreamDrift:
+    def test_a_dropped_stream_is_an_error(self, units: list[Any]) -> None:
+        snapshot = live()
+        snapshot["connections"][0]["configurations"]["streams"] = []
+        report = _run(snapshot, units)
+        assert "no longer carries declared stream" in _messages(report, Severity.ERROR)[0]
+
+    def test_an_extra_stream_is_a_warning(self, units: list[Any]) -> None:
+        snapshot = live()
+        snapshot["connections"][0]["configurations"]["streams"].append(
+            {"name": "auth_group", "syncMode": "incremental_append"}
+        )
+        report = _run(snapshot, units)
+        assert report.errors == []
+        assert "which the unit does not declare" in _messages(report, Severity.WARNING)[0]
+
+    def test_a_changed_sync_mode_is_an_error(self, units: list[Any]) -> None:
+        # This is the case that caught the hand-written edxorg units: seven
+        # streams declared full_refresh_overwrite that Airbyte runs incrementally.
+        snapshot = live()
+        snapshot["connections"][0]["configurations"]["streams"][0]["syncMode"] = "full_refresh_overwrite"
+        report = _run(snapshot, units)
+        assert "sync_mode is 'full_refresh_overwrite' in Airbyte" in _messages(report, Severity.ERROR)[0]
+
+    def test_a_changed_cursor_is_an_error(self, units: list[Any]) -> None:
+        snapshot = live()
+        snapshot["connections"][0]["configurations"]["streams"][0]["cursorField"] = ["updated_at"]
+        report = _run(snapshot, units)
+        assert "cursor_field is ['updated_at'] in Airbyte" in _messages(report, Severity.ERROR)[0]

--- a/src/ol_dbt_cli/tests/test_inventory_drift.py
+++ b/src/ol_dbt_cli/tests/test_inventory_drift.py
@@ -16,7 +16,7 @@ from typing import Any
 import pytest
 import yaml
 
-from ol_dbt_cli.lib.inventory import check_drift, load_units
+from ol_dbt_cli.lib.inventory import Unit, check_drift, load_units
 from ol_dbt_cli.lib.validation import Severity, ValidationReport
 
 PREFIX = "raw__mitxonline__openedx__mysql__"
@@ -76,6 +76,11 @@ def live(**overrides: Any) -> dict[str, Any]:
     }
     connection.update(overrides)
     return {"connections": [connection]}
+
+
+def _unit(data: dict[str, Any]) -> Unit:
+    """Build a Unit in memory, so a case can vary one field without a fixture file."""
+    return Unit(path=Path("unit.yml"), data=data)
 
 
 @pytest.fixture
@@ -144,17 +149,96 @@ class TestScheduleDrift:
         assert schedule, _messages(report, Severity.WARNING)
 
 
-class TestPrefixDrift:
-    def test_a_narrower_live_prefix_is_not_drift(self, units: list[Any]) -> None:
-        # Real case: the mongodb units declare `…__mongodb__` while Airbyte
-        # writes `…__mongodb__forum_`. `table_prefix` is declared documentation
-        # covering a unit's tables (§1.1), not a copy of Airbyte's literal.
-        report = _run(live(prefix=f"{PREFIX}forum_"), units)
-        assert [m for m in _messages(report, Severity.ERROR) if "prefix" in m] == []
+class TestWhereTablesLand:
+    """`prefix + stream` against the declared `raw_table`, not prefix against prefix.
 
-    def test_a_live_prefix_outside_the_declared_one_is_an_error(self, units: list[Any]) -> None:
+    Comparing `table_prefix` to Airbyte's `prefix` cannot work in either
+    direction: the mongodb units declare `…__mongodb__` while Airbyte writes
+    `…__mongodb__forum_`, and twelve connections carry no prefix at all. What
+    matters is the table a stream lands in, which reproduces all 949 declared
+    raw tables exactly across the real workspace.
+    """
+
+    def test_a_prefix_the_declared_raw_table_already_accounts_for_is_not_drift(self) -> None:
+        # The real mongodb shape: the unit's raw_table already contains
+        # `forum_`, so the longer live prefix lands exactly where declared.
+        unit = copy.deepcopy(UNIT)
+        unit["tables"][0]["raw_table"] = f"{PREFIX}forum_auth_user"
+        units = [_unit(unit)]
+        report = _run(live(prefix=f"{PREFIX}forum_"), units)
+        assert report.errors == [], _messages(report, Severity.ERROR)
+
+    def test_a_moved_table_is_an_error(self, units: list[Any]) -> None:
         report = _run(live(prefix="raw__somewhere__else__"), units)
-        assert "outside the unit's declared" in [m for m in _messages(report, Severity.ERROR) if "prefix" in m][0]
+        assert "now lands in 'raw__somewhere__else__auth_user'" in _messages(report, Severity.ERROR)[0]
+
+    def test_a_cleared_prefix_is_caught(self, units: list[Any]) -> None:
+        # The earlier check skipped a falsey prefix, so clearing one on a
+        # database connection — which moves every table it lands — was silent.
+        report = _run(live(prefix=""), units)
+        assert "now lands in 'auth_user'" in _messages(report, Severity.ERROR)[0]
+
+    def test_a_prefixless_connection_matching_its_declaration_is_fine(self) -> None:
+        # The S3 shape: no prefix, because the stream name is already the whole
+        # raw table name.
+        unit = copy.deepcopy(UNIT)
+        unit["tables"][0].update(name="raw__edxorg__s3__tracking_logs", raw_table="raw__edxorg__s3__tracking_logs")
+        unit["airbyte"]["connections"][0]["streams"] = ["raw__edxorg__s3__tracking_logs"]
+        snapshot = live(prefix="")
+        snapshot["connections"][0]["configurations"]["streams"][0]["name"] = "raw__edxorg__s3__tracking_logs"
+        report = _run(snapshot, [_unit(unit)])
+        assert report.errors == [], _messages(report, Severity.ERROR)
+
+
+class TestSourceDrift:
+    """Source-level state, which no stream describes."""
+
+    def test_a_changed_replication_method_is_an_error(self, units: list[Any]) -> None:
+        # §3.4 records this so `rg replication_method: xmin` answers which
+        # connections need a replacement cursor before dlt. Flipping a source
+        # from xmin to a cursor column changes no stream at all.
+        snapshot = live(sourceId="src-1")
+        snapshot["sources"] = [
+            {"sourceId": "src-1", "sourceType": "mysql", "configuration": {"replication_method": {"method": "Xmin"}}}
+        ]
+        report = _run(snapshot, units)
+        assert "replicates by 'xmin', unit declares 'cursor'" in _messages(report, Severity.ERROR)[0]
+
+    def test_a_changed_connector_is_an_error(self, units: list[Any]) -> None:
+        snapshot = live(sourceId="src-1")
+        snapshot["sources"] = [{"sourceId": "src-1", "sourceType": "postgres", "configuration": {}}]
+        report = _run(snapshot, units)
+        assert "now uses connector 'source-postgres'" in _messages(report, Severity.ERROR)[0]
+
+    def test_a_matching_source_is_silent(self, units: list[Any]) -> None:
+        snapshot = live(sourceId="src-1")
+        snapshot["sources"] = [
+            {
+                "sourceId": "src-1",
+                "sourceType": "mysql",
+                "configuration": {"replication_method": {"method": "STANDARD"}},
+            }
+        ]
+        assert _run(snapshot, units).issues == []
+
+
+class TestIncompleteSnapshot:
+    def test_missing_stream_configuration_is_not_read_as_zero_streams(self, units: list[Any]) -> None:
+        # The dumper re-fetches a connection whose list response omitted its
+        # streams, but leaves the key absent if that GET also fails. Collapsing
+        # that to `[]` would turn one transient API failure into "every declared
+        # stream has been dropped" across the workspace.
+        snapshot = live()
+        del snapshot["connections"][0]["configurations"]
+        report = _run(snapshot, units)
+        assert "holds no stream configuration" in _messages(report, Severity.ERROR)[0]
+        assert not [m for m in _messages(report, Severity.ERROR) if "no longer carries" in m]
+
+    def test_an_explicitly_empty_stream_list_is_still_drift(self, units: list[Any]) -> None:
+        snapshot = live()
+        snapshot["connections"][0]["configurations"]["streams"] = []
+        report = _run(snapshot, units)
+        assert "no longer carries declared stream" in _messages(report, Severity.ERROR)[0]
 
 
 class TestStreamDrift:


### PR DESCRIPTION
### What are the relevant tickets?

Steps 5, 6 and 8 of `docs/specs/INGESTION_INVENTORY_SPEC.md`, under RFC https://github.com/mitodl/hq/discussions/12319. No GitHub issue tracks these directly.

### Description (What does it do?)

Two related changes: a decision not to build something, and the check that decision makes load-bearing.

**Steps 5 and 6 are struck — Airbyte's configuration stays hand-managed until Airbyte is retired.** §6.0 records why. Three things measured while starting the work:

- **Airbyte's API masks connector secrets server-side.** An imported source reads the mask into Pulumi state while the declared configuration holds the real value, so they can never match. §6.4's acceptance test — an empty preview after import — is unreachable for **33 of 50 sources**. It survives only for the 17 secret-free sources, the 4 destinations, and the connections.
- **Database sources authenticate with Vault *dynamic* roles**, which mint a new credential per read. Declaring one rotates the database user on every apply and guarantees a dirty preview.
- **The workaround for the first is `ignore_changes` on `configuration`**, after which Pulumi can no longer push a rotated password into Airbyte either — removing the one benefit that would have justified the stack on its own.

Against that, every connection here is scheduled for deletion: the stack was always designed to be destroyed unit by unit as sources move to dlt (§6.5). §6 is kept rather than deleted — it is the record of why, and the starting point if this is ever revisited.

**`ol-dbt inventory drift` (step 8)** is what keeps the file honest instead. It diffs a workspace dump against `render airbyte`, which is already the inventory expressed in Airbyte's own shape. It takes a saved dump rather than reading the API, so the credentialed step stays separate and a report can be re-derived offline.

Severity follows what a finding says about the inventory:

- **ERROR** — the inventory is *wrong* about something it declares, so a model may be reading a table nothing loads: a missing connection, a dropped stream, a changed `sync_mode` or cursor, a status mismatch, a live prefix outside the declared one.
- **WARNING** — something live the inventory does not cover. Usually config that should have been deleted; harmless until something depends on it.

**Its first run found a real error in the merged inventory.** The six edxorg units were hand-written because the generator could not express that deployment, and their `sync_mode`/`cursor_field` came from a default in that script rather than from Airbyte. Seven streams declared `full_refresh_overwrite` with no cursor that Airbyte actually runs `incremental_append` on `_ab_source_file_last_modified`, plus one wrong primary key. Corrected here by re-deriving those fields from the snapshot rather than hand-writing them again.

Two things the check itself got wrong on that first run, both fixed before the data was touched:

- `table_prefix` compares with `startswith`, not equality. It is declared documentation covering a unit's tables (§1.1), not a copy of the literal string Airbyte prepends — the mongodb units legitimately declare `raw__<dep>__openedx__mongodb__` while Airbyte writes `…__mongodb__forum_`.
- An Airbyte-side schedule on a **paused** connection is a warning, not an error. It cannot double-schedule anything while paused; resuming it would.

That second fix also corrects §8.1, which recorded "connections carrying their own Airbyte cron: **0**". Three do — Mailgun legacy, GitHub, HubSpot Bootcamps — all paused, which is presumably why the original count missed them.

### How can this be tested?

All credential-free, all run on this branch:

```
uv run ol-dbt inventory drift --snapshot <a dump>
  → compared 43 live connection(s) against 43 unit(s)
    0 error(s), 5 warning(s)

uv run ol-dbt inventory validate      → 43 units, 982 tables, 0 errors, 8 warnings
uv run pytest src/ol_dbt_cli/tests/   → 494 passed (13 new, one per drift finding type)
uv run pre-commit run --all-files     → clean
```

The 5 warnings are the whole current baseline and every one is deliberate:

- 3 connections that exist in Airbyte and no unit declares — the two legacy S3-Glue ones retired in `retired.yml`, plus the paused `edx.org Production Course Metadata` superseded by `dg_projects/edxorg`. All three are being deleted in Airbyte.
- 2 paused connections carrying their own Airbyte schedule.

To reproduce against the live workspace, take a dump first — it is read-only, every call is a GET:

```
export AIRBYTE_PASSWORD="$(vault kv get -mount=secret-data \
    -field=dagster_unhashed_password dagster-http-auth-password)"
uv run python bin/airbyte-inventory.py dump --username dagster
uv run ol-dbt inventory drift
```

**Not run:** nothing was applied to Airbyte, and no Pulumi preview was taken — this PR removes the need for both.

### Additional Context

`drift` is not wired into CI, deliberately: it needs a workspace dump CI does not have. What remains for step 8 is scheduling it and choosing how it reports, against the spec's "within a day". **Dagster already holds the Airbyte basic-auth credential** (`secret-airbyte/dagster`), which argues for a Dagster schedule over a Concourse pipeline — worth deciding in review.

Work that was done and discarded rather than landed here: a generated `sdks/airbyte` Pulumi SDK and a delete/replace preview gate in ol-infrastructure, plus a sources-artifact generator here. All unpushed; the ol-infrastructure branch is kept locally in case the decision is revisited. Also deliberately *not* landed: a narrowing of `SENSITIVE_KEY_MARKERS` in `bin/airbyte-inventory.py` that would have un-redacted `auth_type`, `database_config.auth_source` and `entra_service_principal_auth`. Those are ordinary configuration rather than credentials, but with no consumer reading them the conservative redaction is the better default. §6.0 notes it so the over-redaction is not rediscovered as a bug.
