### PR TITLE
fix(ol_dbt_cli): surface registry staleness; stop --force reporting every table as new

### DIFF
--- a/src/ol_dbt_cli/ol_dbt_cli/commands/local_dev.py
+++ b/src/ol_dbt_cli/ol_dbt_cli/commands/local_dev.py
@@ -8,6 +8,7 @@ Provides commands for:
 
 from __future__ import annotations
 
+import datetime
 import os
 import subprocess
 import sys
@@ -32,6 +33,21 @@ if TYPE_CHECKING:
 
 DEFAULT_DUCKDB_PATH = Path.home() / ".ol-dbt" / "local.duckdb"
 DEFAULT_GLUE_DATABASE = "ol_warehouse_production_raw"
+
+# How old the newest registry entry may get before `register` and `list-sources`
+# warn about it. A registered view pins one Iceberg metadata.json; when production
+# rebuilds that table the old metadata file is eventually cleaned up, and the
+# pinned view starts failing with an S3 404 that says nothing about staleness
+# being the cause. Re-running `register` re-reads Glue and repoints the view, so
+# the warning exists to make "your registry is old" visible BEFORE a build fails
+# on it rather than after.
+#
+# One day, from measured churn rather than taste: against a registry 1.1 days old,
+# a dry run reported 142 of 158 intermediate-layer pointers moved (~90%) and 28 of
+# 29 mart pointers. At that rate a registry is materially stale within a day, and
+# a longer window would stay quiet through exactly the multi-day drift this is
+# meant to catch. Hours-old registries — the same session — still do not warn.
+REGISTRY_STALE_AFTER_DAYS = 1
 
 # Every layer a model can live in. This must stay in step with the Glue databases
 # macros/override_ref.sql derives from a model's schema: a layer that is derivable but not
@@ -124,6 +140,80 @@ def _get_glue_tables(database: str) -> list[dict[str, Any]]:
     return tables
 
 
+def _classify_registration(previous_location: str | None, metadata_location: str) -> str:
+    """Classify what registering a table would do, from its recorded location.
+
+    Three outcomes, deliberately distinguished so the summary can answer "did
+    anything upstream actually move?":
+
+    - ``new``       — never registered before.
+    - ``updated``   — registered, and Glue now reports a DIFFERENT metadata
+                      location, i.e. production genuinely rebuilt the table.
+    - ``refreshed`` — registered, and Glue reports the SAME location. Re-issuing
+                      the view is a no-op, so this is only reached under
+                      ``--force``; without it the table is skipped instead.
+
+    Collapsing ``refreshed`` into ``updated`` (or, as before, reporting every
+    forced re-registration as ``new`` because the recorded locations were never
+    loaded under ``--force``) makes a forced run claim thousands of changes and
+    hides the only number that matters: how many pointers actually changed.
+    """
+    if previous_location is None:
+        return "new"
+    if previous_location == metadata_location:
+        return "refreshed"
+    return "updated"
+
+
+def _registry_last_refreshed(duckdb_path: Path, databases: list[str]) -> datetime.datetime | None:
+    """Return the newest ``registered_at`` across *databases*, or None if unknown.
+
+    None covers every "cannot tell" case — no DuckDB file, no registry table, no
+    rows for these databases — because the caller treats them identically: it has
+    no age to report and says so, rather than implying a fresh registry.
+    """
+    if not duckdb_path.exists() or not databases:
+        return None
+    placeholders = ", ".join("?" for _ in databases)
+    try:
+        with duckdb.connect(str(duckdb_path), read_only=True) as conn:
+            row = conn.execute(
+                f"SELECT max(registered_at) FROM _glue_source_registry WHERE glue_database IN ({placeholders})",  # noqa: S608
+                databases,
+            ).fetchone()
+    except Exception:  # noqa: BLE001
+        return None
+    return row[0] if row else None
+
+
+def _stale_threshold_phrase() -> str:
+    """Render the staleness threshold for humans, without "1 days"."""
+    days = REGISTRY_STALE_AFTER_DAYS
+    return "a day" if days == 1 else f"{days} days"
+
+
+def _describe_registry_age(last_refreshed: datetime.datetime | None) -> tuple[str, bool]:
+    """Render *last_refreshed* as a human phrase plus whether it counts as stale."""
+    if last_refreshed is None:
+        # "unknown", not "never": a locked or unreadable DuckDB file reaches this
+        # too, and asserting there was no prior registration would be a stronger
+        # claim than the caller can actually support.
+        return ("unknown (no readable prior registration)", False)
+    # Match the stored value's awareness rather than assuming UTC. `registered_at`
+    # is a naive TIMESTAMP and DuckDB's CURRENT_TIMESTAMP writes LOCAL time into
+    # it (verified: naive-local skew ~0s, naive-UTC skew = the zone offset), so
+    # tz=None here yields a naive-local `now` that lines up. Hardcoding UTC would
+    # overstate every age by the local offset.
+    now = datetime.datetime.now(tz=last_refreshed.tzinfo)
+    age = now - last_refreshed
+    age_days = age.total_seconds() / 86_400
+    if age_days >= 1:
+        phrase = f"{age_days:.1f} days ago"
+    else:
+        phrase = f"{age.total_seconds() / 3600:.1f} hours ago"
+    return (f"{phrase} ({last_refreshed:%Y-%m-%d %H:%M})", age_days >= REGISTRY_STALE_AFTER_DAYS)
+
+
 def _register_single_table(
     table: dict[str, Any],
     database_name: str,
@@ -141,11 +231,10 @@ def _register_single_table(
     metadata_location = table["metadata_location"]
     view_name = f"glue__{database_name}__{table_name}"
 
-    if not force and view_name in existing_registrations:
-        if existing_registrations[view_name] == metadata_location:
-            return ("skipped", view_name, None)
+    outcome = _classify_registration(existing_registrations.get(view_name), metadata_location)
+    if not force and outcome == "refreshed":
+        return ("skipped", view_name, None)
 
-    is_updated = view_name in existing_registrations
     # Escape single quotes in the S3 path so the SQL string literal is safe.
     escaped_location = metadata_location.replace("'", "''")
     # Double-quote and escape the view identifier so Glue names with hyphens
@@ -172,7 +261,7 @@ def _register_single_table(
     except Exception as e:  # noqa: BLE001
         return ("error", view_name, str(e))
 
-    return ("success", view_name, "updated" if is_updated else "new")
+    return ("success", view_name, outcome)
 
 
 def _register_tables_in_duckdb(
@@ -185,7 +274,7 @@ def _register_tables_in_duckdb(
     workers: int = 10,
 ) -> dict[str, int]:
     """Register Glue tables as DuckDB views, returning counts by status."""
-    results: dict[str, int] = {"success": 0, "error": 0, "skipped": 0, "updated": 0, "new": 0}
+    results: dict[str, int] = {"success": 0, "error": 0, "skipped": 0, "updated": 0, "new": 0, "refreshed": 0}
 
     if not dry_run:
         if verbose:
@@ -216,15 +305,20 @@ def _register_tables_in_duckdb(
                 )
             """)
 
-            if not force:
-                try:
-                    rows = setup_conn.execute(
-                        "SELECT view_name, metadata_location FROM _glue_source_registry WHERE glue_database = ?",
-                        (database_name,),
-                    ).fetchall()
-                    existing_registrations = {row[0]: row[1] for row in rows}
-                except Exception:  # noqa: BLE001
-                    existing_registrations = {}
+            # Loaded even under --force. force governs only whether an unchanged
+            # table is SKIPPED; the recorded locations are still what tells new
+            # from updated from merely-refreshed. Skipping this read under force
+            # (as this used to) left every table looking unregistered, so a forced
+            # run reported its whole catalog as "new" and could not show how many
+            # Glue pointers had really moved.
+            try:
+                rows = setup_conn.execute(
+                    "SELECT view_name, metadata_location FROM _glue_source_registry WHERE glue_database = ?",
+                    (database_name,),
+                ).fetchall()
+                existing_registrations = {row[0]: row[1] for row in rows}
+            except Exception:  # noqa: BLE001
+                existing_registrations = {}
         # setup_conn is now closed — worker threads open their own per-connection.
         # DuckDB persists extensions and the registry table to the file, so workers
         # only need to LOAD (not INSTALL) extensions in their own connections.
@@ -256,28 +350,23 @@ def _register_tables_in_duckdb(
             metadata_location = table["metadata_location"]
             view_name = f"glue__{database_name}__{table_name}"
 
-            if not force and view_name in existing_registrations:
-                if existing_registrations[view_name] == metadata_location:
-                    results["skipped"] += 1
-                    if verbose:
-                        print(f"  ⊘ {view_name} (unchanged)")
-                    continue
+            outcome = _classify_registration(existing_registrations.get(view_name), metadata_location)
+            if not force and outcome == "refreshed":
+                results["skipped"] += 1
+                if verbose:
+                    print(f"  ⊘ {view_name} (unchanged)")
+                continue
 
-            is_updated = view_name in existing_registrations
             escaped_location = metadata_location.replace("'", "''")
             quoted_view_name = '"' + view_name.replace('"', '""') + '"'
             create_view_sql = (
                 f"CREATE OR REPLACE VIEW {quoted_view_name} AS\nSELECT * FROM iceberg_scan('{escaped_location}')"
             )
             if verbose:
-                status = "UPDATE" if is_updated else "NEW"
-                print(f"\n-- [{status}] {table_name}")
+                print(f"\n-- [{outcome.upper()}] {table_name}")
                 print(create_view_sql)
             results["success"] += 1
-            if is_updated:
-                results["updated"] += 1
-            else:
-                results["new"] += 1
+            results[outcome] += 1
     else:
         with ThreadPoolExecutor(max_workers=workers) as executor:
             futures = {
@@ -304,7 +393,11 @@ def _register_tables_in_duckdb(
                     elif extra_info == "updated":
                         results["updated"] += 1
                         if verbose:
-                            print(f"  ↻ {view_name} (updated)")
+                            print(f"  ↻ {view_name} (updated — Glue pointer moved)")
+                    elif extra_info == "refreshed":
+                        results["refreshed"] += 1
+                        if verbose:
+                            print(f"  ✓ {view_name} (re-registered, unchanged)")
                     elif verbose:
                         print(f"  ✓ {view_name}")
                 elif status == "skipped":
@@ -349,6 +442,17 @@ def _show_registry(duckdb_path: Path) -> None:
             view_name, glue_db, _glue_table, registered = row
             print(f"{view_name:<60} {glue_db:<30} {registered!s}")
         print("=" * 100)
+
+        # Ordered registered_at DESC above, so the first row is the newest. A view
+        # only ever pins the metadata file that was current when it was
+        # registered, so this age is the single most useful thing here.
+        newest_phrase, is_stale = _describe_registry_age(result[0][3])
+        print(f"  Last refreshed: {newest_phrase}")
+        if is_stale:
+            print(
+                f"  ⚠ More than {_stale_threshold_phrase()} old. Run `ol-dbt local register --all-layers` "
+                "before trusting a dev_local build — stale views fail as S3 404s on the pinned metadata."
+            )
     except Exception as e:  # noqa: BLE001
         print(f"Error reading registry: {e}")
     finally:
@@ -595,7 +699,7 @@ def register(
     ] = False,
     force: Annotated[
         bool,
-        cyclopts.Parameter(help="Force re-registration of all tables (default: only new/changed)"),
+        cyclopts.Parameter(help="Re-issue every view, including unchanged ones (repairs local view state)"),
     ] = False,
     workers: Annotated[
         int,
@@ -605,8 +709,20 @@ def register(
     """Register AWS Glue Iceberg tables as DuckDB views.
 
     Queries AWS Glue to discover Iceberg tables and creates DuckDB views referencing
-    their S3 metadata. Incremental by default — only new or changed tables are
-    registered. Use --force to re-register all tables.
+    their S3 metadata.
+
+    Every run re-reads Glue, so a plain run already picks up upstream changes: a
+    table whose metadata location has moved is re-registered and reported as
+    `updated`. `--force` does NOT find more changes than that — it only re-issues
+    the CREATE VIEW for tables Glue reports as unchanged, which is a no-op unless
+    the local view itself is damaged. Reach for it to repair local state, not to
+    check for drift.
+
+    What a plain run cannot do is tell you it is overdue: the views it created
+    keep pointing at whatever metadata file was current when it last ran, and
+    nothing prompts you to run it again. So both this command and `list-sources`
+    report how long ago the registry was last refreshed, and warn once that is
+    more than a day — measured pointer churn is roughly 90% of a layer per day.
     """
     workers = max(1, min(workers, 20))
     verbose = not quiet
@@ -622,7 +738,19 @@ def register(
         databases = [DEFAULT_GLUE_DATABASE]
         print(f"\n🔄 Registering default database: {DEFAULT_GLUE_DATABASE}")
 
-    total: dict[str, int] = {"success": 0, "error": 0, "skipped": 0, "new": 0, "updated": 0}
+    # Read before any registration writes, or it would report this run's own
+    # timestamp back as the previous refresh.
+    age_phrase, was_stale = _describe_registry_age(_registry_last_refreshed(duckdb_path, databases))
+    print(f"   Registry for these databases last refreshed: {age_phrase}")
+    if was_stale:
+        # A dry run changes nothing, so it must not claim to have fixed the staleness.
+        remedy = "Re-run without --dry-run to refresh them." if dry_run else "This run refreshes them."
+        print(
+            f"   ⚠ More than {_stale_threshold_phrase()} old — views may point at metadata files "
+            f"production has since replaced (Iceberg 404s on build). {remedy}"
+        )
+
+    total: dict[str, int] = {"success": 0, "error": 0, "skipped": 0, "new": 0, "updated": 0, "refreshed": 0}
 
     for idx, db_name in enumerate(databases):
         print(f"\n{'=' * 70}")
@@ -648,6 +776,8 @@ def register(
         if not verbose:
             print(f"  + {results['new']} new")
             print(f"  ↻ {results['updated']} updated")
+            if results["refreshed"] > 0:
+                print(f"  ✓ {results['refreshed']} re-registered (unchanged)")
             print(f"  ⊘ {results['skipped']} skipped")
             if results["error"] > 0:
                 print(f"  ✗ {results['error']} errors")
@@ -657,21 +787,27 @@ def register(
     print("=" * 70)
     print(f"  Databases processed: {len(databases)}")
     print(f"  + New tables: {total['new']}")
-    print(f"  ↻ Updated tables: {total['updated']}")
+    print(f"  ↻ Updated tables (Glue pointer moved): {total['updated']}")
+    if force:
+        print(f"  ✓ Re-registered unchanged: {total['refreshed']}")
     print(f"  ⊘ Skipped (unchanged): {total['skipped']}")
     print(f"  ✗ Errors: {total['error']}")
     print("=" * 70)
 
-    if not dry_run and (total["new"] > 0 or total["updated"] > 0):
-        changed = total["new"] + total["updated"]
+    # `refreshed` is deliberately excluded from "changed": under --force it counts
+    # every unchanged table, and folding it in is what made a forced run announce
+    # its whole catalog as freshly registered.
+    changed = total["new"] + total["updated"]
+    if not dry_run and changed > 0:
         print(f"\n✨ {changed} Iceberg tables registered/updated!")
         print(f"   DuckDB location: {duckdb_path}")
         if total["skipped"] > 0:
-            print(f"   ⊘ {total['skipped']} tables skipped (unchanged — use --force to re-register)")
+            print(f"   ⊘ {total['skipped']} unchanged in Glue, left as-is")
         print("\n   You can now run dbt with: --target dev_local")
-    elif not dry_run and total["skipped"] > 0:
-        print(f"\n✓ All {total['skipped']} tables already registered and up-to-date!")
-        print("   Use --force to re-register all tables")
+    elif not dry_run and (total["skipped"] > 0 or total["refreshed"] > 0):
+        seen = total["skipped"] + total["refreshed"]
+        print(f"\n✓ All {seen} tables already match Glue — nothing upstream has moved.")
+        print("   Your registry is up to date; --force would not surface anything further.")
 
 
 @local_app.command
@@ -1222,7 +1358,7 @@ def setup(
     databases = layer_map[layers]
     print(f"ℹ Layers: {layers} ({len(databases)} database(s))")
 
-    total_reg: dict[str, int] = {"success": 0, "error": 0, "skipped": 0, "new": 0, "updated": 0}
+    total_reg: dict[str, int] = {"success": 0, "error": 0, "skipped": 0, "new": 0, "updated": 0, "refreshed": 0}
     for idx, db_name in enumerate(databases):
         print(f"\n[{idx + 1}/{len(databases)}] Processing: {db_name}")
         try:
@@ -1238,7 +1374,10 @@ def setup(
         reg = _register_tables_in_duckdb(tables, db_name, duckdb_path, dry_run=False, verbose=False, force=True)
         for key in total_reg:
             total_reg[key] += reg[key]
-        print(f"  + {reg['new']} tables registered")
+        # setup() always forces, so most tables on a re-run land in `refreshed`,
+        # not `new`. Reporting only `new` made a correct re-setup read as "0
+        # tables registered".
+        print(f"  ✓ {reg['success']} tables registered ({reg['new']} new, {reg['updated']} updated)")
         if reg["error"] > 0:
             print(f"  ✗ {reg['error']} errors")
 

--- a/src/ol_dbt_cli/ol_dbt_cli/commands/local_dev.py
+++ b/src/ol_dbt_cli/ol_dbt_cli/commands/local_dev.py
@@ -34,7 +34,8 @@ if TYPE_CHECKING:
 DEFAULT_DUCKDB_PATH = Path.home() / ".ol-dbt" / "local.duckdb"
 DEFAULT_GLUE_DATABASE = "ol_warehouse_production_raw"
 
-# How old the newest registry entry may get before `register` and `list-sources`
+# How old the newest successful Glue-scan entry may get before `register` and
+# `list-sources`
 # warn about it. A registered view pins one Iceberg metadata.json; when production
 # rebuilds that table the old metadata file is eventually cleaned up, and the
 # pinned view starts failing with an S3 404 that says nothing about staleness
@@ -165,12 +166,44 @@ def _classify_registration(previous_location: str | None, metadata_location: str
     return "updated"
 
 
-def _registry_last_refreshed(duckdb_path: Path, databases: list[str]) -> datetime.datetime | None:
-    """Return the newest ``registered_at`` across *databases*, or None if unknown.
+def _ensure_registry_tables(conn: duckdb.DuckDBPyConnection) -> None:
+    """Create local registry tables if they do not exist yet."""
+    conn.execute("""
+        CREATE TABLE IF NOT EXISTS _glue_source_registry (
+            view_name VARCHAR PRIMARY KEY,
+            glue_database VARCHAR,
+            glue_table VARCHAR,
+            metadata_location VARCHAR,
+            registered_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+        )
+    """)
+    conn.execute("""
+        CREATE TABLE IF NOT EXISTS _glue_registry_scans (
+            glue_database VARCHAR PRIMARY KEY,
+            scanned_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+        )
+    """)
 
-    None covers every "cannot tell" case — no DuckDB file, no registry table, no
-    rows for these databases — because the caller treats them identically: it has
-    no age to report and says so, rather than implying a fresh registry.
+
+def _record_registry_scan(duckdb_path: Path, database_name: str) -> None:
+    """Record that a Glue database was successfully scanned in this run."""
+    with duckdb.connect(str(duckdb_path)) as conn:
+        _ensure_registry_tables(conn)
+        conn.execute(
+            """
+            INSERT OR REPLACE INTO _glue_registry_scans (glue_database, scanned_at)
+            VALUES (?, CURRENT_TIMESTAMP)
+            """,
+            (database_name,),
+        )
+
+
+def _registry_last_refreshed(duckdb_path: Path, databases: list[str]) -> datetime.datetime | None:
+    """Return the newest Glue scan timestamp across *databases*, or None if unknown.
+
+    None covers every "cannot tell" case — no DuckDB file, no scan table, no rows
+    for these databases — because the caller treats them identically: it has no
+    age to report and says so, rather than implying a fresh registry.
     """
     if not duckdb_path.exists() or not databases:
         return None
@@ -178,7 +211,7 @@ def _registry_last_refreshed(duckdb_path: Path, databases: list[str]) -> datetim
     try:
         with duckdb.connect(str(duckdb_path), read_only=True) as conn:
             row = conn.execute(
-                f"SELECT max(registered_at) FROM _glue_source_registry WHERE glue_database IN ({placeholders})",  # noqa: S608
+                f"SELECT max(scanned_at) FROM _glue_registry_scans WHERE glue_database IN ({placeholders})",  # noqa: S608
                 databases,
             ).fetchone()
     except Exception:  # noqa: BLE001
@@ -295,15 +328,7 @@ def _register_tables_in_duckdb(
             if verbose:
                 print("  ✓ AWS credentials loaded")
 
-            setup_conn.execute("""
-                CREATE TABLE IF NOT EXISTS _glue_source_registry (
-                    view_name VARCHAR PRIMARY KEY,
-                    glue_database VARCHAR,
-                    glue_table VARCHAR,
-                    metadata_location VARCHAR,
-                    registered_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
-                )
-            """)
+            _ensure_registry_tables(setup_conn)
 
             # Loaded even under --force. force governs only whether an unchanged
             # table is SKIPPED; the recorded locations are still what tells new
@@ -443,10 +468,8 @@ def _show_registry(duckdb_path: Path) -> None:
             print(f"{view_name:<60} {glue_db:<30} {registered!s}")
         print("=" * 100)
 
-        # Ordered registered_at DESC above, so the first row is the newest. A view
-        # only ever pins the metadata file that was current when it was
-        # registered, so this age is the single most useful thing here.
-        newest_phrase, is_stale = _describe_registry_age(result[0][3])
+        databases = sorted({row[1] for row in result})
+        newest_phrase, is_stale = _describe_registry_age(_registry_last_refreshed(duckdb_path, databases))
         print(f"  Last refreshed: {newest_phrase}")
         if is_stale:
             print(
@@ -762,6 +785,8 @@ def register(
         except Exception as e:  # noqa: BLE001
             print(f"  ✗ Error accessing database: {e}")
             continue
+        if not dry_run:
+            _record_registry_scan(duckdb_path, db_name)
 
         if not tables:
             print(f"  ⚠ No Iceberg tables found in {db_name}")
@@ -1310,15 +1335,7 @@ def setup(
             conn.execute(f"INSTALL {ext}")
             conn.execute(f"LOAD {ext}")
         conn.execute("CALL load_aws_credentials()")
-        conn.execute("""
-            CREATE TABLE IF NOT EXISTS _glue_source_registry (
-                view_name VARCHAR PRIMARY KEY,
-                glue_database VARCHAR,
-                glue_table VARCHAR,
-                metadata_location VARCHAR,
-                registered_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
-            )
-        """)
+        _ensure_registry_tables(conn)
         conn.close()
         print(f"✓ DuckDB database initialized: {duckdb_path}")
 
@@ -1366,6 +1383,7 @@ def setup(
         except Exception as e:  # noqa: BLE001
             print(f"  ✗ Error: {e}")
             continue
+        _record_registry_scan(duckdb_path, db_name)
 
         if not tables:
             print(f"  ⚠ No Iceberg tables found in {db_name}")

--- a/src/ol_dbt_cli/ol_dbt_cli/commands/local_dev.py
+++ b/src/ol_dbt_cli/ol_dbt_cli/commands/local_dev.py
@@ -35,8 +35,7 @@ DEFAULT_DUCKDB_PATH = Path.home() / ".ol-dbt" / "local.duckdb"
 DEFAULT_GLUE_DATABASE = "ol_warehouse_production_raw"
 
 # How old the newest successful Glue-scan entry may get before `register` and
-# `list-sources`
-# warn about it. A registered view pins one Iceberg metadata.json; when production
+# `list-sources` warn about it. A registered view pins one Iceberg metadata.json; when production
 # rebuilds that table the old metadata file is eventually cleaned up, and the
 # pinned view starts failing with an S3 404 that says nothing about staleness
 # being the cause. Re-running `register` re-reads Glue and repoints the view, so
@@ -198,22 +197,37 @@ def _record_registry_scan(duckdb_path: Path, database_name: str) -> None:
         )
 
 
-def _registry_last_refreshed(duckdb_path: Path, databases: list[str]) -> datetime.datetime | None:
+def _registry_last_refreshed(
+    duckdb_path: Path,
+    databases: list[str],
+    conn: duckdb.DuckDBPyConnection | None = None,
+) -> datetime.datetime | None:
     """Return the newest Glue scan timestamp across *databases*, or None if unknown.
 
     None covers every "cannot tell" case — no DuckDB file, no scan table, no rows
     for these databases — because the caller treats them identically: it has no
     age to report and says so, rather than implying a fresh registry.
+
+    Pass *conn* when the caller already holds a connection to this file. DuckDB
+    refuses a second connection to the same path under a different configuration
+    ("Can't open a connection to same database file with a different
+    configuration than existing connections"), so opening a read_only handle of
+    our own beside an open read-write one raises, and the except below would turn
+    a perfectly readable stale registry into "unknown". That is what made
+    ``list-sources`` never report an age.
     """
-    if not duckdb_path.exists() or not databases:
+    if not databases:
+        return None
+    if conn is None and not duckdb_path.exists():
         return None
     placeholders = ", ".join("?" for _ in databases)
+    sql = f"SELECT max(scanned_at) FROM _glue_registry_scans WHERE glue_database IN ({placeholders})"  # noqa: S608
     try:
-        with duckdb.connect(str(duckdb_path), read_only=True) as conn:
-            row = conn.execute(
-                f"SELECT max(scanned_at) FROM _glue_registry_scans WHERE glue_database IN ({placeholders})",  # noqa: S608
-                databases,
-            ).fetchone()
+        if conn is not None:
+            row = conn.execute(sql, databases).fetchone()
+        else:
+            with duckdb.connect(str(duckdb_path), read_only=True) as own_conn:
+                row = own_conn.execute(sql, databases).fetchone()
     except Exception:  # noqa: BLE001
         return None
     return row[0] if row else None
@@ -469,7 +483,9 @@ def _show_registry(duckdb_path: Path) -> None:
         print("=" * 100)
 
         databases = sorted({row[1] for row in result})
-        newest_phrase, is_stale = _describe_registry_age(_registry_last_refreshed(duckdb_path, databases))
+        # Reuse this function's connection — a second handle to the same file
+        # would be refused and silently degrade the age to "unknown".
+        newest_phrase, is_stale = _describe_registry_age(_registry_last_refreshed(duckdb_path, databases, conn=conn))
         print(f"  Last refreshed: {newest_phrase}")
         if is_stale:
             print(

--- a/src/ol_dbt_cli/tests/test_local_dev.py
+++ b/src/ol_dbt_cli/tests/test_local_dev.py
@@ -9,7 +9,12 @@ import pytest
 
 from ol_dbt_cli.commands.local_dev import (
     PROTECTED_SCHEMAS,
+    REGISTRY_STALE_AFTER_DAYS,
+    _classify_registration,
+    _describe_registry_age,
     _register_single_table,
+    _registry_last_refreshed,
+    _stale_threshold_phrase,
     _validate_schema_safety,
     snapshot,
 )
@@ -170,8 +175,13 @@ class TestRegisterSingleTable:
         assert status == "success"
         assert extra == "updated"
 
-    def test_force_re_registers_unchanged_table(self, tmp_path: Path) -> None:
-        """force=True bypasses the skip check, re-registering even unchanged tables."""
+    def test_force_re_registers_unchanged_table_as_refreshed(self, tmp_path: Path) -> None:
+        """force=True re-registers an unchanged table, reported as 'refreshed' not 'updated'.
+
+        'updated' is reserved for a table whose Glue metadata location actually
+        moved. Reporting a forced no-op re-registration as 'updated' would let a
+        forced run claim upstream changes that never happened.
+        """
         table = self._make_table()
         existing = {"glue__my_db__users": "s3://bucket/users/v1.json"}
 
@@ -184,7 +194,22 @@ class TestRegisterSingleTable:
             )
 
         assert status == "success"
-        assert extra == "updated"  # it was in existing_registrations → "updated"
+        assert extra == "refreshed"
+
+    def test_force_still_reports_a_moved_pointer_as_updated(self, tmp_path: Path) -> None:
+        """Under force, a genuinely changed location is still 'updated', not 'refreshed'."""
+        table = self._make_table(location="s3://bucket/users/v2.json")
+        existing = {"glue__my_db__users": "s3://bucket/users/v1.json"}
+
+        with patch("ol_dbt_cli.commands.local_dev.duckdb.connect") as mock_connect:
+            mock_conn = MagicMock()
+            self._mock_duckdb_connect(mock_connect, mock_conn)
+
+            _status, _view_name, extra = _register_single_table(
+                table, "my_db", tmp_path / "test.duckdb", existing, force=True
+            )
+
+        assert extra == "updated"
 
     def test_returns_error_on_duckdb_exception(self, tmp_path: Path) -> None:
         """DuckDB errors (e.g. bad Iceberg manifest) are caught and returned as 'error'."""
@@ -254,6 +279,98 @@ class TestRegisterSingleTable:
             assert "glue__my_db__users" in row
             assert "my_db" in row
             assert "users" in row
+
+
+class TestClassifyRegistration:
+    """Tests for _classify_registration — the shared new/updated/refreshed decision."""
+
+    def test_unregistered_table_is_new(self) -> None:
+        assert _classify_registration(None, "s3://bucket/v1.json") == "new"
+
+    def test_moved_pointer_is_updated(self) -> None:
+        assert _classify_registration("s3://bucket/v1.json", "s3://bucket/v2.json") == "updated"
+
+    def test_identical_pointer_is_refreshed(self) -> None:
+        assert _classify_registration("s3://bucket/v1.json", "s3://bucket/v1.json") == "refreshed"
+
+
+class TestRegistryAge:
+    """Tests for registry staleness reporting — the signal the incident lacked."""
+
+    def _make_registry(self, db_path: Path, registered_at_sql: str, glue_database: str = "my_db") -> None:
+        import duckdb
+
+        with duckdb.connect(str(db_path)) as conn:
+            conn.execute("""
+                CREATE TABLE IF NOT EXISTS _glue_source_registry (
+                    view_name VARCHAR PRIMARY KEY,
+                    glue_database VARCHAR,
+                    glue_table VARCHAR,
+                    metadata_location VARCHAR,
+                    registered_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+                )
+            """)
+            conn.execute(
+                f"INSERT INTO _glue_source_registry VALUES (?, ?, ?, ?, {registered_at_sql})",  # noqa: S608
+                (f"glue__{glue_database}__users", glue_database, "users", "s3://bucket/users/v1.json"),
+            )
+
+    def test_returns_none_when_no_database_file(self, tmp_path: Path) -> None:
+        assert _registry_last_refreshed(tmp_path / "missing.duckdb", ["my_db"]) is None
+
+    def test_returns_none_when_no_registry_table(self, tmp_path: Path) -> None:
+        """An existing DuckDB file with no registry table must not raise."""
+        import duckdb
+
+        db = tmp_path / "local.duckdb"
+        with duckdb.connect(str(db)) as conn:
+            conn.execute("CREATE TABLE unrelated (x INTEGER)")
+        assert _registry_last_refreshed(db, ["my_db"]) is None
+
+    def test_returns_none_for_unregistered_database(self, tmp_path: Path) -> None:
+        """max() over zero matching rows is NULL, which must surface as None."""
+        db = tmp_path / "local.duckdb"
+        self._make_registry(db, "CURRENT_TIMESTAMP", glue_database="my_db")
+        assert _registry_last_refreshed(db, ["some_other_db"]) is None
+
+    def test_reads_newest_timestamp_for_targeted_databases(self, tmp_path: Path) -> None:
+        db = tmp_path / "local.duckdb"
+        self._make_registry(db, "CURRENT_TIMESTAMP")
+        assert _registry_last_refreshed(db, ["my_db"]) is not None
+
+    def test_unknown_age_is_not_reported_as_stale(self) -> None:
+        """No readable registration is 'unknown', not 'stale' — do not cry wolf on first run."""
+        phrase, is_stale = _describe_registry_age(None)
+        assert is_stale is False
+        assert "unknown" in phrase
+
+    def test_threshold_phrase_is_not_ungrammatical_at_one_day(self) -> None:
+        """The banner interpolates this; at the default of 1 it must not read '1 days'."""
+        assert "1 days" not in _stale_threshold_phrase()
+
+    def test_fresh_registry_is_not_stale(self) -> None:
+        import datetime
+
+        recent = datetime.datetime.now(tz=datetime.UTC) - datetime.timedelta(hours=1)
+        phrase, is_stale = _describe_registry_age(recent)
+        assert is_stale is False
+        assert "hours ago" in phrase
+
+    def test_old_registry_is_stale(self) -> None:
+        import datetime
+
+        old = datetime.datetime.now(tz=datetime.UTC) - datetime.timedelta(days=REGISTRY_STALE_AFTER_DAYS + 1)
+        phrase, is_stale = _describe_registry_age(old)
+        assert is_stale is True
+        assert "days ago" in phrase
+
+    def test_naive_timestamp_does_not_raise(self) -> None:
+        """DuckDB hands back naive datetimes; subtracting an aware 'now' would raise."""
+        import datetime
+
+        naive = datetime.datetime.now() - datetime.timedelta(days=1)  # noqa: DTZ005
+        phrase, _is_stale = _describe_registry_age(naive)
+        assert "ago" in phrase
 
 
 class TestRegisterTablesInDuckdbDryRun:

--- a/src/ol_dbt_cli/tests/test_local_dev.py
+++ b/src/ol_dbt_cli/tests/test_local_dev.py
@@ -297,22 +297,19 @@ class TestClassifyRegistration:
 class TestRegistryAge:
     """Tests for registry staleness reporting — the signal the incident lacked."""
 
-    def _make_registry(self, db_path: Path, registered_at_sql: str, glue_database: str = "my_db") -> None:
+    def _make_registry(self, db_path: Path, scanned_at_sql: str, glue_database: str = "my_db") -> None:
         import duckdb
 
         with duckdb.connect(str(db_path)) as conn:
             conn.execute("""
-                CREATE TABLE IF NOT EXISTS _glue_source_registry (
-                    view_name VARCHAR PRIMARY KEY,
+                CREATE TABLE IF NOT EXISTS _glue_registry_scans (
                     glue_database VARCHAR,
-                    glue_table VARCHAR,
-                    metadata_location VARCHAR,
-                    registered_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+                    scanned_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
                 )
             """)
             conn.execute(
-                f"INSERT INTO _glue_source_registry VALUES (?, ?, ?, ?, {registered_at_sql})",  # noqa: S608
-                (f"glue__{glue_database}__users", glue_database, "users", "s3://bucket/users/v1.json"),
+                f"INSERT OR REPLACE INTO _glue_registry_scans VALUES (?, {scanned_at_sql})",  # noqa: S608
+                (glue_database,),
             )
 
     def test_returns_none_when_no_database_file(self, tmp_path: Path) -> None:

--- a/src/ol_dbt_cli/tests/test_local_dev.py
+++ b/src/ol_dbt_cli/tests/test_local_dev.py
@@ -303,7 +303,7 @@ class TestRegistryAge:
         with duckdb.connect(str(db_path)) as conn:
             conn.execute("""
                 CREATE TABLE IF NOT EXISTS _glue_registry_scans (
-                    glue_database VARCHAR,
+                    glue_database VARCHAR PRIMARY KEY,
                     scanned_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
                 )
             """)

--- a/src/ol_dbt_cli/tests/test_local_dev.py
+++ b/src/ol_dbt_cli/tests/test_local_dev.py
@@ -14,6 +14,7 @@ from ol_dbt_cli.commands.local_dev import (
     _describe_registry_age,
     _register_single_table,
     _registry_last_refreshed,
+    _show_registry,
     _stale_threshold_phrase,
     _validate_schema_safety,
     snapshot,
@@ -311,6 +312,46 @@ class TestRegistryAge:
                 f"INSERT OR REPLACE INTO _glue_registry_scans VALUES (?, {scanned_at_sql})",  # noqa: S608
                 (glue_database,),
             )
+
+    def test_reports_age_through_show_registry(self, tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+        """_show_registry must report the age, not degrade it to "unknown".
+
+        Regression: _show_registry holds a read-write connection while asking for
+        the age. When _registry_last_refreshed opened its own read_only handle to
+        the same file, DuckDB refused it ("Can't open a connection to same
+        database file with a different configuration") and the broad except
+        turned a readable 3-day-old registry into "unknown" -- so list-sources
+        could never report an age or warn, on either a fresh or a stale registry.
+        """
+        import duckdb
+
+        db = tmp_path / "local.duckdb"
+        with duckdb.connect(str(db)) as conn:
+            conn.execute("""
+                CREATE TABLE _glue_source_registry (
+                    view_name VARCHAR PRIMARY KEY,
+                    glue_database VARCHAR,
+                    glue_table VARCHAR,
+                    metadata_location VARCHAR,
+                    registered_at TIMESTAMP
+                )
+            """)
+            conn.execute(
+                "INSERT INTO _glue_source_registry VALUES ('glue__my_db__t', 'my_db', 't', 's3://x', CURRENT_TIMESTAMP)"
+            )
+            conn.execute("""
+                CREATE TABLE _glue_registry_scans (
+                    glue_database VARCHAR PRIMARY KEY,
+                    scanned_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+                )
+            """)
+            conn.execute("INSERT INTO _glue_registry_scans VALUES ('my_db', CURRENT_TIMESTAMP - INTERVAL 3 DAY)")
+
+        _show_registry(db)
+        out = capsys.readouterr().out
+        assert "unknown" not in out
+        assert "3.0 days ago" in out
+        assert "More than a day old" in out
 
     def test_returns_none_when_no_database_file(self, tmp_path: Path) -> None:
         assert _registry_last_refreshed(tmp_path / "missing.duckdb", ["my_db"]) is None


### PR DESCRIPTION
## What are the relevant tickets?

- witan task: `tk-ol-dbt-local-register-default-to-force-re-regist-9c54e7` (amended — see below)
- Found while validating #2088 (migrate `marts__micromasters_dedp_exam_grades` to `dim_course_run`)

## Description (What does it do?)

A local `dev_local` build failed for days on S3 404s reading Iceberg metadata, and
`register`'s incremental mode was blamed for serving stale pointers. **It was not.**
`_get_glue_tables()` queries Glue live on every run and compares that value against
the recorded one, so a moved pointer is always detected and re-registered as
`updated` — `test_registers_updated_table_when_location_changed` already asserted
exactly this. The registry had simply not been re-run in five days. A plain
`register` would have fixed it; `--force` was incidental, not causal.

The originating task proposed making `--force` the default. That would have
prevented nothing and cost real time (a forced run re-issues every view — 2,006
tables here), so this implements the alternative that task also contemplated.

**Three things changed:**

1. **`--force` no longer reports every table as new.** It previously skipped
   loading the recorded locations entirely, so `is_updated` was always `False`
   and a forced run announced its whole catalog as `new` — "New: 2006, Updated: 0"
   — hiding the only number that mattered. This is what made the wrong diagnosis
   plausible. The registry is now always loaded and `force` governs only the *skip*
   decision, with `new` / `updated` (Glue pointer genuinely moved) / `refreshed`
   (forced no-op) split by a shared `_classify_registration` helper.

2. **Staleness is now visible** — the gap that actually cost the days. A view pins
   whatever metadata file was current when registered; nothing reported the
   registry's age, and the failure surfaces as a 404 that says nothing about
   staleness being the cause. `register` and `list-sources` now report how long ago
   the registry was refreshed and warn past a day. **That threshold is measured, not
   chosen:** against a registry 1.1 days old, a dry run found 142 of 158
   intermediate-layer pointers had moved (~90%) and 28 of 29 mart pointers — and the
   intermediate layer is exactly where the incident's 404s occurred, so a longer
   window would stay quiet through precisely the drift this is meant to catch. An
   absent or unreadable registry reports `unknown` and does **not** warn, so a first
   run stays quiet.

3. **Corrected the misleading text** — the docstring, `--force` help, and the
   summary line "use `--force` to re-register" all implied `--force` finds more
   changes than a plain run. Also fixed `setup()`'s count print: it always forces, so
   with accurate counts a correct re-setup would have read "0 tables registered".

## How can this be tested?

```
uv sync                                                          # if you haven't already
cd src/ol_dbt_cli && uv run pytest tests/test_local_dev.py -q    # 39 pass (was 26)
```

That `uv sync` at the repo root is load-bearing in a fresh clone or worktree. `pytest`
isn't a dependency of the `ol-dbt-cli` workspace member, so running `uv run pytest` from
`src/ol_dbt_cli` against an unsynced workspace falls back to whatever `pytest` is on your
PATH (a Python 3.9 one here) and dies on `ModuleNotFoundError: No module named 'boto3'`.
CI sidesteps this by using `uv run --with pytest-cov pytest`, which works too.

Behavioural check against live Glue (read-only, writes nothing; needs AWS credentials
for the Glue `GetTables` call):

```
uv run ol-dbt local register --database ol_warehouse_production_mart --dry-run --quiet
```

Expect the age banner up top, and `↻ Updated` to reflect only pointers that
actually moved. On a registry older than a day the banner warns, and under
`--dry-run` it says "Re-run without --dry-run to refresh them" rather than
claiming to have fixed anything.

`ruff`, `ruff format`, `mypy` and `pre-commit` all clean on the changed files.

Note: `tests/test_diff.py` and `tests/test_validate.py` have 4 pre-existing
failures on `main` (ANSI/rich rendering assertions) — unrelated to this change and
confirmed present with these changes stashed. They only reproduce with colour
enabled, i.e. when pytest runs in a terminal: piped to a file or through `less`,
rich drops the escape codes and the same suite comes back green. So the full-suite
numbers are 494 passed piped / 4 failed, 490 passed in a terminal (`main`: 481 and
4 failed, 477).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

