### PR TITLE
feat(ingestion): dlt source for the MITx Online application database

### DIFF
--- a/dg_projects/data_loading/data_loading/defs/ingestion/assets.py
+++ b/dg_projects/data_loading/data_loading/defs/ingestion/assets.py
@@ -18,10 +18,11 @@ from ol_dlt.sources import (
     mit_climate,
     mit_edx_programs,
     mitpe,
+    mitxonline_app,
     oll,
     podcast_rss,
 )
-from ol_orchestrate.lib.constants import EDXORG_DB_TABLES
+from ol_orchestrate.lib.constants import DAGSTER_ENV, EDXORG_DB_TABLES
 from ol_orchestrate.lib.failures import with_failure_hooks
 
 from data_loading.defs.ingestion.translators import (
@@ -79,6 +80,36 @@ keycloak_assets = build_ingest_assets(
     name="keycloak_ingest",
     source=keycloak.build_source(),
     pipeline=keycloak.keycloak_pipeline,
+)
+# Environments where dlt owns the MITx Online app-database load.
+#
+# Production is deliberately absent, and it is not a preference. The Airbyte
+# connection "MITx Online Production App DB → S3 Data Lake" still loads that
+# unit there, and the lakehouse code location builds one asset per stream keyed
+# ol_warehouse_raw_data/raw__mitxonline__app__postgres__<table> -- byte-for-byte
+# the keys these dlt assets produce (definitions.py:182, and dagster_airbyte
+# keys on stream_prefix + stream_name). Registering both is a duplicate asset
+# key across two code locations, and two loaders writing one Iceberg table.
+#
+# QA has nothing to collide with: per the 2026-08-28 Airbyte snapshot its
+# connection is named "MITx Online QA Application DB → OL S3 Glue Data Lake -
+# QA", which the lakehouse selector (endswith "s3 data lake") drops, and it
+# still points at the legacy Glue destination that was never migrated to
+# Iceberg. That is why QA raw for this unit is frozen at 2025-01-19 despite the
+# connection being enabled, and it is what RFC 12711 step 8 exists to fix.
+#
+# Add "production" here in the SAME change that disables the Airbyte connection
+# and flips the inventory unit to `loader: dlt`. Never before.
+MITXONLINE_APP_DLT_ENVIRONMENTS = frozenset({"dev", "ci", "qa"})
+
+mitxonline_app_assets = (
+    build_ingest_assets(
+        name="mitxonline_app_ingest",
+        source=mitxonline_app.build_source(),
+        pipeline=mitxonline_app.mitxonline_app_pipeline,
+    )
+    if DAGSTER_ENV in MITXONLINE_APP_DLT_ENVIRONMENTS
+    else None
 )
 
 
@@ -140,6 +171,7 @@ defs = Definitions(
             mit_edx_programs_assets,
             podcast_rss_assets,
             keycloak_assets,
+            *([mitxonline_app_assets] if mitxonline_app_assets else []),
             *edxorg_s3_table_assets,
         ]
     ),

--- a/dg_projects/data_loading/data_loading/defs/ingestion/schedules.py
+++ b/dg_projects/data_loading/data_loading/defs/ingestion/schedules.py
@@ -1,6 +1,9 @@
 """Schedules for data_loading ingest pipelines."""
 
 import dagster as dg
+from ol_orchestrate.lib.constants import DAGSTER_ENV
+
+from data_loading.defs.ingestion.assets import MITXONLINE_APP_DLT_ENVIRONMENTS
 
 oll_ingest_schedule = dg.ScheduleDefinition(
     name="oll_ingest_daily_schedule",
@@ -57,6 +60,25 @@ keycloak_ingest_schedule = dg.ScheduleDefinition(
     execution_timezone="Etc/UTC",
 )
 
+# Defined only where the assets are (see MITXONLINE_APP_DLT_ENVIRONMENTS): a
+# schedule whose selection matches no asset fails the tick, it does not no-op.
+mitxonline_app_ingest_schedule = (
+    dg.ScheduleDefinition(
+        name="mitxonline_app_ingest_schedule",
+        # Selected by group rather than by key so adding a table to
+        # MITXONLINE_APP_SPEC does not also require editing this schedule.
+        target=dg.AssetSelection.groups("mitxonline"),
+        # Every six hours, matching the cadence of the Airbyte connection this
+        # replaces (inventory unit mitxonline/app_postgres,
+        # sync_interval_hours: 6). Offset off the hour so it does not start
+        # alongside the lakehouse dbt runs.
+        cron_schedule="20 */6 * * *",
+        execution_timezone="Etc/UTC",
+    )
+    if DAGSTER_ENV in MITXONLINE_APP_DLT_ENVIRONMENTS
+    else None
+)
+
 defs = dg.Definitions(
     schedules=[
         oll_ingest_schedule,
@@ -65,5 +87,6 @@ defs = dg.Definitions(
         mit_edx_programs_ingest_schedule,
         podcast_rss_ingest_schedule,
         keycloak_ingest_schedule,
+        *([mitxonline_app_ingest_schedule] if mitxonline_app_ingest_schedule else []),
     ],
 )

--- a/dg_projects/data_loading/data_loading_tests/test_definitions.py
+++ b/dg_projects/data_loading/data_loading_tests/test_definitions.py
@@ -7,10 +7,75 @@ Docker/gRPC round-trip. Importing under the default (dev) profile is hermetic â€
 pipeline/destination objects are constructed but nothing connects to S3/Glue.
 """
 
+import importlib
+import os
+import sys
+from collections.abc import Iterator
+from contextlib import contextmanager
+from typing import Any
+
+import pytest
 from data_loading.definitions import defs
 from data_loading.defs.ingestion.assets import MITXONLINE_APP_DLT_ENVIRONMENTS
 
 _REPO = defs.get_repository_def()
+
+# Packages whose module-level code reads DAGSTER_ENVIRONMENT, so a build under
+# a different environment has to re-import them rather than reuse what the
+# module-level import above cached.
+_ENVIRONMENT_SENSITIVE_ROOTS = frozenset({"data_loading", "ol_orchestrate"})
+
+# The three tables RFC 12711 step 8's pilot slice reads.
+_B2B_PILOT_ASSET_KEYS = (
+    "ol_warehouse_raw_data/raw__mitxonline__app__postgres__b2b_organizationpage",
+    "ol_warehouse_raw_data/raw__mitxonline__app__postgres__b2b_contractpage",
+    "ol_warehouse_raw_data/raw__mitxonline__app__postgres__courses_courserun",
+)
+
+
+@contextmanager
+def _repository_for(environment: str) -> Iterator[Any]:
+    """Build the code location as the gRPC server would under ``environment``.
+
+    ``DAGSTER_ENV`` is resolved once, at import of
+    ``ol_orchestrate.lib.constants``, and the ingestion modules read it at
+    their own import -- so an environment gate can only be exercised by
+    re-importing the tree with the variable set. Asserting on the gate's
+    constant instead would stay green if somebody dropped the conditional it
+    guards, which is the regression worth catching.
+
+    ``DLT_PROFILE`` is pinned to ``dev`` so the re-import stays hermetic: the
+    destination objects are constructed either way, and a production one has
+    no business being built in a test.
+    """
+    saved_modules = {
+        name: module
+        for name, module in sys.modules.items()
+        if name.split(".")[0] in _ENVIRONMENT_SENSITIVE_ROOTS
+    }
+    saved_env = {
+        key: os.environ.get(key) for key in ("DAGSTER_ENVIRONMENT", "DLT_PROFILE")
+    }
+
+    def _purge() -> None:
+        for name in list(sys.modules):
+            if name.split(".")[0] in _ENVIRONMENT_SENSITIVE_ROOTS:
+                del sys.modules[name]
+
+    os.environ["DAGSTER_ENVIRONMENT"] = environment
+    os.environ["DLT_PROFILE"] = "dev"
+    _purge()
+    try:
+        module = importlib.import_module("data_loading.definitions")
+        yield module.defs.get_repository_def()
+    finally:
+        _purge()
+        sys.modules.update(saved_modules)
+        for key, value in saved_env.items():
+            if value is None:
+                os.environ.pop(key, None)
+            else:
+                os.environ[key] = value
 
 
 def test_code_location_builds() -> None:
@@ -42,20 +107,24 @@ def test_dlt_resource_present() -> None:
     assert "dlt" in defs.resources
 
 
-def test_mitxonline_app_assets_load_outside_production() -> None:
-    """The MITx Online app tables are dlt assets everywhere dlt owns them.
+@pytest.mark.parametrize("environment", sorted(MITXONLINE_APP_DLT_ENVIRONMENTS))
+def test_mitxonline_app_assets_load_where_dlt_owns_the_unit(environment: str) -> None:
+    """Every environment in the gate really does get the assets and schedule.
 
-    Tests import under the default ``dev`` profile, which is inside
-    ``MITXONLINE_APP_DLT_ENVIRONMENTS``, so the assets must be here.
+    Parameterized over the gate itself, and each case builds under that
+    environment explicitly, so the result does not depend on whichever
+    environment the test runner happens to be in.
     """
-    asset_keys = {k.to_user_string() for k in _REPO.assets_defs_by_key}
-    for expected in (
-        "ol_warehouse_raw_data/raw__mitxonline__app__postgres__b2b_organizationpage",
-        "ol_warehouse_raw_data/raw__mitxonline__app__postgres__b2b_contractpage",
-        "ol_warehouse_raw_data/raw__mitxonline__app__postgres__courses_courserun",
-    ):
-        assert expected in asset_keys
-    assert "mitxonline_app_ingest_schedule" in {s.name for s in _REPO.schedule_defs}
+    with _repository_for(environment) as repo:
+        asset_keys = {key.to_user_string() for key in repo.assets_defs_by_key}
+        assert set(_B2B_PILOT_ASSET_KEYS) <= asset_keys
+        assert (
+            len(
+                [key for key in asset_keys if "raw__mitxonline__app__postgres__" in key]
+            )
+            == 64
+        )
+        assert "mitxonline_app_ingest_schedule" in {s.name for s in repo.schedule_defs}
 
 
 def test_mitxonline_app_dlt_does_not_run_in_production() -> None:
@@ -65,7 +134,18 @@ def test_mitxonline_app_dlt_does_not_run_in_production() -> None:
     ``ol_warehouse_raw_data`` and keys it on the connection prefix plus the
     stream name -- exactly the keys these dlt assets produce. Two code
     locations claiming one asset key, and two loaders writing one Iceberg
-    table. Adding ``production`` here is only correct in the same change that
-    disables the Airbyte connection.
+    table. Adding ``production`` to the gate is only correct in the same change
+    that disables the Airbyte connection.
+
+    Builds the code location under ``production`` rather than inspecting the
+    gate's constant: dropping the conditional the constant guards is the
+    regression this exists to catch, and a constant-only assertion would not
+    notice.
     """
-    assert "production" not in MITXONLINE_APP_DLT_ENVIRONMENTS
+    with _repository_for("production") as repo:
+        asset_keys = {key.to_user_string() for key in repo.assets_defs_by_key}
+        assert asset_keys, "code location exposed no assets under production"
+        assert not [key for key in asset_keys if "mitxonline" in key]
+        assert "mitxonline_app_ingest_schedule" not in {
+            s.name for s in repo.schedule_defs
+        }

--- a/dg_projects/data_loading/data_loading_tests/test_definitions.py
+++ b/dg_projects/data_loading/data_loading_tests/test_definitions.py
@@ -8,6 +8,7 @@ pipeline/destination objects are constructed but nothing connects to S3/Glue.
 """
 
 from data_loading.definitions import defs
+from data_loading.defs.ingestion.assets import MITXONLINE_APP_DLT_ENVIRONMENTS
 
 _REPO = defs.get_repository_def()
 
@@ -39,3 +40,32 @@ def test_schedules_and_sensors_load() -> None:
 
 def test_dlt_resource_present() -> None:
     assert "dlt" in defs.resources
+
+
+def test_mitxonline_app_assets_load_outside_production() -> None:
+    """The MITx Online app tables are dlt assets everywhere dlt owns them.
+
+    Tests import under the default ``dev`` profile, which is inside
+    ``MITXONLINE_APP_DLT_ENVIRONMENTS``, so the assets must be here.
+    """
+    asset_keys = {k.to_user_string() for k in _REPO.assets_defs_by_key}
+    for expected in (
+        "ol_warehouse_raw_data/raw__mitxonline__app__postgres__b2b_organizationpage",
+        "ol_warehouse_raw_data/raw__mitxonline__app__postgres__b2b_contractpage",
+        "ol_warehouse_raw_data/raw__mitxonline__app__postgres__courses_courserun",
+    ):
+        assert expected in asset_keys
+    assert "mitxonline_app_ingest_schedule" in {s.name for s in _REPO.schedule_defs}
+
+
+def test_mitxonline_app_dlt_does_not_run_in_production() -> None:
+    """Production still loads this unit through Airbyte, and the keys collide.
+
+    The lakehouse code location prefixes every Airbyte stream asset with
+    ``ol_warehouse_raw_data`` and keys it on the connection prefix plus the
+    stream name -- exactly the keys these dlt assets produce. Two code
+    locations claiming one asset key, and two loaders writing one Iceberg
+    table. Adding ``production`` here is only correct in the same change that
+    disables the Airbyte connection.
+    """
+    assert "production" not in MITXONLINE_APP_DLT_ENVIRONMENTS

--- a/ingestion/inventory/units/mitxonline__app_postgres.yml
+++ b/ingestion/inventory/units/mitxonline__app_postgres.yml
@@ -6,7 +6,7 @@ deployment: mitxonline
 layer: app_postgres
 scope: scoped
 strategies:
-  qa: omit
+  qa: ingest
   local: fixture
 loader: airbyte
 table_prefix: raw__mitxonline__app__postgres__

--- a/src/ol_dlt/ol_dlt/sources/mitxonline_app/__init__.py
+++ b/src/ol_dlt/ol_dlt/sources/mitxonline_app/__init__.py
@@ -1,0 +1,172 @@
+"""MITx Online application-database ingestion via dlt.
+
+Replaces the Airbyte connection ``MITx Online Production App DB → S3 Data Lake``
+(RFC 12319 §6.5, RFC 12711 step 8). Scope is the 64 tables that connection
+declares, which is also what the inventory unit ``mitxonline/app_postgres``
+records.
+
+Data flow:
+    MITx Online RDS Postgres  ->  raw__mitxonline__app__postgres__<table>
+
+The database read is aligned with the deployment: QA Dagster reads the QA
+MITx Online database, production reads production, and local development reads
+the ``mitxonline`` database in the local-dev CloudNativePG cluster (see
+``ol_dlt.database``). That alignment is the point of the migration for RFC
+12711: the B2B dimensional models key on Keycloak organization UUIDs
+(``users_user.global_id``, ``b2b_organizationpage``), so a QA build has to read
+the QA app database or nothing joins.
+
+Every table is loaded with ``write_disposition="replace"``; none declares a
+``cursor_column``. Airbyte replicated 36 of these incrementally by ``xmin``,
+which dlt has no practical equivalent for (INGESTION_INVENTORY_SPEC.md §3.4),
+so each of them needed either a replacement cursor or a decision to re-read it
+whole. They are all re-read whole, for three measured reasons:
+
+    Affordable.  The whole unit is 16.5M rows / 1.01 GB across 64 tables at the
+        current Iceberg snapshot (production Glue, 2026-08-31). The largest
+        table, ``openedx_openedxuser``, is 2.7M rows / 126 MB.
+    Not safely keyable.  39 tables carry ``updated_on``, but that is Django's
+        ``auto_now=True``, which fires on ``Model.save()`` and NOT on
+        ``queryset.update()``. Nobody has audited MITx Online's bulk-update
+        paths, and `ol-dbt inventory cursors` reports a candidate column, never
+        an approval -- see the caveat in ``ol_dbt_cli/lib/cursor_audit.py``. A
+        cursor that misses an edit yields a load that looks healthy and drifts.
+    Deletes matter here.  Replace is the only disposition that propagates a
+        source delete. Unlinking an organization from a contract, or retiring a
+        contract, has to disappear from ``dim_organization`` /
+        ``dim_contract``; a ``merge`` load would leave the row behind forever.
+
+Incrementality is a per-table optimization to revisit once the bulk-update
+paths are audited. Run ``ol-dbt inventory cursors --unit mitxonline/app_postgres
+--attention-only`` for the current shortlist; the tables that would actually pay
+for the audit are ``openedx_openedxuser``, ``courses_courserunenrollment`` and
+``courses_courserungrade``, which are 55% of the unit's rows between them.
+
+The Wagtail page subclasses (``b2b_contractpage``, ``b2b_organizationpage``,
+``cms_coursepage``, ...) cannot be incrementalised at all, structurally: they
+are multi-table-inheritance children joined to ``wagtailcore_page`` on
+``page_ptr_id`` and carry no timestamp of their own.
+
+``users_user.password`` is excluded. It is a Django PBKDF2 hash, it is landing
+in the production warehouse today, and no dbt model selects it -- only the
+source YAML declares it, and that declaration goes at cutover.
+
+Run standalone against local-dev (port-forward the CNPG cluster first):
+    kubectl port-forward -n local-infra svc/local-pg-rw 5432:5432
+    DLT_PROFILE=dev python -m ol_dlt.sources.mitxonline_app
+"""
+
+from typing import Any
+
+from ol_dlt.database import (
+    DatabaseSourceSpec,
+    DatabaseTable,
+    build_database_source,
+    pipeline_for,
+)
+
+MITXONLINE_APP_SPEC = DatabaseSourceSpec(
+    name="mitxonline_app",
+    raw_table_prefix="raw__mitxonline__app__postgres__",
+    database="mitxonline",
+    vault_mount="postgres-mitxonline",
+    tables=(
+        # --- B2B: organizations, contracts, and their attachments -----------
+        # The reason this source exists first. dim_organization and
+        # dim_contract read these, and their keys are realm-scoped.
+        DatabaseTable(name="b2b_contractpage", primary_key="page_ptr_id"),
+        DatabaseTable(
+            name="b2b_discountcontractattachmentredemption", primary_key="id"
+        ),
+        DatabaseTable(name="b2b_organizationindexpage", primary_key="page_ptr_id"),
+        DatabaseTable(name="b2b_organizationpage", primary_key="page_ptr_id"),
+        DatabaseTable(name="b2b_userorganization", primary_key="id"),
+        # --- CMS: Wagtail page subclasses -----------------------------------
+        DatabaseTable(name="cms_certificatepage", primary_key="page_ptr_id"),
+        DatabaseTable(name="cms_courseindexpage", primary_key="page_ptr_id"),
+        DatabaseTable(name="cms_coursepage", primary_key="page_ptr_id"),
+        DatabaseTable(name="cms_coursepage_topics", primary_key="id"),
+        DatabaseTable(name="cms_instructorpage", primary_key="page_ptr_id"),
+        DatabaseTable(name="cms_instructorpagelink", primary_key="id"),
+        DatabaseTable(name="cms_programpage", primary_key="page_ptr_id"),
+        DatabaseTable(name="cms_signatoryindexpage", primary_key="page_ptr_id"),
+        DatabaseTable(name="cms_signatorypage", primary_key="page_ptr_id"),
+        # --- courses: catalog, runs, enrollments, grades, certificates ------
+        DatabaseTable(name="courses_blockedcountry", primary_key="id"),
+        DatabaseTable(name="courses_course", primary_key="id"),
+        DatabaseTable(name="courses_course_departments", primary_key="id"),
+        DatabaseTable(name="courses_courserun", primary_key="id"),
+        DatabaseTable(name="courses_courseruncertificate", primary_key="id"),
+        DatabaseTable(name="courses_courserunenrollment", primary_key="id"),
+        DatabaseTable(name="courses_courserunenrollmentaudit", primary_key="id"),
+        DatabaseTable(name="courses_courserungrade", primary_key="id"),
+        DatabaseTable(name="courses_courserungradeaudit", primary_key="id"),
+        DatabaseTable(name="courses_coursestopic", primary_key="id"),
+        DatabaseTable(name="courses_department", primary_key="id"),
+        DatabaseTable(
+            name="courses_learnerprogramrecordshare", primary_key="share_uuid"
+        ),
+        DatabaseTable(name="courses_paidcourserun", primary_key="id"),
+        DatabaseTable(name="courses_partnerschool", primary_key="id"),
+        DatabaseTable(name="courses_program", primary_key="id"),
+        DatabaseTable(name="courses_program_departments", primary_key="id"),
+        DatabaseTable(name="courses_programcertificate", primary_key="id"),
+        DatabaseTable(name="courses_programenrollment", primary_key="id"),
+        DatabaseTable(name="courses_programenrollmentaudit", primary_key="id"),
+        DatabaseTable(name="courses_programrequirement", primary_key="id"),
+        DatabaseTable(name="courses_programrun", primary_key="id"),
+        DatabaseTable(name="courses_relatedprogram", primary_key="id"),
+        # --- Django plumbing the models actually resolve against ------------
+        DatabaseTable(name="django_content_type", primary_key="id"),
+        # --- ecommerce: baskets, orders, discounts, transactions ------------
+        DatabaseTable(name="ecommerce_basket", primary_key="id"),
+        DatabaseTable(name="ecommerce_basketdiscount", primary_key="id"),
+        DatabaseTable(name="ecommerce_basketitem", primary_key="id"),
+        DatabaseTable(name="ecommerce_discount", primary_key="id"),
+        DatabaseTable(name="ecommerce_discountproduct", primary_key="id"),
+        DatabaseTable(name="ecommerce_discountredemption", primary_key="id"),
+        DatabaseTable(name="ecommerce_line", primary_key="id"),
+        DatabaseTable(name="ecommerce_order", primary_key="id"),
+        DatabaseTable(name="ecommerce_product", primary_key="id"),
+        DatabaseTable(name="ecommerce_transaction", primary_key="id"),
+        DatabaseTable(name="ecommerce_userdiscount", primary_key="id"),
+        # --- flexible pricing ------------------------------------------------
+        DatabaseTable(name="flexiblepricing_countryincomethreshold", primary_key="id"),
+        DatabaseTable(name="flexiblepricing_currencyexchangerate", primary_key="id"),
+        DatabaseTable(name="flexiblepricing_flexibleprice", primary_key="id"),
+        DatabaseTable(name="flexiblepricing_flexiblepricetier", primary_key="id"),
+        DatabaseTable(
+            name="flexiblepricing_flexiblepricingrequestsubmission", primary_key="id"
+        ),
+        # --- Open edX linkage --------------------------------------------------
+        DatabaseTable(name="openedx_openedxuser", primary_key="id"),
+        # --- django-reversion audit trail ---------------------------------------
+        DatabaseTable(name="reversion_revision", primary_key="id"),
+        DatabaseTable(name="reversion_version", primary_key="id"),
+        # --- users and profiles --------------------------------------------------
+        DatabaseTable(name="users_legaladdress", primary_key="id"),
+        DatabaseTable(
+            name="users_user",
+            primary_key="id",
+            # Django PBKDF2 password hash. Credential material with no
+            # analytical use, on the same footing as Keycloak's `credential`
+            # table. It lands in the production warehouse today and nothing
+            # reads it; stop carrying it.
+            excluded_columns=("password",),
+        ),
+        DatabaseTable(name="users_user_b2b_contracts", primary_key="id"),
+        DatabaseTable(name="users_userprofile", primary_key="id"),
+        # --- Wagtail core ----------------------------------------------------------
+        DatabaseTable(name="wagtailcore_page", primary_key="id"),
+        DatabaseTable(name="wagtailcore_revision", primary_key="id"),
+        DatabaseTable(name="wagtailimages_image", primary_key="id"),
+        DatabaseTable(name="wagtailusers_userprofile", primary_key="id"),
+    ),
+)
+
+mitxonline_app_pipeline = pipeline_for(MITXONLINE_APP_SPEC)
+
+
+def build_source(tables: list[str] | None = None) -> Any:  # noqa: ANN401
+    """Instantiate the MITx Online app source (uniform entrypoint for Dagster)."""
+    return build_database_source(MITXONLINE_APP_SPEC, tables=tables)

--- a/src/ol_dlt/ol_dlt/sources/mitxonline_app/__main__.py
+++ b/src/ol_dlt/ol_dlt/sources/mitxonline_app/__main__.py
@@ -1,0 +1,14 @@
+"""Standalone smoke run: ``DLT_PROFILE=dev python -m ol_dlt.sources.mitxonline_app``.
+
+Requires the local-dev Postgres cluster to be reachable, e.g.
+``kubectl port-forward -n local-infra svc/local-pg-rw 5432:5432``.
+"""
+
+import logging
+
+from ol_dlt.sources.mitxonline_app import build_source, mitxonline_app_pipeline
+
+logging.basicConfig(level=logging.INFO)
+logging.getLogger(__name__).info(
+    "Pipeline completed: %s", mitxonline_app_pipeline.run(build_source())
+)

--- a/src/ol_dlt/tests/sources/test_mitxonline_app.py
+++ b/src/ol_dlt/tests/sources/test_mitxonline_app.py
@@ -1,0 +1,90 @@
+"""Tests for the MITx Online application-database source."""
+
+from pathlib import Path
+
+import yaml
+
+from ol_dlt.sources import mitxonline_app
+
+# src/ol_dlt/tests/sources/ -> repo root.
+INVENTORY_UNIT = (
+    Path(__file__).parents[4]
+    / "ingestion"
+    / "inventory"
+    / "units"
+    / "mitxonline__app_postgres.yml"
+)
+
+# RFC 12711 step 8's pilot slice. dim_organization, dim_contract and
+# bridge_organization_courserun read exactly these three, so a source that
+# drops one silently produces a partial B2B dimensional build.
+B2B_PILOT_TABLES = frozenset(
+    {"b2b_organizationpage", "b2b_contractpage", "courses_courserun"}
+)
+
+
+def _inventory_streams() -> set[str]:
+    unit = yaml.safe_load(INVENTORY_UNIT.read_text())
+    return {table["name"] for table in unit["tables"]}
+
+
+def test_spec_matches_the_inventory_unit() -> None:
+    """The source and the inventory unit must declare the same tables.
+
+    This is the whole point of the inventory (RFC 12319 §2): the declaration
+    and the loader cannot disagree. A table added to one and not the other is a
+    dbt model that quietly goes stale, with no error anywhere.
+    """
+    assert {
+        table.name for table in mitxonline_app.MITXONLINE_APP_SPEC.tables
+    } == _inventory_streams()
+
+
+def test_b2b_pilot_upstreams_are_covered() -> None:
+    selected = {table.name for table in mitxonline_app.MITXONLINE_APP_SPEC.tables}
+    assert B2B_PILOT_TABLES <= selected
+
+
+def test_password_hash_is_excluded() -> None:
+    """``users_user.password`` is a Django PBKDF2 hash, not analytical data.
+
+    It lands in the production warehouse today and no model reads it. Same
+    footing as Keycloak's ``client.secret``.
+    """
+    users_user = next(
+        table
+        for table in mitxonline_app.MITXONLINE_APP_SPEC.tables
+        if table.name == "users_user"
+    )
+    assert "password" in users_user.excluded_columns
+
+
+def test_no_table_declares_a_cursor() -> None:
+    """Every table is re-read whole -- see the module docstring for why.
+
+    39 tables carry ``updated_on``, but that is Django ``auto_now=True``, which
+    does not fire on ``queryset.update()``, and MITx Online's bulk-update paths
+    have not been audited. Adopting a cursor here must be a deliberate,
+    reviewed act per table rather than a bulk sweep, so pin the current state.
+    """
+    assert not [
+        table.name
+        for table in mitxonline_app.MITXONLINE_APP_SPEC.tables
+        if table.cursor_column
+    ]
+
+
+def test_every_table_declares_a_primary_key() -> None:
+    assert all(table.primary_key for table in mitxonline_app.MITXONLINE_APP_SPEC.tables)
+
+
+def test_resources_follow_the_raw_naming_convention() -> None:
+    source = mitxonline_app.build_source()
+    assert "raw__mitxonline__app__postgres__b2b_organizationpage" in source.resources
+    assert all(
+        name.startswith("raw__mitxonline__app__postgres__") for name in source.resources
+    )
+
+
+def test_pipeline_targets_the_mitxonline_app_prefix() -> None:
+    assert mitxonline_app.mitxonline_app_pipeline.pipeline_name == "mitxonline_app"


### PR DESCRIPTION
RFC 12711 step 8. Builds the dlt source that replaces the Airbyte connection for the `mitxonline/app_postgres` ingestion unit, and wires it into the `data_loading` code location. The cutover itself is a follow-up (below).

## Why not repair the Airbyte path

Per the 2026-08-28 Airbyte snapshot, the QA connection `MITx Online QA Application DB → OL S3 Glue Data Lake - QA` is *enabled* and still writes through the legacy Glue destination that was never migrated to Iceberg. That is why QA `raw__mitxonline__app__postgres__*` is frozen at 2025-01-19 while the connection reads as active, and why the B2B dashboard in RC has no QA-realm rows to join. Connection config is hand-managed today — there is no `airbyte_connections` Pulumi stack, and #2608 strikes the spec steps that would have added one — so anything fixed in the UI is undeclared the moment it is saved.

## Scope

The 64 tables the inventory unit declares. `test_spec_matches_the_inventory_unit` asserts the source and the unit stay in agreement: a table in one and not the other is a dbt model that quietly goes stale.

## Every table is `replace`

Airbyte replicated 36 of these incrementally by `xmin`, which dlt has no practical equivalent for (spec §3.4), so each needed a replacement cursor or a decision to re-read it whole. All are re-read whole:

- **Affordable.** Summed from the current production Iceberg snapshots (Glue, 2026-08-31): 16.5M rows / 1.01 GB across the 64 tables. Largest is `openedx_openedxuser` at 2.7M rows / 126 MB.
- **Not safely keyable.** `ol-dbt inventory cursors --unit mitxonline/app_postgres` finds `updated_on` on 39 tables, but that is Django `auto_now=True`, which fires on `Model.save()` and not on `queryset.update()`. MITx Online's bulk-update paths have not been audited, and the check reports a candidate, never an approval.
- **Deletes matter.** `replace` is the only disposition that propagates a source delete. Unlinking an organization from a contract has to disappear from `dim_organization` / `dim_contract`.

The Wagtail page subclasses (`b2b_contractpage`, `b2b_organizationpage`, `cms_coursepage`, …) cannot be incrementalised at all: they are multi-table-inheritance children joined to `wagtailcore_page` on `page_ptr_id` and carry no timestamp of their own.

## `users_user.password` is dropped

A Django PBKDF2 hash, landing in the production warehouse today, selected by no dbt model. It is still declared as a source column in `_mitxonline__sources.yml`; that declaration is removed at cutover, when the column stops landing in production too.

## The assets are gated to non-production

`MITXONLINE_APP_DLT_ENVIRONMENTS = {"dev", "ci", "qa"}`. Production is excluded because the Airbyte connection still runs there and `lakehouse` builds an asset per stream keyed `ol_warehouse_raw_data/raw__mitxonline__app__postgres__<table>` (`dg_projects/lakehouse/lakehouse/definitions.py:182`, and `dagster_airbyte`'s translator keys on connection prefix + stream name) — byte-for-byte the keys these dlt assets produce. Registering both puts one asset key in two code locations and two loaders on one Iceberg table. QA has nothing to collide with: its connection name does not end in `s3 data lake`, so the lakehouse selector drops it.

## Follow-ups, in order

1. **Companion PR in mitodl/ol-infrastructure** — passes `MITXONLINE_APP_DB_HOST` through to `data_loading` and grants the dagster Vault policy read on `postgres-mitxonline/creds/readonly`. Required before the QA pipeline can connect.
2. Run the QA pipeline; confirm `b2b_organizationpage`, `b2b_contractpage` and `courses_courserun` land in `ol_warehouse_qa_raw`.
3. Add `"qa"` to `DBT_AUTOMATION_ENVIRONMENTS` and run the QA dbt DAG through `dimensional`; verify `dim_organization` carries QA-realm Keycloak org UUIDs that join to the QA MITx Online app.
4. **Cutover, as one change:** disable the production Airbyte connection, add `"production"` to `MITXONLINE_APP_DLT_ENVIRONMENTS`, flip the inventory unit to `loader: dlt` with a `dlt:` block and `strategies.qa: ingest`, and drop the `password` source column. The inventory must not claim dlt owns a unit Airbyte is still loading.

## Incidental finding

`raw__mitxonline__app__postgres__b2b_contractpage_programs` (20 rows) is landed in production Glue but absent from the inventory unit's table list. Not touched here; it belongs to `ol-dbt inventory reconcile`.

## Testing

- `pytest src/ol_dlt/tests` — 97 passed
- `pytest dg_projects/data_loading/data_loading_tests` — 20 passed
- Definitions build verified both ways: 64 mitxonline assets under `DAGSTER_ENVIRONMENT=dev`, 0 under `production`.
- `pre-commit run` on the changed files — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P6BpXQenXw1t9ao2KWxeoX