### PR TITLE
fix(staging): dedupe program certificate models to prevent duplicate rows  

### DIFF
--- a/src/ol_dbt/models/staging/mitxonline/stg__mitxonline__app__postgres__courses_programcertificate.sql
+++ b/src/ol_dbt/models/staging/mitxonline/stg__mitxonline__app__postgres__courses_programcertificate.sql
@@ -2,6 +2,7 @@ with source as (
     select * from {{ source('ol_warehouse_raw_data','raw__mitxonline__app__postgres__courses_programcertificate') }}
 )
 
+{{ deduplicate_raw_table(order_by='id', partition_columns='program_id, user_id') }}
 , cleaned as (
     select
         id as programcertificate_id
@@ -13,7 +14,7 @@ with source as (
         ,{{ cast_timestamp_to_iso8601('created_on') }} as programcertificate_created_on
         ,{{ cast_timestamp_to_iso8601('updated_on') }} as programcertificate_updated_on
         ,{{ cast_timestamp_to_iso8601('issue_date') }} as programcertificate_issued_on
-    from source
+    from most_recent_source
 )
 
 select * from cleaned

--- a/src/ol_dbt/models/staging/mitxpro/stg__mitxpro__app__postgres__courses_programcertificate.sql
+++ b/src/ol_dbt/models/staging/mitxpro/stg__mitxpro__app__postgres__courses_programcertificate.sql
@@ -4,6 +4,7 @@ with source as (
     select * from {{ source('ol_warehouse_raw_data','raw__xpro__app__postgres__courses_programcertificate') }}
 )
 
+{{ deduplicate_raw_table(order_by='id', partition_columns='program_id, user_id') }}
 , cleaned as (
     select
         id as programcertificate_id
@@ -14,7 +15,7 @@ with source as (
         , is_revoked as programcertificate_is_revoked
         ,{{ cast_timestamp_to_iso8601('created_on') }} as programcertificate_created_on
         ,{{ cast_timestamp_to_iso8601('updated_on') }} as programcertificate_updated_on
-    from source
+    from most_recent_source
 )
 
 select * from cleaned


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->

https://pipelines.odl.mit.edu/assets/staging/stg__mitxonline__app__postgres__courses_programcertificate?view=checks

```
[31mFailure in test dbt_expectations_expect_compound_columns_to_be_unique_stg__mitxonline__app__postgres__courses_programcertificate_user_id__program_id (models/staging/mitxonline/_stg_mitxonline__models.yml)[0m

  Got 166 results, configured to fail if >10
```                                                                                                                    

### Description (What does it do?)
<!--- Describe your changes in detail -->

 I refreshed raw__mitxonline__app__postgres__courses_programcertificate to unblock the dbt errors yesterday. This PR adds dedupe to the staging models to guard against this.  
               

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

`dbt build --target dev_production --vars 'schema_suffix: <>'` on both staging models 

### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->


<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
