### PR TITLE
fix(dbt): derive the Glue fallback from the node, not its name prefix

### DIFF
--- a/src/ol_dbt/macros/override_ref.sql
+++ b/src/ol_dbt/macros/override_ref.sql
@@ -1,22 +1,49 @@
+{#
+    ref() override for the local DuckDB dev target.
+
+    Build only what you changed: a model that exists locally is used, and one that does not
+    falls back to the production Glue view registered by `ol-dbt local register`. Everything
+    upstream of your change is then read from production instead of rebuilt.
+
+    Two things this deliberately does NOT do, both of which it used to:
+
+    1. Dispatch on the model NAME. The old version matched `stg__`, `int__`, `dim_`,
+       `marts__`, `rpt__` and sent everything else to a branch that returned the local
+       relation with the comment "will fail if doesn't exist" -- which is what happened.
+       Measured against the manifest, 165 of 672 models matched no prefix: all 110 external,
+       all 27 reporting (the `rpt__` branch matched nothing -- reporting models are bare, e.g.
+       enrollment_detail_report), 11 integrations, the 11 `__`-prefixed models under
+       intermediate/*/subqueries/, 5 migration and 1 dimensional. A quarter of the project
+       was silently exempt from the fallback this macro exists to provide.
+
+       The node already knows its layer. dbt resolves a model's schema to
+       `<target.schema>_<config.schema>` (main_intermediate, main_staging, ...), and that
+       layer maps 1:1 onto the Glue database, so deriving it covers every model with no
+       special cases and no list to keep in sync.
+
+    2. Return a bare string. `{{ glue_view_name }}` rendered as text rather than a Relation,
+       which is why dbt unit tests cannot run on this target at all -- the unit-test
+       machinery calls Relation methods on whatever ref() returns and dies with
+       "'NoneType' object has no attribute 'lower'".
+
+    An unmappable model now raises instead of returning a relation that cannot exist: the
+    failure names the ref, rather than surfacing three layers down as a Catalog Error about
+    a table nobody wrote.
+#}
 {% macro ref(model_name) %}
-  {#
-    Override the default ref() macro for DuckDB dev_local target with smart fallback
-
-    Strategy:
-    1. Check if model exists locally (already built in this session)
-    2. If yes: use local table
-    3. If no: fall back to registered Glue view from production
-
-    This allows incremental development - build what you're working on locally,
-    automatically pull upstream dependencies from production.
-
-    For Trino: Uses the built-in ref() macro behavior
-  #}
   {% if target.type == 'duckdb' and target.name == 'dev_local' %}
-    {# First, try to get the local relation using built-in ref() #}
     {% set local_relation = builtins.ref(model_name) %}
 
-    {# Check if the local relation actually exists #}
+    {#- Two contexts hand back a relation there is nothing to derive from, and in both the
+        value is never rendered as a table name:
+          - parsing, where the schema is still target.schema and there is no adapter to
+            probe; only the dependency registration above matters.
+          - a unit test, where dbt substitutes a fixture CTE for this input and the
+            relation arrives with schema None. -#}
+    {% if not execute or local_relation is none or local_relation.schema is none %}
+      {{ return(local_relation) }}
+    {% endif %}
+
     {% set relation_exists = adapter.get_relation(
       database=target.database,
       schema=local_relation.schema,
@@ -24,39 +51,30 @@
     ) %}
 
     {% if relation_exists %}
-      {# Local table exists, use it #}
       {{ log("Using local table for ref('" ~ model_name ~ "'): " ~ local_relation, info=False) }}
       {{ return(local_relation) }}
-    {% else %}
-      {# Local table doesn't exist, try to fall back to Glue view #}
-      {# Determine layer based on model name prefix #}
-      {% if model_name.startswith('stg__') %}
-        {% set glue_database = 'ol_warehouse_production_staging' %}
-      {% elif model_name.startswith('int__') %}
-        {% set glue_database = 'ol_warehouse_production_intermediate' %}
-      {% elif model_name.startswith('dim_') or model_name.startswith('tfact_') or model_name.startswith('afact_') or model_name.startswith('bridge_') %}
-        {% set glue_database = 'ol_warehouse_production_dimensional' %}
-      {% elif model_name.startswith('marts__') %}
-        {% set glue_database = 'ol_warehouse_production_mart' %}
-      {% elif model_name.startswith('rpt__') %}
-        {% set glue_database = 'ol_warehouse_production_reporting' %}
-      {% else %}
-        {% set glue_database = none %}
-      {% endif %}
-
-      {# If we found a matching layer, use the Glue view #}
-      {% if glue_database %}
-        {% set glue_view_name = 'glue__' ~ glue_database ~ '__' ~ model_name %}
-        {{ log("Falling back to Glue view for ref('" ~ model_name ~ "'): " ~ glue_view_name, info=True) }}
-        {{ glue_view_name }}
-      {% else %}
-        {# No Glue mapping found, return the local relation anyway (will fail if doesn't exist) #}
-        {{ log("No Glue fallback available for ref('" ~ model_name ~ "'), using local reference", info=True) }}
-        {{ return(local_relation) }}
-      {% endif %}
     {% endif %}
+
+    {#- `main_intermediate` -> `intermediate`. A model with no custom schema resolves to
+        target.schema itself and yields an empty layer, which fails below. -#}
+    {% set prefix = target.schema ~ '_' %}
+    {% set layer = local_relation.schema[prefix | length:]
+                   if local_relation.schema.startswith(prefix) else '' %}
+
+    {% if not layer %}
+      {% do exceptions.raise_compiler_error(
+        "No Glue database can be derived for ref('" ~ model_name ~ "'): its schema is '"
+        ~ local_relation.schema ~ "', which is not '" ~ prefix ~ "<layer>'. Build the model "
+        ~ "locally, or give it a +schema so its layer can be resolved."
+      ) %}
+    {% endif %}
+
+    {% set glue_view_name = 'glue__ol_warehouse_production_' ~ layer ~ '__' ~ model_name %}
+    {{ log("Falling back to Glue view for ref('" ~ model_name ~ "'): " ~ glue_view_name, info=True) }}
+    {{ return(api.Relation.create(
+      database=target.database, schema=target.schema, identifier=glue_view_name
+    )) }}
   {% else %}
-    {# For all non-DuckDB targets or other DuckDB targets, use built-in ref() #}
     {{ return(builtins.ref(model_name)) }}
   {% endif %}
 {% endmacro %}

--- a/src/ol_dbt/macros/override_source.sql
+++ b/src/ol_dbt/macros/override_source.sql
@@ -1,31 +1,58 @@
+{#
+    source() override for DuckDB targets: route to the `glue__`-prefixed views registered by
+    `ol-dbt local register`. Trino uses the built-in.
+
+    This used to dispatch on the SOURCE NAME through a hand-maintained map, defaulting
+    unknown names to the raw database. Two of the three source names actually in use were
+    missing from that map: `dimensional` (9 sources) and `reporting` (2), so all 11 resolved
+    to `glue__ol_warehouse_production_raw__<table>` -- a view that does not exist, because
+    those tables live in the dimensional and reporting Glue databases. A default that points
+    somewhere plausible is worse than no default; it turns a missing entry into a confusing
+    Catalog Error instead of a clear one.
+
+    The source already declares where it lives. dbt resolves its schema either to a
+    fully-qualified Glue database (`ol_warehouse_production_dimensional`, as the dimensional
+    and reporting sources declare) or to `<target.schema>_<layer>` (`main_raw`), so both
+    conventions are derivable and neither needs a list kept in sync.
+#}
 {% macro source(source_name, table_name) %}
-  {#
-    Override the default source() macro for DuckDB targets to route to Iceberg views
-
-    For DuckDB: References glue__ prefixed views registered by register-glue-sources.py
-    For Trino: Uses the built-in source() macro behavior
-  #}
   {% if target.type == 'duckdb' %}
-    {# Map source schemas to Glue database names #}
-    {% set source_to_database_map = {
-      'ol_warehouse_raw_data': 'ol_warehouse_production_raw',
-      'ol_warehouse_staging': 'ol_warehouse_production_staging',
-      'ol_warehouse_intermediate': 'ol_warehouse_production_intermediate',
-      'ol_warehouse_dimensional': 'ol_warehouse_production_dimensional',
-      'ol_warehouse_marts': 'ol_warehouse_production_mart',
-      'ol_warehouse_reporting': 'ol_warehouse_production_reporting'
-    } %}
+    {#- Registers the source.* dependency edge in the manifest so lineage and
+        state:modified+ selection still see it on DuckDB targets. The returned relation is
+        deliberately discarded; the Glue view below is what the SQL reads. There is a CI
+        guard for this specific edge (.github/workflows/dbt_pr_ci.yaml). -#}
+    {% set builtin_relation = builtins.source(source_name, table_name) %}
 
-    {% set glue_database = source_to_database_map.get(source_name, 'ol_warehouse_production_raw') %}
+    {#- Two contexts hand back a relation there is nothing to derive from, and in both the
+        value is never rendered as a table name:
+          - parsing, where the schema is still target.schema; only the dependency
+            registration above matters.
+          - a unit test, where dbt substitutes a fixture CTE for this input and the
+            relation arrives with schema None. -#}
+    {% if not execute or builtin_relation is none or builtin_relation.schema is none %}
+      {{ return(builtin_relation) }}
+    {% endif %}
 
-    {# Register the source dependency edge in the manifest (discarding the relation) so
-       lineage/state-based selection sees this model's source.* deps on DuckDB targets too #}
-    {% do builtins.source(source_name, table_name) %}
+    {% set prefix = target.schema ~ '_' %}
+    {% if builtin_relation.schema.startswith('ol_warehouse_') %}
+      {% set glue_database = builtin_relation.schema %}
+    {% elif builtin_relation.schema.startswith(prefix) %}
+      {% set glue_database = 'ol_warehouse_production_'
+                             ~ builtin_relation.schema[prefix | length:] %}
+    {% else %}
+      {% do exceptions.raise_compiler_error(
+        "No Glue database can be derived for source('" ~ source_name ~ "', '" ~ table_name
+        ~ "'): its schema is '" ~ builtin_relation.schema ~ "', which is neither a "
+        ~ "fully-qualified ol_warehouse_* database nor '" ~ prefix ~ "<layer>'."
+      ) %}
+    {% endif %}
 
-    {# Return the fully qualified view name #}
-    glue__{{ glue_database }}__{{ table_name }}
+    {{ return(api.Relation.create(
+      database=target.database,
+      schema=target.schema,
+      identifier='glue__' ~ glue_database ~ '__' ~ table_name
+    )) }}
   {% else %}
-    {# For Trino, use the built-in builtins.source() macro #}
     {{ return(builtins.source(source_name, table_name)) }}
   {% endif %}
 {% endmacro %}

--- a/src/ol_dbt_cli/ol_dbt_cli/commands/local_dev.py
+++ b/src/ol_dbt_cli/ol_dbt_cli/commands/local_dev.py
@@ -33,6 +33,9 @@ if TYPE_CHECKING:
 DEFAULT_DUCKDB_PATH = Path.home() / ".ol-dbt" / "local.duckdb"
 DEFAULT_GLUE_DATABASE = "ol_warehouse_production_raw"
 
+# Every layer a model can live in. This must stay in step with the Glue databases
+# macros/override_ref.sql derives from a model's schema: a layer that is derivable but not
+# registered turns an unbuilt ref into a missing-view error instead of a working fallback.
 LAYER_DATABASES = [
     "ol_warehouse_production_raw",
     "ol_warehouse_production_staging",
@@ -41,6 +44,8 @@ LAYER_DATABASES = [
     "ol_warehouse_production_mart",
     "ol_warehouse_production_reporting",
     "ol_warehouse_production_external",
+    "ol_warehouse_production_integrations",
+    "ol_warehouse_production_migration",
 ]
 
 PROTECTED_SCHEMAS = {
@@ -52,6 +57,8 @@ PROTECTED_SCHEMAS = {
     "ol_warehouse_production_mart",
     "ol_warehouse_production_reporting",
     "ol_warehouse_production_external",
+    "ol_warehouse_production_integrations",
+    "ol_warehouse_production_migration",
     "ol_warehouse_qa",
     "ol_warehouse_qa_raw",
     "ol_warehouse_qa_staging",
@@ -60,6 +67,8 @@ PROTECTED_SCHEMAS = {
     "ol_warehouse_qa_mart",
     "ol_warehouse_qa_reporting",
     "ol_warehouse_qa_external",
+    "ol_warehouse_qa_integrations",
+    "ol_warehouse_qa_migration",
 }
 
 TARGET_CONFIGS: dict[str, dict[str, str]] = {


### PR DESCRIPTION
## What are the relevant tickets?

Witan `tk-derive-the-glue-fallback-database-from-the-node--4d8f37` (this PR) and
`tk-override-ref-sql-cannot-resolve-subqueries-model-365e37` (the symptom that found it).
Partially unblocks `tk-make-dbt-unit-tests-runnable-then-guard-the-user-9ce5c8` — see
"What this does not finish".

## Description (What does it do?)

`macros/override_ref.sql` and `macros/override_source.sql` decide which production Glue
view a local DuckDB build falls back to. Both did it by matching the model or source
**name** against a hand-maintained list, and both sent anything unmatched somewhere wrong.

### override_ref: a quarter of the project was exempt

It matched `stg__`, `int__`, `dim_`/`tfact_`/`afact_`/`bridge_`, `marts__`, `rpt__`, and
sent everything else to a branch that returned the local relation with the comment *"will
fail if doesn't exist"* — which is exactly what happened. Counted from the manifest:

| folder | models matching no prefix |
|---|---|
| external | 110 |
| reporting | 27 |
| integrations | 11 |
| intermediate (`__`-prefixed `subqueries/`) | 11 |
| migration | 5 |
| **total** | **164 of 668** |

The `rpt__` branch matches **nothing** — zero models in the project start with it, because
reporting models are bare-named (`enrollment_detail_report`). That whole layer had been
silently exempt.

The symptom that surfaced it: `dbt run --select int__micromasters__users` dies with
`Catalog Error: Table with name __micromasters__users does not exist`, naming a table
nobody wrote, because `ref('__micromasters__users')` fell to the else branch.

### override_source: a wrong default, and it is live

Same shape, worse consequence — unknown source names defaulted to
`ol_warehouse_production_raw`. Two of the three source names actually in use were missing
from the map: `dimensional` (9 sources) and `reporting` (2). All 11 resolved to
`glue__ol_warehouse_production_raw__<table>`, a view that does not exist.

Not latent: `student_risk_probability_report` is enabled on DuckDB and reads
`source('reporting', 'student_risk_probability')`. It now compiles to
`glue__ol_warehouse_production_reporting` instead of `…_raw`.

### The fix

The node already knows where it lives. dbt resolves a model's schema to
`<target.schema>_<config.schema>` (`main_intermediate`, `main_staging`, …) and a source's
to either that shape or a fully-qualified `ol_warehouse_*` database. Both map 1:1 onto the
Glue database, so deriving covers every model and source with no list to keep in sync:

| `config.schema` | Glue database | models |
|---|---|---|
| staging | `ol_warehouse_production_staging` | 248 |
| intermediate | `…_intermediate` | 183 |
| external | `…_external` | 110 |
| dimensional | `…_dimensional` | 56 |
| mart | `…_mart` | 28 |
| reporting | `…_reporting` | 27 |
| integrations | `…_integrations` | 11 |
| migration | `…_migration` | 5 |

All eight confirmed present in Glue, plus `…_raw` for sources.

### Registering the two layers that derivation newly reaches

Making those layers derivable is only half of it: `LAYER_DATABASES` in
`src/ol_dbt_cli/ol_dbt_cli/commands/local_dev.py` listed 7 databases and omitted
`ol_warehouse_production_integrations` and `…_migration`, so the 11 integrations and 5
migration models would have swapped one missing-view error for another. Both are now
registered (7 and 5 tables), and `PROTECTED_SCHEMAS` — which carried the same 7-layer
assumption, leaving neither layer shielded from `ol-dbt local cleanup` — gains both in the
production and QA lists.

Two smaller changes in the same pass:

- **Underivable now raises**, naming the ref, instead of returning a relation that cannot
  exist and surfacing later as a Catalog Error about an unrelated-looking table.
- **Both return a `Relation`, not a bare string.** That was the first of two things
  blocking dbt unit tests project-wide.

## How can this be tested?

- `dbt parse -t dev`: clean.
- `ol-dbt validate` project-wide: **0 errors** (the 9 warnings are pre-existing, on
  unrelated models).
- The CI source-lineage guard (`assert_manifest_has_source_lineage.py`): still
  356/668 models carry a `source.*` edge, so registering the dependency before deriving
  preserves lineage.
- `dbt compile -t dev --select student_risk_probability_report` → resolves to
  `glue__ol_warehouse_production_reporting` (previously `…_raw`).
- `dbt compile -t dev --select stg__learn_ai__app__postgres__chatbots_userchatsession` →
  still resolves to `…_raw` correctly.
- `dbt compile -t dev_local --select edxorg_to_mitxonline_users` →
  `ref('edxorg_to_mitxonline_enrollments')` falls back to
  `glue__ol_warehouse_production_migration__edxorg_to_mitxonline_enrollments`, and that view
  reads 69 rows. Same check on an integrations view: 282 rows. This is the case that was
  unreachable before, in both the macro and the registration.
- `pytest src/ol_dbt_cli`: 461 pass.
- `pre-commit` including `sqlfluff`, `ruff` and `mypy`: passes.

## Things to look at closely

**The `execute` / `schema is none` guard.** During parsing, and inside a unit test, dbt
hands back a placeholder relation whose schema is either `target.schema` or `None`. In both
cases there is nothing to derive and the value is never rendered as a table name, so the
macro returns the builtin. `builtins.ref`/`builtins.source` is still called **first** in
every path, so the manifest dependency edge is registered regardless — that is what the CI
guard above protects, and it is easy to break by reordering.

## What this does not finish

**dbt unit tests still do not run**, and this PR does not claim otherwise. It removes the
first blocker only.

The second is dbt's own: `dbt/parser/unit_tests.py:139` always passes
`column_name_to_data_types=None`, so `get_fixture_sql` always falls through to
`adapter.get_columns_in_relation` — there is no YAML-declared-types escape hatch in dbt
1.12. The input relation must physically exist.

For a `source()` input, the relation dbt probes is the source's **dbt-resolved** location
(`local.main_raw.raw__…`), not the Glue view `ol-dbt local register` creates
(`local.main.glue__ol_warehouse_production_raw__raw__…`). So the remaining work is to have
`register` also create a source-shaped alias view. I wrote two unit tests against
`stg__bootcamps__app__postgres__profiles_profile` and **removed them rather than ship tests
that error** — they are recorded in the follow-up task with their fixtures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QapG9XRweT7AWGXAforRbj
