### PR TITLE
fix(starrocks): retry the dbt build when StarRocks reports a base table dropped

### DIFF
--- a/dg_projects/lakehouse/lakehouse/lib/starrocks_dbt.py
+++ b/dg_projects/lakehouse/lakehouse/lib/starrocks_dbt.py
@@ -49,8 +49,25 @@ RETRY_BASE_DELAY = 30
 # word boundaries on the numeric codes, so an unrelated number (a row count, a
 # line number, part of a timestamp) can't trip a retry. The two text signatures
 # need no such guard; neither string appears in a successful build's output.
+#
+# "base-table dropped" -- also wrapped in a generic 1064.  The b2b_analytics MVs
+# read the `dimensional` tables through an Iceberg external catalog, and the
+# Trino project rebuilds those (materialized='table') on every run.  For a window
+# afterwards StarRocks refuses to analyze a CREATE against one, reporting the
+# base table as dropped, and the condition then clears on its own.
+#
+# Measured on the 2026-09-03 17:31 UTC run: the first four models dbt started
+# concurrently all failed on dim_organization in 0.61-0.70s, models 5-8 built OK
+# in that same invocation seconds later, and a re-run 60s afterwards built all
+# eight.  A second attempt is all this needs.
+#
+# A base table that is genuinely gone rather than momentarily stale costs the
+# full 210s of backoff before failing the same way.  That is the trade the
+# signatures above already accept, and cheaper than a red asset that only ever
+# needed a second attempt.
 RETRIABLE_ERROR_PATTERN = re.compile(
     r"\b(1044|1045|2003|2006|2013)\b|forward failed|SocketTimeoutException"
+    r"|base-table dropped"
 )
 
 # dbt_project.yml tags the StarRocks-targeted models with this; it is also what

--- a/dg_projects/lakehouse/lakehouse/lib/starrocks_dbt.py
+++ b/dg_projects/lakehouse/lakehouse/lib/starrocks_dbt.py
@@ -47,8 +47,8 @@ RETRY_BASE_DELAY = 30
 # node's logged error message unmodified -- so these do reach us, but as plain
 # text inside a multi-line message rather than a structured field. Hence the
 # word boundaries on the numeric codes, so an unrelated number (a row count, a
-# line number, part of a timestamp) can't trip a retry. The two text signatures
-# need no such guard; neither string appears in a successful build's output.
+# line number, part of a timestamp) can't trip a retry. The three text signatures
+# need no such guard; none of them appears in a successful build's output.
 #
 # "base-table dropped" -- also wrapped in a generic 1064.  The b2b_analytics MVs
 # read the `dimensional` tables through an Iceberg external catalog, and the

--- a/dg_projects/lakehouse/lakehouse_tests/test_starrocks_dbt.py
+++ b/dg_projects/lakehouse/lakehouse_tests/test_starrocks_dbt.py
@@ -43,6 +43,26 @@ Database Error
   1064 (HY000): forward failed: unknown result
 """
 
+# Verbatim from the 2026-09-03 17:31 UTC run, after the Trino project rebuilt the
+# `dimensional` Iceberg tables.  dbt's first four concurrent models all failed on
+# dim_organization; models 5-8 built OK in that same invocation and a re-run 60s
+# later built all eight -- which is what makes this signature worth retrying.
+BASE_TABLE_DROPPED_FAILURE = """The dbt CLI process with command
+
+`dbt build --target starrocks_production --select tag:starrocks`
+
+failed with exit code `1`.
+
+Errors parsed from dbt logs:
+
+3 of 8 ERROR creating sql materialized_view model \
+b2b_analytics.mv_b2b_contract_monthly_engagement_trend  [ERROR in 0.61s]
+
+  Database Error in model mv_b2b_contract_monthly_engagement_trend
+  1064 (HY000): Getting analyzing error. Detail message: base-table dropped: \
+dim_organization.
+"""
+
 CLEAN_BUILD_OUTPUT = """
 1 of 7 OK created sql materialized_view model b2b_analytics.mv_b2b_program_funnel \
 [SUCCESS in 12.06s]
@@ -79,6 +99,22 @@ class TestLooksRetriable:
     )
     def test_wire_protocol_codes(self, code, meaning):
         assert looks_retriable(Exception(f"{code} (HY000): {meaning}"))
+
+    def test_stale_external_base_table_is_retriable(self):
+        """A rebuilt Iceberg base table leaves StarRocks' cached handle stale for
+        a window.  The same invocation went on to build the remaining models and
+        a re-run went green, so this is worth another attempt rather than a red
+        asset.
+        """
+        assert looks_retriable(Exception(BASE_TABLE_DROPPED_FAILURE))
+
+    def test_base_table_dropped_signature(self):
+        assert looks_retriable(
+            Exception(
+                "1064 (HY000): Getting analyzing error. Detail message: "
+                "base-table dropped: dim_organization."
+            )
+        )
 
     def test_successful_build_output_is_not_retriable(self):
         assert not looks_retriable(Exception(CLEAN_BUILD_OUTPUT))


### PR DESCRIPTION
### What are the relevant tickets?

N/A

### Description (What does it do?)

The `b2b_analytics` StarRocks build failed outright on 2026-09-03 with a transient error the retry classifier didn't recognize, so the asset went red without spending any of its four attempts.

- Add `base-table dropped` to `RETRIABLE_ERROR_PATTERN` in `lakehouse/lib/starrocks_dbt.py`.
- Record the production failure verbatim as a test fixture, matching the file's existing convention, plus two tests.

The signature arrives wrapped in a generic `1064`, so the numeric alternation can't catch it — same shape as the `forward failed` / `SocketTimeoutException` entries already there.

<details>
<summary><b>Implementation details</b></summary>
<br>

The MVs read the `dimensional` tables through an Iceberg external catalog, and the Trino project rebuilds those (`materialized='table'`) on every run. For a window afterwards StarRocks refuses to analyze a `CREATE` against one, reporting the base table as dropped even though it is present and queryable:

```
Database Error in model mv_b2b_contract_monthly_engagement_trend
  1064 (HY000): Getting analyzing error. Detail message: base-table dropped: dim_organization.
```

It clears on its own, which is what makes it retriable rather than a real error. From the failed invocation's own dbt output (2026-09-03 17:31 UTC) — dbt runs 4 threads, and only the first concurrent batch failed:

```
3 of 8 ERROR mv_b2b_contract_monthly_engagement_trend [0.61s]
4 of 8 ERROR mv_b2b_contract_utilization              [0.65s]
2 of 8 ERROR mv_b2b_contract_content_engagement_depth [0.66s]
1 of 8 ERROR mv_b2b_content_engagement_depth          [0.70s]
7 of 8 OK    mv_b2b_monthly_engagement_trend          [0.42s]
6 of 8 OK    mv_b2b_mit_admin_contract_health         [0.45s]
5 of 8 OK    mv_b2b_enrollment_completion_funnel      [0.48s]
8 of 8 OK    mv_b2b_program_funnel                    [0.77s]
```

Models 5-8 built in that same invocation seconds after 1-4 failed, and a re-run 60s later built all eight. All eight models join `dim_organization`, so nothing in the SQL distinguishes the failures.

The existing guards still hold, which is the part worth checking on review:

- `test_unrelated_1064_is_not_retriable` — a genuine SQL error (`Unknown table 'mv_b2b_typo'`) is also a 1064 and stays non-retriable. `base-table dropped` doesn't appear in it.
- `TestRetriableCodesAgreeWithTheResource` extracts `\d{4}` from the pattern to compare against `StarRocksResource._RETRIABLE_ERRORS`; the added text carries no digits, so that comparison is unaffected.

Cost of being wrong: a base table that is genuinely gone rather than momentarily stale burns the full 210s of backoff (`MAX_BUILD_ATTEMPTS = 4`, `RETRY_BASE_DELAY = 30`) before failing the same way. That's the trade the existing signatures already accept.

</details>

### How can this be tested?

The two new tests were confirmed to fail against the unfixed classifier before the pattern change, then pass with it:

```
BEFORE (lib/starrocks_dbt.py reverted to HEAD):
  FAILED TestLooksRetriable::test_stale_external_base_table_is_retriable
  FAILED TestLooksRetriable::test_base_table_dropped_signature
  2 failed

AFTER:
  41 passed in 0.99s
```

`uv run pre-commit run --files ...` on both changed files: ruff format, ruff check, mypy, detect-secrets all pass.

Not tested end to end against a live StarRocks — reproducing the failure needs the Iceberg base tables to be rebuilt underneath a running build. The behavioural claim this rests on is the production evidence above, not a synthetic repro.

### Additional Context

This makes the asset survive the failure; it does not remove it. Two larger items are untouched:

- The MV refresh job runs at ~06:04 UTC daily while the mitxonline source sync finishes at 00:22 / 06:16 / 12:26 / 18:13, so the MVs are always built from an earlier snapshot and don't move again for 24h.
- `--full-refresh` drops every selected MV while `ol-analytics-api` queries them live, which is the source of its `Unknown table 'b2b_analytics.mv_b2b_*'` 500s. Fixing that properly means building to a shadow name and swapping.

A pre-build `REFRESH EXTERNAL TABLE` on the `dimensional` sources would stop the staleness reaching dbt at all, rather than retrying past it. Deliberately left out here — it adds a new failure surface inside the asset, and the evidence says one retry is sufficient.
