### PR TITLE
Stage the forum-v2 MySQL tables for all three deployments

### DIFF
--- a/ingestion/inventory/units/mitx__mysql.yml
+++ b/ingestion/inventory/units/mitx__mysql.yml
@@ -403,21 +403,21 @@ tables:
   namespace: edxapp
   primary_key:
   - - id
-  modeled: false
+  modeled: true
 - name: forum_comment
   raw_table: raw__mitx__openedx__mysql__forum_comment
   sync_mode: full_refresh_overwrite
   namespace: edxapp
   primary_key:
   - - id
-  modeled: false
+  modeled: true
 - name: forum_commentthread
   raw_table: raw__mitx__openedx__mysql__forum_commentthread
   sync_mode: full_refresh_overwrite
   namespace: edxapp
   primary_key:
   - - id
-  modeled: false
+  modeled: true
 - name: forum_coursestat
   raw_table: raw__mitx__openedx__mysql__forum_coursestat
   sync_mode: full_refresh_overwrite
@@ -445,7 +445,7 @@ tables:
   namespace: edxapp
   primary_key:
   - - id
-  modeled: false
+  modeled: true
 - name: forum_lastreadtime
   raw_table: raw__mitx__openedx__mysql__forum_lastreadtime
   sync_mode: full_refresh_overwrite
@@ -459,7 +459,7 @@ tables:
   namespace: edxapp
   primary_key:
   - - id
-  modeled: false
+  modeled: true
 - name: forum_readstate
   raw_table: raw__mitx__openedx__mysql__forum_readstate
   sync_mode: full_refresh_overwrite
@@ -480,7 +480,7 @@ tables:
   namespace: edxapp
   primary_key:
   - - id
-  modeled: false
+  modeled: true
 - name: grades_persistentcoursegrade
   raw_table: raw__mitx__openedx__mysql__grades_persistentcoursegrade
   sync_mode: incremental_deduped_history

--- a/ingestion/inventory/units/mitxonline__mysql.yml
+++ b/ingestion/inventory/units/mitxonline__mysql.yml
@@ -348,21 +348,21 @@ tables:
   namespace: edxapp
   primary_key:
   - - id
-  modeled: false
+  modeled: true
 - name: forum_comment
   raw_table: raw__mitxonline__openedx__mysql__forum_comment
   sync_mode: full_refresh_overwrite
   namespace: edxapp
   primary_key:
   - - id
-  modeled: false
+  modeled: true
 - name: forum_commentthread
   raw_table: raw__mitxonline__openedx__mysql__forum_commentthread
   sync_mode: full_refresh_overwrite
   namespace: edxapp
   primary_key:
   - - id
-  modeled: false
+  modeled: true
 - name: forum_coursestat
   raw_table: raw__mitxonline__openedx__mysql__forum_coursestat
   sync_mode: full_refresh_overwrite
@@ -390,7 +390,7 @@ tables:
   namespace: edxapp
   primary_key:
   - - id
-  modeled: false
+  modeled: true
 - name: forum_lastreadtime
   raw_table: raw__mitxonline__openedx__mysql__forum_lastreadtime
   sync_mode: full_refresh_overwrite
@@ -404,7 +404,7 @@ tables:
   namespace: edxapp
   primary_key:
   - - id
-  modeled: false
+  modeled: true
 - name: forum_readstate
   raw_table: raw__mitxonline__openedx__mysql__forum_readstate
   sync_mode: full_refresh_overwrite
@@ -425,7 +425,7 @@ tables:
   namespace: edxapp
   primary_key:
   - - id
-  modeled: false
+  modeled: true
 - name: grades_persistentcoursegrade
   raw_table: raw__mitxonline__openedx__mysql__grades_persistentcoursegrade
   sync_mode: incremental_deduped_history

--- a/ingestion/inventory/units/xpro__mysql.yml
+++ b/ingestion/inventory/units/xpro__mysql.yml
@@ -371,21 +371,21 @@ tables:
   namespace: edxapp
   primary_key:
   - - id
-  modeled: false
+  modeled: true
 - name: forum_comment
   raw_table: raw__xpro__openedx__mysql__forum_comment
   sync_mode: full_refresh_overwrite
   namespace: edxapp
   primary_key:
   - - id
-  modeled: false
+  modeled: true
 - name: forum_commentthread
   raw_table: raw__xpro__openedx__mysql__forum_commentthread
   sync_mode: full_refresh_overwrite
   namespace: edxapp
   primary_key:
   - - id
-  modeled: false
+  modeled: true
 - name: forum_coursestat
   raw_table: raw__xpro__openedx__mysql__forum_coursestat
   sync_mode: full_refresh_overwrite
@@ -413,7 +413,7 @@ tables:
   namespace: edxapp
   primary_key:
   - - id
-  modeled: false
+  modeled: true
 - name: forum_lastreadtime
   raw_table: raw__xpro__openedx__mysql__forum_lastreadtime
   sync_mode: full_refresh_overwrite
@@ -427,7 +427,7 @@ tables:
   namespace: edxapp
   primary_key:
   - - id
-  modeled: false
+  modeled: true
 - name: forum_readstate
   raw_table: raw__xpro__openedx__mysql__forum_readstate
   sync_mode: full_refresh_overwrite
@@ -448,7 +448,7 @@ tables:
   namespace: edxapp
   primary_key:
   - - id
-  modeled: false
+  modeled: true
 - name: grades_persistentcoursegrade
   raw_table: raw__xpro__openedx__mysql__grades_persistentcoursegrade
   sync_mode: incremental_deduped_history

--- a/src/ol_dbt/models/staging/mitxonline/_mitxonline__sources.yml
+++ b/src/ol_dbt/models/staging/mitxonline/_mitxonline__sources.yml
@@ -2190,3 +2190,175 @@ sources:
       description: int, foreign key to users_user for the user who uploaded the image
     - name: description
       description: str, optional description of the image
+  - name: raw__mitxonline__openedx__mysql__forum_commentthread
+    description: MITx Online open edX discussion forum threads
+    columns:
+    - name: id
+      description: int, the auto-incremented ID for this table
+    - name: author_id
+      description: int, foreign key to auth_user for the thread author
+    - name: author_username
+      description: str, username of the thread author
+    - name: retired_username
+      description: str, placeholder username left behind when the author has been
+        retired
+    - name: course_id
+      description: str, Open edX Course ID in the format course-v1:{org}+{course code}+{run_tag}
+    - name: title
+      description: str, the thread title as authored by the learner
+    - name: body
+      description: str, free-text thread body authored by the learner
+    - name: thread_type
+      description: str, discussion or question
+    - name: commentable_id
+      description: str, id of the discussion topic the thread was posted under
+    - name: context
+      description: str, where the thread lives, e.g. course
+    - name: group_id
+      description: int, cohort the thread is scoped to, null when visible to everyone
+    - name: closed
+      description: boolean, whether the thread has been closed to further replies
+    - name: closed_by_id
+      description: int, foreign key to auth_user for whoever closed the thread
+    - name: close_reason_code
+      description: str, reason code recorded when the thread was closed
+    - name: pinned
+      description: boolean, whether the thread is pinned to the top of its topic
+    - name: visible
+      description: boolean, whether the thread is visible, used as a soft delete
+    - name: endorsed
+      description: boolean, whether the thread has an endorsed response
+    - name: anonymous
+      description: boolean, whether the thread was posted anonymously
+    - name: anonymous_to_peers
+      description: boolean, whether the thread is anonymous to other learners but
+        not to staff
+    - name: created_at
+      description: timestamp, when the thread was posted
+    - name: updated_at
+      description: timestamp, when the thread was last edited
+    - name: last_activity_at
+      description: timestamp, when the thread last saw any activity
+  - name: raw__mitxonline__openedx__mysql__forum_comment
+    description: MITx Online open edX discussion forum responses and comments
+    columns:
+    - name: id
+      description: int, the auto-incremented ID for this table
+    - name: comment_thread_id
+      description: int, foreign key to forum_commentthread. This is the thread association;
+        in the pre-migration Mongo data the equivalent field held an ObjectId string
+        rather than an integer
+    - name: parent_id
+      description: int, foreign key to forum_comment for the response this comment
+        replies to. Null for a top-level response to the thread
+    - name: author_id
+      description: int, foreign key to auth_user for the comment author
+    - name: author_username
+      description: str, username of the comment author
+    - name: retired_username
+      description: str, placeholder username left behind when the author has been
+        retired
+    - name: course_id
+      description: str, Open edX Course ID in the format course-v1:{org}+{course code}+{run_tag}
+    - name: body
+      description: str, free-text comment body authored by the learner
+    - name: depth
+      description: int, nesting depth, 0 for a direct response to the thread
+    - name: sort_key
+      description: str, ordering key used to sort sibling comments
+    - name: child_count
+      description: int, number of direct replies to this comment
+    - name: endorsement
+      description: str, JSON object holding the endorsing user and time. Empty object
+        when the comment is not endorsed
+    - name: endorsed
+      description: boolean, whether the comment has been endorsed by staff
+    - name: visible
+      description: boolean, whether the comment is visible, used as a soft delete
+    - name: anonymous
+      description: boolean, whether the comment was posted anonymously
+    - name: anonymous_to_peers
+      description: boolean, whether the comment is anonymous to other learners but
+        not to staff
+    - name: group_id
+      description: int, cohort the comment is scoped to, null when visible to everyone
+    - name: created_at
+      description: timestamp, when the comment was posted
+    - name: updated_at
+      description: timestamp, when the comment was last edited
+  - name: raw__mitxonline__openedx__mysql__forum_uservote
+    description: MITx Online open edX votes cast on discussion forum content
+    columns:
+    - name: id
+      description: int, the auto-incremented ID for this table
+    - name: user_id
+      description: int, foreign key to auth_user for the voter
+    - name: vote
+      description: int, +1 for an upvote and -1 for a downvote. Only upvotes occur
+        in practice, since the Open edX forum UI does not offer a downvote
+    - name: content_type_id
+      description: int, Django content-type id identifying which forum table content_object_id
+        points at. The value is assigned per deployment by migration order, so it
+        is NOT comparable across deployments and must not be hardcoded; resolve it
+        against django_content_type
+    - name: content_object_id
+      description: int, id of the row in the table named by content_type_id. Comment
+        and CommentThread ids both start at 1 and overlap heavily, so this is only
+        meaningful together with content_type_id
+  - name: raw__mitxonline__openedx__mysql__forum_mongocontent
+    description: MITx Online open edX bridge from forum-v2 rows to their pre-migration
+      Mongo ObjectIds
+    columns:
+    - name: id
+      description: int, the auto-incremented ID for this table
+    - name: mongo_id
+      description: str, the 24-character hex ObjectId this row carried in the pre-migration
+        Mongo forum database. Only content that existed at the migration has a row
+        here, so content created since has no ObjectId at all
+    - name: content_type_id
+      description: int, Django content-type id identifying which forum table content_object_id
+        points at. The value is assigned per deployment by migration order, so it
+        is NOT comparable across deployments and must not be hardcoded; resolve it
+        against django_content_type
+    - name: content_object_id
+      description: int, id of the row in the table named by content_type_id. Comment
+        and CommentThread ids both start at 1 and overlap heavily, so this is only
+        meaningful together with content_type_id
+  - name: raw__mitxonline__openedx__mysql__forum_abuseflagger
+    description: MITx Online open edX active abuse flags raised on discussion forum
+      content
+    columns:
+    - name: id
+      description: int, the auto-incremented ID for this table
+    - name: user_id
+      description: int, foreign key to auth_user for whoever raised the flag
+    - name: flagged_at
+      description: timestamp, when the content was flagged
+    - name: content_type_id
+      description: int, Django content-type id identifying which forum table content_object_id
+        points at. The value is assigned per deployment by migration order, so it
+        is NOT comparable across deployments and must not be hardcoded; resolve it
+        against django_content_type
+    - name: content_object_id
+      description: int, id of the row in the table named by content_type_id. Comment
+        and CommentThread ids both start at 1 and overlap heavily, so this is only
+        meaningful together with content_type_id
+  - name: raw__mitxonline__openedx__mysql__forum_historicalabuseflagger
+    description: MITx Online open edX abuse flags that were raised on discussion forum
+      content and later cleared
+    columns:
+    - name: id
+      description: int, the auto-incremented ID for this table
+    - name: user_id
+      description: int, foreign key to auth_user for whoever raised the flag
+    - name: flagged_at
+      description: timestamp, when the content was flagged
+    - name: content_type_id
+      description: int, Django content-type id identifying which forum table content_object_id
+        points at. The value is assigned per deployment by migration order, so it
+        is NOT comparable across deployments and must not be hardcoded; resolve it
+        against django_content_type
+    - name: content_object_id
+      description: int, id of the row in the table named by content_type_id. Comment
+        and CommentThread ids both start at 1 and overlap heavily, so this is only
+        meaningful together with content_type_id

--- a/src/ol_dbt/models/staging/mitxonline/_stg_mitxonline__models.yml
+++ b/src/ol_dbt/models/staging/mitxonline/_stg_mitxonline__models.yml
@@ -2236,6 +2236,9 @@ models:
   columns:
   - name: forumthread_id
     description: int, the auto-incremented ID for this table
+    tests:
+    - unique
+    - not_null
   - name: user_id
     description: int, foreign key to auth_user for the thread author
   - name: user_username
@@ -2285,6 +2288,9 @@ models:
   columns:
   - name: forumcomment_id
     description: int, the auto-incremented ID for this table
+    tests:
+    - unique
+    - not_null
   - name: forumthread_id
     description: int, foreign key to forum_commentthread. This is the thread association;
       in the pre-migration Mongo data the equivalent field held an ObjectId string
@@ -2332,6 +2338,9 @@ models:
   columns:
   - name: forumuservote_id
     description: int, the auto-incremented ID for this table
+    tests:
+    - unique
+    - not_null
   - name: user_id
     description: int, foreign key to auth_user for the voter
   - name: forumuservote_value
@@ -2353,10 +2362,16 @@ models:
   columns:
   - name: forummongocontent_id
     description: int, the auto-incremented ID for this table
+    tests:
+    - unique
+    - not_null
   - name: forumcontent_mongo_id
     description: str, the 24-character hex ObjectId this row carried in the pre-migration
       Mongo forum database. Only content that existed at the migration has a row here,
       so content created since has no ObjectId at all
+    tests:
+    - unique
+    - not_null
   - name: forumcontent_type_id
     description: int, Django content-type id identifying which forum table content_object_id
       points at. The value is assigned per deployment by migration order, so it is
@@ -2373,6 +2388,9 @@ models:
   columns:
   - name: forumabuseflag_id
     description: int, the auto-incremented ID for this table
+    tests:
+    - unique
+    - not_null
   - name: user_id
     description: int, foreign key to auth_user for whoever raised the flag
   - name: forumabuseflag_flagged_on
@@ -2393,6 +2411,9 @@ models:
   columns:
   - name: forumhistoricalabuseflag_id
     description: int, the auto-incremented ID for this table
+    tests:
+    - unique
+    - not_null
   - name: user_id
     description: int, foreign key to auth_user for whoever raised the flag
   - name: forumhistoricalabuseflag_flagged_on

--- a/src/ol_dbt/models/staging/mitxonline/_stg_mitxonline__models.yml
+++ b/src/ol_dbt/models/staging/mitxonline/_stg_mitxonline__models.yml
@@ -2230,3 +2230,179 @@ models:
     description: int, foreign key to users_user for the user who uploaded the image
   - name: image_description
     description: str, optional description of the image as entered in the CMS
+
+- name: stg__mitxonline__openedx__mysql__forum_commentthread
+  description: MITx Online open edX discussion forum threads
+  columns:
+  - name: forumthread_id
+    description: int, the auto-incremented ID for this table
+  - name: user_id
+    description: int, foreign key to auth_user for the thread author
+  - name: user_username
+    description: str, username of the thread author
+  - name: user_retired_username
+    description: str, placeholder username left behind when the author has been retired
+  - name: courserun_readable_id
+    description: str, Open edX Course ID in the format course-v1:{org}+{course code}+{run_tag}
+  - name: forumthread_title
+    description: str, the thread title as authored by the learner
+  - name: forumthread_body
+    description: str, free-text thread body authored by the learner
+  - name: forumthread_type
+    description: str, discussion or question
+  - name: forumthread_commentable_id
+    description: str, id of the discussion topic the thread was posted under
+  - name: forumthread_context
+    description: str, where the thread lives, e.g. course
+  - name: forumthread_group_id
+    description: int, cohort the thread is scoped to, null when visible to everyone
+  - name: forumthread_is_closed
+    description: boolean, whether the thread has been closed to further replies
+  - name: forumthread_closed_by_user_id
+    description: int, foreign key to auth_user for whoever closed the thread
+  - name: forumthread_close_reason_code
+    description: str, reason code recorded when the thread was closed
+  - name: forumthread_is_pinned
+    description: boolean, whether the thread is pinned to the top of its topic
+  - name: forumthread_is_visible
+    description: boolean, whether the thread is visible, used as a soft delete
+  - name: forumthread_is_endorsed
+    description: boolean, whether the thread has an endorsed response
+  - name: forumthread_is_anonymous
+    description: boolean, whether the thread was posted anonymously
+  - name: forumthread_is_anonymous_to_peers
+    description: boolean, whether the thread is anonymous to other learners but not
+      to staff
+  - name: forumthread_created_on
+    description: timestamp, when the thread was posted
+  - name: forumthread_updated_on
+    description: timestamp, when the thread was last edited
+  - name: forumthread_last_activity_on
+    description: timestamp, when the thread last saw any activity
+
+- name: stg__mitxonline__openedx__mysql__forum_comment
+  description: MITx Online open edX discussion forum responses and comments
+  columns:
+  - name: forumcomment_id
+    description: int, the auto-incremented ID for this table
+  - name: forumthread_id
+    description: int, foreign key to forum_commentthread. This is the thread association;
+      in the pre-migration Mongo data the equivalent field held an ObjectId string
+      rather than an integer
+  - name: forumcomment_parent_id
+    description: int, foreign key to forum_comment for the response this comment replies
+      to. Null for a top-level response to the thread
+  - name: user_id
+    description: int, foreign key to auth_user for the comment author
+  - name: user_username
+    description: str, username of the comment author
+  - name: user_retired_username
+    description: str, placeholder username left behind when the author has been retired
+  - name: courserun_readable_id
+    description: str, Open edX Course ID in the format course-v1:{org}+{course code}+{run_tag}
+  - name: forumcomment_body
+    description: str, free-text comment body authored by the learner
+  - name: forumcomment_depth
+    description: int, nesting depth, 0 for a direct response to the thread
+  - name: forumcomment_sort_key
+    description: str, ordering key used to sort sibling comments
+  - name: forumcomment_child_count
+    description: int, number of direct replies to this comment
+  - name: forumcomment_endorsement_data
+    description: str, JSON object holding the endorsing user and time. Empty object
+      when the comment is not endorsed
+  - name: forumcomment_is_endorsed
+    description: boolean, whether the comment has been endorsed by staff
+  - name: forumcomment_is_visible
+    description: boolean, whether the comment is visible, used as a soft delete
+  - name: forumcomment_is_anonymous
+    description: boolean, whether the comment was posted anonymously
+  - name: forumcomment_is_anonymous_to_peers
+    description: boolean, whether the comment is anonymous to other learners but not
+      to staff
+  - name: forumcomment_group_id
+    description: int, cohort the comment is scoped to, null when visible to everyone
+  - name: forumcomment_created_on
+    description: timestamp, when the comment was posted
+  - name: forumcomment_updated_on
+    description: timestamp, when the comment was last edited
+
+- name: stg__mitxonline__openedx__mysql__forum_uservote
+  description: MITx Online open edX votes cast on discussion forum content
+  columns:
+  - name: forumuservote_id
+    description: int, the auto-incremented ID for this table
+  - name: user_id
+    description: int, foreign key to auth_user for the voter
+  - name: forumuservote_value
+    description: int, +1 for an upvote and -1 for a downvote. Only upvotes occur in
+      practice, since the Open edX forum UI does not offer a downvote
+  - name: forumcontent_type_id
+    description: int, Django content-type id identifying which forum table content_object_id
+      points at. The value is assigned per deployment by migration order, so it is
+      NOT comparable across deployments and must not be hardcoded; resolve it against
+      django_content_type
+  - name: forumcontent_object_id
+    description: int, id of the row in the table named by content_type_id. Comment
+      and CommentThread ids both start at 1 and overlap heavily, so this is only meaningful
+      together with content_type_id
+
+- name: stg__mitxonline__openedx__mysql__forum_mongocontent
+  description: MITx Online open edX bridge from forum-v2 rows to their pre-migration
+    mongo objectids
+  columns:
+  - name: forummongocontent_id
+    description: int, the auto-incremented ID for this table
+  - name: forumcontent_mongo_id
+    description: str, the 24-character hex ObjectId this row carried in the pre-migration
+      Mongo forum database. Only content that existed at the migration has a row here,
+      so content created since has no ObjectId at all
+  - name: forumcontent_type_id
+    description: int, Django content-type id identifying which forum table content_object_id
+      points at. The value is assigned per deployment by migration order, so it is
+      NOT comparable across deployments and must not be hardcoded; resolve it against
+      django_content_type
+  - name: forumcontent_object_id
+    description: int, id of the row in the table named by content_type_id. Comment
+      and CommentThread ids both start at 1 and overlap heavily, so this is only meaningful
+      together with content_type_id
+
+- name: stg__mitxonline__openedx__mysql__forum_abuseflagger
+  description: MITx Online open edX active abuse flags raised on discussion forum
+    content
+  columns:
+  - name: forumabuseflag_id
+    description: int, the auto-incremented ID for this table
+  - name: user_id
+    description: int, foreign key to auth_user for whoever raised the flag
+  - name: forumabuseflag_flagged_on
+    description: timestamp, when the content was flagged
+  - name: forumcontent_type_id
+    description: int, Django content-type id identifying which forum table content_object_id
+      points at. The value is assigned per deployment by migration order, so it is
+      NOT comparable across deployments and must not be hardcoded; resolve it against
+      django_content_type
+  - name: forumcontent_object_id
+    description: int, id of the row in the table named by content_type_id. Comment
+      and CommentThread ids both start at 1 and overlap heavily, so this is only meaningful
+      together with content_type_id
+
+- name: stg__mitxonline__openedx__mysql__forum_historicalabuseflagger
+  description: MITx Online open edX abuse flags that were raised on discussion forum
+    content and later cleared
+  columns:
+  - name: forumhistoricalabuseflag_id
+    description: int, the auto-incremented ID for this table
+  - name: user_id
+    description: int, foreign key to auth_user for whoever raised the flag
+  - name: forumhistoricalabuseflag_flagged_on
+    description: timestamp, when the content was flagged
+  - name: forumcontent_type_id
+    description: int, Django content-type id identifying which forum table content_object_id
+      points at. The value is assigned per deployment by migration order, so it is
+      NOT comparable across deployments and must not be hardcoded; resolve it against
+      django_content_type
+  - name: forumcontent_object_id
+    description: int, id of the row in the table named by content_type_id. Comment
+      and CommentThread ids both start at 1 and overlap heavily, so this is only meaningful
+      together with content_type_id

--- a/src/ol_dbt/models/staging/mitxonline/stg__mitxonline__openedx__mysql__forum_abuseflagger.sql
+++ b/src/ol_dbt/models/staging/mitxonline/stg__mitxonline__openedx__mysql__forum_abuseflagger.sql
@@ -1,0 +1,18 @@
+-- MITx Online open edX active abuse flags raised on discussion forum content
+
+with source as (
+    select * from {{ source('ol_warehouse_raw_data', 'raw__mitxonline__openedx__mysql__forum_abuseflagger') }}
+)
+
+, cleaned as (
+
+    select
+        id as forumabuseflag_id
+        , user_id as user_id
+        , {{ cast_timestamp_to_iso8601('flagged_at') }} as forumabuseflag_flagged_on
+        , content_type_id as forumcontent_type_id
+        , content_object_id as forumcontent_object_id
+    from source
+)
+
+select * from cleaned

--- a/src/ol_dbt/models/staging/mitxonline/stg__mitxonline__openedx__mysql__forum_abuseflagger.sql
+++ b/src/ol_dbt/models/staging/mitxonline/stg__mitxonline__openedx__mysql__forum_abuseflagger.sql
@@ -8,7 +8,7 @@ with source as (
 
     select
         id as forumabuseflag_id
-        , user_id as user_id
+        , user_id
         , {{ cast_timestamp_to_iso8601('flagged_at') }} as forumabuseflag_flagged_on
         , content_type_id as forumcontent_type_id
         , content_object_id as forumcontent_object_id

--- a/src/ol_dbt/models/staging/mitxonline/stg__mitxonline__openedx__mysql__forum_comment.sql
+++ b/src/ol_dbt/models/staging/mitxonline/stg__mitxonline__openedx__mysql__forum_comment.sql
@@ -1,0 +1,32 @@
+-- MITx Online open edX discussion forum responses and comments
+
+with source as (
+    select * from {{ source('ol_warehouse_raw_data', 'raw__mitxonline__openedx__mysql__forum_comment') }}
+)
+
+, cleaned as (
+
+    select
+        id as forumcomment_id
+        , comment_thread_id as forumthread_id
+        , parent_id as forumcomment_parent_id
+        , author_id as user_id
+        , author_username as user_username
+        , retired_username as user_retired_username
+        , course_id as courserun_readable_id
+        , body as forumcomment_body
+        , depth as forumcomment_depth
+        , sort_key as forumcomment_sort_key
+        , child_count as forumcomment_child_count
+        , endorsement as forumcomment_endorsement_data
+        , endorsed as forumcomment_is_endorsed
+        , visible as forumcomment_is_visible
+        , anonymous as forumcomment_is_anonymous
+        , anonymous_to_peers as forumcomment_is_anonymous_to_peers
+        , group_id as forumcomment_group_id
+        , {{ cast_timestamp_to_iso8601('created_at') }} as forumcomment_created_on
+        , {{ cast_timestamp_to_iso8601('updated_at') }} as forumcomment_updated_on
+    from source
+)
+
+select * from cleaned

--- a/src/ol_dbt/models/staging/mitxonline/stg__mitxonline__openedx__mysql__forum_commentthread.sql
+++ b/src/ol_dbt/models/staging/mitxonline/stg__mitxonline__openedx__mysql__forum_commentthread.sql
@@ -1,0 +1,35 @@
+-- MITx Online open edX discussion forum threads
+
+with source as (
+    select * from {{ source('ol_warehouse_raw_data', 'raw__mitxonline__openedx__mysql__forum_commentthread') }}
+)
+
+, cleaned as (
+
+    select
+        id as forumthread_id
+        , author_id as user_id
+        , author_username as user_username
+        , retired_username as user_retired_username
+        , course_id as courserun_readable_id
+        , title as forumthread_title
+        , body as forumthread_body
+        , thread_type as forumthread_type
+        , commentable_id as forumthread_commentable_id
+        , context as forumthread_context
+        , group_id as forumthread_group_id
+        , closed as forumthread_is_closed
+        , closed_by_id as forumthread_closed_by_user_id
+        , close_reason_code as forumthread_close_reason_code
+        , pinned as forumthread_is_pinned
+        , visible as forumthread_is_visible
+        , endorsed as forumthread_is_endorsed
+        , anonymous as forumthread_is_anonymous
+        , anonymous_to_peers as forumthread_is_anonymous_to_peers
+        , {{ cast_timestamp_to_iso8601('created_at') }} as forumthread_created_on
+        , {{ cast_timestamp_to_iso8601('updated_at') }} as forumthread_updated_on
+        , {{ cast_timestamp_to_iso8601('last_activity_at') }} as forumthread_last_activity_on
+    from source
+)
+
+select * from cleaned

--- a/src/ol_dbt/models/staging/mitxonline/stg__mitxonline__openedx__mysql__forum_historicalabuseflagger.sql
+++ b/src/ol_dbt/models/staging/mitxonline/stg__mitxonline__openedx__mysql__forum_historicalabuseflagger.sql
@@ -1,0 +1,18 @@
+-- MITx Online open edX abuse flags that were raised on discussion forum content and later cleared
+
+with source as (
+    select * from {{ source('ol_warehouse_raw_data', 'raw__mitxonline__openedx__mysql__forum_historicalabuseflagger') }}
+)
+
+, cleaned as (
+
+    select
+        id as forumhistoricalabuseflag_id
+        , user_id as user_id
+        , {{ cast_timestamp_to_iso8601('flagged_at') }} as forumhistoricalabuseflag_flagged_on
+        , content_type_id as forumcontent_type_id
+        , content_object_id as forumcontent_object_id
+    from source
+)
+
+select * from cleaned

--- a/src/ol_dbt/models/staging/mitxonline/stg__mitxonline__openedx__mysql__forum_historicalabuseflagger.sql
+++ b/src/ol_dbt/models/staging/mitxonline/stg__mitxonline__openedx__mysql__forum_historicalabuseflagger.sql
@@ -8,7 +8,7 @@ with source as (
 
     select
         id as forumhistoricalabuseflag_id
-        , user_id as user_id
+        , user_id
         , {{ cast_timestamp_to_iso8601('flagged_at') }} as forumhistoricalabuseflag_flagged_on
         , content_type_id as forumcontent_type_id
         , content_object_id as forumcontent_object_id

--- a/src/ol_dbt/models/staging/mitxonline/stg__mitxonline__openedx__mysql__forum_mongocontent.sql
+++ b/src/ol_dbt/models/staging/mitxonline/stg__mitxonline__openedx__mysql__forum_mongocontent.sql
@@ -1,0 +1,17 @@
+-- MITx Online open edX bridge from forum-v2 rows to their pre-migration mongo objectids
+
+with source as (
+    select * from {{ source('ol_warehouse_raw_data', 'raw__mitxonline__openedx__mysql__forum_mongocontent') }}
+)
+
+, cleaned as (
+
+    select
+        id as forummongocontent_id
+        , mongo_id as forumcontent_mongo_id
+        , content_type_id as forumcontent_type_id
+        , content_object_id as forumcontent_object_id
+    from source
+)
+
+select * from cleaned

--- a/src/ol_dbt/models/staging/mitxonline/stg__mitxonline__openedx__mysql__forum_uservote.sql
+++ b/src/ol_dbt/models/staging/mitxonline/stg__mitxonline__openedx__mysql__forum_uservote.sql
@@ -1,0 +1,18 @@
+-- MITx Online open edX votes cast on discussion forum content
+
+with source as (
+    select * from {{ source('ol_warehouse_raw_data', 'raw__mitxonline__openedx__mysql__forum_uservote') }}
+)
+
+, cleaned as (
+
+    select
+        id as forumuservote_id
+        , user_id as user_id
+        , vote as forumuservote_value
+        , content_type_id as forumcontent_type_id
+        , content_object_id as forumcontent_object_id
+    from source
+)
+
+select * from cleaned

--- a/src/ol_dbt/models/staging/mitxonline/stg__mitxonline__openedx__mysql__forum_uservote.sql
+++ b/src/ol_dbt/models/staging/mitxonline/stg__mitxonline__openedx__mysql__forum_uservote.sql
@@ -8,7 +8,7 @@ with source as (
 
     select
         id as forumuservote_id
-        , user_id as user_id
+        , user_id
         , vote as forumuservote_value
         , content_type_id as forumcontent_type_id
         , content_object_id as forumcontent_object_id

--- a/src/ol_dbt/models/staging/mitxpro/_mitxpro__sources.yml
+++ b/src/ol_dbt/models/staging/mitxpro/_mitxpro__sources.yml
@@ -2396,3 +2396,174 @@ sources:
     - name: updated_on
       description: timestamp, specifying when the tax rate record was most recently
         updated
+  - name: raw__xpro__openedx__mysql__forum_commentthread
+    description: MITx Pro open edX discussion forum threads
+    columns:
+    - name: id
+      description: int, the auto-incremented ID for this table
+    - name: author_id
+      description: int, foreign key to auth_user for the thread author
+    - name: author_username
+      description: str, username of the thread author
+    - name: retired_username
+      description: str, placeholder username left behind when the author has been
+        retired
+    - name: course_id
+      description: str, Open edX Course ID in the format course-v1:{org}+{course code}+{run_tag}
+    - name: title
+      description: str, the thread title as authored by the learner
+    - name: body
+      description: str, free-text thread body authored by the learner
+    - name: thread_type
+      description: str, discussion or question
+    - name: commentable_id
+      description: str, id of the discussion topic the thread was posted under
+    - name: context
+      description: str, where the thread lives, e.g. course
+    - name: group_id
+      description: int, cohort the thread is scoped to, null when visible to everyone
+    - name: closed
+      description: boolean, whether the thread has been closed to further replies
+    - name: closed_by_id
+      description: int, foreign key to auth_user for whoever closed the thread
+    - name: close_reason_code
+      description: str, reason code recorded when the thread was closed
+    - name: pinned
+      description: boolean, whether the thread is pinned to the top of its topic
+    - name: visible
+      description: boolean, whether the thread is visible, used as a soft delete
+    - name: endorsed
+      description: boolean, whether the thread has an endorsed response
+    - name: anonymous
+      description: boolean, whether the thread was posted anonymously
+    - name: anonymous_to_peers
+      description: boolean, whether the thread is anonymous to other learners but
+        not to staff
+    - name: created_at
+      description: timestamp, when the thread was posted
+    - name: updated_at
+      description: timestamp, when the thread was last edited
+    - name: last_activity_at
+      description: timestamp, when the thread last saw any activity
+  - name: raw__xpro__openedx__mysql__forum_comment
+    description: MITx Pro open edX discussion forum responses and comments
+    columns:
+    - name: id
+      description: int, the auto-incremented ID for this table
+    - name: comment_thread_id
+      description: int, foreign key to forum_commentthread. This is the thread association;
+        in the pre-migration Mongo data the equivalent field held an ObjectId string
+        rather than an integer
+    - name: parent_id
+      description: int, foreign key to forum_comment for the response this comment
+        replies to. Null for a top-level response to the thread
+    - name: author_id
+      description: int, foreign key to auth_user for the comment author
+    - name: author_username
+      description: str, username of the comment author
+    - name: retired_username
+      description: str, placeholder username left behind when the author has been
+        retired
+    - name: course_id
+      description: str, Open edX Course ID in the format course-v1:{org}+{course code}+{run_tag}
+    - name: body
+      description: str, free-text comment body authored by the learner
+    - name: depth
+      description: int, nesting depth, 0 for a direct response to the thread
+    - name: sort_key
+      description: str, ordering key used to sort sibling comments
+    - name: child_count
+      description: int, number of direct replies to this comment
+    - name: endorsement
+      description: str, JSON object holding the endorsing user and time. Empty object
+        when the comment is not endorsed
+    - name: endorsed
+      description: boolean, whether the comment has been endorsed by staff
+    - name: visible
+      description: boolean, whether the comment is visible, used as a soft delete
+    - name: anonymous
+      description: boolean, whether the comment was posted anonymously
+    - name: anonymous_to_peers
+      description: boolean, whether the comment is anonymous to other learners but
+        not to staff
+    - name: group_id
+      description: int, cohort the comment is scoped to, null when visible to everyone
+    - name: created_at
+      description: timestamp, when the comment was posted
+    - name: updated_at
+      description: timestamp, when the comment was last edited
+  - name: raw__xpro__openedx__mysql__forum_uservote
+    description: MITx Pro open edX votes cast on discussion forum content
+    columns:
+    - name: id
+      description: int, the auto-incremented ID for this table
+    - name: user_id
+      description: int, foreign key to auth_user for the voter
+    - name: vote
+      description: int, +1 for an upvote and -1 for a downvote. Only upvotes occur
+        in practice, since the Open edX forum UI does not offer a downvote
+    - name: content_type_id
+      description: int, Django content-type id identifying which forum table content_object_id
+        points at. The value is assigned per deployment by migration order, so it
+        is NOT comparable across deployments and must not be hardcoded; resolve it
+        against django_content_type
+    - name: content_object_id
+      description: int, id of the row in the table named by content_type_id. Comment
+        and CommentThread ids both start at 1 and overlap heavily, so this is only
+        meaningful together with content_type_id
+  - name: raw__xpro__openedx__mysql__forum_mongocontent
+    description: MITx Pro open edX bridge from forum-v2 rows to their pre-migration
+      Mongo ObjectIds
+    columns:
+    - name: id
+      description: int, the auto-incremented ID for this table
+    - name: mongo_id
+      description: str, the 24-character hex ObjectId this row carried in the pre-migration
+        Mongo forum database. Only content that existed at the migration has a row
+        here, so content created since has no ObjectId at all
+    - name: content_type_id
+      description: int, Django content-type id identifying which forum table content_object_id
+        points at. The value is assigned per deployment by migration order, so it
+        is NOT comparable across deployments and must not be hardcoded; resolve it
+        against django_content_type
+    - name: content_object_id
+      description: int, id of the row in the table named by content_type_id. Comment
+        and CommentThread ids both start at 1 and overlap heavily, so this is only
+        meaningful together with content_type_id
+  - name: raw__xpro__openedx__mysql__forum_abuseflagger
+    description: MITx Pro open edX active abuse flags raised on discussion forum content
+    columns:
+    - name: id
+      description: int, the auto-incremented ID for this table
+    - name: user_id
+      description: int, foreign key to auth_user for whoever raised the flag
+    - name: flagged_at
+      description: timestamp, when the content was flagged
+    - name: content_type_id
+      description: int, Django content-type id identifying which forum table content_object_id
+        points at. The value is assigned per deployment by migration order, so it
+        is NOT comparable across deployments and must not be hardcoded; resolve it
+        against django_content_type
+    - name: content_object_id
+      description: int, id of the row in the table named by content_type_id. Comment
+        and CommentThread ids both start at 1 and overlap heavily, so this is only
+        meaningful together with content_type_id
+  - name: raw__xpro__openedx__mysql__forum_historicalabuseflagger
+    description: MITx Pro open edX abuse flags that were raised on discussion forum
+      content and later cleared
+    columns:
+    - name: id
+      description: int, the auto-incremented ID for this table
+    - name: user_id
+      description: int, foreign key to auth_user for whoever raised the flag
+    - name: flagged_at
+      description: timestamp, when the content was flagged
+    - name: content_type_id
+      description: int, Django content-type id identifying which forum table content_object_id
+        points at. The value is assigned per deployment by migration order, so it
+        is NOT comparable across deployments and must not be hardcoded; resolve it
+        against django_content_type
+    - name: content_object_id
+      description: int, id of the row in the table named by content_type_id. Comment
+        and CommentThread ids both start at 1 and overlap heavily, so this is only
+        meaningful together with content_type_id

--- a/src/ol_dbt/models/staging/mitxpro/_stg_mitxpro__models.yml
+++ b/src/ol_dbt/models/staging/mitxpro/_stg_mitxpro__models.yml
@@ -2367,3 +2367,178 @@ models:
     description: int, foreign key to users_user for the user who uploaded the image
   - name: image_description
     description: str, optional description of the image as entered in the CMS
+
+- name: stg__mitxpro__openedx__mysql__forum_commentthread
+  description: MITx Pro open edX discussion forum threads
+  columns:
+  - name: forumthread_id
+    description: int, the auto-incremented ID for this table
+  - name: user_id
+    description: int, foreign key to auth_user for the thread author
+  - name: user_username
+    description: str, username of the thread author
+  - name: user_retired_username
+    description: str, placeholder username left behind when the author has been retired
+  - name: courserun_readable_id
+    description: str, Open edX Course ID in the format course-v1:{org}+{course code}+{run_tag}
+  - name: forumthread_title
+    description: str, the thread title as authored by the learner
+  - name: forumthread_body
+    description: str, free-text thread body authored by the learner
+  - name: forumthread_type
+    description: str, discussion or question
+  - name: forumthread_commentable_id
+    description: str, id of the discussion topic the thread was posted under
+  - name: forumthread_context
+    description: str, where the thread lives, e.g. course
+  - name: forumthread_group_id
+    description: int, cohort the thread is scoped to, null when visible to everyone
+  - name: forumthread_is_closed
+    description: boolean, whether the thread has been closed to further replies
+  - name: forumthread_closed_by_user_id
+    description: int, foreign key to auth_user for whoever closed the thread
+  - name: forumthread_close_reason_code
+    description: str, reason code recorded when the thread was closed
+  - name: forumthread_is_pinned
+    description: boolean, whether the thread is pinned to the top of its topic
+  - name: forumthread_is_visible
+    description: boolean, whether the thread is visible, used as a soft delete
+  - name: forumthread_is_endorsed
+    description: boolean, whether the thread has an endorsed response
+  - name: forumthread_is_anonymous
+    description: boolean, whether the thread was posted anonymously
+  - name: forumthread_is_anonymous_to_peers
+    description: boolean, whether the thread is anonymous to other learners but not
+      to staff
+  - name: forumthread_created_on
+    description: timestamp, when the thread was posted
+  - name: forumthread_updated_on
+    description: timestamp, when the thread was last edited
+  - name: forumthread_last_activity_on
+    description: timestamp, when the thread last saw any activity
+
+- name: stg__mitxpro__openedx__mysql__forum_comment
+  description: MITx Pro open edX discussion forum responses and comments
+  columns:
+  - name: forumcomment_id
+    description: int, the auto-incremented ID for this table
+  - name: forumthread_id
+    description: int, foreign key to forum_commentthread. This is the thread association;
+      in the pre-migration Mongo data the equivalent field held an ObjectId string
+      rather than an integer
+  - name: forumcomment_parent_id
+    description: int, foreign key to forum_comment for the response this comment replies
+      to. Null for a top-level response to the thread
+  - name: user_id
+    description: int, foreign key to auth_user for the comment author
+  - name: user_username
+    description: str, username of the comment author
+  - name: user_retired_username
+    description: str, placeholder username left behind when the author has been retired
+  - name: courserun_readable_id
+    description: str, Open edX Course ID in the format course-v1:{org}+{course code}+{run_tag}
+  - name: forumcomment_body
+    description: str, free-text comment body authored by the learner
+  - name: forumcomment_depth
+    description: int, nesting depth, 0 for a direct response to the thread
+  - name: forumcomment_sort_key
+    description: str, ordering key used to sort sibling comments
+  - name: forumcomment_child_count
+    description: int, number of direct replies to this comment
+  - name: forumcomment_endorsement_data
+    description: str, JSON object holding the endorsing user and time. Empty object
+      when the comment is not endorsed
+  - name: forumcomment_is_endorsed
+    description: boolean, whether the comment has been endorsed by staff
+  - name: forumcomment_is_visible
+    description: boolean, whether the comment is visible, used as a soft delete
+  - name: forumcomment_is_anonymous
+    description: boolean, whether the comment was posted anonymously
+  - name: forumcomment_is_anonymous_to_peers
+    description: boolean, whether the comment is anonymous to other learners but not
+      to staff
+  - name: forumcomment_group_id
+    description: int, cohort the comment is scoped to, null when visible to everyone
+  - name: forumcomment_created_on
+    description: timestamp, when the comment was posted
+  - name: forumcomment_updated_on
+    description: timestamp, when the comment was last edited
+
+- name: stg__mitxpro__openedx__mysql__forum_uservote
+  description: MITx Pro open edX votes cast on discussion forum content
+  columns:
+  - name: forumuservote_id
+    description: int, the auto-incremented ID for this table
+  - name: user_id
+    description: int, foreign key to auth_user for the voter
+  - name: forumuservote_value
+    description: int, +1 for an upvote and -1 for a downvote. Only upvotes occur in
+      practice, since the Open edX forum UI does not offer a downvote
+  - name: forumcontent_type_id
+    description: int, Django content-type id identifying which forum table content_object_id
+      points at. The value is assigned per deployment by migration order, so it is
+      NOT comparable across deployments and must not be hardcoded; resolve it against
+      django_content_type
+  - name: forumcontent_object_id
+    description: int, id of the row in the table named by content_type_id. Comment
+      and CommentThread ids both start at 1 and overlap heavily, so this is only meaningful
+      together with content_type_id
+
+- name: stg__mitxpro__openedx__mysql__forum_mongocontent
+  description: MITx Pro open edX bridge from forum-v2 rows to their pre-migration
+    mongo objectids
+  columns:
+  - name: forummongocontent_id
+    description: int, the auto-incremented ID for this table
+  - name: forumcontent_mongo_id
+    description: str, the 24-character hex ObjectId this row carried in the pre-migration
+      Mongo forum database. Only content that existed at the migration has a row here,
+      so content created since has no ObjectId at all
+  - name: forumcontent_type_id
+    description: int, Django content-type id identifying which forum table content_object_id
+      points at. The value is assigned per deployment by migration order, so it is
+      NOT comparable across deployments and must not be hardcoded; resolve it against
+      django_content_type
+  - name: forumcontent_object_id
+    description: int, id of the row in the table named by content_type_id. Comment
+      and CommentThread ids both start at 1 and overlap heavily, so this is only meaningful
+      together with content_type_id
+
+- name: stg__mitxpro__openedx__mysql__forum_abuseflagger
+  description: MITx Pro open edX active abuse flags raised on discussion forum content
+  columns:
+  - name: forumabuseflag_id
+    description: int, the auto-incremented ID for this table
+  - name: user_id
+    description: int, foreign key to auth_user for whoever raised the flag
+  - name: forumabuseflag_flagged_on
+    description: timestamp, when the content was flagged
+  - name: forumcontent_type_id
+    description: int, Django content-type id identifying which forum table content_object_id
+      points at. The value is assigned per deployment by migration order, so it is
+      NOT comparable across deployments and must not be hardcoded; resolve it against
+      django_content_type
+  - name: forumcontent_object_id
+    description: int, id of the row in the table named by content_type_id. Comment
+      and CommentThread ids both start at 1 and overlap heavily, so this is only meaningful
+      together with content_type_id
+
+- name: stg__mitxpro__openedx__mysql__forum_historicalabuseflagger
+  description: MITx Pro open edX abuse flags that were raised on discussion forum
+    content and later cleared
+  columns:
+  - name: forumhistoricalabuseflag_id
+    description: int, the auto-incremented ID for this table
+  - name: user_id
+    description: int, foreign key to auth_user for whoever raised the flag
+  - name: forumhistoricalabuseflag_flagged_on
+    description: timestamp, when the content was flagged
+  - name: forumcontent_type_id
+    description: int, Django content-type id identifying which forum table content_object_id
+      points at. The value is assigned per deployment by migration order, so it is
+      NOT comparable across deployments and must not be hardcoded; resolve it against
+      django_content_type
+  - name: forumcontent_object_id
+    description: int, id of the row in the table named by content_type_id. Comment
+      and CommentThread ids both start at 1 and overlap heavily, so this is only meaningful
+      together with content_type_id

--- a/src/ol_dbt/models/staging/mitxpro/_stg_mitxpro__models.yml
+++ b/src/ol_dbt/models/staging/mitxpro/_stg_mitxpro__models.yml
@@ -2373,6 +2373,9 @@ models:
   columns:
   - name: forumthread_id
     description: int, the auto-incremented ID for this table
+    tests:
+    - unique
+    - not_null
   - name: user_id
     description: int, foreign key to auth_user for the thread author
   - name: user_username
@@ -2422,6 +2425,9 @@ models:
   columns:
   - name: forumcomment_id
     description: int, the auto-incremented ID for this table
+    tests:
+    - unique
+    - not_null
   - name: forumthread_id
     description: int, foreign key to forum_commentthread. This is the thread association;
       in the pre-migration Mongo data the equivalent field held an ObjectId string
@@ -2469,6 +2475,9 @@ models:
   columns:
   - name: forumuservote_id
     description: int, the auto-incremented ID for this table
+    tests:
+    - unique
+    - not_null
   - name: user_id
     description: int, foreign key to auth_user for the voter
   - name: forumuservote_value
@@ -2490,10 +2499,16 @@ models:
   columns:
   - name: forummongocontent_id
     description: int, the auto-incremented ID for this table
+    tests:
+    - unique
+    - not_null
   - name: forumcontent_mongo_id
     description: str, the 24-character hex ObjectId this row carried in the pre-migration
       Mongo forum database. Only content that existed at the migration has a row here,
       so content created since has no ObjectId at all
+    tests:
+    - unique
+    - not_null
   - name: forumcontent_type_id
     description: int, Django content-type id identifying which forum table content_object_id
       points at. The value is assigned per deployment by migration order, so it is
@@ -2509,6 +2524,9 @@ models:
   columns:
   - name: forumabuseflag_id
     description: int, the auto-incremented ID for this table
+    tests:
+    - unique
+    - not_null
   - name: user_id
     description: int, foreign key to auth_user for whoever raised the flag
   - name: forumabuseflag_flagged_on
@@ -2529,6 +2547,9 @@ models:
   columns:
   - name: forumhistoricalabuseflag_id
     description: int, the auto-incremented ID for this table
+    tests:
+    - unique
+    - not_null
   - name: user_id
     description: int, foreign key to auth_user for whoever raised the flag
   - name: forumhistoricalabuseflag_flagged_on

--- a/src/ol_dbt/models/staging/mitxpro/stg__mitxpro__openedx__mysql__forum_abuseflagger.sql
+++ b/src/ol_dbt/models/staging/mitxpro/stg__mitxpro__openedx__mysql__forum_abuseflagger.sql
@@ -1,0 +1,18 @@
+-- MITx Pro open edX active abuse flags raised on discussion forum content
+
+with source as (
+    select * from {{ source('ol_warehouse_raw_data', 'raw__xpro__openedx__mysql__forum_abuseflagger') }}
+)
+
+, cleaned as (
+
+    select
+        id as forumabuseflag_id
+        , user_id as user_id
+        , {{ cast_timestamp_to_iso8601('flagged_at') }} as forumabuseflag_flagged_on
+        , content_type_id as forumcontent_type_id
+        , content_object_id as forumcontent_object_id
+    from source
+)
+
+select * from cleaned

--- a/src/ol_dbt/models/staging/mitxpro/stg__mitxpro__openedx__mysql__forum_abuseflagger.sql
+++ b/src/ol_dbt/models/staging/mitxpro/stg__mitxpro__openedx__mysql__forum_abuseflagger.sql
@@ -8,7 +8,7 @@ with source as (
 
     select
         id as forumabuseflag_id
-        , user_id as user_id
+        , user_id
         , {{ cast_timestamp_to_iso8601('flagged_at') }} as forumabuseflag_flagged_on
         , content_type_id as forumcontent_type_id
         , content_object_id as forumcontent_object_id

--- a/src/ol_dbt/models/staging/mitxpro/stg__mitxpro__openedx__mysql__forum_comment.sql
+++ b/src/ol_dbt/models/staging/mitxpro/stg__mitxpro__openedx__mysql__forum_comment.sql
@@ -1,0 +1,32 @@
+-- MITx Pro open edX discussion forum responses and comments
+
+with source as (
+    select * from {{ source('ol_warehouse_raw_data', 'raw__xpro__openedx__mysql__forum_comment') }}
+)
+
+, cleaned as (
+
+    select
+        id as forumcomment_id
+        , comment_thread_id as forumthread_id
+        , parent_id as forumcomment_parent_id
+        , author_id as user_id
+        , author_username as user_username
+        , retired_username as user_retired_username
+        , course_id as courserun_readable_id
+        , body as forumcomment_body
+        , depth as forumcomment_depth
+        , sort_key as forumcomment_sort_key
+        , child_count as forumcomment_child_count
+        , endorsement as forumcomment_endorsement_data
+        , endorsed as forumcomment_is_endorsed
+        , visible as forumcomment_is_visible
+        , anonymous as forumcomment_is_anonymous
+        , anonymous_to_peers as forumcomment_is_anonymous_to_peers
+        , group_id as forumcomment_group_id
+        , {{ cast_timestamp_to_iso8601('created_at') }} as forumcomment_created_on
+        , {{ cast_timestamp_to_iso8601('updated_at') }} as forumcomment_updated_on
+    from source
+)
+
+select * from cleaned

--- a/src/ol_dbt/models/staging/mitxpro/stg__mitxpro__openedx__mysql__forum_commentthread.sql
+++ b/src/ol_dbt/models/staging/mitxpro/stg__mitxpro__openedx__mysql__forum_commentthread.sql
@@ -1,0 +1,35 @@
+-- MITx Pro open edX discussion forum threads
+
+with source as (
+    select * from {{ source('ol_warehouse_raw_data', 'raw__xpro__openedx__mysql__forum_commentthread') }}
+)
+
+, cleaned as (
+
+    select
+        id as forumthread_id
+        , author_id as user_id
+        , author_username as user_username
+        , retired_username as user_retired_username
+        , course_id as courserun_readable_id
+        , title as forumthread_title
+        , body as forumthread_body
+        , thread_type as forumthread_type
+        , commentable_id as forumthread_commentable_id
+        , context as forumthread_context
+        , group_id as forumthread_group_id
+        , closed as forumthread_is_closed
+        , closed_by_id as forumthread_closed_by_user_id
+        , close_reason_code as forumthread_close_reason_code
+        , pinned as forumthread_is_pinned
+        , visible as forumthread_is_visible
+        , endorsed as forumthread_is_endorsed
+        , anonymous as forumthread_is_anonymous
+        , anonymous_to_peers as forumthread_is_anonymous_to_peers
+        , {{ cast_timestamp_to_iso8601('created_at') }} as forumthread_created_on
+        , {{ cast_timestamp_to_iso8601('updated_at') }} as forumthread_updated_on
+        , {{ cast_timestamp_to_iso8601('last_activity_at') }} as forumthread_last_activity_on
+    from source
+)
+
+select * from cleaned

--- a/src/ol_dbt/models/staging/mitxpro/stg__mitxpro__openedx__mysql__forum_historicalabuseflagger.sql
+++ b/src/ol_dbt/models/staging/mitxpro/stg__mitxpro__openedx__mysql__forum_historicalabuseflagger.sql
@@ -1,0 +1,18 @@
+-- MITx Pro open edX abuse flags that were raised on discussion forum content and later cleared
+
+with source as (
+    select * from {{ source('ol_warehouse_raw_data', 'raw__xpro__openedx__mysql__forum_historicalabuseflagger') }}
+)
+
+, cleaned as (
+
+    select
+        id as forumhistoricalabuseflag_id
+        , user_id as user_id
+        , {{ cast_timestamp_to_iso8601('flagged_at') }} as forumhistoricalabuseflag_flagged_on
+        , content_type_id as forumcontent_type_id
+        , content_object_id as forumcontent_object_id
+    from source
+)
+
+select * from cleaned

--- a/src/ol_dbt/models/staging/mitxpro/stg__mitxpro__openedx__mysql__forum_historicalabuseflagger.sql
+++ b/src/ol_dbt/models/staging/mitxpro/stg__mitxpro__openedx__mysql__forum_historicalabuseflagger.sql
@@ -8,7 +8,7 @@ with source as (
 
     select
         id as forumhistoricalabuseflag_id
-        , user_id as user_id
+        , user_id
         , {{ cast_timestamp_to_iso8601('flagged_at') }} as forumhistoricalabuseflag_flagged_on
         , content_type_id as forumcontent_type_id
         , content_object_id as forumcontent_object_id

--- a/src/ol_dbt/models/staging/mitxpro/stg__mitxpro__openedx__mysql__forum_mongocontent.sql
+++ b/src/ol_dbt/models/staging/mitxpro/stg__mitxpro__openedx__mysql__forum_mongocontent.sql
@@ -1,0 +1,17 @@
+-- MITx Pro open edX bridge from forum-v2 rows to their pre-migration mongo objectids
+
+with source as (
+    select * from {{ source('ol_warehouse_raw_data', 'raw__xpro__openedx__mysql__forum_mongocontent') }}
+)
+
+, cleaned as (
+
+    select
+        id as forummongocontent_id
+        , mongo_id as forumcontent_mongo_id
+        , content_type_id as forumcontent_type_id
+        , content_object_id as forumcontent_object_id
+    from source
+)
+
+select * from cleaned

--- a/src/ol_dbt/models/staging/mitxpro/stg__mitxpro__openedx__mysql__forum_uservote.sql
+++ b/src/ol_dbt/models/staging/mitxpro/stg__mitxpro__openedx__mysql__forum_uservote.sql
@@ -1,0 +1,18 @@
+-- MITx Pro open edX votes cast on discussion forum content
+
+with source as (
+    select * from {{ source('ol_warehouse_raw_data', 'raw__xpro__openedx__mysql__forum_uservote') }}
+)
+
+, cleaned as (
+
+    select
+        id as forumuservote_id
+        , user_id as user_id
+        , vote as forumuservote_value
+        , content_type_id as forumcontent_type_id
+        , content_object_id as forumcontent_object_id
+    from source
+)
+
+select * from cleaned

--- a/src/ol_dbt/models/staging/mitxpro/stg__mitxpro__openedx__mysql__forum_uservote.sql
+++ b/src/ol_dbt/models/staging/mitxpro/stg__mitxpro__openedx__mysql__forum_uservote.sql
@@ -8,7 +8,7 @@ with source as (
 
     select
         id as forumuservote_id
-        , user_id as user_id
+        , user_id
         , vote as forumuservote_value
         , content_type_id as forumcontent_type_id
         , content_object_id as forumcontent_object_id

--- a/src/ol_dbt/models/staging/mitxresidential/_mitxresidential__sources.yml
+++ b/src/ol_dbt/models/staging/mitxresidential/_mitxresidential__sources.yml
@@ -1142,3 +1142,175 @@ sources:
     - name: course_key
       description: string, unique string to identify a course run on the corresponding
         platform.
+  - name: raw__mitx__openedx__mysql__forum_commentthread
+    description: Residential MITx open edX discussion forum threads
+    columns:
+    - name: id
+      description: int, the auto-incremented ID for this table
+    - name: author_id
+      description: int, foreign key to auth_user for the thread author
+    - name: author_username
+      description: str, username of the thread author
+    - name: retired_username
+      description: str, placeholder username left behind when the author has been
+        retired
+    - name: course_id
+      description: str, Open edX Course ID in the format course-v1:{org}+{course code}+{run_tag}
+    - name: title
+      description: str, the thread title as authored by the learner
+    - name: body
+      description: str, free-text thread body authored by the learner
+    - name: thread_type
+      description: str, discussion or question
+    - name: commentable_id
+      description: str, id of the discussion topic the thread was posted under
+    - name: context
+      description: str, where the thread lives, e.g. course
+    - name: group_id
+      description: int, cohort the thread is scoped to, null when visible to everyone
+    - name: closed
+      description: boolean, whether the thread has been closed to further replies
+    - name: closed_by_id
+      description: int, foreign key to auth_user for whoever closed the thread
+    - name: close_reason_code
+      description: str, reason code recorded when the thread was closed
+    - name: pinned
+      description: boolean, whether the thread is pinned to the top of its topic
+    - name: visible
+      description: boolean, whether the thread is visible, used as a soft delete
+    - name: endorsed
+      description: boolean, whether the thread has an endorsed response
+    - name: anonymous
+      description: boolean, whether the thread was posted anonymously
+    - name: anonymous_to_peers
+      description: boolean, whether the thread is anonymous to other learners but
+        not to staff
+    - name: created_at
+      description: timestamp, when the thread was posted
+    - name: updated_at
+      description: timestamp, when the thread was last edited
+    - name: last_activity_at
+      description: timestamp, when the thread last saw any activity
+  - name: raw__mitx__openedx__mysql__forum_comment
+    description: Residential MITx open edX discussion forum responses and comments
+    columns:
+    - name: id
+      description: int, the auto-incremented ID for this table
+    - name: comment_thread_id
+      description: int, foreign key to forum_commentthread. This is the thread association;
+        in the pre-migration Mongo data the equivalent field held an ObjectId string
+        rather than an integer
+    - name: parent_id
+      description: int, foreign key to forum_comment for the response this comment
+        replies to. Null for a top-level response to the thread
+    - name: author_id
+      description: int, foreign key to auth_user for the comment author
+    - name: author_username
+      description: str, username of the comment author
+    - name: retired_username
+      description: str, placeholder username left behind when the author has been
+        retired
+    - name: course_id
+      description: str, Open edX Course ID in the format course-v1:{org}+{course code}+{run_tag}
+    - name: body
+      description: str, free-text comment body authored by the learner
+    - name: depth
+      description: int, nesting depth, 0 for a direct response to the thread
+    - name: sort_key
+      description: str, ordering key used to sort sibling comments
+    - name: child_count
+      description: int, number of direct replies to this comment
+    - name: endorsement
+      description: str, JSON object holding the endorsing user and time. Empty object
+        when the comment is not endorsed
+    - name: endorsed
+      description: boolean, whether the comment has been endorsed by staff
+    - name: visible
+      description: boolean, whether the comment is visible, used as a soft delete
+    - name: anonymous
+      description: boolean, whether the comment was posted anonymously
+    - name: anonymous_to_peers
+      description: boolean, whether the comment is anonymous to other learners but
+        not to staff
+    - name: group_id
+      description: int, cohort the comment is scoped to, null when visible to everyone
+    - name: created_at
+      description: timestamp, when the comment was posted
+    - name: updated_at
+      description: timestamp, when the comment was last edited
+  - name: raw__mitx__openedx__mysql__forum_uservote
+    description: Residential MITx open edX votes cast on discussion forum content
+    columns:
+    - name: id
+      description: int, the auto-incremented ID for this table
+    - name: user_id
+      description: int, foreign key to auth_user for the voter
+    - name: vote
+      description: int, +1 for an upvote and -1 for a downvote. Only upvotes occur
+        in practice, since the Open edX forum UI does not offer a downvote
+    - name: content_type_id
+      description: int, Django content-type id identifying which forum table content_object_id
+        points at. The value is assigned per deployment by migration order, so it
+        is NOT comparable across deployments and must not be hardcoded; resolve it
+        against django_content_type
+    - name: content_object_id
+      description: int, id of the row in the table named by content_type_id. Comment
+        and CommentThread ids both start at 1 and overlap heavily, so this is only
+        meaningful together with content_type_id
+  - name: raw__mitx__openedx__mysql__forum_mongocontent
+    description: Residential MITx open edX bridge from forum-v2 rows to their pre-migration
+      Mongo ObjectIds
+    columns:
+    - name: id
+      description: int, the auto-incremented ID for this table
+    - name: mongo_id
+      description: str, the 24-character hex ObjectId this row carried in the pre-migration
+        Mongo forum database. Only content that existed at the migration has a row
+        here, so content created since has no ObjectId at all
+    - name: content_type_id
+      description: int, Django content-type id identifying which forum table content_object_id
+        points at. The value is assigned per deployment by migration order, so it
+        is NOT comparable across deployments and must not be hardcoded; resolve it
+        against django_content_type
+    - name: content_object_id
+      description: int, id of the row in the table named by content_type_id. Comment
+        and CommentThread ids both start at 1 and overlap heavily, so this is only
+        meaningful together with content_type_id
+  - name: raw__mitx__openedx__mysql__forum_abuseflagger
+    description: Residential MITx open edX active abuse flags raised on discussion
+      forum content
+    columns:
+    - name: id
+      description: int, the auto-incremented ID for this table
+    - name: user_id
+      description: int, foreign key to auth_user for whoever raised the flag
+    - name: flagged_at
+      description: timestamp, when the content was flagged
+    - name: content_type_id
+      description: int, Django content-type id identifying which forum table content_object_id
+        points at. The value is assigned per deployment by migration order, so it
+        is NOT comparable across deployments and must not be hardcoded; resolve it
+        against django_content_type
+    - name: content_object_id
+      description: int, id of the row in the table named by content_type_id. Comment
+        and CommentThread ids both start at 1 and overlap heavily, so this is only
+        meaningful together with content_type_id
+  - name: raw__mitx__openedx__mysql__forum_historicalabuseflagger
+    description: Residential MITx open edX abuse flags that were raised on discussion
+      forum content and later cleared
+    columns:
+    - name: id
+      description: int, the auto-incremented ID for this table
+    - name: user_id
+      description: int, foreign key to auth_user for whoever raised the flag
+    - name: flagged_at
+      description: timestamp, when the content was flagged
+    - name: content_type_id
+      description: int, Django content-type id identifying which forum table content_object_id
+        points at. The value is assigned per deployment by migration order, so it
+        is NOT comparable across deployments and must not be hardcoded; resolve it
+        against django_content_type
+    - name: content_object_id
+      description: int, id of the row in the table named by content_type_id. Comment
+        and CommentThread ids both start at 1 and overlap heavily, so this is only
+        meaningful together with content_type_id

--- a/src/ol_dbt/models/staging/mitxresidential/_stg_mitxresidential__models.yml
+++ b/src/ol_dbt/models/staging/mitxresidential/_stg_mitxresidential__models.yml
@@ -545,3 +545,179 @@ models:
     description: string, the edX course ID formatted as course-v1:{org}+{course code}+{run_tag}
     tests:
     - not_null
+
+- name: stg__mitxresidential__openedx__mysql__forum_commentthread
+  description: Residential MITx open edX discussion forum threads
+  columns:
+  - name: forumthread_id
+    description: int, the auto-incremented ID for this table
+  - name: user_id
+    description: int, foreign key to auth_user for the thread author
+  - name: user_username
+    description: str, username of the thread author
+  - name: user_retired_username
+    description: str, placeholder username left behind when the author has been retired
+  - name: courserun_readable_id
+    description: str, Open edX Course ID in the format course-v1:{org}+{course code}+{run_tag}
+  - name: forumthread_title
+    description: str, the thread title as authored by the learner
+  - name: forumthread_body
+    description: str, free-text thread body authored by the learner
+  - name: forumthread_type
+    description: str, discussion or question
+  - name: forumthread_commentable_id
+    description: str, id of the discussion topic the thread was posted under
+  - name: forumthread_context
+    description: str, where the thread lives, e.g. course
+  - name: forumthread_group_id
+    description: int, cohort the thread is scoped to, null when visible to everyone
+  - name: forumthread_is_closed
+    description: boolean, whether the thread has been closed to further replies
+  - name: forumthread_closed_by_user_id
+    description: int, foreign key to auth_user for whoever closed the thread
+  - name: forumthread_close_reason_code
+    description: str, reason code recorded when the thread was closed
+  - name: forumthread_is_pinned
+    description: boolean, whether the thread is pinned to the top of its topic
+  - name: forumthread_is_visible
+    description: boolean, whether the thread is visible, used as a soft delete
+  - name: forumthread_is_endorsed
+    description: boolean, whether the thread has an endorsed response
+  - name: forumthread_is_anonymous
+    description: boolean, whether the thread was posted anonymously
+  - name: forumthread_is_anonymous_to_peers
+    description: boolean, whether the thread is anonymous to other learners but not
+      to staff
+  - name: forumthread_created_on
+    description: timestamp, when the thread was posted
+  - name: forumthread_updated_on
+    description: timestamp, when the thread was last edited
+  - name: forumthread_last_activity_on
+    description: timestamp, when the thread last saw any activity
+
+- name: stg__mitxresidential__openedx__mysql__forum_comment
+  description: Residential MITx open edX discussion forum responses and comments
+  columns:
+  - name: forumcomment_id
+    description: int, the auto-incremented ID for this table
+  - name: forumthread_id
+    description: int, foreign key to forum_commentthread. This is the thread association;
+      in the pre-migration Mongo data the equivalent field held an ObjectId string
+      rather than an integer
+  - name: forumcomment_parent_id
+    description: int, foreign key to forum_comment for the response this comment replies
+      to. Null for a top-level response to the thread
+  - name: user_id
+    description: int, foreign key to auth_user for the comment author
+  - name: user_username
+    description: str, username of the comment author
+  - name: user_retired_username
+    description: str, placeholder username left behind when the author has been retired
+  - name: courserun_readable_id
+    description: str, Open edX Course ID in the format course-v1:{org}+{course code}+{run_tag}
+  - name: forumcomment_body
+    description: str, free-text comment body authored by the learner
+  - name: forumcomment_depth
+    description: int, nesting depth, 0 for a direct response to the thread
+  - name: forumcomment_sort_key
+    description: str, ordering key used to sort sibling comments
+  - name: forumcomment_child_count
+    description: int, number of direct replies to this comment
+  - name: forumcomment_endorsement_data
+    description: str, JSON object holding the endorsing user and time. Empty object
+      when the comment is not endorsed
+  - name: forumcomment_is_endorsed
+    description: boolean, whether the comment has been endorsed by staff
+  - name: forumcomment_is_visible
+    description: boolean, whether the comment is visible, used as a soft delete
+  - name: forumcomment_is_anonymous
+    description: boolean, whether the comment was posted anonymously
+  - name: forumcomment_is_anonymous_to_peers
+    description: boolean, whether the comment is anonymous to other learners but not
+      to staff
+  - name: forumcomment_group_id
+    description: int, cohort the comment is scoped to, null when visible to everyone
+  - name: forumcomment_created_on
+    description: timestamp, when the comment was posted
+  - name: forumcomment_updated_on
+    description: timestamp, when the comment was last edited
+
+- name: stg__mitxresidential__openedx__mysql__forum_uservote
+  description: Residential MITx open edX votes cast on discussion forum content
+  columns:
+  - name: forumuservote_id
+    description: int, the auto-incremented ID for this table
+  - name: user_id
+    description: int, foreign key to auth_user for the voter
+  - name: forumuservote_value
+    description: int, +1 for an upvote and -1 for a downvote. Only upvotes occur in
+      practice, since the Open edX forum UI does not offer a downvote
+  - name: forumcontent_type_id
+    description: int, Django content-type id identifying which forum table content_object_id
+      points at. The value is assigned per deployment by migration order, so it is
+      NOT comparable across deployments and must not be hardcoded; resolve it against
+      django_content_type
+  - name: forumcontent_object_id
+    description: int, id of the row in the table named by content_type_id. Comment
+      and CommentThread ids both start at 1 and overlap heavily, so this is only meaningful
+      together with content_type_id
+
+- name: stg__mitxresidential__openedx__mysql__forum_mongocontent
+  description: Residential MITx open edX bridge from forum-v2 rows to their pre-migration
+    mongo objectids
+  columns:
+  - name: forummongocontent_id
+    description: int, the auto-incremented ID for this table
+  - name: forumcontent_mongo_id
+    description: str, the 24-character hex ObjectId this row carried in the pre-migration
+      Mongo forum database. Only content that existed at the migration has a row here,
+      so content created since has no ObjectId at all
+  - name: forumcontent_type_id
+    description: int, Django content-type id identifying which forum table content_object_id
+      points at. The value is assigned per deployment by migration order, so it is
+      NOT comparable across deployments and must not be hardcoded; resolve it against
+      django_content_type
+  - name: forumcontent_object_id
+    description: int, id of the row in the table named by content_type_id. Comment
+      and CommentThread ids both start at 1 and overlap heavily, so this is only meaningful
+      together with content_type_id
+
+- name: stg__mitxresidential__openedx__mysql__forum_abuseflagger
+  description: Residential MITx open edX active abuse flags raised on discussion forum
+    content
+  columns:
+  - name: forumabuseflag_id
+    description: int, the auto-incremented ID for this table
+  - name: user_id
+    description: int, foreign key to auth_user for whoever raised the flag
+  - name: forumabuseflag_flagged_on
+    description: timestamp, when the content was flagged
+  - name: forumcontent_type_id
+    description: int, Django content-type id identifying which forum table content_object_id
+      points at. The value is assigned per deployment by migration order, so it is
+      NOT comparable across deployments and must not be hardcoded; resolve it against
+      django_content_type
+  - name: forumcontent_object_id
+    description: int, id of the row in the table named by content_type_id. Comment
+      and CommentThread ids both start at 1 and overlap heavily, so this is only meaningful
+      together with content_type_id
+
+- name: stg__mitxresidential__openedx__mysql__forum_historicalabuseflagger
+  description: Residential MITx open edX abuse flags that were raised on discussion
+    forum content and later cleared
+  columns:
+  - name: forumhistoricalabuseflag_id
+    description: int, the auto-incremented ID for this table
+  - name: user_id
+    description: int, foreign key to auth_user for whoever raised the flag
+  - name: forumhistoricalabuseflag_flagged_on
+    description: timestamp, when the content was flagged
+  - name: forumcontent_type_id
+    description: int, Django content-type id identifying which forum table content_object_id
+      points at. The value is assigned per deployment by migration order, so it is
+      NOT comparable across deployments and must not be hardcoded; resolve it against
+      django_content_type
+  - name: forumcontent_object_id
+    description: int, id of the row in the table named by content_type_id. Comment
+      and CommentThread ids both start at 1 and overlap heavily, so this is only meaningful
+      together with content_type_id

--- a/src/ol_dbt/models/staging/mitxresidential/_stg_mitxresidential__models.yml
+++ b/src/ol_dbt/models/staging/mitxresidential/_stg_mitxresidential__models.yml
@@ -551,6 +551,9 @@ models:
   columns:
   - name: forumthread_id
     description: int, the auto-incremented ID for this table
+    tests:
+    - unique
+    - not_null
   - name: user_id
     description: int, foreign key to auth_user for the thread author
   - name: user_username
@@ -600,6 +603,9 @@ models:
   columns:
   - name: forumcomment_id
     description: int, the auto-incremented ID for this table
+    tests:
+    - unique
+    - not_null
   - name: forumthread_id
     description: int, foreign key to forum_commentthread. This is the thread association;
       in the pre-migration Mongo data the equivalent field held an ObjectId string
@@ -647,6 +653,9 @@ models:
   columns:
   - name: forumuservote_id
     description: int, the auto-incremented ID for this table
+    tests:
+    - unique
+    - not_null
   - name: user_id
     description: int, foreign key to auth_user for the voter
   - name: forumuservote_value
@@ -668,10 +677,16 @@ models:
   columns:
   - name: forummongocontent_id
     description: int, the auto-incremented ID for this table
+    tests:
+    - unique
+    - not_null
   - name: forumcontent_mongo_id
     description: str, the 24-character hex ObjectId this row carried in the pre-migration
       Mongo forum database. Only content that existed at the migration has a row here,
       so content created since has no ObjectId at all
+    tests:
+    - unique
+    - not_null
   - name: forumcontent_type_id
     description: int, Django content-type id identifying which forum table content_object_id
       points at. The value is assigned per deployment by migration order, so it is
@@ -688,6 +703,9 @@ models:
   columns:
   - name: forumabuseflag_id
     description: int, the auto-incremented ID for this table
+    tests:
+    - unique
+    - not_null
   - name: user_id
     description: int, foreign key to auth_user for whoever raised the flag
   - name: forumabuseflag_flagged_on
@@ -708,6 +726,9 @@ models:
   columns:
   - name: forumhistoricalabuseflag_id
     description: int, the auto-incremented ID for this table
+    tests:
+    - unique
+    - not_null
   - name: user_id
     description: int, foreign key to auth_user for whoever raised the flag
   - name: forumhistoricalabuseflag_flagged_on

--- a/src/ol_dbt/models/staging/mitxresidential/_stg_mitxresidential__models.yml
+++ b/src/ol_dbt/models/staging/mitxresidential/_stg_mitxresidential__models.yml
@@ -659,8 +659,7 @@ models:
   - name: user_id
     description: int, foreign key to auth_user for the voter
   - name: forumuservote_value
-    description: int, +1 for an upvote and -1 for a downvote. Only upvotes occur in
-      practice, since the Open edX forum UI does not offer a downvote
+    description: int, +1 for an upvote and -1 for a downvote
   - name: forumcontent_type_id
     description: int, Django content-type id identifying which forum table content_object_id
       points at. The value is assigned per deployment by migration order, so it is

--- a/src/ol_dbt/models/staging/mitxresidential/stg__mitxresidential__openedx__mysql__forum_abuseflagger.sql
+++ b/src/ol_dbt/models/staging/mitxresidential/stg__mitxresidential__openedx__mysql__forum_abuseflagger.sql
@@ -1,0 +1,18 @@
+-- Residential MITx open edX active abuse flags raised on discussion forum content
+
+with source as (
+    select * from {{ source('ol_warehouse_raw_data', 'raw__mitx__openedx__mysql__forum_abuseflagger') }}
+)
+
+, cleaned as (
+
+    select
+        id as forumabuseflag_id
+        , user_id as user_id
+        , {{ cast_timestamp_to_iso8601('flagged_at') }} as forumabuseflag_flagged_on
+        , content_type_id as forumcontent_type_id
+        , content_object_id as forumcontent_object_id
+    from source
+)
+
+select * from cleaned

--- a/src/ol_dbt/models/staging/mitxresidential/stg__mitxresidential__openedx__mysql__forum_abuseflagger.sql
+++ b/src/ol_dbt/models/staging/mitxresidential/stg__mitxresidential__openedx__mysql__forum_abuseflagger.sql
@@ -8,7 +8,7 @@ with source as (
 
     select
         id as forumabuseflag_id
-        , user_id as user_id
+        , user_id
         , {{ cast_timestamp_to_iso8601('flagged_at') }} as forumabuseflag_flagged_on
         , content_type_id as forumcontent_type_id
         , content_object_id as forumcontent_object_id

--- a/src/ol_dbt/models/staging/mitxresidential/stg__mitxresidential__openedx__mysql__forum_comment.sql
+++ b/src/ol_dbt/models/staging/mitxresidential/stg__mitxresidential__openedx__mysql__forum_comment.sql
@@ -1,0 +1,32 @@
+-- Residential MITx open edX discussion forum responses and comments
+
+with source as (
+    select * from {{ source('ol_warehouse_raw_data', 'raw__mitx__openedx__mysql__forum_comment') }}
+)
+
+, cleaned as (
+
+    select
+        id as forumcomment_id
+        , comment_thread_id as forumthread_id
+        , parent_id as forumcomment_parent_id
+        , author_id as user_id
+        , author_username as user_username
+        , retired_username as user_retired_username
+        , course_id as courserun_readable_id
+        , body as forumcomment_body
+        , depth as forumcomment_depth
+        , sort_key as forumcomment_sort_key
+        , child_count as forumcomment_child_count
+        , endorsement as forumcomment_endorsement_data
+        , endorsed as forumcomment_is_endorsed
+        , visible as forumcomment_is_visible
+        , anonymous as forumcomment_is_anonymous
+        , anonymous_to_peers as forumcomment_is_anonymous_to_peers
+        , group_id as forumcomment_group_id
+        , {{ cast_timestamp_to_iso8601('created_at') }} as forumcomment_created_on
+        , {{ cast_timestamp_to_iso8601('updated_at') }} as forumcomment_updated_on
+    from source
+)
+
+select * from cleaned

--- a/src/ol_dbt/models/staging/mitxresidential/stg__mitxresidential__openedx__mysql__forum_commentthread.sql
+++ b/src/ol_dbt/models/staging/mitxresidential/stg__mitxresidential__openedx__mysql__forum_commentthread.sql
@@ -1,0 +1,35 @@
+-- Residential MITx open edX discussion forum threads
+
+with source as (
+    select * from {{ source('ol_warehouse_raw_data', 'raw__mitx__openedx__mysql__forum_commentthread') }}
+)
+
+, cleaned as (
+
+    select
+        id as forumthread_id
+        , author_id as user_id
+        , author_username as user_username
+        , retired_username as user_retired_username
+        , course_id as courserun_readable_id
+        , title as forumthread_title
+        , body as forumthread_body
+        , thread_type as forumthread_type
+        , commentable_id as forumthread_commentable_id
+        , context as forumthread_context
+        , group_id as forumthread_group_id
+        , closed as forumthread_is_closed
+        , closed_by_id as forumthread_closed_by_user_id
+        , close_reason_code as forumthread_close_reason_code
+        , pinned as forumthread_is_pinned
+        , visible as forumthread_is_visible
+        , endorsed as forumthread_is_endorsed
+        , anonymous as forumthread_is_anonymous
+        , anonymous_to_peers as forumthread_is_anonymous_to_peers
+        , {{ cast_timestamp_to_iso8601('created_at') }} as forumthread_created_on
+        , {{ cast_timestamp_to_iso8601('updated_at') }} as forumthread_updated_on
+        , {{ cast_timestamp_to_iso8601('last_activity_at') }} as forumthread_last_activity_on
+    from source
+)
+
+select * from cleaned

--- a/src/ol_dbt/models/staging/mitxresidential/stg__mitxresidential__openedx__mysql__forum_historicalabuseflagger.sql
+++ b/src/ol_dbt/models/staging/mitxresidential/stg__mitxresidential__openedx__mysql__forum_historicalabuseflagger.sql
@@ -1,0 +1,18 @@
+-- Residential MITx open edX abuse flags that were raised on discussion forum content and later cleared
+
+with source as (
+    select * from {{ source('ol_warehouse_raw_data', 'raw__mitx__openedx__mysql__forum_historicalabuseflagger') }}
+)
+
+, cleaned as (
+
+    select
+        id as forumhistoricalabuseflag_id
+        , user_id as user_id
+        , {{ cast_timestamp_to_iso8601('flagged_at') }} as forumhistoricalabuseflag_flagged_on
+        , content_type_id as forumcontent_type_id
+        , content_object_id as forumcontent_object_id
+    from source
+)
+
+select * from cleaned

--- a/src/ol_dbt/models/staging/mitxresidential/stg__mitxresidential__openedx__mysql__forum_historicalabuseflagger.sql
+++ b/src/ol_dbt/models/staging/mitxresidential/stg__mitxresidential__openedx__mysql__forum_historicalabuseflagger.sql
@@ -8,7 +8,7 @@ with source as (
 
     select
         id as forumhistoricalabuseflag_id
-        , user_id as user_id
+        , user_id
         , {{ cast_timestamp_to_iso8601('flagged_at') }} as forumhistoricalabuseflag_flagged_on
         , content_type_id as forumcontent_type_id
         , content_object_id as forumcontent_object_id

--- a/src/ol_dbt/models/staging/mitxresidential/stg__mitxresidential__openedx__mysql__forum_mongocontent.sql
+++ b/src/ol_dbt/models/staging/mitxresidential/stg__mitxresidential__openedx__mysql__forum_mongocontent.sql
@@ -1,0 +1,17 @@
+-- Residential MITx open edX bridge from forum-v2 rows to their pre-migration mongo objectids
+
+with source as (
+    select * from {{ source('ol_warehouse_raw_data', 'raw__mitx__openedx__mysql__forum_mongocontent') }}
+)
+
+, cleaned as (
+
+    select
+        id as forummongocontent_id
+        , mongo_id as forumcontent_mongo_id
+        , content_type_id as forumcontent_type_id
+        , content_object_id as forumcontent_object_id
+    from source
+)
+
+select * from cleaned

--- a/src/ol_dbt/models/staging/mitxresidential/stg__mitxresidential__openedx__mysql__forum_uservote.sql
+++ b/src/ol_dbt/models/staging/mitxresidential/stg__mitxresidential__openedx__mysql__forum_uservote.sql
@@ -1,0 +1,18 @@
+-- Residential MITx open edX votes cast on discussion forum content
+
+with source as (
+    select * from {{ source('ol_warehouse_raw_data', 'raw__mitx__openedx__mysql__forum_uservote') }}
+)
+
+, cleaned as (
+
+    select
+        id as forumuservote_id
+        , user_id as user_id
+        , vote as forumuservote_value
+        , content_type_id as forumcontent_type_id
+        , content_object_id as forumcontent_object_id
+    from source
+)
+
+select * from cleaned

--- a/src/ol_dbt/models/staging/mitxresidential/stg__mitxresidential__openedx__mysql__forum_uservote.sql
+++ b/src/ol_dbt/models/staging/mitxresidential/stg__mitxresidential__openedx__mysql__forum_uservote.sql
@@ -8,7 +8,7 @@ with source as (
 
     select
         id as forumuservote_id
-        , user_id as user_id
+        , user_id
         , vote as forumuservote_value
         , content_type_id as forumcontent_type_id
         , content_object_id as forumcontent_object_id


### PR DESCRIPTION
### What are the relevant tickets?
Part of https://github.com/mitodl/ol-data-platform/issues/2359 (retire `legacy_openedx`). Also unblocks the forum source in https://github.com/mitodl/ol-data-platform/issues/2534 (feedback aggregation, Phase 2).

### Description (What does it do?)
Stages the forum-v2 MySQL tables so dbt can see them. They have been syncing from the edxapp MySQL every 12h since the Mongo→MySQL migration, but all 12 were `modeled: false`, so no source YAML was generated and the data has been sitting in the lake invisible to dbt.

- Adds 18 staging models — six tables × three deployments — plus their source entries, model docs, and the `modeled: true` flips in the three `ingestion/inventory/units/*__mysql.yml`.
- Six tables, not all 12: `forum_commentthread`, `forum_comment`, `forum_uservote`, `forum_mongocontent`, `forum_abuseflagger`, `forum_historicalabuseflagger`. The other six (`coursestat`, `edithistory`, `forumuser`, `lastreadtime`, `readstate`, `subscription`) have no consumer yet and stay unmodelled.
- Two consumers are waiting on this: the IRx forum export that replaces the legacy mongodump, and the feedback project, whose Phase 2 reads forum posts at turn grain. Columns are named to the warehouse convention rather than to either consumer's contract.
- No `deduplicate_raw_table`. These are `full_refresh_overwrite`, so there are no append duplicates — same as the other full-refresh openedx tables.

**`content_type_id` is carried through unresolved, deliberately.** Four of the six tables are Django generic foreign keys keyed on `(content_type_id, content_object_id)`. Resolving that id needs `django_content_type`, which is not ingested from edxapp for any deployment. It cannot be hardcoded — the value is assigned per deployment by migration order (mitx 688/695, xpro 606/613, mitxonline 570/577) — and it cannot be inferred by joining, because `forum_commentthread.id` and `forum_comment.id` both start at 1 and overlap heavily enough that an unfiltered join matches *both* tables and returns a plausible-looking wrong answer. The hazard is written into the column descriptions so the next reader does not rediscover it. Ingesting `django_content_type` is tracked separately and blocks the irx forum model.

**Bodies are carried through unredacted**, consistent with every other staging model (`auth_user` staging carries `user_email`) and with there being no redaction convention in this layer. `mit_irx` is granted on the `external` directory only, not on staging, so delivering `body` to IRx stays an explicit decision at the `irx__` layer rather than something that leaks through by default.

### How can this be tested?
Built and inspected locally on `dev_local` (DuckDB over prod Iceberg, zero-copy):

```
ol-dbt local register --database ol_warehouse_production_raw
dbt run -t dev_local --select fqn:*forum_commentthread fqn:*forum_comment \
  fqn:*forum_uservote fqn:*forum_mongocontent fqn:*forum_abuseflagger \
  fqn:*forum_historicalabuseflagger
# Done. PASS=19 WARN=0 ERROR=0 SKIP=0     (18 models + 1 project hook)
```

Row counts from that build (local views registered 2026-08-25, so slightly behind live):

| model | mitxresidential | mitxpro | mitxonline |
|---|---:|---:|---:|
| `forum_commentthread` | 7,027 | 104,892 | 48,924 |
| `forum_comment` | 10,882 | 79,656 | 73,832 |
| `forum_uservote` | 2,837 | 16,915 | 23,454 |
| `forum_mongocontent` | 17,758 | 170,911 | 103,595 |
| `forum_abuseflagger` | 6 | 21 | 170 |
| `forum_historicalabuseflagger` | 3 | 3 | 57 |

Spot checks on the built output:
- Timestamps render as ISO 8601, e.g. `2026-08-25T11:37:17.813042Z`.
- No nulls in the columns downstream work depends on: `forumthread_id`, `user_id`, `forumcomment_created_on` (0 of 73,832 each on mitxonline), `forumcontent_mongo_id` (0 of 103,595).
- `forumcontent_mongo_id` is uniformly 24 characters and fully distinct (103,595 of 103,595), consistent with a one-to-one ObjectId bridge.
- `forumuservote_value` is `1` for all 23,454 mitxonline rows — the Open edX forum UI offers no downvote, so any consumer computing a `down_count` will get 0.

Static checks: `dbt parse` clean, `dbt list` shows all 18 registered, `ol-dbt validate --model staging` reports 0 errors (its 4 warnings are pre-existing docs-coverage gaps on unrelated models).

### Additional Context
The first local build failed on all 12 timestamp columns — `to_iso8601` is Trino-only and does not exist in DuckDB. Switched to the dispatched `cast_timestamp_to_iso8601` macro, which is the portable form.

That is worth a separate note: 24 staging models still call `to_iso8601` directly, and they genuinely do not build on `dev_local` — confirmed by running `stg__mitxpro__openedx__mysql__courserun_enrollment`, which fails with `Catalog Error: Scalar Function with name to_iso8601 does not exist`. Not touched here, but it means local-dev coverage is narrower than it looks.

Reviewer questions:
- Column naming: `forumthread_*` / `forumcomment_*` with `user_id`/`courserun_readable_id` for the conformed keys. Two unrelated consumers read these, so I aimed at the warehouse convention rather than either contract — say if you would name them differently, it is cheaper to change now than after both consumers build on them.
- Not macro-ised into one templated model. Three copies matches every other openedx staging table; these should get swept up by the existing per-platform-clone task along with everything else rather than forking the pattern for six tables.
