### PR TITLE
feat(dbt): detect surrogate-key drift and full-refresh the facts it orphans

### DIFF
--- a/.github/workflows/dbt_pr_ci.yaml
+++ b/.github/workflows/dbt_pr_ci.yaml
@@ -110,16 +110,38 @@ jobs:
           } catch (e) {
             // No changed models / non-JSON output → treat as no impact.
           }
-          const counts = { BREAKING: 0, WARNING: 0, INFO: 0 };
+          const counts = { BREAKING: 0, KEY_REGEN: 0, WARNING: 0, INFO: 0 };
           for (const a of alerts) { counts[a.level] = (counts[a.level] || 0) + 1; }
-          const emoji = { BREAKING: '🔴', WARNING: '⚠️', INFO: 'ℹ️' };
+          const emoji = { BREAKING: '🔴', KEY_REGEN: '🔑', WARNING: '⚠️', INFO: 'ℹ️' };
 
           let body = `${marker}\n## 🔎 ol-dbt impact — column-level blast radius\n\n`;
           if (alerts.length === 0) {
             body += '✅ No column-level downstream impact detected for the changed models.';
           } else {
-            body += `**${counts.BREAKING} breaking**, **${counts.WARNING} warning**, ${counts.INFO} info` +
+            body += `**${counts.BREAKING} breaking**, **${counts.KEY_REGEN} surrogate-key regeneration**, ` +
+                    `**${counts.WARNING} warning**, ${counts.INFO} info` +
                     ` across ${alerts.length} changed model(s).\n\n`;
+
+            // Surrogate-key drift gets its own section rather than a line in the
+            // collapsed list: it changes no column, so a reviewer scanning the
+            // details for a renamed field would never look for it — and unlike the
+            // other levels the follow-up is a production rebuild, not a code edit.
+            const keyRegen = alerts.filter(a => a.level === 'KEY_REGEN');
+            for (const a of keyRegen) {
+              const change = (a.column_changes || [])[0] || {};
+              const models = (a.downstream || []).map(d => d.model).join(' ');
+              body += `### 🔑 \`${a.changed_model}.${change.column}\` is hashed from different inputs\n\n`;
+              body += `\`${change.related || ''}\`\n\n`;
+              body += 'Every existing value changes on the next build, orphaning the copies ' +
+                      'these incremental models hold:\n\n';
+              for (const d of a.downstream || []) {
+                body += `- \`${d.model}\` (\`${(d.affected_columns || []).join(', ')}\`)\n`;
+              }
+              body += '\nThe production build repairs this automatically on the first run after ' +
+                      'merge (`lakehouse.lib.surrogate_key_drift`). To repair another environment ' +
+                      `by hand: \`dbt build --full-refresh --select ${models}\`.\n\n`;
+            }
+
             body += '<details><summary>Details</summary>\n\n';
             for (const a of alerts) {
               const cols = (a.column_changes || []).map(c => c.column).filter(Boolean).join(', ');

--- a/dg_projects/lakehouse/Dockerfile
+++ b/dg_projects/lakehouse/Dockerfile
@@ -25,6 +25,10 @@ WORKDIR /app
 COPY packages/ol-orchestrate-lib packages/ol-orchestrate-lib
 COPY dg_projects/lakehouse dg_projects/lakehouse
 COPY src/ol_dbt src/ol_dbt
+# The surrogate-key drift check in assets/lakehouse/dbt.py shares its detector
+# with `ol-dbt impact`, so the same hash-input parser decides what CI warns
+# about pre-merge and what the build full-refreshes afterwards.
+COPY src/ol_dbt_cli src/ol_dbt_cli
 
 # Install dependencies from the lakehouse project
 WORKDIR /app/dg_projects/lakehouse

--- a/dg_projects/lakehouse/lakehouse/assets/lakehouse/dbt.py
+++ b/dg_projects/lakehouse/lakehouse/assets/lakehouse/dbt.py
@@ -1,3 +1,4 @@
+import json
 import os
 from collections.abc import Mapping
 from pathlib import Path
@@ -13,6 +14,7 @@ from dagster import (
 from dagster_dbt import (
     DagsterDbtTranslator,
     DagsterDbtTranslatorSettings,
+    DbtCliInvocation,
     DbtCliResource,
     DbtProject,
     dbt_assets,
@@ -21,6 +23,12 @@ from ol_orchestrate.lib.automation_policies import upstream_or_code_changes
 from ol_orchestrate.lib.constants import DAGSTER_ENV
 
 from lakehouse.lib.dbt_environment import DBT_AUTOMATION_ENABLED, DBT_TARGET
+from lakehouse.lib.surrogate_key_drift import (
+    SURROGATE_KEY_STATE_ARTIFACT,
+    SurrogateKeyDrift,
+    detect_drift,
+    full_refresh_build_args,
+)
 from lakehouse.resources.dbt_s3_artifacts import DbtS3ArtifactsResource
 
 DBT_REPO_DIR = (
@@ -56,6 +64,90 @@ class DbtAutomationTranslator(DagsterDbtTranslator):
         return dbt_resource_props.get("config", {}).get("schema", None)
 
 
+def _surrogate_key_drift(
+    context: AssetExecutionContext, dbt_s3_artifacts: DbtS3ArtifactsResource
+) -> SurrogateKeyDrift | None:
+    """Compare this image's surrogate keys against the last build's, or None.
+
+    None means the check is unavailable, not that nothing drifted — without the
+    artifacts bucket there is nowhere to keep the baseline, so there is nothing
+    to compare against and nothing to record afterwards.
+
+    The parsed manifest is decoded here (rather than through
+    ``load_manifest``) because the hash inputs come from each node's
+    ``raw_code``, which the registry deliberately does not retain.
+    """
+    if not dbt_s3_artifacts.s3_bucket:
+        context.log.warning(
+            "DBT_ARTIFACTS_S3_BUCKET is not configured; surrogate-key drift cannot be "
+            "detected. A re-keyed dimension will silently orphan the FKs its "
+            "incremental descendants hold."
+        )
+        return None
+    manifest = json.loads(dbt_project.manifest_path.read_text())
+    previous = dbt_s3_artifacts.read_json_artifact(
+        SURROGATE_KEY_STATE_ARTIFACT, context
+    )
+    return detect_drift(manifest, previous)
+
+
+def _models_built_by(invocation: DbtCliInvocation) -> set[str]:
+    """Names of the models a finished invocation actually built.
+
+    Read from run_results rather than from the asset selection: this asset is a
+    subset build, and run_results is the only record of which models the subset
+    resolved to.
+    """
+    results = invocation.get_artifact("run_results.json")["results"]
+    return {
+        result["unique_id"].split(".")[-1]
+        for result in results
+        if result["unique_id"].startswith("model.")
+    }
+
+
+def _repair_surrogate_key_drift(
+    context: AssetExecutionContext,
+    dbt: DbtCliResource,
+    drift: SurrogateKeyDrift,
+    built: set[str],
+    build_vars: list[str],
+) -> bool:
+    """Rebuild the incremental models whose FKs this build's re-key invalidated.
+
+    Returns whether the drift is now fully handled, which is the caller's cue
+    to record the new key state. False leaves the previous state in place so
+    the next run re-detects and finishes the job; raising (a failed repair
+    build) has the same effect, since the caller never gets to the write.
+
+    Runs *after* the main build, not before: the repair has to read the
+    dimension's new keys, and those only exist once the build that regenerates
+    them has run. Running first would rebuild the fact tables against the
+    previous keys and orphan them all over again.
+
+    Invoked without a Dagster context so it emits no second materialization for
+    assets the main build already reported, and so its explicit ``--select``
+    is not merged with the context's own selection.
+    """
+    models, complete = drift.resolved_against(built)
+    if models:
+        context.log.info(
+            "Surrogate-key drift since the last build -- rebuilding the affected "
+            "incremental models from scratch so their foreign keys match the "
+            "regenerated dimension: %s",
+            drift.describe(),
+        )
+        dbt.cli(full_refresh_build_args(models, build_vars), raise_on_error=True).wait()
+    if not complete:
+        context.log.warning(
+            "This run did not build every model the surrogate-key drift touches, so "
+            "the key state is not being recorded -- the next run will re-detect and "
+            "finish the repair. Outstanding: %s",
+            ", ".join(sorted(set(drift.models) - built)) or "the re-keyed model itself",
+        )
+    return complete
+
+
 @dbt_assets(
     manifest=dbt_project.manifest_path,
     project=dbt_project,
@@ -72,13 +164,22 @@ def full_dbt_project(
     dbt: DbtCliResource,
     dbt_s3_artifacts: DbtS3ArtifactsResource,
 ):
-    dbt_build_args = ["build"]
+    build_vars: list[str] = []
     if DAGSTER_ENV == "dev":
         schema_suffix = os.getenv("DBT_SCHEMA_SUFFIX", "dev")
-        dbt_build_args += ["--vars", f"schema_suffix: {schema_suffix}"]
+        build_vars = ["--vars", f"schema_suffix: {schema_suffix}"]
 
-    build_invocation = dbt.cli(dbt_build_args, context=context)
+    drift = _surrogate_key_drift(context, dbt_s3_artifacts)
+
+    build_invocation = dbt.cli(["build", *build_vars], context=context)
     yield from (build_invocation.stream().fetch_column_metadata().fetch_row_counts())
+
+    if drift is not None and _repair_surrogate_key_drift(
+        context, dbt, drift, _models_built_by(build_invocation), build_vars
+    ):
+        dbt_s3_artifacts.write_json_artifact(
+            SURROGATE_KEY_STATE_ARTIFACT, drift.current_state, context
+        )
 
     # Upload this run's results to a per-run versioned S3 key so OpenMetadata can
     # ingest the model/test outcomes of every incremental and full run.

--- a/dg_projects/lakehouse/lakehouse/lib/surrogate_key_drift.py
+++ b/dg_projects/lakehouse/lakehouse/lib/surrogate_key_drift.py
@@ -1,0 +1,139 @@
+"""Detect surrogate-key drift between builds and escalate to --full-refresh.
+
+A dimension materialized ``table`` re-derives every ``generate_surrogate_key``
+value on every build. Its incremental descendants stored the previous value as
+a foreign key and only revisit rows inside their watermark, so editing the
+hashed column list orphans every historical FK — silently, because no column
+changed for ``on_schema_change`` to react to. It has happened twice in
+production (``dim_discount.discount_pk``, #2411; the ``dim_user`` re-key,
+#2618), both times needing a hand-run ``dbt build --full-refresh`` that only
+memory and a doc comment were prompting anyone to do.
+
+The comparison is against a small state artifact this module writes to S3 after
+each successful build, not against the warehouse: the hashed column list only
+exists in the model's source, so there is nothing live to read it back from.
+That mirrors ``lakehouse.lib.starrocks_dbt``'s drift check, which compares the
+manifest against StarRocks for the same reason in the other direction, and it
+means the check fires on a re-key however it reached main.
+
+Pure functions only — nothing here imports dagster or opens a connection, so it
+is unit-testable without a parsed manifest on disk (importing the asset module
+that calls it is not).
+"""
+
+from collections.abc import Mapping
+from collections.abc import Set as AbstractSet
+from dataclasses import dataclass, field
+from typing import Any
+
+from ol_dbt_cli.lib.manifest import registry_from_manifest
+from ol_dbt_cli.lib.surrogate_keys import (
+    KeyRegenFinding,
+    SurrogateKeyState,
+    changed_keys_from_state,
+    detect_key_regen,
+    surrogate_key_state,
+)
+
+SURROGATE_KEY_STATE_ARTIFACT = "surrogate-key-state.json"
+"""S3 object (under DbtS3ArtifactsResource's prefix) holding the last build's
+surrogate-key hash inputs. Written only after the repair build succeeds, so a
+failed run leaves the drift pending and the next run retries it."""
+
+
+@dataclass
+class SurrogateKeyDrift:
+    """What this build must full-refresh, and the state to record afterwards."""
+
+    current_state: SurrogateKeyState
+    findings: list[KeyRegenFinding] = field(default_factory=list)
+
+    @property
+    def models(self) -> list[str]:
+        """Every incremental model holding an FK that the new hash invalidates.
+
+        The full set, ignoring what any one run rebuilt — see
+        :meth:`resolved_against` for what a subset build can actually repair.
+        """
+        return sorted({name for f in self.findings for name in f.affected_model_names})
+
+    def describe(self) -> str:
+        """One line per re-keyed column, for the run log."""
+        return "; ".join(
+            f"{f.ancestor}.{f.changed_key_column} re-keyed "
+            f"({_join(f.base_inputs)} -> {_join(f.current_inputs)}), "
+            f"stale in: {', '.join(f.affected_model_names)}"
+            for f in self.findings
+        )
+
+    def resolved_against(self, built: AbstractSet[str]) -> tuple[list[str], bool]:
+        """``(models to full-refresh now, whether the drift is fully handled)``.
+
+        ``full_dbt_project`` is a subset build — Dagster's automation
+        conditions decide which models a run materializes — so what this run
+        can repair is only what it actually rebuilt. A fact table refreshed
+        against a dimension the run never touched would take its keys from the
+        *old* hash and then be recorded as fixed, which is the incident
+        recurring with the check's own blessing.
+
+        So a finding counts as handled only when the run rebuilt both the
+        re-keyed dimension and every incremental model holding its key. When
+        one is missing the caller withholds the state artifact and the next
+        run tries again — redundantly re-refreshing what this run already
+        repaired, which is wasteful but never wrong.
+        """
+        ready = [f for f in self.findings if f.ancestor in built]
+        models = sorted({m for f in ready for m in f.affected_model_names} & built)
+        complete = len(ready) == len(self.findings) and all(
+            set(f.affected_model_names) <= built for f in ready
+        )
+        return models, complete
+
+
+def _join(calls: list[list[str]]) -> str:
+    return " + ".join(", ".join(call) for call in calls)
+
+
+def detect_drift(
+    manifest: Mapping[str, Any], previous_state: Mapping[str, Any] | None
+) -> SurrogateKeyDrift:
+    """Compare *manifest*'s surrogate keys against *previous_state*.
+
+    *previous_state* of None is the first run after this check ships (or after
+    the bucket was emptied): the returned drift has no findings, so the build
+    proceeds normally and the current state becomes the baseline. Escalating
+    instead would full-refresh every fact table in the warehouse on the
+    strength of having nothing to compare against.
+    """
+    current_state = surrogate_key_state(manifest)
+    if previous_state is None:
+        return SurrogateKeyDrift(current_state=current_state)
+    changed = changed_keys_from_state(previous_state, current_state)
+    if not changed:
+        return SurrogateKeyDrift(current_state=current_state)
+    return SurrogateKeyDrift(
+        current_state=current_state,
+        findings=detect_key_regen(changed, registry_from_manifest(dict(manifest))),
+    )
+
+
+def full_refresh_build_args(
+    models: list[str], build_vars: list[str] | None = None
+) -> list[str]:
+    """``dbt build`` args that rebuild exactly *models* from scratch.
+
+    The selector is one space-separated string rather than one argv entry per
+    model: dbt accepts both, but only this spelling is stable across the two
+    ways dbt's CLI has parsed multi-value options.
+
+    *build_vars* carries through whatever ``--vars`` the surrounding build uses
+    (the dev schema suffix), since a repair run against a different schema than
+    the build it is repairing would rebuild the wrong relations.
+    """
+    return [
+        "build",
+        "--full-refresh",
+        "--select",
+        " ".join(models),
+        *(build_vars or []),
+    ]

--- a/dg_projects/lakehouse/lakehouse/lib/surrogate_key_drift.py
+++ b/dg_projects/lakehouse/lakehouse/lib/surrogate_key_drift.py
@@ -69,25 +69,28 @@ class SurrogateKeyDrift:
     def resolved_against(self, built: AbstractSet[str]) -> tuple[list[str], bool]:
         """``(models to full-refresh now, whether the drift is fully handled)``.
 
-        ``full_dbt_project`` is a subset build — Dagster's automation
-        conditions decide which models a run materializes — so what this run
-        can repair is only what it actually rebuilt. A fact table refreshed
-        against a dimension the run never touched would take its keys from the
-        *old* hash and then be recorded as fixed, which is the incident
-        recurring with the check's own blessing.
+        The one thing a run must have done before its repair can be trusted is
+        rebuild the re-keyed dimension: the fact tables have to read its *new*
+        keys, and refreshing them against a dimension this run never touched
+        would copy the old ones straight back in. It is materialized ``table``,
+        so a single build re-keys it whole and being in *built* is the entire
+        precondition.
 
-        So a finding counts as handled only when the run rebuilt both the
-        re-keyed dimension and every incremental model holding its key. When
-        one is missing the caller withholds the state artifact and the next
-        run tries again — redundantly re-refreshing what this run already
-        repaired, which is wasteful but never wrong.
+        The affected fact tables do NOT have to be in *built*. The repair names
+        them in its own ``--select``, so it rebuilds them whether or not
+        Dagster's automation conditions put them in this run — and requiring
+        them here would deadlock the repair outright.
+        ``upstream_or_code_changes`` selects the dimension on the tick its code
+        version changes, and gates its facts behind ``any_deps_updated``, which
+        cannot be true until that build has finished; ``~any_deps_in_progress``
+        keeps them out of the same run besides. The dimension and its facts
+        therefore land in *different* runs by construction: the first would
+        find no facts to refresh and the second no dimension, and the drift
+        would sit unrepaired forever while both runs reported success.
         """
         ready = [f for f in self.findings if f.ancestor in built]
-        models = sorted({m for f in ready for m in f.affected_model_names} & built)
-        complete = len(ready) == len(self.findings) and all(
-            set(f.affected_model_names) <= built for f in ready
-        )
-        return models, complete
+        models = sorted({m for f in ready for m in f.affected_model_names})
+        return models, len(ready) == len(self.findings)
 
 
 def _join(calls: list[list[str]]) -> str:

--- a/dg_projects/lakehouse/lakehouse/lib/surrogate_key_drift.py
+++ b/dg_projects/lakehouse/lakehouse/lib/surrogate_key_drift.py
@@ -6,8 +6,11 @@ a foreign key and only revisit rows inside their watermark, so editing the
 hashed column list orphans every historical FK — silently, because no column
 changed for ``on_schema_change`` to react to. It has happened twice in
 production (``dim_discount.discount_pk``, #2411; the ``dim_user`` re-key,
-#2618), both times needing a hand-run ``dbt build --full-refresh`` that only
-memory and a doc comment were prompting anyone to do.
+#2497), both times needing a hand-run ``dbt build --full-refresh`` that only
+memory and a doc comment were prompting anyone to do. (#2618 is a related but
+distinct incident — a data-driven re-key, not a hashed-column-list edit —
+that this detector cannot see and that self-repairs on the next incremental
+run instead of needing a full refresh.)
 
 The comparison is against a small state artifact this module writes to S3 after
 each successful build, not against the warehouse: the hashed column list only

--- a/dg_projects/lakehouse/lakehouse/resources/dbt_s3_artifacts.py
+++ b/dg_projects/lakehouse/lakehouse/resources/dbt_s3_artifacts.py
@@ -1,5 +1,7 @@
 import hashlib
+import json
 from pathlib import Path
+from typing import Any
 
 import boto3
 from botocore.exceptions import ClientError
@@ -24,6 +26,50 @@ class DbtS3ArtifactsResource(ConfigurableResource):
     def strip_trailing_slash(cls, v: str) -> str:
         """Normalize prefix so keys are always constructed as prefix/filename."""
         return v.rstrip("/")
+
+    def read_json_artifact(
+        self,
+        artifact: str,
+        context: AssetExecutionContext | OpExecutionContext,
+    ) -> Any | None:
+        """Read and decode a JSON artifact at ``<prefix>/<artifact>``.
+
+        Returns None when the object does not exist or does not decode, which
+        callers treat as "no prior state" rather than as an error: the first
+        run after this check ships has nothing to compare against, and a build
+        must not be blocked by a corrupt bookkeeping file.
+        """
+        key = f"{self.s3_prefix}/{artifact}"
+        try:
+            response = boto3.client("s3").get_object(Bucket=self.s3_bucket, Key=key)
+            body = response["Body"].read()
+        except ClientError:
+            context.log.info("No existing s3://%s/%s", self.s3_bucket, key)
+            return None
+        try:
+            return json.loads(body)
+        except ValueError:
+            context.log.warning(
+                "s3://%s/%s is not valid JSON; treating it as absent",
+                self.s3_bucket,
+                key,
+            )
+            return None
+
+    def write_json_artifact(
+        self,
+        artifact: str,
+        payload: Any,
+        context: AssetExecutionContext | OpExecutionContext,
+    ) -> None:
+        """Write *payload* as JSON to ``<prefix>/<artifact>``, overwriting it."""
+        key = f"{self.s3_prefix}/{artifact}"
+        context.log.info("Writing s3://%s/%s", self.s3_bucket, key)
+        boto3.client("s3").put_object(
+            Body=json.dumps(payload, sort_keys=True).encode(),
+            Bucket=self.s3_bucket,
+            Key=key,
+        )
 
     def upload_artifacts(
         self,

--- a/dg_projects/lakehouse/lakehouse/resources/dbt_s3_artifacts.py
+++ b/dg_projects/lakehouse/lakehouse/resources/dbt_s3_artifacts.py
@@ -8,6 +8,12 @@ from botocore.exceptions import ClientError
 from dagster import AssetExecutionContext, ConfigurableResource, OpExecutionContext
 from pydantic import Field, field_validator
 
+# What S3 returns for an object that is not there. GetObject answers NoSuchKey;
+# a bucket-level miss answers NoSuchBucket; some paths (and several
+# S3-compatible endpoints) answer a bare "404" instead. Anything else -- 403,
+# throttling, a 5xx -- is a failed read, not an absent object.
+_MISSING_OBJECT_CODES = frozenset({"NoSuchKey", "NoSuchBucket", "404"})
+
 
 class DbtS3ArtifactsResource(ConfigurableResource):
     """Uploads dbt build artifacts to S3 for consumption by OpenMetadata OMJobs."""
@@ -34,27 +40,39 @@ class DbtS3ArtifactsResource(ConfigurableResource):
     ) -> Any | None:
         """Read and decode a JSON artifact at ``<prefix>/<artifact>``.
 
-        Returns None when the object does not exist or does not decode, which
-        callers treat as "no prior state" rather than as an error: the first
-        run after this check ships has nothing to compare against, and a build
-        must not be blocked by a corrupt bookkeeping file.
+        Returns None only when the object genuinely is not there, which callers
+        read as "no prior state". Every other failure raises.
+
+        Both narrowings matter because callers use the returned state to decide
+        whether something needs repairing, and then overwrite it. A denied,
+        throttled, or 5xx read reported as "absent" would let the run record a
+        fresh baseline over a comparison it never actually made, so whatever
+        had drifted is now indistinguishable from steady state. Undecodable
+        content is the same failure with a different cause: the object exists
+        and says something, and treating it as silence blesses a baseline
+        nothing was checked against. Delete the object deliberately to reset
+        the baseline; do not let a bad read do it by accident.
         """
         key = f"{self.s3_prefix}/{artifact}"
         try:
             response = boto3.client("s3").get_object(Bucket=self.s3_bucket, Key=key)
             body = response["Body"].read()
-        except ClientError:
+        except ClientError as exc:
+            if exc.response.get("Error", {}).get("Code") not in _MISSING_OBJECT_CODES:
+                raise
             context.log.info("No existing s3://%s/%s", self.s3_bucket, key)
             return None
         try:
             return json.loads(body)
-        except ValueError:
-            context.log.warning(
-                "s3://%s/%s is not valid JSON; treating it as absent",
-                self.s3_bucket,
-                key,
+        except ValueError as exc:
+            msg = (
+                f"s3://{self.s3_bucket}/{key} exists but is not valid JSON. It is "
+                "written only by this code, so this means it was corrupted or "
+                "hand-edited. Delete the object to reset the baseline -- the next "
+                "run will then record a fresh one -- rather than letting a run "
+                "treat it as absent and bless a baseline it never compared against."
             )
-            return None
+            raise ValueError(msg) from exc
 
     def write_json_artifact(
         self,

--- a/dg_projects/lakehouse/lakehouse_tests/test_surrogate_key_drift.py
+++ b/dg_projects/lakehouse/lakehouse_tests/test_surrogate_key_drift.py
@@ -1,0 +1,236 @@
+"""Tests for the surrogate-key drift check and its escalation in full_dbt_project.
+
+The behavioural half exercises `lakehouse.lib.surrogate_key_drift` directly.
+The ordering half reads `assets/lakehouse/dbt.py` statically, for the reason
+test_definitions_schedule_ids.py gives: importing that module evaluates a
+`@dbt_assets` decorator that needs /opt/dbt and a parsed manifest, which only
+the container has. The invariants it checks are ones a wrong edit would
+otherwise only break in production — a repair that runs before the build it is
+repairing, or a state file written when the repair failed.
+"""
+
+import ast
+from pathlib import Path
+
+import lakehouse
+import pytest
+from lakehouse.lib.surrogate_key_drift import (
+    SURROGATE_KEY_STATE_ARTIFACT,
+    detect_drift,
+    full_refresh_build_args,
+)
+
+# One re-keyed dimension (dim_thing.thing_pk) and one incremental fact that
+# stores it, declared the way dbt records a `relationships` test.
+MANIFEST = {
+    "nodes": {
+        "model.pkg.dim_thing": {
+            "unique_id": "model.pkg.dim_thing",
+            "name": "dim_thing",
+            "resource_type": "model",
+            "original_file_path": "models/dim_thing.sql",
+            "config": {"materialized": "table"},
+            "raw_code": (
+                "{{ dbt_utils.generate_surrogate_key(['a', 'b']) }} as thing_pk"
+            ),
+            "depends_on": {"nodes": []},
+            "columns": {},
+        },
+        "model.pkg.fact_thing": {
+            "unique_id": "model.pkg.fact_thing",
+            "name": "fact_thing",
+            "resource_type": "model",
+            "original_file_path": "models/fact_thing.sql",
+            "config": {"materialized": "incremental"},
+            "raw_code": "select thing_pk as thing_fk from {{ ref('dim_thing') }}",
+            "depends_on": {"nodes": ["model.pkg.dim_thing"]},
+            "columns": {"thing_fk": {}},
+        },
+        "test.pkg.relationships_fact_thing": {
+            "unique_id": "test.pkg.relationships_fact_thing",
+            "name": "relationships_fact_thing",
+            "resource_type": "test",
+            "original_file_path": "models/_schema.yml",
+            "attached_node": "model.pkg.fact_thing",
+            "column_name": "thing_fk",
+            "config": {"materialized": "test"},
+            "test_metadata": {
+                "name": "relationships",
+                "kwargs": {
+                    "column_name": "thing_fk",
+                    "to": "ref('dim_thing')",
+                    "field": "thing_pk",
+                },
+            },
+            "depends_on": {"nodes": []},
+        },
+    }
+}
+
+MATCHING_STATE = {"dim_thing": {"thing_pk": [["a", "b"]]}}
+PRIOR_STATE = {"dim_thing": {"thing_pk": [["a"]]}}
+
+
+def test_no_baseline_records_state_without_escalating():
+    """The first run has nothing to compare against and must not rebuild the world."""
+    drift = detect_drift(MANIFEST, None)
+    assert drift.models == []
+    assert drift.current_state == MATCHING_STATE
+
+
+def test_unchanged_keys_escalate_nothing():
+    assert detect_drift(MANIFEST, MATCHING_STATE).models == []
+
+
+def test_a_re_key_escalates_the_incremental_models_holding_it():
+    drift = detect_drift(MANIFEST, PRIOR_STATE)
+    assert drift.models == ["fact_thing"]
+    assert drift.current_state == MATCHING_STATE
+    assert "dim_thing.thing_pk re-keyed" in drift.describe()
+    assert "fact_thing" in drift.describe()
+
+
+def test_state_recorded_after_a_repair_stops_it_repeating():
+    """The escalation fires once: the state it writes matches on the next run."""
+    first = detect_drift(MANIFEST, PRIOR_STATE)
+    assert first.models == ["fact_thing"]
+    assert detect_drift(MANIFEST, first.current_state).models == []
+
+
+BOTH_BUILT = {"dim_thing", "fact_thing"}
+
+
+def test_a_run_that_built_both_sides_repairs_and_records():
+    models, complete = detect_drift(MANIFEST, PRIOR_STATE).resolved_against(BOTH_BUILT)
+    assert models == ["fact_thing"]
+    assert complete is True
+
+
+def test_a_run_that_skipped_the_re_keyed_dimension_repairs_nothing():
+    """Refreshing the fact now would just re-copy the old keys and call it fixed."""
+    models, complete = detect_drift(MANIFEST, PRIOR_STATE).resolved_against(
+        {"fact_thing"}
+    )
+    assert models == []
+    assert complete is False
+
+
+def test_a_run_that_skipped_an_affected_fact_withholds_the_state():
+    models, complete = detect_drift(MANIFEST, PRIOR_STATE).resolved_against(
+        {"dim_thing"}
+    )
+    assert models == []
+    assert complete is False
+
+
+def test_a_clean_run_records_the_baseline_whatever_it_built():
+    models, complete = detect_drift(MANIFEST, MATCHING_STATE).resolved_against(set())
+    assert models == []
+    assert complete is True
+
+
+def test_full_refresh_selector_is_one_space_separated_argument():
+    assert full_refresh_build_args(["fact_a", "fact_b"]) == [
+        "build",
+        "--full-refresh",
+        "--select",
+        "fact_a fact_b",
+    ]
+
+
+def test_full_refresh_carries_the_build_vars_through():
+    """A repair against a different schema rebuilds the wrong relations."""
+    args = full_refresh_build_args(["fact_a"], ["--vars", "schema_suffix: dev"])
+    assert args[-2:] == ["--vars", "schema_suffix: dev"]
+
+
+# ---------------------------------------------------------------------------
+# Ordering invariants in the asset
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="module")
+def dbt_asset_module() -> ast.Module:
+    source = Path(lakehouse.__file__).parent / "assets" / "lakehouse" / "dbt.py"
+    return ast.parse(source.read_text())
+
+
+def _function(module: ast.Module, name: str) -> ast.FunctionDef:
+    found = [
+        n for n in ast.walk(module) if isinstance(n, ast.FunctionDef) and n.name == name
+    ]
+    assert found, f"{name} is no longer defined in dbt.py"
+    return found[0]
+
+
+def _called_names(node: ast.AST) -> list[tuple[int, str]]:
+    """``(line, callee)`` for every call under *node*, in source order."""
+    calls: list[tuple[int, str]] = []
+    for child in ast.walk(node):
+        if not isinstance(child, ast.Call):
+            continue
+        func = child.func
+        name = func.id if isinstance(func, ast.Name) else getattr(func, "attr", "")
+        calls.append((child.lineno, name))
+    return sorted(calls)
+
+
+def _first_call_lines(node: ast.AST) -> dict[str, int]:
+    """``{callee: first line it is called on}``."""
+    lines: dict[str, int] = {}
+    for line, name in _called_names(node):
+        lines.setdefault(name, line)
+    return lines
+
+
+def test_the_repair_runs_after_the_build_it_repairs(dbt_asset_module):
+    """The dimension has to carry its new keys before the facts are rebuilt.
+
+    Repairing first would rebuild them against the previous keys and orphan
+    every FK again — a green run that fixed nothing.
+    """
+    lines = _first_call_lines(_function(dbt_asset_module, "full_dbt_project"))
+    assert lines["_surrogate_key_drift"] < lines["stream"]
+    assert lines["stream"] < lines["_repair_surrogate_key_drift"]
+
+
+def test_state_is_written_only_after_a_complete_repair(dbt_asset_module):
+    """A failed or partial repair must leave the drift pending, not marked handled."""
+    asset = _function(dbt_asset_module, "full_dbt_project")
+    lines = _first_call_lines(asset)
+    assert lines["_repair_surrogate_key_drift"] < lines["write_json_artifact"]
+
+    writes = [
+        node
+        for node in ast.walk(asset)
+        if isinstance(node, ast.If)
+        and "write_json_artifact" in {name for _, name in _called_names(node)}
+    ]
+    assert writes, "the key state write must stay conditional"
+    # Gated on the repair's own return value, so a repair that raised or
+    # reported an incomplete run can never reach the write.
+    assert "_repair_surrogate_key_drift" in {
+        name for _, name in _called_names(writes[0].test)
+    }
+
+    repair = _function(dbt_asset_module, "_repair_surrogate_key_drift")
+    guarded = [node for node in repair.body if isinstance(node, ast.If)]
+    assert guarded, (
+        "the full-refresh build must stay conditional on the resolved models"
+    )
+    assert "full_refresh_build_args" in {name for _, name in _called_names(guarded[0])}
+
+
+def test_the_repair_is_scoped_to_what_this_run_actually_built(dbt_asset_module):
+    """A subset build must not mark drift handled for models it never touched."""
+    repair = _function(dbt_asset_module, "_repair_surrogate_key_drift")
+    assert "resolved_against" in {name for _, name in _called_names(repair)}
+    assert "built" in {arg.arg for arg in repair.args.args}
+
+    asset = _function(dbt_asset_module, "full_dbt_project")
+    assert "_models_built_by" in {name for _, name in _called_names(asset)}
+
+
+def test_the_state_artifact_name_is_stable():
+    """Renaming it silently orphans the baseline and re-fires every escalation."""
+    assert SURROGATE_KEY_STATE_ARTIFACT == "surrogate-key-state.json"

--- a/dg_projects/lakehouse/lakehouse_tests/test_surrogate_key_drift.py
+++ b/dg_projects/lakehouse/lakehouse_tests/test_surrogate_key_drift.py
@@ -10,15 +10,19 @@ repairing, or a state file written when the repair failed.
 """
 
 import ast
+import io
 from pathlib import Path
 
 import lakehouse
 import pytest
+from botocore.exceptions import ClientError
 from lakehouse.lib.surrogate_key_drift import (
     SURROGATE_KEY_STATE_ARTIFACT,
     detect_drift,
     full_refresh_build_args,
 )
+from lakehouse.resources import dbt_s3_artifacts
+from lakehouse.resources.dbt_s3_artifacts import DbtS3ArtifactsResource
 
 # One re-keyed dimension (dim_thing.thing_pk) and one incremental fact that
 # stores it, declared the way dbt records a `relationships` test.
@@ -115,12 +119,21 @@ def test_a_run_that_skipped_the_re_keyed_dimension_repairs_nothing():
     assert complete is False
 
 
-def test_a_run_that_skipped_an_affected_fact_withholds_the_state():
+def test_the_ancestor_alone_is_enough_to_repair():
+    """The repair names the facts in its own --select, so the run need not have
+    built them -- and under `upstream_or_code_changes` it never will have.
+
+    A dimension is selected on the tick its code version changes; its facts are
+    gated behind `any_deps_updated`, which cannot be true until that build has
+    finished, and `~any_deps_in_progress` keeps them out of the same run
+    besides. Requiring both in one run deadlocks the repair: the first run has
+    no facts to refresh and the second no dimension, forever.
+    """
     models, complete = detect_drift(MANIFEST, PRIOR_STATE).resolved_against(
         {"dim_thing"}
     )
-    assert models == []
-    assert complete is False
+    assert models == ["fact_thing"]
+    assert complete is True
 
 
 def test_a_clean_run_records_the_baseline_whatever_it_built():
@@ -234,3 +247,72 @@ def test_the_repair_is_scoped_to_what_this_run_actually_built(dbt_asset_module):
 def test_the_state_artifact_name_is_stable():
     """Renaming it silently orphans the baseline and re-fires every escalation."""
     assert SURROGATE_KEY_STATE_ARTIFACT == "surrogate-key-state.json"
+
+
+# ---------------------------------------------------------------------------
+# The state artifact must fail closed
+# ---------------------------------------------------------------------------
+
+
+class _FakeLog:
+    def info(self, *args) -> None:
+        pass
+
+    def warning(self, *args) -> None:
+        pass
+
+
+class _FakeContext:
+    log = _FakeLog()
+
+
+def _resource_reading(monkeypatch, *, error=None, body=b""):
+    """Build a resource whose get_object raises *error* or returns *body*."""
+
+    class _Client:
+        def get_object(self, **_kwargs):
+            if error is not None:
+                raise error
+            return {"Body": io.BytesIO(body)}
+
+    monkeypatch.setattr(dbt_s3_artifacts.boto3, "client", lambda _svc: _Client())
+    return DbtS3ArtifactsResource(s3_bucket="bucket", s3_prefix="prefix")
+
+
+def _client_error(code: str) -> ClientError:
+    return ClientError({"Error": {"Code": code, "Message": code}}, "GetObject")
+
+
+def test_a_missing_object_is_no_prior_state(monkeypatch):
+    resource = _resource_reading(monkeypatch, error=_client_error("NoSuchKey"))
+    assert resource.read_json_artifact("state.json", _FakeContext()) is None
+
+
+def test_a_denied_read_raises_rather_than_faking_a_missing_baseline(monkeypatch):
+    """A 403 reported as absent lets the run record a baseline it never compared
+    against, hiding the drift it was supposed to repair.
+    """
+    resource = _resource_reading(monkeypatch, error=_client_error("AccessDenied"))
+    with pytest.raises(ClientError):
+        resource.read_json_artifact("state.json", _FakeContext())
+
+
+def test_a_throttled_read_raises(monkeypatch):
+    resource = _resource_reading(monkeypatch, error=_client_error("SlowDown"))
+    with pytest.raises(ClientError):
+        resource.read_json_artifact("state.json", _FakeContext())
+
+
+def test_undecodable_state_raises_rather_than_blessing_a_new_baseline(monkeypatch):
+    resource = _resource_reading(monkeypatch, body=b"{not json")
+    with pytest.raises(ValueError, match="not valid JSON"):
+        resource.read_json_artifact("state.json", _FakeContext())
+
+
+def test_valid_state_decodes(monkeypatch):
+    resource = _resource_reading(
+        monkeypatch, body=b'{"dim_thing": {"thing_pk": [["a"]]}}'
+    )
+    assert resource.read_json_artifact("state.json", _FakeContext()) == {
+        "dim_thing": {"thing_pk": [["a"]]}
+    }

--- a/dg_projects/lakehouse/uv.lock
+++ b/dg_projects/lakehouse/uv.lock
@@ -397,7 +397,7 @@ wheels = [
 
 [[package]]
 name = "cyclopts"
-version = "4.23.2"
+version = "4.24.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "attrs" },
@@ -405,9 +405,9 @@ dependencies = [
     { name = "rich" },
     { name = "rich-rst" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/fc/db/becc1331b1eefe8e3370281a2fd7b9685ae6a10dbdd54c7e44ea05bf2ed6/cyclopts-4.23.2.tar.gz", hash = "sha256:1c9de7f245394d3ef9344fc6c976fc373fe1f2ce929b27f08ad4ea8499c13461", size = 196127, upload-time = "2026-08-22T19:20:49.534Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e6/4e/9d8d4ac3be590cc6553047bfdd53dc6ed776fe3e180ad77559629b0d1c66/cyclopts-4.24.0.tar.gz", hash = "sha256:9bf9da3f09a0ff74aa6621e1644abfdde3b22158b0c09b5aaa6f82bd0c31c526", size = 200331, upload-time = "2026-09-03T13:02:13.314Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/35/40/c17d731af4ddbf6dede1f1acb09e6335c2587e8b73b3d4742f3f9c6996d3/cyclopts-4.23.2-py3-none-any.whl", hash = "sha256:eb95b6f221ec8e62ba64f879beb27dff779408a320db730fc184427c463a3695", size = 236258, upload-time = "2026-08-22T19:20:48.106Z" },
+    { url = "https://files.pythonhosted.org/packages/83/9d/be0c38b950999b73befa59006dacd8f83e5ec5c3d3172b61883beacecc56/cyclopts-4.24.0-py3-none-any.whl", hash = "sha256:b3e44fd301ea498f0b30578d6192a9d9565fd0098e736bd9c8ca0a33f6989659", size = 240417, upload-time = "2026-09-03T13:02:11.96Z" },
 ]
 
 [[package]]

--- a/docs/specs/DBT_WAREHOUSE_CI_QA_SPEC.md
+++ b/docs/specs/DBT_WAREHOUSE_CI_QA_SPEC.md
@@ -51,9 +51,13 @@ wiring into four credential/engine-gated phases.
 - **JSON output convention:** build a flat `list[dict]`, `print(json.dumps(data, indent=2))`
   (plain `print`, never rich). Text mode uses `console.print` + a trailing rich `Summary:`
   line. Dual consoles: `console = Console()`, `err_console = Console(stderr=True)`.
-- **Severity enums:** `impact` uses `AlertLevel(StrEnum) = BREAKING|WARNING|INFO`; `validate`
-  uses `Severity(StrEnum) = ERROR|WARNING|INFO`. Exit `1` when the top severity is present,
-  bare `return` for the clean/no-op case.
+- **Severity enums:** `impact` uses `AlertLevel(StrEnum) = BREAKING|KEY_REGEN|WARNING|INFO`;
+  `validate` uses `Severity(StrEnum) = ERROR|WARNING|INFO`. Exit `1` when the top severity is
+  present, bare `return` for the clean/no-op case. `KEY_REGEN` is deliberately outside that
+  exit-code rule: it reports a full-refresh model whose `generate_surrogate_key` inputs
+  changed, orphaning the FK copies its incremental descendants hold. Nothing in the PR is
+  wrong — the follow-up is a production rebuild, which `lakehouse.lib.surrogate_key_drift`
+  performs on the first build after merge.
 - **dbt invocation:** always `subprocess.run([...], cwd=str(dbt_dir))`, argv list, no
   `dbtRunner`. `run.py` passes `--profiles-dir str(dbt_dir)`; `impact`/`validate` rely on
   cwd. `DBT_PROFILES_DIR` is not set by the CLI.
@@ -257,7 +261,9 @@ run `dbt parse`/`compile` against `dev_local`, no warehouse network):
    the BREAKING/WARNING column-level blast radius as a **PR comment** (create-or-update a
    single sticky comment). BREAKING → non-zero (or convert to a required-review signal — decide
    at impl; default: annotate, do not hard-fail, to avoid blocking legitimate breaking changes
-   that are reviewed).
+   that are reviewed). KEY_REGEN alerts get their own section in that comment: they change no
+   column, so a reviewer scanning the collapsed details for a renamed field would not find
+   them.
 4. **dimensional-layering-lint** — see §5 (runs as `ol-dbt validate --only dimensional_layering`
    or a dedicated flag).
 5. **sqlfluff-lint** — run the same sqlfluff config used in pre-commit (today pre-commit only).

--- a/src/ol_dbt/models/dimensional/_fact_tables.yml
+++ b/src/ol_dbt/models/dimensional/_fact_tables.yml
@@ -249,10 +249,14 @@ models:
   - name: discount_fk
     description: >
       Foreign key to dim_discount (null when no discount applied on this line).
-      dim_discount is full-refresh and this table is incremental — a
-      dim_discount.discount_pk hashing change requires a `dbt run --select
-      tfact_order --full-refresh` immediately after to avoid orphaning
-      discount_fk on historical order lines.
+      dim_discount is full-refresh and this table is incremental, so changing
+      what discount_pk is hashed from orphans discount_fk on every historical
+      order line. That no longer needs remembering: `ol-dbt impact` reports it
+      on the PR as KEY_REGEN, and the production build full-refreshes this
+      table on the first run after the change lands (see
+      lakehouse.lib.surrogate_key_drift). The relationships test below is what
+      the detector reads to know this column points at dim_discount.discount_pk
+      — dropping it would take tfact_order out of that repair.
     tests:
     - relationships:
         to: ref('dim_discount')

--- a/src/ol_dbt_cli/ol_dbt_cli/commands/impact.py
+++ b/src/ol_dbt_cli/ol_dbt_cli/commands/impact.py
@@ -38,6 +38,11 @@ from ol_dbt_cli.lib.sql_parser import (
     parse_model_file,
     parse_model_sql_at_content,
 )
+from ol_dbt_cli.lib.surrogate_keys import (
+    SurrogateKeyChange,
+    changed_surrogate_keys,
+    detect_key_regen,
+)
 from ol_dbt_cli.lib.yaml_registry import YamlRegistry, build_yaml_registry
 
 console = Console()
@@ -46,6 +51,7 @@ err_console = Console(stderr=True)
 
 class AlertLevel(StrEnum):
     BREAKING = "BREAKING"
+    KEY_REGEN = "KEY_REGEN"
     WARNING = "WARNING"
     INFO = "INFO"
 
@@ -433,6 +439,66 @@ def _analyse_deleted_model(
     )
 
 
+def _analyse_key_regen(
+    changed_keys: dict[str, list[SurrogateKeyChange]],
+    manifest: ManifestRegistry,
+    sql_models_by_name: dict[str, ParsedModel],
+) -> list[ImpactAlert]:
+    """Alerts for surrogate-key hash-input changes that orphan downstream FKs.
+
+    A full-refresh dimension re-derives every ``generate_surrogate_key`` value
+    on its next build. Its incremental descendants stored the previous value as
+    an FK and will not revisit those rows, so the join silently stops matching
+    — no column changed, so neither the column diff above nor
+    ``on_schema_change`` sees anything. Reported separately from BREAKING
+    because the fix is not an edit to the downstream model: it is a
+    ``--full-refresh`` of the listed tables on the first run after this merges.
+    """
+    alerts: list[ImpactAlert] = []
+    reads: dict[tuple[str, str], set[str] | None] = {}
+
+    def column_reads(child: str, parent: str) -> set[str] | None:
+        if (child, parent) not in reads:
+            parsed = sql_models_by_name.get(child)
+            reads[(child, parent)] = None if parsed is None else get_columns_read_from_ref(parsed, parent)
+        return reads[(child, parent)]
+
+    for finding in detect_key_regen(changed_keys, manifest, column_reads):
+        before = " + ".join(", ".join(call) for call in finding.base_inputs)
+        after = " + ".join(", ".join(call) for call in finding.current_inputs)
+        alerts.append(
+            ImpactAlert(
+                level=AlertLevel.KEY_REGEN,
+                changed_model=finding.ancestor,
+                column_changes=[
+                    ColumnChange(
+                        column=finding.changed_key_column,
+                        change_type="key_inputs_changed",
+                        related=f"{before} → {after}",
+                    )
+                ],
+                downstream=[
+                    DownstreamImpact(
+                        model_name=model.model_name,
+                        unique_id=model.unique_id,
+                        affected_columns=[model.fk_column],
+                        depth=model.depth,
+                    )
+                    for model in finding.affected_models
+                ],
+                message=(
+                    f"'{finding.ancestor}.{finding.changed_key_column}' is hashed from a different "
+                    "column list than at the base ref — every existing value changes on the next build. "
+                    f"{len(finding.affected_model_names)} incremental model(s) store it as an FK and need "
+                    "`dbt build --full-refresh --select "
+                    f"{' '.join(finding.affected_model_names)}` on the first run after this merges."
+                ),
+                manifest_available=True,
+            )
+        )
+    return alerts
+
+
 def _analyse_macro_change(
     macro_rel_path: str,
     affected_models: set[str],
@@ -473,11 +539,13 @@ def _analyse_macro_change(
 
 _LEVEL_COLOR = {
     AlertLevel.BREAKING: "bold red",
+    AlertLevel.KEY_REGEN: "bold magenta",
     AlertLevel.WARNING: "yellow",
     AlertLevel.INFO: "green",
 }
 _LEVEL_ICON = {
     AlertLevel.BREAKING: "🔴",
+    AlertLevel.KEY_REGEN: "🔑",
     AlertLevel.WARNING: "⚠️ ",
     AlertLevel.INFO: "ℹ️ ",
 }
@@ -502,8 +570,14 @@ def _print_text_alerts(alerts: list[ImpactAlert]) -> None:
                     "added": "➕",
                     "renamed_from": "🔄",
                     "renamed_to": "→ ",
+                    "key_inputs_changed": "🔑",
                 }.get(change.change_type, "•")
-                suffix = f" → {change.related}" if change.related and change.change_type == "renamed_from" else ""
+                if change.change_type == "key_inputs_changed":
+                    suffix = f" hashed from: {change.related}"
+                elif change.related and change.change_type == "renamed_from":
+                    suffix = f" → {change.related}"
+                else:
+                    suffix = ""
                 console.print(f"     {prefix} {change.column}{suffix}")
 
         if alert.downstream:
@@ -622,6 +696,8 @@ def impact(
 
     Alert levels:
       🔴 BREAKING  — a removed/renamed column is used by a downstream model
+      🔑 KEY_REGEN — a full-refresh model re-hashes a surrogate key from different
+                     inputs, orphaning the FK copies incremental descendants hold
       ⚠️  WARNING   — column changed but downstream impact cannot be fully determined
       ℹ️  INFO      — only additive changes (new columns), no downstream breakage
 
@@ -848,8 +924,37 @@ def impact(
 
     alerts.extend(macro_alerts)
 
+    # Surrogate-key drift is a separate pass, not a branch of _analyse_model:
+    # re-hashing a key from a different column list changes no column, so the
+    # column diff above returns None for exactly the change that causes it.
+    changed_keys: dict[str, list[SurrogateKeyChange]] = {}
+    for name in target_names:
+        sql_file = sql_file_map.get(name)
+        if sql_file is None:
+            continue
+        base_content = get_file_at_ref(sql_file, merge_base, repo_root=repo_root)
+        if base_content is None:
+            continue  # New model — nothing downstream holds a key it never minted.
+        key_changes = changed_surrogate_keys(base_content, sql_file.read_text())
+        if key_changes:
+            changed_keys[name] = key_changes
+
+    if changed_keys and manifest is not None:
+        alerts.extend(_analyse_key_regen(changed_keys, manifest, sql_models_by_name))
+    elif changed_keys:
+        err_console.print(
+            f"[yellow]Warning:[/] {len(changed_keys)} model(s) changed their surrogate-key hash "
+            "inputs, but no manifest is available to find the incremental models storing those "
+            "keys. Run `dbt parse` (or --auto-compile) so the re-key is analysed."
+        )
+
     # Sort: BREAKING first, then WARNING, then INFO
-    order = {AlertLevel.BREAKING: 0, AlertLevel.WARNING: 1, AlertLevel.INFO: 2}
+    order = {
+        AlertLevel.BREAKING: 0,
+        AlertLevel.KEY_REGEN: 1,
+        AlertLevel.WARNING: 2,
+        AlertLevel.INFO: 3,
+    }
     alerts.sort(key=lambda a: order[a.level])
 
     if output_format == "json":
@@ -857,9 +962,11 @@ def impact(
     else:
         _print_text_alerts(alerts)
         breaking = sum(1 for a in alerts if a.level == AlertLevel.BREAKING)
+        key_regen = sum(1 for a in alerts if a.level == AlertLevel.KEY_REGEN)
         warnings = sum(1 for a in alerts if a.level == AlertLevel.WARNING)
         console.print(
-            f"\n[bold]Summary:[/] {breaking} breaking, {warnings} warning(s) across {len(alerts)} changed model(s)."
+            f"\n[bold]Summary:[/] {breaking} breaking, {key_regen} key regeneration(s), "
+            f"{warnings} warning(s) across {len(alerts)} changed model(s)."
         )
         if models_without_compiled:
             unique_missing = sorted(set(models_without_compiled))

--- a/src/ol_dbt_cli/ol_dbt_cli/lib/manifest.py
+++ b/src/ol_dbt_cli/ol_dbt_cli/lib/manifest.py
@@ -8,6 +8,7 @@ needing to re-parse Jinja-laden SQL.
 from __future__ import annotations
 
 import json
+import re
 from collections import deque
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -33,6 +34,8 @@ class ManifestModel:
     original_file_path: str
     schema: str
     database: str
+    materialized: str = ""
+    """``config.materialized`` — "table"/"view"/"incremental"/"ephemeral"/""."""
     columns: dict[str, ManifestColumn] = field(default_factory=dict)
     depends_on: list[str] = field(default_factory=list)
     """unique_ids of parent nodes."""
@@ -60,6 +63,24 @@ class ManifestMacro:
     """unique_ids of other macros this macro references."""
 
 
+@dataclass(frozen=True)
+class ForeignKeyRef:
+    """A declared FK edge, recovered from a ``relationships`` schema test.
+
+    dbt records each ``relationships`` test as its own node naming both sides
+    and both columns, which makes it a far better source for "this column holds
+    that model's key" than inferring it from the SQL — the test is the
+    convention the dimensional models are already written to, and it survives
+    aliasing (``dim_user.user_pk`` stored as ``tfact_order.user_fk``) that no
+    name-matching heuristic follows.
+    """
+
+    child_unique_id: str
+    child_column: str
+    parent_name: str
+    parent_column: str
+
+
 @dataclass
 class ManifestRegistry:
     """Registry built from a dbt manifest.json."""
@@ -75,6 +96,8 @@ class ManifestRegistry:
     """unique_id -> list of child unique_ids (reverse of depends_on)."""
     macros: dict[str, ManifestMacro] = field(default_factory=dict)
     """macro unique_id -> ManifestMacro for every macro in the project graph."""
+    foreign_keys: dict[str, list[ForeignKeyRef]] = field(default_factory=dict)
+    """child unique_id -> the FK edges its ``relationships`` tests declare."""
 
     def get_model(self, name: str) -> ManifestModel | None:
         return self.by_name.get(name)
@@ -128,6 +151,10 @@ class ManifestRegistry:
             if column_name in child.column_names:
                 matches.append((child, column_name))
         return matches
+
+    def foreign_keys_between(self, child_unique_id: str, parent_name: str) -> list[ForeignKeyRef]:
+        """FK edges *child_unique_id* declares onto the model named *parent_name*."""
+        return [fk for fk in self.foreign_keys.get(child_unique_id, ()) if fk.parent_name == parent_name]
 
     def models_for_changed_macros(self, changed_macro_files: set[str]) -> set[str]:
         """Return the names of models whose output can change when the given macros change.
@@ -196,9 +223,40 @@ def _parse_node(node_data: dict[str, Any]) -> ManifestModel:
         original_file_path=node_data.get("original_file_path", ""),
         schema=node_data.get("schema", ""),
         database=node_data.get("database", ""),
+        materialized=(node_data.get("config") or {}).get("materialized", ""),
         columns=columns,
         depends_on=depends_on.get("nodes", []),
         depends_on_macros=depends_on.get("macros", []),
+    )
+
+
+# `to: ref('dim_discount')` / `to: ref('open_learning', 'dim_discount')` — the
+# last quoted segment is the model name in either spelling.
+_REF_MODEL_NAME = re.compile(r"ref\s*\(\s*(?:[^)]*,)?\s*['\"]([^'\"]+)['\"]")
+
+
+def _parse_relationship_test(node_data: dict[str, Any]) -> ForeignKeyRef | None:
+    """Convert a ``relationships`` test node into a :class:`ForeignKeyRef`.
+
+    Returns None for any other test, and for a ``relationships`` test pointed
+    at a ``source()`` rather than a ``ref()`` — a source is a relation dbt does
+    not build, so it mints no key that could be regenerated.
+    """
+    metadata = node_data.get("test_metadata") or {}
+    if metadata.get("name") != "relationships":
+        return None
+    kwargs = metadata.get("kwargs") or {}
+    child_column = kwargs.get("column_name") or node_data.get("column_name")
+    parent_column = kwargs.get("field")
+    child_unique_id = node_data.get("attached_node")
+    match = _REF_MODEL_NAME.search(kwargs.get("to") or "")
+    if not (child_column and parent_column and child_unique_id and match):
+        return None
+    return ForeignKeyRef(
+        child_unique_id=child_unique_id,
+        child_column=str(child_column).lower(),
+        parent_name=match.group(1),
+        parent_column=str(parent_column).lower(),
     )
 
 
@@ -215,8 +273,17 @@ def _parse_macro(macro_data: dict[str, Any]) -> ManifestMacro:
 
 def load_manifest(manifest_path: Path) -> ManifestRegistry:
     """Load and parse a dbt ``manifest.json`` file into a :class:`ManifestRegistry`."""
-    raw: dict[str, Any] = json.loads(manifest_path.read_text())
+    return registry_from_manifest(json.loads(manifest_path.read_text()))
 
+
+def registry_from_manifest(raw: dict[str, Any]) -> ManifestRegistry:
+    """Build a :class:`ManifestRegistry` from an already-decoded manifest.
+
+    Split out from :func:`load_manifest` so a caller that needs the raw
+    manifest as well (``raw_code``, say, which the registry deliberately does
+    not carry — it would roughly double the resident size of a 20MB manifest)
+    can decode the JSON once instead of twice.
+    """
     registry = ManifestRegistry()
 
     all_nodes: dict[str, Any] = {}
@@ -239,6 +306,11 @@ def load_manifest(manifest_path: Path) -> ManifestRegistry:
             table_name = node_data.get("name", "")
             if source_name and table_name:
                 registry.sources[f"{source_name}.{table_name}"] = model
+
+    for node_data in raw.get("nodes", {}).values():
+        fk = _parse_relationship_test(node_data)
+        if fk is not None:
+            registry.foreign_keys.setdefault(fk.child_unique_id, []).append(fk)
 
     for uid, macro_data in raw.get("macros", {}).items():
         registry.macros[uid] = _parse_macro(macro_data)

--- a/src/ol_dbt_cli/ol_dbt_cli/lib/surrogate_keys.py
+++ b/src/ol_dbt_cli/ol_dbt_cli/lib/surrogate_keys.py
@@ -224,6 +224,35 @@ def _balanced_call_args(sql: str, open_paren: int) -> tuple[str, int] | None:
     return None
 
 
+def _argument_literals(args: str) -> tuple[str, ...]:
+    r"""Return the hashed expressions in a ``generate_surrogate_key`` argument list.
+
+    Two string literals separated by nothing but whitespace are one argument,
+    not two: Jinja concatenates adjacent literals, so ``['O' 'Brien']`` reaches
+    dbt as the single value ``OBrien``. Reading them as two would make
+    ``['O' 'Brien']`` and ``['O', 'Brien']`` — which hash differently, one
+    input versus two — compare identical, and a re-key between them would go
+    unreported.
+
+    Jinja's lexer has no backslash escape (``['it\\'s']`` is a syntax error),
+    so a quote inside a literal can only be written by delimiting with the
+    other quote character. That is why the literal pattern needs no escape
+    handling at this level; the ``''`` doubling that SQL uses is one level
+    down, inside the expression, and is handled by :func:`_normalize_input`.
+    """
+    inputs: list[str] = []
+    previous_end: int | None = None
+    for match in _STRING_LITERAL.finditer(args):
+        single, double = match.group(1), match.group(2)
+        value = single if single is not None else double
+        if previous_end is not None and not args[previous_end : match.start()].strip():
+            inputs[-1] += value
+        else:
+            inputs.append(value)
+        previous_end = match.end()
+    return tuple(_normalize_input(value) for value in inputs)
+
+
 def extract_surrogate_keys(sql: str) -> list[SurrogateKeyDef]:
     """Every ``generate_surrogate_key`` call in *sql*, in source order.
 
@@ -244,7 +273,7 @@ def extract_surrogate_keys(sql: str) -> list[SurrogateKeyDef]:
         if call is None:
             continue
         args, after = call
-        inputs = tuple(_normalize_input(single or double) for single, double in _STRING_LITERAL.findall(args))
+        inputs = _argument_literals(args)
         alias_match = _KEY_ALIAS.match(sql, after)
         column = alias_match.group(1).lower() if alias_match else ""
         keys.append(SurrogateKeyDef(column=column, inputs=inputs))

--- a/src/ol_dbt_cli/ol_dbt_cli/lib/surrogate_keys.py
+++ b/src/ol_dbt_cli/ol_dbt_cli/lib/surrogate_keys.py
@@ -50,6 +50,8 @@ _KEY_ALIAS = re.compile(r"\s*(?:\}\})?\s*as\s+\"?([A-Za-z_][A-Za-z0-9_]*)\"?", r
 
 _STRING_LITERAL = re.compile(r"'([^']*)'|\"([^\"]*)\"")
 
+_WHITESPACE_RUN = re.compile(r"\s+")
+
 
 @dataclass(frozen=True)
 class SurrogateKeyDef:
@@ -130,14 +132,68 @@ def _normalize_input(expression: str) -> str:
     changes no hash in the warehouse, so it must not full-refresh a fact table
     here either.
 
-    Deliberately no further than that: collapsing spaces around punctuation
-    would also equate ``concat(a, ', ', b)`` with ``concat(a, ',', b)``, which
-    really do hash differently. The same caveat applies to lowercasing and a
-    literal like ``'A'``. Both are contrived next to the reformats above, and
-    the failure they would cause — a silent miss — is the one this check
-    exists to prevent, so normalization stops here.
+    Quoted regions are copied through untouched. A SQL string literal and a
+    quoted identifier are both case- and space-sensitive: ``concat(kind, 'A')``
+    and ``concat(kind, 'a')`` hash differently, and folding them together would
+    make the detector miss the exact re-key it exists to catch. ``''`` inside a
+    single-quoted literal is SQL's own escape for a quote and stays inside the
+    literal.
+
+    Outside a quoted region, each run of whitespace folds to a single space —
+    enough to absorb a reindent, and safe there because whitespace between SQL
+    tokens is insignificant. ``concat(a, ', ', b)`` and ``concat(a, ',', b)``
+    still compare different, since what separates them lives inside a literal.
     """
-    return " ".join(expression.split()).lower()
+    out: list[str] = []
+    for text, quote in _quoted_regions(expression):
+        # Each run of whitespace collapses to a single space rather than being
+        # removed: dropping it would join a literal to its neighbour, turning
+        # `'a' 'b'` into `'a''b'` -- a different expression, since `''` is an
+        # escaped quote inside one literal rather than two adjacent ones.
+        out.append(text if quote else _WHITESPACE_RUN.sub(" ", text).lower())
+    return "".join(out).strip()
+
+
+def _quoted_regions(text: str) -> list[tuple[str, str | None]]:
+    """Split *text* into ``(chunk, quote_char_or_None)`` runs.
+
+    A chunk tagged with a quote character is a complete SQL string literal or
+    quoted identifier including its delimiters, with ``''``/``""`` doubling
+    treated as an escaped quote inside it rather than as a close followed by a
+    reopen. An unterminated quote runs to the end of *text*, which keeps the
+    split total: a malformed expression must still normalize to something
+    stable rather than raise.
+    """
+    regions: list[tuple[str, str | None]] = []
+    start = 0
+    index = 0
+    while index < len(text):
+        char = text[index]
+        if char not in "'\"":
+            index += 1
+            continue
+        if start != index:
+            regions.append((text[start:index], None))
+        end = _end_of_quoted(text, index)
+        regions.append((text[index:end], char))
+        start = index = end
+    if start < len(text):
+        regions.append((text[start:], None))
+    return regions
+
+
+def _end_of_quoted(text: str, start: int) -> int:
+    """Index just past the literal opening at *start*, or the end of *text*."""
+    quote = text[start]
+    index = start + 1
+    while index < len(text):
+        if text[index] != quote:
+            index += 1
+        elif index + 1 < len(text) and text[index + 1] == quote:
+            index += 2  # doubled quote: SQL's escape, still inside the literal
+        else:
+            return index + 1
+    return len(text)
 
 
 def _balanced_call_args(sql: str, open_paren: int) -> tuple[str, int] | None:
@@ -301,37 +357,45 @@ def affected_incremental_descendants(
     rows, but an incremental model downstream of *it* copied the stale FK too
     and needs the same treatment.
 
-    Each node is visited once, on the shortest path that reaches it. A second,
-    longer path could in principle carry a different column, but rediscovering
-    the same subgraph per path turns a wide dimension's fan-out into an
-    exponential walk for a case that has not arisen.
+    A node is re-walked whenever a path reaches it carrying a column it has not
+    been seen holding before, rather than being marked visited on first sight.
+    Marking on sight makes the result depend on traversal order: where two
+    paths converge, the first to arrive might carry nothing the child reads,
+    and the child -- along with every incremental model below it -- would be
+    struck off before the path that does carry the key is ever tried. Carried
+    sets only grow and are bounded by the column names in the graph, so the
+    worklist still terminates.
     """
     results: dict[tuple[str, str], AffectedIncrementalModel] = {}
     queue: deque[tuple[ManifestModel, frozenset[str], int]] = deque([(ancestor, frozenset({key_column}), 0)])
-    seen: set[str] = {ancestor.unique_id}
+    carried_by: dict[str, frozenset[str]] = {ancestor.unique_id: frozenset({key_column})}
 
     while queue:
         parent, carried, depth = queue.popleft()
         for child in registry.get_model_children(parent.unique_id):
-            if child.unique_id in seen:
-                continue
-            seen.add(child.unique_id)
-
             child_carried = _carried_into(registry, parent, child, carried, column_reads)
             if not child_carried:
                 continue
 
+            known = carried_by.get(child.unique_id, frozenset())
+            if child_carried.keys() <= known:
+                continue  # nothing this path carries is new to the child
+
             if child.materialized == INCREMENTAL_MATERIALIZATION:
                 for column, evidence in child_carried.items():
+                    found = results.get((child.name, column))
+                    if found is not None and _EVIDENCE_RANK.get(found.evidence, 9) <= _EVIDENCE_RANK.get(evidence, 9):
+                        continue
                     results[(child.name, column)] = AffectedIncrementalModel(
                         model_name=child.name,
                         unique_id=child.unique_id,
                         fk_column=column,
                         evidence=evidence,
-                        depth=depth + 1,
+                        depth=min(depth + 1, found.depth if found else depth + 1),
                     )
 
-            queue.append((child, frozenset(child_carried), depth + 1))
+            carried_by[child.unique_id] = known | child_carried.keys()
+            queue.append((child, carried_by[child.unique_id], depth + 1))
 
     return sorted(
         results.values(),

--- a/src/ol_dbt_cli/ol_dbt_cli/lib/surrogate_keys.py
+++ b/src/ol_dbt_cli/ol_dbt_cli/lib/surrogate_keys.py
@@ -1,0 +1,440 @@
+"""Surrogate-key hash-input extraction and downstream drift detection.
+
+``dbt_utils.generate_surrogate_key([...])`` mints a primary key by hashing an
+ordered list of expressions. A model materialized ``table`` or ``view`` re-runs
+that hash over every row on every build, so editing the input list silently
+re-keys the whole dimension. Its incremental descendants stored the *old* key
+as a foreign key at insert time and only revisit rows inside their watermark,
+so those FKs orphan — and because no column was added or removed,
+``on_schema_change='append_new_columns'`` sees nothing to react to. Two
+production incidents came from exactly this: the ``dim_discount.discount_pk``
+hash-input change (#2411) and the ``dim_user`` re-key (#2618).
+
+Nothing in this module touches disk, git, or a database. Callers supply SQL
+text and a parsed manifest, which is what lets both consumers share one
+implementation: ``ol-dbt impact`` diffs a branch against its merge base, while
+the Dagster build diffs the deployed manifest against the key state recorded
+after the previous build.
+"""
+
+from __future__ import annotations
+
+import re
+from collections import deque
+from collections.abc import Callable, Mapping, Sequence
+from dataclasses import dataclass, field
+from typing import Any
+
+from ol_dbt_cli.lib.manifest import ManifestModel, ManifestRegistry
+
+# Materializations that rebuild the whole relation on every run, and therefore
+# re-derive every surrogate key they mint. A change to the hash inputs of a
+# model materialized any other way is not this failure mode: an incremental
+# ancestor keeps its already-minted keys, and an ephemeral one is inlined into
+# its consumers rather than stored.
+FULL_REFRESH_MATERIALIZATIONS = frozenset({"table", "view"})
+
+INCREMENTAL_MATERIALIZATION = "incremental"
+
+# `dbt_utils.` is optional because the macro is also reachable unqualified when
+# dbt_utils is in the project's dispatch search path.
+_SURROGATE_KEY_CALL = re.compile(r"(?:dbt_utils\s*\.\s*)?generate_surrogate_key\s*\(", re.IGNORECASE)
+
+# The alias the minted key is bound to, matched from just past the call's
+# closing paren (no anchor: `Pattern.match(s, pos)` already anchors there, and
+# `\A` would instead demand the start of the file). `as` is required rather
+# than optional: without the keyword the next identifier after the Jinja block
+# is just as likely to be `from` or the start of the following select item, and
+# a wrong alias here silently attributes the change to a column nobody stores.
+_KEY_ALIAS = re.compile(r"\s*(?:\}\})?\s*as\s+\"?([A-Za-z_][A-Za-z0-9_]*)\"?", re.IGNORECASE)
+
+_STRING_LITERAL = re.compile(r"'([^']*)'|\"([^\"]*)\"")
+
+
+@dataclass(frozen=True)
+class SurrogateKeyDef:
+    """One ``generate_surrogate_key`` call site and the column it is bound to."""
+
+    column: str
+    """The ``as <alias>`` the minted key is bound to; empty when unaliased."""
+    inputs: tuple[str, ...]
+    """The hashed expressions, normalized, in the order they are hashed."""
+
+
+@dataclass(frozen=True)
+class SurrogateKeyChange:
+    """A key column whose hash inputs differ between two versions of a model."""
+
+    column: str
+    base_inputs: tuple[tuple[str, ...], ...]
+    current_inputs: tuple[tuple[str, ...], ...]
+
+
+@dataclass(frozen=True)
+class AffectedIncrementalModel:
+    """An incremental model holding a value derived from a re-keyed column."""
+
+    model_name: str
+    unique_id: str
+    fk_column: str
+    evidence: str
+    """How the link was established — see :data:`_EVIDENCE_RANK`."""
+    depth: int
+    """Hops from the re-keyed ancestor; 1 is a direct consumer."""
+
+
+@dataclass
+class KeyRegenFinding:
+    """A hash-input change plus the incremental models it orphans."""
+
+    ancestor: str
+    ancestor_unique_id: str
+    changed_key_column: str
+    base_inputs: list[list[str]]
+    current_inputs: list[list[str]]
+    affected_models: list[AffectedIncrementalModel] = field(default_factory=list)
+
+    @property
+    def affected_model_names(self) -> list[str]:
+        return sorted({m.model_name for m in self.affected_models})
+
+
+# Strongest first. A `relationships` test is a declared FK edge naming both
+# sides and both columns, so it beats anything inferred from the SQL; a column
+# read seen by the parser beats the manifest's documented column list, which
+# only says the name exists on both sides.
+_EVIDENCE_RANK = {"relationships_test": 0, "column_read": 1, "column_metadata": 2}
+
+ColumnReadLookup = Callable[[str, str], set[str] | None]
+"""``(child_model, parent_model) -> columns the child reads from that parent``.
+
+Returns ``None`` when the SQL could not be analysed, which is the signal to
+fall back to the manifest's documented columns rather than to conclude the
+child reads nothing.
+"""
+
+
+def _no_column_reads(_child: str, _parent: str) -> set[str] | None:
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Extraction
+# ---------------------------------------------------------------------------
+
+
+def _normalize_input(expression: str) -> str:
+    """Fold indentation and keyword case so a reformat is not read as a re-key.
+
+    Reindenting a multi-line argument list, or recasing ``CAST``/``LOWER``,
+    changes no hash in the warehouse, so it must not full-refresh a fact table
+    here either.
+
+    Deliberately no further than that: collapsing spaces around punctuation
+    would also equate ``concat(a, ', ', b)`` with ``concat(a, ',', b)``, which
+    really do hash differently. The same caveat applies to lowercasing and a
+    literal like ``'A'``. Both are contrived next to the reformats above, and
+    the failure they would cause — a silent miss — is the one this check
+    exists to prevent, so normalization stops here.
+    """
+    return " ".join(expression.split()).lower()
+
+
+def _balanced_call_args(sql: str, open_paren: int) -> tuple[str, int] | None:
+    """Return the argument text of the call whose ``(`` is at *open_paren*.
+
+    Also returns the index just past the matching ``)``. Quote-aware so a
+    parenthesis inside a hashed SQL expression (``cast(x as varchar)`` is
+    itself parenthesised, and string literals may contain either) does not end
+    the scan early. Returns None if the parentheses never balance.
+    """
+    depth = 0
+    quote: str | None = None
+    index = open_paren
+    while index < len(sql):
+        char = sql[index]
+        if quote is not None:
+            if char == quote:
+                quote = None
+        elif char in "'\"":
+            quote = char
+        elif char == "(":
+            depth += 1
+        elif char == ")":
+            depth -= 1
+            if depth == 0:
+                return sql[open_paren + 1 : index], index + 1
+        index += 1
+    return None
+
+
+def extract_surrogate_keys(sql: str) -> list[SurrogateKeyDef]:
+    """Every ``generate_surrogate_key`` call in *sql*, in source order.
+
+    Reads the raw (Jinja) SQL rather than compiled output on purpose: the
+    compiled form is an opaque nested ``md5(...)`` expression whose text also
+    changes whenever the adapter or dbt_utils version does, while the argument
+    list is exactly the thing whose change re-keys the dimension.
+
+    Only string-literal arguments are recovered. ``generate_surrogate_key`` is
+    documented to take a list of quoted column names or SQL expressions, so a
+    call built from a Jinja variable instead yields an empty input tuple —
+    which compares equal across versions and is therefore reported as
+    unchanged rather than as a spurious re-key.
+    """
+    keys: list[SurrogateKeyDef] = []
+    for match in _SURROGATE_KEY_CALL.finditer(sql):
+        call = _balanced_call_args(sql, match.end() - 1)
+        if call is None:
+            continue
+        args, after = call
+        inputs = tuple(_normalize_input(single or double) for single, double in _STRING_LITERAL.findall(args))
+        alias_match = _KEY_ALIAS.match(sql, after)
+        column = alias_match.group(1).lower() if alias_match else ""
+        keys.append(SurrogateKeyDef(column=column, inputs=inputs))
+    return keys
+
+
+def surrogate_key_inputs(sql: str) -> dict[str, tuple[tuple[str, ...], ...]]:
+    """Map each key column in *sql* to the input tuple of every call binding it.
+
+    A column is mapped to a tuple *of* input tuples rather than to one, so a
+    model that mints the same alias in several union branches compares all of
+    them — changing any one branch re-keys some of the rows, which is the same
+    incident with a smaller blast radius.
+
+    Unaliased calls are dropped: with no column name there is nothing
+    downstream can have stored, and nothing to match the two versions of the
+    model on.
+    """
+    grouped: dict[str, list[tuple[str, ...]]] = {}
+    for key in extract_surrogate_keys(sql):
+        if not key.column:
+            continue
+        grouped.setdefault(key.column, []).append(key.inputs)
+    return {column: tuple(inputs) for column, inputs in grouped.items()}
+
+
+def changed_surrogate_keys(base_sql: str, current_sql: str) -> list[SurrogateKeyChange]:
+    """Key columns whose hash inputs differ between *base_sql* and *current_sql*.
+
+    Only columns present on both sides are compared. A key column that appeared
+    or disappeared is an ordinary column addition or removal — nothing
+    downstream can hold a stale value of a column that did not exist, and a
+    column that is gone breaks its consumers outright rather than silently, so
+    both are already covered by ``ol-dbt impact``'s column diff.
+    """
+    base = surrogate_key_inputs(base_sql)
+    current = surrogate_key_inputs(current_sql)
+    return [
+        SurrogateKeyChange(
+            column=column,
+            base_inputs=base[column],
+            current_inputs=current[column],
+        )
+        for column in sorted(base.keys() & current.keys())
+        if base[column] != current[column]
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Downstream tracing
+# ---------------------------------------------------------------------------
+
+
+def _carried_into(
+    registry: ManifestRegistry,
+    parent: ManifestModel,
+    child: ManifestModel,
+    carried: frozenset[str],
+    column_reads: ColumnReadLookup,
+) -> dict[str, str]:
+    """Columns of *child* that hold a value derived from *carried* on *parent*.
+
+    Returns ``{child_column: evidence}``. The keys are named in *child*'s own
+    schema, so they are what propagates to the next hop — a fact table's
+    ``discount_fk`` is the same stale value as ``dim_discount.discount_pk``
+    under a different name, and only the child's spelling survives further
+    downstream.
+    """
+    found: dict[str, str] = {}
+
+    explained: set[str] = set()
+    for fk in registry.foreign_keys_between(child.unique_id, parent.name):
+        if fk.parent_column in carried:
+            found[fk.child_column] = "relationships_test"
+            explained.add(fk.parent_column)
+
+    # A column the test already accounted for is not looked for again: the read
+    # of `dim_discount.discount_pk` is how `tfact_order.discount_fk` gets its
+    # value, so counting both would report one stale FK as two.
+    remaining = carried - explained
+    if not remaining:
+        return found
+
+    read = column_reads(child.name, parent.name)
+    if read is not None:
+        for column in remaining & read:
+            found.setdefault(column, "column_read")
+    else:
+        # The SQL could not be analysed. The manifest's documented columns are
+        # the weaker fallback: a same-named column on both sides usually is the
+        # upstream one carried through, and over-selecting here costs a
+        # redundant rebuild while under-selecting reproduces the incident.
+        for column in remaining & child.column_names:
+            found.setdefault(column, "column_metadata")
+
+    return found
+
+
+def affected_incremental_descendants(
+    registry: ManifestRegistry,
+    ancestor: ManifestModel,
+    key_column: str,
+    column_reads: ColumnReadLookup = _no_column_reads,
+) -> list[AffectedIncrementalModel]:
+    """Incremental models holding a value derived from *ancestor*.*key_column*.
+
+    Walks the manifest's child map breadth-first, carrying the re-keyed value
+    forward under whatever name each hop binds it to. Tracing does not stop at
+    the first incremental model: full-refreshing that table corrects its own
+    rows, but an incremental model downstream of *it* copied the stale FK too
+    and needs the same treatment.
+
+    Each node is visited once, on the shortest path that reaches it. A second,
+    longer path could in principle carry a different column, but rediscovering
+    the same subgraph per path turns a wide dimension's fan-out into an
+    exponential walk for a case that has not arisen.
+    """
+    results: dict[tuple[str, str], AffectedIncrementalModel] = {}
+    queue: deque[tuple[ManifestModel, frozenset[str], int]] = deque([(ancestor, frozenset({key_column}), 0)])
+    seen: set[str] = {ancestor.unique_id}
+
+    while queue:
+        parent, carried, depth = queue.popleft()
+        for child in registry.get_model_children(parent.unique_id):
+            if child.unique_id in seen:
+                continue
+            seen.add(child.unique_id)
+
+            child_carried = _carried_into(registry, parent, child, carried, column_reads)
+            if not child_carried:
+                continue
+
+            if child.materialized == INCREMENTAL_MATERIALIZATION:
+                for column, evidence in child_carried.items():
+                    results[(child.name, column)] = AffectedIncrementalModel(
+                        model_name=child.name,
+                        unique_id=child.unique_id,
+                        fk_column=column,
+                        evidence=evidence,
+                        depth=depth + 1,
+                    )
+
+            queue.append((child, frozenset(child_carried), depth + 1))
+
+    return sorted(
+        results.values(),
+        key=lambda m: (m.model_name, _EVIDENCE_RANK.get(m.evidence, 9), m.fk_column),
+    )
+
+
+def detect_key_regen(
+    changed_keys: Mapping[str, Sequence[SurrogateKeyChange]],
+    registry: ManifestRegistry,
+    column_reads: ColumnReadLookup = _no_column_reads,
+) -> list[KeyRegenFinding]:
+    """Report every re-keyed full-refresh model that has incremental consumers.
+
+    *changed_keys* maps a model name to the key columns whose hash inputs
+    changed, as produced by :func:`changed_surrogate_keys`.
+
+    A change is dropped when the model is not materialized ``table``/``view``
+    (nothing re-derives the key on the next build) or when nothing incremental
+    stores a value derived from it (nothing is left holding a stale copy).
+    """
+    findings: list[KeyRegenFinding] = []
+    for model_name in sorted(changed_keys):
+        model = registry.get_model(model_name)
+        if model is None or model.materialized not in FULL_REFRESH_MATERIALIZATIONS:
+            continue
+        for change in changed_keys[model_name]:
+            affected = affected_incremental_descendants(registry, model, change.column, column_reads)
+            if not affected:
+                continue
+            findings.append(
+                KeyRegenFinding(
+                    ancestor=model.name,
+                    ancestor_unique_id=model.unique_id,
+                    changed_key_column=change.column,
+                    base_inputs=[list(i) for i in change.base_inputs],
+                    current_inputs=[list(i) for i in change.current_inputs],
+                    affected_models=affected,
+                )
+            )
+    return findings
+
+
+# ---------------------------------------------------------------------------
+# Manifest-level key state
+# ---------------------------------------------------------------------------
+
+SurrogateKeyState = dict[str, dict[str, list[list[str]]]]
+"""``{model_name: {key_column: [[hashed_expression, ...], ...]}}``.
+
+Plain JSON types on purpose: this is what gets written to S3 after a build and
+read back before the next one, so it has to survive a round trip through
+``json.dumps`` unchanged.
+"""
+
+
+def surrogate_key_state(manifest: Mapping[str, Any]) -> SurrogateKeyState:
+    """Hash inputs of every key minted by a full-refresh model in *manifest*.
+
+    Reads ``raw_code`` straight from the decoded manifest rather than from the
+    checkout, so a deployment that only ships the parsed manifest can still
+    compare its keys against the previous build's. Models with no surrogate key
+    are omitted, which keeps the artifact small enough to read on every run.
+    """
+    state: SurrogateKeyState = {}
+    for node in manifest.get("nodes", {}).values():
+        if node.get("resource_type") != "model":
+            continue
+        if (node.get("config") or {}).get("materialized") not in FULL_REFRESH_MATERIALIZATIONS:
+            continue
+        keys = surrogate_key_inputs(node.get("raw_code") or "")
+        if keys:
+            state[node["name"]] = {column: [list(inputs) for inputs in calls] for column, calls in keys.items()}
+    return state
+
+
+def changed_keys_from_state(
+    previous: Mapping[str, Any], current: Mapping[str, Any]
+) -> dict[str, list[SurrogateKeyChange]]:
+    """Diff two :data:`SurrogateKeyState` snapshots into per-model key changes.
+
+    Same comparison rule as :func:`changed_surrogate_keys`: only key columns
+    present in both snapshots, since a column that appeared or disappeared is
+    an ordinary schema change with its own, louder failure mode.
+
+    A model absent from *previous* is skipped rather than treated as new — a
+    snapshot predating this check, or one written before the model existed,
+    should not full-refresh the whole downstream on the next build.
+    """
+    changed: dict[str, list[SurrogateKeyChange]] = {}
+    for model_name, current_keys in current.items():
+        previous_keys = previous.get(model_name)
+        if not previous_keys:
+            continue
+        model_changes = [
+            SurrogateKeyChange(
+                column=column,
+                base_inputs=tuple(tuple(call) for call in previous_keys[column]),
+                current_inputs=tuple(tuple(call) for call in current_keys[column]),
+            )
+            for column in sorted(previous_keys.keys() & current_keys.keys())
+            if previous_keys[column] != current_keys[column]
+        ]
+        if model_changes:
+            changed[model_name] = model_changes
+    return changed

--- a/src/ol_dbt_cli/ol_dbt_cli/lib/surrogate_keys.py
+++ b/src/ol_dbt_cli/ol_dbt_cli/lib/surrogate_keys.py
@@ -8,7 +8,7 @@ as a foreign key at insert time and only revisit rows inside their watermark,
 so those FKs orphan — and because no column was added or removed,
 ``on_schema_change='append_new_columns'`` sees nothing to react to. Two
 production incidents came from exactly this: the ``dim_discount.discount_pk``
-hash-input change (#2411) and the ``dim_user`` re-key (#2618).
+hash-input change (#2411) and the ``dim_user`` re-key (#2497).
 
 Nothing in this module touches disk, git, or a database. Callers supply SQL
 text and a parsed manifest, which is what lets both consumers share one

--- a/src/ol_dbt_cli/tests/fixtures/surrogate_keys/dim_discount_after.sql
+++ b/src/ol_dbt_cli/tests/fixtures/surrogate_keys/dim_discount_after.sql
@@ -1,0 +1,9 @@
+-- Carved verbatim from src/ol_dbt/models/dimensional/dim_discount.sql at e2c87bd3f (#2411).
+--
+-- Only the generate_surrogate_key call sites are kept: they are the entire
+-- input to the drift detector, and the surrounding 800 lines of union branches
+-- would not change what it reads. Do not reformat -- the point of the fixture
+-- is that it is the text the incident actually shipped.
+
+select
+    {{ dbt_utils.generate_surrogate_key(['cast(source_discount_id as varchar)', 'platform_code']) }} as discount_pk

--- a/src/ol_dbt_cli/tests/fixtures/surrogate_keys/dim_discount_before.sql
+++ b/src/ol_dbt_cli/tests/fixtures/surrogate_keys/dim_discount_before.sql
@@ -1,0 +1,9 @@
+-- Carved verbatim from src/ol_dbt/models/dimensional/dim_discount.sql at e2c87bd3f^ (before #2411).
+--
+-- Only the generate_surrogate_key call sites are kept: they are the entire
+-- input to the drift detector, and the surrounding 800 lines of union branches
+-- would not change what it reads. Do not reformat -- the point of the fixture
+-- is that it is the text the incident actually shipped.
+
+select
+    {{ dbt_utils.generate_surrogate_key(['cast(source_discount_id as varchar)', 'discount_code', 'platform_code']) }} as discount_pk

--- a/src/ol_dbt_cli/tests/fixtures/surrogate_keys/dim_user_after.sql
+++ b/src/ol_dbt_cli/tests/fixtures/surrogate_keys/dim_user_after.sql
@@ -1,0 +1,12 @@
+-- Carved verbatim from src/ol_dbt/models/dimensional/dim_user.sql at a20a72865 (#2497).
+--
+-- Only the generate_surrogate_key call sites are kept: they are the entire
+-- input to the drift detector, and the surrounding 800 lines of union branches
+-- would not change what it reads. Do not reformat -- the point of the fixture
+-- is that it is the text the incident actually shipped.
+
+select
+        {{ dbt_utils.generate_surrogate_key([
+            'user_identity_source',
+            'user_identity_id'
+        ]) }} as user_pk

--- a/src/ol_dbt_cli/tests/fixtures/surrogate_keys/dim_user_before.sql
+++ b/src/ol_dbt_cli/tests/fixtures/surrogate_keys/dim_user_before.sql
@@ -1,0 +1,14 @@
+-- Carved verbatim from src/ol_dbt/models/dimensional/dim_user.sql at a20a72865^ (before #2497).
+--
+-- Only the generate_surrogate_key call sites are kept: they are the entire
+-- input to the drift detector, and the surrounding 800 lines of union branches
+-- would not change what it reads. Do not reformat -- the point of the fixture
+-- is that it is the text the incident actually shipped.
+
+select
+        {{ dbt_utils.generate_surrogate_key(['lower(email)']) }} as user_pk
+        {{ dbt_utils.generate_surrogate_key(['lower(mitxpro_user_view.user_email)']) }} as user_pk
+        {{ dbt_utils.generate_surrogate_key(['lower(user_email)']) }} as user_pk
+        {{ dbt_utils.generate_surrogate_key(['lower(user_email)']) }} as user_pk
+        {{ dbt_utils.generate_surrogate_key(['lower(mitxresidential_user_view.user_email)']) }} as user_pk
+        {{ dbt_utils.generate_surrogate_key(['lower(bootcamps_user_view.user_email)']) }} as user_pk

--- a/src/ol_dbt_cli/tests/fixtures/surrogate_keys/dimensional_manifest.json
+++ b/src/ol_dbt_cli/tests/fixtures/surrogate_keys/dimensional_manifest.json
@@ -1,0 +1,4778 @@
+{
+ "macros": {},
+ "nodes": {
+  "model.open_learning.afact_course_page_engagement": {
+   "columns": {
+    "block_fk": {
+     "description": ""
+    },
+    "chapter_block_fk": {
+     "description": ""
+    },
+    "courserun_readable_id": {
+     "description": ""
+    },
+    "last_view_timestamp": {
+     "description": ""
+    },
+    "num_of_views": {
+     "description": ""
+    },
+    "openedx_user_id": {
+     "description": ""
+    },
+    "platform": {
+     "description": ""
+    },
+    "platform_fk": {
+     "description": ""
+    },
+    "sequential_block_fk": {
+     "description": ""
+    },
+    "user_fk": {
+     "description": ""
+    },
+    "user_username": {
+     "description": ""
+    }
+   },
+   "config": {
+    "materialized": "table"
+   },
+   "database": "ol_data_lake_production",
+   "depends_on": {
+    "macros": [],
+    "nodes": [
+     "model.open_learning.dim_course_content",
+     "model.open_learning.tfact_course_navigation_events"
+    ]
+   },
+   "name": "afact_course_page_engagement",
+   "original_file_path": "models/dimensional/afact_course_page_engagement.sql",
+   "resource_type": "model",
+   "schema": "ol_warehouse_production_dimensional",
+   "unique_id": "model.open_learning.afact_course_page_engagement"
+  },
+  "model.open_learning.afact_discussion_engagement": {
+   "columns": {
+    "chapter_block_fk": {
+     "description": ""
+    },
+    "commentable_id": {
+     "description": ""
+    },
+    "content_block_fk": {
+     "description": ""
+    },
+    "courserun_readable_id": {
+     "description": ""
+    },
+    "discussion_topic_fk": {
+     "description": ""
+    },
+    "discussion_type": {
+     "description": ""
+    },
+    "openedx_user_id": {
+     "description": ""
+    },
+    "platform": {
+     "description": ""
+    },
+    "platform_fk": {
+     "description": ""
+    },
+    "post_commented": {
+     "description": ""
+    },
+    "post_created": {
+     "description": ""
+    },
+    "post_id": {
+     "description": ""
+    },
+    "post_replied": {
+     "description": ""
+    },
+    "post_title": {
+     "description": ""
+    },
+    "post_viewed": {
+     "description": ""
+    },
+    "post_voted": {
+     "description": ""
+    },
+    "response_voted": {
+     "description": ""
+    },
+    "sequential_block_fk": {
+     "description": ""
+    },
+    "user_fk": {
+     "description": ""
+    },
+    "user_username": {
+     "description": ""
+    }
+   },
+   "config": {
+    "materialized": "table"
+   },
+   "database": "ol_data_lake_production",
+   "depends_on": {
+    "macros": [],
+    "nodes": [
+     "model.open_learning.tfact_discussion_events",
+     "model.open_learning.dim_discussion_topic",
+     "model.open_learning.dim_course_content"
+    ]
+   },
+   "name": "afact_discussion_engagement",
+   "original_file_path": "models/dimensional/afact_discussion_engagement.sql",
+   "resource_type": "model",
+   "schema": "ol_warehouse_production_dimensional",
+   "unique_id": "model.open_learning.afact_discussion_engagement"
+  },
+  "model.open_learning.afact_feedback_conversation": {
+   "columns": {
+    "category_fk": {
+     "description": ""
+    },
+    "cluster_id": {
+     "description": ""
+    },
+    "cluster_probability": {
+     "description": ""
+    },
+    "cluster_run_id": {
+     "description": ""
+    },
+    "conversation_id": {
+     "description": ""
+    },
+    "conversation_ingested_at": {
+     "description": ""
+    },
+    "conversation_summary": {
+     "description": ""
+    },
+    "conversation_text_chars": {
+     "description": ""
+    },
+    "embedded_at": {
+     "description": ""
+    },
+    "embedding_dim": {
+     "description": ""
+    },
+    "embedding_input": {
+     "description": ""
+    },
+    "embedding_model_version": {
+     "description": ""
+    },
+    "embedding_vector": {
+     "description": ""
+    },
+    "explicit_rating": {
+     "description": ""
+    },
+    "feedback_conversation_pk": {
+     "description": ""
+    },
+    "feedback_source_fk": {
+     "description": ""
+    },
+    "final_priority": {
+     "description": ""
+    },
+    "final_status": {
+     "description": ""
+    },
+    "last_turn_date_fk": {
+     "description": ""
+    },
+    "opened_by_user_fk": {
+     "description": ""
+    },
+    "opened_date_fk": {
+     "description": ""
+    },
+    "participant_count": {
+     "description": ""
+    },
+    "sentiment_fk": {
+     "description": ""
+    },
+    "sentiment_source": {
+     "description": ""
+    },
+    "summarized_at": {
+     "description": ""
+    },
+    "summary_model_version": {
+     "description": ""
+    },
+    "turn_count": {
+     "description": ""
+    }
+   },
+   "config": {
+    "materialized": "table"
+   },
+   "database": "ol_data_lake_production",
+   "depends_on": {
+    "macros": [],
+    "nodes": [
+     "model.open_learning.tfact_feedback",
+     "model.open_learning.bridge_feedback_tag",
+     "model.open_learning.dim_feedback_tag",
+     "model.open_learning.dim_feedback_category"
+    ]
+   },
+   "name": "afact_feedback_conversation",
+   "original_file_path": "models/dimensional/afact_feedback_conversation.sql",
+   "resource_type": "model",
+   "schema": "ol_warehouse_production_dimensional",
+   "unique_id": "model.open_learning.afact_feedback_conversation"
+  },
+  "model.open_learning.afact_problem_engagement": {
+   "columns": {
+    "chapter_block_fk": {
+     "description": ""
+    },
+    "courserun_readable_id": {
+     "description": ""
+    },
+    "last_attempt_timestamp": {
+     "description": ""
+    },
+    "num_of_attempts": {
+     "description": ""
+    },
+    "num_of_correct_attempts": {
+     "description": ""
+    },
+    "openedx_user_id": {
+     "description": ""
+    },
+    "platform": {
+     "description": ""
+    },
+    "platform_fk": {
+     "description": ""
+    },
+    "problem_block_fk": {
+     "description": ""
+    },
+    "sequential_block_fk": {
+     "description": ""
+    },
+    "user_fk": {
+     "description": ""
+    },
+    "user_username": {
+     "description": ""
+    }
+   },
+   "config": {
+    "materialized": "table"
+   },
+   "database": "ol_data_lake_production",
+   "depends_on": {
+    "macros": [],
+    "nodes": [
+     "model.open_learning.dim_course_content",
+     "model.open_learning.tfact_problem_events"
+    ]
+   },
+   "name": "afact_problem_engagement",
+   "original_file_path": "models/dimensional/afact_problem_engagement.sql",
+   "resource_type": "model",
+   "schema": "ol_warehouse_production_dimensional",
+   "unique_id": "model.open_learning.afact_problem_engagement"
+  },
+  "model.open_learning.afact_video_engagement": {
+   "columns": {
+    "courserun_readable_id": {
+     "description": ""
+    },
+    "estimated_time_played": {
+     "description": ""
+    },
+    "latest_activity_timestamp": {
+     "description": ""
+    },
+    "openedx_user_id": {
+     "description": ""
+    },
+    "platform": {
+     "description": ""
+    },
+    "platform_fk": {
+     "description": ""
+    },
+    "section_content_fk": {
+     "description": ""
+    },
+    "section_title": {
+     "description": ""
+    },
+    "subsection_content_fk": {
+     "description": ""
+    },
+    "subsection_title": {
+     "description": ""
+    },
+    "unit_content_fk": {
+     "description": ""
+    },
+    "unit_title": {
+     "description": ""
+    },
+    "user_fk": {
+     "description": ""
+    },
+    "user_username": {
+     "description": ""
+    },
+    "video_completed_count": {
+     "description": ""
+    },
+    "video_id": {
+     "description": ""
+    },
+    "video_played_count": {
+     "description": ""
+    },
+    "video_title": {
+     "description": ""
+    }
+   },
+   "config": {
+    "materialized": "table"
+   },
+   "database": "ol_data_lake_production",
+   "depends_on": {
+    "macros": [],
+    "nodes": [
+     "model.open_learning.dim_course_content",
+     "model.open_learning.tfact_video_events",
+     "model.open_learning.dim_video"
+    ]
+   },
+   "name": "afact_video_engagement",
+   "original_file_path": "models/dimensional/afact_video_engagement.sql",
+   "resource_type": "model",
+   "schema": "ol_warehouse_production_dimensional",
+   "unique_id": "model.open_learning.afact_video_engagement"
+  },
+  "model.open_learning.bridge_course_department": {
+   "columns": {
+    "course_fk": {
+     "description": ""
+    },
+    "department_fk": {
+     "description": ""
+    }
+   },
+   "config": {
+    "materialized": "table"
+   },
+   "database": "ol_data_lake_production",
+   "depends_on": {
+    "macros": [],
+    "nodes": [
+     "model.open_learning.dim_course",
+     "model.open_learning.dim_department"
+    ]
+   },
+   "name": "bridge_course_department",
+   "original_file_path": "models/dimensional/bridge_course_department.sql",
+   "resource_type": "model",
+   "schema": "ol_warehouse_production_dimensional",
+   "unique_id": "model.open_learning.bridge_course_department"
+  },
+  "model.open_learning.bridge_course_instructor": {
+   "columns": {
+    "course_fk": {
+     "description": ""
+    },
+    "instructor_fk": {
+     "description": ""
+    }
+   },
+   "config": {
+    "materialized": "table"
+   },
+   "database": "ol_data_lake_production",
+   "depends_on": {
+    "macros": [],
+    "nodes": [
+     "model.open_learning.dim_course",
+     "model.open_learning.dim_instructor"
+    ]
+   },
+   "name": "bridge_course_instructor",
+   "original_file_path": "models/dimensional/bridge_course_instructor.sql",
+   "resource_type": "model",
+   "schema": "ol_warehouse_production_dimensional",
+   "unique_id": "model.open_learning.bridge_course_instructor"
+  },
+  "model.open_learning.bridge_course_topic": {
+   "columns": {
+    "course_fk": {
+     "description": ""
+    },
+    "topic_fk": {
+     "description": ""
+    }
+   },
+   "config": {
+    "materialized": "table"
+   },
+   "database": "ol_data_lake_production",
+   "depends_on": {
+    "macros": [],
+    "nodes": [
+     "model.open_learning.dim_course",
+     "model.open_learning.dim_topic"
+    ]
+   },
+   "name": "bridge_course_topic",
+   "original_file_path": "models/dimensional/bridge_course_topic.sql",
+   "resource_type": "model",
+   "schema": "ol_warehouse_production_dimensional",
+   "unique_id": "model.open_learning.bridge_course_topic"
+  },
+  "model.open_learning.bridge_feedback_tag": {
+   "columns": {
+    "feedback_pk": {
+     "description": ""
+    },
+    "feedback_tag_pk": {
+     "description": ""
+    }
+   },
+   "config": {
+    "materialized": "table"
+   },
+   "database": "ol_data_lake_production",
+   "depends_on": {
+    "macros": [],
+    "nodes": [
+     "model.open_learning.dim_feedback_tag",
+     "model.open_learning.tfact_feedback"
+    ]
+   },
+   "name": "bridge_feedback_tag",
+   "original_file_path": "models/dimensional/bridge_feedback_tag.sql",
+   "resource_type": "model",
+   "schema": "ol_warehouse_production_dimensional",
+   "unique_id": "model.open_learning.bridge_feedback_tag"
+  },
+  "model.open_learning.bridge_organization_courserun": {
+   "columns": {
+    "contract_fk": {
+     "description": ""
+    },
+    "courserun_fk": {
+     "description": ""
+    },
+    "organization_fk": {
+     "description": ""
+    }
+   },
+   "config": {
+    "materialized": "table"
+   },
+   "database": "ol_data_lake_production",
+   "depends_on": {
+    "macros": [],
+    "nodes": [
+     "model.open_learning.dim_contract",
+     "model.open_learning.dim_course_run"
+    ]
+   },
+   "name": "bridge_organization_courserun",
+   "original_file_path": "models/dimensional/bridge_organization_courserun.sql",
+   "resource_type": "model",
+   "schema": "ol_warehouse_production_dimensional",
+   "unique_id": "model.open_learning.bridge_organization_courserun"
+  },
+  "model.open_learning.bridge_program_course": {
+   "columns": {
+    "course_fk": {
+     "description": ""
+    },
+    "course_order": {
+     "description": ""
+    },
+    "is_required": {
+     "description": ""
+    },
+    "program_fk": {
+     "description": ""
+    }
+   },
+   "config": {
+    "materialized": "table"
+   },
+   "database": "ol_data_lake_production",
+   "depends_on": {
+    "macros": [],
+    "nodes": [
+     "model.open_learning.dim_program",
+     "model.open_learning.dim_course"
+    ]
+   },
+   "name": "bridge_program_course",
+   "original_file_path": "models/dimensional/bridge_program_course.sql",
+   "resource_type": "model",
+   "schema": "ol_warehouse_production_dimensional",
+   "unique_id": "model.open_learning.bridge_program_course"
+  },
+  "model.open_learning.bridge_user_account_link": {
+   "columns": {
+    "from_platform": {
+     "description": ""
+    },
+    "from_user_id": {
+     "description": ""
+    },
+    "observed_on": {
+     "description": ""
+    },
+    "to_platform": {
+     "description": ""
+    },
+    "to_user_id": {
+     "description": ""
+    }
+   },
+   "config": {
+    "materialized": "table"
+   },
+   "database": "ol_data_lake_production",
+   "depends_on": {
+    "macros": [],
+    "nodes": []
+   },
+   "name": "bridge_user_account_link",
+   "original_file_path": "models/dimensional/bridge_user_account_link.sql",
+   "resource_type": "model",
+   "schema": "ol_warehouse_production_dimensional",
+   "unique_id": "model.open_learning.bridge_user_account_link"
+  },
+  "model.open_learning.bridge_user_courserun_role": {
+   "columns": {
+    "courseaccess_role": {
+     "description": ""
+    },
+    "courserun_fk": {
+     "description": ""
+    },
+    "courserun_readable_id": {
+     "description": ""
+    },
+    "platform_code": {
+     "description": ""
+    },
+    "user_fk": {
+     "description": ""
+    }
+   },
+   "config": {
+    "materialized": "table"
+   },
+   "database": "ol_data_lake_production",
+   "depends_on": {
+    "macros": [],
+    "nodes": [
+     "model.open_learning.dim_user",
+     "model.open_learning.dim_course_run"
+    ]
+   },
+   "name": "bridge_user_courserun_role",
+   "original_file_path": "models/dimensional/bridge_user_courserun_role.sql",
+   "resource_type": "model",
+   "schema": "ol_warehouse_production_dimensional",
+   "unique_id": "model.open_learning.bridge_user_courserun_role"
+  },
+  "model.open_learning.bridge_user_organization": {
+   "columns": {
+    "organization_fk": {
+     "description": ""
+    },
+    "user_fk": {
+     "description": ""
+    },
+    "userorganization_is_manager": {
+     "description": ""
+    },
+    "userorganization_keep_until_seen": {
+     "description": ""
+    }
+   },
+   "config": {
+    "materialized": "table"
+   },
+   "database": "ol_data_lake_production",
+   "depends_on": {
+    "macros": [],
+    "nodes": [
+     "model.open_learning.dim_user",
+     "model.open_learning.dim_organization"
+    ]
+   },
+   "name": "bridge_user_organization",
+   "original_file_path": "models/dimensional/bridge_user_organization.sql",
+   "resource_type": "model",
+   "schema": "ol_warehouse_production_dimensional",
+   "unique_id": "model.open_learning.bridge_user_organization"
+  },
+  "model.open_learning.dim_certificate_type": {
+   "columns": {
+    "certificate_requires_id_verification": {
+     "description": ""
+    },
+    "certificate_type_code": {
+     "description": ""
+    },
+    "certificate_type_name": {
+     "description": ""
+    },
+    "certificate_type_pk": {
+     "description": ""
+    }
+   },
+   "config": {
+    "materialized": "table"
+   },
+   "database": "ol_data_lake_production",
+   "depends_on": {
+    "macros": [],
+    "nodes": []
+   },
+   "name": "dim_certificate_type",
+   "original_file_path": "models/dimensional/dim_certificate_type.sql",
+   "resource_type": "model",
+   "schema": "ol_warehouse_production_dimensional",
+   "unique_id": "model.open_learning.dim_certificate_type"
+  },
+  "model.open_learning.dim_contract": {
+   "columns": {
+    "b2b_contract_description": {
+     "description": ""
+    },
+    "b2b_contract_end_date": {
+     "description": ""
+    },
+    "b2b_contract_enrollment_fixed_price": {
+     "description": ""
+    },
+    "b2b_contract_is_active": {
+     "description": ""
+    },
+    "b2b_contract_max_learners": {
+     "description": ""
+    },
+    "b2b_contract_membership_type": {
+     "description": ""
+    },
+    "b2b_contract_name": {
+     "description": ""
+    },
+    "b2b_contract_start_date": {
+     "description": ""
+    },
+    "contract_id": {
+     "description": ""
+    },
+    "contract_pk": {
+     "description": ""
+    },
+    "organization_fk": {
+     "description": ""
+    }
+   },
+   "config": {
+    "materialized": "table"
+   },
+   "database": "ol_data_lake_production",
+   "depends_on": {
+    "macros": [],
+    "nodes": [
+     "model.open_learning.dim_organization"
+    ]
+   },
+   "name": "dim_contract",
+   "original_file_path": "models/dimensional/dim_contract.sql",
+   "resource_type": "model",
+   "schema": "ol_warehouse_production_dimensional",
+   "unique_id": "model.open_learning.dim_contract"
+  },
+  "model.open_learning.dim_course": {
+   "columns": {
+    "course_description": {
+     "description": ""
+    },
+    "course_is_live": {
+     "description": ""
+    },
+    "course_number": {
+     "description": ""
+    },
+    "course_pk": {
+     "description": ""
+    },
+    "course_readable_id": {
+     "description": ""
+    },
+    "course_title": {
+     "description": ""
+    },
+    "effective_date": {
+     "description": ""
+    },
+    "end_date": {
+     "description": ""
+    },
+    "is_current": {
+     "description": ""
+    },
+    "primary_platform": {
+     "description": ""
+    },
+    "source_id": {
+     "description": ""
+    }
+   },
+   "config": {
+    "materialized": "incremental"
+   },
+   "database": "ol_data_lake_production",
+   "depends_on": {
+    "macros": [],
+    "nodes": []
+   },
+   "name": "dim_course",
+   "original_file_path": "models/dimensional/dim_course.sql",
+   "resource_type": "model",
+   "schema": "ol_warehouse_production_dimensional",
+   "unique_id": "model.open_learning.dim_course"
+  },
+  "model.open_learning.dim_course_content": {
+   "columns": {
+    "block_category": {
+     "description": ""
+    },
+    "block_id": {
+     "description": ""
+    },
+    "block_index": {
+     "description": ""
+    },
+    "block_metadata": {
+     "description": ""
+    },
+    "block_title": {
+     "description": ""
+    },
+    "chapter_block_id": {
+     "description": ""
+    },
+    "content_block_pk": {
+     "description": ""
+    },
+    "courserun_readable_id": {
+     "description": ""
+    },
+    "is_latest": {
+     "description": ""
+    },
+    "parent_block_id": {
+     "description": ""
+    },
+    "platform": {
+     "description": ""
+    },
+    "retrieved_at": {
+     "description": ""
+    },
+    "sequential_block_id": {
+     "description": ""
+    }
+   },
+   "config": {
+    "materialized": "table"
+   },
+   "database": "ol_data_lake_production",
+   "depends_on": {
+    "macros": [],
+    "nodes": []
+   },
+   "name": "dim_course_content",
+   "original_file_path": "models/dimensional/dim_course_content.sql",
+   "resource_type": "model",
+   "schema": "ol_warehouse_production_dimensional",
+   "unique_id": "model.open_learning.dim_course_content"
+  },
+  "model.open_learning.dim_course_run": {
+   "columns": {
+    "course_fk": {
+     "description": ""
+    },
+    "courserun_created_on": {
+     "description": ""
+    },
+    "courserun_end_date_key": {
+     "description": ""
+    },
+    "courserun_end_on": {
+     "description": ""
+    },
+    "courserun_is_live": {
+     "description": ""
+    },
+    "courserun_pk": {
+     "description": ""
+    },
+    "courserun_readable_id": {
+     "description": ""
+    },
+    "courserun_start_date_key": {
+     "description": ""
+    },
+    "courserun_start_on": {
+     "description": ""
+    },
+    "courserun_title": {
+     "description": ""
+    },
+    "courserun_upgrade_deadline": {
+     "description": ""
+    },
+    "effective_date": {
+     "description": ""
+    },
+    "end_date": {
+     "description": ""
+    },
+    "enrollment_end": {
+     "description": ""
+    },
+    "enrollment_end_date_key": {
+     "description": ""
+    },
+    "enrollment_start": {
+     "description": ""
+    },
+    "enrollment_start_date_key": {
+     "description": ""
+    },
+    "is_current": {
+     "description": ""
+    },
+    "passing_grade": {
+     "description": ""
+    },
+    "platform": {
+     "description": ""
+    },
+    "platform_fk": {
+     "description": ""
+    },
+    "semester": {
+     "description": ""
+    },
+    "source_id": {
+     "description": ""
+    }
+   },
+   "config": {
+    "materialized": "incremental"
+   },
+   "database": "ol_data_lake_production",
+   "depends_on": {
+    "macros": [],
+    "nodes": [
+     "model.open_learning.dim_course",
+     "model.open_learning.dim_platform"
+    ]
+   },
+   "name": "dim_course_run",
+   "original_file_path": "models/dimensional/dim_course_run.sql",
+   "resource_type": "model",
+   "schema": "ol_warehouse_production_dimensional",
+   "unique_id": "model.open_learning.dim_course_run"
+  },
+  "model.open_learning.dim_date": {
+   "columns": {
+    "academic_term": {
+     "description": ""
+    },
+    "academic_year": {
+     "description": ""
+    },
+    "date": {
+     "description": ""
+    },
+    "date_key": {
+     "description": ""
+    },
+    "day": {
+     "description": ""
+    },
+    "day_name": {
+     "description": ""
+    },
+    "day_of_week": {
+     "description": ""
+    },
+    "fiscal_quarter": {
+     "description": ""
+    },
+    "fiscal_year": {
+     "description": ""
+    },
+    "is_weekend": {
+     "description": ""
+    },
+    "month": {
+     "description": ""
+    },
+    "quarter": {
+     "description": ""
+    },
+    "week_of_year": {
+     "description": ""
+    },
+    "year": {
+     "description": ""
+    }
+   },
+   "config": {
+    "materialized": "table"
+   },
+   "database": "ol_data_lake_production",
+   "depends_on": {
+    "macros": [],
+    "nodes": []
+   },
+   "name": "dim_date",
+   "original_file_path": "models/dimensional/dim_date.sql",
+   "resource_type": "model",
+   "schema": "ol_warehouse_production_dimensional",
+   "unique_id": "model.open_learning.dim_date"
+  },
+  "model.open_learning.dim_department": {
+   "columns": {
+    "department_name": {
+     "description": ""
+    },
+    "department_number": {
+     "description": ""
+    },
+    "department_pk": {
+     "description": ""
+    },
+    "primary_platform": {
+     "description": ""
+    }
+   },
+   "config": {
+    "materialized": "table"
+   },
+   "database": "ol_data_lake_production",
+   "depends_on": {
+    "macros": [],
+    "nodes": []
+   },
+   "name": "dim_department",
+   "original_file_path": "models/dimensional/dim_department.sql",
+   "resource_type": "model",
+   "schema": "ol_warehouse_production_dimensional",
+   "unique_id": "model.open_learning.dim_department"
+  },
+  "model.open_learning.dim_discount": {
+   "columns": {
+    "activated_on": {
+     "description": ""
+    },
+    "created_on": {
+     "description": ""
+    },
+    "discount_amount": {
+     "description": ""
+    },
+    "discount_code": {
+     "description": ""
+    },
+    "discount_pk": {
+     "description": ""
+    },
+    "discount_source": {
+     "description": ""
+    },
+    "discount_type": {
+     "description": ""
+    },
+    "expires_on": {
+     "description": ""
+    },
+    "max_redemptions": {
+     "description": ""
+    },
+    "platform_code": {
+     "description": ""
+    },
+    "redemption_type": {
+     "description": ""
+    },
+    "source_discount_id": {
+     "description": ""
+    },
+    "updated_on": {
+     "description": ""
+    }
+   },
+   "config": {
+    "materialized": "table"
+   },
+   "database": "ol_data_lake_production",
+   "depends_on": {
+    "macros": [],
+    "nodes": []
+   },
+   "name": "dim_discount",
+   "original_file_path": "models/dimensional/dim_discount.sql",
+   "resource_type": "model",
+   "schema": "ol_warehouse_production_dimensional",
+   "unique_id": "model.open_learning.dim_discount"
+  },
+  "model.open_learning.dim_discount_type": {
+   "columns": {
+    "discount_type_code": {
+     "description": ""
+    },
+    "discount_type_name": {
+     "description": ""
+    },
+    "discount_type_pk": {
+     "description": ""
+    }
+   },
+   "config": {
+    "materialized": "table"
+   },
+   "database": "ol_data_lake_production",
+   "depends_on": {
+    "macros": [],
+    "nodes": []
+   },
+   "name": "dim_discount_type",
+   "original_file_path": "models/dimensional/dim_discount_type.sql",
+   "resource_type": "model",
+   "schema": "ol_warehouse_production_dimensional",
+   "unique_id": "model.open_learning.dim_discount_type"
+  },
+  "model.open_learning.dim_discussion_topic": {
+   "columns": {
+    "category_name": {
+     "description": ""
+    },
+    "commentable_id": {
+     "description": ""
+    },
+    "content_block_fk": {
+     "description": ""
+    },
+    "courserun_readable_id": {
+     "description": ""
+    },
+    "discussion_block_pk": {
+     "description": ""
+    },
+    "discussion_topic_pk": {
+     "description": ""
+    },
+    "discussion_type": {
+     "description": ""
+    },
+    "platform": {
+     "description": ""
+    },
+    "topic_name": {
+     "description": ""
+    }
+   },
+   "config": {
+    "materialized": "table"
+   },
+   "database": "ol_data_lake_production",
+   "depends_on": {
+    "macros": [],
+    "nodes": [
+     "model.open_learning.dim_course_content"
+    ]
+   },
+   "name": "dim_discussion_topic",
+   "original_file_path": "models/dimensional/dim_discussion_topic.sql",
+   "resource_type": "model",
+   "schema": "ol_warehouse_production_dimensional",
+   "unique_id": "model.open_learning.dim_discussion_topic"
+  },
+  "model.open_learning.dim_feedback_category": {
+   "columns": {
+    "category_label": {
+     "description": ""
+    },
+    "category_parent_slug": {
+     "description": ""
+    },
+    "category_slug": {
+     "description": ""
+    },
+    "category_source": {
+     "description": ""
+    },
+    "category_status": {
+     "description": ""
+    },
+    "cluster_run_id": {
+     "description": ""
+    },
+    "feedback_category_pk": {
+     "description": ""
+    },
+    "first_seen_at": {
+     "description": ""
+    },
+    "updated_at": {
+     "description": ""
+    }
+   },
+   "config": {
+    "materialized": "table"
+   },
+   "database": "ol_data_lake_production",
+   "depends_on": {
+    "macros": [],
+    "nodes": [
+     "model.open_learning.dim_feedback_tag"
+    ]
+   },
+   "name": "dim_feedback_category",
+   "original_file_path": "models/dimensional/dim_feedback_category.sql",
+   "resource_type": "model",
+   "schema": "ol_warehouse_production_dimensional",
+   "unique_id": "model.open_learning.dim_feedback_category"
+  },
+  "model.open_learning.dim_feedback_channel": {
+   "columns": {
+    "channel_name": {
+     "description": ""
+    },
+    "channel_slug": {
+     "description": ""
+    },
+    "feedback_channel_pk": {
+     "description": ""
+    },
+    "is_solicited": {
+     "description": ""
+    }
+   },
+   "config": {
+    "materialized": "table"
+   },
+   "database": "ol_data_lake_production",
+   "depends_on": {
+    "macros": [],
+    "nodes": []
+   },
+   "name": "dim_feedback_channel",
+   "original_file_path": "models/dimensional/dim_feedback_channel.sql",
+   "resource_type": "model",
+   "schema": "ol_warehouse_production_dimensional",
+   "unique_id": "model.open_learning.dim_feedback_channel"
+  },
+  "model.open_learning.dim_feedback_source": {
+   "columns": {
+    "feedback_source_pk": {
+     "description": ""
+    },
+    "is_conversational": {
+     "description": ""
+    },
+    "is_course_scoped": {
+     "description": ""
+    },
+    "source_audience_scope": {
+     "description": ""
+    },
+    "source_medium": {
+     "description": ""
+    },
+    "source_name": {
+     "description": ""
+    },
+    "source_slug": {
+     "description": ""
+    }
+   },
+   "config": {
+    "materialized": "table"
+   },
+   "database": "ol_data_lake_production",
+   "depends_on": {
+    "macros": [],
+    "nodes": []
+   },
+   "name": "dim_feedback_source",
+   "original_file_path": "models/dimensional/dim_feedback_source.sql",
+   "resource_type": "model",
+   "schema": "ol_warehouse_production_dimensional",
+   "unique_id": "model.open_learning.dim_feedback_source"
+  },
+  "model.open_learning.dim_feedback_tag": {
+   "columns": {
+    "feedback_tag_pk": {
+     "description": ""
+    },
+    "source_slug": {
+     "description": ""
+    },
+    "tag_label": {
+     "description": ""
+    },
+    "tag_slug": {
+     "description": ""
+    }
+   },
+   "config": {
+    "materialized": "table"
+   },
+   "database": "ol_data_lake_production",
+   "depends_on": {
+    "macros": [],
+    "nodes": []
+   },
+   "name": "dim_feedback_tag",
+   "original_file_path": "models/dimensional/dim_feedback_tag.sql",
+   "resource_type": "model",
+   "schema": "ol_warehouse_production_dimensional",
+   "unique_id": "model.open_learning.dim_feedback_tag"
+  },
+  "model.open_learning.dim_instructor": {
+   "columns": {
+    "instructor_bio_long": {
+     "description": ""
+    },
+    "instructor_bio_short": {
+     "description": ""
+    },
+    "instructor_name": {
+     "description": ""
+    },
+    "instructor_pk": {
+     "description": ""
+    },
+    "instructor_source_id": {
+     "description": ""
+    },
+    "instructor_title": {
+     "description": ""
+    },
+    "primary_platform": {
+     "description": ""
+    }
+   },
+   "config": {
+    "materialized": "table"
+   },
+   "database": "ol_data_lake_production",
+   "depends_on": {
+    "macros": [],
+    "nodes": []
+   },
+   "name": "dim_instructor",
+   "original_file_path": "models/dimensional/dim_instructor.sql",
+   "resource_type": "model",
+   "schema": "ol_warehouse_production_dimensional",
+   "unique_id": "model.open_learning.dim_instructor"
+  },
+  "model.open_learning.dim_ocw_course": {
+   "columns": {
+    "course_department_numbers": {
+     "description": ""
+    },
+    "course_extra_course_numbers": {
+     "description": ""
+    },
+    "course_first_published_on": {
+     "description": ""
+    },
+    "course_has_never_published": {
+     "description": ""
+    },
+    "course_is_unpublished": {
+     "description": ""
+    },
+    "course_learning_resource_types": {
+     "description": ""
+    },
+    "course_level": {
+     "description": ""
+    },
+    "course_live_url": {
+     "description": ""
+    },
+    "course_name": {
+     "description": ""
+    },
+    "course_publish_date_updated_on": {
+     "description": ""
+    },
+    "course_readable_id": {
+     "description": ""
+    },
+    "course_term": {
+     "description": ""
+    },
+    "course_topics": {
+     "description": ""
+    },
+    "course_year": {
+     "description": ""
+    }
+   },
+   "config": {
+    "materialized": "table"
+   },
+   "database": "ol_data_lake_production",
+   "depends_on": {
+    "macros": [],
+    "nodes": []
+   },
+   "name": "dim_ocw_course",
+   "original_file_path": "models/dimensional/dim_ocw_course.sql",
+   "resource_type": "model",
+   "schema": "ol_warehouse_production_dimensional",
+   "unique_id": "model.open_learning.dim_ocw_course"
+  },
+  "model.open_learning.dim_ocw_resource": {
+   "columns": {
+    "content_type": {
+     "description": ""
+    },
+    "course_live_url": {
+     "description": ""
+    },
+    "course_name": {
+     "description": ""
+    },
+    "course_number": {
+     "description": ""
+    },
+    "course_term": {
+     "description": ""
+    },
+    "course_title": {
+     "description": ""
+    },
+    "course_uuid": {
+     "description": ""
+    },
+    "course_year": {
+     "description": ""
+    },
+    "external_resource_backup_url": {
+     "description": ""
+    },
+    "external_resource_backup_url_status_code": {
+     "description": ""
+    },
+    "external_resource_is_broken": {
+     "description": ""
+    },
+    "external_resource_license_warning": {
+     "description": ""
+    },
+    "external_resource_status": {
+     "description": ""
+    },
+    "external_resource_url": {
+     "description": ""
+    },
+    "external_resource_url_status_code": {
+     "description": ""
+    },
+    "external_resource_wayback_url": {
+     "description": ""
+    },
+    "image_alt_text": {
+     "description": ""
+    },
+    "image_caption": {
+     "description": ""
+    },
+    "image_credit": {
+     "description": ""
+    },
+    "learning_resource_types": {
+     "description": ""
+    },
+    "resource_audience": {
+     "description": ""
+    },
+    "resource_description": {
+     "description": ""
+    },
+    "resource_draft": {
+     "description": ""
+    },
+    "resource_file_size": {
+     "description": ""
+    },
+    "resource_file_type": {
+     "description": ""
+    },
+    "resource_filename": {
+     "description": ""
+    },
+    "resource_level": {
+     "description": ""
+    },
+    "resource_license": {
+     "description": ""
+    },
+    "resource_live_url": {
+     "description": ""
+    },
+    "resource_ocw_type": {
+     "description": ""
+    },
+    "resource_title": {
+     "description": ""
+    },
+    "resource_type": {
+     "description": ""
+    },
+    "resource_uuid": {
+     "description": ""
+    },
+    "studio_url": {
+     "description": ""
+    },
+    "video_archive_url": {
+     "description": ""
+    },
+    "video_captions_file": {
+     "description": ""
+    },
+    "video_thumbnail_file": {
+     "description": ""
+    },
+    "video_transcript_file": {
+     "description": ""
+    },
+    "video_youtube_description": {
+     "description": ""
+    },
+    "video_youtube_id": {
+     "description": ""
+    },
+    "video_youtube_speakers": {
+     "description": ""
+    },
+    "video_youtube_tags": {
+     "description": ""
+    },
+    "website_title": {
+     "description": ""
+    }
+   },
+   "config": {
+    "materialized": "table"
+   },
+   "database": "ol_data_lake_production",
+   "depends_on": {
+    "macros": [],
+    "nodes": []
+   },
+   "name": "dim_ocw_resource",
+   "original_file_path": "models/dimensional/dim_ocw_resource.sql",
+   "resource_type": "model",
+   "schema": "ol_warehouse_production_dimensional",
+   "unique_id": "model.open_learning.dim_ocw_resource"
+  },
+  "model.open_learning.dim_organization": {
+   "columns": {
+    "organization_description": {
+     "description": ""
+    },
+    "organization_id": {
+     "description": ""
+    },
+    "organization_key": {
+     "description": ""
+    },
+    "organization_logo": {
+     "description": ""
+    },
+    "organization_name": {
+     "description": ""
+    },
+    "organization_pk": {
+     "description": ""
+    },
+    "platform": {
+     "description": ""
+    },
+    "sso_organization_id": {
+     "description": ""
+    }
+   },
+   "config": {
+    "materialized": "table"
+   },
+   "database": "ol_data_lake_production",
+   "depends_on": {
+    "macros": [],
+    "nodes": []
+   },
+   "name": "dim_organization",
+   "original_file_path": "models/dimensional/dim_organization.sql",
+   "resource_type": "model",
+   "schema": "ol_warehouse_production_dimensional",
+   "unique_id": "model.open_learning.dim_organization"
+  },
+  "model.open_learning.dim_payment_method": {
+   "columns": {
+    "payment_method_code": {
+     "description": ""
+    },
+    "payment_method_name": {
+     "description": ""
+    },
+    "payment_method_pk": {
+     "description": ""
+    },
+    "payment_method_provider": {
+     "description": ""
+    },
+    "payment_method_type": {
+     "description": ""
+    }
+   },
+   "config": {
+    "materialized": "table"
+   },
+   "database": "ol_data_lake_production",
+   "depends_on": {
+    "macros": [],
+    "nodes": []
+   },
+   "name": "dim_payment_method",
+   "original_file_path": "models/dimensional/dim_payment_method.sql",
+   "resource_type": "model",
+   "schema": "ol_warehouse_production_dimensional",
+   "unique_id": "model.open_learning.dim_payment_method"
+  },
+  "model.open_learning.dim_platform": {
+   "columns": {
+    "platform_description": {
+     "description": ""
+    },
+    "platform_domain": {
+     "description": ""
+    },
+    "platform_name": {
+     "description": ""
+    },
+    "platform_pk": {
+     "description": ""
+    },
+    "platform_readable_id": {
+     "description": ""
+    }
+   },
+   "config": {
+    "materialized": "table"
+   },
+   "database": "ol_data_lake_production",
+   "depends_on": {
+    "macros": [],
+    "nodes": []
+   },
+   "name": "dim_platform",
+   "original_file_path": "models/dimensional/dim_platform.sql",
+   "resource_type": "model",
+   "schema": "ol_warehouse_production_dimensional",
+   "unique_id": "model.open_learning.dim_platform"
+  },
+  "model.open_learning.dim_problem": {
+   "columns": {
+    "content_block_fk": {
+     "description": ""
+    },
+    "courserun_readable_id": {
+     "description": ""
+    },
+    "due_date": {
+     "description": ""
+    },
+    "markdown": {
+     "description": ""
+    },
+    "max_attempts": {
+     "description": ""
+    },
+    "platform": {
+     "description": ""
+    },
+    "problem_block_pk": {
+     "description": ""
+    },
+    "problem_name": {
+     "description": ""
+    },
+    "problem_types": {
+     "description": ""
+    },
+    "start_date": {
+     "description": ""
+    },
+    "weight": {
+     "description": ""
+    }
+   },
+   "config": {
+    "materialized": "table"
+   },
+   "database": "ol_data_lake_production",
+   "depends_on": {
+    "macros": [],
+    "nodes": [
+     "model.open_learning.dim_course_content"
+    ]
+   },
+   "name": "dim_problem",
+   "original_file_path": "models/dimensional/dim_problem.sql",
+   "resource_type": "model",
+   "schema": "ol_warehouse_production_dimensional",
+   "unique_id": "model.open_learning.dim_problem"
+  },
+  "model.open_learning.dim_product": {
+   "columns": {
+    "courserun_fk": {
+     "description": ""
+    },
+    "created_date_key": {
+     "description": ""
+    },
+    "effective_date": {
+     "description": ""
+    },
+    "end_date": {
+     "description": ""
+    },
+    "is_current": {
+     "description": ""
+    },
+    "platform": {
+     "description": ""
+    },
+    "platform_fk": {
+     "description": ""
+    },
+    "product_currency": {
+     "description": ""
+    },
+    "product_is_active": {
+     "description": ""
+    },
+    "product_pk": {
+     "description": ""
+    },
+    "product_price": {
+     "description": ""
+    },
+    "product_type": {
+     "description": ""
+    },
+    "program_fk": {
+     "description": ""
+    },
+    "source_product_id": {
+     "description": ""
+    }
+   },
+   "config": {
+    "materialized": "incremental"
+   },
+   "database": "ol_data_lake_production",
+   "depends_on": {
+    "macros": [],
+    "nodes": [
+     "model.open_learning.dim_course_run",
+     "model.open_learning.dim_program",
+     "model.open_learning.dim_platform"
+    ]
+   },
+   "name": "dim_product",
+   "original_file_path": "models/dimensional/dim_product.sql",
+   "resource_type": "model",
+   "schema": "ol_warehouse_production_dimensional",
+   "unique_id": "model.open_learning.dim_product"
+  },
+  "model.open_learning.dim_program": {
+   "columns": {
+    "enrollment_end_date": {
+     "description": ""
+    },
+    "enrollment_start_date": {
+     "description": ""
+    },
+    "first_published_date": {
+     "description": ""
+    },
+    "is_active": {
+     "description": ""
+    },
+    "is_external": {
+     "description": ""
+    },
+    "partner_platform_name": {
+     "description": ""
+    },
+    "platform_code": {
+     "description": ""
+    },
+    "platform_fk": {
+     "description": ""
+    },
+    "platform_readable_id": {
+     "description": ""
+    },
+    "program_availability": {
+     "description": ""
+    },
+    "program_certification_type": {
+     "description": ""
+    },
+    "program_description": {
+     "description": ""
+    },
+    "program_effort": {
+     "description": ""
+    },
+    "program_is_dedp": {
+     "description": ""
+    },
+    "program_is_micromasters": {
+     "description": ""
+    },
+    "program_length": {
+     "description": ""
+    },
+    "program_name": {
+     "description": ""
+    },
+    "program_pk": {
+     "description": ""
+    },
+    "program_prerequisites": {
+     "description": ""
+    },
+    "program_price": {
+     "description": ""
+    },
+    "program_readable_id": {
+     "description": ""
+    },
+    "program_title": {
+     "description": ""
+    },
+    "program_track": {
+     "description": ""
+    },
+    "program_type": {
+     "description": ""
+    },
+    "program_what_you_learn": {
+     "description": ""
+    },
+    "published_date": {
+     "description": ""
+    },
+    "published_date_key": {
+     "description": ""
+    },
+    "source_id": {
+     "description": ""
+    }
+   },
+   "config": {
+    "materialized": "table"
+   },
+   "database": "ol_data_lake_production",
+   "depends_on": {
+    "macros": [],
+    "nodes": [
+     "model.open_learning.dim_platform"
+    ]
+   },
+   "name": "dim_program",
+   "original_file_path": "models/dimensional/dim_program.sql",
+   "resource_type": "model",
+   "schema": "ol_warehouse_production_dimensional",
+   "unique_id": "model.open_learning.dim_program"
+  },
+  "model.open_learning.dim_sentiment": {
+   "columns": {
+    "polarity_score_bucket": {
+     "description": ""
+    },
+    "sentiment_pk": {
+     "description": ""
+    },
+    "sentiment_slug": {
+     "description": ""
+    }
+   },
+   "config": {
+    "materialized": "table"
+   },
+   "database": "ol_data_lake_production",
+   "depends_on": {
+    "macros": [],
+    "nodes": []
+   },
+   "name": "dim_sentiment",
+   "original_file_path": "models/dimensional/dim_sentiment.sql",
+   "resource_type": "model",
+   "schema": "ol_warehouse_production_dimensional",
+   "unique_id": "model.open_learning.dim_sentiment"
+  },
+  "model.open_learning.dim_tax_rate": {
+   "columns": {
+    "country_code": {
+     "description": ""
+    },
+    "is_active": {
+     "description": ""
+    },
+    "tax_rate": {
+     "description": ""
+    },
+    "tax_rate_name": {
+     "description": ""
+    },
+    "tax_rate_pk": {
+     "description": ""
+    }
+   },
+   "config": {
+    "materialized": "table"
+   },
+   "database": "ol_data_lake_production",
+   "depends_on": {
+    "macros": [],
+    "nodes": []
+   },
+   "name": "dim_tax_rate",
+   "original_file_path": "models/dimensional/dim_tax_rate.sql",
+   "resource_type": "model",
+   "schema": "ol_warehouse_production_dimensional",
+   "unique_id": "model.open_learning.dim_tax_rate"
+  },
+  "model.open_learning.dim_time": {
+   "columns": {
+    "am_pm": {
+     "description": ""
+    },
+    "hour": {
+     "description": ""
+    },
+    "hour_12": {
+     "description": ""
+    },
+    "hour_of_day_label": {
+     "description": ""
+    },
+    "minute": {
+     "description": ""
+    },
+    "minute_of_day": {
+     "description": ""
+    },
+    "time_key": {
+     "description": ""
+    },
+    "time_of_day_bucket": {
+     "description": ""
+    }
+   },
+   "config": {
+    "materialized": "table"
+   },
+   "database": "ol_data_lake_production",
+   "depends_on": {
+    "macros": [],
+    "nodes": []
+   },
+   "name": "dim_time",
+   "original_file_path": "models/dimensional/dim_time.sql",
+   "resource_type": "model",
+   "schema": "ol_warehouse_production_dimensional",
+   "unique_id": "model.open_learning.dim_time"
+  },
+  "model.open_learning.dim_topic": {
+   "columns": {
+    "parent_topic_fk": {
+     "description": ""
+    },
+    "parent_topic_name": {
+     "description": ""
+    },
+    "primary_platform": {
+     "description": ""
+    },
+    "topic_name": {
+     "description": ""
+    },
+    "topic_pk": {
+     "description": ""
+    }
+   },
+   "config": {
+    "materialized": "table"
+   },
+   "database": "ol_data_lake_production",
+   "depends_on": {
+    "macros": [],
+    "nodes": []
+   },
+   "name": "dim_topic",
+   "original_file_path": "models/dimensional/dim_topic.sql",
+   "resource_type": "model",
+   "schema": "ol_warehouse_production_dimensional",
+   "unique_id": "model.open_learning.dim_topic"
+  },
+  "model.open_learning.dim_user": {
+   "columns": {
+    "address_country": {
+     "description": ""
+    },
+    "address_state": {
+     "description": ""
+    },
+    "birth_year": {
+     "description": ""
+    },
+    "bootcamps_application_user_id": {
+     "description": ""
+    },
+    "certificate_desired": {
+     "description": ""
+    },
+    "company": {
+     "description": ""
+    },
+    "completed_onboarding": {
+     "description": ""
+    },
+    "delivery_preference": {
+     "description": ""
+    },
+    "edxorg_openedx_user_id": {
+     "description": ""
+    },
+    "email": {
+     "description": ""
+    },
+    "emeritus_user_id": {
+     "description": ""
+    },
+    "full_name": {
+     "description": ""
+    },
+    "gender": {
+     "description": ""
+    },
+    "global_alumni_user_id": {
+     "description": ""
+    },
+    "goals": {
+     "description": ""
+    },
+    "highest_education": {
+     "description": ""
+    },
+    "industry": {
+     "description": ""
+    },
+    "job_title": {
+     "description": ""
+    },
+    "latest_income_usd": {
+     "description": ""
+    },
+    "latest_original_currency": {
+     "description": ""
+    },
+    "latest_original_income": {
+     "description": ""
+    },
+    "micromasters_user_id": {
+     "description": ""
+    },
+    "mitlearn_openedx_user_id": {
+     "description": ""
+    },
+    "mitlearn_user_id": {
+     "description": ""
+    },
+    "mitxonline_application_user_id": {
+     "description": ""
+    },
+    "mitxonline_openedx_user_id": {
+     "description": ""
+    },
+    "mitxpro_application_user_id": {
+     "description": ""
+    },
+    "mitxpro_openedx_user_id": {
+     "description": ""
+    },
+    "residential_openedx_user_id": {
+     "description": ""
+    },
+    "topic_interests": {
+     "description": ""
+    },
+    "user_edxorg_username": {
+     "description": ""
+    },
+    "user_global_id": {
+     "description": ""
+    },
+    "user_is_active_on_bootcamps": {
+     "description": ""
+    },
+    "user_is_active_on_edxorg": {
+     "description": ""
+    },
+    "user_is_active_on_mitlearn": {
+     "description": ""
+    },
+    "user_is_active_on_mitxonline": {
+     "description": ""
+    },
+    "user_is_active_on_mitxpro": {
+     "description": ""
+    },
+    "user_is_active_on_residential": {
+     "description": ""
+    },
+    "user_joined_on_bootcamps": {
+     "description": ""
+    },
+    "user_joined_on_edxorg": {
+     "description": ""
+    },
+    "user_joined_on_mitlearn": {
+     "description": ""
+    },
+    "user_joined_on_mitxonline": {
+     "description": ""
+    },
+    "user_joined_on_mitxpro": {
+     "description": ""
+    },
+    "user_joined_on_residential": {
+     "description": ""
+    },
+    "user_mitxonline_username": {
+     "description": ""
+    },
+    "user_mitxpro_username": {
+     "description": ""
+    },
+    "user_pk": {
+     "description": ""
+    },
+    "user_pk_source": {
+     "description": ""
+    },
+    "user_residential_username": {
+     "description": ""
+    }
+   },
+   "config": {
+    "materialized": "table"
+   },
+   "database": "ol_data_lake_production",
+   "depends_on": {
+    "macros": [],
+    "nodes": []
+   },
+   "name": "dim_user",
+   "original_file_path": "models/dimensional/dim_user.sql",
+   "resource_type": "model",
+   "schema": "ol_warehouse_production_dimensional",
+   "unique_id": "model.open_learning.dim_user"
+  },
+  "model.open_learning.dim_video": {
+   "columns": {
+    "content_block_fk": {
+     "description": ""
+    },
+    "courserun_readable_id": {
+     "description": ""
+    },
+    "due_date": {
+     "description": ""
+    },
+    "edx_video_id": {
+     "description": ""
+    },
+    "html5_sources": {
+     "description": ""
+    },
+    "platform": {
+     "description": ""
+    },
+    "start_date": {
+     "description": ""
+    },
+    "transcripts": {
+     "description": ""
+    },
+    "video_block_pk": {
+     "description": ""
+    },
+    "video_duration": {
+     "description": ""
+    },
+    "video_edx_uuid": {
+     "description": ""
+    },
+    "video_name": {
+     "description": ""
+    }
+   },
+   "config": {
+    "materialized": "table"
+   },
+   "database": "ol_data_lake_production",
+   "depends_on": {
+    "macros": [],
+    "nodes": [
+     "model.open_learning.dim_course_content"
+    ]
+   },
+   "name": "dim_video",
+   "original_file_path": "models/dimensional/dim_video.sql",
+   "resource_type": "model",
+   "schema": "ol_warehouse_production_dimensional",
+   "unique_id": "model.open_learning.dim_video"
+  },
+  "model.open_learning.tfact_certificate": {
+   "columns": {
+    "certificate_created_on": {
+     "description": ""
+    },
+    "certificate_id": {
+     "description": ""
+    },
+    "certificate_is_revoked": {
+     "description": ""
+    },
+    "certificate_issued_date_key": {
+     "description": ""
+    },
+    "certificate_issued_on": {
+     "description": ""
+    },
+    "certificate_key": {
+     "description": ""
+    },
+    "certificate_scope": {
+     "description": ""
+    },
+    "certificate_type_fk": {
+     "description": ""
+    },
+    "certificate_updated_on": {
+     "description": ""
+    },
+    "certificate_uuid": {
+     "description": ""
+    },
+    "courserun_fk": {
+     "description": ""
+    },
+    "platform": {
+     "description": ""
+    },
+    "platform_fk": {
+     "description": ""
+    },
+    "program_fk": {
+     "description": ""
+    },
+    "user_fk": {
+     "description": ""
+    }
+   },
+   "config": {
+    "materialized": "incremental"
+   },
+   "database": "ol_data_lake_production",
+   "depends_on": {
+    "macros": [],
+    "nodes": [
+     "model.open_learning.dim_user",
+     "model.open_learning.dim_course_run",
+     "model.open_learning.dim_platform",
+     "model.open_learning.dim_certificate_type",
+     "model.open_learning.dim_program"
+    ]
+   },
+   "name": "tfact_certificate",
+   "original_file_path": "models/dimensional/tfact_certificate.sql",
+   "resource_type": "model",
+   "schema": "ol_warehouse_production_dimensional",
+   "unique_id": "model.open_learning.tfact_certificate"
+  },
+  "model.open_learning.tfact_chatbot_events": {
+   "columns": {
+    "block_id": {
+     "description": ""
+    },
+    "block_name": {
+     "description": ""
+    },
+    "chatbot_source": {
+     "description": ""
+    },
+    "chatbot_type": {
+     "description": ""
+    },
+    "courserun_readable_id": {
+     "description": ""
+    },
+    "date_fk": {
+     "description": ""
+    },
+    "event_json": {
+     "description": ""
+    },
+    "event_timestamp": {
+     "description": ""
+    },
+    "event_timestamp_iso8601": {
+     "description": ""
+    },
+    "event_type": {
+     "description": ""
+    },
+    "event_value": {
+     "description": ""
+    },
+    "learn_ai_checkpoint_pk": {
+     "description": ""
+    },
+    "learn_ai_thread_id": {
+     "description": ""
+    },
+    "openedx_user_id": {
+     "description": ""
+    },
+    "org_id": {
+     "description": ""
+    },
+    "platform_fk": {
+     "description": ""
+    },
+    "session_id": {
+     "description": ""
+    },
+    "time_fk": {
+     "description": ""
+    },
+    "user_fk": {
+     "description": ""
+    },
+    "user_username": {
+     "description": ""
+    }
+   },
+   "config": {
+    "materialized": "table"
+   },
+   "database": "ol_data_lake_production",
+   "depends_on": {
+    "macros": [],
+    "nodes": [
+     "model.open_learning.dim_user"
+    ]
+   },
+   "name": "tfact_chatbot_events",
+   "original_file_path": "models/dimensional/tfact_chatbot_events.sql",
+   "resource_type": "model",
+   "schema": "ol_warehouse_production_dimensional",
+   "unique_id": "model.open_learning.tfact_chatbot_events"
+  },
+  "model.open_learning.tfact_course_navigation_events": {
+   "columns": {
+    "block_fk": {
+     "description": ""
+    },
+    "courserun_readable_id": {
+     "description": ""
+    },
+    "date_fk": {
+     "description": ""
+    },
+    "ending_position": {
+     "description": ""
+    },
+    "event_json": {
+     "description": ""
+    },
+    "event_timestamp": {
+     "description": ""
+    },
+    "event_timestamp_iso8601": {
+     "description": ""
+    },
+    "event_type": {
+     "description": ""
+    },
+    "openedx_user_id": {
+     "description": ""
+    },
+    "platform": {
+     "description": ""
+    },
+    "platform_fk": {
+     "description": ""
+    },
+    "starting_position": {
+     "description": ""
+    },
+    "time_fk": {
+     "description": ""
+    },
+    "user_fk": {
+     "description": ""
+    },
+    "user_username": {
+     "description": ""
+    }
+   },
+   "config": {
+    "materialized": "table"
+   },
+   "database": "ol_data_lake_production",
+   "depends_on": {
+    "macros": [],
+    "nodes": [
+     "model.open_learning.dim_user",
+     "model.open_learning.dim_platform"
+    ]
+   },
+   "name": "tfact_course_navigation_events",
+   "original_file_path": "models/dimensional/tfact_course_navigation_events.sql",
+   "resource_type": "model",
+   "schema": "ol_warehouse_production_dimensional",
+   "unique_id": "model.open_learning.tfact_course_navigation_events"
+  },
+  "model.open_learning.tfact_discussion_events": {
+   "columns": {
+    "commentable_id": {
+     "description": ""
+    },
+    "courserun_fk": {
+     "description": ""
+    },
+    "courserun_readable_id": {
+     "description": ""
+    },
+    "date_fk": {
+     "description": ""
+    },
+    "discussion_component_id": {
+     "description": ""
+    },
+    "discussion_component_name": {
+     "description": ""
+    },
+    "event_json": {
+     "description": ""
+    },
+    "event_timestamp": {
+     "description": ""
+    },
+    "event_timestamp_iso8601": {
+     "description": ""
+    },
+    "event_type": {
+     "description": ""
+    },
+    "openedx_user_id": {
+     "description": ""
+    },
+    "page_url": {
+     "description": ""
+    },
+    "platform": {
+     "description": ""
+    },
+    "platform_fk": {
+     "description": ""
+    },
+    "post_content": {
+     "description": ""
+    },
+    "post_id": {
+     "description": ""
+    },
+    "post_title": {
+     "description": ""
+    },
+    "time_fk": {
+     "description": ""
+    },
+    "user_fk": {
+     "description": ""
+    },
+    "user_forums_roles": {
+     "description": ""
+    },
+    "user_username": {
+     "description": ""
+    }
+   },
+   "config": {
+    "materialized": "table"
+   },
+   "database": "ol_data_lake_production",
+   "depends_on": {
+    "macros": [],
+    "nodes": [
+     "model.open_learning.dim_user",
+     "model.open_learning.dim_course_run",
+     "model.open_learning.dim_platform"
+    ]
+   },
+   "name": "tfact_discussion_events",
+   "original_file_path": "models/dimensional/tfact_discussion_events.sql",
+   "resource_type": "model",
+   "schema": "ol_warehouse_production_dimensional",
+   "unique_id": "model.open_learning.tfact_discussion_events"
+  },
+  "model.open_learning.tfact_enrollment": {
+   "columns": {
+    "courserun_fk": {
+     "description": ""
+    },
+    "enrollment_created_on": {
+     "description": ""
+    },
+    "enrollment_date_key": {
+     "description": ""
+    },
+    "enrollment_id": {
+     "description": ""
+    },
+    "enrollment_is_active": {
+     "description": ""
+    },
+    "enrollment_is_edx_enrolled": {
+     "description": ""
+    },
+    "enrollment_key": {
+     "description": ""
+    },
+    "enrollment_mode": {
+     "description": ""
+    },
+    "enrollment_status": {
+     "description": ""
+    },
+    "enrollment_type": {
+     "description": ""
+    },
+    "enrollment_updated_on": {
+     "description": ""
+    },
+    "order_id": {
+     "description": ""
+    },
+    "platform": {
+     "description": ""
+    },
+    "platform_fk": {
+     "description": ""
+    },
+    "program_fk": {
+     "description": ""
+    },
+    "user_fk": {
+     "description": ""
+    }
+   },
+   "config": {
+    "materialized": "incremental"
+   },
+   "database": "ol_data_lake_production",
+   "depends_on": {
+    "macros": [],
+    "nodes": [
+     "model.open_learning.dim_user",
+     "model.open_learning.dim_course_run",
+     "model.open_learning.dim_program",
+     "model.open_learning.dim_platform"
+    ]
+   },
+   "name": "tfact_enrollment",
+   "original_file_path": "models/dimensional/tfact_enrollment.sql",
+   "resource_type": "model",
+   "schema": "ol_warehouse_production_dimensional",
+   "unique_id": "model.open_learning.tfact_enrollment"
+  },
+  "model.open_learning.tfact_enrollment_order": {
+   "columns": {
+    "discount_fk": {
+     "description": ""
+    },
+    "discount_type_fk": {
+     "description": ""
+    },
+    "enrollment_key": {
+     "description": ""
+    },
+    "line_price": {
+     "description": ""
+    },
+    "order_fk": {
+     "description": ""
+    },
+    "order_id": {
+     "description": ""
+    },
+    "order_reference_number": {
+     "description": ""
+    },
+    "order_state": {
+     "description": ""
+    },
+    "order_updated_on": {
+     "description": ""
+    }
+   },
+   "config": {
+    "materialized": "table"
+   },
+   "database": "ol_data_lake_production",
+   "depends_on": {
+    "macros": [],
+    "nodes": [
+     "model.open_learning.tfact_enrollment",
+     "model.open_learning.dim_product",
+     "model.open_learning.tfact_order"
+    ]
+   },
+   "name": "tfact_enrollment_order",
+   "original_file_path": "models/dimensional/tfact_enrollment_order.sql",
+   "resource_type": "model",
+   "schema": "ol_warehouse_production_dimensional",
+   "unique_id": "model.open_learning.tfact_enrollment_order"
+  },
+  "model.open_learning.tfact_feedback": {
+   "columns": {
+    "content_block_fk": {
+     "description": ""
+    },
+    "conversation_id": {
+     "description": ""
+    },
+    "courserun_fk": {
+     "description": ""
+    },
+    "created_date_fk": {
+     "description": ""
+    },
+    "created_time_fk": {
+     "description": ""
+    },
+    "explicit_rating": {
+     "description": ""
+    },
+    "feedback_channel_fk": {
+     "description": ""
+    },
+    "feedback_created_at": {
+     "description": ""
+    },
+    "feedback_ingested_at": {
+     "description": ""
+    },
+    "feedback_occurred_at": {
+     "description": ""
+    },
+    "feedback_pk": {
+     "description": ""
+    },
+    "feedback_source_fk": {
+     "description": ""
+    },
+    "feedback_text": {
+     "description": ""
+    },
+    "feedback_text_chars": {
+     "description": ""
+    },
+    "feedback_title": {
+     "description": ""
+    },
+    "feedback_updated_at": {
+     "description": ""
+    },
+    "is_conversation_opening": {
+     "description": ""
+    },
+    "occurred_date_fk": {
+     "description": ""
+    },
+    "occurred_time_fk": {
+     "description": ""
+    },
+    "organization_fk": {
+     "description": ""
+    },
+    "platform_fk": {
+     "description": ""
+    },
+    "source_metadata": {
+     "description": ""
+    },
+    "source_record_id": {
+     "description": ""
+    },
+    "source_url": {
+     "description": ""
+    },
+    "subject_ref": {
+     "description": ""
+    },
+    "subject_type": {
+     "description": ""
+    },
+    "subject_url": {
+     "description": ""
+    },
+    "subject_user_ref": {
+     "description": ""
+    },
+    "turn_index": {
+     "description": ""
+    },
+    "updated_date_fk": {
+     "description": ""
+    },
+    "updated_time_fk": {
+     "description": ""
+    },
+    "user_fk": {
+     "description": ""
+    }
+   },
+   "config": {
+    "materialized": "incremental"
+   },
+   "database": "ol_data_lake_production",
+   "depends_on": {
+    "macros": [],
+    "nodes": [
+     "model.open_learning.dim_user"
+    ]
+   },
+   "name": "tfact_feedback",
+   "original_file_path": "models/dimensional/tfact_feedback.sql",
+   "resource_type": "model",
+   "schema": "ol_warehouse_production_dimensional",
+   "unique_id": "model.open_learning.tfact_feedback"
+  },
+  "model.open_learning.tfact_grade": {
+   "columns": {
+    "courserun_fk": {
+     "description": ""
+    },
+    "grade_created_on": {
+     "description": ""
+    },
+    "grade_date_key": {
+     "description": ""
+    },
+    "grade_id": {
+     "description": ""
+    },
+    "grade_key": {
+     "description": ""
+    },
+    "grade_updated_on": {
+     "description": ""
+    },
+    "grade_value": {
+     "description": ""
+    },
+    "is_passing": {
+     "description": ""
+    },
+    "letter_grade": {
+     "description": ""
+    },
+    "platform": {
+     "description": ""
+    },
+    "platform_fk": {
+     "description": ""
+    },
+    "user_fk": {
+     "description": ""
+    }
+   },
+   "config": {
+    "materialized": "incremental"
+   },
+   "database": "ol_data_lake_production",
+   "depends_on": {
+    "macros": [],
+    "nodes": [
+     "model.open_learning.dim_user",
+     "model.open_learning.dim_course_run",
+     "model.open_learning.dim_platform"
+    ]
+   },
+   "name": "tfact_grade",
+   "original_file_path": "models/dimensional/tfact_grade.sql",
+   "resource_type": "model",
+   "schema": "ol_warehouse_production_dimensional",
+   "unique_id": "model.open_learning.tfact_grade"
+  },
+  "model.open_learning.tfact_order": {
+   "columns": {
+    "discount_fk": {
+     "description": ""
+    },
+    "discount_type_fk": {
+     "description": ""
+    },
+    "line_id": {
+     "description": ""
+    },
+    "line_price": {
+     "description": ""
+    },
+    "order_date_key": {
+     "description": ""
+    },
+    "order_id": {
+     "description": ""
+    },
+    "order_key": {
+     "description": ""
+    },
+    "order_reference_number": {
+     "description": ""
+    },
+    "order_state": {
+     "description": ""
+    },
+    "order_tax_amount": {
+     "description": ""
+    },
+    "order_tax_rate": {
+     "description": ""
+    },
+    "order_total_price_paid": {
+     "description": ""
+    },
+    "order_total_price_paid_plus_tax": {
+     "description": ""
+    },
+    "order_updated_date_key": {
+     "description": ""
+    },
+    "order_updated_on": {
+     "description": ""
+    },
+    "platform": {
+     "description": ""
+    },
+    "platform_fk": {
+     "description": ""
+    },
+    "product_fk": {
+     "description": ""
+    },
+    "tax_rate_fk": {
+     "description": ""
+    },
+    "user_fk": {
+     "description": ""
+    }
+   },
+   "config": {
+    "materialized": "incremental"
+   },
+   "database": "ol_data_lake_production",
+   "depends_on": {
+    "macros": [],
+    "nodes": [
+     "model.open_learning.dim_user",
+     "model.open_learning.dim_discount_type",
+     "model.open_learning.dim_product",
+     "model.open_learning.dim_platform",
+     "model.open_learning.dim_discount",
+     "model.open_learning.dim_tax_rate"
+    ]
+   },
+   "name": "tfact_order",
+   "original_file_path": "models/dimensional/tfact_order.sql",
+   "resource_type": "model",
+   "schema": "ol_warehouse_production_dimensional",
+   "unique_id": "model.open_learning.tfact_order"
+  },
+  "model.open_learning.tfact_payment": {
+   "columns": {
+    "order_id": {
+     "description": ""
+    },
+    "payment_date_key": {
+     "description": ""
+    },
+    "payment_id": {
+     "description": ""
+    },
+    "payment_key": {
+     "description": ""
+    },
+    "payment_method_fk": {
+     "description": ""
+    },
+    "platform": {
+     "description": ""
+    },
+    "platform_fk": {
+     "description": ""
+    },
+    "transaction_amount": {
+     "description": ""
+    },
+    "transaction_created_on": {
+     "description": ""
+    },
+    "transaction_status": {
+     "description": ""
+    },
+    "transaction_type": {
+     "description": ""
+    },
+    "user_fk": {
+     "description": ""
+    }
+   },
+   "config": {
+    "materialized": "incremental"
+   },
+   "database": "ol_data_lake_production",
+   "depends_on": {
+    "macros": [],
+    "nodes": [
+     "model.open_learning.dim_user",
+     "model.open_learning.dim_platform",
+     "model.open_learning.dim_payment_method"
+    ]
+   },
+   "name": "tfact_payment",
+   "original_file_path": "models/dimensional/tfact_payment.sql",
+   "resource_type": "model",
+   "schema": "ol_warehouse_production_dimensional",
+   "unique_id": "model.open_learning.tfact_payment"
+  },
+  "model.open_learning.tfact_problem_events": {
+   "columns": {
+    "answers": {
+     "description": ""
+    },
+    "attempt": {
+     "description": ""
+    },
+    "courserun_readable_id": {
+     "description": ""
+    },
+    "date_fk": {
+     "description": ""
+    },
+    "event_id": {
+     "description": ""
+    },
+    "event_json": {
+     "description": ""
+    },
+    "event_timestamp": {
+     "description": ""
+    },
+    "event_timestamp_iso8601": {
+     "description": ""
+    },
+    "event_type": {
+     "description": ""
+    },
+    "grade": {
+     "description": ""
+    },
+    "max_grade": {
+     "description": ""
+    },
+    "openedx_user_id": {
+     "description": ""
+    },
+    "platform": {
+     "description": ""
+    },
+    "platform_fk": {
+     "description": ""
+    },
+    "problem_block_fk": {
+     "description": ""
+    },
+    "success": {
+     "description": ""
+    },
+    "time_fk": {
+     "description": ""
+    },
+    "user_fk": {
+     "description": ""
+    },
+    "user_username": {
+     "description": ""
+    }
+   },
+   "config": {
+    "materialized": "incremental"
+   },
+   "database": "ol_data_lake_production",
+   "depends_on": {
+    "macros": [],
+    "nodes": [
+     "model.open_learning.dim_user",
+     "model.open_learning.dim_platform",
+     "model.open_learning.tfact_studentmodule_problems"
+    ]
+   },
+   "name": "tfact_problem_events",
+   "original_file_path": "models/dimensional/tfact_problem_events.sql",
+   "resource_type": "model",
+   "schema": "ol_warehouse_production_dimensional",
+   "unique_id": "model.open_learning.tfact_problem_events"
+  },
+  "model.open_learning.tfact_studentmodule_problems": {
+   "columns": {
+    "answers": {
+     "description": ""
+    },
+    "attempt": {
+     "description": ""
+    },
+    "correct_map": {
+     "description": ""
+    },
+    "courserun_readable_id": {
+     "description": ""
+    },
+    "date_fk": {
+     "description": ""
+    },
+    "event_timestamp": {
+     "description": ""
+    },
+    "event_timestamp_iso8601": {
+     "description": ""
+    },
+    "grade": {
+     "description": ""
+    },
+    "max_grade": {
+     "description": ""
+    },
+    "openedx_user_id": {
+     "description": ""
+    },
+    "platform": {
+     "description": ""
+    },
+    "problem_block_id": {
+     "description": ""
+    },
+    "seed": {
+     "description": ""
+    },
+    "studentmodule_id": {
+     "description": ""
+    },
+    "studentmodulehistoryextended_id": {
+     "description": ""
+    },
+    "success": {
+     "description": ""
+    },
+    "time_fk": {
+     "description": ""
+    },
+    "user_fk": {
+     "description": ""
+    },
+    "user_username": {
+     "description": ""
+    }
+   },
+   "config": {
+    "materialized": "incremental"
+   },
+   "database": "ol_data_lake_production",
+   "depends_on": {
+    "macros": [],
+    "nodes": [
+     "model.open_learning.dim_user"
+    ]
+   },
+   "name": "tfact_studentmodule_problems",
+   "original_file_path": "models/dimensional/tfact_studentmodule_problems.sql",
+   "resource_type": "model",
+   "schema": "ol_warehouse_production_dimensional",
+   "unique_id": "model.open_learning.tfact_studentmodule_problems"
+  },
+  "model.open_learning.tfact_video_events": {
+   "columns": {
+    "courserun_readable_id": {
+     "description": ""
+    },
+    "date_fk": {
+     "description": ""
+    },
+    "ending_position": {
+     "description": ""
+    },
+    "event_json": {
+     "description": ""
+    },
+    "event_timestamp": {
+     "description": ""
+    },
+    "event_timestamp_iso8601": {
+     "description": ""
+    },
+    "event_type": {
+     "description": ""
+    },
+    "openedx_user_id": {
+     "description": ""
+    },
+    "platform": {
+     "description": ""
+    },
+    "platform_fk": {
+     "description": ""
+    },
+    "starting_position": {
+     "description": ""
+    },
+    "time_fk": {
+     "description": ""
+    },
+    "user_fk": {
+     "description": ""
+    },
+    "user_username": {
+     "description": ""
+    },
+    "video_block_fk": {
+     "description": ""
+    },
+    "video_duration": {
+     "description": ""
+    },
+    "video_position": {
+     "description": ""
+    }
+   },
+   "config": {
+    "materialized": "table"
+   },
+   "database": "ol_data_lake_production",
+   "depends_on": {
+    "macros": [],
+    "nodes": [
+     "model.open_learning.dim_user",
+     "model.open_learning.dim_platform"
+    ]
+   },
+   "name": "tfact_video_events",
+   "original_file_path": "models/dimensional/tfact_video_events.sql",
+   "resource_type": "model",
+   "schema": "ol_warehouse_production_dimensional",
+   "unique_id": "model.open_learning.tfact_video_events"
+  },
+  "test.open_learning.relationships_afact_feedback_conversation_feedback_source_fk__feedback_source_pk__ref_dim_feedback_source_.cf48ead2ec": {
+   "attached_node": "model.open_learning.afact_feedback_conversation",
+   "column_name": "feedback_source_fk",
+   "config": {
+    "materialized": "test"
+   },
+   "database": "ol_data_lake_production",
+   "depends_on": {
+    "macros": [],
+    "nodes": []
+   },
+   "name": "relationships_afact_feedback_conversation_feedback_source_fk__feedback_source_pk__ref_dim_feedback_source_",
+   "original_file_path": "models/dimensional/_feedback_facts.yml",
+   "resource_type": "test",
+   "schema": "ol_warehouse_production_dbt_test__audit",
+   "test_metadata": {
+    "kwargs": {
+     "column_name": "feedback_source_fk",
+     "field": "feedback_source_pk",
+     "model": "{{ get_where_subquery(ref('afact_feedback_conversation')) }}",
+     "to": "ref('dim_feedback_source')"
+    },
+    "name": "relationships"
+   },
+   "unique_id": "test.open_learning.relationships_afact_feedback_conversation_feedback_source_fk__feedback_source_pk__ref_dim_feedback_source_.cf48ead2ec"
+  },
+  "test.open_learning.relationships_afact_feedback_conversation_sentiment_fk__sentiment_pk__ref_dim_sentiment_.e4a83cc59d": {
+   "attached_node": "model.open_learning.afact_feedback_conversation",
+   "column_name": "sentiment_fk",
+   "config": {
+    "materialized": "test"
+   },
+   "database": "ol_data_lake_production",
+   "depends_on": {
+    "macros": [],
+    "nodes": []
+   },
+   "name": "relationships_afact_feedback_conversation_sentiment_fk__sentiment_pk__ref_dim_sentiment_",
+   "original_file_path": "models/dimensional/_feedback_facts.yml",
+   "resource_type": "test",
+   "schema": "ol_warehouse_production_dbt_test__audit",
+   "test_metadata": {
+    "kwargs": {
+     "column_name": "sentiment_fk",
+     "field": "sentiment_pk",
+     "model": "{{ get_where_subquery(ref('afact_feedback_conversation')) }}",
+     "to": "ref('dim_sentiment')"
+    },
+    "name": "relationships"
+   },
+   "unique_id": "test.open_learning.relationships_afact_feedback_conversation_sentiment_fk__sentiment_pk__ref_dim_sentiment_.e4a83cc59d"
+  },
+  "test.open_learning.relationships_bridge_course_department_course_fk__course_pk__ref_dim_course_.5939f8572b": {
+   "attached_node": "model.open_learning.bridge_course_department",
+   "column_name": "course_fk",
+   "config": {
+    "materialized": "test"
+   },
+   "database": "ol_data_lake_production",
+   "depends_on": {
+    "macros": [],
+    "nodes": []
+   },
+   "name": "relationships_bridge_course_department_course_fk__course_pk__ref_dim_course_",
+   "original_file_path": "models/dimensional/_bridge_tables.yml",
+   "resource_type": "test",
+   "schema": "ol_warehouse_production_dbt_test__audit",
+   "test_metadata": {
+    "kwargs": {
+     "column_name": "course_fk",
+     "field": "course_pk",
+     "model": "{{ get_where_subquery(ref('bridge_course_department')) }}",
+     "to": "ref('dim_course')"
+    },
+    "name": "relationships"
+   },
+   "unique_id": "test.open_learning.relationships_bridge_course_department_course_fk__course_pk__ref_dim_course_.5939f8572b"
+  },
+  "test.open_learning.relationships_bridge_course_department_department_fk__department_pk__ref_dim_department_.9c30cf8b68": {
+   "attached_node": "model.open_learning.bridge_course_department",
+   "column_name": "department_fk",
+   "config": {
+    "materialized": "test"
+   },
+   "database": "ol_data_lake_production",
+   "depends_on": {
+    "macros": [],
+    "nodes": []
+   },
+   "name": "relationships_bridge_course_department_department_fk__department_pk__ref_dim_department_",
+   "original_file_path": "models/dimensional/_bridge_tables.yml",
+   "resource_type": "test",
+   "schema": "ol_warehouse_production_dbt_test__audit",
+   "test_metadata": {
+    "kwargs": {
+     "column_name": "department_fk",
+     "field": "department_pk",
+     "model": "{{ get_where_subquery(ref('bridge_course_department')) }}",
+     "to": "ref('dim_department')"
+    },
+    "name": "relationships"
+   },
+   "unique_id": "test.open_learning.relationships_bridge_course_department_department_fk__department_pk__ref_dim_department_.9c30cf8b68"
+  },
+  "test.open_learning.relationships_bridge_course_instructor_course_fk__course_pk__ref_dim_course_.fb27b1e26a": {
+   "attached_node": "model.open_learning.bridge_course_instructor",
+   "column_name": "course_fk",
+   "config": {
+    "materialized": "test"
+   },
+   "database": "ol_data_lake_production",
+   "depends_on": {
+    "macros": [],
+    "nodes": []
+   },
+   "name": "relationships_bridge_course_instructor_course_fk__course_pk__ref_dim_course_",
+   "original_file_path": "models/dimensional/_bridge_tables.yml",
+   "resource_type": "test",
+   "schema": "ol_warehouse_production_dbt_test__audit",
+   "test_metadata": {
+    "kwargs": {
+     "column_name": "course_fk",
+     "field": "course_pk",
+     "model": "{{ get_where_subquery(ref('bridge_course_instructor')) }}",
+     "to": "ref('dim_course')"
+    },
+    "name": "relationships"
+   },
+   "unique_id": "test.open_learning.relationships_bridge_course_instructor_course_fk__course_pk__ref_dim_course_.fb27b1e26a"
+  },
+  "test.open_learning.relationships_bridge_course_instructor_instructor_fk__instructor_pk__ref_dim_instructor_.a760e7613d": {
+   "attached_node": "model.open_learning.bridge_course_instructor",
+   "column_name": "instructor_fk",
+   "config": {
+    "materialized": "test"
+   },
+   "database": "ol_data_lake_production",
+   "depends_on": {
+    "macros": [],
+    "nodes": []
+   },
+   "name": "relationships_bridge_course_instructor_instructor_fk__instructor_pk__ref_dim_instructor_",
+   "original_file_path": "models/dimensional/_bridge_tables.yml",
+   "resource_type": "test",
+   "schema": "ol_warehouse_production_dbt_test__audit",
+   "test_metadata": {
+    "kwargs": {
+     "column_name": "instructor_fk",
+     "field": "instructor_pk",
+     "model": "{{ get_where_subquery(ref('bridge_course_instructor')) }}",
+     "to": "ref('dim_instructor')"
+    },
+    "name": "relationships"
+   },
+   "unique_id": "test.open_learning.relationships_bridge_course_instructor_instructor_fk__instructor_pk__ref_dim_instructor_.a760e7613d"
+  },
+  "test.open_learning.relationships_bridge_course_topic_course_fk__course_pk__ref_dim_course_.0e8de2afd0": {
+   "attached_node": "model.open_learning.bridge_course_topic",
+   "column_name": "course_fk",
+   "config": {
+    "materialized": "test"
+   },
+   "database": "ol_data_lake_production",
+   "depends_on": {
+    "macros": [],
+    "nodes": []
+   },
+   "name": "relationships_bridge_course_topic_course_fk__course_pk__ref_dim_course_",
+   "original_file_path": "models/dimensional/_bridge_tables.yml",
+   "resource_type": "test",
+   "schema": "ol_warehouse_production_dbt_test__audit",
+   "test_metadata": {
+    "kwargs": {
+     "column_name": "course_fk",
+     "field": "course_pk",
+     "model": "{{ get_where_subquery(ref('bridge_course_topic')) }}",
+     "to": "ref('dim_course')"
+    },
+    "name": "relationships"
+   },
+   "unique_id": "test.open_learning.relationships_bridge_course_topic_course_fk__course_pk__ref_dim_course_.0e8de2afd0"
+  },
+  "test.open_learning.relationships_bridge_course_topic_topic_fk__topic_pk__ref_dim_topic_.a5166aeefc": {
+   "attached_node": "model.open_learning.bridge_course_topic",
+   "column_name": "topic_fk",
+   "config": {
+    "materialized": "test"
+   },
+   "database": "ol_data_lake_production",
+   "depends_on": {
+    "macros": [],
+    "nodes": []
+   },
+   "name": "relationships_bridge_course_topic_topic_fk__topic_pk__ref_dim_topic_",
+   "original_file_path": "models/dimensional/_bridge_tables.yml",
+   "resource_type": "test",
+   "schema": "ol_warehouse_production_dbt_test__audit",
+   "test_metadata": {
+    "kwargs": {
+     "column_name": "topic_fk",
+     "field": "topic_pk",
+     "model": "{{ get_where_subquery(ref('bridge_course_topic')) }}",
+     "to": "ref('dim_topic')"
+    },
+    "name": "relationships"
+   },
+   "unique_id": "test.open_learning.relationships_bridge_course_topic_topic_fk__topic_pk__ref_dim_topic_.a5166aeefc"
+  },
+  "test.open_learning.relationships_bridge_feedback_tag_feedback_pk__feedback_pk__ref_tfact_feedback_.5157661797": {
+   "attached_node": "model.open_learning.bridge_feedback_tag",
+   "column_name": "feedback_pk",
+   "config": {
+    "materialized": "test"
+   },
+   "database": "ol_data_lake_production",
+   "depends_on": {
+    "macros": [],
+    "nodes": []
+   },
+   "name": "relationships_bridge_feedback_tag_feedback_pk__feedback_pk__ref_tfact_feedback_",
+   "original_file_path": "models/dimensional/_feedback_bridge.yml",
+   "resource_type": "test",
+   "schema": "ol_warehouse_production_dbt_test__audit",
+   "test_metadata": {
+    "kwargs": {
+     "column_name": "feedback_pk",
+     "field": "feedback_pk",
+     "model": "{{ get_where_subquery(ref('bridge_feedback_tag')) }}",
+     "to": "ref('tfact_feedback')"
+    },
+    "name": "relationships"
+   },
+   "unique_id": "test.open_learning.relationships_bridge_feedback_tag_feedback_pk__feedback_pk__ref_tfact_feedback_.5157661797"
+  },
+  "test.open_learning.relationships_bridge_feedback_tag_feedback_tag_pk__feedback_tag_pk__ref_dim_feedback_tag_.16f3598534": {
+   "attached_node": "model.open_learning.bridge_feedback_tag",
+   "column_name": "feedback_tag_pk",
+   "config": {
+    "materialized": "test"
+   },
+   "database": "ol_data_lake_production",
+   "depends_on": {
+    "macros": [],
+    "nodes": []
+   },
+   "name": "relationships_bridge_feedback_tag_feedback_tag_pk__feedback_tag_pk__ref_dim_feedback_tag_",
+   "original_file_path": "models/dimensional/_feedback_bridge.yml",
+   "resource_type": "test",
+   "schema": "ol_warehouse_production_dbt_test__audit",
+   "test_metadata": {
+    "kwargs": {
+     "column_name": "feedback_tag_pk",
+     "field": "feedback_tag_pk",
+     "model": "{{ get_where_subquery(ref('bridge_feedback_tag')) }}",
+     "to": "ref('dim_feedback_tag')"
+    },
+    "name": "relationships"
+   },
+   "unique_id": "test.open_learning.relationships_bridge_feedback_tag_feedback_tag_pk__feedback_tag_pk__ref_dim_feedback_tag_.16f3598534"
+  },
+  "test.open_learning.relationships_bridge_organization_courserun_contract_fk__contract_pk__ref_dim_contract_.37a50fe178": {
+   "attached_node": "model.open_learning.bridge_organization_courserun",
+   "column_name": "contract_fk",
+   "config": {
+    "materialized": "test"
+   },
+   "database": "ol_data_lake_production",
+   "depends_on": {
+    "macros": [],
+    "nodes": []
+   },
+   "name": "relationships_bridge_organization_courserun_contract_fk__contract_pk__ref_dim_contract_",
+   "original_file_path": "models/dimensional/_dim_organization.yml",
+   "resource_type": "test",
+   "schema": "ol_warehouse_production_dbt_test__audit",
+   "test_metadata": {
+    "kwargs": {
+     "column_name": "contract_fk",
+     "field": "contract_pk",
+     "model": "{{ get_where_subquery(ref('bridge_organization_courserun')) }}",
+     "to": "ref('dim_contract')"
+    },
+    "name": "relationships"
+   },
+   "unique_id": "test.open_learning.relationships_bridge_organization_courserun_contract_fk__contract_pk__ref_dim_contract_.37a50fe178"
+  },
+  "test.open_learning.relationships_bridge_organization_courserun_courserun_fk__courserun_pk__ref_dim_course_run_.bcc6a85185": {
+   "attached_node": "model.open_learning.bridge_organization_courserun",
+   "column_name": "courserun_fk",
+   "config": {
+    "materialized": "test"
+   },
+   "database": "ol_data_lake_production",
+   "depends_on": {
+    "macros": [],
+    "nodes": []
+   },
+   "name": "relationships_bridge_organization_courserun_courserun_fk__courserun_pk__ref_dim_course_run_",
+   "original_file_path": "models/dimensional/_dim_organization.yml",
+   "resource_type": "test",
+   "schema": "ol_warehouse_production_dbt_test__audit",
+   "test_metadata": {
+    "kwargs": {
+     "column_name": "courserun_fk",
+     "field": "courserun_pk",
+     "model": "{{ get_where_subquery(ref('bridge_organization_courserun')) }}",
+     "to": "ref('dim_course_run')"
+    },
+    "name": "relationships"
+   },
+   "unique_id": "test.open_learning.relationships_bridge_organization_courserun_courserun_fk__courserun_pk__ref_dim_course_run_.bcc6a85185"
+  },
+  "test.open_learning.relationships_bridge_organization_courserun_organization_fk__organization_pk__ref_dim_organization_.b7eefb95c1": {
+   "attached_node": "model.open_learning.bridge_organization_courserun",
+   "column_name": "organization_fk",
+   "config": {
+    "materialized": "test"
+   },
+   "database": "ol_data_lake_production",
+   "depends_on": {
+    "macros": [],
+    "nodes": []
+   },
+   "name": "relationships_bridge_organization_courserun_organization_fk__organization_pk__ref_dim_organization_",
+   "original_file_path": "models/dimensional/_dim_organization.yml",
+   "resource_type": "test",
+   "schema": "ol_warehouse_production_dbt_test__audit",
+   "test_metadata": {
+    "kwargs": {
+     "column_name": "organization_fk",
+     "field": "organization_pk",
+     "model": "{{ get_where_subquery(ref('bridge_organization_courserun')) }}",
+     "to": "ref('dim_organization')"
+    },
+    "name": "relationships"
+   },
+   "unique_id": "test.open_learning.relationships_bridge_organization_courserun_organization_fk__organization_pk__ref_dim_organization_.b7eefb95c1"
+  },
+  "test.open_learning.relationships_bridge_program_course_course_fk__course_pk__ref_dim_course_.4c5011b69f": {
+   "attached_node": "model.open_learning.bridge_program_course",
+   "column_name": "course_fk",
+   "config": {
+    "materialized": "test"
+   },
+   "database": "ol_data_lake_production",
+   "depends_on": {
+    "macros": [],
+    "nodes": []
+   },
+   "name": "relationships_bridge_program_course_course_fk__course_pk__ref_dim_course_",
+   "original_file_path": "models/dimensional/_bridge_tables.yml",
+   "resource_type": "test",
+   "schema": "ol_warehouse_production_dbt_test__audit",
+   "test_metadata": {
+    "kwargs": {
+     "column_name": "course_fk",
+     "field": "course_pk",
+     "model": "{{ get_where_subquery(ref('bridge_program_course')) }}",
+     "to": "ref('dim_course')"
+    },
+    "name": "relationships"
+   },
+   "unique_id": "test.open_learning.relationships_bridge_program_course_course_fk__course_pk__ref_dim_course_.4c5011b69f"
+  },
+  "test.open_learning.relationships_bridge_program_course_program_fk__program_pk__ref_dim_program_.7abedd51f0": {
+   "attached_node": "model.open_learning.bridge_program_course",
+   "column_name": "program_fk",
+   "config": {
+    "materialized": "test"
+   },
+   "database": "ol_data_lake_production",
+   "depends_on": {
+    "macros": [],
+    "nodes": []
+   },
+   "name": "relationships_bridge_program_course_program_fk__program_pk__ref_dim_program_",
+   "original_file_path": "models/dimensional/_bridge_tables.yml",
+   "resource_type": "test",
+   "schema": "ol_warehouse_production_dbt_test__audit",
+   "test_metadata": {
+    "kwargs": {
+     "column_name": "program_fk",
+     "field": "program_pk",
+     "model": "{{ get_where_subquery(ref('bridge_program_course')) }}",
+     "to": "ref('dim_program')"
+    },
+    "name": "relationships"
+   },
+   "unique_id": "test.open_learning.relationships_bridge_program_course_program_fk__program_pk__ref_dim_program_.7abedd51f0"
+  },
+  "test.open_learning.relationships_bridge_user_courserun_role_courserun_fk__courserun_pk__ref_dim_course_run_.9e58c2e6dc": {
+   "attached_node": "model.open_learning.bridge_user_courserun_role",
+   "column_name": "courserun_fk",
+   "config": {
+    "materialized": "test"
+   },
+   "database": "ol_data_lake_production",
+   "depends_on": {
+    "macros": [],
+    "nodes": []
+   },
+   "name": "relationships_bridge_user_courserun_role_courserun_fk__courserun_pk__ref_dim_course_run_",
+   "original_file_path": "models/dimensional/_bridge_tables.yml",
+   "resource_type": "test",
+   "schema": "ol_warehouse_production_dbt_test__audit",
+   "test_metadata": {
+    "kwargs": {
+     "column_name": "courserun_fk",
+     "field": "courserun_pk",
+     "model": "{{ get_where_subquery(ref('bridge_user_courserun_role')) }}",
+     "to": "ref('dim_course_run')"
+    },
+    "name": "relationships"
+   },
+   "unique_id": "test.open_learning.relationships_bridge_user_courserun_role_courserun_fk__courserun_pk__ref_dim_course_run_.9e58c2e6dc"
+  },
+  "test.open_learning.relationships_bridge_user_courserun_role_user_fk__user_pk__ref_dim_user_.d09080058c": {
+   "attached_node": "model.open_learning.bridge_user_courserun_role",
+   "column_name": "user_fk",
+   "config": {
+    "materialized": "test"
+   },
+   "database": "ol_data_lake_production",
+   "depends_on": {
+    "macros": [],
+    "nodes": []
+   },
+   "name": "relationships_bridge_user_courserun_role_user_fk__user_pk__ref_dim_user_",
+   "original_file_path": "models/dimensional/_bridge_tables.yml",
+   "resource_type": "test",
+   "schema": "ol_warehouse_production_dbt_test__audit",
+   "test_metadata": {
+    "kwargs": {
+     "column_name": "user_fk",
+     "field": "user_pk",
+     "model": "{{ get_where_subquery(ref('bridge_user_courserun_role')) }}",
+     "to": "ref('dim_user')"
+    },
+    "name": "relationships"
+   },
+   "unique_id": "test.open_learning.relationships_bridge_user_courserun_role_user_fk__user_pk__ref_dim_user_.d09080058c"
+  },
+  "test.open_learning.relationships_bridge_user_organization_organization_fk__organization_pk__ref_dim_organization_.2cb52cf87b": {
+   "attached_node": "model.open_learning.bridge_user_organization",
+   "column_name": "organization_fk",
+   "config": {
+    "materialized": "test"
+   },
+   "database": "ol_data_lake_production",
+   "depends_on": {
+    "macros": [],
+    "nodes": []
+   },
+   "name": "relationships_bridge_user_organization_organization_fk__organization_pk__ref_dim_organization_",
+   "original_file_path": "models/dimensional/_bridge_tables.yml",
+   "resource_type": "test",
+   "schema": "ol_warehouse_production_dbt_test__audit",
+   "test_metadata": {
+    "kwargs": {
+     "column_name": "organization_fk",
+     "field": "organization_pk",
+     "model": "{{ get_where_subquery(ref('bridge_user_organization')) }}",
+     "to": "ref('dim_organization')"
+    },
+    "name": "relationships"
+   },
+   "unique_id": "test.open_learning.relationships_bridge_user_organization_organization_fk__organization_pk__ref_dim_organization_.2cb52cf87b"
+  },
+  "test.open_learning.relationships_bridge_user_organization_user_fk__user_pk__ref_dim_user_.bef8b230f5": {
+   "attached_node": "model.open_learning.bridge_user_organization",
+   "column_name": "user_fk",
+   "config": {
+    "materialized": "test"
+   },
+   "database": "ol_data_lake_production",
+   "depends_on": {
+    "macros": [],
+    "nodes": []
+   },
+   "name": "relationships_bridge_user_organization_user_fk__user_pk__ref_dim_user_",
+   "original_file_path": "models/dimensional/_bridge_tables.yml",
+   "resource_type": "test",
+   "schema": "ol_warehouse_production_dbt_test__audit",
+   "test_metadata": {
+    "kwargs": {
+     "column_name": "user_fk",
+     "field": "user_pk",
+     "model": "{{ get_where_subquery(ref('bridge_user_organization')) }}",
+     "to": "ref('dim_user')"
+    },
+    "name": "relationships"
+   },
+   "unique_id": "test.open_learning.relationships_bridge_user_organization_user_fk__user_pk__ref_dim_user_.bef8b230f5"
+  },
+  "test.open_learning.relationships_dim_contract_organization_fk__organization_pk__ref_dim_organization_.db862a5d14": {
+   "attached_node": "model.open_learning.dim_contract",
+   "column_name": "organization_fk",
+   "config": {
+    "materialized": "test"
+   },
+   "database": "ol_data_lake_production",
+   "depends_on": {
+    "macros": [],
+    "nodes": []
+   },
+   "name": "relationships_dim_contract_organization_fk__organization_pk__ref_dim_organization_",
+   "original_file_path": "models/dimensional/_dim_contract.yml",
+   "resource_type": "test",
+   "schema": "ol_warehouse_production_dbt_test__audit",
+   "test_metadata": {
+    "kwargs": {
+     "column_name": "organization_fk",
+     "field": "organization_pk",
+     "model": "{{ get_where_subquery(ref('dim_contract')) }}",
+     "to": "ref('dim_organization')"
+    },
+    "name": "relationships"
+   },
+   "unique_id": "test.open_learning.relationships_dim_contract_organization_fk__organization_pk__ref_dim_organization_.db862a5d14"
+  },
+  "test.open_learning.relationships_dim_course_run_course_fk__course_pk__ref_dim_course_.170b8ba846": {
+   "attached_node": "model.open_learning.dim_course_run",
+   "column_name": "course_fk",
+   "config": {
+    "materialized": "test"
+   },
+   "database": "ol_data_lake_production",
+   "depends_on": {
+    "macros": [],
+    "nodes": []
+   },
+   "name": "relationships_dim_course_run_course_fk__course_pk__ref_dim_course_",
+   "original_file_path": "models/dimensional/_dim_course_run.yml",
+   "resource_type": "test",
+   "schema": "ol_warehouse_production_dbt_test__audit",
+   "test_metadata": {
+    "kwargs": {
+     "column_name": "course_fk",
+     "field": "course_pk",
+     "model": "{{ get_where_subquery(ref('dim_course_run')) }}",
+     "to": "ref('dim_course')"
+    },
+    "name": "relationships"
+   },
+   "unique_id": "test.open_learning.relationships_dim_course_run_course_fk__course_pk__ref_dim_course_.170b8ba846"
+  },
+  "test.open_learning.relationships_dim_course_run_courserun_end_date_key__date_key__ref_dim_date_.28b0c89ff5": {
+   "attached_node": "model.open_learning.dim_course_run",
+   "column_name": "courserun_end_date_key",
+   "config": {
+    "materialized": "test"
+   },
+   "database": "ol_data_lake_production",
+   "depends_on": {
+    "macros": [],
+    "nodes": []
+   },
+   "name": "relationships_dim_course_run_courserun_end_date_key__date_key__ref_dim_date_",
+   "original_file_path": "models/dimensional/_dim_course_run.yml",
+   "resource_type": "test",
+   "schema": "ol_warehouse_production_dbt_test__audit",
+   "test_metadata": {
+    "kwargs": {
+     "column_name": "courserun_end_date_key",
+     "field": "date_key",
+     "model": "{{ get_where_subquery(ref('dim_course_run')) }}",
+     "to": "ref('dim_date')"
+    },
+    "name": "relationships"
+   },
+   "unique_id": "test.open_learning.relationships_dim_course_run_courserun_end_date_key__date_key__ref_dim_date_.28b0c89ff5"
+  },
+  "test.open_learning.relationships_dim_course_run_courserun_start_date_key__date_key__ref_dim_date_.303d53be0d": {
+   "attached_node": "model.open_learning.dim_course_run",
+   "column_name": "courserun_start_date_key",
+   "config": {
+    "materialized": "test"
+   },
+   "database": "ol_data_lake_production",
+   "depends_on": {
+    "macros": [],
+    "nodes": []
+   },
+   "name": "relationships_dim_course_run_courserun_start_date_key__date_key__ref_dim_date_",
+   "original_file_path": "models/dimensional/_dim_course_run.yml",
+   "resource_type": "test",
+   "schema": "ol_warehouse_production_dbt_test__audit",
+   "test_metadata": {
+    "kwargs": {
+     "column_name": "courserun_start_date_key",
+     "field": "date_key",
+     "model": "{{ get_where_subquery(ref('dim_course_run')) }}",
+     "to": "ref('dim_date')"
+    },
+    "name": "relationships"
+   },
+   "unique_id": "test.open_learning.relationships_dim_course_run_courserun_start_date_key__date_key__ref_dim_date_.303d53be0d"
+  },
+  "test.open_learning.relationships_dim_feedback_tag_source_slug__source_slug__ref_dim_feedback_source_.f8b7491bc4": {
+   "attached_node": "model.open_learning.dim_feedback_tag",
+   "column_name": "source_slug",
+   "config": {
+    "materialized": "test"
+   },
+   "database": "ol_data_lake_production",
+   "depends_on": {
+    "macros": [],
+    "nodes": []
+   },
+   "name": "relationships_dim_feedback_tag_source_slug__source_slug__ref_dim_feedback_source_",
+   "original_file_path": "models/dimensional/_feedback_dimensions.yml",
+   "resource_type": "test",
+   "schema": "ol_warehouse_production_dbt_test__audit",
+   "test_metadata": {
+    "kwargs": {
+     "column_name": "source_slug",
+     "field": "source_slug",
+     "model": "{{ get_where_subquery(ref('dim_feedback_tag')) }}",
+     "to": "ref('dim_feedback_source')"
+    },
+    "name": "relationships"
+   },
+   "unique_id": "test.open_learning.relationships_dim_feedback_tag_source_slug__source_slug__ref_dim_feedback_source_.f8b7491bc4"
+  },
+  "test.open_learning.relationships_dim_product_courserun_fk__courserun_pk__ref_dim_course_run_.db60315c2f": {
+   "attached_node": "model.open_learning.dim_product",
+   "column_name": "courserun_fk",
+   "config": {
+    "materialized": "test"
+   },
+   "database": "ol_data_lake_production",
+   "depends_on": {
+    "macros": [],
+    "nodes": []
+   },
+   "name": "relationships_dim_product_courserun_fk__courserun_pk__ref_dim_course_run_",
+   "original_file_path": "models/dimensional/_dim_product.yml",
+   "resource_type": "test",
+   "schema": "ol_warehouse_production_dbt_test__audit",
+   "test_metadata": {
+    "kwargs": {
+     "column_name": "courserun_fk",
+     "field": "courserun_pk",
+     "model": "{{ get_where_subquery(ref('dim_product')) }}",
+     "to": "ref('dim_course_run')"
+    },
+    "name": "relationships"
+   },
+   "unique_id": "test.open_learning.relationships_dim_product_courserun_fk__courserun_pk__ref_dim_course_run_.db60315c2f"
+  },
+  "test.open_learning.relationships_dim_product_created_date_key__date_key__ref_dim_date_.aa48fec436": {
+   "attached_node": "model.open_learning.dim_product",
+   "column_name": "created_date_key",
+   "config": {
+    "materialized": "test"
+   },
+   "database": "ol_data_lake_production",
+   "depends_on": {
+    "macros": [],
+    "nodes": []
+   },
+   "name": "relationships_dim_product_created_date_key__date_key__ref_dim_date_",
+   "original_file_path": "models/dimensional/_dim_product.yml",
+   "resource_type": "test",
+   "schema": "ol_warehouse_production_dbt_test__audit",
+   "test_metadata": {
+    "kwargs": {
+     "column_name": "created_date_key",
+     "field": "date_key",
+     "model": "{{ get_where_subquery(ref('dim_product')) }}",
+     "to": "ref('dim_date')"
+    },
+    "name": "relationships"
+   },
+   "unique_id": "test.open_learning.relationships_dim_product_created_date_key__date_key__ref_dim_date_.aa48fec436"
+  },
+  "test.open_learning.relationships_dim_product_program_fk__program_pk__ref_dim_program_.edb044018f": {
+   "attached_node": "model.open_learning.dim_product",
+   "column_name": "program_fk",
+   "config": {
+    "materialized": "test"
+   },
+   "database": "ol_data_lake_production",
+   "depends_on": {
+    "macros": [],
+    "nodes": []
+   },
+   "name": "relationships_dim_product_program_fk__program_pk__ref_dim_program_",
+   "original_file_path": "models/dimensional/_dim_product.yml",
+   "resource_type": "test",
+   "schema": "ol_warehouse_production_dbt_test__audit",
+   "test_metadata": {
+    "kwargs": {
+     "column_name": "program_fk",
+     "field": "program_pk",
+     "model": "{{ get_where_subquery(ref('dim_product')) }}",
+     "to": "ref('dim_program')"
+    },
+    "name": "relationships"
+   },
+   "unique_id": "test.open_learning.relationships_dim_product_program_fk__program_pk__ref_dim_program_.edb044018f"
+  },
+  "test.open_learning.relationships_dim_program_published_date_key__date_key__ref_dim_date_.df193ceccc": {
+   "attached_node": "model.open_learning.dim_program",
+   "column_name": "published_date_key",
+   "config": {
+    "materialized": "test"
+   },
+   "database": "ol_data_lake_production",
+   "depends_on": {
+    "macros": [],
+    "nodes": []
+   },
+   "name": "relationships_dim_program_published_date_key__date_key__ref_dim_date_",
+   "original_file_path": "models/dimensional/_dim_program.yml",
+   "resource_type": "test",
+   "schema": "ol_warehouse_production_dbt_test__audit",
+   "test_metadata": {
+    "kwargs": {
+     "column_name": "published_date_key",
+     "field": "date_key",
+     "model": "{{ get_where_subquery(ref('dim_program')) }}",
+     "to": "ref('dim_date')"
+    },
+    "name": "relationships"
+   },
+   "unique_id": "test.open_learning.relationships_dim_program_published_date_key__date_key__ref_dim_date_.df193ceccc"
+  },
+  "test.open_learning.relationships_tfact_certificate_certificate_issued_date_key__date_key__ref_dim_date_.52f87d9ce7": {
+   "attached_node": "model.open_learning.tfact_certificate",
+   "column_name": "certificate_issued_date_key",
+   "config": {
+    "materialized": "test"
+   },
+   "database": "ol_data_lake_production",
+   "depends_on": {
+    "macros": [],
+    "nodes": []
+   },
+   "name": "relationships_tfact_certificate_certificate_issued_date_key__date_key__ref_dim_date_",
+   "original_file_path": "models/dimensional/_fact_tables.yml",
+   "resource_type": "test",
+   "schema": "ol_warehouse_production_dbt_test__audit",
+   "test_metadata": {
+    "kwargs": {
+     "column_name": "certificate_issued_date_key",
+     "field": "date_key",
+     "model": "{{ get_where_subquery(ref('tfact_certificate')) }}",
+     "to": "ref('dim_date')"
+    },
+    "name": "relationships"
+   },
+   "unique_id": "test.open_learning.relationships_tfact_certificate_certificate_issued_date_key__date_key__ref_dim_date_.52f87d9ce7"
+  },
+  "test.open_learning.relationships_tfact_certificate_certificate_type_fk__certificate_type_pk__ref_dim_certificate_type_.4e8ad043cc": {
+   "attached_node": "model.open_learning.tfact_certificate",
+   "column_name": "certificate_type_fk",
+   "config": {
+    "materialized": "test"
+   },
+   "database": "ol_data_lake_production",
+   "depends_on": {
+    "macros": [],
+    "nodes": []
+   },
+   "name": "relationships_tfact_certificate_certificate_type_fk__certificate_type_pk__ref_dim_certificate_type_",
+   "original_file_path": "models/dimensional/_fact_tables.yml",
+   "resource_type": "test",
+   "schema": "ol_warehouse_production_dbt_test__audit",
+   "test_metadata": {
+    "kwargs": {
+     "column_name": "certificate_type_fk",
+     "field": "certificate_type_pk",
+     "model": "{{ get_where_subquery(ref('tfact_certificate')) }}",
+     "to": "ref('dim_certificate_type')"
+    },
+    "name": "relationships"
+   },
+   "unique_id": "test.open_learning.relationships_tfact_certificate_certificate_type_fk__certificate_type_pk__ref_dim_certificate_type_.4e8ad043cc"
+  },
+  "test.open_learning.relationships_tfact_certificate_courserun_fk__courserun_pk__ref_dim_course_run_.929c56062f": {
+   "attached_node": "model.open_learning.tfact_certificate",
+   "column_name": "courserun_fk",
+   "config": {
+    "materialized": "test"
+   },
+   "database": "ol_data_lake_production",
+   "depends_on": {
+    "macros": [],
+    "nodes": []
+   },
+   "name": "relationships_tfact_certificate_courserun_fk__courserun_pk__ref_dim_course_run_",
+   "original_file_path": "models/dimensional/_fact_tables.yml",
+   "resource_type": "test",
+   "schema": "ol_warehouse_production_dbt_test__audit",
+   "test_metadata": {
+    "kwargs": {
+     "column_name": "courserun_fk",
+     "field": "courserun_pk",
+     "model": "{{ get_where_subquery(ref('tfact_certificate')) }}",
+     "to": "ref('dim_course_run')"
+    },
+    "name": "relationships"
+   },
+   "unique_id": "test.open_learning.relationships_tfact_certificate_courserun_fk__courserun_pk__ref_dim_course_run_.929c56062f"
+  },
+  "test.open_learning.relationships_tfact_certificate_platform_fk__platform_pk__ref_dim_platform_.4778b9058f": {
+   "attached_node": "model.open_learning.tfact_certificate",
+   "column_name": "platform_fk",
+   "config": {
+    "materialized": "test"
+   },
+   "database": "ol_data_lake_production",
+   "depends_on": {
+    "macros": [],
+    "nodes": []
+   },
+   "name": "relationships_tfact_certificate_platform_fk__platform_pk__ref_dim_platform_",
+   "original_file_path": "models/dimensional/_fact_tables.yml",
+   "resource_type": "test",
+   "schema": "ol_warehouse_production_dbt_test__audit",
+   "test_metadata": {
+    "kwargs": {
+     "column_name": "platform_fk",
+     "field": "platform_pk",
+     "model": "{{ get_where_subquery(ref('tfact_certificate')) }}",
+     "to": "ref('dim_platform')"
+    },
+    "name": "relationships"
+   },
+   "unique_id": "test.open_learning.relationships_tfact_certificate_platform_fk__platform_pk__ref_dim_platform_.4778b9058f"
+  },
+  "test.open_learning.relationships_tfact_certificate_program_fk__program_pk__ref_dim_program_.94c4128ffc": {
+   "attached_node": "model.open_learning.tfact_certificate",
+   "column_name": "program_fk",
+   "config": {
+    "materialized": "test"
+   },
+   "database": "ol_data_lake_production",
+   "depends_on": {
+    "macros": [],
+    "nodes": []
+   },
+   "name": "relationships_tfact_certificate_program_fk__program_pk__ref_dim_program_",
+   "original_file_path": "models/dimensional/_fact_tables.yml",
+   "resource_type": "test",
+   "schema": "ol_warehouse_production_dbt_test__audit",
+   "test_metadata": {
+    "kwargs": {
+     "column_name": "program_fk",
+     "field": "program_pk",
+     "model": "{{ get_where_subquery(ref('tfact_certificate')) }}",
+     "to": "ref('dim_program')"
+    },
+    "name": "relationships"
+   },
+   "unique_id": "test.open_learning.relationships_tfact_certificate_program_fk__program_pk__ref_dim_program_.94c4128ffc"
+  },
+  "test.open_learning.relationships_tfact_certificate_user_fk__user_pk__ref_dim_user_.a004b8dc56": {
+   "attached_node": "model.open_learning.tfact_certificate",
+   "column_name": "user_fk",
+   "config": {
+    "materialized": "test"
+   },
+   "database": "ol_data_lake_production",
+   "depends_on": {
+    "macros": [],
+    "nodes": []
+   },
+   "name": "relationships_tfact_certificate_user_fk__user_pk__ref_dim_user_",
+   "original_file_path": "models/dimensional/_fact_tables.yml",
+   "resource_type": "test",
+   "schema": "ol_warehouse_production_dbt_test__audit",
+   "test_metadata": {
+    "kwargs": {
+     "column_name": "user_fk",
+     "field": "user_pk",
+     "model": "{{ get_where_subquery(ref('tfact_certificate')) }}",
+     "to": "ref('dim_user')"
+    },
+    "name": "relationships"
+   },
+   "unique_id": "test.open_learning.relationships_tfact_certificate_user_fk__user_pk__ref_dim_user_.a004b8dc56"
+  },
+  "test.open_learning.relationships_tfact_enrollment_courserun_fk__courserun_pk__ref_dim_course_run_.c52010472a": {
+   "attached_node": "model.open_learning.tfact_enrollment",
+   "column_name": "courserun_fk",
+   "config": {
+    "materialized": "test"
+   },
+   "database": "ol_data_lake_production",
+   "depends_on": {
+    "macros": [],
+    "nodes": []
+   },
+   "name": "relationships_tfact_enrollment_courserun_fk__courserun_pk__ref_dim_course_run_",
+   "original_file_path": "models/dimensional/_fact_tables.yml",
+   "resource_type": "test",
+   "schema": "ol_warehouse_production_dbt_test__audit",
+   "test_metadata": {
+    "kwargs": {
+     "column_name": "courserun_fk",
+     "field": "courserun_pk",
+     "model": "{{ get_where_subquery(ref('tfact_enrollment')) }}",
+     "to": "ref('dim_course_run')"
+    },
+    "name": "relationships"
+   },
+   "unique_id": "test.open_learning.relationships_tfact_enrollment_courserun_fk__courserun_pk__ref_dim_course_run_.c52010472a"
+  },
+  "test.open_learning.relationships_tfact_enrollment_enrollment_date_key__date_key__ref_dim_date_.ca6457c182": {
+   "attached_node": "model.open_learning.tfact_enrollment",
+   "column_name": "enrollment_date_key",
+   "config": {
+    "materialized": "test"
+   },
+   "database": "ol_data_lake_production",
+   "depends_on": {
+    "macros": [],
+    "nodes": []
+   },
+   "name": "relationships_tfact_enrollment_enrollment_date_key__date_key__ref_dim_date_",
+   "original_file_path": "models/dimensional/_fact_tables.yml",
+   "resource_type": "test",
+   "schema": "ol_warehouse_production_dbt_test__audit",
+   "test_metadata": {
+    "kwargs": {
+     "column_name": "enrollment_date_key",
+     "field": "date_key",
+     "model": "{{ get_where_subquery(ref('tfact_enrollment')) }}",
+     "to": "ref('dim_date')"
+    },
+    "name": "relationships"
+   },
+   "unique_id": "test.open_learning.relationships_tfact_enrollment_enrollment_date_key__date_key__ref_dim_date_.ca6457c182"
+  },
+  "test.open_learning.relationships_tfact_enrollment_order_discount_fk__discount_pk__ref_dim_discount_.095aba9244": {
+   "attached_node": "model.open_learning.tfact_enrollment_order",
+   "column_name": "discount_fk",
+   "config": {
+    "materialized": "test"
+   },
+   "database": "ol_data_lake_production",
+   "depends_on": {
+    "macros": [],
+    "nodes": []
+   },
+   "name": "relationships_tfact_enrollment_order_discount_fk__discount_pk__ref_dim_discount_",
+   "original_file_path": "models/dimensional/_fact_tables.yml",
+   "resource_type": "test",
+   "schema": "ol_warehouse_production_dbt_test__audit",
+   "test_metadata": {
+    "kwargs": {
+     "column_name": "discount_fk",
+     "field": "discount_pk",
+     "model": "{{ get_where_subquery(ref('tfact_enrollment_order')) }}",
+     "to": "ref('dim_discount')"
+    },
+    "name": "relationships"
+   },
+   "unique_id": "test.open_learning.relationships_tfact_enrollment_order_discount_fk__discount_pk__ref_dim_discount_.095aba9244"
+  },
+  "test.open_learning.relationships_tfact_enrollment_order_discount_type_fk__discount_type_pk__ref_dim_discount_type_.d20a7f48c6": {
+   "attached_node": "model.open_learning.tfact_enrollment_order",
+   "column_name": "discount_type_fk",
+   "config": {
+    "materialized": "test"
+   },
+   "database": "ol_data_lake_production",
+   "depends_on": {
+    "macros": [],
+    "nodes": []
+   },
+   "name": "relationships_tfact_enrollment_order_discount_type_fk__discount_type_pk__ref_dim_discount_type_",
+   "original_file_path": "models/dimensional/_fact_tables.yml",
+   "resource_type": "test",
+   "schema": "ol_warehouse_production_dbt_test__audit",
+   "test_metadata": {
+    "kwargs": {
+     "column_name": "discount_type_fk",
+     "field": "discount_type_pk",
+     "model": "{{ get_where_subquery(ref('tfact_enrollment_order')) }}",
+     "to": "ref('dim_discount_type')"
+    },
+    "name": "relationships"
+   },
+   "unique_id": "test.open_learning.relationships_tfact_enrollment_order_discount_type_fk__discount_type_pk__ref_dim_discount_type_.d20a7f48c6"
+  },
+  "test.open_learning.relationships_tfact_enrollment_order_enrollment_key__enrollment_key__ref_tfact_enrollment_.904c575173": {
+   "attached_node": "model.open_learning.tfact_enrollment_order",
+   "column_name": "enrollment_key",
+   "config": {
+    "materialized": "test"
+   },
+   "database": "ol_data_lake_production",
+   "depends_on": {
+    "macros": [],
+    "nodes": []
+   },
+   "name": "relationships_tfact_enrollment_order_enrollment_key__enrollment_key__ref_tfact_enrollment_",
+   "original_file_path": "models/dimensional/_fact_tables.yml",
+   "resource_type": "test",
+   "schema": "ol_warehouse_production_dbt_test__audit",
+   "test_metadata": {
+    "kwargs": {
+     "column_name": "enrollment_key",
+     "field": "enrollment_key",
+     "model": "{{ get_where_subquery(ref('tfact_enrollment_order')) }}",
+     "to": "ref('tfact_enrollment')"
+    },
+    "name": "relationships"
+   },
+   "unique_id": "test.open_learning.relationships_tfact_enrollment_order_enrollment_key__enrollment_key__ref_tfact_enrollment_.904c575173"
+  },
+  "test.open_learning.relationships_tfact_enrollment_order_order_fk__order_key__ref_tfact_order_.eb964b4fb5": {
+   "attached_node": "model.open_learning.tfact_enrollment_order",
+   "column_name": "order_fk",
+   "config": {
+    "materialized": "test"
+   },
+   "database": "ol_data_lake_production",
+   "depends_on": {
+    "macros": [],
+    "nodes": []
+   },
+   "name": "relationships_tfact_enrollment_order_order_fk__order_key__ref_tfact_order_",
+   "original_file_path": "models/dimensional/_fact_tables.yml",
+   "resource_type": "test",
+   "schema": "ol_warehouse_production_dbt_test__audit",
+   "test_metadata": {
+    "kwargs": {
+     "column_name": "order_fk",
+     "field": "order_key",
+     "model": "{{ get_where_subquery(ref('tfact_enrollment_order')) }}",
+     "to": "ref('tfact_order')"
+    },
+    "name": "relationships"
+   },
+   "unique_id": "test.open_learning.relationships_tfact_enrollment_order_order_fk__order_key__ref_tfact_order_.eb964b4fb5"
+  },
+  "test.open_learning.relationships_tfact_enrollment_platform_fk__platform_pk__ref_dim_platform_.b5921b339b": {
+   "attached_node": "model.open_learning.tfact_enrollment",
+   "column_name": "platform_fk",
+   "config": {
+    "materialized": "test"
+   },
+   "database": "ol_data_lake_production",
+   "depends_on": {
+    "macros": [],
+    "nodes": []
+   },
+   "name": "relationships_tfact_enrollment_platform_fk__platform_pk__ref_dim_platform_",
+   "original_file_path": "models/dimensional/_fact_tables.yml",
+   "resource_type": "test",
+   "schema": "ol_warehouse_production_dbt_test__audit",
+   "test_metadata": {
+    "kwargs": {
+     "column_name": "platform_fk",
+     "field": "platform_pk",
+     "model": "{{ get_where_subquery(ref('tfact_enrollment')) }}",
+     "to": "ref('dim_platform')"
+    },
+    "name": "relationships"
+   },
+   "unique_id": "test.open_learning.relationships_tfact_enrollment_platform_fk__platform_pk__ref_dim_platform_.b5921b339b"
+  },
+  "test.open_learning.relationships_tfact_enrollment_program_fk__program_pk__ref_dim_program_.72c9ec309b": {
+   "attached_node": "model.open_learning.tfact_enrollment",
+   "column_name": "program_fk",
+   "config": {
+    "materialized": "test"
+   },
+   "database": "ol_data_lake_production",
+   "depends_on": {
+    "macros": [],
+    "nodes": []
+   },
+   "name": "relationships_tfact_enrollment_program_fk__program_pk__ref_dim_program_",
+   "original_file_path": "models/dimensional/_fact_tables.yml",
+   "resource_type": "test",
+   "schema": "ol_warehouse_production_dbt_test__audit",
+   "test_metadata": {
+    "kwargs": {
+     "column_name": "program_fk",
+     "field": "program_pk",
+     "model": "{{ get_where_subquery(ref('tfact_enrollment')) }}",
+     "to": "ref('dim_program')"
+    },
+    "name": "relationships"
+   },
+   "unique_id": "test.open_learning.relationships_tfact_enrollment_program_fk__program_pk__ref_dim_program_.72c9ec309b"
+  },
+  "test.open_learning.relationships_tfact_enrollment_user_fk__user_pk__ref_dim_user_.f8b363749b": {
+   "attached_node": "model.open_learning.tfact_enrollment",
+   "column_name": "user_fk",
+   "config": {
+    "materialized": "test"
+   },
+   "database": "ol_data_lake_production",
+   "depends_on": {
+    "macros": [],
+    "nodes": []
+   },
+   "name": "relationships_tfact_enrollment_user_fk__user_pk__ref_dim_user_",
+   "original_file_path": "models/dimensional/_fact_tables.yml",
+   "resource_type": "test",
+   "schema": "ol_warehouse_production_dbt_test__audit",
+   "test_metadata": {
+    "kwargs": {
+     "column_name": "user_fk",
+     "field": "user_pk",
+     "model": "{{ get_where_subquery(ref('tfact_enrollment')) }}",
+     "to": "ref('dim_user')"
+    },
+    "name": "relationships"
+   },
+   "unique_id": "test.open_learning.relationships_tfact_enrollment_user_fk__user_pk__ref_dim_user_.f8b363749b"
+  },
+  "test.open_learning.relationships_tfact_feedback_feedback_channel_fk__feedback_channel_pk__ref_dim_feedback_channel_.c57c406a59": {
+   "attached_node": "model.open_learning.tfact_feedback",
+   "column_name": "feedback_channel_fk",
+   "config": {
+    "materialized": "test"
+   },
+   "database": "ol_data_lake_production",
+   "depends_on": {
+    "macros": [],
+    "nodes": []
+   },
+   "name": "relationships_tfact_feedback_feedback_channel_fk__feedback_channel_pk__ref_dim_feedback_channel_",
+   "original_file_path": "models/dimensional/_feedback_facts.yml",
+   "resource_type": "test",
+   "schema": "ol_warehouse_production_dbt_test__audit",
+   "test_metadata": {
+    "kwargs": {
+     "column_name": "feedback_channel_fk",
+     "field": "feedback_channel_pk",
+     "model": "{{ get_where_subquery(ref('tfact_feedback')) }}",
+     "to": "ref('dim_feedback_channel')"
+    },
+    "name": "relationships"
+   },
+   "unique_id": "test.open_learning.relationships_tfact_feedback_feedback_channel_fk__feedback_channel_pk__ref_dim_feedback_channel_.c57c406a59"
+  },
+  "test.open_learning.relationships_tfact_feedback_feedback_source_fk__feedback_source_pk__ref_dim_feedback_source_.ebdd014b97": {
+   "attached_node": "model.open_learning.tfact_feedback",
+   "column_name": "feedback_source_fk",
+   "config": {
+    "materialized": "test"
+   },
+   "database": "ol_data_lake_production",
+   "depends_on": {
+    "macros": [],
+    "nodes": []
+   },
+   "name": "relationships_tfact_feedback_feedback_source_fk__feedback_source_pk__ref_dim_feedback_source_",
+   "original_file_path": "models/dimensional/_feedback_facts.yml",
+   "resource_type": "test",
+   "schema": "ol_warehouse_production_dbt_test__audit",
+   "test_metadata": {
+    "kwargs": {
+     "column_name": "feedback_source_fk",
+     "field": "feedback_source_pk",
+     "model": "{{ get_where_subquery(ref('tfact_feedback')) }}",
+     "to": "ref('dim_feedback_source')"
+    },
+    "name": "relationships"
+   },
+   "unique_id": "test.open_learning.relationships_tfact_feedback_feedback_source_fk__feedback_source_pk__ref_dim_feedback_source_.ebdd014b97"
+  },
+  "test.open_learning.relationships_tfact_feedback_user_fk__user_pk__ref_dim_user_.ccf6bef76b": {
+   "attached_node": "model.open_learning.tfact_feedback",
+   "column_name": "user_fk",
+   "config": {
+    "materialized": "test"
+   },
+   "database": "ol_data_lake_production",
+   "depends_on": {
+    "macros": [],
+    "nodes": []
+   },
+   "name": "relationships_tfact_feedback_user_fk__user_pk__ref_dim_user_",
+   "original_file_path": "models/dimensional/_feedback_facts.yml",
+   "resource_type": "test",
+   "schema": "ol_warehouse_production_dbt_test__audit",
+   "test_metadata": {
+    "kwargs": {
+     "column_name": "user_fk",
+     "field": "user_pk",
+     "model": "{{ get_where_subquery(ref('tfact_feedback')) }}",
+     "to": "ref('dim_user')"
+    },
+    "name": "relationships"
+   },
+   "unique_id": "test.open_learning.relationships_tfact_feedback_user_fk__user_pk__ref_dim_user_.ccf6bef76b"
+  },
+  "test.open_learning.relationships_tfact_grade_courserun_fk__courserun_pk__ref_dim_course_run_.031404a850": {
+   "attached_node": "model.open_learning.tfact_grade",
+   "column_name": "courserun_fk",
+   "config": {
+    "materialized": "test"
+   },
+   "database": "ol_data_lake_production",
+   "depends_on": {
+    "macros": [],
+    "nodes": []
+   },
+   "name": "relationships_tfact_grade_courserun_fk__courserun_pk__ref_dim_course_run_",
+   "original_file_path": "models/dimensional/_fact_tables.yml",
+   "resource_type": "test",
+   "schema": "ol_warehouse_production_dbt_test__audit",
+   "test_metadata": {
+    "kwargs": {
+     "column_name": "courserun_fk",
+     "field": "courserun_pk",
+     "model": "{{ get_where_subquery(ref('tfact_grade')) }}",
+     "to": "ref('dim_course_run')"
+    },
+    "name": "relationships"
+   },
+   "unique_id": "test.open_learning.relationships_tfact_grade_courserun_fk__courserun_pk__ref_dim_course_run_.031404a850"
+  },
+  "test.open_learning.relationships_tfact_grade_grade_date_key__date_key__ref_dim_date_.80b5f61d90": {
+   "attached_node": "model.open_learning.tfact_grade",
+   "column_name": "grade_date_key",
+   "config": {
+    "materialized": "test"
+   },
+   "database": "ol_data_lake_production",
+   "depends_on": {
+    "macros": [],
+    "nodes": []
+   },
+   "name": "relationships_tfact_grade_grade_date_key__date_key__ref_dim_date_",
+   "original_file_path": "models/dimensional/_fact_tables.yml",
+   "resource_type": "test",
+   "schema": "ol_warehouse_production_dbt_test__audit",
+   "test_metadata": {
+    "kwargs": {
+     "column_name": "grade_date_key",
+     "field": "date_key",
+     "model": "{{ get_where_subquery(ref('tfact_grade')) }}",
+     "to": "ref('dim_date')"
+    },
+    "name": "relationships"
+   },
+   "unique_id": "test.open_learning.relationships_tfact_grade_grade_date_key__date_key__ref_dim_date_.80b5f61d90"
+  },
+  "test.open_learning.relationships_tfact_grade_platform_fk__platform_pk__ref_dim_platform_.8c450418e3": {
+   "attached_node": "model.open_learning.tfact_grade",
+   "column_name": "platform_fk",
+   "config": {
+    "materialized": "test"
+   },
+   "database": "ol_data_lake_production",
+   "depends_on": {
+    "macros": [],
+    "nodes": []
+   },
+   "name": "relationships_tfact_grade_platform_fk__platform_pk__ref_dim_platform_",
+   "original_file_path": "models/dimensional/_fact_tables.yml",
+   "resource_type": "test",
+   "schema": "ol_warehouse_production_dbt_test__audit",
+   "test_metadata": {
+    "kwargs": {
+     "column_name": "platform_fk",
+     "field": "platform_pk",
+     "model": "{{ get_where_subquery(ref('tfact_grade')) }}",
+     "to": "ref('dim_platform')"
+    },
+    "name": "relationships"
+   },
+   "unique_id": "test.open_learning.relationships_tfact_grade_platform_fk__platform_pk__ref_dim_platform_.8c450418e3"
+  },
+  "test.open_learning.relationships_tfact_grade_user_fk__user_pk__ref_dim_user_.60ae35e54b": {
+   "attached_node": "model.open_learning.tfact_grade",
+   "column_name": "user_fk",
+   "config": {
+    "materialized": "test"
+   },
+   "database": "ol_data_lake_production",
+   "depends_on": {
+    "macros": [],
+    "nodes": []
+   },
+   "name": "relationships_tfact_grade_user_fk__user_pk__ref_dim_user_",
+   "original_file_path": "models/dimensional/_fact_tables.yml",
+   "resource_type": "test",
+   "schema": "ol_warehouse_production_dbt_test__audit",
+   "test_metadata": {
+    "kwargs": {
+     "column_name": "user_fk",
+     "field": "user_pk",
+     "model": "{{ get_where_subquery(ref('tfact_grade')) }}",
+     "to": "ref('dim_user')"
+    },
+    "name": "relationships"
+   },
+   "unique_id": "test.open_learning.relationships_tfact_grade_user_fk__user_pk__ref_dim_user_.60ae35e54b"
+  },
+  "test.open_learning.relationships_tfact_order_discount_fk__discount_pk__ref_dim_discount_.fdda9ac321": {
+   "attached_node": "model.open_learning.tfact_order",
+   "column_name": "discount_fk",
+   "config": {
+    "materialized": "test"
+   },
+   "database": "ol_data_lake_production",
+   "depends_on": {
+    "macros": [],
+    "nodes": []
+   },
+   "name": "relationships_tfact_order_discount_fk__discount_pk__ref_dim_discount_",
+   "original_file_path": "models/dimensional/_fact_tables.yml",
+   "resource_type": "test",
+   "schema": "ol_warehouse_production_dbt_test__audit",
+   "test_metadata": {
+    "kwargs": {
+     "column_name": "discount_fk",
+     "field": "discount_pk",
+     "model": "{{ get_where_subquery(ref('tfact_order')) }}",
+     "to": "ref('dim_discount')"
+    },
+    "name": "relationships"
+   },
+   "unique_id": "test.open_learning.relationships_tfact_order_discount_fk__discount_pk__ref_dim_discount_.fdda9ac321"
+  },
+  "test.open_learning.relationships_tfact_order_order_date_key__date_key__ref_dim_date_.bd5b81da3e": {
+   "attached_node": "model.open_learning.tfact_order",
+   "column_name": "order_date_key",
+   "config": {
+    "materialized": "test"
+   },
+   "database": "ol_data_lake_production",
+   "depends_on": {
+    "macros": [],
+    "nodes": []
+   },
+   "name": "relationships_tfact_order_order_date_key__date_key__ref_dim_date_",
+   "original_file_path": "models/dimensional/_fact_tables.yml",
+   "resource_type": "test",
+   "schema": "ol_warehouse_production_dbt_test__audit",
+   "test_metadata": {
+    "kwargs": {
+     "column_name": "order_date_key",
+     "field": "date_key",
+     "model": "{{ get_where_subquery(ref('tfact_order')) }}",
+     "to": "ref('dim_date')"
+    },
+    "name": "relationships"
+   },
+   "unique_id": "test.open_learning.relationships_tfact_order_order_date_key__date_key__ref_dim_date_.bd5b81da3e"
+  },
+  "test.open_learning.relationships_tfact_order_order_updated_date_key__date_key__ref_dim_date_.8842e9fc5d": {
+   "attached_node": "model.open_learning.tfact_order",
+   "column_name": "order_updated_date_key",
+   "config": {
+    "materialized": "test"
+   },
+   "database": "ol_data_lake_production",
+   "depends_on": {
+    "macros": [],
+    "nodes": []
+   },
+   "name": "relationships_tfact_order_order_updated_date_key__date_key__ref_dim_date_",
+   "original_file_path": "models/dimensional/_fact_tables.yml",
+   "resource_type": "test",
+   "schema": "ol_warehouse_production_dbt_test__audit",
+   "test_metadata": {
+    "kwargs": {
+     "column_name": "order_updated_date_key",
+     "field": "date_key",
+     "model": "{{ get_where_subquery(ref('tfact_order')) }}",
+     "to": "ref('dim_date')"
+    },
+    "name": "relationships"
+   },
+   "unique_id": "test.open_learning.relationships_tfact_order_order_updated_date_key__date_key__ref_dim_date_.8842e9fc5d"
+  },
+  "test.open_learning.relationships_tfact_order_platform_fk__platform_pk__ref_dim_platform_.2c8af08c1b": {
+   "attached_node": "model.open_learning.tfact_order",
+   "column_name": "platform_fk",
+   "config": {
+    "materialized": "test"
+   },
+   "database": "ol_data_lake_production",
+   "depends_on": {
+    "macros": [],
+    "nodes": []
+   },
+   "name": "relationships_tfact_order_platform_fk__platform_pk__ref_dim_platform_",
+   "original_file_path": "models/dimensional/_fact_tables.yml",
+   "resource_type": "test",
+   "schema": "ol_warehouse_production_dbt_test__audit",
+   "test_metadata": {
+    "kwargs": {
+     "column_name": "platform_fk",
+     "field": "platform_pk",
+     "model": "{{ get_where_subquery(ref('tfact_order')) }}",
+     "to": "ref('dim_platform')"
+    },
+    "name": "relationships"
+   },
+   "unique_id": "test.open_learning.relationships_tfact_order_platform_fk__platform_pk__ref_dim_platform_.2c8af08c1b"
+  },
+  "test.open_learning.relationships_tfact_order_product_fk__product_pk__ref_dim_product_.95d0840096": {
+   "attached_node": "model.open_learning.tfact_order",
+   "column_name": "product_fk",
+   "config": {
+    "materialized": "test"
+   },
+   "database": "ol_data_lake_production",
+   "depends_on": {
+    "macros": [],
+    "nodes": []
+   },
+   "name": "relationships_tfact_order_product_fk__product_pk__ref_dim_product_",
+   "original_file_path": "models/dimensional/_fact_tables.yml",
+   "resource_type": "test",
+   "schema": "ol_warehouse_production_dbt_test__audit",
+   "test_metadata": {
+    "kwargs": {
+     "column_name": "product_fk",
+     "field": "product_pk",
+     "model": "{{ get_where_subquery(ref('tfact_order')) }}",
+     "to": "ref('dim_product')"
+    },
+    "name": "relationships"
+   },
+   "unique_id": "test.open_learning.relationships_tfact_order_product_fk__product_pk__ref_dim_product_.95d0840096"
+  },
+  "test.open_learning.relationships_tfact_order_tax_rate_fk__tax_rate_pk__ref_dim_tax_rate_.124c4f12c7": {
+   "attached_node": "model.open_learning.tfact_order",
+   "column_name": "tax_rate_fk",
+   "config": {
+    "materialized": "test"
+   },
+   "database": "ol_data_lake_production",
+   "depends_on": {
+    "macros": [],
+    "nodes": []
+   },
+   "name": "relationships_tfact_order_tax_rate_fk__tax_rate_pk__ref_dim_tax_rate_",
+   "original_file_path": "models/dimensional/_fact_tables.yml",
+   "resource_type": "test",
+   "schema": "ol_warehouse_production_dbt_test__audit",
+   "test_metadata": {
+    "kwargs": {
+     "column_name": "tax_rate_fk",
+     "field": "tax_rate_pk",
+     "model": "{{ get_where_subquery(ref('tfact_order')) }}",
+     "to": "ref('dim_tax_rate')"
+    },
+    "name": "relationships"
+   },
+   "unique_id": "test.open_learning.relationships_tfact_order_tax_rate_fk__tax_rate_pk__ref_dim_tax_rate_.124c4f12c7"
+  },
+  "test.open_learning.relationships_tfact_order_user_fk__user_pk__ref_dim_user_.62220e9215": {
+   "attached_node": "model.open_learning.tfact_order",
+   "column_name": "user_fk",
+   "config": {
+    "materialized": "test"
+   },
+   "database": "ol_data_lake_production",
+   "depends_on": {
+    "macros": [],
+    "nodes": []
+   },
+   "name": "relationships_tfact_order_user_fk__user_pk__ref_dim_user_",
+   "original_file_path": "models/dimensional/_fact_tables.yml",
+   "resource_type": "test",
+   "schema": "ol_warehouse_production_dbt_test__audit",
+   "test_metadata": {
+    "kwargs": {
+     "column_name": "user_fk",
+     "field": "user_pk",
+     "model": "{{ get_where_subquery(ref('tfact_order')) }}",
+     "to": "ref('dim_user')"
+    },
+    "name": "relationships"
+   },
+   "unique_id": "test.open_learning.relationships_tfact_order_user_fk__user_pk__ref_dim_user_.62220e9215"
+  },
+  "test.open_learning.relationships_tfact_payment_payment_date_key__date_key__ref_dim_date_.952ac7e6c7": {
+   "attached_node": "model.open_learning.tfact_payment",
+   "column_name": "payment_date_key",
+   "config": {
+    "materialized": "test"
+   },
+   "database": "ol_data_lake_production",
+   "depends_on": {
+    "macros": [],
+    "nodes": []
+   },
+   "name": "relationships_tfact_payment_payment_date_key__date_key__ref_dim_date_",
+   "original_file_path": "models/dimensional/_fact_tables.yml",
+   "resource_type": "test",
+   "schema": "ol_warehouse_production_dbt_test__audit",
+   "test_metadata": {
+    "kwargs": {
+     "column_name": "payment_date_key",
+     "field": "date_key",
+     "model": "{{ get_where_subquery(ref('tfact_payment')) }}",
+     "to": "ref('dim_date')"
+    },
+    "name": "relationships"
+   },
+   "unique_id": "test.open_learning.relationships_tfact_payment_payment_date_key__date_key__ref_dim_date_.952ac7e6c7"
+  },
+  "test.open_learning.relationships_tfact_payment_payment_method_fk__payment_method_pk__ref_dim_payment_method_.442de8b9cd": {
+   "attached_node": "model.open_learning.tfact_payment",
+   "column_name": "payment_method_fk",
+   "config": {
+    "materialized": "test"
+   },
+   "database": "ol_data_lake_production",
+   "depends_on": {
+    "macros": [],
+    "nodes": []
+   },
+   "name": "relationships_tfact_payment_payment_method_fk__payment_method_pk__ref_dim_payment_method_",
+   "original_file_path": "models/dimensional/_fact_tables.yml",
+   "resource_type": "test",
+   "schema": "ol_warehouse_production_dbt_test__audit",
+   "test_metadata": {
+    "kwargs": {
+     "column_name": "payment_method_fk",
+     "field": "payment_method_pk",
+     "model": "{{ get_where_subquery(ref('tfact_payment')) }}",
+     "to": "ref('dim_payment_method')"
+    },
+    "name": "relationships"
+   },
+   "unique_id": "test.open_learning.relationships_tfact_payment_payment_method_fk__payment_method_pk__ref_dim_payment_method_.442de8b9cd"
+  },
+  "test.open_learning.relationships_tfact_payment_platform_fk__platform_pk__ref_dim_platform_.938e3b55d7": {
+   "attached_node": "model.open_learning.tfact_payment",
+   "column_name": "platform_fk",
+   "config": {
+    "materialized": "test"
+   },
+   "database": "ol_data_lake_production",
+   "depends_on": {
+    "macros": [],
+    "nodes": []
+   },
+   "name": "relationships_tfact_payment_platform_fk__platform_pk__ref_dim_platform_",
+   "original_file_path": "models/dimensional/_fact_tables.yml",
+   "resource_type": "test",
+   "schema": "ol_warehouse_production_dbt_test__audit",
+   "test_metadata": {
+    "kwargs": {
+     "column_name": "platform_fk",
+     "field": "platform_pk",
+     "model": "{{ get_where_subquery(ref('tfact_payment')) }}",
+     "to": "ref('dim_platform')"
+    },
+    "name": "relationships"
+   },
+   "unique_id": "test.open_learning.relationships_tfact_payment_platform_fk__platform_pk__ref_dim_platform_.938e3b55d7"
+  },
+  "test.open_learning.relationships_tfact_payment_user_fk__user_pk__ref_dim_user_.a31e008e8c": {
+   "attached_node": "model.open_learning.tfact_payment",
+   "column_name": "user_fk",
+   "config": {
+    "materialized": "test"
+   },
+   "database": "ol_data_lake_production",
+   "depends_on": {
+    "macros": [],
+    "nodes": []
+   },
+   "name": "relationships_tfact_payment_user_fk__user_pk__ref_dim_user_",
+   "original_file_path": "models/dimensional/_fact_tables.yml",
+   "resource_type": "test",
+   "schema": "ol_warehouse_production_dbt_test__audit",
+   "test_metadata": {
+    "kwargs": {
+     "column_name": "user_fk",
+     "field": "user_pk",
+     "model": "{{ get_where_subquery(ref('tfact_payment')) }}",
+     "to": "ref('dim_user')"
+    },
+    "name": "relationships"
+   },
+   "unique_id": "test.open_learning.relationships_tfact_payment_user_fk__user_pk__ref_dim_user_.a31e008e8c"
+  },
+  "test.open_learning.relationships_tfact_problem_events_user_fk__user_pk__ref_dim_user_.fb74ee8234": {
+   "attached_node": "model.open_learning.tfact_problem_events",
+   "column_name": "user_fk",
+   "config": {
+    "materialized": "test"
+   },
+   "database": "ol_data_lake_production",
+   "depends_on": {
+    "macros": [],
+    "nodes": []
+   },
+   "name": "relationships_tfact_problem_events_user_fk__user_pk__ref_dim_user_",
+   "original_file_path": "models/dimensional/_dim__models.yml",
+   "resource_type": "test",
+   "schema": "ol_warehouse_production_dbt_test__audit",
+   "test_metadata": {
+    "kwargs": {
+     "column_name": "user_fk",
+     "field": "user_pk",
+     "model": "{{ get_where_subquery(ref('tfact_problem_events')) }}",
+     "to": "ref('dim_user')"
+    },
+    "name": "relationships"
+   },
+   "unique_id": "test.open_learning.relationships_tfact_problem_events_user_fk__user_pk__ref_dim_user_.fb74ee8234"
+  },
+  "test.open_learning.relationships_tfact_studentmodule_problems_user_fk__user_pk__ref_dim_user_.d669541014": {
+   "attached_node": "model.open_learning.tfact_studentmodule_problems",
+   "column_name": "user_fk",
+   "config": {
+    "materialized": "test"
+   },
+   "database": "ol_data_lake_production",
+   "depends_on": {
+    "macros": [],
+    "nodes": []
+   },
+   "name": "relationships_tfact_studentmodule_problems_user_fk__user_pk__ref_dim_user_",
+   "original_file_path": "models/dimensional/_dim__models.yml",
+   "resource_type": "test",
+   "schema": "ol_warehouse_production_dbt_test__audit",
+   "test_metadata": {
+    "kwargs": {
+     "column_name": "user_fk",
+     "field": "user_pk",
+     "model": "{{ get_where_subquery(ref('tfact_studentmodule_problems')) }}",
+     "to": "ref('dim_user')"
+    },
+    "name": "relationships"
+   },
+   "unique_id": "test.open_learning.relationships_tfact_studentmodule_problems_user_fk__user_pk__ref_dim_user_.d669541014"
+  }
+ },
+ "sources": {}
+}

--- a/src/ol_dbt_cli/tests/test_surrogate_keys.py
+++ b/src/ol_dbt_cli/tests/test_surrogate_keys.py
@@ -87,6 +87,56 @@ def test_reindenting_and_recasing_do_not_count_as_a_re_key():
     assert changed_surrogate_keys(tidy, reformatted) == []
 
 
+def test_a_changed_sql_string_literal_is_a_re_key():
+    """`concat(kind, 'A')` and `concat(kind, 'a')` hash differently.
+
+    Folding case across the whole expression would equate them and miss the
+    exact re-key this detector exists to catch.
+    """
+    change = changed_surrogate_keys(
+        "{{ generate_surrogate_key([\"concat(kind, 'A')\"]) }} as pk",
+        "{{ generate_surrogate_key([\"concat(kind, 'a')\"]) }} as pk",
+    )
+    assert [c.column for c in change] == ["pk"]
+
+
+def test_whitespace_inside_a_sql_literal_is_a_re_key():
+    change = changed_surrogate_keys(
+        "{{ generate_surrogate_key([\"concat(a, ', ', b)\"]) }} as pk",
+        "{{ generate_surrogate_key([\"concat(a, ',', b)\"]) }} as pk",
+    )
+    assert [c.column for c in change] == ["pk"]
+
+
+def test_a_quoted_identifier_keeps_its_case():
+    """Trino folds a bare identifier and preserves a quoted one."""
+    change = changed_surrogate_keys(
+        "{{ generate_surrogate_key(['cast(\"Col\" as varchar)']) }} as pk",
+        "{{ generate_surrogate_key(['cast(\"col\" as varchar)']) }} as pk",
+    )
+    assert [c.column for c in change] == ["pk"]
+
+
+def test_recasing_outside_a_literal_is_still_not_a_re_key():
+    """The fold that keeps a reindent quiet must survive the literal-awareness."""
+    change = changed_surrogate_keys(
+        "{{ generate_surrogate_key([\"CONCAT(KIND, 'A')\"]) }} as pk",
+        "{{ generate_surrogate_key([\"concat(kind, 'A')\"]) }} as pk",
+    )
+    assert change == []
+
+
+def test_a_doubled_quote_stays_inside_its_literal():
+    """`''` is SQL's escape for a quote, not a close followed by a reopen."""
+    keys = extract_surrogate_keys("{{ generate_surrogate_key([\"concat(a, 'it''s')\"]) }} as pk")
+    assert keys[0].inputs == ("concat(a, 'it''s')",)
+
+
+def test_an_unterminated_quote_normalizes_without_raising():
+    keys = extract_surrogate_keys('{{ generate_surrogate_key(["concat(a, \'x)"]) }} as pk')
+    assert keys[0].column == "pk"
+
+
 def test_unaliased_calls_are_dropped():
     """A key minted inside a join predicate defines no column to go stale."""
     sql = """
@@ -252,6 +302,53 @@ def test_no_finding_when_nothing_incremental_stores_the_key():
     )
 
     assert detect_key_regen({"dim_thing": changed}, registry, lambda *_: {"thing_pk"}) == []
+
+
+def test_a_diamond_does_not_lose_the_path_that_carries_the_key():
+    """Marking a node seen on first sight makes the result traversal-ordered.
+
+    Here `dim_thing` reaches `fact_thing` two ways: through `int_bare`, which
+    carries nothing, and through `int_carrier`, which carries the key. Whichever
+    the walk reaches first, the fact must still be flagged.
+    """
+    dim = _model("dim_thing", "table")
+    bare = _model("int_bare", "table", ["dim_thing"])
+    carrier = _model("int_carrier", "table", ["dim_thing"])
+    fact = _model("fact_thing", "incremental", ["int_bare", "int_carrier"])
+    reads = {
+        ("int_bare", "dim_thing"): set(),
+        ("int_carrier", "dim_thing"): {"thing_pk"},
+        ("fact_thing", "int_bare"): set(),
+        ("fact_thing", "int_carrier"): {"thing_pk"},
+    }
+
+    for order in ([bare, carrier], [carrier, bare]):
+        registry = _registry(dim, *order, fact)
+        affected = affected_incremental_descendants(
+            registry,
+            dim,
+            "thing_pk",
+            lambda child, parent: reads.get((child, parent), set()),
+        )
+        assert [m.model_name for m in affected] == ["fact_thing"], order
+
+
+def test_a_second_path_carrying_a_new_column_reopens_the_node():
+    """A node already reached under one column must be re-walked for another."""
+    dim = _model("dim_thing", "table")
+    fact = _model("fact_thing", "incremental", ["dim_thing"])
+    registry = _registry(dim, fact)
+    registry.foreign_keys[fact.unique_id] = [
+        ForeignKeyRef(
+            child_unique_id=fact.unique_id,
+            child_column="thing_fk",
+            parent_name="dim_thing",
+            parent_column="thing_pk",
+        )
+    ]
+
+    affected = affected_incremental_descendants(registry, dim, "thing_pk")
+    assert [(m.model_name, m.fk_column) for m in affected] == [("fact_thing", "thing_fk")]
 
 
 # ---------------------------------------------------------------------------

--- a/src/ol_dbt_cli/tests/test_surrogate_keys.py
+++ b/src/ol_dbt_cli/tests/test_surrogate_keys.py
@@ -154,6 +154,31 @@ def test_repeated_alias_keeps_every_call():
     assert surrogate_key_inputs(sql) == {"pk": (("a",), ("b",))}
 
 
+def test_adjacent_literals_are_one_argument():
+    """Jinja concatenates them, so `['O' 'Brien']` reaches dbt as one value.
+
+    Reading them as two would make it compare equal to `['O', 'Brien']`, which
+    hashes differently -- one input versus two -- and a re-key between the two
+    spellings would go unreported.
+    """
+    joined = extract_surrogate_keys("{{ generate_surrogate_key(['O' 'Brien']) }} as pk")
+    assert joined[0].inputs == ("obrien",)
+
+    separate = extract_surrogate_keys("{{ generate_surrogate_key(['O', 'Brien']) }} as pk")
+    assert separate[0].inputs == ("o", "brien")
+
+    assert changed_surrogate_keys(
+        "{{ generate_surrogate_key(['O' 'Brien']) }} as pk",
+        "{{ generate_surrogate_key(['O', 'Brien']) }} as pk",
+    )
+
+
+def test_doubled_quotes_at_the_argument_level_concatenate():
+    """`['O''Brien']` is two adjacent literals to Jinja, not a SQL escape."""
+    keys = extract_surrogate_keys("{{ generate_surrogate_key(['O''Brien']) }} as pk")
+    assert keys[0].inputs == ("obrien",)
+
+
 def test_unbalanced_call_is_skipped_not_raised():
     assert extract_surrogate_keys("{{ generate_surrogate_key(['a'] as pk") == []
 

--- a/src/ol_dbt_cli/tests/test_surrogate_keys.py
+++ b/src/ol_dbt_cli/tests/test_surrogate_keys.py
@@ -1,0 +1,353 @@
+"""Tests for surrogate-key hash-input extraction and drift detection."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from ol_dbt_cli.lib.manifest import (
+    ForeignKeyRef,
+    ManifestColumn,
+    ManifestModel,
+    ManifestRegistry,
+    registry_from_manifest,
+)
+from ol_dbt_cli.lib.surrogate_keys import (
+    affected_incremental_descendants,
+    changed_keys_from_state,
+    changed_surrogate_keys,
+    detect_key_regen,
+    extract_surrogate_keys,
+    surrogate_key_inputs,
+    surrogate_key_state,
+)
+
+FIXTURES = Path(__file__).parent / "fixtures" / "surrogate_keys"
+
+
+@pytest.fixture(scope="module")
+def dimensional_registry() -> ManifestRegistry:
+    """Real lineage: every dimensional model plus its relationships tests.
+
+    Extracted mechanically from a `dbt parse` of the project (all models under
+    models/dimensional/, all relationships tests attached to one), carrying
+    only the fields the detector reads. Nothing in it was selected per
+    incident, so the regression tests below are not being handed their answer.
+    """
+    return registry_from_manifest(json.loads((FIXTURES / "dimensional_manifest.json").read_text()))
+
+
+def fixture_sql(name: str) -> str:
+    return (FIXTURES / name).read_text()
+
+
+# ---------------------------------------------------------------------------
+# Extraction
+# ---------------------------------------------------------------------------
+
+
+def test_extracts_inputs_and_alias():
+    keys = extract_surrogate_keys(
+        "select {{ dbt_utils.generate_surrogate_key(['order_id', 'platform']) }} as order_key"
+    )
+    assert [(k.column, k.inputs) for k in keys] == [("order_key", ("order_id", "platform"))]
+
+
+def test_extracts_unqualified_macro_call():
+    keys = extract_surrogate_keys("select {{ generate_surrogate_key(['a']) }} as pk")
+    assert keys[0].column == "pk"
+
+
+def test_input_order_is_preserved():
+    """Order is part of the hash, so a reordered list is a different key."""
+    forward = surrogate_key_inputs("{{ generate_surrogate_key(['a', 'b']) }} as pk")
+    reversed_ = surrogate_key_inputs("{{ generate_surrogate_key(['b', 'a']) }} as pk")
+    assert forward != reversed_
+
+
+def test_parenthesised_and_multiline_expressions():
+    sql = """
+        {{ dbt_utils.generate_surrogate_key([
+            'cast(source_discount_id as varchar)',
+            'platform_code'
+        ]) }} as discount_pk
+    """
+    assert extract_surrogate_keys(sql)[0].inputs == (
+        "cast(source_discount_id as varchar)",
+        "platform_code",
+    )
+
+
+def test_reindenting_and_recasing_do_not_count_as_a_re_key():
+    """Reformatting a dimension must not full-refresh its fact tables."""
+    tidy = "{{ generate_surrogate_key(['cast(id as varchar)', 'platform']) }} as pk"
+    reformatted = "{{ generate_surrogate_key([\n    'CAST(id AS varchar)',\n    'Platform'\n]) }} as pk"
+    assert changed_surrogate_keys(tidy, reformatted) == []
+
+
+def test_unaliased_calls_are_dropped():
+    """A key minted inside a join predicate defines no column to go stale."""
+    sql = """
+        select 1
+        from a join b
+          on a.k = {{ dbt_utils.generate_surrogate_key(['b.id', 'b.platform']) }}
+    """
+    assert extract_surrogate_keys(sql)[0].column == ""
+    assert surrogate_key_inputs(sql) == {}
+
+
+def test_repeated_alias_keeps_every_call():
+    """A key minted per union branch has to compare branch by branch."""
+    sql = "select {{ generate_surrogate_key(['a']) }} as pk union all select {{ generate_surrogate_key(['b']) }} as pk"
+    assert surrogate_key_inputs(sql) == {"pk": (("a",), ("b",))}
+
+
+def test_unbalanced_call_is_skipped_not_raised():
+    assert extract_surrogate_keys("{{ generate_surrogate_key(['a'] as pk") == []
+
+
+# ---------------------------------------------------------------------------
+# Diffing
+# ---------------------------------------------------------------------------
+
+
+def test_added_and_removed_key_columns_are_not_reported():
+    """Both are ordinary column changes with their own, louder failure mode."""
+    assert changed_surrogate_keys("select 1", "{{ generate_surrogate_key(['a']) }} as pk") == []
+    assert changed_surrogate_keys("{{ generate_surrogate_key(['a']) }} as pk", "select 1") == []
+
+
+def test_changed_inputs_are_reported():
+    change = changed_surrogate_keys(
+        "{{ generate_surrogate_key(['a', 'b']) }} as pk",
+        "{{ generate_surrogate_key(['a']) }} as pk",
+    )
+    assert [(c.column, c.base_inputs, c.current_inputs) for c in change] == [("pk", (("a", "b"),), (("a",),))]
+
+
+# ---------------------------------------------------------------------------
+# Downstream tracing
+# ---------------------------------------------------------------------------
+
+
+def _model(name: str, materialized: str, parents: list[str] | None = None) -> ManifestModel:
+    return ManifestModel(
+        unique_id=f"model.pkg.{name}",
+        name=name,
+        resource_type="model",
+        original_file_path=f"models/{name}.sql",
+        schema="dim",
+        database="db",
+        materialized=materialized,
+        columns={},
+        depends_on=[f"model.pkg.{p}" for p in parents or []],
+    )
+
+
+def _registry(*models: ManifestModel) -> ManifestRegistry:
+    registry = ManifestRegistry()
+    for model in models:
+        registry.nodes[model.unique_id] = model
+        registry.by_name[model.name] = model
+    for model in models:
+        for parent in model.depends_on:
+            registry.children.setdefault(parent, []).append(model.unique_id)
+    return registry
+
+
+def test_only_incremental_descendants_are_flagged():
+    dim = _model("dim_thing", "table")
+    fact = _model("fact_thing", "incremental", ["dim_thing"])
+    bridge = _model("bridge_thing", "table", ["dim_thing"])
+    registry = _registry(dim, fact, bridge)
+    reads = {"fact_thing": {"thing_pk"}, "bridge_thing": {"thing_pk"}}
+
+    affected = affected_incremental_descendants(registry, dim, "thing_pk", lambda child, _parent: reads.get(child))
+    assert [m.model_name for m in affected] == ["fact_thing"]
+
+
+def test_a_descendant_that_never_reads_the_key_is_not_flagged():
+    dim = _model("dim_thing", "table")
+    fact = _model("fact_thing", "incremental", ["dim_thing"])
+    registry = _registry(dim, fact)
+
+    affected = affected_incremental_descendants(registry, dim, "thing_pk", lambda _child, _parent: {"thing_name"})
+    assert affected == []
+
+
+def test_the_key_propagates_through_a_full_refresh_intermediate():
+    """A table in the middle carries the stale value on to the fact below it."""
+    dim = _model("dim_thing", "table")
+    mid = _model("int_thing", "table", ["dim_thing"])
+    fact = _model("fact_thing", "incremental", ["int_thing"])
+    registry = _registry(dim, mid, fact)
+
+    affected = affected_incremental_descendants(registry, dim, "thing_pk", lambda _child, _parent: {"thing_pk"})
+    assert [(m.model_name, m.depth) for m in affected] == [("fact_thing", 2)]
+
+
+def test_tracing_continues_past_the_first_incremental_model():
+    """Full-refreshing one fact does not fix the stale copy in the next."""
+    dim = _model("dim_thing", "table")
+    first = _model("fact_a", "incremental", ["dim_thing"])
+    second = _model("fact_b", "incremental", ["fact_a"])
+    registry = _registry(dim, first, second)
+
+    affected = affected_incremental_descendants(registry, dim, "thing_pk", lambda _child, _parent: {"thing_pk"})
+    assert [m.model_name for m in affected] == ["fact_a", "fact_b"]
+
+
+def test_a_declared_fk_is_not_double_counted_with_the_read_behind_it():
+    """Reading dim.thing_pk is how fact.thing_fk gets its value, not a second FK."""
+    dim = _model("dim_thing", "table")
+    fact = _model("fact_thing", "incremental", ["dim_thing"])
+    registry = _registry(dim, fact)
+    registry.foreign_keys[fact.unique_id] = [
+        ForeignKeyRef(
+            child_unique_id=fact.unique_id,
+            child_column="thing_fk",
+            parent_name="dim_thing",
+            parent_column="thing_pk",
+        )
+    ]
+
+    affected = affected_incremental_descendants(registry, dim, "thing_pk", lambda _child, _parent: {"thing_pk"})
+    assert [(m.model_name, m.fk_column, m.evidence) for m in affected] == [
+        ("fact_thing", "thing_fk", "relationships_test")
+    ]
+
+
+def test_unparseable_sql_falls_back_to_documented_columns():
+    dim = _model("dim_thing", "table")
+    fact = _model("fact_thing", "incremental", ["dim_thing"])
+    fact.columns = {"thing_pk": ManifestColumn(name="thing_pk")}
+    registry = _registry(dim, fact)
+
+    affected = affected_incremental_descendants(registry, dim, "thing_pk")
+    assert [(m.model_name, m.evidence) for m in affected] == [("fact_thing", "column_metadata")]
+
+
+def test_an_incremental_ancestor_is_not_this_failure_mode():
+    """It keeps the keys it already minted; only a full-refresh model re-derives them."""
+    dim = _model("dim_thing", "incremental")
+    fact = _model("fact_thing", "incremental", ["dim_thing"])
+    registry = _registry(dim, fact)
+    changed = changed_surrogate_keys(
+        "{{ generate_surrogate_key(['a', 'b']) }} as thing_pk",
+        "{{ generate_surrogate_key(['a']) }} as thing_pk",
+    )
+
+    assert detect_key_regen({"dim_thing": changed}, registry, lambda *_: {"thing_pk"}) == []
+
+
+def test_no_finding_when_nothing_incremental_stores_the_key():
+    dim = _model("dim_thing", "table")
+    other = _model("dim_other", "table", ["dim_thing"])
+    registry = _registry(dim, other)
+    changed = changed_surrogate_keys(
+        "{{ generate_surrogate_key(['a', 'b']) }} as thing_pk",
+        "{{ generate_surrogate_key(['a']) }} as thing_pk",
+    )
+
+    assert detect_key_regen({"dim_thing": changed}, registry, lambda *_: {"thing_pk"}) == []
+
+
+# ---------------------------------------------------------------------------
+# Regression: the two incidents this check exists for
+# ---------------------------------------------------------------------------
+
+
+def test_flags_the_dim_discount_re_key_of_2411(dimensional_registry):
+    """#2411 narrowed discount_pk's hash from three columns to two.
+
+    tfact_order is incremental and stores it as discount_fk, which is why that
+    PR needed a hand-run `dbt run --select tfact_order --full-refresh`.
+    """
+    changed = changed_surrogate_keys(fixture_sql("dim_discount_before.sql"), fixture_sql("dim_discount_after.sql"))
+    findings = detect_key_regen({"dim_discount": changed}, dimensional_registry)
+
+    assert len(findings) == 1
+    assert findings[0].changed_key_column == "discount_pk"
+    assert findings[0].affected_model_names == ["tfact_order"]
+    assert [(m.fk_column, m.evidence) for m in findings[0].affected_models] == [("discount_fk", "relationships_test")]
+
+
+def test_flags_the_dim_user_re_key_of_2497(dimensional_registry):
+    """#2497 re-keyed user_pk off durable ids instead of email.
+
+    The orphaned FKs surfaced later as #2618, which repaired six fact tables by
+    hand. The detector finds those six plus tfact_problem_events and
+    tfact_studentmodule_problems, which are incremental, declare the same
+    user_fk -> dim_user.user_pk relationship, and were not repaired.
+    """
+    changed = changed_surrogate_keys(fixture_sql("dim_user_before.sql"), fixture_sql("dim_user_after.sql"))
+    findings = detect_key_regen({"dim_user": changed}, dimensional_registry)
+
+    assert len(findings) == 1
+    assert findings[0].changed_key_column == "user_pk"
+    repaired_by_2618 = {
+        "tfact_certificate",
+        "tfact_enrollment",
+        "tfact_feedback",
+        "tfact_grade",
+        "tfact_order",
+        "tfact_payment",
+    }
+    assert repaired_by_2618 <= set(findings[0].affected_model_names)
+    assert set(findings[0].affected_model_names) - repaired_by_2618 == {
+        "tfact_problem_events",
+        "tfact_studentmodule_problems",
+    }
+
+
+def test_an_unchanged_dimension_produces_no_finding(dimensional_registry):
+    unchanged = fixture_sql("dim_user_after.sql")
+    assert changed_surrogate_keys(unchanged, unchanged) == []
+    assert detect_key_regen({}, dimensional_registry) == []
+
+
+# ---------------------------------------------------------------------------
+# Manifest-level state
+# ---------------------------------------------------------------------------
+
+
+def test_state_covers_only_full_refresh_models():
+    manifest = {
+        "nodes": {
+            "model.pkg.dim_thing": {
+                "name": "dim_thing",
+                "resource_type": "model",
+                "config": {"materialized": "table"},
+                "raw_code": "{{ generate_surrogate_key(['a', 'b']) }} as thing_pk",
+            },
+            "model.pkg.fact_thing": {
+                "name": "fact_thing",
+                "resource_type": "model",
+                "config": {"materialized": "incremental"},
+                "raw_code": "{{ generate_surrogate_key(['c']) }} as fact_key",
+            },
+            "model.pkg.dim_plain": {
+                "name": "dim_plain",
+                "resource_type": "model",
+                "config": {"materialized": "table"},
+                "raw_code": "select 1",
+            },
+        }
+    }
+    assert surrogate_key_state(manifest) == {"dim_thing": {"thing_pk": [["a", "b"]]}}
+
+
+def test_state_diff_reports_changed_inputs_only():
+    previous = {"dim_thing": {"thing_pk": [["a", "b"]]}, "dim_other": {"other_pk": [["x"]]}}
+    current = {"dim_thing": {"thing_pk": [["a"]]}, "dim_other": {"other_pk": [["x"]]}}
+
+    changed = changed_keys_from_state(previous, current)
+    assert list(changed) == ["dim_thing"]
+    assert changed["dim_thing"][0].current_inputs == (("a",),)
+
+
+def test_a_model_missing_from_the_baseline_is_not_treated_as_changed():
+    """A snapshot predating this check must not full-refresh everything below."""
+    assert changed_keys_from_state({}, {"dim_thing": {"thing_pk": [["a"]]}}) == {}

--- a/src/ol_dbt_cli/tests/test_surrogate_keys.py
+++ b/src/ol_dbt_cli/tests/test_surrogate_keys.py
@@ -399,10 +399,13 @@ def test_flags_the_dim_discount_re_key_of_2411(dimensional_registry):
 def test_flags_the_dim_user_re_key_of_2497(dimensional_registry):
     """#2497 re-keyed user_pk off durable ids instead of email.
 
-    The orphaned FKs surfaced later as #2618, which repaired six fact tables by
-    hand. The detector finds those six plus tfact_problem_events and
+    #2618 later added self-healing catch-up SQL to six of the affected fact
+    tables (tfact_certificate, tfact_enrollment, tfact_feedback, tfact_grade,
+    tfact_order, tfact_payment) for a separate data-driven re-key scenario —
+    not a hashed-column-list edit, so this detector doesn't see it. The
+    detector finds those six plus tfact_problem_events and
     tfact_studentmodule_problems, which are incremental, declare the same
-    user_fk -> dim_user.user_pk relationship, and were not repaired.
+    user_fk -> dim_user.user_pk relationship, and have no such catch-up.
     """
     changed = changed_surrogate_keys(fixture_sql("dim_user_before.sql"), fixture_sql("dim_user_after.sql"))
     findings = detect_key_regen({"dim_user": changed}, dimensional_registry)


### PR DESCRIPTION
### What are the relevant tickets?

Follow-up to #2411 and #2618, both of which were manual fixes for this failure mode.

### Description (What does it do?)

`dim_discount` and `dim_user` are `materialized='table'`, so every run re-derives every `*_pk` from a hash of source columns. Their incremental descendants (`tfact_order`, `tfact_enrollment`, `tfact_certificate`, `tfact_grade`, `tfact_payment`, `tfact_feedback`, …) stored that value as an FK at insert time and only revisit rows inside their watermark. Change what the hash is computed from and every historical FK orphans — silently, because no column changed for `on_schema_change='append_new_columns'` to react to. #2411 and #2618 were both this. The only safeguard was a doc comment in `_fact_tables.yml` telling the next person to remember.

- New detector in `ol_dbt_cli.lib.surrogate_keys`: pull each `generate_surrogate_key` call's hashed argument list out of the raw SQL, diff it, then walk the manifest's child map to the incremental descendants holding the regenerated key.
- `ol-dbt impact` reports it pre-merge as a new `KEY_REGEN` alert level, with its own section in the PR comment.
- `full_dbt_project` repairs it: it compares the deployed manifest against a `surrogate-key-state.json` kept beside the other dbt artifacts in S3, then runs `dbt build --full-refresh` over the affected models after the main build and records the new state.
- The `_fact_tables.yml` doc comment now describes the automation instead of asking for a hand-run rebuild.

### Deviation from the planned design

The plan had CI write a pending-full-refresh artifact to S3 on merge to main, for Dagster to consume. No workflow in `.github/workflows/` has AWS credentials (only `publish_dbt_docs.yaml` requests `id-token`, for Pages), and adding an OIDC role is the new infrastructure the task ruled out. Comparing against state the build itself keeps needs neither, and catches a re-key however it reached main — not only one that arrived through a PR.

<details>
<summary><b>Implementation details</b></summary>
<br>

**Where the FK edge comes from.** The strongest signal is the `relationships` schema tests dbt already records in the manifest: each names both models and both columns, so it survives the `*_pk` → `*_fk` aliasing that no name-matching heuristic follows (`dim_user.user_pk` is stored as `tfact_order.user_fk`). 113 of them exist today. `ManifestRegistry` now parses them into `ForeignKeyRef` edges. Behind that, in order: columns the SQL parser sees the child read from the parent, then the manifest's documented column names.

**Why `raw_code` and not compiled SQL.** The compiled form is an opaque nested `md5(...)` whose text also changes when dbt_utils or the adapter does. The argument list is the thing whose change re-keys the dimension.

**Normalization is quote-aware.** Reindenting a multi-line argument list or recasing `CAST` must not full-refresh a fact table, so both fold. Quoted regions are copied through untouched (honouring `''`/`""` doubling): a SQL string literal and a quoted identifier are case- and space-sensitive, and folding `concat(kind, 'A')` together with `concat(kind, 'a')` would miss the exact re-key this exists to catch.

**Ordering.** The repair runs *after* the main build. Running first would rebuild the fact tables against the dimension's previous keys and orphan them again — a green run that fixed nothing. It is invoked without a Dagster context so it emits no second materialization for assets the main build already reported (same reason `generate_dbt_docs_artifacts` does).

**Partial runs.** `full_dbt_project` is a subset build, so the repair is gated on the run having rebuilt the re-keyed dimension (`SurrogateKeyDrift.resolved_against`, read from `run_results.json`) — the facts must read its *new* keys, and refreshing them against a dimension this run never touched would copy the old ones back in. The affected facts deliberately do *not* have to be in the run: the repair names them in its own `--select`, and requiring them would deadlock it, since `upstream_or_code_changes` puts a dimension and its facts in different runs by construction.

**Fail-closed state reads.** `read_json_artifact` treats only NoSuchKey/NoSuchBucket/404 as "no prior state"; a denied, throttled, or undecodable read raises rather than letting a run record a baseline over a comparison it never made.

**Shared detector.** `lakehouse` now depends on `ol-dbt-cli` so one parser decides both what CI warns about and what the build rebuilds. `uv lock` added 4 packages (`cyclopts`, `ol-dbt-cli`, `pyhcl`, `rich-rst`); the Dockerfile copies `src/ol_dbt_cli` alongside `src/ol_dbt`.

</details>

### How can this be tested?

Unit tests: `uv run pytest src/ol_dbt_cli/tests/test_surrogate_keys.py` (32 pass) and `cd dg_projects/lakehouse && uv run pytest lakehouse_tests/test_surrogate_key_drift.py` (19 pass). Full suites pass: 544 in `src/ol_dbt_cli/tests/`, 122 in `lakehouse_tests/`. `pre-commit run` is clean.

The two regression tests replay the real incident diffs against dimensional lineage extracted mechanically from a parsed manifest (every model under `models/dimensional/` plus every `relationships` test attached to one — nothing selected per incident):

- `dim_discount` before/after e2c87bd3f (#2411) → flags `tfact_order.discount_fk`.
- `dim_user` before/after a20a72865 (#2497, whose fallout was #2618) → flags the six fact tables #2618 repaired, **plus** `tfact_problem_events` and `tfact_studentmodule_problems`. Both are `materialized='incremental'`, both declare `user_fk → dim_user.user_pk`, and both select `users.user_pk as user_fk` from `ref('dim_user')` — they hold the same stale FKs and were not repaired at the time.

End to end on the CLI, simulating a re-key by adding `discount_source` to `dim_discount`'s hash:

```
🔑 KEY_REGEN dim_discount
   'dim_discount.discount_pk' is hashed from a different column list than at the base ref
   — every existing value changes on the next build. 1 incremental model(s) store it as an
   FK and need `dbt build --full-refresh --select tfact_order` on the first run after this
   merges.
   Column changes:
     🔑 discount_pk hashed from: cast(source_discount_id as varchar), platform_code
        → cast(source_discount_id as varchar), discount_source, platform_code
   Downstream impact:
       ↳ tfact_order (uses: discount_fk)
```

Not verified: the Dagster side has not run against a real warehouse. The asset module cannot be imported outside the container (the `@dbt_assets` decorator needs `/opt/dbt` and a parsed manifest), so its ordering and gating invariants are asserted statically over `dbt.py`'s AST — the same approach `test_definitions_schedule_ids.py` takes and for the same reason. Live confirmation needs a QA deploy: the first build after it records the baseline and escalates nothing, and the next build after a hash change should log the escalation and full-refresh the named models.

### Additional Context

- `KEY_REGEN` deliberately does not affect `ol-dbt impact`'s exit code. Nothing in the PR is wrong; the follow-up is a production rebuild, which the build now does itself.
- Removing a `relationships` test takes its model out of the automatic repair. The `_fact_tables.yml` comment says so at the one place a reviewer would be tempted to drop one.
- `dbt_starrocks.py`'s `_stale_materialized_views` solves the same shape of problem in the other direction (manifest vs. what is live in StarRocks); this follows its lib/asset split so the comparison is unit-testable without a parsed manifest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VB3MYfTqH9HXoUrTU6ftPT
