### PR TITLE
fix(dimensional): recover stale user_fk in fact tables after dim_user re-key 

### DIFF
--- a/src/ol_dbt/models/dimensional/_fact_tables.yml
+++ b/src/ol_dbt/models/dimensional/_fact_tables.yml
@@ -544,3 +544,431 @@ models:
   - name: grade_updated_on
     description: Grade last update timestamp (for incremental processing). Null for
       edX.org.
+
+unit_tests:
+- name: test_tfact_payment_refreshes_stale_user_fk_after_dim_user_rekey
+  description: >
+    Regression test for the dim_user re-key incident: when dim_user.user_pk changes
+    for
+    a user, tfact_payment's incremental filter must re-select the affected payment
+    and
+    write the refreshed user_fk, even though the source row's own timestamp did not
+    change and the activity-timestamp watermark alone would not have caught it.
+  model: tfact_payment
+  overrides:
+    macros:
+      is_incremental: true
+  given:
+  - input: ref('int__mitxonline__ecommerce_transaction')
+    rows:
+    - transaction_id: 90001
+      order_id: 8001
+      transaction_amount: 100.00
+      transaction_type: "payment"
+      transaction_status: "fulfilled"
+      transaction_payment_method: "card"
+      transaction_created_on: "2024-01-15T00:00:00"
+  - input: ref('int__mitxpro__ecommerce_receipt')
+    rows: []
+  - input: ref('stg__mitxonline__app__postgres__ecommerce_order')
+    rows:
+    - order_id: 8001
+      order_purchaser_user_id: 555
+  - input: ref('stg__mitxpro__app__postgres__ecommerce_order')
+    rows: []
+      # dim_user has since re-keyed this user; user_pk no longer matches the target row below.
+  - input: ref('dim_user')
+    rows:
+    - user_pk: "NEW_USER_PK"
+      mitxonline_application_user_id: 555
+      mitxpro_application_user_id:
+  - input: ref('dim_platform')
+    rows:
+    - platform_pk: "PLATFORM_MITXONLINE"
+      platform_readable_id: "mitxonline"
+  - input: ref('dim_payment_method')
+    rows:
+    - payment_method_pk: "PM_CARD"
+      payment_method_code: "card"
+  - input: this
+    # Carries the pre-rekey user_fk; payment's watermark uses `>` so a lone row already
+    # fails it, isolating the stale-user_fk check without needing an extra row.
+    rows:
+    - payment_key: "53bc02a4e3704d46d59ab7f6f7924c47"  # pragma: allowlist secret
+      payment_id: 90001
+      order_id: 8001
+      payment_date_key: 20240115
+      user_fk: "OLD_USER_PK"
+      platform_fk: "PLATFORM_MITXONLINE"
+      platform: "mitxonline"
+      payment_method_fk: "PM_CARD"
+      transaction_amount: 100.00
+      transaction_type: "payment"
+      transaction_status: "fulfilled"
+      transaction_created_on: "2024-01-15T00:00:00"
+  expect:
+    rows:
+    - payment_key: "53bc02a4e3704d46d59ab7f6f7924c47"  # pragma: allowlist secret
+      payment_id: 90001
+      order_id: 8001
+      payment_date_key: 20240115
+      user_fk: "NEW_USER_PK"
+      platform_fk: "PLATFORM_MITXONLINE"
+      platform: "mitxonline"
+      payment_method_fk: "PM_CARD"
+      transaction_amount: 100.00
+      transaction_type: "payment"
+      transaction_status: "fulfilled"
+      transaction_created_on: "2024-01-15T00:00:00"
+- name: test_tfact_certificate_refreshes_stale_user_fk_after_dim_user_rekey
+  description: >
+    Regression test for the dim_user re-key incident: when dim_user.user_pk changes
+    for
+    a user, tfact_certificate's incremental filter must re-select the affected certificate
+    and write the refreshed user_fk, even though the source row's own timestamp did
+    not
+    change and the activity-timestamp watermark alone would not have caught it.
+  model: tfact_certificate
+  overrides:
+    macros:
+      is_incremental: true
+  given:
+  - input: ref('int__mitxonline__courserun_certificates')
+    rows:
+    - courseruncertificate_id: 5001
+      user_id: 555
+      courserun_readable_id: "course-v1:MITxT+1"
+      courseruncertificate_uuid: "uuid-1"
+      courseruncertificate_is_revoked: false
+      courseruncertificate_created_on: "2024-01-15T00:00:00"
+      courseruncertificate_updated_on: "2024-01-15T00:00:00"
+      courseruncertificate_issued_on: "2024-01-15T00:00:00"
+  - input: ref('int__mitxpro__courserun_certificates')
+    rows: []
+  - input: ref('int__edxorg__mitx_courserun_certificates')
+    rows: []
+  - input: ref('int__micromasters__course_certificates')
+    rows: []
+  - input: ref('int__mitxonline__program_certificates')
+    rows: []
+  - input: ref('int__mitxpro__program_certificates')
+    rows: []
+  - input: ref('int__edxorg__mitx_program_certificates')
+    rows: []
+  - input: ref('int__bootcamps__courserun_certificates')
+    rows: []
+      # dim_user has since re-keyed this user; user_pk no longer matches the target row below.
+  - input: ref('dim_user')
+    rows:
+    - user_pk: "NEW_USER_PK"
+      mitxonline_application_user_id: 555
+  - input: ref('dim_course_run')
+    rows: []
+  - input: ref('dim_platform')
+    rows:
+    - platform_pk: "PLATFORM_MITXONLINE"
+      platform_readable_id: "mitxonline"
+  - input: ref('dim_certificate_type')
+    rows:
+    - certificate_type_pk: "CERT_TYPE_VERIFIED"
+      certificate_type_code: "verified"
+  - input: ref('dim_program')
+    rows: []
+      # Existing target state carries the pre-rekey user_fk; an unrelated later-dated certificate pushes the watermark past our row so only the stale-user_fk check can reselect it.
+  - input: this
+    rows:
+    - certificate_key: "341dbc50d750419afb7297181f38422a"  # pragma: allowlist secret
+      certificate_id: "5001"
+      certificate_issued_date_key: 20240115
+      user_fk: "OLD_USER_PK"
+      platform: "mitxonline"
+      certificate_scope: "course"
+      certificate_uuid: "uuid-1"
+      certificate_is_revoked: false
+      certificate_created_on: "2024-01-15T00:00:00"
+      certificate_updated_on: "2024-01-15T00:00:00"
+      certificate_issued_on: "2024-01-15T00:00:00"
+    - certificate_key: "unrelated-later-certificate"
+      certificate_id: "9999"
+      certificate_issued_date_key: 20240201
+      user_fk: "SOME_OTHER_USER_PK"
+      platform: "mitxonline"
+      certificate_scope: "course"
+      certificate_uuid: "uuid-9999"
+      certificate_is_revoked: false
+      certificate_created_on: "2024-02-01T00:00:00"
+      certificate_updated_on: "2024-02-01T00:00:00"
+      certificate_issued_on: "2024-02-01T00:00:00"
+  expect:
+    rows:
+    - certificate_key: "341dbc50d750419afb7297181f38422a"  # pragma: allowlist secret
+      certificate_id: "5001"
+      certificate_issued_date_key: 20240115
+      user_fk: "NEW_USER_PK"
+      platform: "mitxonline"
+      certificate_scope: "course"
+      certificate_uuid: "uuid-1"
+      certificate_is_revoked: false
+      certificate_created_on: "2024-01-15T00:00:00"
+      certificate_updated_on: "2024-01-15T00:00:00"
+      certificate_issued_on: "2024-01-15T00:00:00"
+- name: test_tfact_enrollment_refreshes_stale_user_fk_after_dim_user_rekey
+  description: >
+    Regression test for the dim_user re-key incident: when dim_user.user_pk changes
+    for
+    a user, tfact_enrollment's incremental filter must re-select the affected enrollment
+    and write the refreshed user_fk, even though the source row's own timestamp did
+    not
+    change and the activity-timestamp watermark alone would not have caught it.
+  model: tfact_enrollment
+  overrides:
+    macros:
+      is_incremental: true
+  given:
+  - input: ref('int__mitxonline__courserunenrollments')
+    rows:
+    - courserunenrollment_id: 6001
+      user_id: 555
+      courserun_readable_id: "course-v1:MITxT+1"
+      courserunenrollment_created_on: "2024-01-15T00:00:00"
+      courserunenrollment_updated_on: "2024-01-15T00:00:00"
+      courserunenrollment_is_active: true
+      courserunenrollment_enrollment_mode: "verified"
+      courserunenrollment_enrollment_status: "enrolled"
+      courserunenrollment_is_edx_enrolled: true
+  - input: ref('int__mitxpro__programenrollments')
+    rows: []
+  - input: ref('int__mitxpro__courserunenrollments')
+    rows: []
+  - input: ref('int__edxorg__mitx_courserun_enrollments')
+    rows: []
+  - input: ref('int__mitxonline__programenrollments')
+    rows: []
+  - input: ref('int__mitxresidential__courserun_enrollments')
+    rows: []
+  - input: ref('int__bootcamps__courserunenrollments')
+    rows: []
+  - input: ref('int__micromasters__course_enrollments')
+    rows: []
+      # dim_user has since re-keyed this user; user_pk no longer matches the target row below.
+  - input: ref('dim_user')
+    rows:
+    - user_pk: "NEW_USER_PK"
+      mitxonline_application_user_id: 555
+  - input: ref('dim_course_run')
+    rows: []
+  - input: ref('dim_program')
+    rows: []
+  - input: ref('dim_platform')
+    rows:
+    - platform_pk: "PLATFORM_MITXONLINE"
+      platform_readable_id: "mitxonline"
+      # Existing target state carries the pre-rekey user_fk; an unrelated later-dated enrollment pushes the watermark past our row so only the stale-user_fk check can reselect it.
+  - input: this
+    rows:
+    - enrollment_key: "138707f4f49de0845e4263b5ebdd013d"  # pragma: allowlist secret
+      enrollment_id: "6001"
+      enrollment_type: "course"
+      enrollment_date_key: 20240115
+      user_fk: "OLD_USER_PK"
+      platform: "mitxonline"
+      enrollment_is_active: true
+      enrollment_mode: "verified"
+      enrollment_status: "enrolled"
+      enrollment_created_on: "2024-01-15T00:00:00"
+      enrollment_updated_on: "2024-01-15T00:00:00"
+      enrollment_is_edx_enrolled: true
+    - enrollment_key: "unrelated-later-enrollment"
+      enrollment_id: "9999"
+      enrollment_type: "course"
+      enrollment_date_key: 20240201
+      user_fk: "SOME_OTHER_USER_PK"
+      platform: "mitxonline"
+      enrollment_is_active: true
+      enrollment_mode: "verified"
+      enrollment_status: "enrolled"
+      enrollment_created_on: "2024-02-01T00:00:00"
+      enrollment_updated_on: "2024-02-01T00:00:00"
+      enrollment_is_edx_enrolled: true
+  expect:
+    rows:
+    - enrollment_key: "138707f4f49de0845e4263b5ebdd013d"  # pragma: allowlist secret
+      enrollment_id: "6001"
+      enrollment_type: "course"
+      enrollment_date_key: 20240115
+      user_fk: "NEW_USER_PK"
+      platform: "mitxonline"
+      enrollment_is_active: true
+      enrollment_mode: "verified"
+      enrollment_status: "enrolled"
+      enrollment_created_on: "2024-01-15T00:00:00"
+      enrollment_updated_on: "2024-01-15T00:00:00"
+      enrollment_is_edx_enrolled: true
+- name: test_tfact_grade_refreshes_stale_user_fk_after_dim_user_rekey
+  description: >
+    Regression test for the dim_user re-key incident: when dim_user.user_pk changes
+    for
+    a user, tfact_grade's incremental filter must re-select the affected grade and
+    write
+    the refreshed user_fk, even though the source row's own timestamp did not change
+    and
+    the activity-timestamp watermark alone would not have caught it.
+  model: tfact_grade
+  overrides:
+    macros:
+      is_incremental: true
+  given:
+  - input: ref('int__mitxonline__courserun_grades')
+    rows:
+    - courserungrade_id: 7001
+      user_id: 555
+      courserun_readable_id: "course-v1:MITxT+1"
+      courserun_platform: "MITx Online"
+      courserungrade_grade: 0.95
+      courserungrade_letter_grade: "A"
+      courserungrade_is_passing: true
+      courserungrade_created_on: "2024-01-15T00:00:00"
+      courserungrade_updated_on: "2024-01-15T00:00:00"
+  - input: ref('int__mitxpro__courserun_grades')
+    rows: []
+  - input: ref('int__edxorg__mitx_courserun_grades')
+    rows: []
+      # dim_user has since re-keyed this user; user_pk no longer matches the target row below.
+  - input: ref('dim_user')
+    rows:
+    - user_pk: "NEW_USER_PK"
+      mitxonline_application_user_id: 555
+  - input: ref('dim_course_run')
+    rows: []
+  - input: ref('dim_platform')
+    rows:
+    - platform_pk: "PLATFORM_MITXONLINE"
+      platform_readable_id: "mitxonline"
+      # Existing target state carries the pre-rekey user_fk; an unrelated later-dated grade pushes the watermark past our row so only the stale-user_fk check can reselect it.
+  - input: this
+    rows:
+    - grade_key: "e466cc3cac58c5170c9703eed3b27a11"  # pragma: allowlist secret
+      grade_id: "7001"
+      grade_date_key: 20240115
+      user_fk: "OLD_USER_PK"
+      platform: "mitxonline"
+      grade_value: 0.95
+      is_passing: true
+      letter_grade: "A"
+      grade_created_on: "2024-01-15T00:00:00"
+      grade_updated_on: "2024-01-15T00:00:00"
+    - grade_key: "unrelated-later-grade"
+      grade_id: "9999"
+      grade_date_key: 20240201
+      user_fk: "SOME_OTHER_USER_PK"
+      platform: "mitxonline"
+      grade_value: 0.80
+      is_passing: true
+      letter_grade: "B"
+      grade_created_on: "2024-02-01T00:00:00"
+      grade_updated_on: "2024-02-01T00:00:00"
+  expect:
+    rows:
+    - grade_key: "e466cc3cac58c5170c9703eed3b27a11"  # pragma: allowlist secret
+      grade_id: "7001"
+      grade_date_key: 20240115
+      user_fk: "NEW_USER_PK"
+      platform: "mitxonline"
+      grade_value: 0.95
+      is_passing: true
+      letter_grade: "A"
+      grade_created_on: "2024-01-15T00:00:00"
+      grade_updated_on: "2024-01-15T00:00:00"
+- name: test_tfact_order_refreshes_stale_user_fk_after_dim_user_rekey
+  description: >
+    Regression test for the dim_user re-key incident: when dim_user.user_pk changes
+    for
+    a user, tfact_order's incremental filter must re-select the affected order line
+    and
+    write the refreshed user_fk, even though the source row's own timestamp did not
+    change and the activity-timestamp watermark alone would not have caught it.
+  model: tfact_order
+  overrides:
+    macros:
+      is_incremental: true
+  given:
+  - input: ref('int__mitxonline__ecommerce_order')
+    rows:
+    - line_id: 1
+      order_id: 9001
+      user_id: 555
+      product_price: 100.00
+      order_state: "fulfilled"
+      order_total_price_paid: 100.00
+      order_reference_number: "REF1"
+      order_created_on: "2024-01-15T00:00:00"
+      order_updated_on: "2024-01-15T00:00:00"
+  - input: ref('int__mitxpro__ecommerce_order')
+    rows: []
+  - input: ref('int__mitxpro__ecommerce_line')
+    rows: []
+  - input: ref('int__bootcamps__ecommerce_order')
+    rows: []
+  - input: ref('int__micromasters__orders')
+    rows: []
+      # dim_user has since re-keyed this user; user_pk no longer matches the target row below.
+  - input: ref('dim_user')
+    rows:
+    - user_pk: "NEW_USER_PK"
+      mitxonline_application_user_id: 555
+  - input: ref('dim_discount_type')
+    rows: []
+  - input: ref('dim_product')
+    rows: []
+  - input: ref('dim_platform')
+    rows:
+    - platform_pk: "PLATFORM_MITXONLINE"
+      platform_readable_id: "mitxonline"
+  - input: ref('dim_discount')
+    rows: []
+  - input: ref('dim_tax_rate')
+    rows: []
+      # Existing target state carries the pre-rekey user_fk; an unrelated later-dated order line pushes the watermark past our row so only the stale-user_fk check can reselect it.
+  - input: this
+    rows:
+    - order_key: "8ae1602610f2897cc24802a9e453aaa3"  # pragma: allowlist secret
+      order_id: 9001
+      line_id: "1"
+      order_date_key: 20240115
+      order_updated_date_key: 20240115
+      user_fk: "OLD_USER_PK"
+      platform_fk: "PLATFORM_MITXONLINE"
+      platform: "mitxonline"
+      order_state: "fulfilled"
+      line_price: 100.00
+      order_total_price_paid: 100.00
+      order_reference_number: "REF1"
+      order_updated_on: "2024-01-15T00:00:00"
+    - order_key: "unrelated-later-order"
+      order_id: 9999
+      line_id: "1"
+      order_date_key: 20240201
+      order_updated_date_key: 20240201
+      user_fk: "SOME_OTHER_USER_PK"
+      platform_fk: "PLATFORM_MITXONLINE"
+      platform: "mitxonline"
+      order_state: "fulfilled"
+      line_price: 100.00
+      order_total_price_paid: 100.00
+      order_reference_number: "REF9999"
+      order_updated_on: "2024-02-01T00:00:00"
+  expect:
+    rows:
+    - order_key: "8ae1602610f2897cc24802a9e453aaa3"  # pragma: allowlist secret
+      order_id: 9001
+      line_id: "1"
+      order_date_key: 20240115
+      order_updated_date_key: 20240115
+      user_fk: "NEW_USER_PK"
+      platform_fk: "PLATFORM_MITXONLINE"
+      platform: "mitxonline"
+      order_state: "fulfilled"
+      line_price: 100.00
+      order_total_price_paid: 100.00
+      order_reference_number: "REF1"
+      order_updated_on: "2024-01-15T00:00:00"

--- a/src/ol_dbt/models/dimensional/_feedback_facts.yml
+++ b/src/ol_dbt/models/dimensional/_feedback_facts.yml
@@ -252,3 +252,103 @@ models:
     description: double, cohesion signal for ranking systemic issues.
   - name: conversation_ingested_at
     description: str, ISO8601 timestamp this row was materialized.
+
+unit_tests:
+- name: test_tfact_feedback_refreshes_stale_user_fk_after_dim_user_rekey
+  description: >
+    Regression test for the dim_user re-key incident: when dim_user.user_pk changes
+    for
+    a user, tfact_feedback's incremental filter must re-select the affected turn and
+    write
+    the refreshed user_fk, even though the source ticket's updated_at did not change
+    and
+    the conversation-level watermark alone would not have caught it.
+  model: tfact_feedback
+  overrides:
+    macros:
+      is_incremental: true
+  given:
+  - input: ref('int__feedback__unioned')
+    rows:
+    - source_slug: "zendesk"
+      source_record_ref: "TICKET-1"
+      channel_slug: "support"
+      conversation_ref: "CONV-1"
+      turn_index: 1
+      is_conversation_opening: true
+      source_url: "http://example.com/ticket/1"
+      subject_type: "ticket"
+      subject_ref: "TICKET-1"
+      subject_url: "http://example.com/ticket/1"
+      subject_user_ref: "learner@example.com"
+      feedback_text_chars: 20
+      occurred_at: "2024-01-15T00:00:00"
+      created_at: "2024-01-15T00:00:00"
+      updated_at: "2024-01-15T00:00:00"
+      # dim_user has since re-keyed this user; user_pk no longer matches the target row below.
+  - input: ref('dim_user')
+    rows:
+    - user_pk: "NEW_USER_PK"
+      email: "learner@example.com"
+  - input: source('feedback_intermediate', 'feedback_redacted')
+    rows:
+    - source_slug: "zendesk"
+      source_record_ref: "TICKET-1"
+      title_redacted: "Title"
+      text_redacted: "Some feedback text"
+  - input: this
+    # Carries the pre-rekey user_fk; a lone row already fails the `>` watermark, isolating
+    # the stale-user_fk check.
+    rows:
+    - feedback_pk: "ff8fd307a4dfe4d8794b3b59332b1e07"  # pragma: allowlist secret
+      feedback_source_fk: "01260647de9803dd69df3ecc34a8d908"  # pragma: allowlist secret
+      feedback_channel_fk: "434990c8a25d2be94863561ae98bd682"  # pragma: allowlist secret
+      user_fk: "OLD_USER_PK"
+      occurred_date_fk: 20240115
+      occurred_time_fk: 0
+      created_date_fk: 20240115
+      created_time_fk: 0
+      updated_date_fk: 20240115
+      updated_time_fk: 0
+      conversation_id: "CONV-1"
+      turn_index: 1
+      is_conversation_opening: true
+      source_record_id: "TICKET-1"
+      source_url: "http://example.com/ticket/1"
+      subject_type: "ticket"
+      subject_ref: "TICKET-1"
+      subject_url: "http://example.com/ticket/1"
+      subject_user_ref: "learner@example.com"
+      feedback_title: "Title"
+      feedback_text: "Some feedback text"
+      feedback_text_chars: 20
+      feedback_occurred_at: "2024-01-15T00:00:00"
+      feedback_created_at: "2024-01-15T00:00:00"
+      feedback_updated_at: "2024-01-15T00:00:00"
+  expect:
+    rows:
+    - feedback_pk: "ff8fd307a4dfe4d8794b3b59332b1e07"  # pragma: allowlist secret
+      feedback_source_fk: "01260647de9803dd69df3ecc34a8d908"  # pragma: allowlist secret
+      feedback_channel_fk: "434990c8a25d2be94863561ae98bd682"  # pragma: allowlist secret
+      user_fk: "NEW_USER_PK"
+      occurred_date_fk: 20240115
+      occurred_time_fk: 0
+      created_date_fk: 20240115
+      created_time_fk: 0
+      updated_date_fk: 20240115
+      updated_time_fk: 0
+      conversation_id: "CONV-1"
+      turn_index: 1
+      is_conversation_opening: true
+      source_record_id: "TICKET-1"
+      source_url: "http://example.com/ticket/1"
+      subject_type: "ticket"
+      subject_ref: "TICKET-1"
+      subject_url: "http://example.com/ticket/1"
+      subject_user_ref: "learner@example.com"
+      feedback_title: "Title"
+      feedback_text: "Some feedback text"
+      feedback_text_chars: 20
+      feedback_occurred_at: "2024-01-15T00:00:00"
+      feedback_created_at: "2024-01-15T00:00:00"
+      feedback_updated_at: "2024-01-15T00:00:00"

--- a/src/ol_dbt/models/dimensional/dim_user.sql
+++ b/src/ol_dbt/models/dimensional/dim_user.sql
@@ -631,29 +631,27 @@ with mitx_users as (
 
 -- Shared email still groups accounts into one person: for MITx Pro, Bootcamps, Residential,
 -- Emeritus and Global Alumni it is the only signal we have. But the key is named after one
--- account in the group - global id first, else the earliest-created account - so a user
--- editing their email, or signing up on a new platform later, no longer re-keys them.
--- (Ranking by a fixed platform priority instead of join date was tried first, but it
--- re-keyed a user every time they signed up on a higher-priority platform later.)
+-- account in the group - global id first, else the highest-ranked id source - so a user
+-- editing their email no longer re-keys them.
 -- Ranked so the key lands on the same account whose id agg_view's max() surfaces below.
 , ranked_accounts as (
     select
-        -- Outranks earliest_joined_on: an id-less emeritus/global_alumni row must still
-        -- lose to an id-bearing row, regardless of which joined earlier.
+        -- Outranks id_source_rank: an id-less emeritus row (9) must still lose to an
+        -- id-bearing global_alumni row (10).
         case when id_source_user_id is null then 1 else 0 end as has_no_source_id
-        -- A global id is the platform's own permanent cross-account identity, so it always
-        -- wins over picking by join date.
-        , case when user_global_id is not null then 0 else 1 end as has_no_global_id
-        -- Emeritus, Global Alumni and Micromasters have no join-date column, so they sort
-        -- after every dated account here and fall through to the sort_id tie-break below.
-        , least(
-            coalesce(user_joined_on_mitlearn, '9999-12-31T23:59:59')
-            , coalesce(user_joined_on_mitxonline, '9999-12-31T23:59:59')
-            , coalesce(user_joined_on_edxorg, '9999-12-31T23:59:59')
-            , coalesce(user_joined_on_mitxpro, '9999-12-31T23:59:59')
-            , coalesce(user_joined_on_residential, '9999-12-31T23:59:59')
-            , coalesce(user_joined_on_bootcamps, '9999-12-31T23:59:59')
-        ) as earliest_joined_on
+        , case
+            when user_global_id is not null then 0
+            when id_source = 'mitlearn' then 1
+            when id_source = 'mitxonline' then 2
+            when id_source = 'edxorg' then 3
+            when id_source = 'micromasters' then 4
+            when id_source = 'mitxonline_openedx' then 5
+            when id_source = 'mitxpro' then 6
+            when id_source = 'residential' then 7
+            when id_source = 'bootcamps' then 8
+            when id_source = 'emeritus' then 9
+            when id_source = 'global_alumni' then 10
+        end as id_source_rank
         -- Emeritus and Global Alumni ids are varchar, and agg_view surfaces them with a
         -- lexicographic max(). Nulling sort_id falls the ordering through to the
         -- lexicographic key below so the key names the account agg_view's ids come from.
@@ -680,8 +678,8 @@ with mitx_users as (
         partition by email
         order by
             has_no_source_id
-            , has_no_global_id
-            , earliest_joined_on
+            , id_source_rank
+            , user_global_id desc
             , sort_id desc nulls last
             , id_source_user_id desc
     )

--- a/src/ol_dbt/models/dimensional/dim_user.sql
+++ b/src/ol_dbt/models/dimensional/dim_user.sql
@@ -631,27 +631,29 @@ with mitx_users as (
 
 -- Shared email still groups accounts into one person: for MITx Pro, Bootcamps, Residential,
 -- Emeritus and Global Alumni it is the only signal we have. But the key is named after one
--- account in the group - global id first, else the highest-ranked id source - so a user
--- editing their email no longer re-keys them.
+-- account in the group - global id first, else the earliest-created account - so a user
+-- editing their email, or signing up on a new platform later, no longer re-keys them.
+-- (Ranking by a fixed platform priority instead of join date was tried first, but it
+-- re-keyed a user every time they signed up on a higher-priority platform later.)
 -- Ranked so the key lands on the same account whose id agg_view's max() surfaces below.
 , ranked_accounts as (
     select
-        -- Outranks id_source_rank: an id-less emeritus row (9) must still lose to an
-        -- id-bearing global_alumni row (10).
+        -- Outranks earliest_joined_on: an id-less emeritus/global_alumni row must still
+        -- lose to an id-bearing row, regardless of which joined earlier.
         case when id_source_user_id is null then 1 else 0 end as has_no_source_id
-        , case
-            when user_global_id is not null then 0
-            when id_source = 'mitlearn' then 1
-            when id_source = 'mitxonline' then 2
-            when id_source = 'edxorg' then 3
-            when id_source = 'micromasters' then 4
-            when id_source = 'mitxonline_openedx' then 5
-            when id_source = 'mitxpro' then 6
-            when id_source = 'residential' then 7
-            when id_source = 'bootcamps' then 8
-            when id_source = 'emeritus' then 9
-            when id_source = 'global_alumni' then 10
-        end as id_source_rank
+        -- A global id is the platform's own permanent cross-account identity, so it always
+        -- wins over picking by join date.
+        , case when user_global_id is not null then 0 else 1 end as has_no_global_id
+        -- Emeritus, Global Alumni and Micromasters have no join-date column, so they sort
+        -- after every dated account here and fall through to the sort_id tie-break below.
+        , least(
+            coalesce(user_joined_on_mitlearn, '9999-12-31T23:59:59')
+            , coalesce(user_joined_on_mitxonline, '9999-12-31T23:59:59')
+            , coalesce(user_joined_on_edxorg, '9999-12-31T23:59:59')
+            , coalesce(user_joined_on_mitxpro, '9999-12-31T23:59:59')
+            , coalesce(user_joined_on_residential, '9999-12-31T23:59:59')
+            , coalesce(user_joined_on_bootcamps, '9999-12-31T23:59:59')
+        ) as earliest_joined_on
         -- Emeritus and Global Alumni ids are varchar, and agg_view surfaces them with a
         -- lexicographic max(). Nulling sort_id falls the ordering through to the
         -- lexicographic key below so the key names the account agg_view's ids come from.
@@ -678,8 +680,8 @@ with mitx_users as (
         partition by email
         order by
             has_no_source_id
-            , id_source_rank
-            , user_global_id desc
+            , has_no_global_id
+            , earliest_joined_on
             , sort_id desc nulls last
             , id_source_user_id desc
     )

--- a/src/ol_dbt/models/dimensional/tfact_certificate.sql
+++ b/src/ol_dbt/models/dimensional/tfact_certificate.sql
@@ -303,6 +303,16 @@ with mitxonline_certificates as (
          , max(coalesce(certificate_updated_on, certificate_created_on)) as max_activity_on
     from {{ this }}
     group by platform, certificate_scope)
+
+-- Snapshot of the target's current (certificate_key, user_fk) pairs, used to re-select rows
+-- whose user_fk has gone stale after a dim_user re-key (the source row itself did not
+-- change, so the activity-timestamp watermark alone would never catch it).
+, stale_user_fk_lookup as (
+    select
+        certificate_key
+        , user_fk as stored_user_fk
+    from {{ this }}
+)
 {% endif %}
 
 , final as (
@@ -333,11 +343,19 @@ with mitxonline_certificates as (
     left join incremental_watermarks w
         on w.watermark_platform = cwf.platform
         and w.watermark_certificate_type = cwf.certificate_scope
+    left join stale_user_fk_lookup as sufk
+        on sufk.certificate_key = {{ dbt_utils.generate_surrogate_key([
+            "cast(cwf.certificate_id as varchar)",
+            "cwf.platform",
+            "cwf.certificate_scope"
+        ]) }}
     where cwf._cross_source_row_num = 1
     and (
         w.max_activity_on is null  -- platform/type not yet in target, include all
         or coalesce(cwf.certificate_updated_on, cwf.certificate_created_on) >= w.max_activity_on
         or cwf.certificate_created_on is null
+        -- dim_user re-key: re-select rows whose resolved user_fk no longer matches the target
+        or sufk.stored_user_fk is distinct from cwf.user_fk
     )
     {% else %}
     where cwf._cross_source_row_num = 1

--- a/src/ol_dbt/models/dimensional/tfact_enrollment.sql
+++ b/src/ol_dbt/models/dimensional/tfact_enrollment.sql
@@ -305,6 +305,16 @@ with mitxonline_enrollments as (
     from {{ this }}
     group by platform, enrollment_type
 )
+
+-- Snapshot of the target's current (enrollment_key, user_fk) pairs, used to re-select rows
+-- whose user_fk has gone stale after a dim_user re-key (the source row itself did not
+-- change, so the activity-timestamp watermark alone would never catch it).
+, stale_user_fk_lookup as (
+    select
+        enrollment_key
+        , user_fk as stored_user_fk
+    from {{ this }}
+)
 {% endif %}
 
 , final as (
@@ -336,6 +346,12 @@ with mitxonline_enrollments as (
     left join incremental_watermarks w
         on w.watermark_platform = ewf.platform
         and w.watermark_enrollment_type = ewf.enrollment_scope
+    left join stale_user_fk_lookup as sufk
+        on sufk.enrollment_key = {{ dbt_utils.generate_surrogate_key([
+            "cast(ewf.enrollment_id as varchar)",
+            "ewf.platform",
+            "ewf.enrollment_scope"
+        ]) }}
     where (
         w.max_activity_on is null  -- platform/type not yet in target, include all
         -- Use >= for updated_on watermark: updated_on can equal max on state changes within same second
@@ -348,6 +364,8 @@ with mitxonline_enrollments as (
             and ewf.enrollment_created_on >= {{ cast_timestamp_to_iso8601("current_timestamp - interval '7' day") }}
         )
         or ewf.enrollment_created_on is null
+        -- dim_user re-key: re-select rows whose resolved user_fk no longer matches the target
+        or sufk.stored_user_fk is distinct from ewf.user_fk
     )
     {% endif %}
 )

--- a/src/ol_dbt/models/dimensional/tfact_feedback.sql
+++ b/src/ol_dbt/models/dimensional/tfact_feedback.sql
@@ -86,4 +86,13 @@ left join redacted
             and stale.feedback_text is null
             and redacted.text_redacted is not null
     )
+    -- dim_user re-key: a stored user_fk that no longer matches the current dim_user
+    -- resolution means the turn's subject_user_ref was re-keyed after ingestion, and
+    -- the source row's updated_at won't have moved to trigger the watermark above.
+    or exists (
+        select 1
+        from {{ this }} as stale
+        where stale.feedback_pk = {{ dbt_utils.generate_surrogate_key(['unioned.source_slug', 'unioned.source_record_ref']) }}
+            and stale.user_fk is distinct from users.user_pk
+    )
 {% endif %}

--- a/src/ol_dbt/models/dimensional/tfact_grade.sql
+++ b/src/ol_dbt/models/dimensional/tfact_grade.sql
@@ -130,6 +130,16 @@ with mitxonline_grades as (
     from {{ this }}
     group by platform
 )
+
+-- Snapshot of the target's current (grade_key, user_fk) pairs, used to re-select rows
+-- whose user_fk has gone stale after a dim_user re-key (the source row itself did not
+-- change, so the activity-timestamp watermark alone would never catch it).
+, stale_user_fk_lookup as (
+    select
+        grade_key
+        , user_fk as stored_user_fk
+    from {{ this }}
+)
 {% endif %}
 
 , final as (
@@ -152,12 +162,16 @@ with mitxonline_grades as (
     -- Left join preserves grades from platforms not yet in the target table
     left join incremental_watermarks w
         on w.watermark_platform = gwf.platform
+    left join stale_user_fk_lookup as sufk
+        on sufk.grade_key = {{ dbt_utils.generate_surrogate_key(["gwf.grade_id", "gwf.platform"]) }}
     where (
         w.max_activity_on is null  -- platform not yet in target, include all
         -- Use >= to capture updated_on changes within the same second as the watermark
         or coalesce(gwf.grade_updated_on, gwf.grade_created_on) >= w.max_activity_on
         -- edxorg has no timestamps; always re-ingest (delete+insert is idempotent)
         or gwf.grade_created_on is null
+        -- dim_user re-key: re-select rows whose resolved user_fk no longer matches the target
+        or sufk.stored_user_fk is distinct from gwf.user_fk
     )
     {% endif %}
 )

--- a/src/ol_dbt/models/dimensional/tfact_order.sql
+++ b/src/ol_dbt/models/dimensional/tfact_order.sql
@@ -226,6 +226,16 @@ with mitxonline_orders as (
     from {{ this }}
     group by platform
 )
+
+-- Snapshot of the target's current (order_key, user_fk) pairs, used to re-select rows
+-- whose user_fk has gone stale after a dim_user re-key (the source row itself did not
+-- change, so the activity-timestamp watermark alone would never catch it).
+, stale_user_fk_lookup as (
+    select
+        order_key
+        , user_fk as stored_user_fk
+    from {{ this }}
+)
 {% endif %}
 
 , final as (
@@ -261,10 +271,18 @@ with mitxonline_orders as (
     -- past MITx Online order creation times, which would cause silent data loss.
     -- left join preserves orders from platforms not yet in the target table
     left join incremental_watermarks w on w.watermark_platform = owf.platform
+    left join stale_user_fk_lookup as sufk
+        on sufk.order_key = {{ dbt_utils.generate_surrogate_key([
+            "cast(owf.order_id as varchar)",
+            "owf.line_id",
+            "owf.platform"
+        ]) }}
     where (
         w.max_updated_on is null  -- platform not yet in target, include all
         or owf.order_updated_on >= w.max_updated_on
         or owf.order_updated_on is null
+        -- dim_user re-key: re-select rows whose resolved user_fk no longer matches the target
+        or sufk.stored_user_fk is distinct from owf.user_fk
     )
     {% endif %}
 )

--- a/src/ol_dbt/models/dimensional/tfact_payment.sql
+++ b/src/ol_dbt/models/dimensional/tfact_payment.sql
@@ -115,6 +115,16 @@ with mitxonline_payments as (
     from {{ this }}
     group by platform
 )
+
+-- Snapshot of the target's current (payment_key, user_fk) pairs, used to re-select rows
+-- whose user_fk has gone stale after a dim_user re-key (the source row itself did not
+-- change, so the activity-timestamp watermark alone would never catch it).
+, stale_user_fk_lookup as (
+    select
+        payment_key
+        , user_fk as stored_user_fk
+    from {{ this }}
+)
 {% endif %}
 
 , final as (
@@ -139,10 +149,17 @@ with mitxonline_payments as (
     {% if is_incremental() %}
     -- left join preserves payments from platforms not yet in the target table
     left join incremental_watermarks w on w.watermark_platform = pwf.platform
+    left join stale_user_fk_lookup as sufk
+        on sufk.payment_key = {{ dbt_utils.generate_surrogate_key([
+            "cast(pwf.payment_id as varchar)",
+            "pwf.platform"
+        ]) }}
     where (
         w.max_created_on is null  -- platform not yet in target, include all
         or pwf.transaction_created_on > w.max_created_on
         or pwf.transaction_created_on is null
+        -- dim_user re-key: re-select rows whose resolved user_fk no longer matches the target
+        or sufk.stored_user_fk is distinct from pwf.user_fk
     )
     {% endif %}
 )


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
NA

### Description (What does it do?)
<!--- Describe your changes in detail -->
  - When `dim_user.user_pk` changes for a user (e.g. they're assigned a `user_global_id` later), the incremental tfact models keep the old user_fk forever. This fix ensures affected rows get picked up and corrected on the next incremental run.                                                                                                                                    
  - Adds a unit test per model proving the re-key catch-up actually fires.  



### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

```
dbt build --target dev_production --select tfact_payment tfact_certificate tfact_enrollment  tfact_grade tfact_order tfact_feedback                                    
dbt test --target dev_production --select test_type:unit
```
  All 5 fact tables verified against real production data: `tfact_certificate`, `tfact_enrollment`, `tfact_order`, `tfact_grade`, `tfact_payment`. In every case,  staled `user_fk`  produced the correct restored user_fk on  re-query.  

### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->

I noticed this issue when working on https://github.com/mitodl/hq/issues/13021. I fixed the immediate data problem with a full-refresh on 4 of the affected tfact_* incremental models, but that doesn't prevent it from happening again. This PR adds the defensive fix. 


<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
