### PR TITLE
Close the irx model gaps against the delivered IRx CSVs

### DIFF
--- a/src/ol_dbt/models/external/IRX_SIMEON_MAPPING.md
+++ b/src/ol_dbt/models/external/IRX_SIMEON_MAPPING.md
@@ -63,7 +63,7 @@ transform: `irx__{deployment}__openedx__mysql__{table}` → `{table}-analytics.s
 | `auth_user-analytics.sql` | `auth_user` | ✅ | ✅ | ✅ |
 | `auth_userprofile-analytics.sql` | `auth_userprofile` | ✅ | ✅ | ✅ |
 | `certificates_generatedcertificate-analytics.sql` | `certificates_generatedcertificate` | ✅ | ✅ | ✅ |
-| `courseware_studentmodule-analytics.sql` | `courseware_studentmodule` | ❌ | ❌ | ❌ |
+| `courseware_studentmodule-analytics.sql` | `courseware_studentmodule` | ✅ | ✅ | ✅ |
 | `django_comment_client_role_users-analytics.sql` | `django_comment_client_role_users` | ✅ | ✅ | ✅ |
 | `grades_persistentcoursegrade-analytics.sql` | `grades_persistentcoursegrade` | ✅ | ✅ | ✅ |
 | `grades_persistentsubsectiongrade-analytics.sql` | `grades_persistentsubsectiongrade` | ✅ | ✅ | ✅ |
@@ -74,7 +74,7 @@ transform: `irx__{deployment}__openedx__mysql__{table}` → `{table}-analytics.s
 | `course_structure-analytics.json` | — (openedx `course_structure` asset) | ✅ | ✅ | ✅ |
 | `forum.mongo` | — (see the forum track) | ❌ | ❌ | ❌ |
 
-Ten of the thirteen are one rename away. The `assessment_*`, `submissions_*` and `workflow_*`
+Eleven of the thirteen are one rename away. The `assessment_*`, `submissions_*` and `workflow_*`
 models map into `ora/` in the same way; no Simeon report query reads them, so they are carried, not
 consumed.
 
@@ -93,26 +93,28 @@ from the query builders. **They are byte-identical across all three deployments*
 `consecutive_days_visit_count` — all hardcoded `''`/`0`. Those are the Askbot forum-user columns
 the edX SQL bundle's `auth_user` carries, which is the contract the model was built for.
 
-**Gap:** `course_id` is not selected. The model already inner-joins `student_courseenrollment`, so
-one row is emitted per (user, enrollment) — but with no `course_id` column those rows are
-indistinguishable duplicates. One-line fix; the join is already there.
+**Gap, closed here:** `course_id` was not selected. The model already inner-joins
+`student_courseenrollment`, so one row was emitted per (user, enrollment) with no `course_id`
+column to tell them apart — on mitxonline that was 542,616 rows for 241,833 distinct users, i.e.
+300,783 indistinguishable duplicates. `course_id` is now carried from the existing join, and
+`(id, course_id)` is distinct at exactly the row count.
 
 ### `enrollment_query.csv`
 `id,user_id,course_id,created,is_active,mode`
 
 `irx__{d}__openedx__mysql__student_courseenrollment` emits `course_id, mode, id, is_active`.
 
-**Gaps:** `user_id` and `created` are missing. Both exist on
+**Gaps, closed here:** `user_id` and `created` were missing. Both exist on
 `raw__{d}__openedx__mysql__student_courseenrollment` (`id, mode, created, user_id, course_id,
-is_active`), so this is two added lines. `user_id` is load-bearing — an enrollment file without it
-is not usable.
+is_active`) and are now selected. `user_id` is load-bearing — an enrollment file without it is not
+usable.
 
 ### `role_query.csv`
 `id,user_id,org,course_id,role` — from `student_courseaccessrole` (course *staff* access roles).
 
 `irx__{d}__openedx__mysql__student_courseaccessrole` emits `org, course_id, user_id, role`.
 
-**Gap:** `id` is missing. Present on the raw table. One line.
+**Gap, closed here:** `id` was missing. It is present on the raw table and is now selected.
 
 Note `student_courseaccessrole.org` is free text and drifts in case from the course key (mitxonline
 production has both `MITxt` and `MITxT`). Use the column, do not derive it.
@@ -124,8 +126,10 @@ production has both `MITxt` and `MITxT`). Use the column, do not derive it.
 `irx__{d}__openedx__mysql__django_comment_client_role_users` emits `course_id, user_id, name`.
 
 **Gaps:**
-- `id` — present on `raw__{d}__openedx__mysql__django_comment_client_role_users`. One line.
-- `name` → `role` — a rename.
+- `id` — **closed here**; it is present on
+  `raw__{d}__openedx__mysql__django_comment_client_role_users` and is now selected.
+- `name` → `role` — a rename the export applies when projecting the header. `name` stays correct
+  for the source shape, so this is not a model change.
 - `org` — **not derivable from anything currently ingested.** The legacy op joins
   `organizations_organizationcourse` and `organizations_organization`; neither table exists in
   `ol_warehouse_production_raw` for any deployment. This is an *ingestion* gap, not a modelling one.
@@ -140,10 +144,17 @@ production has both `MITxt` and `MITxT`). Use the column, do not derive it.
 `id,module_type,module_id,student_id,state,grade,created,modified,max_grade,done,course_id`
 
 `irx__{d}__openedx__mysql__courseware_studentmodule`, added for all three deployments.
-`raw__{d}__openedx__mysql__courseware_studentmodule` carries exactly those eleven columns, and
-`simeon/upload/schemas/schema_studentmodule.json` declares exactly those eleven fields in the same
-order — legacy CSV, raw table and Simeon schema all agree, so the model is a plain `select` in that
-order.
+`raw__{d}__openedx__mysql__courseware_studentmodule` carries exactly those eleven columns, though
+in a different order (`id, done, grade, state, created, modified, course_id, max_grade, module_id,
+student_id, module_type`), so the model restates them in the delivered order — which is also the
+order `simeon/upload/schemas/schema_studentmodule.json` declares.
+
+**This source needs deduplicating, unlike the forum tables.** It syncs
+`incremental_deduped_history` with a `modified` cursor, so the raw table accumulates a row per
+version rather than per learner-block. The model therefore applies
+`deduplicate_raw_table(order_by='modified', partition_columns='course_id, student_id, module_id')`,
+matching the partition columns each deployment's own staging model already uses. Selecting straight
+from source would ship superseded versions alongside current state.
 
 The model is deliberately **unscoped**. The legacy op loops over `edx_course_ids` and filters
 `where course_id = <course>` per course; the facade applies that scoping at export time from the

--- a/src/ol_dbt/models/external/IRX_SIMEON_MAPPING.md
+++ b/src/ol_dbt/models/external/IRX_SIMEON_MAPPING.md
@@ -1,0 +1,178 @@
+# irx__ models → Simeon file mapping
+
+Spec artifact for [#2359](https://github.com/mitodl/ol-data-platform/issues/2359). Verified
+2026-08-31 against the delivered files in the legacy buckets, the raw Iceberg tables, and
+[MIT-IR/simeon](https://github.com/MIT-IR/simeon) at `main`.
+
+## The two contracts are not the same, and this is the open question
+
+`README.md` in this directory records that the `irx__` models "were written to match the SQL file
+output of the edx-analytics-exporter", deliberately breaking with "a legacy interface that is no
+longer being used".
+
+On 2026-07-07 IRx replied on #2359: *"It would be great if the file format stays the same as the
+legacy data exports."*
+
+Those are two different targets. None of the six legacy CSV filenames appears anywhere in the
+Simeon source tree, and the legacy per-deployment layout is not the per-course layout Simeon walks.
+So "the same format" cannot mean both. **Resolve this with IRx before building the facade's tabular
+assets.** Everything below documents both contracts so the conversation has something concrete
+under it.
+
+## What Simeon actually expects
+
+`simeon/report/utilities.py` defines `TARGET_FILES` and `_course_has_all_files(folder, ...)`, which
+checks *"a given course's folder from unpacking the SQL archive"*. The unit is a **course run**, not
+a deployment:
+
+```
+{course_dir}/
+├── auth_user-analytics.sql
+├── auth_userprofile-analytics.sql
+├── certificates_generatedcertificate-analytics.sql
+├── course-analytics.xml.tar.gz
+├── course_structure-analytics.json
+├── courseware_studentmodule-analytics.sql
+├── django_comment_client_role_users-analytics.sql
+├── forum.mongo
+├── grades_persistentcoursegrade-analytics.sql
+├── grades_persistentsubsectiongrade-analytics.sql
+├── student_courseaccessrole-analytics.sql
+├── student_courseenrollment-analytics.sql
+├── user_id_map-analytics.sql
+└── ora/{table}-analytics.sql        (carried by the unpacker; no report query reads these)
+```
+
+`format_sql_filename` (`simeon/download/utilities.py:181`) is what produces that layout from an
+edx.org GPG-encrypted bundle. The naming rule for our purposes is just
+`{table}-analytics.sql`, with the forum dump named `forum.mongo`.
+
+## Coverage: `irx__` model → Simeon filename
+
+The `irx__` model names were chosen to line up with `TARGET_FILES`, so the mapping is a pure name
+transform: `irx__{deployment}__openedx__mysql__{table}` → `{table}-analytics.sql`.
+
+| Simeon filename | `irx__` model (`{table}` part) | mitx | xpro | mitxonline |
+|---|---|:--:|:--:|:--:|
+| `auth_user-analytics.sql` | `auth_user` | ✅ | ✅ | ✅ |
+| `auth_userprofile-analytics.sql` | `auth_userprofile` | ✅ | ✅ | ✅ |
+| `certificates_generatedcertificate-analytics.sql` | `certificates_generatedcertificate` | ✅ | ✅ | ✅ |
+| `courseware_studentmodule-analytics.sql` | `courseware_studentmodule` | ❌ | ❌ | ❌ |
+| `django_comment_client_role_users-analytics.sql` | `django_comment_client_role_users` | ✅ | ✅ | ✅ |
+| `grades_persistentcoursegrade-analytics.sql` | `grades_persistentcoursegrade` | ✅ | ✅ | ✅ |
+| `grades_persistentsubsectiongrade-analytics.sql` | `grades_persistentsubsectiongrade` | ✅ | ✅ | ✅ |
+| `student_courseaccessrole-analytics.sql` | `student_courseaccessrole` | ✅ | ✅ | ✅ |
+| `student_courseenrollment-analytics.sql` | `student_courseenrollment` | ✅ | ✅ | ✅ |
+| `user_id_map-analytics.sql` | `user_id_map` | ✅ | ✅ | ✅ |
+| `course-analytics.xml.tar.gz` | — (openedx `course_xml` asset) | ✅ | ✅ | ✅ |
+| `course_structure-analytics.json` | — (openedx `course_structure` asset) | ✅ | ✅ | ✅ |
+| `forum.mongo` | — (see the forum track) | ❌ | ❌ | ❌ |
+
+Ten of the thirteen are one rename away. The `assessment_*`, `submissions_*` and `workflow_*`
+models map into `ora/` in the same way; no Simeon report query reads them, so they are carried, not
+consumed.
+
+## Legacy CSV → `irx__` model, column by column
+
+Headers below were read from the delivered objects (`20260830/*.csv` in each legacy bucket), not
+from the query builders. **They are byte-identical across all three deployments**, and so are the
+`irx__` model select lists, so this mapping is deployment-invariant.
+
+### `users_query.csv`
+`id,username,first_name,last_name,email,is_staff,is_active,is_superuser,last_login,date_joined,course_id`
+
+`irx__{d}__openedx__mysql__auth_user` emits 22 columns: the 10 shared ones plus `pass_word`,
+`status`, `email_key`, `avatar_type`, `country`, `show_country`, `date_of_birth`,
+`interesting_tags`, `ignored_tags`, `email_tag_filter_strategy`, `display_tag_filter_strategy`,
+`consecutive_days_visit_count` — all hardcoded `''`/`0`. Those are the Askbot forum-user columns
+the edX SQL bundle's `auth_user` carries, which is the contract the model was built for.
+
+**Gap:** `course_id` is not selected. The model already inner-joins `student_courseenrollment`, so
+one row is emitted per (user, enrollment) — but with no `course_id` column those rows are
+indistinguishable duplicates. One-line fix; the join is already there.
+
+### `enrollment_query.csv`
+`id,user_id,course_id,created,is_active,mode`
+
+`irx__{d}__openedx__mysql__student_courseenrollment` emits `course_id, mode, id, is_active`.
+
+**Gaps:** `user_id` and `created` are missing. Both exist on
+`raw__{d}__openedx__mysql__student_courseenrollment` (`id, mode, created, user_id, course_id,
+is_active`), so this is two added lines. `user_id` is load-bearing — an enrollment file without it
+is not usable.
+
+### `role_query.csv`
+`id,user_id,org,course_id,role` — from `student_courseaccessrole` (course *staff* access roles).
+
+`irx__{d}__openedx__mysql__student_courseaccessrole` emits `org, course_id, user_id, role`.
+
+**Gap:** `id` is missing. Present on the raw table. One line.
+
+Note `student_courseaccessrole.org` is free text and drifts in case from the course key (mitxonline
+production has both `MITxt` and `MITxT`). Use the column, do not derive it.
+
+### `role_users.csv`
+`id,user_id,org,course_id,role` — same header as `role_query.csv`, different meaning: these are
+*forum* roles (Student, Moderator, Community TA), from `django_comment_client_role_users`.
+
+`irx__{d}__openedx__mysql__django_comment_client_role_users` emits `course_id, user_id, name`.
+
+**Gaps:**
+- `id` — present on `raw__{d}__openedx__mysql__django_comment_client_role_users`. One line.
+- `name` → `role` — a rename.
+- `org` — **not derivable from anything currently ingested.** The legacy op joins
+  `organizations_organizationcourse` and `organizations_organization`; neither table exists in
+  `ol_warehouse_production_raw` for any deployment. This is an *ingestion* gap, not a modelling one.
+
+  Deriving `org` from the course key is a 99.55% approximation, not an equivalence: measured against
+  the delivered mitxonline `role_users.csv` (549,130 rows), 2,476 rows disagree, because the
+  organization a course belongs to is not always its course-key org (e.g.
+  `course-v1:UAI_ET+UAI.1+2025_C503` belongs to organization `UAI_SOURCE`). Either ingest the two
+  tables or agree the approximation with IRx explicitly.
+
+### `studentmodule_query.csv`
+`id,module_type,module_id,student_id,state,grade,created,modified,max_grade,done,course_id`
+
+No `irx__` model in any deployment. **But this is the cheapest gap on the list:**
+`raw__{d}__openedx__mysql__courseware_studentmodule` exists in all three deployments with exactly
+those eleven columns, and `simeon/upload/schemas/schema_studentmodule.json` declares exactly those
+eleven fields in exactly that order. Legacy CSV, raw table and Simeon schema all agree — the model
+is a plain `select` over the raw table.
+
+Size caution: `legacy_openedx` carries a 32Gi memory limit in ol-infrastructure specifically
+"because of studentmodule loading to memory". `get_dbt_model_as_dataframe` returns a
+`pl.LazyFrame`, so the export asset must `sink_csv` it rather than `.collect().write_csv()` the way
+`b2b_organization/assets/data_export.py` does.
+
+### `course_ids.csv`
+`course_id` — single column. No `irx__` equivalent, and there does not need to be one. The legacy
+pipeline builds it from the Open edX course API via `list_courses`; the `openedx` code location
+already does the same enumeration in `sensors/openedx.py::course_run_sensor`, which calls
+`get_edx_course_ids()` and registers every course run as a dynamic partition
+(`{deployment}_openedx_course_run`). `course_ids.csv` is that partition set serialised — no new API
+call and no new source.
+
+## Summary of gaps
+
+| gap | kind | cost |
+|---|---|---|
+| `courseware_studentmodule` model absent (×3) | modelling | plain `select`; raw table already matches the Simeon schema exactly |
+| `auth_user` missing `course_id` | modelling | one line; join already present |
+| `student_courseenrollment` missing `user_id`, `created` | modelling | two lines |
+| `student_courseaccessrole` missing `id` | modelling | one line |
+| `django_comment_client_role_users` missing `id`, `name`→`role` | modelling | two lines |
+| `django_comment_client_role_users` missing `org` | **ingestion** | needs `organizations_organizationcourse` + `organizations_organization`, or an agreed 99.55% approximation |
+| `course_ids.csv` has no warehouse source | none | already available as the `{deployment}_openedx_course_run` dynamic partition set |
+| `forum.mongo` replacement | modelling | 12 `forum_*` tables are ingested but all `modeled: false` |
+
+The issue body calls the `irx__` set "a **superset**" of the six legacy CSVs. It is not. Correct
+that claim whenever #2359 is next updated.
+
+## Why this all lands in the `openedx` code location
+
+Decided 2026-08-31. The `irx_export` code location #2359 proposes is blocked by the code-location
+freeze, and `openedx` already holds three of the thirteen Simeon files locally — `course_xml`,
+`course_structure`, and the course-run enumeration that `course_ids.csv` is. The remaining ten come
+from Glue via `get_dbt_model_as_dataframe`. The facade needs its own S3 io-manager key, because
+`openedx`'s `s3file_io_manager` is bound to the landing-zone bucket
+(`openedx/definitions.py:155`), not to the IRx bucket.

--- a/src/ol_dbt/models/external/IRX_SIMEON_MAPPING.md
+++ b/src/ol_dbt/models/external/IRX_SIMEON_MAPPING.md
@@ -4,22 +4,28 @@ Spec artifact for [#2359](https://github.com/mitodl/ol-data-platform/issues/2359
 2026-08-31 against the delivered files in the legacy buckets, the raw Iceberg tables, and
 [MIT-IR/simeon](https://github.com/MIT-IR/simeon) at `main`.
 
-## The two contracts are not the same, and this is the open question
+## Which shape we deliver — decided
+
+There are two candidate targets and they are not the same.
 
 `README.md` in this directory records that the `irx__` models "were written to match the SQL file
 output of the edx-analytics-exporter", deliberately breaking with "a legacy interface that is no
-longer being used".
+longer being used". On 2026-07-07 IRx replied on #2359: *"It would be great if the file format
+stays the same as the legacy data exports."* None of the six legacy CSV filenames appears anywhere
+in the Simeon source tree, and the legacy per-deployment layout is not the per-course layout Simeon
+walks — so "the same format" cannot mean both.
 
-On 2026-07-07 IRx replied on #2359: *"It would be great if the file format stays the same as the
-legacy data exports."*
+**Decision (2026-08-31): the facade reproduces the shape we have been shipping all along — the six
+per-deployment CSVs, with the headers documented below.** We do not gate delivery on exact parity
+with Simeon's bundle. We deliver that shape, document it, and IRx adapts on their side or comes back
+with requested changes.
 
-Those are two different targets. None of the six legacy CSV filenames appears anywhere in the
-Simeon source tree, and the legacy per-deployment layout is not the per-course layout Simeon walks.
-So "the same format" cannot mean both. **Resolve this with IRx before building the facade's tabular
-assets.** Everything below documents both contracts so the conversation has something concrete
-under it.
+That makes the legacy headers the build target and the acceptance criterion for the parallel run.
+The Simeon bundle mapping in the next section is documented because it is the destination the data
+eventually reaches, and because it is what makes several column decisions legible — not because it
+is what the facade emits.
 
-## What Simeon actually expects
+## What Simeon expects downstream (reference, not the build target)
 
 `simeon/report/utilities.py` defines `TARGET_FILES` and `_course_has_all_files(folder, ...)`, which
 checks *"a given course's folder from unpacking the SQL archive"*. The unit is a **course run**, not
@@ -133,11 +139,15 @@ production has both `MITxt` and `MITxT`). Use the column, do not derive it.
 ### `studentmodule_query.csv`
 `id,module_type,module_id,student_id,state,grade,created,modified,max_grade,done,course_id`
 
-No `irx__` model in any deployment. **But this is the cheapest gap on the list:**
-`raw__{d}__openedx__mysql__courseware_studentmodule` exists in all three deployments with exactly
-those eleven columns, and `simeon/upload/schemas/schema_studentmodule.json` declares exactly those
-eleven fields in exactly that order. Legacy CSV, raw table and Simeon schema all agree — the model
-is a plain `select` over the raw table.
+`irx__{d}__openedx__mysql__courseware_studentmodule`, added for all three deployments.
+`raw__{d}__openedx__mysql__courseware_studentmodule` carries exactly those eleven columns, and
+`simeon/upload/schemas/schema_studentmodule.json` declares exactly those eleven fields in the same
+order — legacy CSV, raw table and Simeon schema all agree, so the model is a plain `select` in that
+order.
+
+The model is deliberately **unscoped**. The legacy op loops over `edx_course_ids` and filters
+`where course_id = <course>` per course; the facade applies that scoping at export time from the
+course list, so the same list drives the tabular files and the `courses/` prefix.
 
 Size caution: `legacy_openedx` carries a 32Gi memory limit in ol-infrastructure specifically
 "because of studentmodule loading to memory". `get_dbt_model_as_dataframe` returns a
@@ -154,16 +164,21 @@ call and no new source.
 
 ## Summary of gaps
 
-| gap | kind | cost |
+| gap | kind | status |
 |---|---|---|
-| `courseware_studentmodule` model absent (×3) | modelling | plain `select`; raw table already matches the Simeon schema exactly |
-| `auth_user` missing `course_id` | modelling | one line; join already present |
-| `student_courseenrollment` missing `user_id`, `created` | modelling | two lines |
-| `student_courseaccessrole` missing `id` | modelling | one line |
-| `django_comment_client_role_users` missing `id`, `name`→`role` | modelling | two lines |
-| `django_comment_client_role_users` missing `org` | **ingestion** | needs `organizations_organizationcourse` + `organizations_organization`, or an agreed 99.55% approximation |
-| `course_ids.csv` has no warehouse source | none | already available as the `{deployment}_openedx_course_run` dynamic partition set |
-| `forum.mongo` replacement | modelling | 12 `forum_*` tables are ingested but all `modeled: false` |
+| `courseware_studentmodule` model absent (×3) | modelling | **closed** — added; plain `select`, column order matches the legacy file and `schema_studentmodule.json` |
+| `auth_user` missing `course_id` | modelling | **closed** — carried from the enrolment join that was already there |
+| `student_courseenrollment` missing `user_id`, `created` | modelling | **closed** |
+| `student_courseaccessrole` missing `id` | modelling | **closed** |
+| `django_comment_client_role_users` missing `id` | modelling | **closed**; `name`→`role` is a projection the export applies, not a model change |
+| `django_comment_client_role_users` missing `org` | **ingestion** | **OPEN** — needs `organizations_organizationcourse` + `organizations_organization`, or an agreed 99.55% approximation |
+| `course_ids.csv` has no warehouse source | none | not a gap — the `{deployment}_openedx_course_run` dynamic partition set is the same API enumeration legacy makes |
+| `forum.mongo` replacement | modelling | open — 12 `forum_*` tables are ingested but all `modeled: false` |
+
+The added columns are all additive: `ol-dbt impact` reports 0 breaking and 0 warnings across the 15
+changed models. Column order in the models is not the delivery order — the export projects the
+legacy header explicitly by name — so the new columns were appended rather than inserted, which
+keeps the existing `mit_irx` grants on these tables stable for anyone already querying them.
 
 The issue body calls the `irx__` set "a **superset**" of the six legacy CSVs. It is not. Correct
 that claim whenever #2359 is next updated.

--- a/src/ol_dbt/models/external/irx/mitx/_irx_mitx__models.yml
+++ b/src/ol_dbt/models/external/irx/mitx/_irx_mitx__models.yml
@@ -56,6 +56,10 @@ models:
     description: int, the auto-incremented ID for this table
   - name: is_active
     description: boolean, whether the user has been active in a course
+  - name: user_id
+    description: int, foreign key to auth_user
+  - name: created
+    description: timestamp, when the enrolment was created
 
 - name: irx__mitx__openedx__mysql__grades_persistentcoursegrade
   description: MITx open edX course grades
@@ -179,6 +183,43 @@ models:
     description: int, display_tag_filter_strategy
   - name: consecutive_days_visit_count
     description: int, consecutive_days_visit_count
+  - name: course_id
+    description: string, unique ID representing a single MITx course run the user
+      is enrolled in. A user appears once per enrolment.
+
+- name: irx__mitx__openedx__mysql__courseware_studentmodule
+  description: Current learner state per course block in MITx OpenedX. Backs the studentmodule
+    file in the IRx delivery; the column order matches that file.
+  config:
+    grants:
+      select: ['mit_irx']
+  columns:
+  - name: id
+    description: int, the auto-incremented ID for this table
+  - name: module_type
+    description: str, category/type of the block, referencing course_structure
+  - name: module_id
+    description: str, block ID for a distinct piece of content in a course, referencing
+      course_structure
+  - name: student_id
+    description: int, foreign key to auth_user
+  - name: state
+    description: str, JSON text indicating the learner's last known state within a
+      course
+  - name: grade
+    description: str, floating point value indicating the total unweighted grade the
+      learner scored for this problem
+  - name: created
+    description: timestamp, when the row was created
+  - name: modified
+    description: timestamp, when the row was last updated
+  - name: max_grade
+    description: str, floating point value indicating the total possible unweighted
+      grade for this problem
+  - name: done
+    description: str, not used. The value is 'na' in every row
+  - name: course_id
+    description: string, unique ID representing a single MITx course run
 
 - name: irx__mitx__openedx__mysql__courseware_studentmodulehistoryextended
   description: history of studentmodule in Residential MITx open edx platform
@@ -635,6 +676,8 @@ models:
     description: int, foreign key to auth_user
   - name: name
     description: string, name of the discussion role e.g. Moderator
+  - name: id
+    description: int, the auto-incremented ID for this table
 
 - name: irx__mitx__openedx__mysql__student_anonymoususerid
   description: Mapping of MITx OpenedX learners to their anonymous user IDs per course
@@ -663,6 +706,8 @@ models:
     description: int, foreign key to auth_user
   - name: role
     description: string, the role name e.g. instructor, staff
+  - name: id
+    description: int, the auto-incremented ID for this table
 
 - name: irx__mitx__openedx__mysql__student_languageproficiency
   description: Language proficiency records for MITx OpenedX learners enrolled in

--- a/src/ol_dbt/models/external/irx/mitx/irx__mitx__openedx__mysql__auth_user.sql
+++ b/src/ol_dbt/models/external/irx/mitx/irx__mitx__openedx__mysql__auth_user.sql
@@ -29,5 +29,6 @@ select
     , 0 as email_tag_filter_strategy
     , 0 as display_tag_filter_strategy
     , 0 as consecutive_days_visit_count
+    , student_courseenrollment.course_id
 from auth_user
 inner join student_courseenrollment on auth_user.id = student_courseenrollment.user_id

--- a/src/ol_dbt/models/external/irx/mitx/irx__mitx__openedx__mysql__courseware_studentmodule.sql
+++ b/src/ol_dbt/models/external/irx/mitx/irx__mitx__openedx__mysql__courseware_studentmodule.sql
@@ -1,3 +1,9 @@
+with source as (
+    select * from {{ source('ol_warehouse_raw_data','raw__mitx__openedx__mysql__courseware_studentmodule') }}
+)
+
+{{ deduplicate_raw_table(order_by='modified' , partition_columns = 'course_id, student_id, module_id') }}
+
 select
     id
     , module_type
@@ -10,4 +16,4 @@ select
     , max_grade
     , done
     , course_id
-from {{ source('ol_warehouse_raw_data','raw__mitx__openedx__mysql__courseware_studentmodule') }}
+from most_recent_source

--- a/src/ol_dbt/models/external/irx/mitx/irx__mitx__openedx__mysql__courseware_studentmodule.sql
+++ b/src/ol_dbt/models/external/irx/mitx/irx__mitx__openedx__mysql__courseware_studentmodule.sql
@@ -1,0 +1,13 @@
+select
+    id
+    , module_type
+    , module_id
+    , student_id
+    , state
+    , grade
+    , created
+    , modified
+    , max_grade
+    , done
+    , course_id
+from {{ source('ol_warehouse_raw_data','raw__mitx__openedx__mysql__courseware_studentmodule') }}

--- a/src/ol_dbt/models/external/irx/mitx/irx__mitx__openedx__mysql__django_comment_client_role_users.sql
+++ b/src/ol_dbt/models/external/irx/mitx/irx__mitx__openedx__mysql__django_comment_client_role_users.sql
@@ -12,5 +12,6 @@ select
     dccr.course_id
     , dccru.user_id
     , dccr.name
+    , dccru.id
 from dccr
 inner join dccru on dccr.id = dccru.role_id

--- a/src/ol_dbt/models/external/irx/mitx/irx__mitx__openedx__mysql__student_courseaccessrole.sql
+++ b/src/ol_dbt/models/external/irx/mitx/irx__mitx__openedx__mysql__student_courseaccessrole.sql
@@ -3,4 +3,5 @@ select
     , course_id
     , user_id
     , role
+    , id
 from {{ source('ol_warehouse_raw_data','raw__mitx__openedx__mysql__student_courseaccessrole') }}

--- a/src/ol_dbt/models/external/irx/mitx/irx__mitx__openedx__mysql__student_courseenrollment.sql
+++ b/src/ol_dbt/models/external/irx/mitx/irx__mitx__openedx__mysql__student_courseenrollment.sql
@@ -3,4 +3,6 @@ select
     , mode
     , id
     , is_active
+    , user_id
+    , created
 from {{ source('ol_warehouse_raw_data','raw__mitx__openedx__mysql__student_courseenrollment') }}

--- a/src/ol_dbt/models/external/irx/mitxonline/_irx_mitxonline__models.yml
+++ b/src/ol_dbt/models/external/irx/mitxonline/_irx_mitxonline__models.yml
@@ -56,6 +56,10 @@ models:
     description: int, the auto-incremented ID for this table
   - name: is_active
     description: boolean, whether the user has been active in a course
+  - name: user_id
+    description: int, foreign key to auth_user
+  - name: created
+    description: timestamp, when the enrolment was created
 
 - name: irx__mitxonline__openedx__mysql__grades_persistentcoursegrade
   description: MITx Online open edX course grades
@@ -179,6 +183,9 @@ models:
     description: int, display_tag_filter_strategy
   - name: consecutive_days_visit_count
     description: int, consecutive_days_visit_count
+  - name: course_id
+    description: string, unique ID representing a single MITx Online course run the
+      user is enrolled in. A user appears once per enrolment.
 
 - name: irx__mitxonline__openedx__bigquery__email_opt_in
   description: Stores data on the email preferences of unique users.
@@ -476,6 +483,8 @@ models:
     description: int, foreign key to auth_user
   - name: name
     description: string, name of the discussion role e.g. Moderator
+  - name: id
+    description: int, the auto-incremented ID for this table
 
 - name: irx__mitxonline__openedx__mysql__student_anonymoususerid
   description: Mapping of MITx Online OpenedX learners to their anonymous user IDs
@@ -491,6 +500,40 @@ models:
   - name: id
     description: int, auto-incremented ID for this table
 
+- name: irx__mitxonline__openedx__mysql__courseware_studentmodule
+  description: Current learner state per course block in MITx Online OpenedX. Backs
+    the studentmodule file in the IRx delivery; the column order matches that file.
+  config:
+    grants:
+      select: ['mit_irx']
+  columns:
+  - name: id
+    description: int, the auto-incremented ID for this table
+  - name: module_type
+    description: str, category/type of the block, referencing course_structure
+  - name: module_id
+    description: str, block ID for a distinct piece of content in a course, referencing
+      course_structure
+  - name: student_id
+    description: int, foreign key to auth_user
+  - name: state
+    description: str, JSON text indicating the learner's last known state within a
+      course
+  - name: grade
+    description: str, floating point value indicating the total unweighted grade the
+      learner scored for this problem
+  - name: created
+    description: timestamp, when the row was created
+  - name: modified
+    description: timestamp, when the row was last updated
+  - name: max_grade
+    description: str, floating point value indicating the total possible unweighted
+      grade for this problem
+  - name: done
+    description: str, not used. The value is 'na' in every row
+  - name: course_id
+    description: string, unique ID representing a single MITx Online course run
+
 - name: irx__mitxonline__openedx__mysql__student_courseaccessrole
   description: Course staff and instructor role assignments in MITx Online OpenedX
   config:
@@ -505,6 +548,8 @@ models:
     description: int, foreign key to auth_user
   - name: role
     description: string, the role name e.g. instructor, staff
+  - name: id
+    description: int, the auto-incremented ID for this table
 
 - name: irx__mitxonline__openedx__mysql__student_languageproficiency
   description: Language proficiency records for MITx Online OpenedX learners enrolled

--- a/src/ol_dbt/models/external/irx/mitxonline/irx__mitxonline__openedx__mysql__auth_user.sql
+++ b/src/ol_dbt/models/external/irx/mitxonline/irx__mitxonline__openedx__mysql__auth_user.sql
@@ -29,5 +29,6 @@ select
     , 0 as email_tag_filter_strategy
     , 0 as display_tag_filter_strategy
     , 0 as consecutive_days_visit_count
+    , student_courseenrollment.course_id
 from auth_user
 inner join student_courseenrollment on auth_user.id = student_courseenrollment.user_id

--- a/src/ol_dbt/models/external/irx/mitxonline/irx__mitxonline__openedx__mysql__courseware_studentmodule.sql
+++ b/src/ol_dbt/models/external/irx/mitxonline/irx__mitxonline__openedx__mysql__courseware_studentmodule.sql
@@ -1,3 +1,9 @@
+with source as (
+    select * from {{ source('ol_warehouse_raw_data','raw__mitxonline__openedx__mysql__courseware_studentmodule') }}
+)
+
+{{ deduplicate_raw_table(order_by='modified' , partition_columns = 'course_id, module_id, student_id') }}
+
 select
     id
     , module_type
@@ -10,4 +16,4 @@ select
     , max_grade
     , done
     , course_id
-from {{ source('ol_warehouse_raw_data','raw__mitxonline__openedx__mysql__courseware_studentmodule') }}
+from most_recent_source

--- a/src/ol_dbt/models/external/irx/mitxonline/irx__mitxonline__openedx__mysql__courseware_studentmodule.sql
+++ b/src/ol_dbt/models/external/irx/mitxonline/irx__mitxonline__openedx__mysql__courseware_studentmodule.sql
@@ -1,0 +1,13 @@
+select
+    id
+    , module_type
+    , module_id
+    , student_id
+    , state
+    , grade
+    , created
+    , modified
+    , max_grade
+    , done
+    , course_id
+from {{ source('ol_warehouse_raw_data','raw__mitxonline__openedx__mysql__courseware_studentmodule') }}

--- a/src/ol_dbt/models/external/irx/mitxonline/irx__mitxonline__openedx__mysql__django_comment_client_role_users.sql
+++ b/src/ol_dbt/models/external/irx/mitxonline/irx__mitxonline__openedx__mysql__django_comment_client_role_users.sql
@@ -12,5 +12,6 @@ select
     dccr.course_id
     , dccru.user_id
     , dccr.name
+    , dccru.id
 from dccr
 inner join dccru on dccr.id = dccru.role_id

--- a/src/ol_dbt/models/external/irx/mitxonline/irx__mitxonline__openedx__mysql__student_courseaccessrole.sql
+++ b/src/ol_dbt/models/external/irx/mitxonline/irx__mitxonline__openedx__mysql__student_courseaccessrole.sql
@@ -3,4 +3,5 @@ select
     , course_id
     , user_id
     , role
+    , id
 from {{ source('ol_warehouse_raw_data','raw__mitxonline__openedx__mysql__student_courseaccessrole') }}

--- a/src/ol_dbt/models/external/irx/mitxonline/irx__mitxonline__openedx__mysql__student_courseenrollment.sql
+++ b/src/ol_dbt/models/external/irx/mitxonline/irx__mitxonline__openedx__mysql__student_courseenrollment.sql
@@ -3,4 +3,6 @@ select
     , mode
     , id
     , is_active
+    , user_id
+    , created
 from {{ source('ol_warehouse_raw_data','raw__mitxonline__openedx__mysql__student_courseenrollment') }}

--- a/src/ol_dbt/models/external/irx/xpro/_irx_xpro__models.yml
+++ b/src/ol_dbt/models/external/irx/xpro/_irx_xpro__models.yml
@@ -56,6 +56,10 @@ models:
     description: int, the auto-incremented ID for this table
   - name: is_active
     description: boolean, whether the user has been active in a course
+  - name: user_id
+    description: int, foreign key to auth_user
+  - name: created
+    description: timestamp, when the enrolment was created
 
 - name: irx__xpro__openedx__mysql__grades_persistentcoursegrade
   description: xPro open edX course grades
@@ -179,6 +183,9 @@ models:
     description: int, display_tag_filter_strategy
   - name: consecutive_days_visit_count
     description: int, consecutive_days_visit_count
+  - name: course_id
+    description: string, unique ID representing a single xPro course run the user
+      is enrolled in. A user appears once per enrolment.
 
 - name: irx__xpro__openedx__bigquery__email_opt_in
   description: Email opt-in preferences for xPRO learners from BigQuery
@@ -468,6 +475,8 @@ models:
     description: int, foreign key to auth_user
   - name: name
     description: string, name of the discussion role e.g. Moderator
+  - name: id
+    description: int, the auto-incremented ID for this table
 
 - name: irx__xpro__openedx__mysql__student_anonymoususerid
   description: Mapping of xPRO OpenedX learners to their anonymous user IDs per course
@@ -481,6 +490,40 @@ models:
     description: string, unique ID representing a single xPRO course run
   - name: id
     description: int, auto-incremented ID for this table
+
+- name: irx__xpro__openedx__mysql__courseware_studentmodule
+  description: Current learner state per course block in xPRO OpenedX. Backs the studentmodule
+    file in the IRx delivery; the column order matches that file.
+  config:
+    grants:
+      select: ['mit_irx']
+  columns:
+  - name: id
+    description: int, the auto-incremented ID for this table
+  - name: module_type
+    description: str, category/type of the block, referencing course_structure
+  - name: module_id
+    description: str, block ID for a distinct piece of content in a course, referencing
+      course_structure
+  - name: student_id
+    description: int, foreign key to auth_user
+  - name: state
+    description: str, JSON text indicating the learner's last known state within a
+      course
+  - name: grade
+    description: str, floating point value indicating the total unweighted grade the
+      learner scored for this problem
+  - name: created
+    description: timestamp, when the row was created
+  - name: modified
+    description: timestamp, when the row was last updated
+  - name: max_grade
+    description: str, floating point value indicating the total possible unweighted
+      grade for this problem
+  - name: done
+    description: str, not used. The value is 'na' in every row
+  - name: course_id
+    description: string, unique ID representing a single xPro course run
 
 - name: irx__xpro__openedx__mysql__student_courseaccessrole
   description: Course staff and instructor role assignments in xPRO OpenedX
@@ -496,6 +539,8 @@ models:
     description: int, foreign key to auth_user
   - name: role
     description: string, the role name e.g. instructor, staff
+  - name: id
+    description: int, the auto-incremented ID for this table
 
 - name: irx__xpro__openedx__mysql__student_languageproficiency
   description: Language proficiency records for xPRO OpenedX learners enrolled in

--- a/src/ol_dbt/models/external/irx/xpro/irx__xpro__openedx__mysql__auth_user.sql
+++ b/src/ol_dbt/models/external/irx/xpro/irx__xpro__openedx__mysql__auth_user.sql
@@ -29,5 +29,6 @@ select
     , 0 as email_tag_filter_strategy
     , 0 as display_tag_filter_strategy
     , 0 as consecutive_days_visit_count
+    , student_courseenrollment.course_id
 from auth_user
 inner join student_courseenrollment on auth_user.id = student_courseenrollment.user_id

--- a/src/ol_dbt/models/external/irx/xpro/irx__xpro__openedx__mysql__courseware_studentmodule.sql
+++ b/src/ol_dbt/models/external/irx/xpro/irx__xpro__openedx__mysql__courseware_studentmodule.sql
@@ -1,3 +1,9 @@
+with source as (
+    select * from {{ source('ol_warehouse_raw_data','raw__xpro__openedx__mysql__courseware_studentmodule') }}
+)
+
+{{ deduplicate_raw_table(order_by='modified' , partition_columns = 'course_id, module_id, student_id') }}
+
 select
     id
     , module_type
@@ -10,4 +16,4 @@ select
     , max_grade
     , done
     , course_id
-from {{ source('ol_warehouse_raw_data','raw__xpro__openedx__mysql__courseware_studentmodule') }}
+from most_recent_source

--- a/src/ol_dbt/models/external/irx/xpro/irx__xpro__openedx__mysql__courseware_studentmodule.sql
+++ b/src/ol_dbt/models/external/irx/xpro/irx__xpro__openedx__mysql__courseware_studentmodule.sql
@@ -1,0 +1,13 @@
+select
+    id
+    , module_type
+    , module_id
+    , student_id
+    , state
+    , grade
+    , created
+    , modified
+    , max_grade
+    , done
+    , course_id
+from {{ source('ol_warehouse_raw_data','raw__xpro__openedx__mysql__courseware_studentmodule') }}

--- a/src/ol_dbt/models/external/irx/xpro/irx__xpro__openedx__mysql__django_comment_client_role_users.sql
+++ b/src/ol_dbt/models/external/irx/xpro/irx__xpro__openedx__mysql__django_comment_client_role_users.sql
@@ -12,5 +12,6 @@ select
     dccr.course_id
     , dccru.user_id
     , dccr.name
+    , dccru.id
 from dccr
 inner join dccru on dccr.id = dccru.role_id

--- a/src/ol_dbt/models/external/irx/xpro/irx__xpro__openedx__mysql__student_courseaccessrole.sql
+++ b/src/ol_dbt/models/external/irx/xpro/irx__xpro__openedx__mysql__student_courseaccessrole.sql
@@ -3,4 +3,5 @@ select
     , course_id
     , user_id
     , role
+    , id
 from {{ source('ol_warehouse_raw_data','raw__xpro__openedx__mysql__student_courseaccessrole') }}

--- a/src/ol_dbt/models/external/irx/xpro/irx__xpro__openedx__mysql__student_courseenrollment.sql
+++ b/src/ol_dbt/models/external/irx/xpro/irx__xpro__openedx__mysql__student_courseenrollment.sql
@@ -3,4 +3,6 @@ select
     , mode
     , id
     , is_active
+    , user_id
+    , created
 from {{ source('ol_warehouse_raw_data','raw__xpro__openedx__mysql__student_courseenrollment') }}


### PR DESCRIPTION
### What are the relevant tickets?
Part of https://github.com/mitodl/ol-data-platform/issues/2359 (retire `legacy_openedx`).

### Description (What does it do?)
Closes the gaps between the `irx__` models and the six CSVs IRx actually receives every night. We are keeping the shape we have been shipping all along rather than gating on exact parity with Simeon's per-course bundle — we deliver that shape, document it, and IRx adapts or asks for changes. That makes the legacy headers the build target, and against them the models were short by more than the two gaps already tracked.

**New: `courseware_studentmodule` for all three deployments.** It backs `studentmodule_query.csv` and had no model anywhere. The raw table carries exactly the eleven columns of the legacy file — though in a different order (`id, done, grade, state, created, modified, course_id, max_grade, module_id, student_id, module_type`), so the model restates them in the delivered order, which is also the order `simeon/upload/schemas/schema_studentmodule.json` declares. Left deliberately **unscoped**: the legacy op loops over the API course list and filters per course, so the facade applies that scoping at export time and one list drives both the tabular files and the `courses/` prefix.

**Four column gaps closed**, found by diffing the delivered CSVs against the model select lists rather than reading the query builders:

| model | added | why it matters |
|---|---|---|
| `auth_user` | `course_id` | the model already inner-joins enrollment, so it emitted one row per enrolment with no column to tell them apart |
| `student_courseenrollment` | `user_id`, `created` | an enrollment file without `user_id` is not usable |
| `student_courseaccessrole` | `id` | in the legacy header |
| `django_comment_client_role_users` | `id` | in the legacy header |

Columns are **appended rather than inserted**. The export projects the header by name so model order does not matter, and these tables carry `mit_irx` select grants, so anyone already querying them keeps stable positions. `name` → `role` on the role-users model stays a projection the export applies, not a model change, since `name` is correct for the source shape.

Also adds `src/ol_dbt/models/external/IRX_SIMEON_MAPPING.md`, which documents both contracts — the legacy CSV headers we build to, and the Simeon bundle the data reaches downstream — plus the remaining gaps. Worth reading first; it is the reason the rest of the diff looks the way it does.

**One gap is deliberately left open.** `role_users.csv` carries an `org` column sourced from `organizations_organizationcourse` + `organizations_organization`, and neither table is ingested for any deployment. Deriving `org` from the course key looks right and is not: measured against the delivered mitxonline `role_users.csv` (549,130 rows), it disagrees on 2,476 — a course keyed to one org can belong to a differently-named organization (`course-v1:UAI_ET+UAI.1+2025_C503` belongs to `UAI_SOURCE`), and there are case variants (`MITxt` vs `MITxT`). That is a decision to make, not a fallback to assume quietly, so it is tracked separately rather than papered over here.

The issue body's claim that the `irx__` set is "a **superset**" of the six legacy CSVs is false; the doc flags it for correction.

### How can this be tested?
Built on `dev_local` (DuckDB over prod Iceberg, zero-copy):

```
ol-dbt local register --database ol_warehouse_production_raw
dbt run -t dev_local --select fqn:*irx*auth_user fqn:*irx*student_courseenrollment \
  fqn:*irx*student_courseaccessrole fqn:*irx*django_comment_client_role_users
# Done. PASS=13 WARN=0 ERROR=0 SKIP=0     (12 models + 1 project hook)
```

Row counts and null checks on the four changed models (local views registered 2026-08-25, so slightly behind live):

| model | mitx | xpro | mitxonline |
|---|---:|---:|---:|
| `auth_user` | 192,995 | 72,458 | 542,616 |
| `student_courseenrollment` | 192,995 | 72,458 | 542,616 |
| `student_courseaccessrole` | 19,412 | 10,821 | 11,456 |
| `django_comment_client_role_users` | 200,940 | 74,206 | 543,622 |

Every newly added column is fully populated — 0 nulls for `auth_user.course_id`, `student_courseenrollment.user_id`, `student_courseenrollment.created`, `student_courseaccessrole.id` and `django_comment_client_role_users.id`, in all three deployments.

**The `auth_user` duplicate problem is measurable.** On mitxonline the model emits 542,616 rows for 241,833 distinct users. Before this change there was no `course_id` column, so 300,783 of those rows were byte-identical duplicates of another row with no way to tell them apart. With `course_id` added, `(id, course_id)` is distinct at 542,616 — exactly the row count, one row per enrolment as intended.

Enrollment output spot-check (mitxonline), showing the two added columns in place:
```
(543471, 912648, 'course-v1:UAI_B2C+UAI.1+1T2026',  2026-08-25 12:10:03.511253, True, 'audit')
(543470, 923173, 'course-v1:MITxT+CTL.SC0x+2T2026', 2026-08-25 12:10:02.553472, True, 'audit')
 id      user_id  course_id                          created                     is_active  mode
```

**The three `courseware_studentmodule` models were NOT built locally.** They parse, compile and validate, but I could not materialize them on `dev_local`: the raw sources are 5.0 GB (mitx), 0.9 GB (xpro) and 5.1 GB (mitxonline) of compressed Parquet, the `state` column is large JSON text that expands considerably, and the machine had 71 GB free. A first attempt at all three ran long enough to look like a disk-fill risk and was stopped; xpro alone then exceeded a ten-minute budget. No partial tables were left behind. **These three need a check on the warehouse rather than locally** — the SQL is a plain `select` whose eleven column names and their order were verified against both the delivered CSV header and `schema_studentmodule.json`, but "it runs at that scale" is not something this PR demonstrates.

Static checks:
- `dbt parse` clean — all three raw `courseware_studentmodule` sources were already declared, so no source YAML was needed.
- `ol-dbt validate --model external` — 0 errors, 0 warnings with a manifest present. (Without one it emits 258 "cannot resolve column list" warnings and is not really checking anything; run `dbt deps && dbt parse -t dev_local` first.)
- `ol-dbt impact` — **0 breaking, 0 warnings across all 15 changed models**, every change additive.

Header parity was checked against the delivered objects, not the code: the header line of each `20260830/*.csv` in `mitx-etl-residential-live-mitx-production`, `mitx-etl-xpro-production-mitxpro-production` and `mitx-etl-mitxonline-production` is byte-identical across the three deployments, and so are the `irx__` select lists, so the mapping is deployment-invariant.

### Additional Context
Reviewer questions:
- `courseware_studentmodule` is big — 5.0 GB of compressed Parquet on mitx, though not the biggest in the schema (`courseware_studentmodulehistory` is 9.6 GB). `legacy_openedx` carries a 32Gi memory limit in ol-infrastructure specifically "because of studentmodule loading to memory". When the facade export lands it must `sink_csv` the LazyFrame that `get_dbt_model_as_dataframe` returns, not `.collect().write_csv()` the way `b2b_organization/assets/data_export.py` does, or that limit follows it into whichever code location hosts it.
- Appending rather than inserting columns was a deliberate call to protect existing `mit_irx` readers. Say if you would rather have the models match the legacy header order directly.
