### PR TITLE
feat(inventory): per-environment Airbyte snapshots and a cursor-viability check

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,5 +25,8 @@ src/ol_dbt/.user.yml
 .sup/
 
 # Airbyte inventory working files — regenerate with bin/airbyte-inventory.py
-airbyte-snapshot.json
+# Snapshots are per-environment (airbyte-snapshot-production.json,
+# airbyte-snapshot-qa.json) and hold connector configuration, redacted but not
+# worth committing.
+airbyte-snapshot*.json
 airbyte-findings.md

--- a/bin/airbyte-inventory.py
+++ b/bin/airbyte-inventory.py
@@ -12,12 +12,33 @@ Nothing here writes to Airbyte. Every call is a GET.
 Usage::
 
     export AIRBYTE_PASSWORD='...'          # or pass --password
-    uv run python bin/airbyte-inventory.py all --username dagster
+    uv run python bin/airbyte-inventory.py all --environment qa
 
     # or one step at a time
-    uv run python bin/airbyte-inventory.py dump --username dagster --password "$PW"
+    uv run python bin/airbyte-inventory.py dump --environment qa
     uv run python bin/airbyte-inventory.py report --output findings.md
     uv run python bin/airbyte-inventory.py render --output-dir ingestion/inventory/units
+
+Each environment runs its OWN Airbyte deployment with its own connections, so a
+snapshot is per-environment: ``--environment`` picks the host from
+``AIRBYTE_SERVERS`` and writes ``airbyte-snapshot-<environment>.json``.
+``render`` merges however many exist into one inventory, tagging each connection
+with the environment it came from.
+
+**One environment per run.** Each deployment's basic-auth credential comes from
+its own Vault service, so a single ``--username``/``--password`` cannot reach
+two of them. Run the whole thing once per environment with that environment's
+credential; ``render`` picks up whatever snapshots are on disk, so the merged
+inventory accumulates across runs.
+
+That merge is what makes the QA side legible. Outside production most
+connections are ``inactive`` — configured once, then disabled as they fell out
+of use — and an inactive connection produces no Dagster asset, so reading the
+asset graph makes QA look nearly empty when it is merely switched off. The
+distinction matters twice over: it is the evidence ``strategies.qa`` is meant to
+be decided on (RFC 12711 §3), and it is the scope of what a replacement dlt
+pipeline has to cover, since a disabled connection still records the streams
+someone once wanted in QA.
 
 The password is the same Vault KV v1 secret Dagster uses::
 
@@ -67,9 +88,49 @@ app = App(
 )
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
-DEFAULT_SNAPSHOT = Path("airbyte-snapshot.json")
-DEFAULT_SERVER_URL = "https://api-airbyte.odl.mit.edu"
 PUBLIC_API_PATH = "/api/public/v1"
+
+# One Airbyte deployment per environment, each with its own connections. Hosts
+# come from ol-infrastructure's `airbyte:api_host_domain` (applications/airbyte/
+# Pulumi.<Env>.yaml). Exhaustive on purpose, matching the no-fallback rule the
+# dbt target maps follow: an unknown environment raises rather than quietly
+# snapshotting production and filing the result under another name.
+#
+# `ci` is deliberately absent. ol-infrastructure defines an api-airbyte-ci host,
+# but nothing runs there -- the CI code location sets SKIP_AIRBYTE and loads an
+# empty workspace (definitions.py). Listing it would offer a snapshot that can
+# only ever come back empty, and an empty snapshot is indistinguishable from a
+# workspace whose connections were all deleted.
+AIRBYTE_SERVERS: dict[str, str] = {
+    "production": "https://api-airbyte.odl.mit.edu",
+    "qa": "https://api-airbyte-qa.odl.mit.edu",
+}
+DEFAULT_ENVIRONMENT = "production"
+
+
+def snapshot_path_for(environment: str) -> Path:
+    """Default snapshot filename for an environment.
+
+    Environment-qualified so a QA dump cannot silently overwrite the production
+    snapshot -- `render` reads several at once and the two are not
+    interchangeable.
+    """
+    return Path(f"airbyte-snapshot-{environment}.json")
+
+
+def _resolve_server_url(environment: str, server_url: str | None) -> str:
+    if server_url:
+        return server_url
+    try:
+        return AIRBYTE_SERVERS[environment]
+    except KeyError:
+        msg = (
+            f"No Airbyte server known for environment {environment!r} "
+            f"(known: {sorted(AIRBYTE_SERVERS)}). Add it to AIRBYTE_SERVERS or "
+            f"pass --server-url."
+        )
+        raise SystemExit(msg) from None
+
 
 DEFINITIONS_PY = (
     REPO_ROOT / "dg_projects" / "lakehouse" / "lakehouse" / "definitions.py"
@@ -197,15 +258,34 @@ def dump(  # noqa: PLR0913
     password: Annotated[
         str | None, Parameter(env_var="AIRBYTE_PASSWORD", show_default=False)
     ] = None,
+    environment: Annotated[
+        str,
+        Parameter(
+            env_var="AIRBYTE_ENVIRONMENT",
+            help=(
+                "Which Airbyte deployment to snapshot: "
+                f"{', '.join(sorted(AIRBYTE_SERVERS))}."
+            ),
+        ),
+    ] = DEFAULT_ENVIRONMENT,
     server_url: Annotated[
-        str, Parameter(env_var="AIRBYTE_SERVER_URL")
-    ] = DEFAULT_SERVER_URL,
+        str | None,
+        Parameter(
+            env_var="AIRBYTE_SERVER_URL",
+            help="Override the host for --environment.",
+            show_default=False,
+        ),
+    ] = None,
     workspace_id: Annotated[
         str | None, Parameter(help="Limit to one workspace.")
     ] = None,
     output: Annotated[
-        Path, Parameter(help="Where to write the JSON snapshot.")
-    ] = DEFAULT_SNAPSHOT,
+        Path | None,
+        Parameter(
+            help="Where to write the JSON snapshot.",
+            show_default=False,
+        ),
+    ] = None,
     page_size: int = 50,
     timeout: float = 60.0,
     include_deleted: bool = False,
@@ -228,7 +308,9 @@ def dump(  # noqa: PLR0913
 ) -> Path:
     """Fetch workspaces, sources, destinations and connections into a JSON snapshot."""
     secret = _resolve_password(password)
-    base_url = server_url.rstrip("/") + PUBLIC_API_PATH
+    resolved_url = _resolve_server_url(environment, server_url)
+    output = output or snapshot_path_for(environment)
+    base_url = resolved_url.rstrip("/") + PUBLIC_API_PATH
 
     with httpx.Client(
         base_url=base_url,
@@ -241,7 +323,7 @@ def dump(  # noqa: PLR0913
         if workspace_id:
             common["workspaceIds"] = [workspace_id]
 
-        _progress(f"Fetching from {base_url} as {username} …")
+        _progress(f"Fetching {environment} from {base_url} as {username} …")
         workspaces = _paginated_get(client, "/workspaces", dict(common), "workspaceId")
         _progress(f"  workspaces:   {len(workspaces)}")
         sources = _paginated_get(client, "/sources", dict(common), "sourceId")
@@ -253,7 +335,15 @@ def dump(  # noqa: PLR0913
         connections = _paginated_get(
             client, "/connections", dict(common), "connectionId"
         )
-        _progress(f"  connections:  {len(connections)}")
+        # Broken out by status because outside production most connections are
+        # `inactive` -- disabled after falling out of use, not absent. A count
+        # alone reads as "QA has almost nothing", which is the wrong conclusion
+        # and the reason this command grew an --environment flag.
+        by_status = Counter(c.get("status", "unknown") for c in connections)
+        _progress(
+            f"  connections:  {len(connections)} "
+            f"({', '.join(f'{n} {s}' for s, n in sorted(by_status.items()))})"
+        )
 
         # Some server versions omit stream configs from the list response.
         for connection in connections:
@@ -299,7 +389,8 @@ def dump(  # noqa: PLR0913
 
     snapshot = {
         "fetched_at": datetime.now(UTC).isoformat(),
-        "server_url": server_url,
+        "environment": environment,
+        "server_url": resolved_url,
         "redacted": not full_config,
         "workspaces": workspaces,
         "sources": sources,
@@ -349,6 +440,10 @@ def _load_snapshot(path: Path) -> dict[str, Any]:
             "broken pagination loop; re-run `airbyte-inventory dump`."
         )
         raise SystemExit(msg)
+
+    # Snapshots predate --environment; they can only have come from the one
+    # server the script used to hard-code.
+    snapshot.setdefault("environment", DEFAULT_ENVIRONMENT)
     return snapshot
 
 
@@ -798,17 +893,27 @@ def _finding_f_prefixes(snapshot: dict[str, Any]) -> list[str]:
 def report(
     *,
     snapshot: Annotated[
-        Path, Parameter(help="Snapshot written by `dump`.")
-    ] = DEFAULT_SNAPSHOT,
+        Path | None,
+        Parameter(help="Snapshot written by `dump`.", show_default=False),
+    ] = None,
     output: Annotated[
         Path | None, Parameter(help="Write markdown here instead of stdout.")
     ] = None,
 ) -> None:
-    """Derive the findings from a snapshot and print them as markdown."""
+    """Derive the findings from ONE snapshot and print them as markdown.
+
+    Single-environment by design, unlike `render`. Findings C and E join against
+    production-only facts -- ``group_name_to_interval`` (guarded by
+    ``DAGSTER_ENV == "production"``) and the dbt sources, which describe the
+    production warehouse -- so running them over a QA snapshot would report every
+    QA connection as miswired. Point it at one environment at a time.
+    """
+    snapshot = snapshot or snapshot_path_for(DEFAULT_ENVIRONMENT)
     data = _load_snapshot(snapshot)
     lines = [
         "# Airbyte ingestion inventory — findings",
         "",
+        f"Environment: `{data['environment']}`.",
         f"Source: `{data['server_url']}`, fetched {data['fetched_at']}.",
         f"- {len(data['sources'])} sources, {len(data['destinations'])} destinations",
         f"- {len(data['connections'])} connections",
@@ -870,44 +975,90 @@ def _infer_unit_key(prefix: str) -> tuple[str, str, bool]:  # noqa: PLR0911
 @app.command
 def render(  # noqa: C901, PLR0912, PLR0915
     *,
-    snapshot: Annotated[
-        Path, Parameter(help="Snapshot written by `dump`.")
-    ] = DEFAULT_SNAPSHOT,
+    snapshots: Annotated[
+        list[Path] | None,
+        Parameter(
+            help=(
+                "Snapshots written by `dump`, one per environment. Repeat the "
+                "flag to merge several; defaults to whichever "
+                "airbyte-snapshot-<env>.json files exist."
+            ),
+            show_default=False,
+        ),
+    ] = None,
     output_dir: Annotated[
         Path, Parameter(help="Directory for the draft unit files.")
     ] = Path("ingestion/inventory/units"),
 ) -> None:
-    """Render a DRAFT inventory from the snapshot — for review, not for merging as-is.
+    """Render a DRAFT inventory from the snapshots — for review, not for merging as-is.
 
     Every field the API cannot answer (`scope`, `strategies`, `modeled` for
     tables dbt does not declare) is emitted with a TODO so the reviewer has to
     decide it rather than inherit a guess.
+
+    Merges across environments. A unit is (deployment, layer) regardless of where
+    it runs, so the same unit's production and QA connections land in one
+    `airbyte.connections` list, each tagged with its `environment`. That is what
+    makes `strategies.qa` decidable from evidence instead of assumption: a unit
+    with no QA connection at all, and a unit whose QA connection exists but is
+    `inactive`, are different situations and used to look identical here.
     """
-    data = _load_snapshot(snapshot)
-    sources_by_id = {s["sourceId"]: s for s in data["sources"]}
+    paths = snapshots or [
+        candidate
+        for environment in sorted(AIRBYTE_SERVERS)
+        if (candidate := snapshot_path_for(environment)).exists()
+    ]
+    if not paths:
+        msg = (
+            "No snapshots found. Run `airbyte-inventory dump --environment "
+            f"<{'|'.join(sorted(AIRBYTE_SERVERS))}>` first, or pass --snapshots."
+        )
+        raise SystemExit(msg)
+
     dbt_tables = {table.lower() for table in _dbt_raw_tables()}
     interval_map = _parse_interval_map()
 
-    grouped: dict[tuple[str, str], list[dict[str, Any]]] = defaultdict(list)
+    sources_by_id: dict[str, dict[str, Any]] = {}
+    grouped: dict[tuple[str, str], list[tuple[str, dict[str, Any]]]] = defaultdict(list)
     unresolved: list[str] = []
-    for connection in sorted(data["connections"], key=lambda c: c["name"].lower()):
-        prefix = _effective_prefix(connection)
-        deployment, layer, confident = _infer_unit_key(prefix)
-        if not confident:
-            unresolved.append(f"{connection['name']} (prefix {prefix or '(none)'})")
-        grouped[deployment, layer].append(connection)
+    environments: list[str] = []
+    for path in paths:
+        data = _load_snapshot(path)
+        environment = data["environment"]
+        if environment in environments:
+            msg = (
+                f"Two snapshots claim environment {environment!r} "
+                f"(latest: {path}). Renders would double-count its connections."
+            )
+            raise SystemExit(msg)
+        environments.append(environment)
+        _progress(
+            f"  {path}: {environment}, {len(data['connections'])} connection(s), "
+            f"fetched {data['fetched_at']}"
+        )
+        sources_by_id.update({s["sourceId"]: s for s in data["sources"]})
+        for connection in sorted(data["connections"], key=lambda c: c["name"].lower()):
+            prefix = _effective_prefix(connection)
+            deployment, layer, confident = _infer_unit_key(prefix)
+            if not confident:
+                unresolved.append(
+                    f"[{environment}] {connection['name']} "
+                    f"(prefix {prefix or '(none)'})"
+                )
+            grouped[deployment, layer].append((environment, connection))
 
     units: dict[tuple[str, str], dict[str, Any]] = {}
     todos_by_key: dict[tuple[str, str], list[str]] = {}
-    for key, connections in grouped.items():
+    for key, tagged_connections in grouped.items():
         deployment, layer = key
         todos: list[str] = []
         actors = []
-        for connection in connections:
+        for environment, connection in tagged_connections:
             source = sources_by_id.get(connection["sourceId"], {})
             group = dagster_group_name(connection["name"])
             actors.append(
                 {
+                    "environment": environment,
                     "connection_name": connection["name"],
                     "source_kind": f"source-{source.get('sourceType', 'unknown')}",
                     "replication_method": _normalized_replication_method(
@@ -920,7 +1071,14 @@ def render(  # noqa: C901, PLR0912, PLR0915
                     ),
                     "table_prefix": _effective_prefix(connection),
                     "dagster_group": group,
-                    "sync_interval_hours": interval_map.get(group),
+                    # group_name_to_interval in definitions.py is guarded by
+                    # `if DAGSTER_ENV == "production"`, so it says nothing about
+                    # any other environment. Reading it for a QA connection would
+                    # invent a cadence -- and QA's schedules are all STOPPED
+                    # anyway, so there is no cadence to report.
+                    "sync_interval_hours": (
+                        interval_map.get(group) if environment == "production" else None
+                    ),
                 }
             )
 
@@ -943,6 +1101,51 @@ def render(  # noqa: C901, PLR0912, PLR0915
                 "(deployment, layer) could not be inferred — assign it by hand"
             )
 
+        by_environment: dict[str, list[dict[str, Any]]] = defaultdict(list)
+        for actor in actors:
+            by_environment[actor["environment"]].append(actor)
+        reference = next(
+            (a for a in actors if a["environment"] == DEFAULT_ENVIRONMENT), actors[0]
+        )
+
+        # The per-environment notes below are the whole point of merging
+        # snapshots: they are the evidence `strategies.qa` is supposed to be
+        # decided on, and equally the scoping input for replacing this unit with
+        # a dlt pipeline -- what a QA loader would have to cover, whatever loads
+        # it. Only emitted for environments actually snapshotted, so a
+        # production-only render says nothing about QA rather than implying
+        # absence.
+        production_streams = {
+            stream
+            for actor in by_environment.get(DEFAULT_ENVIRONMENT, [])
+            for stream in actor["streams"]
+        }
+        for environment in environments:
+            if environment == DEFAULT_ENVIRONMENT:
+                continue
+            peers = by_environment.get(environment, [])
+            if not peers:
+                todos.append(
+                    f"no {environment} connection exists for this unit — "
+                    f"`strategies.{environment}` cannot be `ingest` without "
+                    f"building one"
+                )
+                continue
+            if all(actor["status"] != "active" for actor in peers):
+                todos.append(
+                    f"every {environment} connection is disabled "
+                    f"({', '.join(sorted(a['connection_name'] for a in peers))}) — "
+                    f"the unit is configured there but has gone dark"
+                )
+            peer_streams = {s for actor in peers for s in actor["streams"]}
+            if missing := sorted(production_streams - peer_streams):
+                shown = ", ".join(missing[:5])
+                more = f", +{len(missing) - 5} more" if len(missing) > 5 else ""  # noqa: PLR2004
+                todos.append(
+                    f"{len(missing)} stream(s) in production are absent from "
+                    f"{environment}: {shown}{more}"
+                )
+
         # Structurally schema-valid (§3): every required key present and every
         # list in the right shape, so `ol-dbt inventory validate` reports only
         # the TODO values a human still has to decide — not a wall of shape
@@ -956,16 +1159,24 @@ def render(  # noqa: C901, PLR0912, PLR0915
             "loader": "airbyte",
             "table_prefix": sorted(prefixes)[0],
             "airbyte": {
-                "source_kind": actors[0]["source_kind"],
-                "replication_method": actors[0]["replication_method"],
+                # Production is the reference for the unit-level facts when a
+                # unit runs in several environments: QA's connector can lag a
+                # version or sit on an older replication method without that
+                # being what the unit means.
+                "source_kind": reference["source_kind"],
+                "replication_method": reference["replication_method"],
                 "connections": [
                     {
+                        "environment": actor["environment"],
                         "name": actor["connection_name"],
                         "status": actor["status"],
-                        "sync_interval_hours": actor["sync_interval_hours"] or 24,
+                        "sync_interval_hours": actor["sync_interval_hours"],
                         "streams": actor["streams"],
                     }
-                    for actor in actors
+                    for actor in sorted(
+                        actors,
+                        key=lambda a: (a["environment"], a["connection_name"].lower()),
+                    )
                 ],
             },
         }
@@ -974,7 +1185,15 @@ def render(  # noqa: C901, PLR0912, PLR0915
             todos.append(f"connections use different source kinds ({sorted(kinds)})")
 
         tables: dict[str, dict[str, Any]] = {}
-        for connection in connections:
+        # Production first, so it wins every raw_table it defines. `tables` is
+        # the unit's intended contract, not a description of any one
+        # environment's current wiring -- and a QA connection frozen before a
+        # schema change would otherwise overwrite the live definition with a
+        # stale one purely on iteration order.
+        for environment, connection in sorted(
+            tagged_connections,
+            key=lambda pair: (pair[0] != DEFAULT_ENVIRONMENT, pair[0]),
+        ):
             for stream in sorted(
                 _streams_of(connection), key=lambda s: s.get("name", "")
             ):
@@ -999,12 +1218,40 @@ def render(  # noqa: C901, PLR0912, PLR0915
                     # is indistinguishable from two nested segments once joined.
                     entry["primary_key"] = [list(part) for part in stream["primaryKey"]]
                 entry["modeled"] = raw_table.lower() in dbt_tables
-                if raw_table in tables and tables[raw_table] != entry:
-                    todos.append(
-                        f"{raw_table} is configured differently by two connections"
-                    )
-                tables.setdefault(raw_table, entry)
-        unit["tables"] = sorted(tables.values(), key=lambda t: t["raw_table"])
+                held = tables.get(raw_table)
+                # Compare on the stream config alone: `held` also carries the
+                # `_environment` scratch key, so comparing whole dicts would
+                # report every table as differing.
+                if (
+                    held is not None
+                    and {k: v for k, v in held.items() if k != "_environment"} != entry
+                ):
+                    # Across environments this is drift, not a conflict to
+                    # resolve: production defines the table and the other
+                    # environment has fallen behind it. Only same-environment
+                    # disagreement means two connections genuinely contradict.
+                    if environment == tables[raw_table]["_environment"]:
+                        todos.append(
+                            f"{raw_table} is configured differently by two "
+                            f"{environment} connections"
+                        )
+                    else:
+                        todos.append(
+                            f"{raw_table} differs between "
+                            f"{tables[raw_table]['_environment']} and {environment} "
+                            f"— keeping the "
+                            f"{tables[raw_table]['_environment']} definition"
+                        )
+                tables.setdefault(raw_table, {**entry, "_environment": environment})
+        # `_environment` is renderer scratch for the drift note above; the schema
+        # forbids unknown keys, so it never reaches the file.
+        unit["tables"] = sorted(
+            (
+                {k: v for k, v in entry.items() if k != "_environment"}
+                for entry in tables.values()
+            ),
+            key=lambda t: t["raw_table"],
+        )
         # Kept beside the unit rather than inside it: the schema forbids unknown
         # keys, and renderer scratch notes should not earn a slot in it.
         todos_by_key[key] = todos
@@ -1018,8 +1265,8 @@ def render(  # noqa: C901, PLR0912, PLR0915
         path = path.with_suffix(".yml")
         header = (
             "---\n"
-            "# DRAFT — generated by bin/airbyte-inventory.py from a live "
-            "Airbyte snapshot.\n"
+            "# DRAFT — generated by bin/airbyte-inventory.py from live Airbyte\n"
+            f"# snapshots of: {', '.join(environments)}.\n"
             "# Every TODO is a decision the API cannot make: scope, per-environment\n"
             "# strategies, and any layer that could not be inferred from the prefix.\n"
             "# See docs/specs/INGESTION_INVENTORY_SPEC.md §3.\n"
@@ -1056,17 +1303,57 @@ def run_all(  # noqa: PLR0913
     password: Annotated[
         str | None, Parameter(env_var="AIRBYTE_PASSWORD", show_default=False)
     ] = None,
+    environment: Annotated[
+        str,
+        Parameter(
+            env_var="AIRBYTE_ENVIRONMENT",
+            help=(
+                "Which Airbyte deployment to snapshot: "
+                f"{', '.join(sorted(AIRBYTE_SERVERS))}."
+            ),
+        ),
+    ] = DEFAULT_ENVIRONMENT,
     server_url: Annotated[
-        str, Parameter(env_var="AIRBYTE_SERVER_URL")
-    ] = DEFAULT_SERVER_URL,
-    snapshot: Path = DEFAULT_SNAPSHOT,
+        str | None,
+        Parameter(
+            env_var="AIRBYTE_SERVER_URL",
+            help="Override the host for --environment.",
+            show_default=False,
+        ),
+    ] = None,
     findings: Path = Path("airbyte-findings.md"),
     output_dir: Path = Path("ingestion/inventory/units"),
 ) -> None:
-    """Dump → report → render in one go."""
-    dump(username=username, password=password, server_url=server_url, output=snapshot)
-    report(snapshot=snapshot, output=findings)
-    render(snapshot=snapshot, output_dir=output_dir)
+    """Dump ONE environment → report → render from every snapshot on disk.
+
+    One environment per run, because each Airbyte deployment has its own
+    credentials from its own Vault service -- a single set of
+    --username/--password cannot reach two of them. Run it once per
+    environment; the render step picks up whatever snapshots are present, so
+    the merged inventory builds up across runs rather than needing one pass
+    that could authenticate everywhere.
+    """
+    dump(
+        username=username,
+        password=password,
+        environment=environment,
+        server_url=server_url,
+    )
+
+    # Findings C and E join against production-only facts, so they are derived
+    # from the production snapshot whenever one exists -- this run's, or an
+    # earlier one's. Nothing to report from without it.
+    production_snapshot = snapshot_path_for(DEFAULT_ENVIRONMENT)
+    if production_snapshot.exists():
+        report(snapshot=production_snapshot, output=findings)
+    else:
+        _progress(
+            f"No {production_snapshot} yet — skipping findings, which are "
+            f"production-only. Run `all --environment {DEFAULT_ENVIRONMENT}` "
+            f"to produce them."
+        )
+
+    render(output_dir=output_dir)
 
 
 if __name__ == "__main__":

--- a/docs/specs/INGESTION_INVENTORY_SPEC.md
+++ b/docs/specs/INGESTION_INVENTORY_SPEC.md
@@ -176,12 +176,19 @@ loader: airbyte                   # airbyte | dlt
 table_prefix: raw__mitxonline__app__postgres__   # §1.1; must be unique across all units
 
 airbyte:                          # required iff loader == airbyte; dropped at cutover
-  connections:                    # a LIST — one unit can have several (§3.5)
-    - name: "MITx Online Open edX DB → S3 Data Lake"   # §1.3, byte-exact
+  connections:                    # a LIST — one unit can have several (§3.5),
+                                  # in one or more environments (§3.8)
+    - environment: production     # production | qa | ci — which Airbyte, §3.8
+      name: "MITx Online Open edX DB → S3 Data Lake"   # §1.3, byte-exact
       status: active              # active | inactive — §3.6
       sync_interval_hours: 12     # per connection (§3.5); drives the DAGSTER
                                   # schedule only — Airbyte renders as `manual`
       streams: [assessment_assessment, …]             # which tables this one carries
+    - environment: qa
+      name: "MITx Online QA App DB → S3 Data Lake"
+      status: inactive            # configured, then disabled — §3.8
+      sync_interval_hours: null   # null outside production — §3.8
+      streams: [assessment_assessment]
   source_kind: source-postgres
   replication_method: xmin        # xmin | cursor | cdc  — see §3.4
 
@@ -350,6 +357,53 @@ layers instead of deployments.
 
 **This is a change to RFC 12711's schema, not just this spec's**, since the key is shared.
 Raise it on 12711 before the inventory is populated (step 3), not after.
+
+### 3.8 Each environment runs its own Airbyte, so `environment` is on the connection
+
+The unit key is `(deployment, layer)` and stays environment-agnostic — a unit is the same
+analytics object wherever it runs. What differs per environment is the *wiring*: production
+and QA each run a separate Airbyte deployment (`api-airbyte.odl.mit.edu` and
+`api-airbyte-qa.odl.mit.edu`, from ol-infrastructure's `airbyte:api_host_domain`), each with
+its own connections against its own lake. So `environment` is a required field on each
+connection, and one unit's `airbyte.connections` list legitimately holds both.
+
+There is no `ci`. ol-infrastructure defines an `api-airbyte-ci.odl.mit.edu` host, but nothing
+runs behind it — the CI code location sets `SKIP_AIRBYTE` and loads an empty workspace. The
+enum omits the value rather than documenting it as always-empty, because an empty snapshot is
+indistinguishable from a workspace whose connections were all deleted.
+
+`bin/airbyte-inventory.py dump --environment <env>` writes `airbyte-snapshot-<env>.json`;
+`render` merges however many exist into one inventory. **One environment per run**: each
+deployment's basic-auth credential comes from its own Vault service, so no single invocation
+can authenticate to both. Run `all --environment <env>` once per environment; the render step
+reads whatever snapshots are on disk, so the merged inventory accumulates across runs rather
+than requiring one pass with universal credentials.
+
+Three consequences the validator and renderer encode:
+
+1. **The duplicate-stream rule counts per environment, not per unit.** It exists to catch two
+   connections writing one raw table; across environments the writes land in different lakes,
+   so the same stream in a production and a QA connection is the normal case for a unit
+   ingested in both.
+2. **`sync_interval_hours` is null outside production.** The cadence lives in
+   `group_name_to_interval` in `lakehouse/definitions.py`, which is guarded by
+   `DAGSTER_ENV == "production"` and therefore says nothing about any other environment.
+   Emitting a number there would invent one.
+3. **`environment` crosses the repo boundary** in `render airbyte` (§4), so a consumer —
+   Pulumi, or the drift check of §8 — can select one workspace's connections instead of
+   being handed the union of two as though it were one.
+
+Omission is the dangerous direction here, which is why the field is required rather than
+defaulted: an untagged QA connection reads as production, and a silent fall-through to
+production is precisely the class of bug RFC 12711 exists to end.
+
+This is also what makes `strategies.qa` decidable from evidence. Outside production most
+connections are `inactive` — configured once, then disabled as they fell out of use — and an
+inactive connection produces no Dagster asset, so reading the asset graph makes QA look nearly
+empty when it is merely switched off. A unit with **no** QA connection and a unit whose QA
+connection exists but is disabled are different situations calling for different work, and
+before this they looked identical here. The same distinction scopes the dlt migration: a
+disabled connection still records the streams someone once wanted in QA.
 
 ---
 

--- a/docs/specs/INGESTION_INVENTORY_SPEC.md
+++ b/docs/specs/INGESTION_INVENTORY_SPEC.md
@@ -178,11 +178,12 @@ table_prefix: raw__mitxonline__app__postgres__   # §1.1; must be unique across 
 airbyte:                          # required iff loader == airbyte; dropped at cutover
   connections:                    # a LIST — one unit can have several (§3.5),
                                   # in one or more environments (§3.8)
-    - environment: production     # production | qa | ci — which Airbyte, §3.8
+    - environment: production     # production | qa — which Airbyte, §3.8
       name: "MITx Online Open edX DB → S3 Data Lake"   # §1.3, byte-exact
       status: active              # active | inactive — §3.6
       sync_interval_hours: 12     # per connection (§3.5); drives the DAGSTER
-                                  # schedule only — Airbyte renders as `manual`
+                                  # schedule only — Airbyte renders as `manual`.
+                                  # Required in production, null elsewhere §3.8
       streams: [assessment_assessment, …]             # which tables this one carries
     - environment: qa
       name: "MITx Online QA App DB → S3 Data Lake"
@@ -751,11 +752,16 @@ already uses:
 export AIRBYTE_PASSWORD="$(vault kv get -mount=secret-data \
     -field=dagster_unhashed_password dagster-http-auth-password)"
 
-uv run python bin/airbyte-inventory.py all --username dagster
-#   → airbyte-snapshot.json   redacted JSON snapshot
-#   → airbyte-findings.md     findings A–F below
-#   → ingestion/inventory/units/*.yml   draft units, TODO-marked
+uv run python bin/airbyte-inventory.py all --environment production
+#   → airbyte-snapshot-production.json   redacted JSON snapshot
+#   → airbyte-findings.md                findings A–F below
+#   → ingestion/inventory/units/*.yml    draft units, TODO-marked
 ```
+
+One environment per run — each Airbyte deployment's basic-auth credential comes from its own
+Vault service, so no single invocation reaches both (§3.8). Repeat with `--environment qa` and
+that environment's password; `render` merges whatever snapshots are on disk, so the inventory
+accumulates across runs rather than needing one pass with universal credentials.
 
 `report` and `render` re-run offline against a saved snapshot, so iterating on the derivation
 costs nothing and needs no further credentials. Findings produced:

--- a/docs/specs/INGESTION_INVENTORY_SPEC.md
+++ b/docs/specs/INGESTION_INVENTORY_SPEC.md
@@ -258,6 +258,15 @@ populated:
 - `tk-determine-per-source-incremental-cursor-viabilit-51f299` — which connections use xmin,
   and therefore which need a replacement cursor column chosen before dlt can take over. Today
   that answer requires crawling the Airbyte UI; after this lands it is `rg replication_method: xmin`.
+
+  Choosing the replacement is `ol-dbt inventory cursors`, which reads the LANDED column list
+  from Glue and reports, per table, whether a modification timestamp exists to key on. It is a
+  standing check rather than a one-off audit for two reasons: a new app is covered the moment
+  its unit exists, nothing is hard-coded per source; and a declared `cursor_field` whose column
+  is later dropped or renamed does not fail loudly — the load just stops advancing. That case
+  (`cursor_missing`) exits non-zero. Note what it cannot tell you: whether the column is stamped
+  on *every* mutation path. A write-once column yields a load that captures inserts and silently
+  never reflects an edit, so a `cursor_available` finding is a shortlist entry, not an approval.
 - The Airbyte-side deadline: source-postgres 3.8+ refuses xmin mode outright on any database
   that has ever exceeded 2^32 lifetime transactions
   (`les-airbyte-source-postgres-3-8-refuses-xmin-mode-on-a5438b`). That deadline is independent

--- a/ingestion/inventory/schema/unit.schema.json
+++ b/ingestion/inventory/schema/unit.schema.json
@@ -77,6 +77,21 @@
             "type": "object",
             "additionalProperties": false,
             "required": ["environment", "name", "status", "sync_interval_hours", "streams"],
+            "allOf": [
+              {
+                "description": "The cadence is required in production and must be absent elsewhere. A production `null` is the dangerous direction and the reason this is enforced rather than described: render_dagster_intervals skips a non-integer, so the group falls through to `group_name_to_interval`'s 24-hour default in definitions.py and a 6-hour sync silently becomes daily.",
+                "if": {
+                  "properties": {"environment": {"const": "production"}},
+                  "required": ["environment"]
+                },
+                "then": {
+                  "properties": {"sync_interval_hours": {"type": "integer", "enum": [6, 12, 24]}}
+                },
+                "else": {
+                  "properties": {"sync_interval_hours": {"type": "null"}}
+                }
+              }
+            ],
             "properties": {
               "environment": {
                 "enum": ["production", "qa"],

--- a/ingestion/inventory/schema/unit.schema.json
+++ b/ingestion/inventory/schema/unit.schema.json
@@ -76,8 +76,12 @@
           "items": {
             "type": "object",
             "additionalProperties": false,
-            "required": ["name", "status", "sync_interval_hours", "streams"],
+            "required": ["environment", "name", "status", "sync_interval_hours", "streams"],
             "properties": {
+              "environment": {
+                "enum": ["production", "qa"],
+                "description": "Which Airbyte deployment this connection lives in. Each environment runs its own, so one unit legitimately has a connection in both — and a unit with no `qa` entry has no QA connection at all, which is a different fact from having one that is `inactive`. `ci` is not a value: an api-airbyte-ci host exists but nothing runs there, since the CI code location sets SKIP_AIRBYTE and loads an empty workspace."
+              },
               "name": {
                 "type": "string",
                 "minLength": 1,
@@ -87,8 +91,9 @@
                 "enum": ["active", "inactive"]
               },
               "sync_interval_hours": {
-                "type": "integer",
-                "enum": [6, 12, 24]
+                "type": ["integer", "null"],
+                "enum": [6, 12, 24, null],
+                "description": "Null outside production. The cadence lives in `group_name_to_interval` in lakehouse/definitions.py, which is guarded by `DAGSTER_ENV == \"production\"` and so says nothing about any other environment; emitting a number there would invent one."
               },
               "streams": {
                 "type": "array",

--- a/ingestion/inventory/units/bootcamps__hubspot.yml
+++ b/ingestion/inventory/units/bootcamps__hubspot.yml
@@ -14,7 +14,8 @@ airbyte:
   source_kind: source-hubspot
   replication_method: n/a
   connections:
-  - name: HubSpot Bootcamps → S3
+  - environment: production
+    name: HubSpot Bootcamps → S3
     status: inactive
     sync_interval_hours: 24
     streams:

--- a/ingestion/inventory/units/edxorg__google_sheets.yml
+++ b/ingestion/inventory/units/edxorg__google_sheets.yml
@@ -14,7 +14,8 @@ airbyte:
   source_kind: source-google-sheets
   replication_method: n/a
   connections:
-  - name: MITx Program Entitlements → S3 Data Lake
+  - environment: production
+    name: MITx Program Entitlements → S3 Data Lake
     status: active
     sync_interval_hours: 24
     streams:

--- a/ingestion/inventory/units/edxorg__s3.yml
+++ b/ingestion/inventory/units/edxorg__s3.yml
@@ -14,12 +14,14 @@ airbyte:
   source_kind: source-s3
   replication_method: n/a
   connections:
-  - name: edx.org Production Course Structure→ S3 Data Lake
+  - environment: production
+    name: edx.org Production Course Structure→ S3 Data Lake
     status: active
     sync_interval_hours: 24
     streams:
     - raw__edxorg__s3__course_blocks
-  - name: S3 edX.org course and program → S3 Data Lake
+  - environment: production
+    name: S3 edX.org course and program → S3 Data Lake
     status: active
     sync_interval_hours: 24
     streams:
@@ -27,7 +29,8 @@ airbyte:
     - raw__edxorg__s3__mitx_course_run
     - raw__edxorg__s3__program
     - raw__edxorg__s3__program_course
-  - name: S3 edX.org Program Credentials → S3 Data Lake
+  - environment: production
+    name: S3 edX.org Program Credentials → S3 Data Lake
     status: active
     sync_interval_hours: 24
     streams:

--- a/ingestion/inventory/units/edxorg__tracking_logs.yml
+++ b/ingestion/inventory/units/edxorg__tracking_logs.yml
@@ -14,7 +14,8 @@ airbyte:
   source_kind: source-s3
   replication_method: n/a
   connections:
-  - name: edx.org Tracking Logs → S3 Data Lake
+  - environment: production
+    name: edx.org Tracking Logs → S3 Data Lake
     status: active
     sync_interval_hours: 24
     streams:

--- a/ingestion/inventory/units/emeritus__bigquery.yml
+++ b/ingestion/inventory/units/emeritus__bigquery.yml
@@ -14,7 +14,8 @@ airbyte:
   source_kind: source-bigquery
   replication_method: n/a
   connections:
-  - name: Emeritus BigQuery → S3 Data Lake
+  - environment: production
+    name: Emeritus BigQuery → S3 Data Lake
     status: active
     sync_interval_hours: 24
     streams:

--- a/ingestion/inventory/units/github__api.yml
+++ b/ingestion/inventory/units/github__api.yml
@@ -14,7 +14,8 @@ airbyte:
   source_kind: source-github
   replication_method: n/a
   connections:
-  - name: GitHub - MIT ODL → S3 Data Lake
+  - environment: production
+    name: GitHub - MIT ODL → S3 Data Lake
     status: inactive
     sync_interval_hours: 24
     streams:

--- a/ingestion/inventory/units/global_alumni__bigquery.yml
+++ b/ingestion/inventory/units/global_alumni__bigquery.yml
@@ -14,7 +14,8 @@ airbyte:
   source_kind: source-bigquery
   replication_method: n/a
   connections:
-  - name: Global Alumni BigQuery → S3 Data Lake
+  - environment: production
+    name: Global Alumni BigQuery → S3 Data Lake
     status: active
     sync_interval_hours: 24
     streams:

--- a/ingestion/inventory/units/irx__bigquery.yml
+++ b/ingestion/inventory/units/irx__bigquery.yml
@@ -14,12 +14,14 @@ airbyte:
   source_kind: source-bigquery
   replication_method: n/a
   connections:
-  - name: IRx BigQuery - Email Opt In → S3 Data Lake
+  - environment: production
+    name: IRx BigQuery - Email Opt In → S3 Data Lake
     status: active
     sync_interval_hours: 24
     streams:
     - email_opt_in
-  - name: IRx BigQuery → S3 Data Lake
+  - environment: production
+    name: IRx BigQuery → S3 Data Lake
     status: active
     sync_interval_hours: 24
     streams:

--- a/ingestion/inventory/units/learn_ai__app_postgres.yml
+++ b/ingestion/inventory/units/learn_ai__app_postgres.yml
@@ -14,7 +14,8 @@ airbyte:
   source_kind: source-postgres
   replication_method: xmin
   connections:
-  - name: Learn AI Production → S3 Data Lake
+  - environment: production
+    name: Learn AI Production → S3 Data Lake
     status: active
     sync_interval_hours: 6
     streams:

--- a/ingestion/inventory/units/mailgun__api.yml
+++ b/ingestion/inventory/units/mailgun__api.yml
@@ -14,7 +14,8 @@ airbyte:
   source_kind: source-mailgun
   replication_method: n/a
   connections:
-  - name: Mailgun → S3 Data Lake
+  - environment: production
+    name: Mailgun → S3 Data Lake
     status: active
     sync_interval_hours: 24
     streams:

--- a/ingestion/inventory/units/micromasters__app_postgres.yml
+++ b/ingestion/inventory/units/micromasters__app_postgres.yml
@@ -14,7 +14,8 @@ airbyte:
   source_kind: source-postgres
   replication_method: xmin
   connections:
-  - name: MicroMasters Production App DB → S3 Data Lake
+  - environment: production
+    name: MicroMasters Production App DB → S3 Data Lake
     status: active
     sync_interval_hours: 24
     streams:

--- a/ingestion/inventory/units/mitlearn__app_postgres.yml
+++ b/ingestion/inventory/units/mitlearn__app_postgres.yml
@@ -14,7 +14,8 @@ airbyte:
   source_kind: source-postgres
   replication_method: xmin
   connections:
-  - name: MIT Learn Production → S3 Data Lake
+  - environment: production
+    name: MIT Learn Production → S3 Data Lake
     status: active
     sync_interval_hours: 24
     streams:

--- a/ingestion/inventory/units/mitx__api.yml
+++ b/ingestion/inventory/units/mitx__api.yml
@@ -14,7 +14,8 @@ airbyte:
   source_kind: source-s3
   replication_method: n/a
   connections:
-  - name: S3 MITx Open edX Extracts → S3 Data Lake
+  - environment: production
+    name: S3 MITx Open edX Extracts → S3 Data Lake
     status: active
     sync_interval_hours: 12
     streams:

--- a/ingestion/inventory/units/mitx__mongodb.yml
+++ b/ingestion/inventory/units/mitx__mongodb.yml
@@ -14,7 +14,8 @@ airbyte:
   source_kind: source-mongodb-v2
   replication_method: n/a
   connections:
-  - name: mitx-forum-production → S3 Data Lake
+  - environment: production
+    name: mitx-forum-production → S3 Data Lake
     status: inactive
     sync_interval_hours: 12
     streams:

--- a/ingestion/inventory/units/mitx__mysql.yml
+++ b/ingestion/inventory/units/mitx__mysql.yml
@@ -14,12 +14,14 @@ airbyte:
   source_kind: source-mysql
   replication_method: cursor
   connections:
-  - name: MITx Residential Open edX DB Studentmodule History → S3 Data Lake
+  - environment: production
+    name: MITx Residential Open edX DB Studentmodule History → S3 Data Lake
     status: active
     sync_interval_hours: 12
     streams:
     - coursewarehistoryextended_studentmodulehistoryextended
-  - name: MITx Residential Open edX DB → S3 Data Lake
+  - environment: production
+    name: MITx Residential Open edX DB → S3 Data Lake
     status: active
     sync_interval_hours: 12
     streams:

--- a/ingestion/inventory/units/mitx__tracking_logs.yml
+++ b/ingestion/inventory/units/mitx__tracking_logs.yml
@@ -14,7 +14,8 @@ airbyte:
   source_kind: source-s3
   replication_method: n/a
   connections:
-  - name: MITx Tracking Logs → S3 Data Lake
+  - environment: production
+    name: MITx Tracking Logs → S3 Data Lake
     status: active
     sync_interval_hours: 12
     streams:

--- a/ingestion/inventory/units/mitxonline__api.yml
+++ b/ingestion/inventory/units/mitxonline__api.yml
@@ -14,7 +14,8 @@ airbyte:
   source_kind: source-s3
   replication_method: n/a
   connections:
-  - name: S3 MITx Online Open edX Extracts → S3 Data Lake
+  - environment: production
+    name: S3 MITx Online Open edX Extracts → S3 Data Lake
     status: active
     sync_interval_hours: 12
     streams:

--- a/ingestion/inventory/units/mitxonline__app_postgres.yml
+++ b/ingestion/inventory/units/mitxonline__app_postgres.yml
@@ -14,7 +14,8 @@ airbyte:
   source_kind: source-postgres
   replication_method: xmin
   connections:
-  - name: MITx Online Production App DB → S3 Data Lake
+  - environment: production
+    name: MITx Online Production App DB → S3 Data Lake
     status: active
     sync_interval_hours: 6
     streams:

--- a/ingestion/inventory/units/mitxonline__hubspot.yml
+++ b/ingestion/inventory/units/mitxonline__hubspot.yml
@@ -14,7 +14,8 @@ airbyte:
   source_kind: source-hubspot
   replication_method: n/a
   connections:
-  - name: HubSpot MITx Online → S3 Data Lake
+  - environment: production
+    name: HubSpot MITx Online → S3 Data Lake
     status: inactive
     sync_interval_hours: 24
     streams:

--- a/ingestion/inventory/units/mitxonline__mongodb.yml
+++ b/ingestion/inventory/units/mitxonline__mongodb.yml
@@ -14,7 +14,8 @@ airbyte:
   source_kind: source-mongodb-v2
   replication_method: n/a
   connections:
-  - name: mitxonline-forum-production → S3 Data Lake
+  - environment: production
+    name: mitxonline-forum-production → S3 Data Lake
     status: inactive
     sync_interval_hours: 12
     streams:

--- a/ingestion/inventory/units/mitxonline__mysql.yml
+++ b/ingestion/inventory/units/mitxonline__mysql.yml
@@ -14,7 +14,8 @@ airbyte:
   source_kind: source-mysql
   replication_method: cursor
   connections:
-  - name: MITx Online Open edX DB → S3 Data Lake
+  - environment: production
+    name: MITx Online Open edX DB → S3 Data Lake
     status: active
     sync_interval_hours: 12
     streams:
@@ -82,7 +83,8 @@ airbyte:
     - workflow_assessmentworkflow
     - workflow_assessmentworkflowstep
     - workflow_teamassessmentworkflow
-  - name: MITx Online Production Open edX Student Module History → S3 Data Lake
+  - environment: production
+    name: MITx Online Production Open edX Student Module History → S3 Data Lake
     status: active
     sync_interval_hours: 12
     streams:

--- a/ingestion/inventory/units/mitxonline__openedx_notes.yml
+++ b/ingestion/inventory/units/mitxonline__openedx_notes.yml
@@ -15,7 +15,8 @@ airbyte:
   source_kind: source-mysql
   replication_method: cursor
   connections:
-  - name: MITx Online Production edX Notes → Ol S3 Glue Data Lake - Production
+  - environment: production
+    name: MITx Online Production edX Notes → Ol S3 Glue Data Lake - Production
     status: inactive
     sync_interval_hours: 24
     streams:

--- a/ingestion/inventory/units/mitxonline__tracking_logs.yml
+++ b/ingestion/inventory/units/mitxonline__tracking_logs.yml
@@ -14,7 +14,8 @@ airbyte:
   source_kind: source-s3
   replication_method: n/a
   connections:
-  - name: MITx Online Tracking Logs → S3 Data Lake
+  - environment: production
+    name: MITx Online Tracking Logs → S3 Data Lake
     status: active
     sync_interval_hours: 12
     streams:

--- a/ingestion/inventory/units/ocw__app_postgres.yml
+++ b/ingestion/inventory/units/ocw__app_postgres.yml
@@ -14,7 +14,8 @@ airbyte:
   source_kind: source-postgres
   replication_method: xmin
   connections:
-  - name: OCW Studio App DB → S3 Data Lake
+  - environment: production
+    name: OCW Studio App DB → S3 Data Lake
     status: active
     sync_interval_hours: 6
     streams:

--- a/ingestion/inventory/units/open_discussions__app_postgres.yml
+++ b/ingestion/inventory/units/open_discussions__app_postgres.yml
@@ -14,7 +14,8 @@ airbyte:
   source_kind: source-postgres
   replication_method: xmin
   connections:
-  - name: Open Discussions App Postgres Production → S3 Data Lake
+  - environment: production
+    name: Open Discussions App Postgres Production → S3 Data Lake
     status: inactive
     sync_interval_hours: 24
     streams:

--- a/ingestion/inventory/units/ovs__app_postgres.yml
+++ b/ingestion/inventory/units/ovs__app_postgres.yml
@@ -14,7 +14,8 @@ airbyte:
   source_kind: source-postgres
   replication_method: xmin
   connections:
-  - name: ODL Video Service → S3 Data Lake
+  - environment: production
+    name: ODL Video Service → S3 Data Lake
     status: active
     sync_interval_hours: 6
     streams:

--- a/ingestion/inventory/units/salesforce__api.yml
+++ b/ingestion/inventory/units/salesforce__api.yml
@@ -14,7 +14,8 @@ airbyte:
   source_kind: source-salesforce
   replication_method: n/a
   connections:
-  - name: OL Salesforce → S3 Data Lake
+  - environment: production
+    name: OL Salesforce → S3 Data Lake
     status: inactive
     sync_interval_hours: 24
     streams:

--- a/ingestion/inventory/units/xpro__api.yml
+++ b/ingestion/inventory/units/xpro__api.yml
@@ -14,7 +14,8 @@ airbyte:
   source_kind: source-s3
   replication_method: n/a
   connections:
-  - name: S3 xPRO Open edX Extracts → S3 Data Lake
+  - environment: production
+    name: S3 xPRO Open edX Extracts → S3 Data Lake
     status: active
     sync_interval_hours: 12
     streams:

--- a/ingestion/inventory/units/xpro__app_postgres.yml
+++ b/ingestion/inventory/units/xpro__app_postgres.yml
@@ -14,7 +14,8 @@ airbyte:
   source_kind: source-postgres
   replication_method: xmin
   connections:
-  - name: xPro Production App DB → S3 Data Lake
+  - environment: production
+    name: xPro Production App DB → S3 Data Lake
     status: active
     sync_interval_hours: 6
     streams:

--- a/ingestion/inventory/units/xpro__hubspot.yml
+++ b/ingestion/inventory/units/xpro__hubspot.yml
@@ -14,7 +14,8 @@ airbyte:
   source_kind: source-hubspot
   replication_method: n/a
   connections:
-  - name: HubSpot xPro → S3 Data Lake
+  - environment: production
+    name: HubSpot xPro → S3 Data Lake
     status: inactive
     sync_interval_hours: 24
     streams:

--- a/ingestion/inventory/units/xpro__mongodb.yml
+++ b/ingestion/inventory/units/xpro__mongodb.yml
@@ -14,7 +14,8 @@ airbyte:
   source_kind: source-mongodb-v2
   replication_method: n/a
   connections:
-  - name: xpro-forum-production → S3 Data Lake
+  - environment: production
+    name: xpro-forum-production → S3 Data Lake
     status: inactive
     sync_interval_hours: 12
     streams:

--- a/ingestion/inventory/units/xpro__mysql.yml
+++ b/ingestion/inventory/units/xpro__mysql.yml
@@ -14,12 +14,14 @@ airbyte:
   source_kind: source-mysql
   replication_method: cursor
   connections:
-  - name: xPro Open edX DB Studentmodule History → S3 Data Lake
+  - environment: production
+    name: xPro Open edX DB Studentmodule History → S3 Data Lake
     status: active
     sync_interval_hours: 24
     streams:
     - coursewarehistoryextended_studentmodulehistoryextended
-  - name: xPro Open edX DB → S3 Data Lake
+  - environment: production
+    name: xPro Open edX DB → S3 Data Lake
     status: active
     sync_interval_hours: 12
     streams:

--- a/ingestion/inventory/units/xpro__tracking_logs.yml
+++ b/ingestion/inventory/units/xpro__tracking_logs.yml
@@ -14,7 +14,8 @@ airbyte:
   source_kind: source-s3
   replication_method: n/a
   connections:
-  - name: xPro Tracking Logs → S3 Data Lake
+  - environment: production
+    name: xPro Tracking Logs → S3 Data Lake
     status: active
     sync_interval_hours: 12
     streams:

--- a/ingestion/inventory/units/zendesk__api.yml
+++ b/ingestion/inventory/units/zendesk__api.yml
@@ -14,7 +14,8 @@ airbyte:
   source_kind: source-zendesk-support
   replication_method: n/a
   connections:
-  - name: Zendesk Support → S3 Data Lake
+  - environment: production
+    name: Zendesk Support → S3 Data Lake
     status: active
     sync_interval_hours: 24
     streams:

--- a/src/ol_dbt_cli/ol_dbt_cli/commands/inventory.py
+++ b/src/ol_dbt_cli/ol_dbt_cli/commands/inventory.py
@@ -16,18 +16,19 @@ from __future__ import annotations
 import json
 import sys
 from pathlib import Path
-from typing import Annotated, Any
+from typing import Annotated, Any, cast
 
 from cyclopts import App, Parameter
 from rich.console import Console
 from rich.markup import escape
 
-from ol_dbt_cli.lib.cursor_audit import Verdict, audit
+from ol_dbt_cli.lib.cursor_audit import Verdict, audit, select_units
 from ol_dbt_cli.lib.git_utils import get_repo_root, resolve_merge_base
 from ol_dbt_cli.lib.glue_schema import DEFAULT_GLUE_DATABASE, columns_by_table
 from ol_dbt_cli.lib.inventory import (
     DEFAULT_INVENTORY_DIR,
     RenderError,
+    Unit,
     check_removals,
     load_snapshot,
     load_snapshot_at_ref,
@@ -471,11 +472,11 @@ def cursors(
     """
     units = load_units(inventory_dir)
     if unit:
-        wanted = set(unit)
-        units = [u for u in units if f"{u.data.get('deployment')}/{u.data.get('layer')}" in wanted]
-        if not units:
-            err_console.print(f"[bold red]No unit matched {sorted(wanted)}")
+        selected, missing = select_units(units, unit)
+        if missing:
+            err_console.print(f"[bold red]No unit matched: {', '.join(missing)}")
             sys.exit(1)
+        units = cast("list[Unit]", selected)
 
     prefixes = sorted({str(u.data["table_prefix"]) for u in units if u.data.get("table_prefix")})
     columns = columns_by_table(glue_database, prefixes=prefixes, region=region)

--- a/src/ol_dbt_cli/ol_dbt_cli/commands/inventory.py
+++ b/src/ol_dbt_cli/ol_dbt_cli/commands/inventory.py
@@ -22,7 +22,9 @@ from cyclopts import App, Parameter
 from rich.console import Console
 from rich.markup import escape
 
+from ol_dbt_cli.lib.cursor_audit import Verdict, audit
 from ol_dbt_cli.lib.git_utils import get_repo_root, resolve_merge_base
+from ol_dbt_cli.lib.glue_schema import DEFAULT_GLUE_DATABASE, columns_by_table
 from ol_dbt_cli.lib.inventory import (
     DEFAULT_INVENTORY_DIR,
     RenderError,
@@ -396,3 +398,129 @@ def _emit_text(issues: list[ValidationIssue]) -> None:
         console.print(f"[{style}]{issue.severity.value}[/] {escape(issue.model)}: {escape(issue.message)}")
         if issue.detail:
             console.print(f"    [dim]{escape(issue.detail)}[/]")
+
+
+VERDICT_STYLE = {
+    Verdict.CURSOR_MISSING: "bold red",
+    Verdict.NOT_LANDED: "yellow",
+    Verdict.INSERT_ONLY: "yellow",
+    Verdict.REPLACE: "dim",
+    Verdict.SECONDARY_AVAILABLE: "cyan",
+    Verdict.CURSOR_AVAILABLE: "green",
+    Verdict.CURSOR_OK: "dim green",
+}
+
+
+@inventory_app.command
+def cursors(
+    *,
+    inventory_dir: Annotated[
+        Path,
+        Parameter(
+            name=["--inventory-dir", "-i"],
+            help="Directory holding vocabulary.yml, schema/ and units/.",
+        ),
+    ] = DEFAULT_INVENTORY_DIR,
+    glue_database: Annotated[
+        str,
+        Parameter(help="Glue database holding the landed raw tables."),
+    ] = DEFAULT_GLUE_DATABASE,
+    region: str = "us-east-1",
+    unit: Annotated[
+        list[str] | None,
+        Parameter(
+            help="Limit to these units, as deployment/layer. Repeatable.",
+            show_default=False,
+        ),
+    ] = None,
+    attention_only: Annotated[
+        bool,
+        Parameter(
+            help=(
+                "Show only findings a human needs to decide: a declared cursor "
+                "whose column vanished, an insert-only timestamp, or a wide "
+                "table with no time column. Hides join tables and settled rows."
+            ),
+        ),
+    ] = False,
+    output_format: Annotated[
+        str,
+        Parameter(name=["--format", "-f"], help="Output format: text or json."),
+    ] = "text",
+) -> None:
+    """Report which column each table could drive an incremental load from.
+
+    Reads the LANDED schema from Glue, so it answers what a loader can actually
+    key on rather than what an ORM declares. Needs AWS credentials; every other
+    `inventory` subcommand is offline.
+
+    Run it when an app is added or an app's schema changes. Adding a unit is
+    enough to bring a new source into scope -- nothing here is hard-coded per
+    app. Exits non-zero if any declared cursor_field names a column that is no
+    longer in the landed schema, which is the failure worth gating on: the load
+    does not error, it just quietly stops advancing.
+
+    A `cursor_available` finding is a shortlist entry, NOT an approval. Whether
+    the column is stamped on every mutation path is not answerable from a
+    schema -- see the module docstring in lib/cursor_audit.py.
+
+    --glue-database must name the environment the units describe. Point a
+    production-rendered inventory at a QA catalogue (or the reverse) and every
+    table it has not loaded there reports `not_landed`, which reads like a
+    finding and is really a mismatched argument.
+    """
+    units = load_units(inventory_dir)
+    if unit:
+        wanted = set(unit)
+        units = [u for u in units if f"{u.data.get('deployment')}/{u.data.get('layer')}" in wanted]
+        if not units:
+            err_console.print(f"[bold red]No unit matched {sorted(wanted)}")
+            sys.exit(1)
+
+    prefixes = sorted({str(u.data["table_prefix"]) for u in units if u.data.get("table_prefix")})
+    columns = columns_by_table(glue_database, prefixes=prefixes, region=region)
+    result = audit(units, columns)
+
+    findings = [f for f in result.findings if not attention_only or f.needs_attention]
+
+    if output_format == "json":
+        print(  # noqa: T201
+            json.dumps(
+                [
+                    {
+                        "unit": f.unit_key,
+                        "raw_table": f.raw_table,
+                        "stream": f.stream,
+                        "verdict": f.verdict.value,
+                        "declared_cursor": f.declared_cursor,
+                        "candidate": f.candidate,
+                        "source_columns": f.source_columns,
+                        "time_like_columns": list(f.time_like_columns),
+                    }
+                    for f in findings
+                ],
+                indent=2,
+            )
+        )
+    else:
+        for finding in findings:
+            style = VERDICT_STYLE[finding.verdict]
+            candidate = f" -> {finding.candidate}" if finding.candidate else ""
+            console.print(
+                f"[{style}]{finding.verdict.value:<19}[/] "
+                f"{escape(finding.unit_key)}  {escape(finding.stream)}"
+                f"{escape(candidate)}"
+            )
+        console.print(
+            "\n[bold]Summary:[/] "
+            + ", ".join(f"{count} {verdict.value}" for verdict, count in result.counts.items() if count)
+        )
+        if result.broken:
+            console.print(
+                f"\n[bold red]{len(result.broken)} declared cursor_field(s) name a "
+                f"column that is no longer in the landed schema.[/] An incremental "
+                f"load on one of these does not fail - it stops advancing."
+            )
+
+    if result.broken:
+        sys.exit(1)

--- a/src/ol_dbt_cli/ol_dbt_cli/commands/inventory.py
+++ b/src/ol_dbt_cli/ol_dbt_cli/commands/inventory.py
@@ -403,6 +403,7 @@ def _emit_text(issues: list[ValidationIssue]) -> None:
 
 VERDICT_STYLE = {
     Verdict.CURSOR_MISSING: "bold red",
+    Verdict.CURSOR_NESTED: "yellow",
     Verdict.NOT_LANDED: "yellow",
     Verdict.INSERT_ONLY: "yellow",
     Verdict.REPLACE: "dim",
@@ -410,6 +411,16 @@ VERDICT_STYLE = {
     Verdict.CURSOR_AVAILABLE: "green",
     Verdict.CURSOR_OK: "dim green",
 }
+
+if _unstyled := [verdict for verdict in Verdict if verdict not in VERDICT_STYLE]:
+    # The text renderer indexes this map directly, so a verdict added to the
+    # enum without a style here crashes the command the first time that verdict
+    # occurs -- which, for a rare one, is long after the change that caused it.
+    # Cheap to rule out at import instead. A .get() default would paper over the
+    # omission rather than report it.
+    _names = ", ".join(verdict.value for verdict in _unstyled)
+    msg = f"VERDICT_STYLE is missing an entry for: {_names}"
+    raise RuntimeError(msg)
 
 
 @inventory_app.command

--- a/src/ol_dbt_cli/ol_dbt_cli/lib/cursor_audit.py
+++ b/src/ol_dbt_cli/ol_dbt_cli/lib/cursor_audit.py
@@ -1,0 +1,258 @@
+"""Which column an incremental load could key on, per table, and whether it still holds.
+
+Airbyte's Postgres sources mostly replicate by ``xmin``, which dlt has no
+practical equivalent for (INGESTION_INVENTORY_SPEC.md §3.4). Every such table
+needs either a replacement cursor column or an explicit decision to re-read it
+whole. This module answers that from the LANDED warehouse schema, which is the
+only thing that actually constrains what a loader can key on -- a column the ORM
+declares but that never reached the warehouse is not a cursor.
+
+Two questions, deliberately separated:
+
+*Candidate* -- does a column of the right shape exist? Pure name matching, done
+here, cheap, and re-runnable as schemas drift.
+
+*Usable* -- is that column stamped on EVERY mutation path? Not answerable from a
+schema, and it is the one that bites. A write-once column yields a load that
+captures new rows and silently never reflects an edit; see the Keycloak
+``LAST_MODIFIED_TIMESTAMP`` note in ``ol_dlt/database.py``, and note that
+Django's ``auto_now=True`` covers ``Model.save()`` but not ``queryset.update()``.
+So a ``CURSOR_AVAILABLE`` finding is a shortlist entry, never an approval.
+
+The reason this is a standing check and not a one-off audit: apps are added and
+app schemas change. A declared ``cursor_field`` whose column has since been
+dropped or renamed does not fail loudly -- the load just stops advancing, or
+falls back to a full read, and nobody is told. ``CURSOR_MISSING`` is that case,
+and it is the finding this module exists for.
+
+No boto3 here, matching ``lib.inventory``: the Glue read happens at the command
+edge and this stays pure, offline-testable, and importable from the dlt code
+location.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from enum import StrEnum
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable, Mapping, Sequence
+
+# Ordered by preference. Django's own convention first, then the variants the
+# other apps in this estate actually use -- measured across 608 landed tables:
+# updated_on 253, updated 15, updated_at 13, modified 5, last_modified 2.
+MODIFIED_COLUMNS: tuple[str, ...] = (
+    "updated_on",
+    "updated_at",
+    "modified",
+    "modified_on",
+    "last_modified",
+    "date_modified",
+    "updated",
+)
+
+# Wagtail pages carry no modification timestamp of their own. A revision
+# timestamp is the nearest thing and is offered as a SECONDARY candidate --
+# weaker, because it moves only when a revision is created, so a field changed
+# outside the revision flow does not advance it.
+SECONDARY_COLUMNS: tuple[str, ...] = (
+    "latest_revision_created_at",
+    "last_published_at",
+)
+
+# A creation timestamp is a perfectly good cursor for an append-only ledger and
+# a trap for anything mutable, and the schema cannot tell the two apart. Hence
+# its own bucket rather than being folded into either neighbour.
+CREATED_COLUMNS: tuple[str, ...] = (
+    "created_on",
+    "created_at",
+    "created",
+    "date_created",
+    "added_on",
+)
+
+# Loader bookkeeping, not source columns. Airbyte's `_airbyte_*` and dlt's
+# `_dlt_*` both appear in landed schemas depending on which loaded the table.
+LOADER_COLUMN = re.compile(r"^_(airbyte|dlt)_")
+
+# Join tables are id plus a couple of foreign keys. Narrow tables with no
+# timestamp are the normal, uninteresting case for `replace`; wide ones are
+# where somebody has to think.
+JOIN_TABLE_MAX_COLUMNS = 4
+
+
+class Verdict(StrEnum):
+    """What the landed schema supports for this table."""
+
+    CURSOR_OK = "cursor_ok"
+    """A cursor_field is declared and the column is present. Nothing to do."""
+
+    CURSOR_MISSING = "cursor_missing"
+    """A cursor_field is declared but the column is GONE from the landed schema.
+
+    The failure this check exists to catch: silent, and it does not surface as
+    an error anywhere else.
+    """
+
+    CURSOR_AVAILABLE = "cursor_available"
+    """No cursor_field declared, but a modification timestamp exists."""
+
+    SECONDARY_AVAILABLE = "secondary_available"
+    """Only a revision/publish timestamp exists. Weaker; see SECONDARY_COLUMNS."""
+
+    INSERT_ONLY = "insert_only"
+    """Only a creation timestamp. Valid for an append-only ledger, a trap otherwise."""
+
+    REPLACE = "replace"
+    """No time column at all. Re-read whole, which also propagates deletes."""
+
+    NOT_LANDED = "not_landed"
+    """Declared in the inventory but absent from the warehouse schema."""
+
+
+@dataclass(frozen=True)
+class TableFinding:
+    """One table's cursor situation."""
+
+    unit_key: str
+    raw_table: str
+    stream: str
+    verdict: Verdict
+    declared_cursor: str | None = None
+    candidate: str | None = None
+    source_columns: int = 0
+    time_like_columns: tuple[str, ...] = ()
+
+    @property
+    def is_join_table_shaped(self) -> bool:
+        """Narrow enough that a full re-read is obviously the right call."""
+        return self.source_columns <= JOIN_TABLE_MAX_COLUMNS
+
+    @property
+    def needs_attention(self) -> bool:
+        """Worth a human looking, as opposed to a settled or obvious case."""
+        if self.verdict is Verdict.CURSOR_MISSING:
+            return True
+        if self.verdict is Verdict.INSERT_ONLY:
+            return True
+        if self.verdict is Verdict.REPLACE:
+            return not self.is_join_table_shaped
+        return False
+
+
+@dataclass
+class AuditResult:
+    findings: list[TableFinding] = field(default_factory=list)
+
+    def by_verdict(self, verdict: Verdict) -> list[TableFinding]:
+        return [f for f in self.findings if f.verdict is verdict]
+
+    @property
+    def counts(self) -> dict[Verdict, int]:
+        return {v: len(self.by_verdict(v)) for v in Verdict}
+
+    @property
+    def broken(self) -> list[TableFinding]:
+        """Declared cursors whose column has vanished. The gate-worthy set."""
+        return self.by_verdict(Verdict.CURSOR_MISSING)
+
+
+def _source_columns(columns: Iterable[str]) -> list[str]:
+    return sorted({c.lower() for c in columns if not LOADER_COLUMN.match(c.lower())})
+
+
+def _first_present(candidates: Sequence[str], columns: set[str]) -> str | None:
+    return next((c for c in candidates if c in columns), None)
+
+
+_TIME_LIKE = re.compile(r"(_at|_on|_date|_time|stamp)$|^(date|time)_")
+
+
+def classify_table(
+    *,
+    unit_key: str,
+    raw_table: str,
+    stream: str,
+    columns: Iterable[str] | None,
+    declared_cursor: str | None = None,
+) -> TableFinding:
+    """Classify one table against its landed column list.
+
+    ``columns`` is None when the table is declared but has not landed.
+    ``declared_cursor`` is the inventory's ``cursor_field`` for the table, if any
+    -- checking it against reality is the point of the standing check.
+    """
+    if columns is None:
+        return TableFinding(
+            unit_key=unit_key,
+            raw_table=raw_table,
+            stream=stream,
+            verdict=Verdict.NOT_LANDED,
+            declared_cursor=declared_cursor,
+        )
+
+    source = _source_columns(columns)
+    present = set(source)
+    time_like = tuple(c for c in source if _TIME_LIKE.search(c))
+
+    def finding(verdict: Verdict, candidate: str | None = None) -> TableFinding:
+        return TableFinding(
+            unit_key=unit_key,
+            raw_table=raw_table,
+            stream=stream,
+            verdict=verdict,
+            declared_cursor=declared_cursor,
+            candidate=candidate,
+            source_columns=len(source),
+            time_like_columns=time_like,
+        )
+
+    if declared_cursor:
+        return finding(
+            Verdict.CURSOR_OK if declared_cursor.lower() in present else Verdict.CURSOR_MISSING,
+            declared_cursor,
+        )
+
+    if modified := _first_present(MODIFIED_COLUMNS, present):
+        return finding(Verdict.CURSOR_AVAILABLE, modified)
+    if secondary := _first_present(SECONDARY_COLUMNS, present):
+        return finding(Verdict.SECONDARY_AVAILABLE, secondary)
+    if created := _first_present(CREATED_COLUMNS, present):
+        return finding(Verdict.INSERT_ONLY, created)
+    return finding(Verdict.REPLACE)
+
+
+def audit(
+    units: Iterable[object],
+    columns_by_table: Mapping[str, list[str]],
+) -> AuditResult:
+    """Classify every table of every Airbyte-loaded unit.
+
+    ``units`` are ``lib.inventory.Unit`` objects, taken structurally rather than
+    imported so this module keeps no dependency on the inventory loader.
+    ``columns_by_table`` maps raw table name -> landed column names.
+    """
+    result = AuditResult()
+    for unit in units:
+        data = getattr(unit, "data", {}) or {}
+        key = f"{data.get('deployment', '?')}/{data.get('layer', '?')}"
+        for table in getattr(unit, "tables", []) or []:
+            raw_table = str(table.get("raw_table", ""))
+            cursor = table.get("cursor_field")
+            # The inventory stores cursor_field as a list of path segments; a
+            # composite cursor is not something this check can reason about, so
+            # it takes the first and lets the finding carry it verbatim.
+            declared = str(cursor[0]) if isinstance(cursor, list) and cursor else None
+            result.findings.append(
+                classify_table(
+                    unit_key=key,
+                    raw_table=raw_table,
+                    stream=str(table.get("name", "")),
+                    columns=columns_by_table.get(raw_table),
+                    declared_cursor=declared,
+                )
+            )
+    result.findings.sort(key=lambda f: (f.unit_key, f.raw_table))
+    return result

--- a/src/ol_dbt_cli/ol_dbt_cli/lib/cursor_audit.py
+++ b/src/ol_dbt_cli/ol_dbt_cli/lib/cursor_audit.py
@@ -111,6 +111,19 @@ class Verdict(StrEnum):
     NOT_LANDED = "not_landed"
     """Declared in the inventory but absent from the warehouse schema."""
 
+    CURSOR_NESTED = "cursor_nested"
+    """The declared cursor_field is a multi-segment path this check cannot verify.
+
+    ``cursor_field`` is a PATH, as Airbyte spells it -- ``["payload",
+    "updated_at"]`` means the ``updated_at`` key inside the ``payload`` struct,
+    not two cursor columns. Glue gives us a flat top-level column list, so
+    confirming a nested path would mean walking the struct type. Reporting it
+    rather than checking the first segment: ``payload`` existing says nothing
+    about ``updated_at`` still being in it, so a first-segment check would
+    return ``cursor_ok`` for a cursor that had silently vanished -- the exact
+    failure this module exists to catch, inverted.
+    """
+
 
 @dataclass(frozen=True)
 class TableFinding:
@@ -134,6 +147,9 @@ class TableFinding:
     def needs_attention(self) -> bool:
         """Worth a human looking, as opposed to a settled or obvious case."""
         if self.verdict is Verdict.CURSOR_MISSING:
+            return True
+        # Unverifiable is not the same as fine: nobody is checking that cursor.
+        if self.verdict is Verdict.CURSOR_NESTED:
             return True
         if self.verdict is Verdict.INSERT_ONLY:
             return True
@@ -176,21 +192,28 @@ def classify_table(
     raw_table: str,
     stream: str,
     columns: Iterable[str] | None,
-    declared_cursor: str | None = None,
+    declared_cursor: Sequence[str] | None = None,
 ) -> TableFinding:
     """Classify one table against its landed column list.
 
     ``columns`` is None when the table is declared but has not landed.
-    ``declared_cursor`` is the inventory's ``cursor_field`` for the table, if any
-    -- checking it against reality is the point of the standing check.
+
+    ``declared_cursor`` is the inventory's ``cursor_field``: a PATH, as Airbyte
+    spells it, so it arrives as a sequence of segments even when there is only
+    one. Checking it against reality is the point of the standing check; a
+    multi-segment path is reported as unverifiable rather than guessed at (see
+    ``Verdict.CURSOR_NESTED``).
     """
+    # Rendered dotted for display; the segments are what the checks below use.
+    declared_display = ".".join(declared_cursor) if declared_cursor else None
+
     if columns is None:
         return TableFinding(
             unit_key=unit_key,
             raw_table=raw_table,
             stream=stream,
             verdict=Verdict.NOT_LANDED,
-            declared_cursor=declared_cursor,
+            declared_cursor=declared_display,
         )
 
     source = _source_columns(columns)
@@ -203,16 +226,18 @@ def classify_table(
             raw_table=raw_table,
             stream=stream,
             verdict=verdict,
-            declared_cursor=declared_cursor,
+            declared_cursor=declared_display,
             candidate=candidate,
             source_columns=len(source),
             time_like_columns=time_like,
         )
 
     if declared_cursor:
+        if len(declared_cursor) > 1:
+            return finding(Verdict.CURSOR_NESTED, declared_display)
         return finding(
-            Verdict.CURSOR_OK if declared_cursor.lower() in present else Verdict.CURSOR_MISSING,
-            declared_cursor,
+            Verdict.CURSOR_OK if declared_cursor[0].lower() in present else Verdict.CURSOR_MISSING,
+            declared_display,
         )
 
     if modified := _first_present(MODIFIED_COLUMNS, present):
@@ -222,6 +247,22 @@ def classify_table(
     if created := _first_present(CREATED_COLUMNS, present):
         return finding(Verdict.INSERT_ONLY, created)
     return finding(Verdict.REPLACE)
+
+
+def select_units(units: Iterable[object], wanted: Iterable[str]) -> tuple[list[object], list[str]]:
+    """Pick the requested units by ``deployment/layer``, reporting any that miss.
+
+    Returns ``(selected, missing)``. Missing keys are returned rather than
+    ignored because the caller's job is to audit everything it was asked about:
+    filtering and checking only for an empty result would let a typo alongside a
+    valid key pass silently, and the command would report success having covered
+    fewer units than requested.
+    """
+    by_key = {f"{getattr(u, 'data', {}).get('deployment')}/{getattr(u, 'data', {}).get('layer')}": u for u in units}
+    requested = set(wanted)
+    missing = sorted(requested - by_key.keys())
+    selected = [by_key[key] for key in sorted(requested & by_key.keys())]
+    return selected, missing
 
 
 def audit(
@@ -241,10 +282,9 @@ def audit(
         for table in getattr(unit, "tables", []) or []:
             raw_table = str(table.get("raw_table", ""))
             cursor = table.get("cursor_field")
-            # The inventory stores cursor_field as a list of path segments; a
-            # composite cursor is not something this check can reason about, so
-            # it takes the first and lets the finding carry it verbatim.
-            declared = str(cursor[0]) if isinstance(cursor, list) and cursor else None
+            # Passed through as the full path. classify_table decides what a
+            # multi-segment one means; truncating it here would hide that.
+            declared = [str(part) for part in cursor] if isinstance(cursor, list) and cursor else None
             result.findings.append(
                 classify_table(
                     unit_key=key,

--- a/src/ol_dbt_cli/ol_dbt_cli/lib/glue_schema.py
+++ b/src/ol_dbt_cli/ol_dbt_cli/lib/glue_schema.py
@@ -1,0 +1,55 @@
+"""Read landed table schemas out of AWS Glue.
+
+Split from ``lib.cursor_audit`` so the classification stays pure and
+offline-testable: this is the only part that needs credentials, and it is the
+only part that cannot be unit-tested without them.
+
+The Glue catalog is used rather than the source database on purpose. What a
+loader can key on is constrained by what actually LANDED, not by what the
+application's ORM declares -- a column that exists upstream but was never
+selected into the connection is not a cursor, and reading Glue needs no source
+replica credential.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+
+DEFAULT_GLUE_DATABASE = "ol_warehouse_production_raw"
+
+
+def columns_by_table(
+    database: str = DEFAULT_GLUE_DATABASE,
+    *,
+    prefixes: Iterable[str] | None = None,
+    region: str = "us-east-1",
+) -> dict[str, list[str]]:
+    """Map raw table name -> its landed column names.
+
+    ``prefixes`` narrows the scan with a Glue expression per prefix, which is
+    much cheaper than listing a 2,000-table database when only a few units are
+    of interest. Omitted, the whole database is read.
+
+    boto3 is imported here rather than at module scope so that importing this
+    module -- which ``ol-dbt`` does at startup to register the command -- does
+    not pull boto3 in for every other subcommand.
+    """
+    import boto3  # noqa: PLC0415
+
+    client = boto3.client("glue", region_name=region)
+    paginator = client.get_paginator("get_tables")
+    expressions = [f"{p}.*" for p in prefixes] if prefixes else [None]
+
+    out: dict[str, list[str]] = {}
+    for expression in expressions:
+        kwargs = {"DatabaseName": database}
+        if expression:
+            kwargs["Expression"] = expression
+        for page in paginator.paginate(**kwargs):
+            for table in page["TableList"]:
+                storage = table.get("StorageDescriptor") or {}
+                out[table["Name"]] = [column["Name"] for column in storage.get("Columns", [])]
+    return out

--- a/src/ol_dbt_cli/ol_dbt_cli/lib/inventory.py
+++ b/src/ol_dbt_cli/ol_dbt_cli/lib/inventory.py
@@ -15,7 +15,7 @@ from __future__ import annotations
 
 import json
 import re
-from collections import Counter
+from collections import Counter, defaultdict
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
@@ -42,6 +42,10 @@ INCREMENTAL_PREFIX = "incremental"
 XMIN_REPLICATION = "xmin"
 MIRROR_STRATEGY = "mirror"
 AIRBYTE_LOADER = "airbyte"
+# Which Airbyte deployment a connection belongs to when it does not say.
+# Units written before connections carried `environment` describe the
+# production workspace, the only one the generator could reach.
+DEFAULT_ENVIRONMENT = "production"
 
 
 @dataclass
@@ -261,9 +265,15 @@ def _check_connections(unit: Unit, report: ValidationReport) -> None:
     # here would invent disagreements that are not the author's error.
     declared = {str(table.get("name", "")) for table in unit.tables}
 
-    carried: dict[str, int] = {}
+    # Counted per environment, not per unit. Each environment runs its own
+    # Airbyte against its own lake, so the same stream appearing in a production
+    # and a QA connection is the normal case for a unit that is ingested in
+    # both — the collision this guards against is two connections in the SAME
+    # environment writing one raw table.
+    carried_by_environment: dict[str, dict[str, int]] = defaultdict(dict)
     for connection in unit.connections:
         name = connection.get("name", "")
+        environment = str(connection.get("environment", DEFAULT_ENVIRONMENT))
         if dagster_visible and not name.lower().endswith(DAGSTER_SELECTOR_SUFFIX):
             report.add(
                 CHECK,
@@ -273,33 +283,41 @@ def _check_connections(unit: Unit, report: ValidationReport) -> None:
                 "Dagster's connection_selector_fn drops it, so its tables would "
                 "never materialize. Set dagster_visible: false if that is intended.",
             )
+        counts = carried_by_environment[environment]
         for stream in connection.get("streams") or []:
-            carried[str(stream)] = carried.get(str(stream), 0) + 1
+            counts[str(stream)] = counts.get(str(stream), 0) + 1
 
-    for stream in sorted(declared - set(carried)):
+    # The declared/carried reconciliation below is a union across environments:
+    # `tables` states the unit's contract, and an environment whose connection
+    # is disabled or predates a schema change legitimately carries fewer
+    # streams. Only a stream no environment carries is an error.
+    carried = {stream for counts in carried_by_environment.values() for stream in counts}
+
+    for stream in sorted(declared - carried):
         report.add(
             CHECK,
             Severity.ERROR,
             unit.key,
             f"table {stream!r} is declared but no connection carries that stream",
         )
-    for stream in sorted(set(carried) - declared):
+    for stream in sorted(carried - declared):
         report.add(
             CHECK,
             Severity.ERROR,
             unit.key,
             f"a connection carries stream {stream!r} but the unit declares no such table",
         )
-    for stream, count in sorted(carried.items()):
-        if count > 1:
-            report.add(
-                CHECK,
-                Severity.ERROR,
-                unit.key,
-                f"stream {stream!r} is carried {count} times within this unit",
-                "Whether that is two connections or one connection listing the "
-                "stream twice, both writes land in the same raw table.",
-            )
+    for environment, counts in sorted(carried_by_environment.items()):
+        for stream, count in sorted(counts.items()):
+            if count > 1:
+                report.add(
+                    CHECK,
+                    Severity.ERROR,
+                    unit.key,
+                    f"stream {stream!r} is carried {count} times by {environment} connections in this unit",
+                    "Whether that is two connections or one connection listing the "
+                    "stream twice, both writes land in the same raw table.",
+                )
 
     # The renderer joins a connection's stream name to its table entry to find
     # the stream's `namespace` (§6.2), so the name has to identify one table.
@@ -668,6 +686,12 @@ def render_airbyte(units: list[Unit]) -> dict[str, Any]:
             "source_kind": airbyte.get("source_kind"),
             "connections": [
                 {
+                    # Carried across the boundary so the consumer can select one
+                    # environment's connections. Without it a unit ingested in
+                    # both would hand Pulumi -- or a drift check comparing
+                    # against one workspace -- the union of two Airbyte
+                    # deployments as though it were one.
+                    "environment": connection.get("environment", DEFAULT_ENVIRONMENT),
                     "name": connection.get("name"),
                     "status": connection.get("status"),
                     "sync_interval_hours": connection.get("sync_interval_hours"),

--- a/src/ol_dbt_cli/tests/test_cursor_audit.py
+++ b/src/ol_dbt_cli/tests/test_cursor_audit.py
@@ -146,6 +146,18 @@ class FakeUnit:
         return self.data.get("tables", [])
 
 
+def test_every_verdict_has_a_display_style() -> None:
+    """The text renderer indexes VERDICT_STYLE directly, so a gap is a crash.
+
+    Importing the command module already raises on a gap; this asserts it from
+    the test suite too, so the failure names the missing verdict instead of
+    surfacing as an unrelated collection error.
+    """
+    from ol_dbt_cli.commands.inventory import VERDICT_STYLE
+
+    assert not [verdict for verdict in Verdict if verdict not in VERDICT_STYLE]
+
+
 class TestSelectUnits:
     """A partial match must not read as success — the caller audits what it was asked for."""
 

--- a/src/ol_dbt_cli/tests/test_cursor_audit.py
+++ b/src/ol_dbt_cli/tests/test_cursor_audit.py
@@ -1,0 +1,191 @@
+"""Cursor-viability classification. No AWS: the Glue read lives at the command edge."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from ol_dbt_cli.lib.cursor_audit import Verdict, audit, classify_table
+
+AIRBYTE_COLUMNS = [
+    "_airbyte_raw_id",
+    "_airbyte_extracted_at",
+    "_airbyte_meta",
+    "_airbyte_generation_id",
+]
+
+
+def classify(columns: list[str] | None, declared: str | None = None) -> Any:
+    return classify_table(
+        unit_key="mitxonline/app_postgres",
+        raw_table="raw__mitxonline__app__postgres__thing",
+        stream="thing",
+        columns=columns,
+        declared_cursor=declared,
+    )
+
+
+class TestCandidateDetection:
+    def test_django_modification_timestamp_is_a_candidate(self) -> None:
+        f = classify([*AIRBYTE_COLUMNS, "id", "title", "created_on", "updated_on"])
+        assert f.verdict is Verdict.CURSOR_AVAILABLE
+        assert f.candidate == "updated_on"
+
+    def test_modification_wins_over_creation(self) -> None:
+        # Both present is the common Django shape; keying on created_on would
+        # capture inserts and never reflect an edit.
+        f = classify([*AIRBYTE_COLUMNS, "id", "created_at", "updated_at"])
+        assert f.candidate == "updated_at"
+
+    def test_creation_only_is_its_own_bucket(self) -> None:
+        # Valid for an append-only ledger, a trap for a mutable row, and the
+        # schema cannot tell which -- so it must not be folded into either side.
+        f = classify([*AIRBYTE_COLUMNS, "id", "amount", "created_at"])
+        assert f.verdict is Verdict.INSERT_ONLY
+        assert f.candidate == "created_at"
+
+    def test_wagtail_revision_timestamp_is_only_a_secondary_candidate(self) -> None:
+        f = classify([*AIRBYTE_COLUMNS, "id", "title", "latest_revision_created_at", "live"])
+        assert f.verdict is Verdict.SECONDARY_AVAILABLE
+        assert f.candidate == "latest_revision_created_at"
+
+    def test_no_time_column_means_replace(self) -> None:
+        f = classify([*AIRBYTE_COLUMNS, "id", "course_id", "topic_id"])
+        assert f.verdict is Verdict.REPLACE
+        assert f.candidate is None
+
+    def test_loader_bookkeeping_columns_are_not_source_columns(self) -> None:
+        # Airbyte's _airbyte_extracted_at would otherwise read as a cursor, and
+        # it describes the load rather than the row.
+        f = classify([*AIRBYTE_COLUMNS, "id", "course_id"])
+        assert f.verdict is Verdict.REPLACE
+        assert f.source_columns == 2
+
+    def test_dlt_bookkeeping_columns_are_also_excluded(self) -> None:
+        f = classify(["_dlt_id", "_dlt_load_id", "id", "course_id"])
+        assert f.verdict is Verdict.REPLACE
+        assert f.source_columns == 2
+
+
+class TestDeclaredCursorIsCheckedAgainstReality:
+    """The standing check: schemas change, and a dead cursor fails silently."""
+
+    def test_declared_and_present_is_settled(self) -> None:
+        f = classify([*AIRBYTE_COLUMNS, "id", "updated_on"], declared="updated_on")
+        assert f.verdict is Verdict.CURSOR_OK
+
+    def test_declared_but_column_is_gone(self) -> None:
+        f = classify([*AIRBYTE_COLUMNS, "id", "modified"], declared="updated_on")
+        assert f.verdict is Verdict.CURSOR_MISSING
+        assert f.declared_cursor == "updated_on"
+
+    def test_a_declaration_is_not_second_guessed(self) -> None:
+        # A better-looking candidate does not override an explicit choice: the
+        # author may know something about which column is actually maintained.
+        f = classify([*AIRBYTE_COLUMNS, "id", "updated_on", "modified"], declared="modified")
+        assert f.verdict is Verdict.CURSOR_OK
+        assert f.candidate == "modified"
+
+    def test_declared_column_matching_is_case_insensitive(self) -> None:
+        f = classify([*AIRBYTE_COLUMNS, "id", "updated_on"], declared="UPDATED_ON")
+        assert f.verdict is Verdict.CURSOR_OK
+
+    def test_table_declared_but_never_landed(self) -> None:
+        f = classify(None, declared="updated_on")
+        assert f.verdict is Verdict.NOT_LANDED
+
+
+class TestNeedsAttention:
+    def test_a_narrow_replace_table_is_not_worth_a_human(self) -> None:
+        # id + two FKs is a Django M2M join table: replace is correct, not a
+        # compromise, and 213 of them should not be a review queue.
+        f = classify([*AIRBYTE_COLUMNS, "id", "course_id", "topic_id"])
+        assert f.verdict is Verdict.REPLACE
+        assert not f.needs_attention
+
+    def test_a_wide_replace_table_is(self) -> None:
+        f = classify([*AIRBYTE_COLUMNS, *(f"col_{n}" for n in range(12))])
+        assert f.verdict is Verdict.REPLACE
+        assert f.needs_attention
+
+    def test_a_broken_declaration_always_is(self) -> None:
+        f = classify([*AIRBYTE_COLUMNS, "id"], declared="updated_on")
+        assert f.needs_attention
+
+    def test_a_settled_cursor_is_not(self) -> None:
+        f = classify([*AIRBYTE_COLUMNS, "id", "updated_on"], declared="updated_on")
+        assert not f.needs_attention
+
+
+@dataclass
+class FakeUnit:
+    data: dict[str, Any]
+
+    @property
+    def tables(self) -> list[dict[str, Any]]:
+        return self.data.get("tables", [])
+
+
+class TestAudit:
+    def test_walks_units_and_sorts_stably(self) -> None:
+        unit = FakeUnit(
+            {
+                "deployment": "mitxonline",
+                "layer": "app_postgres",
+                "table_prefix": "raw__mitxonline__app__postgres__",
+                "tables": [
+                    {"name": "zeta", "raw_table": "raw__z"},
+                    {"name": "alpha", "raw_table": "raw__a"},
+                ],
+            }
+        )
+        result = audit(
+            [unit],
+            {
+                "raw__z": [*AIRBYTE_COLUMNS, "id", "updated_on"],
+                "raw__a": [*AIRBYTE_COLUMNS, "id", "b_id"],
+            },
+        )
+        assert [f.raw_table for f in result.findings] == ["raw__a", "raw__z"]
+        assert result.counts[Verdict.CURSOR_AVAILABLE] == 1
+        assert result.counts[Verdict.REPLACE] == 1
+
+    def test_cursor_field_is_read_from_the_inventory_list_form(self) -> None:
+        # The schema stores cursor_field as a list of path segments.
+        unit = FakeUnit(
+            {
+                "deployment": "d",
+                "layer": "l",
+                "tables": [
+                    {
+                        "name": "t",
+                        "raw_table": "raw__t",
+                        "cursor_field": ["updated_on"],
+                    }
+                ],
+            }
+        )
+        result = audit([unit], {"raw__t": [*AIRBYTE_COLUMNS, "id", "updated_on"]})
+        assert result.findings[0].verdict is Verdict.CURSOR_OK
+
+    def test_broken_collects_only_vanished_cursors(self) -> None:
+        unit = FakeUnit(
+            {
+                "deployment": "d",
+                "layer": "l",
+                "tables": [
+                    {"name": "ok", "raw_table": "raw__ok", "cursor_field": ["updated_on"]},
+                    {"name": "bad", "raw_table": "raw__bad", "cursor_field": ["gone_on"]},
+                    {"name": "plain", "raw_table": "raw__plain"},
+                ],
+            }
+        )
+        result = audit(
+            [unit],
+            {
+                "raw__ok": [*AIRBYTE_COLUMNS, "updated_on"],
+                "raw__bad": [*AIRBYTE_COLUMNS, "id"],
+                "raw__plain": [*AIRBYTE_COLUMNS, "id"],
+            },
+        )
+        assert [f.stream for f in result.broken] == ["bad"]

--- a/src/ol_dbt_cli/tests/test_cursor_audit.py
+++ b/src/ol_dbt_cli/tests/test_cursor_audit.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Any
 
-from ol_dbt_cli.lib.cursor_audit import Verdict, audit, classify_table
+from ol_dbt_cli.lib.cursor_audit import Verdict, audit, classify_table, select_units
 
 AIRBYTE_COLUMNS = [
     "_airbyte_raw_id",
@@ -15,7 +15,10 @@ AIRBYTE_COLUMNS = [
 ]
 
 
-def classify(columns: list[str] | None, declared: str | None = None) -> Any:
+def classify(columns: list[str] | None, declared: str | list[str] | None = None) -> Any:
+    """Classify one table, wrapping a bare `declared` string into a path."""
+    if isinstance(declared, str):
+        declared = [declared]
     return classify_table(
         unit_key="mitxonline/app_postgres",
         raw_table="raw__mitxonline__app__postgres__thing",
@@ -94,6 +97,23 @@ class TestDeclaredCursorIsCheckedAgainstReality:
         f = classify(None, declared="updated_on")
         assert f.verdict is Verdict.NOT_LANDED
 
+    def test_a_nested_cursor_path_is_reported_not_guessed(self) -> None:
+        # cursor_field is a PATH. Checking only the first segment would report
+        # cursor_ok whenever the struct still exists, even after the field
+        # inside it vanished — the failure this module exists to catch, but
+        # inverted into a false all-clear.
+        f = classify([*AIRBYTE_COLUMNS, "id", "payload"], declared=["payload", "updated_at"])
+        assert f.verdict is Verdict.CURSOR_NESTED
+        assert f.declared_cursor == "payload.updated_at"
+        assert f.needs_attention
+
+    def test_a_nested_path_is_not_rescued_by_a_present_first_segment(self) -> None:
+        f = classify([*AIRBYTE_COLUMNS, "payload"], declared=["payload", "gone_at"])
+        assert f.verdict is not Verdict.CURSOR_OK
+
+    def test_a_single_segment_path_is_checked_normally(self) -> None:
+        assert classify([*AIRBYTE_COLUMNS, "updated_on"], declared=["updated_on"]).verdict is Verdict.CURSOR_OK
+
 
 class TestNeedsAttention:
     def test_a_narrow_replace_table_is_not_worth_a_human(self) -> None:
@@ -124,6 +144,32 @@ class FakeUnit:
     @property
     def tables(self) -> list[dict[str, Any]]:
         return self.data.get("tables", [])
+
+
+class TestSelectUnits:
+    """A partial match must not read as success — the caller audits what it was asked for."""
+
+    def _units(self) -> list[FakeUnit]:
+        return [
+            FakeUnit({"deployment": "mitxonline", "layer": "app_postgres"}),
+            FakeUnit({"deployment": "xpro", "layer": "mysql"}),
+        ]
+
+    def test_selects_the_requested_units(self) -> None:
+        selected, missing = select_units(self._units(), ["xpro/mysql"])
+        assert not missing
+        assert [u.data["deployment"] for u in selected] == ["xpro"]
+
+    def test_a_typo_alongside_a_valid_key_is_reported(self) -> None:
+        # The regression: filtering and checking only for an empty result left
+        # this silent, so the command audited one unit and reported success.
+        selected, missing = select_units(self._units(), ["mitxonline/app_postgres", "xpro/mysqlx"])
+        assert missing == ["xpro/mysqlx"]
+        assert len(selected) == 1
+
+    def test_every_key_missing_is_reported_too(self) -> None:
+        _, missing = select_units(self._units(), ["nope/nothing"])
+        assert missing == ["nope/nothing"]
 
 
 class TestAudit:

--- a/src/ol_dbt_cli/tests/test_inventory.py
+++ b/src/ol_dbt_cli/tests/test_inventory.py
@@ -356,6 +356,29 @@ class TestRules:
         report = _run(inventory)
         assert not report.errors, _messages(report)
 
+    def test_a_production_connection_may_not_omit_its_cadence(self, inventory: Path) -> None:
+        # The dangerous direction: render_dagster_intervals skips a non-integer,
+        # so the group falls through to definitions.py's 24-hour default and a
+        # 6-hour sync silently becomes daily. Nothing else would report it.
+        unit = copy.deepcopy(APP_UNIT)
+        unit["airbyte"]["connections"][0]["environment"] = "production"
+        unit["airbyte"]["connections"][0]["sync_interval_hours"] = None
+        _write(inventory, "mitxonline__mysql", unit)
+        report = _run(inventory)
+        assert report.errors
+        assert "sync_interval_hours" in _messages(report)
+
+    def test_a_qa_connection_may_not_state_a_cadence(self, inventory: Path) -> None:
+        # The inverse case, and why this is an if/then rather than merely a
+        # nullable field: a number here reads as a schedule nothing will run.
+        unit = copy.deepcopy(APP_UNIT)
+        unit["airbyte"]["connections"][1]["environment"] = "qa"
+        unit["airbyte"]["connections"][1]["sync_interval_hours"] = 12
+        _write(inventory, "mitxonline__mysql", unit)
+        report = _run(inventory)
+        assert report.errors
+        assert "sync_interval_hours" in _messages(report)
+
     def test_a_connection_must_declare_its_environment(self, inventory: Path) -> None:
         # Omission is the dangerous direction, not the safe one: an untagged QA
         # connection reads as production, which is the exact fall-through RFC

--- a/src/ol_dbt_cli/tests/test_inventory.py
+++ b/src/ol_dbt_cli/tests/test_inventory.py
@@ -37,12 +37,14 @@ APP_UNIT: dict[str, Any] = {
         "replication_method": "cursor",
         "connections": [
             {
+                "environment": "production",
                 "name": "MITx Online Open edX DB → S3 Data Lake",
                 "status": "active",
                 "sync_interval_hours": 12,
                 "streams": ["auth_user"],
             },
             {
+                "environment": "production",
                 "name": "MITx Online Production Open edX Student Module History → S3 Data Lake",
                 "status": "active",
                 "sync_interval_hours": 24,
@@ -325,7 +327,44 @@ class TestRules:
         unit["tables"] = [unit["tables"][0]]
         _write(inventory, "mitxonline__mysql", unit)
         report = _run(inventory)
-        assert "is carried 2 times within this unit" in _messages(report)
+        assert "is carried 2 times by production connections" in _messages(report)
+
+    def test_the_same_stream_in_two_environments_is_not_a_collision(self, inventory: Path) -> None:
+        # The rule above guards two connections writing one raw table. Each
+        # environment runs its own Airbyte against its own lake, so a unit
+        # ingested in both legitimately carries the same stream twice — and
+        # counting per unit rather than per environment would make every such
+        # unit an error the moment a QA snapshot is merged in.
+        unit = copy.deepcopy(APP_UNIT)
+        unit["airbyte"]["connections"][1]["environment"] = "qa"
+        unit["airbyte"]["connections"][1]["sync_interval_hours"] = None
+        unit["airbyte"]["connections"][1]["status"] = "inactive"
+        unit["airbyte"]["connections"][1]["streams"] = ["auth_user"]
+        unit["tables"] = [unit["tables"][0]]
+        _write(inventory, "mitxonline__mysql", unit)
+        report = _run(inventory)
+        assert not report.errors, _messages(report)
+
+    def test_a_qa_connection_may_omit_its_cadence(self, inventory: Path) -> None:
+        # group_name_to_interval in definitions.py is production-guarded, so
+        # there is no cadence to state for any other environment. Null is the
+        # honest value and the schema has to accept it.
+        unit = copy.deepcopy(APP_UNIT)
+        unit["airbyte"]["connections"][1]["environment"] = "qa"
+        unit["airbyte"]["connections"][1]["sync_interval_hours"] = None
+        _write(inventory, "mitxonline__mysql", unit)
+        report = _run(inventory)
+        assert not report.errors, _messages(report)
+
+    def test_a_connection_must_declare_its_environment(self, inventory: Path) -> None:
+        # Omission is the dangerous direction, not the safe one: an untagged QA
+        # connection reads as production, which is the exact fall-through RFC
+        # 12711 exists to end.
+        unit = copy.deepcopy(APP_UNIT)
+        del unit["airbyte"]["connections"][0]["environment"]
+        _write(inventory, "mitxonline__mysql", unit)
+        report = _run(inventory)
+        assert "'environment' is a required property" in _messages(report)
 
 
 class TestCrossUnit:

--- a/src/ol_dbt_cli/tests/test_inventory_removals.py
+++ b/src/ol_dbt_cli/tests/test_inventory_removals.py
@@ -46,6 +46,7 @@ UNIT: dict[str, Any] = {
         "replication_method": "cursor",
         "connections": [
             {
+                "environment": "production",
                 "name": "MITx Online Open edX DB → S3 Data Lake",
                 "status": "active",
                 "sync_interval_hours": 12,


### PR DESCRIPTION
### What are the relevant tickets?

- RFC 12319 — https://github.com/mitodl/hq/discussions/12319
- RFC 12711 — https://github.com/mitodl/hq/discussions/12711
- https://github.com/mitodl/hq/issues/8238

### Description (What does it do?)

Two changes to the ingestion inventory tooling.

**Snapshot Airbyte per environment.** `bin/airbyte-inventory.py` hard-coded the production host, so the inventory could say nothing about QA — units carried `strategies: {qa: TODO}` with no evidence in the file to decide from.

- `dump --environment {production,qa}` picks the host from `AIRBYTE_SERVERS` and writes `airbyte-snapshot-<env>.json`. `render` merges however many exist, tagging each connection with `environment`.
- One environment per run, including in `all`: each deployment's basic-auth credential comes from its own Vault service, so no single invocation can authenticate to both. `render` reads whatever snapshots are on disk, so the merged inventory accumulates across runs.
- `environment` is required rather than defaulted. Omission fails in the dangerous direction — an untagged QA connection reads as production, the same fall-through RFC 12711 exists to end.
- Two rules follow the field. The duplicate-stream check counts per environment (across environments the writes land in different lakes, so every unit ingested in both would otherwise error), and `sync_interval_hours` is null outside production, since `group_name_to_interval` is guarded by `DAGSTER_ENV == "production"` and says nothing about any other environment.
- Only `production` and `qa`. An `api-airbyte-ci.odl.mit.edu` host is defined in ol-infrastructure, but CI is a dead environment for Airbyte — nothing runs behind it. The mechanism is `SKIP_AIRBYTE` ([definitions.py:109](https://github.com/mitodl/ol-data-platform/blob/main/dg_projects/lakehouse/lakehouse/definitions.py#L109)), which loads an empty workspace. Offering `ci` would mean offering a snapshot that can only come back empty, and an empty workspace is indistinguishable from one whose connections were all deleted.

What it found on first run: QA has 28 connections, 9 active. Only 5 point at the `s3-data-lake` (Iceberg) destination; the other 23 are on the legacy S3/Glue destination and never migrated. That correlates exactly with Dagster's `connection_selector_fn`, which matches on names ending `s3 data lake` — so the selector is correctly excluding unmigrated connections, and reading the Dagster asset graph makes QA look nearly empty when it is mostly unmigrated and disabled.

**`ol-dbt inventory cursors`.** Airbyte's Postgres sources mostly replicate by `xmin`, which dlt has no practical equivalent for, so each table needs a replacement cursor column or an explicit decision to re-read it whole. Answering that meant crawling schemas by hand, per source.

- Reads the **landed** column list from Glue, not the ORM: what a loader can key on is constrained by what actually arrived.
- Scope comes from each unit's `table_prefix`, so a new app is covered the moment its unit exists. Nothing is hard-coded per source.
- Checks declared `cursor_field` against reality. A column later dropped or renamed does not fail loudly — the load stops advancing or falls back to a full read. That is `cursor_missing`, and it exits non-zero.
- Five buckets. `insert_only` is separate because a creation timestamp is a correct cursor for an append-only ledger and a trap for a mutable row, and a schema cannot tell them apart. `secondary_available` covers Wagtail pages, whose only timestamp moves on revision rather than on write. `replace` carries a source-column count so join tables do not read as decisions.
- `--attention-only` filters to what needs a human. Across the 8 xmin sources that is 104 of 608 tables; the rest are settled declarations or join tables.

Measured across the 8 xmin sources, 608 landed production tables: 288 have a modification timestamp, 3 only a revision timestamp, 15 only a creation timestamp, 302 none. Of those 302, 213 are join-table shaped (≤4 source columns — id plus a couple of FKs), where full replace is correct rather than a compromise: it is the only disposition that propagates the delete an unlink produces. That leaves 89 wider tables in `replace` that want a real decision.

### How can this be tested?

Run by me on this branch:

- `uv run pytest src/ol_dbt_cli/tests/` — 483 pass, 19 of them new for `cursor_audit`.
- `uv run pre-commit run --files <changed>` — clean, including mypy and ruff.
- `render`'s cross-environment merge against synthetic production+QA snapshot fixtures, covering a unit present in both, a production-only unit, and a QA connection carrying fewer streams. Fixtures were scratch and are not committed; the committed coverage is the unit tests.
- A live QA Airbyte dump: `uv run python bin/airbyte-inventory.py all --environment qa` → 28 connections (9 active, 19 inactive), 23 draft units rendered.
- A live `ol-dbt inventory cursors --unit mitxonline/app_postgres --attention-only` against `ol_warehouse_production_raw`.

Not run: a production Airbyte dump — I had no production credential in the session. `dump --environment production` resolves to the same host the script used to hard-code, and `report` reads a single snapshot as before, but neither was exercised end to end against production.

To reproduce the QA dump you need the QA Airbyte basic-auth password from that environment's own Vault:

```
export AIRBYTE_PASSWORD=$(VAULT_ADDR=https://vault-qa.odl.mit.edu \
  vault kv get -mount=secret-data -field=dagster_unhashed_password dagster-http-auth-password)
uv run python bin/airbyte-inventory.py all --environment qa
```

`ol-dbt inventory cursors` needs only AWS credentials, no source-database access.

### Additional Context

- **`environment` is a required field on `airbyte.connections[]`.** ~~No unit files are committed in this repo yet, so nothing in-tree breaks.~~ **Correction:** that was true of the commit this branch started from and stopped being true before the PR opened — #2599 landed 43 units on `main`, and requiring the field broke `ol-dbt inventory validate` on all of them (40 errors, the whole Ingestion inventory CI job). Fixed in 3c4f70ce, which rebases onto current `main` and tags every committed connection `environment: production`. That is the correct value rather than a convenient one: the generator could only reach the production workspace when those units were rendered. Anyone holding a rendered inventory on another branch still needs to re-run `render` or apply the same backfill.
- **The CLI surface changed**, so any saved invocation needs updating: the default snapshot filename is now `airbyte-snapshot-<env>.json` (`.gitignore` widened to match); `render --snapshot X` became `--snapshots X`, repeatable; and `all` dropped `--snapshot` and gained `--environment`. There is no compatibility shim — these are developer commands run by hand, and a silently-ignored old flag would be worse than an error.
- `report` stays deliberately single-environment. Findings C and E join against production-only facts (the Dagster interval map and the dbt sources), so running them over a QA snapshot would report every QA connection as miswired.
- A `cursor_available` finding is a shortlist entry, not an approval: the check cannot tell whether a column is stamped on *every* mutation path. Django's `auto_now=True` covers `Model.save()` but not `queryset.update()`. I did not verify which apps use bulk-update paths, and the caveat is stated in both the module docstring and the command help.
- `lib/cursor_audit.py` deliberately imports no boto3, matching `lib/inventory.py`'s rule about staying importable from the dlt code location. The Glue read lives in `lib/glue_schema.py` and imports boto3 inside the function so registering the command does not pull it in for every other subcommand.

