### PR TITLE
fix(openedx): read the Tika access token from the Vault path that is actually written

### DIFF
--- a/dg_projects/openedx/openedx/definitions.py
+++ b/dg_projects/openedx/openedx/definitions.py
@@ -78,7 +78,9 @@ TIKA_BASE_URL = TIKA_ENVIRONMENTS.get(DAGSTER_ENV, "https://tika-qa.ol.mit.edu")
 # authenticates to its own Vault (vault-$DAGSTER_ENV), and the tika stack writes
 # secret-operations/tika/access-token there from the same value it inlines as
 # the `expected` token in the APISIX route guarding that environment's Tika, so
-# a token read from this path always matches the gateway it will be sent to.
+# a token read from this path matches the gateway it will be sent to -- with the
+# exception of `ci`, which reads from vault-ci but posts to the QA host above.
+# That pre-existing host/Vault mismatch is out of scope here.
 # Reading the env-scoped secret-operations/{production-apps,rc-apps}/tika/
 # access-token is what broke this asset: the tika stack stopped writing those
 # paths, the Dagster Vault policy never granted them, and the denial below
@@ -87,9 +89,11 @@ TIKA_BASE_URL = TIKA_ENVIRONMENTS.get(DAGSTER_ENV, "https://tika-qa.ol.mit.edu")
 # Resilient, but not silent. Substituting an empty token without saying so is
 # how this shipped broken for a day: the location loaded healthy, nothing
 # logged, and the only symptom was a 401 buried in the run logs of an asset
-# that had never once succeeded. Log loudly enough for Sentry to raise it,
-# then carry on -- an empty token costs one asset, whereas failing the import
-# costs every asset in the location.
+# that had never once succeeded. Log at ERROR in the code location's process
+# logs, then carry on -- an empty token costs one asset, whereas failing the
+# import costs every asset in the location. Note that this does not raise in
+# Sentry: init_sentry configures LoggingIntegration(event_level=None), so log
+# records become breadcrumbs and never events.
 if not vault_authenticated:
     log.error(
         "Vault is unauthenticated, so the Tika access token is empty. Tika "

--- a/dg_projects/openedx/openedx/definitions.py
+++ b/dg_projects/openedx/openedx/definitions.py
@@ -1,5 +1,6 @@
 """OpenEdX data extraction and tracking log normalization definitions."""
 
+import logging
 import os
 from datetime import UTC, datetime
 from functools import partial
@@ -31,6 +32,8 @@ from openedx.jobs.normalize_logs import (
 )
 
 init_sentry("openedx")
+
+log = logging.getLogger(__name__)
 
 # Initialize vault with resilient loading
 try:
@@ -80,17 +83,33 @@ TIKA_BASE_URL = TIKA_ENVIRONMENTS.get(DAGSTER_ENV, "https://tika-qa.ol.mit.edu")
 # access-token is what broke this asset: the tika stack stopped writing those
 # paths, the Dagster Vault policy never granted them, and the denial below
 # turned into an empty token and a 401 on every extraction.
-try:
-    tika_access_token = (
-        vault.client.secrets.kv.v1.read_secret(
+#
+# Resilient, but not silent. Substituting an empty token without saying so is
+# how this shipped broken for a day: the location loaded healthy, nothing
+# logged, and the only symptom was a 401 buried in the run logs of an asset
+# that had never once succeeded. Log loudly enough for Sentry to raise it,
+# then carry on -- an empty token costs one asset, whereas failing the import
+# costs every asset in the location.
+if not vault_authenticated:
+    log.error(
+        "Vault is unauthenticated, so the Tika access token is empty. Tika "
+        "extraction will fail with a 401 until Vault auth is restored."
+    )
+    tika_access_token = ""
+else:
+    try:
+        tika_access_token = vault.client.secrets.kv.v1.read_secret(
             mount_point="secret-operations",
             path="tika/access-token",
         )["data"]["value"]
-        if vault_authenticated
-        else ""
-    )
-except Exception:  # noqa: BLE001 (resilient loading, as above)
-    tika_access_token = ""
+    except Exception:
+        log.exception(
+            "Could not read the Tika access token from Vault at "
+            "secret-operations/tika/access-token, so it is empty. Tika "
+            "extraction will fail with a 401 until this is resolved. Check "
+            "that the Dagster Vault policy grants read on that path."
+        )
+        tika_access_token = ""
 
 
 def s3_uploads_bucket(

--- a/dg_projects/openedx/openedx/definitions.py
+++ b/dg_projects/openedx/openedx/definitions.py
@@ -55,28 +55,36 @@ dagster_env: Literal["dev", "ci", "qa", "production"] = cast(
     os.environ.get("DAGSTER_ENVIRONMENT", DAGSTER_ENV),
 )
 
-# Tika text extraction. Host and Vault path are per environment; see
+# Tika text extraction. Only the host varies by environment; see
 # ol_orchestrate/resources/tika.py and ol-infrastructure applications/tika/.
 # Only production has its own deployment -- everything else points at QA, which
 # is deliberate: a dev run extracting text is harmless, and standing up a third
 # Tika for it would not change the result.
 TIKA_ENVIRONMENTS = {
-    "production": ("https://tika-production.ol.mit.edu", "production-apps"),
+    "production": "https://tika-production.ol.mit.edu",
 }
-TIKA_BASE_URL, TIKA_VAULT_APP_PATH = TIKA_ENVIRONMENTS.get(
-    DAGSTER_ENV, ("https://tika-qa.ol.mit.edu", "rc-apps")
-)
+TIKA_BASE_URL = TIKA_ENVIRONMENTS.get(DAGSTER_ENV, "https://tika-qa.ol.mit.edu")
 
 # Read at definition time, matching how this code location already loads other
 # static secrets. An unauthenticated Vault yields an empty token rather than
 # failing the whole location to load -- the same resilient-loading posture used
 # for Vault auth above. A run that actually needs Tika then fails on the call,
 # where the error is legible, instead of at import.
+#
+# The path is flat rather than environment-scoped on purpose. Each environment
+# authenticates to its own Vault (vault-$DAGSTER_ENV), and the tika stack writes
+# secret-operations/tika/access-token there from the same value it inlines as
+# the `expected` token in the APISIX route guarding that environment's Tika, so
+# a token read from this path always matches the gateway it will be sent to.
+# Reading the env-scoped secret-operations/{production-apps,rc-apps}/tika/
+# access-token is what broke this asset: the tika stack stopped writing those
+# paths, the Dagster Vault policy never granted them, and the denial below
+# turned into an empty token and a 401 on every extraction.
 try:
     tika_access_token = (
         vault.client.secrets.kv.v1.read_secret(
             mount_point="secret-operations",
-            path=f"{TIKA_VAULT_APP_PATH}/tika/access-token",
+            path="tika/access-token",
         )["data"]["value"]
         if vault_authenticated
         else ""

--- a/packages/ol-orchestrate-lib/src/ol_orchestrate/resources/tika.py
+++ b/packages/ol-orchestrate-lib/src/ol_orchestrate/resources/tika.py
@@ -7,9 +7,12 @@ Deployment details:
   Production:  https://tika-production.ol.mit.edu
   QA:          https://tika-qa.ol.mit.edu
   Auth:        X-Access-Token header
-  Vault paths:
-    production  secret-operations/production-apps/tika/access-token  key: value
-    qa          secret-operations/rc-apps/tika/access-token           key: value
+  Vault path:  secret-operations/tika/access-token  key: value
+
+    The same path in every environment -- the environment is selected by which
+    Vault you authenticate to, not by the path. Do not use the env-scoped
+    secret-operations/{production-apps,rc-apps}/tika/access-token: nothing
+    writes those paths any more, so a token read there earns a 401.
 
 Infrastructure source:
   ol-infrastructure/src/ol_infrastructure/applications/tika/
@@ -131,10 +134,8 @@ class TikaResource(ConfigurableResource[None]):
     access_token: str = Field(
         description=(
             "X-Access-Token value for the Tika service. "
-            "Read from Vault at "
-            "secret-operations/production-apps/tika/access-token (key: value) "
-            "for production or "
-            "secret-operations/rc-apps/tika/access-token for QA."
+            "Read from Vault at secret-operations/tika/access-token "
+            "(key: value), the same path in every environment."
         ),
     )
     timeout: int = Field(


### PR DESCRIPTION
### What are the relevant tickets?
N/A — found while investigating a `DagsterRunFailureRateCritical` page against `data-production` on 2026-09-04. Companion to https://github.com/mitodl/ol-infrastructure/pull/5752, which adds the Vault grant this change depends on.

### Description (What does it do?)

- Repoints the `openedx` code location's Tika `X-Access-Token` read at `secret-operations/tika/access-token`, the path the tika stack actually writes. It was reading the env-scoped `secret-operations/{production-apps,rc-apps}/tika/access-token`, which nothing writes any more.
- Makes both empty-token paths log at `ERROR` instead of silently substituting `""`.
- Corrects the Vault paths documented in `TikaResource`, which are where the wrong convention most likely came from.

`course_document_text` has **never materialized** on mitxonline, mitx, or xpro. This is the app half of the fix; the Vault policy grant is in ol-infrastructure#5752 and both are needed.

<details>
<summary><b>Implementation details</b></summary>
<br>

**Failure chain**

1. `definitions.py` read the token at definition load time from `secret-operations/production-apps/tika/access-token`.
2. Vault denied it — `applications/tika/__main__.py` stopped writing that path, and the Dagster Vault policy never granted it.
3. `except Exception: tika_access_token = ""` swallowed the 403 with no log, so the location loaded healthy carrying an empty token.
4. The APISIX route in front of `tika-production.ol.mit.edu` string-compares `X-Access-Token` against a literal, so an empty token got a 401.
5. `content_files.py` raised `TikaUnavailableError`; the level-triggered automation condition re-requested every sensor tick and `run_retries.max_retries: 3` multiplied each ×4, taking `data-production` to a 71.7% run failure rate (398 failures / 555 terminal runs in 6h, from 99 root runs).

Observed from inside the running code location pod before the change:

```
loaded-at-startup: vault_authenticated=True vault_path='production-apps' token_len=0 sha8=e3b0c442
live vault read FAILED: Forbidden 1 error occurred:
	* permission denied
, on get https://vault-production.odl.mit.edu/v1/secret-operations/production-apps/tika/access-token
```

`sha8=e3b0c442` is the SHA-256 prefix of the empty string — Vault auth succeeded, only the token was missing.

**Why the path needs no environment scoping**

`VAULT_ADDRESS` is `https://vault-$DAGSTER_ENV.odl.mit.edu`, so the environment is already selected by which Vault you authenticate to. The tika stack writes `secret-operations/tika/access-token` into each environment's Vault from the same `x_access_token` value it inlines as the `expected` token in that environment's APISIX route, so a token read from this path always matches the gateway it will be sent to. `mit_learn` already reads the flat path for this reason and grants it at `mitlearn_policy.hcl:42`.

`TIKA_ENVIRONMENTS` keeps its per-environment entry for the host, which does still vary; only the second tuple element (the Vault path segment) and `TIKA_VAULT_APP_PATH` are gone.

**Resilient but not silent**

The load-time read stays wrapped so a Vault problem costs the one Tika asset rather than every asset in the location — but it now logs at `ERROR` in the code location's process logs. That is process logging only, not a Sentry alert: `init_sentry` configures `LoggingIntegration(event_level=None)`, so log records become breadcrumbs and never events. Both paths that can yield an empty token are covered: Vault unauthenticated, and the read itself failing.

**Not fixed here:** for `ci`, `VAULT_ADDR` resolves to `vault-ci` while `TIKA_BASE_URL` points at `tika-qa`, so CI reads a CI token and sends it to the QA gateway. That mismatch predates this change and is unaffected by it; `dev` incidentally improves, since `vault-qa` does have the flat path written.

</details>

### How can this be tested?

Automated — run locally, all passing:

```
cd dg_projects/openedx && uv run --frozen pytest openedx_tests/     # 131 passed
uv run --frozen pytest packages/ol-orchestrate-lib/tests/resources/test_tika.py   # 20 passed
pre-commit run --files dg_projects/openedx/openedx/definitions.py \
  packages/ol-orchestrate-lib/src/ol_orchestrate/resources/tika.py   # ruff + mypy pass
```

The host still resolves on both branches after dropping the tuple unpacking:

```
production -> base_url=https://tika-production.ol.mit.edu
qa         -> base_url=https://tika-qa.ol.mit.edu
```

The new logging was exercised in both directions rather than assumed. Simulating a denied read against an authenticated Vault:

```
ERROR:openedx.definitions:Could not read the Tika access token from Vault at
secret-operations/tika/access-token, so it is empty. Tika extraction will fail
with a 401 until this is resolved. Check that the Dagster Vault policy grants
read on that path.
Traceback (most recent call last):
	* permission denied
RESULT token_len=0 location_still_imported=True
```

`location_still_imported=True` confirms resilience is preserved. The unauthenticated path logs its own `ERROR` equivalently.

No test asserts the Vault path itself, before or after — nothing in the suite pinned the old one.

To validate in a deployed environment, once ol-infrastructure#5752 has applied and the code location has been restarted:

- The token should resolve from the pod, with a SHA-256 prefix that is *not* `e3b0c442`:
  ```
  kubectl exec -n dagster deploy/dagster-user-code-dagster-user-deployments-openedx \
    -c dagster-user-deployments -- python3 -c \
    'import hashlib; from openedx.definitions import tika_access_token as t; \
     print(len(t), hashlib.sha256(t.encode()).hexdigest()[:8])'
  ```
- `mitxonline/openedx/processed_data/course_document_text` should record its first-ever materialization, and `DagsterRunFailureRateCritical` on `data-production` should clear.

### Additional Context

- The token is read at **import time**, so neither this change nor the policy grant affects a running pod until the code location restarts.
- Merge order does not matter, but production stays broken until both are deployed. Applying the policy grant first is the safer sequence: it is inert on its own, whereas this change alone still reads a path Dagster has no grant for.
- `tika_server_policy.hcl:1-5` in ol-infrastructure still grants the two env-scoped paths that nothing writes. Worth deleting — that stale grant is the most likely origin of this bug, and it will mislead the next reader the same way.

### Checklist:
- [ ] Merge and apply https://github.com/mitodl/ol-infrastructure/pull/5752 (Vault grant) to `data-production`
- [ ] Build and deploy this change to the `openedx` code location
- [ ] Restart the code location so the token is re-read at import
- [ ] Confirm the first `course_document_text` materialization and that `DagsterRunFailureRateCritical` clears

