### PR TITLE
feat(dagster): bake the OTel auto-instrumentation agent into the Dagster images

### DIFF
--- a/dg_deployments/Dockerfile.dagster-k8s
+++ b/dg_deployments/Dockerfile.dagster-k8s
@@ -33,3 +33,34 @@ COPY dg_deployments/reconcile_edxorg_partitions.py /opt/dagster/app/reconcile_ed
 # not handle, raising AttributeError at launch time. Pin until dagster-k8s upstream
 # resolves the incompatibility.
 RUN uv pip install --system /opt/dagster/packages/ol-orchestrate-lib dagster==${DAGSTER_VERSION} dagster-azure dagster-postgres dagster-k8s "kubernetes<36" dagster-aws dagster-gcp dagster-graphql dagster-webserver
+
+# OpenTelemetry auto-instrumentation for the webserver and the daemon.
+#
+# Installed outside the pinned line above because these are agent packages, not
+# runtime dependencies: nothing in ol-orchestrate-lib imports them, and the
+# whole agent can be added or removed without a resolve. Only the HTTP OTLP
+# exporter is installed -- the SDK default "otlp" resolves to the gRPC exporter,
+# so ol-infrastructure sets OTEL_TRACES_EXPORTER=otlp_proto_http to match.
+#
+# The instrumentation list is explicit rather than whatever opentelemetry-bootstrap
+# would select, because bootstrap picks psycopg2 alongside sqlalchemy and that
+# emits two spans for every query.
+RUN uv pip install --system \
+        opentelemetry-distro \
+        opentelemetry-exporter-otlp-proto-http \
+        opentelemetry-instrumentation-sqlalchemy \
+        opentelemetry-instrumentation-grpc \
+        opentelemetry-instrumentation-botocore \
+        opentelemetry-instrumentation-requests \
+        opentelemetry-instrumentation-urllib3
+
+# A stable path to the agent directory, so ol-infrastructure can turn
+# instrumentation on with PYTHONPATH without encoding this image's Python
+# version. That directory holds a sitecustomize.py, which is the whole of what
+# `opentelemetry-instrument` does: it prepends this path and execs the command.
+# PYTHONPATH is the only workable lever here because the Dagster Helm chart
+# hardcodes `command: ["/bin/bash", "-c", ...]` for both the webserver and the
+# daemon, so an ENTRYPOINT would never run.
+RUN mkdir -p /opt/otel && \
+    ln -s "$(python -c 'import opentelemetry.instrumentation.auto_instrumentation as m, pathlib; print(pathlib.Path(m.__file__).parent)')" \
+        /opt/otel/auto_instrumentation

--- a/dg_projects/b2b_organization/Dockerfile
+++ b/dg_projects/b2b_organization/Dockerfile
@@ -72,10 +72,12 @@ ENV PATH="/app/.venv/bin:$PATH"
 # the command.
 #
 # PYTHONPATH rather than an ENTRYPOINT because run worker pods share this image
-# and are deliberately NOT instrumented yet; PYTHONPATH is the one of the two a
-# run launcher can override back off, which is what dagster_instance.yaml in
-# ol-infrastructure does. The gRPC health-check probes run `env -u PYTHONPATH`
-# for the same reason.
+# and are deliberately NOT instrumented yet. An ENTRYPOINT applies to every
+# process the image starts, so there would be nothing left to switch off; a
+# variable can be stripped for one workload and not another. dagster_instance.yaml
+# in ol-infrastructure strips it from run workers by giving their container a
+# `command` of `env -u PYTHONPATH`, and the gRPC health-check probes prepend the
+# same thing for the same reason.
 RUN mkdir -p /opt/otel && \
     ln -s "$(python -c 'import opentelemetry.instrumentation.auto_instrumentation as m, pathlib; print(pathlib.Path(m.__file__).parent)')" \
         /opt/otel/auto_instrumentation

--- a/dg_projects/b2b_organization/Dockerfile
+++ b/dg_projects/b2b_organization/Dockerfile
@@ -31,6 +31,28 @@ RUN --mount=type=cache,target=/root/.cache/uv \
 RUN --mount=type=cache,target=/root/.cache/uv \
     uv sync --frozen --no-dev --no-editable
 
+# OpenTelemetry auto-instrumentation agent, activated by PYTHONPATH (see the
+# /opt/otel symlink in the final stage).
+#
+# Installed with `uv pip install` rather than added to pyproject.toml so the
+# agent can be added or removed without a resolve across all ten code
+# locations. It has to come after the syncs above, which prune anything the
+# lockfile does not name. Only the HTTP OTLP exporter is installed -- the SDK
+# default "otlp" resolves to the gRPC exporter, which is why ol-infrastructure
+# sets OTEL_TRACES_EXPORTER=otlp_proto_http.
+#
+# The instrumentation list is explicit rather than whatever
+# opentelemetry-bootstrap would select, because bootstrap picks psycopg2
+# alongside sqlalchemy and that emits two spans for every query.
+RUN --mount=type=cache,target=/root/.cache/uv \
+    uv pip install --python .venv \
+        opentelemetry-distro \
+        opentelemetry-exporter-otlp-proto-http \
+        opentelemetry-instrumentation-sqlalchemy \
+        opentelemetry-instrumentation-grpc \
+        opentelemetry-instrumentation-botocore \
+        opentelemetry-instrumentation-requests \
+        opentelemetry-instrumentation-urllib3
 
 # Then, use a final image without uv
 FROM python:3.14-slim-bookworm
@@ -42,5 +64,20 @@ COPY --from=builder /app/dg_projects/b2b_organization /app
 
 # Place executables in the environment at the front of the path
 ENV PATH="/app/.venv/bin:$PATH"
+
+# A stable path to the auto-instrumentation agent directory, so ol-infrastructure
+# can switch tracing on with PYTHONPATH without encoding this image's Python
+# version or venv layout. The directory holds a sitecustomize.py, which is the
+# whole of what `opentelemetry-instrument` does: it prepends this path and execs
+# the command.
+#
+# PYTHONPATH rather than an ENTRYPOINT because run worker pods share this image
+# and are deliberately NOT instrumented yet; PYTHONPATH is the one of the two a
+# run launcher can override back off, which is what dagster_instance.yaml in
+# ol-infrastructure does. The gRPC health-check probes run `env -u PYTHONPATH`
+# for the same reason.
+RUN mkdir -p /opt/otel && \
+    ln -s "$(python -c 'import opentelemetry.instrumentation.auto_instrumentation as m, pathlib; print(pathlib.Path(m.__file__).parent)')" \
+        /opt/otel/auto_instrumentation
 
 WORKDIR /app

--- a/dg_projects/canvas/Dockerfile
+++ b/dg_projects/canvas/Dockerfile
@@ -31,6 +31,28 @@ RUN --mount=type=cache,target=/root/.cache/uv \
 RUN --mount=type=cache,target=/root/.cache/uv \
     uv sync --frozen --no-dev --no-editable
 
+# OpenTelemetry auto-instrumentation agent, activated by PYTHONPATH (see the
+# /opt/otel symlink in the final stage).
+#
+# Installed with `uv pip install` rather than added to pyproject.toml so the
+# agent can be added or removed without a resolve across all ten code
+# locations. It has to come after the syncs above, which prune anything the
+# lockfile does not name. Only the HTTP OTLP exporter is installed -- the SDK
+# default "otlp" resolves to the gRPC exporter, which is why ol-infrastructure
+# sets OTEL_TRACES_EXPORTER=otlp_proto_http.
+#
+# The instrumentation list is explicit rather than whatever
+# opentelemetry-bootstrap would select, because bootstrap picks psycopg2
+# alongside sqlalchemy and that emits two spans for every query.
+RUN --mount=type=cache,target=/root/.cache/uv \
+    uv pip install --python .venv \
+        opentelemetry-distro \
+        opentelemetry-exporter-otlp-proto-http \
+        opentelemetry-instrumentation-sqlalchemy \
+        opentelemetry-instrumentation-grpc \
+        opentelemetry-instrumentation-botocore \
+        opentelemetry-instrumentation-requests \
+        opentelemetry-instrumentation-urllib3
 
 # Then, use a final image without uv
 FROM python:3.14-slim-bookworm
@@ -42,5 +64,20 @@ COPY --from=builder /app/dg_projects/canvas /app
 
 # Place executables in the environment at the front of the path
 ENV PATH="/app/.venv/bin:$PATH"
+
+# A stable path to the auto-instrumentation agent directory, so ol-infrastructure
+# can switch tracing on with PYTHONPATH without encoding this image's Python
+# version or venv layout. The directory holds a sitecustomize.py, which is the
+# whole of what `opentelemetry-instrument` does: it prepends this path and execs
+# the command.
+#
+# PYTHONPATH rather than an ENTRYPOINT because run worker pods share this image
+# and are deliberately NOT instrumented yet; PYTHONPATH is the one of the two a
+# run launcher can override back off, which is what dagster_instance.yaml in
+# ol-infrastructure does. The gRPC health-check probes run `env -u PYTHONPATH`
+# for the same reason.
+RUN mkdir -p /opt/otel && \
+    ln -s "$(python -c 'import opentelemetry.instrumentation.auto_instrumentation as m, pathlib; print(pathlib.Path(m.__file__).parent)')" \
+        /opt/otel/auto_instrumentation
 
 WORKDIR /app

--- a/dg_projects/canvas/Dockerfile
+++ b/dg_projects/canvas/Dockerfile
@@ -72,10 +72,12 @@ ENV PATH="/app/.venv/bin:$PATH"
 # the command.
 #
 # PYTHONPATH rather than an ENTRYPOINT because run worker pods share this image
-# and are deliberately NOT instrumented yet; PYTHONPATH is the one of the two a
-# run launcher can override back off, which is what dagster_instance.yaml in
-# ol-infrastructure does. The gRPC health-check probes run `env -u PYTHONPATH`
-# for the same reason.
+# and are deliberately NOT instrumented yet. An ENTRYPOINT applies to every
+# process the image starts, so there would be nothing left to switch off; a
+# variable can be stripped for one workload and not another. dagster_instance.yaml
+# in ol-infrastructure strips it from run workers by giving their container a
+# `command` of `env -u PYTHONPATH`, and the gRPC health-check probes prepend the
+# same thing for the same reason.
 RUN mkdir -p /opt/otel && \
     ln -s "$(python -c 'import opentelemetry.instrumentation.auto_instrumentation as m, pathlib; print(pathlib.Path(m.__file__).parent)')" \
         /opt/otel/auto_instrumentation

--- a/dg_projects/data_loading/Dockerfile
+++ b/dg_projects/data_loading/Dockerfile
@@ -78,10 +78,12 @@ ENV PATH="/app/.venv/bin:$PATH"
 # the command.
 #
 # PYTHONPATH rather than an ENTRYPOINT because run worker pods share this image
-# and are deliberately NOT instrumented yet; PYTHONPATH is the one of the two a
-# run launcher can override back off, which is what dagster_instance.yaml in
-# ol-infrastructure does. The gRPC health-check probes run `env -u PYTHONPATH`
-# for the same reason.
+# and are deliberately NOT instrumented yet. An ENTRYPOINT applies to every
+# process the image starts, so there would be nothing left to switch off; a
+# variable can be stripped for one workload and not another. dagster_instance.yaml
+# in ol-infrastructure strips it from run workers by giving their container a
+# `command` of `env -u PYTHONPATH`, and the gRPC health-check probes prepend the
+# same thing for the same reason.
 RUN mkdir -p /opt/otel && \
     ln -s "$(python -c 'import opentelemetry.instrumentation.auto_instrumentation as m, pathlib; print(pathlib.Path(m.__file__).parent)')" \
         /opt/otel/auto_instrumentation

--- a/dg_projects/data_loading/Dockerfile
+++ b/dg_projects/data_loading/Dockerfile
@@ -32,6 +32,28 @@ RUN --mount=type=cache,target=/root/.cache/uv \
 RUN --mount=type=cache,target=/root/.cache/uv \
     uv sync --frozen --no-dev --no-editable
 
+# OpenTelemetry auto-instrumentation agent, activated by PYTHONPATH (see the
+# /opt/otel symlink in the final stage).
+#
+# Installed with `uv pip install` rather than added to pyproject.toml so the
+# agent can be added or removed without a resolve across all ten code
+# locations. It has to come after the syncs above, which prune anything the
+# lockfile does not name. Only the HTTP OTLP exporter is installed -- the SDK
+# default "otlp" resolves to the gRPC exporter, which is why ol-infrastructure
+# sets OTEL_TRACES_EXPORTER=otlp_proto_http.
+#
+# The instrumentation list is explicit rather than whatever
+# opentelemetry-bootstrap would select, because bootstrap picks psycopg2
+# alongside sqlalchemy and that emits two spans for every query.
+RUN --mount=type=cache,target=/root/.cache/uv \
+    uv pip install --python .venv \
+        opentelemetry-distro \
+        opentelemetry-exporter-otlp-proto-http \
+        opentelemetry-instrumentation-sqlalchemy \
+        opentelemetry-instrumentation-grpc \
+        opentelemetry-instrumentation-botocore \
+        opentelemetry-instrumentation-requests \
+        opentelemetry-instrumentation-urllib3
 
 # Then, use a final image without uv
 FROM python:3.14-slim-bookworm
@@ -48,6 +70,21 @@ COPY --from=builder /app/src/ol_dlt/.dlt /app/.dlt
 
 # Place executables in the environment at the front of the path
 ENV PATH="/app/.venv/bin:$PATH"
+
+# A stable path to the auto-instrumentation agent directory, so ol-infrastructure
+# can switch tracing on with PYTHONPATH without encoding this image's Python
+# version or venv layout. The directory holds a sitecustomize.py, which is the
+# whole of what `opentelemetry-instrument` does: it prepends this path and execs
+# the command.
+#
+# PYTHONPATH rather than an ENTRYPOINT because run worker pods share this image
+# and are deliberately NOT instrumented yet; PYTHONPATH is the one of the two a
+# run launcher can override back off, which is what dagster_instance.yaml in
+# ol-infrastructure does. The gRPC health-check probes run `env -u PYTHONPATH`
+# for the same reason.
+RUN mkdir -p /opt/otel && \
+    ln -s "$(python -c 'import opentelemetry.instrumentation.auto_instrumentation as m, pathlib; print(pathlib.Path(m.__file__).parent)')" \
+        /opt/otel/auto_instrumentation
 
 # Tell dlt where to find .dlt/config.toml and pyiceberg where to find
 # .pyiceberg.yaml. Without these, dlt cannot resolve [iceberg_catalog] and

--- a/dg_projects/data_platform/Dockerfile
+++ b/dg_projects/data_platform/Dockerfile
@@ -72,10 +72,12 @@ ENV PATH="/app/.venv/bin:$PATH"
 # the command.
 #
 # PYTHONPATH rather than an ENTRYPOINT because run worker pods share this image
-# and are deliberately NOT instrumented yet; PYTHONPATH is the one of the two a
-# run launcher can override back off, which is what dagster_instance.yaml in
-# ol-infrastructure does. The gRPC health-check probes run `env -u PYTHONPATH`
-# for the same reason.
+# and are deliberately NOT instrumented yet. An ENTRYPOINT applies to every
+# process the image starts, so there would be nothing left to switch off; a
+# variable can be stripped for one workload and not another. dagster_instance.yaml
+# in ol-infrastructure strips it from run workers by giving their container a
+# `command` of `env -u PYTHONPATH`, and the gRPC health-check probes prepend the
+# same thing for the same reason.
 RUN mkdir -p /opt/otel && \
     ln -s "$(python -c 'import opentelemetry.instrumentation.auto_instrumentation as m, pathlib; print(pathlib.Path(m.__file__).parent)')" \
         /opt/otel/auto_instrumentation

--- a/dg_projects/data_platform/Dockerfile
+++ b/dg_projects/data_platform/Dockerfile
@@ -31,6 +31,28 @@ RUN --mount=type=cache,target=/root/.cache/uv \
 RUN --mount=type=cache,target=/root/.cache/uv \
     uv sync --frozen --no-dev --no-editable
 
+# OpenTelemetry auto-instrumentation agent, activated by PYTHONPATH (see the
+# /opt/otel symlink in the final stage).
+#
+# Installed with `uv pip install` rather than added to pyproject.toml so the
+# agent can be added or removed without a resolve across all ten code
+# locations. It has to come after the syncs above, which prune anything the
+# lockfile does not name. Only the HTTP OTLP exporter is installed -- the SDK
+# default "otlp" resolves to the gRPC exporter, which is why ol-infrastructure
+# sets OTEL_TRACES_EXPORTER=otlp_proto_http.
+#
+# The instrumentation list is explicit rather than whatever
+# opentelemetry-bootstrap would select, because bootstrap picks psycopg2
+# alongside sqlalchemy and that emits two spans for every query.
+RUN --mount=type=cache,target=/root/.cache/uv \
+    uv pip install --python .venv \
+        opentelemetry-distro \
+        opentelemetry-exporter-otlp-proto-http \
+        opentelemetry-instrumentation-sqlalchemy \
+        opentelemetry-instrumentation-grpc \
+        opentelemetry-instrumentation-botocore \
+        opentelemetry-instrumentation-requests \
+        opentelemetry-instrumentation-urllib3
 
 # Then, use a final image without uv
 FROM python:3.14-slim-bookworm
@@ -42,5 +64,20 @@ COPY --from=builder /app/dg_projects/data_platform /app
 
 # Place executables in the environment at the front of the path
 ENV PATH="/app/.venv/bin:$PATH"
+
+# A stable path to the auto-instrumentation agent directory, so ol-infrastructure
+# can switch tracing on with PYTHONPATH without encoding this image's Python
+# version or venv layout. The directory holds a sitecustomize.py, which is the
+# whole of what `opentelemetry-instrument` does: it prepends this path and execs
+# the command.
+#
+# PYTHONPATH rather than an ENTRYPOINT because run worker pods share this image
+# and are deliberately NOT instrumented yet; PYTHONPATH is the one of the two a
+# run launcher can override back off, which is what dagster_instance.yaml in
+# ol-infrastructure does. The gRPC health-check probes run `env -u PYTHONPATH`
+# for the same reason.
+RUN mkdir -p /opt/otel && \
+    ln -s "$(python -c 'import opentelemetry.instrumentation.auto_instrumentation as m, pathlib; print(pathlib.Path(m.__file__).parent)')" \
+        /opt/otel/auto_instrumentation
 
 WORKDIR /app

--- a/dg_projects/edxorg/Dockerfile
+++ b/dg_projects/edxorg/Dockerfile
@@ -72,10 +72,12 @@ ENV PATH="/app/.venv/bin:$PATH"
 # the command.
 #
 # PYTHONPATH rather than an ENTRYPOINT because run worker pods share this image
-# and are deliberately NOT instrumented yet; PYTHONPATH is the one of the two a
-# run launcher can override back off, which is what dagster_instance.yaml in
-# ol-infrastructure does. The gRPC health-check probes run `env -u PYTHONPATH`
-# for the same reason.
+# and are deliberately NOT instrumented yet. An ENTRYPOINT applies to every
+# process the image starts, so there would be nothing left to switch off; a
+# variable can be stripped for one workload and not another. dagster_instance.yaml
+# in ol-infrastructure strips it from run workers by giving their container a
+# `command` of `env -u PYTHONPATH`, and the gRPC health-check probes prepend the
+# same thing for the same reason.
 RUN mkdir -p /opt/otel && \
     ln -s "$(python -c 'import opentelemetry.instrumentation.auto_instrumentation as m, pathlib; print(pathlib.Path(m.__file__).parent)')" \
         /opt/otel/auto_instrumentation

--- a/dg_projects/edxorg/Dockerfile
+++ b/dg_projects/edxorg/Dockerfile
@@ -31,6 +31,29 @@ RUN --mount=type=cache,target=/root/.cache/uv \
 RUN --mount=type=cache,target=/root/.cache/uv \
     uv sync --frozen --no-dev --no-editable
 
+# OpenTelemetry auto-instrumentation agent, activated by PYTHONPATH (see the
+# /opt/otel symlink in the final stage).
+#
+# Installed with `uv pip install` rather than added to pyproject.toml so the
+# agent can be added or removed without a resolve across all ten code
+# locations. It has to come after the syncs above, which prune anything the
+# lockfile does not name. Only the HTTP OTLP exporter is installed -- the SDK
+# default "otlp" resolves to the gRPC exporter, which is why ol-infrastructure
+# sets OTEL_TRACES_EXPORTER=otlp_proto_http.
+#
+# The instrumentation list is explicit rather than whatever
+# opentelemetry-bootstrap would select, because bootstrap picks psycopg2
+# alongside sqlalchemy and that emits two spans for every query.
+RUN --mount=type=cache,target=/root/.cache/uv \
+    uv pip install --python .venv \
+        opentelemetry-distro \
+        opentelemetry-exporter-otlp-proto-http \
+        opentelemetry-instrumentation-sqlalchemy \
+        opentelemetry-instrumentation-grpc \
+        opentelemetry-instrumentation-botocore \
+        opentelemetry-instrumentation-requests \
+        opentelemetry-instrumentation-urllib3
+
 # Then, use a final image without uv
 FROM python:3.14-slim-bookworm
 # It is important to use the image that matches the builder, as the path to the
@@ -41,5 +64,20 @@ COPY --from=builder /app/dg_projects/edxorg /app
 
 # Place executables in the environment at the front of the path
 ENV PATH="/app/.venv/bin:$PATH"
+
+# A stable path to the auto-instrumentation agent directory, so ol-infrastructure
+# can switch tracing on with PYTHONPATH without encoding this image's Python
+# version or venv layout. The directory holds a sitecustomize.py, which is the
+# whole of what `opentelemetry-instrument` does: it prepends this path and execs
+# the command.
+#
+# PYTHONPATH rather than an ENTRYPOINT because run worker pods share this image
+# and are deliberately NOT instrumented yet; PYTHONPATH is the one of the two a
+# run launcher can override back off, which is what dagster_instance.yaml in
+# ol-infrastructure does. The gRPC health-check probes run `env -u PYTHONPATH`
+# for the same reason.
+RUN mkdir -p /opt/otel && \
+    ln -s "$(python -c 'import opentelemetry.instrumentation.auto_instrumentation as m, pathlib; print(pathlib.Path(m.__file__).parent)')" \
+        /opt/otel/auto_instrumentation
 
 WORKDIR /app

--- a/dg_projects/lakehouse/Dockerfile
+++ b/dg_projects/lakehouse/Dockerfile
@@ -114,10 +114,12 @@ ENV PATH="/app/.venv/bin:$PATH"
 # the command.
 #
 # PYTHONPATH rather than an ENTRYPOINT because run worker pods share this image
-# and are deliberately NOT instrumented yet; PYTHONPATH is the one of the two a
-# run launcher can override back off, which is what dagster_instance.yaml in
-# ol-infrastructure does. The gRPC health-check probes run `env -u PYTHONPATH`
-# for the same reason.
+# and are deliberately NOT instrumented yet. An ENTRYPOINT applies to every
+# process the image starts, so there would be nothing left to switch off; a
+# variable can be stripped for one workload and not another. dagster_instance.yaml
+# in ol-infrastructure strips it from run workers by giving their container a
+# `command` of `env -u PYTHONPATH`, and the gRPC health-check probes prepend the
+# same thing for the same reason.
 RUN mkdir -p /opt/otel && \
     ln -s "$(python -c 'import opentelemetry.instrumentation.auto_instrumentation as m, pathlib; print(pathlib.Path(m.__file__).parent)')" \
         /opt/otel/auto_instrumentation

--- a/dg_projects/lakehouse/Dockerfile
+++ b/dg_projects/lakehouse/Dockerfile
@@ -36,6 +36,29 @@ RUN --mount=type=cache,target=/root/.cache/uv \
 RUN --mount=type=cache,target=/root/.cache/uv \
     uv sync --frozen --no-dev --no-editable
 
+# OpenTelemetry auto-instrumentation agent, activated by PYTHONPATH (see the
+# /opt/otel symlink in the final stage).
+#
+# Installed with `uv pip install` rather than added to pyproject.toml so the
+# agent can be added or removed without a resolve across all ten code
+# locations. It has to come after the syncs above, which prune anything the
+# lockfile does not name. Only the HTTP OTLP exporter is installed -- the SDK
+# default "otlp" resolves to the gRPC exporter, which is why ol-infrastructure
+# sets OTEL_TRACES_EXPORTER=otlp_proto_http.
+#
+# The instrumentation list is explicit rather than whatever
+# opentelemetry-bootstrap would select, because bootstrap picks psycopg2
+# alongside sqlalchemy and that emits two spans for every query.
+RUN --mount=type=cache,target=/root/.cache/uv \
+    uv pip install --python .venv \
+        opentelemetry-distro \
+        opentelemetry-exporter-otlp-proto-http \
+        opentelemetry-instrumentation-sqlalchemy \
+        opentelemetry-instrumentation-grpc \
+        opentelemetry-instrumentation-botocore \
+        opentelemetry-instrumentation-requests \
+        opentelemetry-instrumentation-urllib3
+
 # Compile dbt to generate manifest.json (CRITICAL for @dbt_assets)
 WORKDIR /app/src/ol_dbt
 RUN /app/dg_projects/lakehouse/.venv/bin/dbt deps && \
@@ -83,6 +106,21 @@ RUN apt-get update && \
 
 # Place executables in the environment at the front of the path
 ENV PATH="/app/.venv/bin:$PATH"
+
+# A stable path to the auto-instrumentation agent directory, so ol-infrastructure
+# can switch tracing on with PYTHONPATH without encoding this image's Python
+# version or venv layout. The directory holds a sitecustomize.py, which is the
+# whole of what `opentelemetry-instrument` does: it prepends this path and execs
+# the command.
+#
+# PYTHONPATH rather than an ENTRYPOINT because run worker pods share this image
+# and are deliberately NOT instrumented yet; PYTHONPATH is the one of the two a
+# run launcher can override back off, which is what dagster_instance.yaml in
+# ol-infrastructure does. The gRPC health-check probes run `env -u PYTHONPATH`
+# for the same reason.
+RUN mkdir -p /opt/otel && \
+    ln -s "$(python -c 'import opentelemetry.instrumentation.auto_instrumentation as m, pathlib; print(pathlib.Path(m.__file__).parent)')" \
+        /opt/otel/auto_instrumentation
 
 WORKDIR /app
 

--- a/dg_projects/learning_resources/Dockerfile
+++ b/dg_projects/learning_resources/Dockerfile
@@ -78,10 +78,12 @@ ENV PATH="/app/.venv/bin:$PATH"
 # the command.
 #
 # PYTHONPATH rather than an ENTRYPOINT because run worker pods share this image
-# and are deliberately NOT instrumented yet; PYTHONPATH is the one of the two a
-# run launcher can override back off, which is what dagster_instance.yaml in
-# ol-infrastructure does. The gRPC health-check probes run `env -u PYTHONPATH`
-# for the same reason.
+# and are deliberately NOT instrumented yet. An ENTRYPOINT applies to every
+# process the image starts, so there would be nothing left to switch off; a
+# variable can be stripped for one workload and not another. dagster_instance.yaml
+# in ol-infrastructure strips it from run workers by giving their container a
+# `command` of `env -u PYTHONPATH`, and the gRPC health-check probes prepend the
+# same thing for the same reason.
 RUN mkdir -p /opt/otel && \
     ln -s "$(python -c 'import opentelemetry.instrumentation.auto_instrumentation as m, pathlib; print(pathlib.Path(m.__file__).parent)')" \
         /opt/otel/auto_instrumentation

--- a/dg_projects/learning_resources/Dockerfile
+++ b/dg_projects/learning_resources/Dockerfile
@@ -31,6 +31,28 @@ RUN --mount=type=cache,target=/root/.cache/uv \
 RUN --mount=type=cache,target=/root/.cache/uv \
     uv sync --frozen --no-dev --no-editable
 
+# OpenTelemetry auto-instrumentation agent, activated by PYTHONPATH (see the
+# /opt/otel symlink in the final stage).
+#
+# Installed with `uv pip install` rather than added to pyproject.toml so the
+# agent can be added or removed without a resolve across all ten code
+# locations. It has to come after the syncs above, which prune anything the
+# lockfile does not name. Only the HTTP OTLP exporter is installed -- the SDK
+# default "otlp" resolves to the gRPC exporter, which is why ol-infrastructure
+# sets OTEL_TRACES_EXPORTER=otlp_proto_http.
+#
+# The instrumentation list is explicit rather than whatever
+# opentelemetry-bootstrap would select, because bootstrap picks psycopg2
+# alongside sqlalchemy and that emits two spans for every query.
+RUN --mount=type=cache,target=/root/.cache/uv \
+    uv pip install --python .venv \
+        opentelemetry-distro \
+        opentelemetry-exporter-otlp-proto-http \
+        opentelemetry-instrumentation-sqlalchemy \
+        opentelemetry-instrumentation-grpc \
+        opentelemetry-instrumentation-botocore \
+        opentelemetry-instrumentation-requests \
+        opentelemetry-instrumentation-urllib3
 
 # Then, use a final image without uv
 FROM python:3.14-slim-bookworm
@@ -48,5 +70,20 @@ COPY --from=builder /app/dg_projects/learning_resources /app
 
 # Place executables in the environment at the front of the path
 ENV PATH="/app/.venv/bin:$PATH"
+
+# A stable path to the auto-instrumentation agent directory, so ol-infrastructure
+# can switch tracing on with PYTHONPATH without encoding this image's Python
+# version or venv layout. The directory holds a sitecustomize.py, which is the
+# whole of what `opentelemetry-instrument` does: it prepends this path and execs
+# the command.
+#
+# PYTHONPATH rather than an ENTRYPOINT because run worker pods share this image
+# and are deliberately NOT instrumented yet; PYTHONPATH is the one of the two a
+# run launcher can override back off, which is what dagster_instance.yaml in
+# ol-infrastructure does. The gRPC health-check probes run `env -u PYTHONPATH`
+# for the same reason.
+RUN mkdir -p /opt/otel && \
+    ln -s "$(python -c 'import opentelemetry.instrumentation.auto_instrumentation as m, pathlib; print(pathlib.Path(m.__file__).parent)')" \
+        /opt/otel/auto_instrumentation
 
 WORKDIR /app

--- a/dg_projects/legacy_openedx/Dockerfile
+++ b/dg_projects/legacy_openedx/Dockerfile
@@ -33,6 +33,28 @@ RUN --mount=type=cache,target=/root/.cache/uv \
 RUN --mount=type=cache,target=/root/.cache/uv \
     uv sync --frozen --no-dev --no-editable
 
+# OpenTelemetry auto-instrumentation agent, activated by PYTHONPATH (see the
+# /opt/otel symlink in the final stage).
+#
+# Installed with `uv pip install` rather than added to pyproject.toml so the
+# agent can be added or removed without a resolve across all ten code
+# locations. It has to come after the syncs above, which prune anything the
+# lockfile does not name. Only the HTTP OTLP exporter is installed -- the SDK
+# default "otlp" resolves to the gRPC exporter, which is why ol-infrastructure
+# sets OTEL_TRACES_EXPORTER=otlp_proto_http.
+#
+# The instrumentation list is explicit rather than whatever
+# opentelemetry-bootstrap would select, because bootstrap picks psycopg2
+# alongside sqlalchemy and that emits two spans for every query.
+RUN --mount=type=cache,target=/root/.cache/uv \
+    uv pip install --python .venv \
+        opentelemetry-distro \
+        opentelemetry-exporter-otlp-proto-http \
+        opentelemetry-instrumentation-sqlalchemy \
+        opentelemetry-instrumentation-grpc \
+        opentelemetry-instrumentation-botocore \
+        opentelemetry-instrumentation-requests \
+        opentelemetry-instrumentation-urllib3
 
 # Then, use a final image without uv
 FROM python:3.14-slim-bookworm
@@ -60,5 +82,20 @@ COPY --from=builder /app/dg_projects/legacy_openedx /app
 
 # Place executables in the environment at the front of the path
 ENV PATH="/app/.venv/bin:$PATH"
+
+# A stable path to the auto-instrumentation agent directory, so ol-infrastructure
+# can switch tracing on with PYTHONPATH without encoding this image's Python
+# version or venv layout. The directory holds a sitecustomize.py, which is the
+# whole of what `opentelemetry-instrument` does: it prepends this path and execs
+# the command.
+#
+# PYTHONPATH rather than an ENTRYPOINT because run worker pods share this image
+# and are deliberately NOT instrumented yet; PYTHONPATH is the one of the two a
+# run launcher can override back off, which is what dagster_instance.yaml in
+# ol-infrastructure does. The gRPC health-check probes run `env -u PYTHONPATH`
+# for the same reason.
+RUN mkdir -p /opt/otel && \
+    ln -s "$(python -c 'import opentelemetry.instrumentation.auto_instrumentation as m, pathlib; print(pathlib.Path(m.__file__).parent)')" \
+        /opt/otel/auto_instrumentation
 
 WORKDIR /app

--- a/dg_projects/legacy_openedx/Dockerfile
+++ b/dg_projects/legacy_openedx/Dockerfile
@@ -90,10 +90,12 @@ ENV PATH="/app/.venv/bin:$PATH"
 # the command.
 #
 # PYTHONPATH rather than an ENTRYPOINT because run worker pods share this image
-# and are deliberately NOT instrumented yet; PYTHONPATH is the one of the two a
-# run launcher can override back off, which is what dagster_instance.yaml in
-# ol-infrastructure does. The gRPC health-check probes run `env -u PYTHONPATH`
-# for the same reason.
+# and are deliberately NOT instrumented yet. An ENTRYPOINT applies to every
+# process the image starts, so there would be nothing left to switch off; a
+# variable can be stripped for one workload and not another. dagster_instance.yaml
+# in ol-infrastructure strips it from run workers by giving their container a
+# `command` of `env -u PYTHONPATH`, and the gRPC health-check probes prepend the
+# same thing for the same reason.
 RUN mkdir -p /opt/otel && \
     ln -s "$(python -c 'import opentelemetry.instrumentation.auto_instrumentation as m, pathlib; print(pathlib.Path(m.__file__).parent)')" \
         /opt/otel/auto_instrumentation

--- a/dg_projects/ml/Dockerfile
+++ b/dg_projects/ml/Dockerfile
@@ -31,6 +31,28 @@ RUN --mount=type=cache,target=/root/.cache/uv \
 RUN --mount=type=cache,target=/root/.cache/uv \
     uv sync --frozen --no-dev --no-editable
 
+# OpenTelemetry auto-instrumentation agent, activated by PYTHONPATH (see the
+# /opt/otel symlink in the final stage).
+#
+# Installed with `uv pip install` rather than added to pyproject.toml so the
+# agent can be added or removed without a resolve across all ten code
+# locations. It has to come after the syncs above, which prune anything the
+# lockfile does not name. Only the HTTP OTLP exporter is installed -- the SDK
+# default "otlp" resolves to the gRPC exporter, which is why ol-infrastructure
+# sets OTEL_TRACES_EXPORTER=otlp_proto_http.
+#
+# The instrumentation list is explicit rather than whatever
+# opentelemetry-bootstrap would select, because bootstrap picks psycopg2
+# alongside sqlalchemy and that emits two spans for every query.
+RUN --mount=type=cache,target=/root/.cache/uv \
+    uv pip install --python .venv \
+        opentelemetry-distro \
+        opentelemetry-exporter-otlp-proto-http \
+        opentelemetry-instrumentation-sqlalchemy \
+        opentelemetry-instrumentation-grpc \
+        opentelemetry-instrumentation-botocore \
+        opentelemetry-instrumentation-requests \
+        opentelemetry-instrumentation-urllib3
 
 # Then, use a final image without uv
 FROM python:3.14-slim-bookworm
@@ -42,5 +64,20 @@ COPY --from=builder /app/dg_projects/ml /app
 
 # Place executables in the environment at the front of the path
 ENV PATH="/app/.venv/bin:$PATH"
+
+# A stable path to the auto-instrumentation agent directory, so ol-infrastructure
+# can switch tracing on with PYTHONPATH without encoding this image's Python
+# version or venv layout. The directory holds a sitecustomize.py, which is the
+# whole of what `opentelemetry-instrument` does: it prepends this path and execs
+# the command.
+#
+# PYTHONPATH rather than an ENTRYPOINT because run worker pods share this image
+# and are deliberately NOT instrumented yet; PYTHONPATH is the one of the two a
+# run launcher can override back off, which is what dagster_instance.yaml in
+# ol-infrastructure does. The gRPC health-check probes run `env -u PYTHONPATH`
+# for the same reason.
+RUN mkdir -p /opt/otel && \
+    ln -s "$(python -c 'import opentelemetry.instrumentation.auto_instrumentation as m, pathlib; print(pathlib.Path(m.__file__).parent)')" \
+        /opt/otel/auto_instrumentation
 
 WORKDIR /app

--- a/dg_projects/ml/Dockerfile
+++ b/dg_projects/ml/Dockerfile
@@ -72,10 +72,12 @@ ENV PATH="/app/.venv/bin:$PATH"
 # the command.
 #
 # PYTHONPATH rather than an ENTRYPOINT because run worker pods share this image
-# and are deliberately NOT instrumented yet; PYTHONPATH is the one of the two a
-# run launcher can override back off, which is what dagster_instance.yaml in
-# ol-infrastructure does. The gRPC health-check probes run `env -u PYTHONPATH`
-# for the same reason.
+# and are deliberately NOT instrumented yet. An ENTRYPOINT applies to every
+# process the image starts, so there would be nothing left to switch off; a
+# variable can be stripped for one workload and not another. dagster_instance.yaml
+# in ol-infrastructure strips it from run workers by giving their container a
+# `command` of `env -u PYTHONPATH`, and the gRPC health-check probes prepend the
+# same thing for the same reason.
 RUN mkdir -p /opt/otel && \
     ln -s "$(python -c 'import opentelemetry.instrumentation.auto_instrumentation as m, pathlib; print(pathlib.Path(m.__file__).parent)')" \
         /opt/otel/auto_instrumentation

--- a/dg_projects/openedx/Dockerfile
+++ b/dg_projects/openedx/Dockerfile
@@ -31,6 +31,28 @@ RUN --mount=type=cache,target=/root/.cache/uv \
 RUN --mount=type=cache,target=/root/.cache/uv \
     uv sync --frozen --no-dev --no-editable
 
+# OpenTelemetry auto-instrumentation agent, activated by PYTHONPATH (see the
+# /opt/otel symlink in the final stage).
+#
+# Installed with `uv pip install` rather than added to pyproject.toml so the
+# agent can be added or removed without a resolve across all ten code
+# locations. It has to come after the syncs above, which prune anything the
+# lockfile does not name. Only the HTTP OTLP exporter is installed -- the SDK
+# default "otlp" resolves to the gRPC exporter, which is why ol-infrastructure
+# sets OTEL_TRACES_EXPORTER=otlp_proto_http.
+#
+# The instrumentation list is explicit rather than whatever
+# opentelemetry-bootstrap would select, because bootstrap picks psycopg2
+# alongside sqlalchemy and that emits two spans for every query.
+RUN --mount=type=cache,target=/root/.cache/uv \
+    uv pip install --python .venv \
+        opentelemetry-distro \
+        opentelemetry-exporter-otlp-proto-http \
+        opentelemetry-instrumentation-sqlalchemy \
+        opentelemetry-instrumentation-grpc \
+        opentelemetry-instrumentation-botocore \
+        opentelemetry-instrumentation-requests \
+        opentelemetry-instrumentation-urllib3
 
 # Then, use a final image without uv
 FROM python:3.14-slim-bookworm
@@ -42,5 +64,20 @@ COPY --from=builder /app/dg_projects/openedx /app
 
 # Place executables in the environment at the front of the path
 ENV PATH="/app/.venv/bin:$PATH"
+
+# A stable path to the auto-instrumentation agent directory, so ol-infrastructure
+# can switch tracing on with PYTHONPATH without encoding this image's Python
+# version or venv layout. The directory holds a sitecustomize.py, which is the
+# whole of what `opentelemetry-instrument` does: it prepends this path and execs
+# the command.
+#
+# PYTHONPATH rather than an ENTRYPOINT because run worker pods share this image
+# and are deliberately NOT instrumented yet; PYTHONPATH is the one of the two a
+# run launcher can override back off, which is what dagster_instance.yaml in
+# ol-infrastructure does. The gRPC health-check probes run `env -u PYTHONPATH`
+# for the same reason.
+RUN mkdir -p /opt/otel && \
+    ln -s "$(python -c 'import opentelemetry.instrumentation.auto_instrumentation as m, pathlib; print(pathlib.Path(m.__file__).parent)')" \
+        /opt/otel/auto_instrumentation
 
 WORKDIR /app

--- a/dg_projects/openedx/Dockerfile
+++ b/dg_projects/openedx/Dockerfile
@@ -72,10 +72,12 @@ ENV PATH="/app/.venv/bin:$PATH"
 # the command.
 #
 # PYTHONPATH rather than an ENTRYPOINT because run worker pods share this image
-# and are deliberately NOT instrumented yet; PYTHONPATH is the one of the two a
-# run launcher can override back off, which is what dagster_instance.yaml in
-# ol-infrastructure does. The gRPC health-check probes run `env -u PYTHONPATH`
-# for the same reason.
+# and are deliberately NOT instrumented yet. An ENTRYPOINT applies to every
+# process the image starts, so there would be nothing left to switch off; a
+# variable can be stripped for one workload and not another. dagster_instance.yaml
+# in ol-infrastructure strips it from run workers by giving their container a
+# `command` of `env -u PYTHONPATH`, and the gRPC health-check probes prepend the
+# same thing for the same reason.
 RUN mkdir -p /opt/otel && \
     ln -s "$(python -c 'import opentelemetry.instrumentation.auto_instrumentation as m, pathlib; print(pathlib.Path(m.__file__).parent)')" \
         /opt/otel/auto_instrumentation


### PR DESCRIPTION
### What are the relevant tickets?

N/A — tracked in witan as `tk-otel-auto-instrumentation-for-the-dagster-contro-142adc`, under the "Dagster + PgBouncer observability and pool tuning" project.

### Description (What does it do?)

The image half of a two-repo change. The Pulumi half is mitodl/ol-infrastructure#5733, which switches tracing on for the webserver, the daemon and the ten code locations by putting an agent directory on `PYTHONPATH`. This PR puts that agent in the images and gives the directory a stable name.

- Installs `opentelemetry-distro` + the HTTP OTLP exporter + an explicit instrumentation list (sqlalchemy, grpc, botocore, requests, urllib3) into `dg_deployments/Dockerfile.dagster-k8s` and all ten `dg_projects/*/Dockerfile`.
- Symlinks the agent directory to `/opt/otel/auto_instrumentation` in each final stage.

Nothing is activated by this PR on its own: no `ENV PYTHONPATH`, no `ENTRYPOINT` change. The images carry a dormant agent until ol-infrastructure names the path.

<details>
<summary><b>Implementation details</b></summary>
<br>

**Why a symlink and not the real path.** The three image families have three different layouts: code locations are Python 3.14 in a relocatable `uv` venv at `/app/.venv`, `dagster-k8s` is Python 3.13 installed system-wide, and `lakehouse` is back on 3.13 for dbt-core's mashumaro constraint. Encoding any of those in the Pulumi stack would mean a Renovate bump here silently disabling instrumentation there.

**Why `PYTHONPATH` is the activation lever at all.** The directory holds a `sitecustomize.py`, and prepending it to `PYTHONPATH` is the whole of what `opentelemetry-instrument` does — the console script computes the same directory, prepends it, and `execl`s the command ([`auto_instrumentation/__init__.py`](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/opentelemetry-instrumentation/src/opentelemetry/instrumentation/auto_instrumentation/__init__.py)). An `ENTRYPOINT` would not work for the webserver or the daemon, whose command the Dagster chart hardcodes as `["/bin/bash", "-c", ...]`. For the code locations it would also apply to every process the image starts — run worker pods share this image and are deliberately not instrumented — leaving nothing to switch off, whereas a variable can be stripped per workload.

**Why `uv pip install` and not a pyproject dependency.** These are an agent, not a runtime dependency — nothing in the code imports them. Keeping them out of the lockfiles means the whole thing can be added, upgraded or removed without a resolve across ten projects. It follows the existing unpinned `uv pip install --system` line in `Dockerfile.dagster-k8s`. In the builder stages it has to come after both `uv sync --frozen` calls, which prune anything the lockfile does not name.

**Why the instrumentation list is explicit.** `opentelemetry-bootstrap` selects psycopg2 alongside sqlalchemy, which emits two spans for the one statement.

**Why only the HTTP exporter.** The SDK default `otlp` resolves to the gRPC exporter, and an unresolvable exporter aborts SDK initialisation outright — traces included. ol-infrastructure names `OTEL_TRACES_EXPORTER=otlp_proto_http` to match.

</details>

### How can this be tested?

Both image families were built locally from this branch (`docker build -f dg_projects/openedx/Dockerfile .` and `-f dg_deployments/Dockerfile.dagster-k8s .`), and the resulting images checked directly:

- With `PYTHONPATH=/opt/otel/auto_instrumentation` plus the OTEL_* set ol-infrastructure produces, `trace.get_tracer_provider()` is a real `TracerProvider`, the span processor's exporter is `OTLPSpanExporter` pointed at `http://…alloy-receiver…:4318/v1/traces`, and `SQLAlchemyInstrumentor`/`GrpcInstrumentorClient` both report `is_instrumented_by_opentelemetry == True`.
- Under `env -u PYTHONPATH` the same checks return `ProxyTracerProvider` and `False` — the off switch the Pulumi side uses for both the health-check probes and (after review on mitodl/ol-infrastructure#5733) run worker pods.
- `env -u PYTHONPATH dagster api grpc-health-check -p 4006` still runs (fails to connect, as expected with nothing listening).

Dependency impact from the install, read off the build logs: in the code-location image it adds only opentelemetry packages, no existing pin moves. In `dagster-k8s` it upgrades the opentelemetry 1.43.0/0.64b0 that `dagster-azure` already pulled in transitively to 1.44.0/0.65b0.

Reviewer validation is the same two `docker build`s plus the checks above; there is no runtime behaviour change until ol-infrastructure merges.

### Additional Context

`dagster-azure` brings `azure-monitor-opentelemetry`, which registers a second `opentelemetry_distro` and `opentelemetry_configurator` entry point in the `dagster-k8s` image. The loader takes "the first to come up" when nothing is named, so ol-infrastructure pins `OTEL_PYTHON_DISTRO=distro` and `OTEL_PYTHON_CONFIGURATOR=configurator`. Worth knowing if either image's dependency set changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PmBR31urv7W1hZe8cGpBzn

