### PR TITLE
fix(ml): use classic AnthropicBedrock client, not Bedrock Mantle

### DIFF
--- a/dg_projects/ml/ml/lib/summarize.py
+++ b/dg_projects/ml/ml/lib/summarize.py
@@ -5,7 +5,7 @@ import os
 from typing import Any, Protocol
 
 import polars as pl
-from anthropic import Anthropic, AnthropicBedrockMantle
+from anthropic import Anthropic, AnthropicBedrock
 from ml.resources.llm import LLMClientFactory
 from openai import OpenAI
 from pyiceberg.catalog import Catalog
@@ -64,11 +64,11 @@ class SummaryClient(Protocol):
 class AnthropicSummaryClient:
     """Adapts an Anthropic-compatible client to the SummaryClient protocol.
 
-    Also covers AnthropicBedrockMantle, which exposes the same messages.create
+    Also covers AnthropicBedrock, which exposes the same messages.create
     interface but is not an Anthropic subclass.
     """
 
-    def __init__(self, client: Anthropic | AnthropicBedrockMantle) -> None:
+    def __init__(self, client: Anthropic | AnthropicBedrock) -> None:
         self._client = client
         self.model_version = SUMMARY_MODEL_VERSION
 
@@ -124,7 +124,7 @@ def build_summary_client(
     llm: LLMClientFactory,
 ) -> AnthropicSummaryClient | OpenAISummaryClient:
     client = llm.get_client()
-    if isinstance(client, Anthropic | AnthropicBedrockMantle):
+    if isinstance(client, Anthropic | AnthropicBedrock):
         return AnthropicSummaryClient(client)
     return OpenAISummaryClient(client)
 

--- a/dg_projects/ml/ml/lib/summarize.py
+++ b/dg_projects/ml/ml/lib/summarize.py
@@ -46,6 +46,14 @@ SKIP_CHAR_THRESHOLD = 500
 # this to a matching id (e.g. "gpt-4o-mini") -- there is no one id valid everywhere.
 SUMMARY_MODEL_VERSION = os.environ.get("SUMMARY_MODEL_VERSION", "claude-haiku-4-5")
 
+# Bedrock uses its own model id namespace (a Bedrock model or inference-profile
+# id, e.g. "global.anthropic.claude-haiku-4-5-20251001-v1:0"), never the plain
+# Anthropic API id above -- client_class="bedrock" needs this override instead.
+BEDROCK_SUMMARY_MODEL_VERSION = os.environ.get(
+    "BEDROCK_SUMMARY_MODEL_VERSION",
+    "global.anthropic.claude-haiku-4-5-20251001-v1:0",
+)
+
 SUMMARY_PROMPT = (
     "Summarize the following support conversation from the requester's point of "
     "view. Focus on the problem reported and its resolution if one is present. "
@@ -70,7 +78,11 @@ class AnthropicSummaryClient:
 
     def __init__(self, client: Anthropic | AnthropicBedrock) -> None:
         self._client = client
-        self.model_version = SUMMARY_MODEL_VERSION
+        self.model_version = (
+            BEDROCK_SUMMARY_MODEL_VERSION
+            if isinstance(client, AnthropicBedrock)
+            else SUMMARY_MODEL_VERSION
+        )
 
     def summarize(self, conversation_text: str) -> str | None:
         message = self._client.messages.create(

--- a/dg_projects/ml/ml/resources/llm.py
+++ b/dg_projects/ml/ml/resources/llm.py
@@ -3,7 +3,7 @@
 import os
 from typing import ClassVar
 
-from anthropic import Anthropic, AnthropicBedrockMantle
+from anthropic import Anthropic, AnthropicBedrock
 from dagster import ConfigurableResource
 from ol_orchestrate.resources.secrets.vault import Vault
 from openai import OpenAI
@@ -52,19 +52,17 @@ class LLMClientFactory(ConfigurableResource):
         ),
     )
 
-    _client: Anthropic | OpenAI | AnthropicBedrockMantle | None = PrivateAttr(
-        default=None
-    )
+    _client: Anthropic | OpenAI | AnthropicBedrock | None = PrivateAttr(default=None)
 
     supported_client_class: ClassVar[dict[str, type]] = {
         "anthropic": Anthropic,
         "openai": OpenAI,
         "openai_compatible": OpenAI,
         "azure_openai": OpenAI,
-        "bedrock": AnthropicBedrockMantle,
+        "bedrock": AnthropicBedrock,
     }
 
-    def get_client(self) -> Anthropic | OpenAI | AnthropicBedrockMantle:
+    def get_client(self) -> Anthropic | OpenAI | AnthropicBedrock:
         """Create and return an authenticated LLM client."""
         if self._client is not None:
             return self._client
@@ -80,7 +78,7 @@ class LLMClientFactory(ConfigurableResource):
 
         if self.client_class == "bedrock":
             # Deployed environments: no API key at all, auth is the same IAM
-            # metadata credentials used for S3 access - AnthropicBedrockMantle
+            # metadata credentials used for S3 access - AnthropicBedrock
             # picks these up from the standard AWS credential chain.
             self._client = sdk_client_class(aws_region=self.aws_region)
             return self._client

--- a/dg_projects/ml/ml_tests/test_llm.py
+++ b/dg_projects/ml/ml_tests/test_llm.py
@@ -1,7 +1,7 @@
 """Tests for ml.resources.llm.LLMClientFactory."""
 
 import pytest
-from anthropic import Anthropic, AnthropicBedrockMantle
+from anthropic import Anthropic, AnthropicBedrock
 from ml.resources.llm import LLMClientFactory
 from ol_orchestrate.resources.secrets.vault import Vault
 from openai import OpenAI
@@ -98,7 +98,7 @@ def test_get_client_bedrock_skips_vault_and_uses_iam_auth() -> None:
 
     client = factory.get_client()
 
-    assert isinstance(client, AnthropicBedrockMantle)
+    assert isinstance(client, AnthropicBedrock)
     assert client.aws_region == "us-west-2"
     assert kv_v1.reads == 0
 

--- a/dg_projects/ml/ml_tests/test_summarize.py
+++ b/dg_projects/ml/ml_tests/test_summarize.py
@@ -2,7 +2,7 @@
 
 import polars as pl
 import pytest
-from anthropic import Anthropic
+from anthropic import Anthropic, AnthropicBedrock
 from ml.lib import summarize
 from openai import OpenAI
 
@@ -150,6 +150,27 @@ def test_build_summary_client_uses_configured_model_for_anthropic(
 
     assert isinstance(client, summarize.AnthropicSummaryClient)
     assert client.model_version == "claude-haiku-4-5"
+
+
+def test_build_summary_client_uses_bedrock_model_for_bedrock(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """SUMMARY_MODEL_VERSION is an Anthropic API id and never valid on Bedrock, so
+    the Bedrock path must use BEDROCK_SUMMARY_MODEL_VERSION instead.
+    """
+    monkeypatch.setattr(summarize, "SUMMARY_MODEL_VERSION", "claude-haiku-4-5")
+    monkeypatch.setattr(
+        summarize,
+        "BEDROCK_SUMMARY_MODEL_VERSION",
+        "global.anthropic.claude-haiku-4-5-20251001-v1:0",
+    )
+
+    client = summarize.build_summary_client(
+        _FakeLLM(AnthropicBedrock(aws_region="us-east-1"))
+    )
+
+    assert isinstance(client, summarize.AnthropicSummaryClient)
+    assert client.model_version == "global.anthropic.claude-haiku-4-5-20251001-v1:0"
 
 
 def test_filter_unsummarized_resubmits_conversations_with_new_turns() -> None:


### PR DESCRIPTION
## Summary
- Swap `AnthropicBedrockMantle` for `AnthropicBedrock` in `LLMClientFactory` so `client_class="bedrock"` matches the classic `bedrock:InvokeModel` IAM grant in mitodl/ol-infrastructure#5750, not the separate Bedrock Mantle service/IAM prefix.

Fixes: https://github.com/mitodl/ol-data-platform/pull/2604#issuecomment-5544343130

## Test plan
- [x] `uv run pytest ml_tests/test_llm.py` — 9 passed
- [x] `uv run pytest ml_tests/test_summarize.py` — 19 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)