### PR TITLE
fix(couponredemption): deduplicate redemptions 

### DIFF
--- a/src/ol_dbt/models/staging/mitxpro/stg__mitxpro__app__postgres__ecommerce_couponredemption.sql
+++ b/src/ol_dbt/models/staging/mitxpro/stg__mitxpro__app__postgres__ecommerce_couponredemption.sql
@@ -4,6 +4,7 @@ with source as (
 
 )
 
+{{ deduplicate_raw_table(order_by="id", partition_columns="order_id, coupon_version_id") }}
 , renamed as (
 
     select
@@ -12,7 +13,7 @@ with source as (
         , coupon_version_id as couponversion_id
         ,{{ cast_timestamp_to_iso8601('created_on') }} as couponredemption_created_on
         ,{{ cast_timestamp_to_iso8601('updated_on') }} as couponredemption_updated_on
-    from source
+    from most_recent_source
 
 )
 


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
NA

### Description (What does it do?)
<!--- Describe your changes in detail -->

Duplicates xPro coupon redemptions to fix duplicate rows in `marts__combined__orders`.

See https://pipelines.odl.mit.edu/runs/91a24b1d-e715-449f-9e84-41e815dcdb09 , which blocks other dbt models from updating

`raw__xpro__app__postgres__ecommerce_couponredemption` has hard-delete-and-recreate rows


### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->
 dbt build --select stg__mitxpro__app__postgres__ecommerce_couponredemption 

### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->


<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
