### PR TITLE
fix(marimo): authenticate to Galaxy via its own OAuth2 flow, split the notebook templates

### DIFF
--- a/images/marimo-jupyterlab/Dockerfile
+++ b/images/marimo-jupyterlab/Dockerfile
@@ -18,5 +18,8 @@ RUN pip install --no-cache-dir \
     'marimo[sandbox]>=0.19.11' \
     marimo-jupyter-extension
 
-# Seed notebook copied to ~/notebooks/ on first user login via postStart hook.
+# Seed notebooks and the environment README. The JupyterHub singleuser
+# postStart hook copies these into ~/notebooks/ with `cp -n`, so a user's
+# edited copy on the persistent home volume is never overwritten. See
+# ol-infrastructure applications/jupyterhub_data/deployment.py.
 COPY templates/ /usr/local/share/marimo/templates/

--- a/images/marimo-jupyterlab/templates/README.md
+++ b/images/marimo-jupyterlab/templates/README.md
@@ -95,12 +95,14 @@ column completion, result is a dataframe, cell joins the reactive graph. One
 statement, whole result in memory, no parameter binding.
 
 **The cursor** — `cur.execute("SELECT ...")`. Ordinary Python: loops, dynamic
-SQL, `fetchmany` streaming, and anything that is not a single `SELECT` (`SHOW`,
-`EXPLAIN`, `SET SESSION`). `cur.stats` is how you find out why a query is slow.
-Returns tuples; marimo cannot see the dependency.
+SQL, `fetchmany` streaming, and connection-scoped state like `SET SESSION`,
+which a SQL cell cannot hold because it opens a fresh connection per statement.
+`cur.stats` is how you find out why a query is slow. Returns tuples; marimo
+cannot see the dependency.
 
-Reach for a SQL cell. Drop to the cursor for a loop, a stream, or a
-non-`SELECT`. `demo.py` §3 has the full trade-off.
+Reach for a SQL cell — it runs `SHOW`, `EXPLAIN` and DDL too, not only
+`SELECT`. Drop to the cursor for a loop, a stream, session state, or
+`cur.stats`. `demo.py` §3 has the full trade-off.
 
 ## Personal data
 
@@ -121,7 +123,7 @@ Kernels are culled after 4 hours idle; there is no absolute session limit.
 | Symptom | Cause |
 |---|---|
 | `401 Authentication required` | Sign-in never completed, or the kernel restarted. Re-run the connect cell and open the link. |
-| Login link never appears | Look at the cell's **console** output, not its rendered output. |
+| Login link never appears | It renders as a callout in the cell's own output while the cell blocks. If that is empty, check the cell's **console** pane — the `print()` there is a fallback. |
 | The login link does not work | Each attempt mints a new link and retires the previous one. Re-run the connect cell to get a fresh one. |
 | `Catalog must be specified` | Unqualified table name with no session catalog. Qualify it, or use the `warehouse` engine. |
 | Counts look too high | A join to an SCD2 dimension missing `AND is_current`. |

--- a/images/marimo-jupyterlab/templates/README.md
+++ b/images/marimo-jupyterlab/templates/README.md
@@ -33,8 +33,6 @@ Configured for you:
 | `TRINO_PORT` | `443` |
 | `TRINO_CATALOG` | Default warehouse catalog |
 
-AWS credentials for S3 and Glue arrive via IRSA — no `AWS_ACCESS_KEY_ID` needed.
-
 ## Adding a package
 
 Each notebook has its own isolated environment, built from the `/// script`

--- a/images/marimo-jupyterlab/templates/README.md
+++ b/images/marimo-jupyterlab/templates/README.md
@@ -19,8 +19,10 @@ second gets you into the warehouse: Starburst Galaxy authenticates query clients
 itself, federating the login to the same MIT OL SSO, so the first query of a
 session prints a link for you to open.
 
-The token is cached in memory for the life of the kernel, so you sign in once
-per session. Restarting the kernel means signing in again.
+The token is cached in memory and reused while Galaxy accepts it, so signing in
+is not per-query — but it is not guaranteed to be once per session either. If
+the token expires or is revoked, the next query 401s and a fresh login link
+appears. Restarting the kernel also means signing in again.
 
 Queries run as **you** — your access is exactly what your role grants, and your
 queries are attributable.
@@ -86,7 +88,11 @@ every historical row.
 
 So a join on the key alone matches every version, and counts multiply by the
 number of times that row has been edited. **Every join to an SCD2 dimension
-needs `AND <dim>.is_current`.** `demo.py` §4 measures the difference.
+needs a version filter.** For current-state questions that is
+`AND <dim>.is_current`; for a point-in-time question, match the fact's date
+against the row's `effective_date`/`end_date` interval instead, because
+`is_current` would assign today's attributes to a past fact. `demo.py` §4
+measures the difference.
 
 ## Two ways to query
 

--- a/images/marimo-jupyterlab/templates/README.md
+++ b/images/marimo-jupyterlab/templates/README.md
@@ -1,0 +1,138 @@
+# Notebooks on the OL Data Platform
+
+A quick reference you can read without leaving the notebook. The full guide —
+including how the environment is deployed and operated — lives at
+<https://engineering.ol.mit.edu/application_specific_guides/jupyterhub/data_platform_notebooks/>.
+
+## The three files
+
+| File | Purpose |
+|---|---|
+| `getting_started.py` | Minimal template. Signs in, registers the `warehouse` engine, loads the usual libraries. Copy it to start something new. |
+| `demo.py` | Full tour — finding tables, both query styles, star-schema joins, reactive inputs, charts, and the traps. Read once, then raid for patterns. |
+| `README.md` | This file. |
+
+## Signing in
+
+There are two sign-ins. The first gets you into this notebook environment. The
+second gets you into the warehouse: Starburst Galaxy authenticates query clients
+itself, federating the login to the same MIT OL SSO, so the first query of a
+session prints a link for you to open.
+
+The token is cached in memory for the life of the kernel, so you sign in once
+per session. Restarting the kernel means signing in again.
+
+Queries run as **you** — your access is exactly what your role grants, and your
+queries are attributable.
+
+Configured for you:
+
+| Variable | Meaning |
+|---|---|
+| `TRINO_HOST` | Starburst Galaxy endpoint |
+| `TRINO_PORT` | `443` |
+| `TRINO_CATALOG` | Default warehouse catalog |
+
+AWS credentials for S3 and Glue arrive via IRSA — no `AWS_ACCESS_KEY_ID` needed.
+
+## Adding a package
+
+Each notebook has its own isolated environment, built from the `/// script`
+header at the top of the file. **`pip install` does not persist.** Add the
+package to that list and restart the kernel:
+
+```python
+# /// script
+# requires-python = ">=3.11"
+# dependencies = [
+#   "polars>=1.0",
+#   "trino[sqlalchemy]>=0.330",
+# ]
+# ///
+```
+
+The templates ship with polars, pandas, numpy, pyarrow, and altair.
+
+## Finding data
+
+Open **Explore variables and data sources** in the sidebar and expand
+`warehouse`. Schemas load when you expand them, so an unexpanded tree is not an
+empty one.
+
+The schema suffix names the dbt layer:
+
+| Suffix | Contents | Query it? |
+|---|---|---|
+| `_raw` | Untransformed source loads, ~1,400 tables | No — no cleaning, no keys |
+| `_staging` | One model per source table | Rarely — no conformed keys |
+| `_intermediate` | Reusable joins | No — implementation detail |
+| `_dimensional` | The star schema | **Start here** |
+| `_mart` | Wide tables per business area | Yes, if one fits |
+| `_reporting` | Shaped for dashboards | Only to reproduce a dashboard figure |
+
+In `_dimensional`: `dim_*` groups or filters, `tfact_*` is one row per event,
+`afact_*` is pre-summarised, `bridge_*` is a many-to-many link.
+
+**Most of what you see in the panel is not on that list.** There are also dozens
+of `ol_warehouse_production_<username>_*` schemas — developer sandboxes from
+`ol-dbt local`, not authoritative and not maintained. If a schema name has a
+person in it, it is not for you.
+
+
+## The one thing that will silently give you wrong numbers
+
+Several dimensions are slowly-changing (type 2): editing a course run writes a
+new row and keeps the old one, marked by `is_current`. The surrogate key is
+*stable across versions* — the same `courserun_pk` is on the current row and on
+every historical row.
+
+So a join on the key alone matches every version, and counts multiply by the
+number of times that row has been edited. **Every join to an SCD2 dimension
+needs `AND <dim>.is_current`.** `demo.py` §4 measures the difference.
+
+## Two ways to query
+
+**SQL cells** — `mo.sql("SELECT ...", engine=warehouse)`. SQL editing with
+column completion, result is a dataframe, cell joins the reactive graph. One
+statement, whole result in memory, no parameter binding.
+
+**The cursor** — `cur.execute("SELECT ...")`. Ordinary Python: loops, dynamic
+SQL, `fetchmany` streaming, and anything that is not a single `SELECT` (`SHOW`,
+`EXPLAIN`, `SET SESSION`). `cur.stats` is how you find out why a query is slow.
+Returns tuples; marimo cannot see the dependency.
+
+Reach for a SQL cell. Drop to the cursor for a loop, a stream, or a
+non-`SELECT`. `demo.py` §3 has the full trade-off.
+
+## Personal data
+
+`dim_user` holds names and email addresses, and neither template touches it.
+Before you write a query that does: aggregate if you can (the facts carry
+`user_fk`, so `count(DISTINCT user_fk)` answers most questions without
+returning a person), select named columns rather than `*`, put a floor on group
+sizes, and remember your home directory is a persistent volume — a CSV of
+learner rows written there outlives the question you wrote it to answer.
+
+## Limits
+
+Standard is 2 CPU / 8 GB, Large is 4 CPU / 32 GB. Home is 5 GB and persists.
+Kernels are culled after 4 hours idle; there is no absolute session limit.
+
+## Troubleshooting
+
+| Symptom | Cause |
+|---|---|
+| `401 Authentication required` | Sign-in never completed, or the kernel restarted. Re-run the connect cell and open the link. |
+| Login link never appears | Look at the cell's **console** output, not its rendered output. |
+| The login link does not work | Each attempt mints a new link and retires the previous one. Re-run the connect cell to get a fresh one. |
+| `Catalog must be specified` | Unqualified table name with no session catalog. Qualify it, or use the `warehouse` engine. |
+| Counts look too high | A join to an SCD2 dimension missing `AND is_current`. |
+| Panel looks empty | Expand `warehouse`; schemas load lazily. An entry reading *no databases available* is a raw DB-API connection and can never show a tree. |
+| Query never returns | Missing `LIMIT` on a fact table. `cur.stats` shows what the cluster is processing. |
+| `ModuleNotFoundError` after `pip install` | Sandbox mode. Add the package to the `/// script` header and restart the kernel. |
+
+## Sharing
+
+`marimo run <file>.py` serves the notebook as an app with the code hidden.
+Export to self-contained HTML, or to `.ipynb` for a Jupyter collaborator. The
+notebook is a `.py` file, so it commits and code-reviews like source.

--- a/images/marimo-jupyterlab/templates/README.md
+++ b/images/marimo-jupyterlab/templates/README.md
@@ -133,6 +133,11 @@ Kernels are culled after 4 hours idle; there is no absolute session limit.
 
 ## Sharing
 
-`marimo run <file>.py` serves the notebook as an app with the code hidden.
-Export to self-contained HTML, or to `.ipynb` for a Jupyter collaborator. The
-notebook is a `.py` file, so it commits and code-reviews like source.
+`marimo run --sandbox <file>.py` serves the notebook as an app with the code
+hidden. Export to self-contained HTML, or to `.ipynb` for a Jupyter
+collaborator. The notebook is a `.py` file, so it commits and code-reviews like
+source.
+
+`--sandbox` is what builds the environment from the `/// script` header. Without
+it marimo runs in the base environment, which has none of the notebook
+packages.

--- a/images/marimo-jupyterlab/templates/demo.py
+++ b/images/marimo-jupyterlab/templates/demo.py
@@ -384,9 +384,18 @@ def _(mo):
 
     So a join on the key alone matches every version of the run, and your
     counts multiply by however many times that run has been edited. Every join
-    to an SCD2 dimension needs `AND <dim>.is_current`, on both dimensions. The
-    dbt schema for `courserun_pk` says so outright: *"Always filter with
-    is_current=true when looking up by this key."*
+    to an SCD2 dimension needs a version filter, on both dimensions. For
+    current-state questions — almost everything you will ask — that filter is
+    `AND <dim>.is_current`, and the dbt schema for `courserun_pk` says so
+    outright: *"Always filter with is_current=true when looking up by this
+    key."*
+
+    For a point-in-time question — what the course was called *when* that
+    certificate was issued — `is_current` is the wrong filter: it staples
+    today's attributes onto a past fact. Match the interval instead, e.g.
+    `AND cert.certificate_created_on >= run.effective_date AND
+    (cert.certificate_created_on < run.end_date OR run.end_date IS NULL)`.
+    Every example here is current-state.
 
     **Why this hides.** Only 144 of ~8,000 course runs have more than one
     version, so a query that forgets the filter looks right on almost
@@ -897,9 +906,10 @@ def _(mo):
       them to anyone who knows the cohort.
     - Your home directory is a persistent volume. A CSV of learner rows written
       there is a copy that outlives the question you wrote it to answer.
-    - Everything you run is attributed to you: Galaxy authorises the query
+    - Queries through Galaxy are attributed to you: Galaxy authorises each one
       against your own SSO identity, so your access is exactly your role's
-      access, and it is logged.
+      access, and it is logged. That guarantee is specific to the Trino path —
+      it is the reason this notebook queries the warehouse and nothing else.
     """)
     return
 

--- a/images/marimo-jupyterlab/templates/demo.py
+++ b/images/marimo-jupyterlab/templates/demo.py
@@ -1,0 +1,965 @@
+# /// script
+# requires-python = ">=3.11"
+# dependencies = [
+#   "altair>=5.4",
+#   "numpy>=2.0",
+#   "pandas>=2.0",
+#   "polars>=1.0",
+#   "pyarrow>=17.0",
+#   "sqlalchemy>=2.0",
+#   "trino[sqlalchemy]>=0.330",
+# ]
+# ///
+
+import marimo
+
+__generated_with = "0.24.0"
+app = marimo.App(width="medium")
+
+
+@app.cell
+def _():
+    import marimo as mo
+
+    return (mo,)
+
+
+@app.cell
+def _(mo):
+    mo.md(r"""
+    # A tour of the OL warehouse in marimo
+
+    This notebook is meant to be read top to bottom once, then raided for
+    patterns. It covers signing in, finding tables, the two ways to run a
+    query, the star-schema joins the dimensional model is built for, reactive
+    inputs, charts, and the traps specific to this warehouse.
+
+    For a blank starting point, use `getting_started.py`.
+
+    **Everything here queries aggregates.** No example selects individual
+    learner rows, and none of them touch `dim_user`. See *Working with
+    personal data* at the bottom before you write anything that does.
+    """)
+    return
+
+
+@app.cell
+def _(mo):
+    mo.md(r"""
+    ## 1. Connect
+
+    Identical to `getting_started.py` — see the comments in the cell below for
+    why each piece is shaped the way it is.
+    """)
+    return
+
+
+@app.cell
+def _():
+    import os
+
+    import sqlalchemy
+    import trino
+    import trino.sqlalchemy  # registers the "trino://" SQLAlchemy dialect
+
+    def _show_login_url(url: str) -> None:
+        # Printed rather than rendered with mo.md: this runs while the calling
+        # cell is still blocked inside execute(), polling Galaxy for the token,
+        # so the cell's rendered output is not on screen yet. marimo streams
+        # stdout to the cell's console area live, which is where this lands.
+        print(  # noqa: T201
+            "\nStarburst Galaxy login required. Open this URL, sign in with "
+            f"MIT OL SSO, then come back — the query resumes on its own:\n\n"
+            f"    {url}\n",
+            flush=True,
+        )
+
+    # One auth object shared by the engine and the cursor, so you sign in once.
+    # Galaxy is itself the authorization server: it federates the login to
+    # Keycloak SSO and issues its own token. It does not accept a
+    # Keycloak-issued JWT, so JWTAuthentication cannot be used here.
+    _auth = trino.auth.OAuth2Authentication(redirect_auth_url_handler=_show_login_url)
+
+    _host = os.environ["TRINO_HOST"]
+    _port = int(os.environ.get("TRINO_PORT", "443"))
+    catalog = os.environ.get("TRINO_CATALOG", "ol_data_lake_production")
+
+    # http_scheme must be explicit: the SQLAlchemy dialect's
+    # create_connect_args() never sets it and would default to plain http.
+    # request_timeout is the HTTP read timeout for every request, including the
+    # poll that waits for you to finish the Galaxy login. The library default is
+    # 30 seconds, which is not enough time to open a browser, get through SSO
+    # and come back — and each retry mints a NEW login URL, so the one already
+    # printed goes dead. 600 seconds gives a realistic window, and also lets a
+    # slow query keep polling instead of erroring.
+    _connect_args = {
+        "auth": _auth,
+        "http_scheme": "https",
+        "request_timeout": 600,
+    }
+
+    warehouse = sqlalchemy.create_engine(
+        trino.sqlalchemy.URL(host=_host, port=_port, catalog=catalog),
+        connect_args=_connect_args,
+    )
+
+    # Connection stays cell-local so the data sources panel does not show a
+    # second, permanently empty entry; the cursor keeps it alive.
+    _conn = trino.dbapi.connect(
+        host=_host, port=_port, catalog=catalog, **_connect_args
+    )
+    cur = _conn.cursor()
+    return catalog, cur, warehouse
+
+
+@app.cell
+def _(cur, mo):
+    cur.execute("SHOW CATALOGS")
+    mo.md(
+        "**Catalogs available to you:** "
+        + ", ".join(f"`{row[0]}`" for row in cur.fetchall())
+    )
+    return
+
+
+@app.cell
+def _(mo):
+    mo.md(r"""
+    ## 2. Finding your way around
+
+    Open **Explore variables and data sources** in the left sidebar and expand
+    `warehouse`. Schemas load when you expand them rather than up front —
+    marimo will not eagerly scan a remote warehouse, so an unexpanded tree is
+    not an empty one.
+
+    The warehouse is built by dbt in layers, and the schema name tells you
+    which layer you are in. dbt appends the model's folder to the target
+    schema, so `ol_warehouse_production` + `dimensional` becomes
+    `ol_warehouse_production_dimensional`:
+
+    | Schema | What lives there | Use it? |
+    |---|---|---|
+    | `_raw` | Untransformed source loads, ~1,400 tables | No — no cleaning, no keys |
+    | `_staging` | One model per source table, lightly cleaned | Rarely — no conformed keys |
+    | `_intermediate` | Reusable joins and reshapes | No — implementation detail |
+    | `_dimensional` | The star schema: `dim_*`, `tfact_*`, `afact_*`, `bridge_*` | **Yes, start here** |
+    | `_mart` | Purpose-built wide tables per business area | Yes, if one fits your question |
+    | `_reporting` | Shaped for specific dashboards | Only to reproduce a dashboard number |
+    | `_external` | Extracts shaped for outside consumers | Only if you are that consumer |
+    | `_integrations` | Payloads for other MIT applications | No |
+
+    **Most of what you see in the panel is not on that list.** Alongside these
+    there are dozens of schemas named `ol_warehouse_production_<username>_*` —
+    developer sandboxes from `ol-dbt local`, holding whatever someone was
+    working on. They are not authoritative and not maintained; one is even
+    called `ol_warehouse_production_<your name>_staging`. If a schema name has
+    a person in it, it is not for you.
+
+    Table name prefixes in the dimensional layer:
+
+    - `dim_*` — a thing you group or filter by (course, platform, date)
+    - `tfact_*` — a *transaction* fact, one row per event (an enrollment, a grade)
+    - `afact_*` — an *aggregate* fact, pre-summarised
+    - `bridge_*` — a many-to-many link (a course has many instructors)
+    """)
+    return
+
+
+@app.cell
+def _(mo):
+    mo.md(r"""
+    ### What is actually in there
+
+    The query below is the panel's information in table form, which is handy
+    when you want to search or filter it. `information_schema` is a Trino
+    built-in and exists in every catalog.
+    """)
+    return
+
+
+@app.cell
+def _(mo, warehouse):
+    layers = mo.sql(
+        """
+        SELECT
+            table_schema
+            , count(*) AS tables
+        FROM information_schema.tables
+        -- Only the canonical layers. Dropping this filter returns ~80 schemas,
+        -- most of them per-developer sandboxes, which buries the ones you want.
+        WHERE table_schema IN (
+            'ol_warehouse_production_raw'
+            , 'ol_warehouse_production_staging'
+            , 'ol_warehouse_production_intermediate'
+            , 'ol_warehouse_production_dimensional'
+            , 'ol_warehouse_production_mart'
+            , 'ol_warehouse_production_reporting'
+            , 'ol_warehouse_production_external'
+            , 'ol_warehouse_production_integrations'
+        )
+        GROUP BY table_schema
+        ORDER BY tables DESC
+        """,
+        engine=warehouse,
+    )
+    return
+
+
+@app.cell
+def _(mo):
+    mo.md(r"""
+    ## 3. Two ways to run a query
+
+    Both go to the same warehouse over the same authenticated session. They
+    differ in what they hand back and how much of marimo you get.
+
+    ### SQL cells — `mo.sql(..., engine=warehouse)`
+
+    **Advantages**
+
+    - The editor treats it as SQL: syntax highlighting, and column completion
+      fed by the data sources panel.
+    - The result is a dataframe (polars here, because polars is installed;
+      pandas if it were not), so charting and `mo.ui.table` work directly on it.
+    - The cell joins marimo's reactive graph. Name the result, use that name in
+      another cell, and the second cell re-runs by itself when the query does.
+    - An engine dropdown appears on the cell, so switching catalogs is a click
+      once you have more than one engine.
+    - It is the form a colleague can read without knowing Python.
+
+    **Disadvantages**
+
+    - One statement, one result. No `fetchmany` loop, no cursor state.
+    - Building the query text conditionally means f-string interpolation, which
+      gets awkward past a couple of variables and has no parameter binding — so
+      never interpolate anything you did not construct yourself.
+    - The whole result is materialised in memory. A missing `LIMIT` on a fact
+      table will hurt.
+    - Session-level statements (`SET SESSION`, `USE`) do not belong here; they
+      apply to a connection, and the engine pools those.
+
+    ### The DB-API cursor — `cur.execute(...)`
+
+    **Advantages**
+
+    - Ordinary Python. Loop it, build SQL from a list, wrap it in a function,
+      call it from a helper module.
+    - `fetchmany(n)` streams, so you can process more than fits in memory.
+    - Handles everything that is not a single `SELECT`: `SHOW CATALOGS`,
+      `EXPLAIN`, `SET SESSION`, DDL.
+    - `cur.stats` and `cur.query_id` expose Galaxy's own view of the running
+      query, which is how you find out why something is slow.
+
+    **Disadvantages**
+
+    - You get tuples and a `description`; turning that into a dataframe is on
+      you.
+    - No SQL editing support — it is a Python string.
+    - Invisible to the reactive graph. marimo cannot tell that a cell using
+      `cur` depends on a query in another cell, so ordering is your problem.
+
+    **Rule of thumb:** reach for a SQL cell. Drop to the cursor when you need a
+    loop, a stream, or a statement that is not a `SELECT`.
+    """)
+    return
+
+
+@app.cell
+def _(mo):
+    mo.md(r"""
+    ### The same question both ways
+
+    Live courses per platform — first as a SQL cell.
+    """)
+    return
+
+
+@app.cell
+def _(mo, warehouse):
+    courses_by_platform = mo.sql(
+        """
+        SELECT
+            primary_platform
+            , count(*) AS live_courses
+        FROM ol_warehouse_production_dimensional.dim_course
+        WHERE is_current AND course_is_live
+        GROUP BY primary_platform
+        ORDER BY live_courses DESC
+        """,
+        engine=warehouse,
+    )
+    return
+
+
+@app.cell
+def _(mo):
+    mo.md("""
+    Then through the cursor, ending up at the same dataframe.
+    """)
+    return
+
+
+@app.cell
+def _(cur, pl):
+    cur.execute("""
+        SELECT
+            primary_platform
+            , count(*) AS live_courses
+        FROM ol_warehouse_production_dimensional.dim_course
+        WHERE is_current AND course_is_live
+        GROUP BY primary_platform
+        ORDER BY live_courses DESC
+    """)
+    # description[0] is the column name; the rest of the tuple is type info.
+    _columns = [d[0] for d in cur.description]
+    courses_via_cursor = pl.DataFrame(cur.fetchall(), schema=_columns, orient="row")
+    courses_via_cursor
+    return (courses_via_cursor,)
+
+
+@app.cell
+def _(courses_via_cursor, cur, mo):
+    # Galaxy's own accounting for the query that cursor just ran — the reason
+    # to keep a cursor around even when SQL cells do the querying.
+    #
+    # courses_via_cursor is taken as an argument purely to order this cell
+    # after the one that ran the query. marimo cannot see that `cur` carries
+    # state, so without that edge it could run this cell first and report the
+    # stats of SHOW CATALOGS instead. This is the DB-API cursor's "invisible to
+    # the reactive graph" disadvantage, in the flesh.
+    _ = courses_via_cursor
+    mo.md(f"""
+    Stats from the last cursor query (`{cur.query_id}`):
+
+    - rows: `{cur.stats.get("processedRows")}`
+    - bytes scanned: `{cur.stats.get("processedBytes")}`
+    - wall time (ms): `{cur.stats.get("elapsedTimeMillis")}`
+    """)
+    return
+
+
+@app.cell
+def _(mo):
+    mo.md(r"""
+    ## 4. The star schema, and the trap in it
+
+    A fact table holds keys and measures; the dimensions hold the labels you
+    group by. Every fact here carries `courserun_fk` pointing at
+    `dim_course_run.courserun_pk`, and `dim_course_run.course_fk` points on at
+    `dim_course.course_pk` — so one join chain gets you from any of
+    `tfact_certificate`, `tfact_enrollment` or `tfact_grade` to a course title.
+
+    **The trap.** `dim_course_run` and `dim_course` are slowly-changing
+    dimensions (type 2): when a course run's attributes change, a new row is
+    written and the old one is kept, with `effective_date`, `end_date` and
+    `is_current` marking the versions. `courserun_pk` is *deliberately stable
+    across versions* — the same key appears on the current row and on every
+    historical row.
+
+    So a join on the key alone matches every version of the run, and your
+    counts multiply by however many times that run has been edited. Every join
+    to an SCD2 dimension needs `AND <dim>.is_current`, on both dimensions. The
+    dbt schema for `courserun_pk` says so outright: *"Always filter with
+    is_current=true when looking up by this key."*
+
+    **Why this hides.** Only 144 of ~8,000 course runs have more than one
+    version, so a query that forgets the filter looks right on almost
+    everything. The damage is concentrated: two runs currently carry over a
+    thousand versions each. Forget `is_current` and those two multiply by
+    ~1,000 while the rest are untouched.
+
+    **And the filter is not quite sufficient.** Those same two runs each have
+    *twelve* rows flagged `is_current`, which breaks the one-current-row-per-key
+    rule an SCD2 dimension is supposed to guarantee. Run the next cell to see
+    it: `current_rows` should never exceed `distinct_course_runs`, and it does.
+
+    Those two runs have issued no certificates yet, so nothing below is
+    currently wrong — which is the least reassuring reason for a query to be
+    right. That is why the aggregate counts `count(DISTINCT cert.user_fk)` and
+    `count(DISTINCT cert.certificate_key)` rather than `count(*)`: distinct on
+    the fact's own key cannot be multiplied by a duplicated dimension row, so
+    the query stays correct on the day those runs start certifying people.
+    """)
+    return
+
+
+@app.cell
+def _(mo, warehouse):
+    scd_fanout = mo.sql(
+        """
+        SELECT
+            count(*) AS courserun_rows
+            , count(DISTINCT courserun_pk) AS distinct_course_runs
+            , count(*) FILTER (WHERE is_current) AS current_rows
+        FROM ol_warehouse_production_dimensional.dim_course_run
+        """,
+        engine=warehouse,
+    )
+    return
+
+
+@app.cell
+def _(mo):
+    mo.md(r"""
+    ### Certificates per course
+
+    The join the dimensional model exists to make easy: a fact rolled up
+    through two dimensions to readable labels, `tfact_certificate` →
+    `dim_course_run` → `dim_course`. Both dimensions are SCD2, so both need
+    `is_current` — miss either one and the counts inflate.
+
+    Aggregate-only by construction: `count(DISTINCT user_fk)` counts learners
+    without returning any, and the `HAVING` floor keeps courses with a handful
+    of identifiable people out of the result.
+
+    `tfact_certificate` is deliberately the fact here. It holds ~870k rows
+    against `tfact_enrollment`'s ~16M and `tfact_grade`'s ~43M, so this
+    finishes quickly — worth knowing when you pick a fact to explore from.
+    """)
+    return
+
+
+@app.cell
+def _(mo, warehouse):
+    course_certificates = mo.sql(
+        """
+        SELECT
+            course.course_readable_id
+            , course.course_title
+            , run.platform
+            , count(DISTINCT run.courserun_pk) AS runs
+            , count(DISTINCT cert.user_fk) AS learners_certified
+            -- DISTINCT on the fact's own key, not count(*): if a dimension row
+            -- is duplicated (see the note above), count(*) multiplies with it
+            , count(DISTINCT cert.certificate_key) AS certificates
+        FROM ol_warehouse_production_dimensional.tfact_certificate AS cert
+        -- is_current on BOTH dimensions, or the SCD2 versions fan the counts out
+        INNER JOIN ol_warehouse_production_dimensional.dim_course_run AS run
+            ON cert.courserun_fk = run.courserun_pk
+            AND run.is_current
+        INNER JOIN ol_warehouse_production_dimensional.dim_course AS course
+            ON run.course_fk = course.course_pk
+            AND course.is_current
+        WHERE NOT cert.certificate_is_revoked
+        GROUP BY
+            course.course_readable_id
+            , course.course_title
+            , run.platform
+        HAVING count(DISTINCT cert.user_fk) >= 100
+        ORDER BY learners_certified DESC
+        LIMIT 100
+        """,
+        engine=warehouse,
+    )
+    return (course_certificates,)
+
+
+@app.cell
+def _(mo):
+    mo.md(r"""
+    ### Many-to-many, and a dimension that is not SCD2
+
+    A course *can* belong to several departments, so the link lives in a
+    `bridge_` table of nothing but two foreign keys. Joining through it fans
+    each course out to one row per department — which is what you want when
+    counting by department, and what you must undo before summing a per-course
+    measure.
+
+    Worth knowing how thin that ice is: of the 398 courses in this bridge,
+    exactly **two** have more than one department. A fan-out bug here would
+    double-count those two rows and look perfectly correct everywhere else,
+    which is why `count(DISTINCT course_pk)` below is deliberate rather than
+    stylistic.
+
+    Note the asymmetry too: `dim_course` needs `AND is_current`;
+    `dim_department` has no such column. Not every dimension is versioned, so
+    check rather than copying the filter everywhere.
+
+    Two things the real data will show you. `department_number` is absent from
+    these rows, because this bridge covers only mitxonline courses while the
+    numbers arrive with the OCW ones. And EECS appears twice, under two
+    spellings the source systems disagree on. Warehouse data is like this.
+    """)
+    return
+
+
+@app.cell
+def _(mo, warehouse):
+    courses_by_department = mo.sql(
+        """
+        SELECT
+            dept.department_name
+            , count(DISTINCT course.course_pk) AS courses
+            , count(DISTINCT CASE
+                WHEN course.course_is_live THEN course.course_pk
+              END) AS live_courses
+        FROM ol_warehouse_production_dimensional.bridge_course_department AS link
+        INNER JOIN ol_warehouse_production_dimensional.dim_department AS dept
+            ON link.department_fk = dept.department_pk
+        INNER JOIN ol_warehouse_production_dimensional.dim_course AS course
+            ON link.course_fk = course.course_pk
+            AND course.is_current
+        GROUP BY dept.department_name
+        HAVING count(DISTINCT course.course_pk) > 1
+        ORDER BY courses DESC
+        LIMIT 25
+        """,
+        engine=warehouse,
+    )
+    return
+
+
+@app.cell
+def _(mo):
+    mo.md(r"""
+    ## 5. Reactive inputs
+
+    This is the part that has no Jupyter equivalent. A `mo.ui` element is a
+    value other cells can read, and marimo re-runs exactly the cells that read
+    it when it changes — no re-execute button, and no stale output, because
+    there is no hidden execution order to get out of sync with.
+
+    Pick a platform below and watch the query under it follow.
+
+    One thing worth copying from the next cell: its options come from a query
+    over the same tables the driven queries read, not from a convenient nearby
+    column. `primary_platform` in `dim_course` would have been the obvious
+    source and it is quietly wrong — the three tables disagree about which
+    platforms exist. `ocw` has courses but no course runs and no certificates,
+    `residential` has runs but no certificates, `micromasters` has certificates
+    but no runs. Offer any of those and the cells below return nothing, which
+    reads as a broken notebook rather than an honest empty set.
+    """)
+    return
+
+
+@app.cell
+def _(mo, warehouse):
+    queryable_platforms = mo.sql(
+        """
+        SELECT DISTINCT run.platform
+        FROM ol_warehouse_production_dimensional.dim_course_run AS run
+        WHERE run.is_current
+          AND run.courserun_start_on IS NOT NULL
+          AND run.platform IN (
+            SELECT DISTINCT cert.platform
+            FROM ol_warehouse_production_dimensional.tfact_certificate AS cert
+          )
+        ORDER BY run.platform
+        """,
+        engine=warehouse,
+    )
+    return (queryable_platforms,)
+
+
+@app.cell
+def _(mo, queryable_platforms):
+    _options = sorted(
+        p for p in queryable_platforms["platform"].to_list() if p is not None
+    )
+    # A default value means the cells below are live on first load rather than
+    # waiting on a click; the mo.stop guards further down still cover the
+    # empty-options case.
+    platform = mo.ui.dropdown(
+        options=_options,
+        value=_options[0] if _options else None,
+        label="Platform",
+        searchable=True,
+    )
+    platform
+    return (platform,)
+
+
+@app.cell
+def _(mo, platform, warehouse):
+    # Interpolating a value from a dropdown whose options came from the
+    # warehouse. There is no parameter binding in a SQL cell, so only ever
+    # interpolate values you produced yourself — never raw text a user typed.
+    platform_runs = mo.sql(
+        f"""
+        SELECT
+            run.courserun_readable_id
+            , run.courserun_title
+            , run.semester
+            , run.courserun_start_on
+        FROM ol_warehouse_production_dimensional.dim_course_run AS run
+        WHERE run.is_current
+          AND run.platform = '{platform.value}'
+          AND run.courserun_start_on IS NOT NULL
+        ORDER BY run.courserun_start_on DESC
+        LIMIT 50
+        """,  # noqa: S608 — interpolates a closed dropdown list, not typed text
+        engine=warehouse,
+    )
+    return (platform_runs,)
+
+
+@app.cell
+def _(mo):
+    mo.md(r"""
+    `mo.stop` halts a cell early. Note where it can and cannot help: the SQL
+    cell above is a single `mo.sql(...)` call, which is what makes marimo render
+    it as SQL, so there is no room for a guard inside it. If the dropdown had no
+    value it would interpolate `'None'` and quietly return zero rows — which is
+    the real reason the dropdown above sets a default.
+
+    So the guard goes downstream, on the cell that would otherwise format a
+    `None` into text.
+    """)
+    return
+
+
+@app.cell
+def _(mo, platform, platform_runs):
+    mo.stop(
+        platform.value is None,
+        mo.md("Pick a platform above to see its course runs."),
+    )
+    mo.md(f"**{len(platform_runs)}** current runs on `{platform.value}`.")
+    return
+
+
+@app.cell
+def _(mo):
+    mo.md(r"""
+    ## 6. Charts
+
+    `dim_date` is a calendar table: one row per date, with the parts already
+    split out (`year`, `quarter`, `month`, `academic_term`). Facts carry a
+    `*_date_key` into it, which is how you get a monthly series without
+    date-truncation gymnastics — here `certificate_issued_date_key`.
+    """)
+    return
+
+
+@app.cell
+def _(mo, warehouse):
+    certificates_by_month = mo.sql(
+        """
+        SELECT
+            calendar.year
+            , calendar.month
+            , cert.platform
+            , count(*) AS certificates
+        FROM ol_warehouse_production_dimensional.tfact_certificate AS cert
+        INNER JOIN ol_warehouse_production_dimensional.dim_date AS calendar
+            ON cert.certificate_issued_date_key = calendar.date_key
+        WHERE calendar.year >= 2020
+          AND NOT cert.certificate_is_revoked
+        GROUP BY calendar.year, calendar.month, cert.platform
+        ORDER BY calendar.year, calendar.month
+        """,
+        engine=warehouse,
+    )
+    return (certificates_by_month,)
+
+
+@app.cell
+def _(alt, certificates_by_month, mo, pl):
+    _plot_data = certificates_by_month.with_columns(
+        pl.date(pl.col("year"), pl.col("month"), 1).alias("month_start")
+    )
+
+    _chart = (
+        alt.Chart(_plot_data)
+        .mark_line(point=True)
+        .encode(
+            x=alt.X("month_start:T", title="Month"),
+            y=alt.Y("certificates:Q", title="Certificates issued"),
+            color=alt.Color("platform:N", title="Platform"),
+            tooltip=["month_start:T", "platform:N", "certificates:Q"],
+        )
+        .properties(height=320)
+    )
+
+    # mo.ui.altair_chart makes the selection readable from Python: drag on the
+    # chart and the next cell sees the selected rows.
+    certificate_chart = mo.ui.altair_chart(_chart)
+    certificate_chart
+    return (certificate_chart,)
+
+
+@app.cell
+def _(certificate_chart, mo):
+    mo.stop(
+        certificate_chart.value is None or len(certificate_chart.value) == 0,
+        mo.md("*Drag a selection on the chart to filter these rows.*"),
+    )
+    certificate_chart.value
+    return
+
+
+@app.cell
+def _(mo):
+    mo.md(r"""
+    ## 7. polars, pandas, and which one you get
+
+    SQL cells return **polars** here. marimo picks the dataframe library by
+    what is installed, preferring polars, so removing polars from the
+    `/// script` header would silently switch every result to pandas.
+
+    polars is worth learning for warehouse work: expressions instead of
+    indexing, and no index to reason about.
+    """)
+    return
+
+
+@app.cell
+def _(course_certificates, pl):
+    # Everything below happens locally, on rows the warehouse already returned.
+    top_by_platform = (
+        course_certificates.filter(pl.col("learners_certified") > 0)
+        .with_columns(
+            # >1 means learners certified in more than one run of the course
+            (pl.col("certificates") / pl.col("learners_certified")).alias(
+                "certificates_per_learner"
+            )
+        )
+        .sort("learners_certified", descending=True)
+        .group_by("platform")
+        .head(3)
+        .select(
+            "platform",
+            "course_readable_id",
+            "runs",
+            "learners_certified",
+            "certificates_per_learner",
+        )
+        .sort(["platform", "learners_certified"], descending=[False, True])
+    )
+    top_by_platform
+    return
+
+
+@app.cell
+def _(course_certificates, mo):
+    import textwrap
+
+    # to_pandas() is the escape hatch for anything that wants a pandas object —
+    # statsmodels, scikit-learn, an older internal helper.
+    _as_pandas = course_certificates.to_pandas()
+
+    # The indent matters. mo.md() runs inspect.cleandoc() on the string, which
+    # strips the indent COMMON to every line — so interpolating unindented
+    # multi-line text into an indented literal drops the common indent to zero,
+    # nothing is stripped, and the whole cell renders as an indented code block
+    # instead of prose. Match the literal's indent, then lstrip the first line
+    # because the literal already supplies its leading spaces.
+    _summary = textwrap.indent(
+        _as_pandas["learners_certified"].describe().to_string(), "    "
+    ).lstrip()
+
+    mo.md(f"""
+    Converted to pandas: `{type(_as_pandas).__name__}`,
+    shape `{_as_pandas.shape}`.
+
+    Describing `learners_certified` through pandas:
+
+    ```
+    {_summary}
+    ```
+    """)
+    return
+
+
+@app.cell
+def _(mo):
+    mo.md(r"""
+    ## 8. Sortable, searchable tables
+
+    `mo.ui.table` beats a bare dataframe for anything you want to hand to
+    someone: it paginates, sorts, searches, and its selection is readable from
+    Python.
+    """)
+    return
+
+
+@app.cell
+def _(course_certificates, mo):
+    certificates_table = mo.ui.table(
+        course_certificates,
+        selection="multi",
+        page_size=10,
+        label="Courses by certificates — select rows to inspect",
+    )
+    certificates_table
+    return (certificates_table,)
+
+
+@app.cell
+def _(certificates_table, mo):
+    mo.stop(
+        len(certificates_table.value) == 0,
+        mo.md("*Select rows above to summarise them.*"),
+    )
+    mo.md(
+        f"Selected **{len(certificates_table.value)}** courses, "
+        f"**{certificates_table.value['learners_certified'].sum():,}** certified learners."
+    )
+    return
+
+
+@app.cell
+def _(mo):
+    mo.md(r"""
+    ## 9. Caching expensive queries
+
+    Re-running a cell re-runs its query. `mo.cache` memoises on the arguments,
+    so a query you are iterating around gets paid for once per distinct
+    argument set. The cache lives in the kernel, so a restart clears it.
+
+    Use it on a *function*, not on a cell — the point is to key on inputs.
+    """)
+    return
+
+
+@app.cell
+def _(catalog, mo, pl, warehouse):
+    @mo.cache
+    def certificate_summary(platform_name: str):
+        # No return annotation: `pl` is an untyped marimo cell parameter, so
+        # `-> pl.DataFrame` is not a resolvable type to a static checker.
+        """Certificates by year for one platform, as a polars DataFrame.
+
+        Cached per platform, in the kernel, for the life of the session.
+        """
+        query = f"""
+            SELECT
+                calendar.year
+                , count(*) AS certificates
+                , count(DISTINCT cert.user_fk) AS learners
+            FROM {catalog}.ol_warehouse_production_dimensional.tfact_certificate
+                AS cert
+            INNER JOIN {catalog}.ol_warehouse_production_dimensional.dim_date
+                AS calendar
+                ON cert.certificate_issued_date_key = calendar.date_key
+            WHERE cert.platform = '{platform_name}'
+              AND NOT cert.certificate_is_revoked
+            GROUP BY calendar.year
+            ORDER BY calendar.year DESC
+        """  # noqa: S608 — platform_name comes from the same dropdown
+        return pl.read_database(query, connection=warehouse)
+
+    return (certificate_summary,)
+
+
+@app.cell
+def _(certificate_summary, mo, platform):
+    mo.stop(platform.value is None, mo.md("Pick a platform above."))
+    # Change the dropdown and come back: the second visit is served from cache.
+    certificate_summary(platform.value)
+    return
+
+
+@app.cell
+def _(mo):
+    mo.md(r"""
+    ## 10. Reading Iceberg directly, without Trino
+
+    The warehouse is Iceberg tables on S3 with a Glue catalog, and the pod's
+    IRSA role can read both. For a full-table scan feeding a model, going
+    straight to the files with `pyiceberg` skips the query engine entirely.
+    For anything with a filter, a join, or an aggregate, use Trino — that is
+    what it is for.
+
+    Add `pyiceberg[glue,s3fs]>=0.9` to the `/// script` header and restart the
+    kernel to try it:
+
+    ```python
+    from pyiceberg.catalog.glue import GlueCatalog
+
+    glue = GlueCatalog(name="ol", **{"region_name": "us-east-1"})
+    table = glue.load_table(
+        ("ol_warehouse_production_dimensional", "dim_course")
+    )
+    arrow_table = table.scan(
+        selected_fields=("course_readable_id", "course_title"),
+        row_filter="is_current = true",
+    ).to_arrow()
+    ```
+
+    **This works on `nb.data.ol.mit.edu` and will not work on `nb-qa`.** The
+    IRSA policy grants S3 and Glue on `ol-data-lake-*-<environment>`, so the QA
+    pod holds QA-scoped credentials — while `TRINO_HOST` points every
+    environment at the production Galaxy cluster. Trino reaches production data
+    from QA; a direct S3 read does not.
+    """)
+    return
+
+
+@app.cell
+def _(mo):
+    mo.md(r"""
+    ## 11. Working with personal data
+
+    `dim_user` exists, and joining to it is sometimes the right thing. Nothing
+    in this notebook does, on purpose — a getting-started file should not
+    normalise `SELECT *` on a table full of names and email addresses.
+
+    Before you write a query that touches it:
+
+    - Aggregate if you can. `count(DISTINCT user_fk)` answers most questions
+      about people without returning a person. The facts carry `user_fk`, so
+      per-learner *counting* rarely needs the user dimension at all.
+    - Select the columns you need, never `*`. Identifiers travel further than
+      you expect once they are in a dataframe.
+    - Set a floor on group sizes. A pass rate over four learners identifies
+      them to anyone who knows the cohort.
+    - Your home directory is a persistent volume. A CSV of learner rows written
+      there is a copy that outlives the question you wrote it to answer.
+    - Everything you run is attributed to you: Galaxy authorises the query
+      against your own SSO identity, so your access is exactly your role's
+      access, and it is logged.
+    """)
+    return
+
+
+@app.cell
+def _(mo):
+    mo.md(r"""
+    ## 12. Sharing what you made
+
+    - **`mo.ui` inputs plus `marimo run`** turn this file into an app with the
+      code hidden — the notebook *is* the app, no port or rewrite involved.
+    - **Export** to HTML (static, self-contained), or to `.ipynb` if a
+      collaborator needs Jupyter.
+    - **The file is a Python script.** It diffs and reviews like code, and
+      `python demo.py` runs it head-first outside marimo. Notebook JSON is a
+      merge conflict waiting to happen; this is not.
+    - The kernel is culled after 4 hours idle. Your home directory persists;
+      anything held only in memory does not.
+    """)
+    return
+
+
+@app.cell
+def _(mo):
+    mo.md(r"""
+    ## 13. When something goes wrong
+
+    | Symptom | Cause |
+    |---|---|
+    | `401 Authentication required` | Sign-in never completed, or the kernel restarted. Re-run the connect cell and open the link. |
+    | Login link never appears | Look at the cell's *console* output, not its rendered output. |
+    | The login link does not work | Each attempt mints a new link and retires the previous one. Re-run the connect cell to get a fresh one. |
+    | `Catalog must be specified` | Unqualified table name with no session catalog. Qualify it, or use the `warehouse` engine. |
+    | Counts look inflated | A join to an SCD2 dimension missing `AND is_current` — see section 4. |
+    | Data sources panel is empty | Expand `warehouse`; schemas load lazily. A `conn`-style entry saying *no databases* is a raw DB-API connection and can never show a tree. |
+    | Query never returns | No `LIMIT` on a fact table. `cur.stats` shows what Galaxy is chewing through. |
+    | `ModuleNotFoundError` after `pip install` | Sandbox mode. Add the package to the `/// script` header and restart the kernel. |
+    """)
+    return
+
+
+@app.cell
+def _():
+    import altair as alt
+    import numpy as np
+    import pandas as pd
+    import polars as pl
+
+    return alt, pl
+
+
+if __name__ == "__main__":
+    app.run()

--- a/images/marimo-jupyterlab/templates/demo.py
+++ b/images/marimo-jupyterlab/templates/demo.py
@@ -268,8 +268,9 @@ def _(mo):
     - Ordinary Python. Loop it, build SQL from a list, wrap it in a function,
       call it from a helper module.
     - `fetchmany(n)` streams, so you can process more than fits in memory.
-    - Handles everything that is not a single `SELECT`: `SHOW CATALOGS`,
-      `EXPLAIN`, `SET SESSION`, DDL.
+    - Carries connection-scoped state. `SET SESSION` and `USE` apply to a
+      connection, and a SQL cell opens a fresh one per statement, so state set
+      in one cell is gone by the next. On the cursor it persists.
     - `cur.stats` and `cur.query_id` expose Galaxy's own view of the running
       query, which is how you find out why something is slow.
 
@@ -281,8 +282,10 @@ def _(mo):
     - Invisible to the reactive graph. marimo cannot tell that a cell using
       `cur` depends on a query in another cell, so ordering is your problem.
 
-    **Rule of thumb:** reach for a SQL cell. Drop to the cursor when you need a
-    loop, a stream, or a statement that is not a `SELECT`.
+    **Rule of thumb:** reach for a SQL cell. It is not limited to `SELECT` —
+    `SHOW`, `EXPLAIN` and DDL all run there, and a statement that returns rows
+    comes back as a dataframe. Drop to the cursor when you need a loop, a
+    stream, session state, or `cur.stats`.
     """)
     return
 
@@ -931,7 +934,7 @@ def _(mo):
     | Symptom | Cause |
     |---|---|
     | `401 Authentication required` | Sign-in never completed, or the kernel restarted. Re-run the connect cell and open the link. |
-    | Login link never appears | Look at the cell's *console* output, not its rendered output. |
+    | Login link never appears | It renders as a callout in the cell's own output while the cell blocks. If that is empty, check the cell's *console* pane — the `print()` there is the fallback for when `mo.output.append()` cannot reach the frontend. |
     | The login link does not work | Each attempt mints a new link and retires the previous one. Re-run the connect cell to get a fresh one. |
     | `Catalog must be specified` | Unqualified table name with no session catalog. Qualify it, or use the `warehouse` engine. |
     | Counts look inflated | A join to an SCD2 dimension missing `AND is_current` — see section 4. |

--- a/images/marimo-jupyterlab/templates/demo.py
+++ b/images/marimo-jupyterlab/templates/demo.py
@@ -36,9 +36,10 @@ def _(mo):
 
     For a blank starting point, use `getting_started.py`.
 
-    **Everything here queries aggregates.** No example selects individual
-    learner rows, and none of them touch `dim_user`. See *Working with
-    personal data* at the bottom before you write anything that does.
+    **No example here returns learner-level data.** Nothing selects individual
+    learner rows and none of these queries touch `dim_user` — course and
+    course-run rows appear, but people never do. See *Working with personal
+    data* at the bottom before you write anything that does.
     """)
     return
 
@@ -941,13 +942,17 @@ def _(mo):
     mo.md(r"""
     ## 12. Sharing what you made
 
-    - **`mo.ui` inputs plus `marimo run`** turn this file into an app with the
-      code hidden — the notebook *is* the app, no port or rewrite involved.
+    - **`mo.ui` inputs plus `marimo run --sandbox`** turn this file into an app
+      with the code hidden — the notebook *is* the app, no port or rewrite
+      involved.
     - **Export** to HTML (static, self-contained), or to `.ipynb` if a
       collaborator needs Jupyter.
-    - **The file is a Python script.** It diffs and reviews like code, and
-      `python demo.py` runs it head-first outside marimo. Notebook JSON is a
-      merge conflict waiting to happen; this is not.
+    - **The file is a Python script.** It diffs and reviews like code — notebook
+      JSON is a merge conflict waiting to happen; this is not. To run it outside
+      JupyterLab, use `marimo edit --sandbox demo.py`: sandbox mode builds the
+      environment from the `/// script` header and adds marimo itself. Plain
+      `python demo.py` ignores that header and fails on the connect cell's
+      imports, because this image installs no notebook-level packages.
     - The kernel is culled after 4 hours idle. Your home directory persists;
       anything held only in memory does not.
     """)

--- a/images/marimo-jupyterlab/templates/demo.py
+++ b/images/marimo-jupyterlab/templates/demo.py
@@ -877,43 +877,7 @@ def _(certificate_summary, mo, platform):
 @app.cell
 def _(mo):
     mo.md(r"""
-    ## 10. Reading Iceberg directly, without Trino
-
-    The warehouse is Iceberg tables on S3 with a Glue catalog, and the pod's
-    IRSA role can read both. For a full-table scan feeding a model, going
-    straight to the files with `pyiceberg` skips the query engine entirely.
-    For anything with a filter, a join, or an aggregate, use Trino — that is
-    what it is for.
-
-    Add `pyiceberg[glue,s3fs]>=0.9` to the `/// script` header and restart the
-    kernel to try it:
-
-    ```python
-    from pyiceberg.catalog.glue import GlueCatalog
-
-    glue = GlueCatalog(name="ol", **{"region_name": "us-east-1"})
-    table = glue.load_table(
-        ("ol_warehouse_production_dimensional", "dim_course")
-    )
-    arrow_table = table.scan(
-        selected_fields=("course_readable_id", "course_title"),
-        row_filter="is_current = true",
-    ).to_arrow()
-    ```
-
-    **This works on `nb.data.ol.mit.edu` and will not work on `nb-qa`.** The
-    IRSA policy grants S3 and Glue on `ol-data-lake-*-<environment>`, so the QA
-    pod holds QA-scoped credentials — while `TRINO_HOST` points every
-    environment at the production Galaxy cluster. Trino reaches production data
-    from QA; a direct S3 read does not.
-    """)
-    return
-
-
-@app.cell
-def _(mo):
-    mo.md(r"""
-    ## 11. Working with personal data
+    ## 10. Working with personal data
 
     `dim_user` exists, and joining to it is sometimes the right thing. Nothing
     in this notebook does, on purpose — a getting-started file should not
@@ -940,7 +904,7 @@ def _(mo):
 @app.cell
 def _(mo):
     mo.md(r"""
-    ## 12. Sharing what you made
+    ## 11. Sharing what you made
 
     - **`mo.ui` inputs plus `marimo run --sandbox`** turn this file into an app
       with the code hidden — the notebook *is* the app, no port or rewrite
@@ -962,7 +926,7 @@ def _(mo):
 @app.cell
 def _(mo):
     mo.md(r"""
-    ## 13. When something goes wrong
+    ## 12. When something goes wrong
 
     | Symptom | Cause |
     |---|---|

--- a/images/marimo-jupyterlab/templates/demo.py
+++ b/images/marimo-jupyterlab/templates/demo.py
@@ -55,7 +55,7 @@ def _(mo):
 
 
 @app.cell
-def _():
+def _(mo):
     import os
 
     import sqlalchemy
@@ -63,10 +63,32 @@ def _():
     import trino.sqlalchemy  # registers the "trino://" SQLAlchemy dialect
 
     def _show_login_url(url: str) -> None:
-        # Printed rather than rendered with mo.md: this runs while the calling
-        # cell is still blocked inside execute(), polling Galaxy for the token,
-        # so the cell's rendered output is not on screen yet. marimo streams
-        # stdout to the cell's console area live, which is where this lands.
+        # mo.output.append() writes to the cell's OUTPUT area and pushes to the
+        # frontend immediately, while this cell is still blocked inside
+        # execute() waiting for the login. That matters: printing alone puts the
+        # link in the cell's *console* pane, which is easy to miss, and a missed
+        # link means a restart. Rendering it as a callout with a real hyperlink
+        # is the difference between "it hung" and "click here".
+        #
+        # It no-ops outside a marimo runtime (ContextNotInitializedError), so
+        # the print below is the fallback for `python <file>.py` and for the
+        # console pane.
+        mo.output.append(
+            mo.callout(
+                mo.md(
+                    f"""
+                    ### Sign in to Starburst Galaxy
+
+                    **[Open the login page]({url})** — sign in with MIT OL SSO
+                    and this cell resumes on its own.
+
+                    The link is single-use and expires. If you miss it, re-run
+                    this cell to get a new one.
+                    """
+                ),
+                kind="warn",
+            )
+        )
         print(  # noqa: T201
             "\nStarburst Galaxy login required. Open this URL, sign in with "
             f"MIT OL SSO, then come back — the query resumes on its own:\n\n"

--- a/images/marimo-jupyterlab/templates/getting_started.py
+++ b/images/marimo-jupyterlab/templates/getting_started.py
@@ -74,7 +74,7 @@ def _(mo):
 
 
 @app.cell
-def _():
+def _(mo):
     import os
 
     import sqlalchemy
@@ -82,10 +82,32 @@ def _():
     import trino.sqlalchemy  # registers the "trino://" SQLAlchemy dialect
 
     def _show_login_url(url: str) -> None:
-        # Printed rather than rendered with mo.md: this runs while the calling
-        # cell is still blocked inside execute(), polling Galaxy for the token,
-        # so the cell's rendered output is not on screen yet. marimo streams
-        # stdout to the cell's console area live, which is where this lands.
+        # mo.output.append() writes to the cell's OUTPUT area and pushes to the
+        # frontend immediately, while this cell is still blocked inside
+        # execute() waiting for the login. That matters: printing alone puts the
+        # link in the cell's *console* pane, which is easy to miss, and a missed
+        # link means a restart. Rendering it as a callout with a real hyperlink
+        # is the difference between "it hung" and "click here".
+        #
+        # It no-ops outside a marimo runtime (ContextNotInitializedError), so
+        # the print below is the fallback for `python <file>.py` and for the
+        # console pane.
+        mo.output.append(
+            mo.callout(
+                mo.md(
+                    f"""
+                    ### Sign in to Starburst Galaxy
+
+                    **[Open the login page]({url})** — sign in with MIT OL SSO
+                    and this cell resumes on its own.
+
+                    The link is single-use and expires. If you miss it, re-run
+                    this cell to get a new one.
+                    """
+                ),
+                kind="warn",
+            )
+        )
         print(  # noqa: T201
             "\nStarburst Galaxy login required. Open this URL, sign in with "
             f"MIT OL SSO, then come back — the query resumes on its own:\n\n"

--- a/images/marimo-jupyterlab/templates/getting_started.py
+++ b/images/marimo-jupyterlab/templates/getting_started.py
@@ -59,8 +59,7 @@ def _(mo):
 
     There is no token to manage. Galaxy authenticates query clients itself and
     federates the login to MIT OL SSO, so the first query of a session prints a
-    link for you to open. AWS credentials for S3 and Glue arrive via IRSA — no
-    `AWS_ACCESS_KEY_ID` needed.
+    link for you to open.
     """)
     return
 

--- a/images/marimo-jupyterlab/templates/getting_started.py
+++ b/images/marimo-jupyterlab/templates/getting_started.py
@@ -1,17 +1,19 @@
 # /// script
 # requires-python = ">=3.11"
 # dependencies = [
+#   "altair>=5.4",
+#   "numpy>=2.0",
 #   "pandas>=2.0",
-#   "trino>=0.330",
+#   "polars>=1.0",
+#   "pyarrow>=17.0",
+#   "sqlalchemy>=2.0",
+#   "trino[sqlalchemy]>=0.330",
 # ]
 # ///
-# ruff: noqa: PLC0415, B018
-# PLC0415/B018: marimo requires imports inside cell functions and bare
-# expressions for cell output — these are intentional patterns, not errors.
 
 import marimo
 
-__generated_with = "0.19.11"
+__generated_with = "0.24.0"
 app = marimo.App(width="medium")
 
 
@@ -25,84 +27,188 @@ def _():
 @app.cell
 def _(mo):
     mo.md(r"""
-    # OL Data Platform
+    # Warehouse notebook
 
-    This notebook runs in **sandbox mode**: each notebook gets its own isolated
-    Python environment. Packages are declared in the `/// script` header at the
-    top of the file. Add a package there and restart the kernel to use it.
+    A minimal starting point: signs you in to the data warehouse and gives you
+    a `warehouse` engine to query. Everything below the connection cell is
+    yours to replace.
 
-    Connection credentials are injected as environment variables by JupyterHub:
+    See `demo.py` for a tour of what this environment can do, and `README.md`
+    for the data model.
+
+    ## Sandbox mode
+
+    Each notebook gets its own isolated Python environment, built from the
+    `/// script` header at the top of this file. To add a package, put it in
+    that list and restart the kernel — do not `pip install`, it will not
+    persist.
+
+    The last cell imports polars as `pl`, pandas as `pd`, numpy as `np` and
+    altair as `alt`, so they are ready to use in any cell you add. pyarrow is
+    declared but not imported: polars needs it internally, and
+    `.to_pandas()` raises `ModuleNotFoundError` without it. Leave it in the
+    list.
+
+    ## Credentials
 
     | Variable | Value |
     |---|---|
     | `TRINO_HOST` | Starburst Galaxy endpoint |
     | `TRINO_PORT` | 443 |
-    | `TRINO_TOKEN` | Your Keycloak OIDC access token (rotated per session) |
+    | `TRINO_CATALOG` | Default warehouse catalog |
 
-    AWS credentials for S3 and Glue are provided automatically via IRSA
-    (no `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` needed).
+    There is no token to manage. Galaxy authenticates query clients itself and
+    federates the login to MIT OL SSO, so the first query of a session prints a
+    link for you to open. AWS credentials for S3 and Glue arrive via IRSA — no
+    `AWS_ACCESS_KEY_ID` needed.
     """)
+    return
 
 
 @app.cell
 def _(mo):
-    mo.md("## Connect to Starburst")
+    mo.md("""
+    ## Connect
+    """)
+    return
 
 
 @app.cell
 def _():
     import os
 
+    import sqlalchemy
     import trino
+    import trino.sqlalchemy  # registers the "trino://" SQLAlchemy dialect
 
-    conn = trino.dbapi.connect(
-        host=os.environ["TRINO_HOST"],
-        port=int(os.environ.get("TRINO_PORT", "443")),
-        http_scheme="https",
-        auth=trino.auth.JWTAuthentication(os.environ["TRINO_TOKEN"]),
+    def _show_login_url(url: str) -> None:
+        # Printed rather than rendered with mo.md: this runs while the calling
+        # cell is still blocked inside execute(), polling Galaxy for the token,
+        # so the cell's rendered output is not on screen yet. marimo streams
+        # stdout to the cell's console area live, which is where this lands.
+        print(  # noqa: T201
+            "\nStarburst Galaxy login required. Open this URL, sign in with "
+            f"MIT OL SSO, then come back — the query resumes on its own:\n\n"
+            f"    {url}\n",
+            flush=True,
+        )
+
+    # One auth object shared by the engine and the cursor, so you sign in once.
+    # Galaxy is itself the authorization server: it federates the login to
+    # Keycloak SSO and issues its own token. It does not accept a
+    # Keycloak-issued JWT, so JWTAuthentication cannot be used here.
+    # The default redirect handler is replaced because it calls
+    # webbrowser.open_new(), which is a no-op inside the notebook pod.
+    _auth = trino.auth.OAuth2Authentication(redirect_auth_url_handler=_show_login_url)
+
+    _host = os.environ["TRINO_HOST"]
+    _port = int(os.environ.get("TRINO_PORT", "443"))
+    _catalog = os.environ.get("TRINO_CATALOG", "ol_data_lake_production")
+
+    # http_scheme must be explicit: the SQLAlchemy dialect's
+    # create_connect_args() never sets it, so it would default to plain http
+    # against Galaxy's 443.
+    # request_timeout is the HTTP read timeout for every request, including the
+    # poll that waits for you to finish the Galaxy login. The library default is
+    # 30 seconds, which is not enough time to open a browser, get through SSO
+    # and come back — and each retry mints a NEW login URL, so the one already
+    # printed goes dead. 600 seconds gives a realistic window, and also lets a
+    # slow query keep polling instead of erroring.
+    _connect_args = {
+        "auth": _auth,
+        "http_scheme": "https",
+        "request_timeout": 600,
+    }
+
+    # The SQLAlchemy engine is what populates "Explore variables and data
+    # sources" in the sidebar, because marimo only builds a catalog tree for
+    # engines it recognises as catalogs. It reads exactly the catalog named in
+    # the URL, so browsing a second catalog means a second engine — one
+    # top-level variable each, or marimo will not find it.
+    #
+    # The auth object goes in connect_args rather than the dialect's
+    # ?externalAuthentication=true URL flag: that flag makes the dialect build
+    # a fresh OAuth2Authentication per physical connection, and so a fresh
+    # login prompt each time.
+    warehouse = sqlalchemy.create_engine(
+        trino.sqlalchemy.URL(host=_host, port=_port, catalog=_catalog),
+        connect_args=_connect_args,
     )
-    cur = conn.cursor()
-    return conn, cur, os, trino
+
+    # The cursor is for the cases SQL cells cannot cover (see demo.py). The
+    # connection itself stays cell-local: marimo would otherwise list it in the
+    # data sources panel as a second, permanently empty entry, since a raw
+    # DB-API connection cannot carry a catalog tree. The cursor holds a
+    # reference, so the connection stays alive.
+    _conn = trino.dbapi.connect(
+        host=_host, port=_port, catalog=_catalog, **_connect_args
+    )
+    cur = _conn.cursor()
+    return cur, warehouse
+
+
+@app.cell
+def _(mo):
+    mo.md(r"""
+    ## Sign in
+
+    Running the next cell triggers the login. It blocks until you have opened
+    the printed link and signed in, then lists the catalogs you can reach.
+
+    The token is cached in memory for the life of this kernel, so you sign in
+    once per session — not once per query. Restarting the kernel, or re-running
+    the connection cell above, starts a new session and asks again.
+    """)
+    return
 
 
 @app.cell
 def _(cur, mo):
     cur.execute("SHOW CATALOGS")
     catalogs = [row[0] for row in cur.fetchall()]
-    mo.md(f"**Available catalogs:** {', '.join(catalogs)}")
-    return (catalogs,)
+    mo.md(f"**Catalogs available to you:** {', '.join(catalogs)}")
+    return
 
 
 @app.cell
 def _(mo):
     mo.md(r"""
-    ## Query example
+    ## Your work starts here
 
-    Replace `<catalog>`, `<schema>`, and `<table>` with real names from the
-    catalog list above, then run the cell.
+    The cell below is a SQL cell: it runs against the `warehouse` engine and
+    returns a dataframe (polars, since polars is installed). Expand the
+    `warehouse` entry in the data sources panel to find tables, or start from
+    the layer guide in `README.md`.
     """)
+    return
 
 
 @app.cell
-def _(cur, pd):
-    _query = """
-    SELECT *
-    FROM <catalog>.<schema>.<table>
-    LIMIT 100
-    """
-    cur.execute(_query)
-    rows = cur.fetchall()
-    cols = [d[0] for d in cur.description]
-    df = pd.DataFrame(rows, columns=cols)
-    df
-    return cols, df, rows
+def _(mo, warehouse):
+    courses = mo.sql(
+        """
+        SELECT
+            course_readable_id
+            , course_title
+            , primary_platform
+        FROM ol_warehouse_production_dimensional.dim_course
+        WHERE is_current AND course_is_live
+        ORDER BY course_readable_id
+        LIMIT 20
+        """,
+        engine=warehouse,
+    )
+    return
 
 
 @app.cell
 def _():
+    import altair as alt
+    import numpy as np
     import pandas as pd
+    import polars as pl
 
-    return (pd,)
+    return
 
 
 if __name__ == "__main__":

--- a/images/marimo-jupyterlab/templates/getting_started.py
+++ b/images/marimo-jupyterlab/templates/getting_started.py
@@ -176,9 +176,12 @@ def _(mo):
     Running the next cell triggers the login. It blocks until you have opened
     the printed link and signed in, then lists the catalogs you can reach.
 
-    The token is cached in memory for the life of this kernel, so you sign in
-    once per session — not once per query. Restarting the kernel, or re-running
-    the connection cell above, starts a new session and asks again.
+    The token is cached in memory and reused for as long as Galaxy accepts it,
+    so signing in is not per-query. It is not guaranteed to be once per
+    session either: if the token expires or is revoked, Galaxy answers the next
+    query with a 401 and the client starts the flow again, so a fresh login
+    callout appears mid-session. Restarting the kernel, or re-running the
+    connection cell above, also asks again.
     """)
     return
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -224,6 +224,18 @@ inline-quotes = "double"
 builtins-allowed-modules = ["secrets", "platform"]
 
 [tool.ruff.lint.per-file-ignores]
+# marimo notebooks are a machine-managed file format. `marimo check --fix` and
+# the marimo UI both rewrite these files on save, so the patterns below are the
+# tool's output rather than authored style, and fighting them means CI breaks
+# every time a user saves a notebook. They are also user-facing teaching files,
+# so the suppressions live here instead of cluttering the top of each notebook.
+#   PLC0415  imports must be inside cell functions
+#   B018     a bare expression is how a cell renders its output
+#   PLR1711  marimo emits a bare `return` in cells nothing else consumes
+#   F401     libraries are pre-imported for the reader's own cells to use
+#   F841     a named cell result is the rendered output, not a dead local
+#   E501     markdown tables inside mo.md() cells cannot be wrapped
+"images/marimo-jupyterlab/templates/*.py" = ["PLC0415", "B018", "PLR1711", "F401", "F841", "E501"]
 "scripts/**" = ["T201", "ERA001", "B", "BLE001", "PLR", "E501", "G004", "FBT", "C90", "INP001"]
 "**/tests/**" = ["S101", "PLR", "RUF059", "S106", "SLF001", "ERA001"]
 "**/*_tests/**" = ["S101", "PLR", "RUF059", "S106", "SLF001", "ERA001", "D103"]


### PR DESCRIPTION
Closes #2624

## What are the relevant tickets?

#2624

## Description (What does it do?)

The marimo notebook template could not query the warehouse at all — every query returned `error 401: b'Authentication required'`.

**Starburst Galaxy does not accept externally-issued JWTs.** Customer-JWKS JWT auth is a Starburst *Enterprise* feature. Galaxy authenticates query clients only by Galaxy username/password over HTTP Basic, or by its own OAuth2 flow in which Galaxy is the authorization server and federates the login to the customer IdP. The template passed a Keycloak access token to `trino.auth.JWTAuthentication`, which Galaxy simply does not recognise. Every other consumer of this cluster already uses a supported method (`method: ldap` / `method: oauth` in `src/ol_dbt/profiles.yml`, `BasicAuthentication` in `trino_maintenance.py`).

This switches to `trino.auth.OAuth2Authentication`. Verified working end to end by a user in the live notebook.

Three non-obvious details the fix depends on:

- The library default handler is `CompositeRedirectHandler([WebBrowserRedirectHandler(), ConsoleRedirectHandler()])`, and `webbrowser.open_new()` is a no-op in a pod. A custom handler that prints the URL is required.
- The auth object is shared between engine and cursor and passed via `connect_args`, **not** the dialect's `?externalAuthentication=true` URL flag — `TrinoDialect.create_connect_args()` runs per physical connection and builds a fresh `OAuth2Authentication`, i.e. a fresh token cache and login prompt for every pooled connection.
- `create_connect_args()` never sets `http_scheme`, so it must be passed explicitly or the dialect defaults to plain `http` against Galaxy's 443.
- `request_timeout=600`. The library default of 30s bounds the HTTP poll that waits for the user to finish the Galaxy login, and each retry mints a new URL retiring the old one. At the default, a user who takes more than ~30s to get through SSO loses the flow with no explanation. This was found by executing the flow, not by reading it.

**Data sources panel.** A raw `trino.dbapi.Connection` matches marimo's `DBAPIEngine`, which implements `QueryEngine` but not `EngineCatalog`, so it is a usable SQL target with a permanently empty catalog tree. Registering a SQLAlchemy engine fixes it. `SQLAlchemyEngine._get_database_names()` branches only for snowflake/starrocks and otherwise returns `[url.database]`, so the catalog must be in the engine URL and it is one engine per catalog. `trino` is absent from marimo's `CHEAP_DISCOVERY_DATABASES`, so schemas load lazily on expand — left as-is deliberately, since forcing eager discovery would scan the whole warehouse on every kernel start.

**Three template files.** `getting_started.py` is now a minimal starting point (auth, engine, and polars/pandas/numpy/pyarrow/altair). `demo.py` is a full tour: layer orientation, the `mo.sql`-vs-cursor trade-off with advantages and disadvantages, star-schema joins, many-to-many bridges, reactive `mo.ui` inputs, altair charts, `mo.cache`, direct Iceberg reads, and troubleshooting. `README.md` is an in-notebook quick reference; the fuller guide is in the companion docs-site PR.

Every example is aggregate-only and none touch `dim_user`.

**Query cost.** All demo queries were sized against Iceberg metadata and deliberately read the light fact. `tfact_grade` is 42.7M rows / 2.3GB and `tfact_enrollment` is 16M / 997MB; `tfact_certificate` is 867k / 70MB. Three sections originally scanned the heavy facts and now use certificates — 18–49x less data — so the demo loads fast.

`pyproject.toml` gains a `per-file-ignores` entry for the templates. marimo rewrites these files on every save, so its output has to win over ruff, and they are user-facing teaching files that should not open with six lint directives.

## How can this be tested?

Local verification, all green:

- `marimo check --strict` — exit 0 on both notebooks
- `ruff format` / `ruff check` / `mypy` / full `pre-commit`
- **13/13** SQL statements parse as Trino (sqlglot) with every qualified column checked against the dimensional `_*.yml` schemas
- **11/11** statements executed against **real production Iceberg data** via pyiceberg + Glue + DuckDB, 0 failures, slowest 0.114s
- Every dropdown option verified to return rows in both cells it drives
- §10's pyiceberg snippet executed verbatim (4,069 rows)
- `pl.date()`, altair-with-polars, and `.to_pandas()` all executed against real results

Not yet done: no query has gone through Galaxy's planner (results and relative cost were validated through the Iceberg files), and the `mo.ui` widgets cannot be exercised headlessly. The image has not been built locally — Docker was unavailable — but the Dockerfile change is comment-only.

## Merge and deploy order

**This PR should merge first, and must be deployed before the ol-infrastructure PR is applied.**

1. **This PR** (`ol-data-platform`) — merging triggers the `Build and Publish marimo-jupyterlab Image` workflow, which publishes `ghcr.io/mitodl/marimo-jupyterlab:latest` containing `demo.py` and `README.md`.
2. **[ol-infrastructure PR](https://github.com/mitodl/ol-infrastructure/pull/5700)** — extends the singleuser `postStart` hook to copy the whole templates directory. If applied *before* the image above exists, the hook copies only `getting_started.py` (harmless, but `demo.py` and `README.md` silently never arrive).
3. **[platform-engineering-site PR](https://github.com/mitodl/platform-engineering-site/pull/71)** — docs only, independent, merge any time.

`singleuser.image.pullPolicy` is already `Always`, so a pod respawn picks up the new image without a Pulumi change.

**One rollout caveat for whoever coordinates this:** the postStart hook uses `cp -n`, which never overwrites. Users who already have `~/notebooks/getting_started.py` **keep their old copy** and will not receive this fix. That is the deliberate never-destroy-someone's-work trade-off, but it means the rollout is not self-completing — existing users need to delete their copy (or be told to).

## Additional Context

Two follow-ups found while doing this, filed rather than fixed here:

- **Published (run-mode) marimo apps will hit the same 401.** `applications/marimo_data/__main__.py` documents that they use the `ol-marimo-app-client` service account for Trino, which yields another Keycloak JWT. Those apps have no user session so the OAuth2 flow is unavailable to them; they need a Galaxy service account. Nothing consumes that Vault secret yet, so nothing is broken in production today.
- **`dim_course_run` currently violates its own one-current-row SCD2 invariant** — 8,041 `is_current` rows for 8,019 distinct keys, with two runs carrying 12 current rows each. The `dbt_utils.unique_combination_of_columns` test in `_dim_course_run.yml` that guards this must therefore be failing unnoticed. Tracked under the dimensional-layer correctness epic (#2375); not a blocker here because both affected runs have zero certificates, and this PR's aggregates use `count(DISTINCT ...)` on the fact's own key so they stay correct regardless.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
