### PR TITLE
feat(dlt): stamp _dlt_load_id on every loaded row

### DIFF
--- a/src/ol_dlt/.dlt/config.toml
+++ b/src/ol_dlt/.dlt/config.toml
@@ -21,6 +21,33 @@ dlthub_telemetry = true
 workers = 1
 max_parallel_items = 20
 
+# Stamp every loaded row with the load package id (`_dlt_load_id`).
+#
+# dlt only turns this on by default for the JSON normalizer; the parquet
+# normalizer defaults both `add_dlt_id` and `add_dlt_load_id` to False
+# (dlt/normalize/configuration.py). Every ol_dlt relational source builds its
+# resources with `backend="pyarrow"` (ol_dlt/database.py), so without this the
+# raw tables carry no metadata column at all -- which is how the dlt-loaded
+# staging models came to dedup on Airbyte's `_airbyte_extracted_at`, a column
+# their tables never had (ol-data-platform#2443).
+#
+# `_dlt_load_id` is `str(increasing_precise_time())` and dlt guarantees it
+# increases over time for a given schema/destination/dataset, so it is a valid
+# "latest load wins" ordering key.
+#
+# This lands ahead of the dbt side on purpose. Writing the column is inert until
+# something reads it, and it has to be written before the staging models can be
+# pointed at it -- ordering by a column no load has stamped yet is the same
+# COLUMN_NOT_FOUND this is meant to end. #2650 is what teaches the dedup macro to
+# resolve it through the ingestion inventory.
+#
+# `add_dlt_id` is deliberately left off: on the pyarrow path `_dlt_id` is a
+# random per-row value (arrow.py generates it with `generate_dlt_ids`, and the
+# deterministic key_hash/row_hash variants are only wired into the relational
+# normalizer), so it orders nothing and costs a column.
+[normalize.parquet_normalizer]
+add_dlt_load_id = true
+
 # Iceberg Catalog Configuration
 #
 # dlt reads [iceberg_catalog] (flat, not named sub-sections). The "aws_glue"


### PR DESCRIPTION
### What are the relevant tickets?

Prerequisite for https://github.com/mitodl/ol-data-platform/issues/2443 — split out of #2650 so the effect can be validated on real data before anything reads the column.

### Description (What does it do?)

Sets `normalize.parquet_normalizer.add_dlt_load_id = true` for every ol_dlt pipeline, so each loaded row carries the load package id.

dlt turns that column on only for its **JSON** normalizer; the **parquet** normalizer defaults both `add_dlt_id` and `add_dlt_load_id` to `False`. Every ol_dlt relational source builds its resources with `backend="pyarrow"`, so our raw tables carry no metadata column at all — neither `_airbyte_*` nor `_dlt_*`. That absence is why the dlt-loaded staging models still dedup on Airbyte's `_airbyte_extracted_at`, a column their tables never had: there was nothing else to order by.

One config line, no code. **Nothing reads the column yet** — #2650 is what teaches the dedup macro to resolve it.

<details>
<summary><b>Implementation details</b></summary>
<br>

**The defaults, from dlt 1.30.0 `dlt/normalize/configuration.py`:**

```python
json_normalizer    = ItemsNormalizerConfiguration(add_dlt_id=True,  add_dlt_load_id=True)
parquet_normalizer = ItemsNormalizerConfiguration(add_dlt_id=False, add_dlt_load_id=False)
model_normalizer   = ItemsNormalizerConfiguration(add_dlt_id=False, add_dlt_load_id=True)
```

`ol_dlt.database` passes `backend="pyarrow"` (`src/ol_dlt/ol_dlt/database.py:244`), which puts every relational source on the parquet path.

**Why `_dlt_load_id` is a valid ordering key.** It is `str(increasing_precise_time())`, and `create_load_id()` documents the guarantee: *"They must maintain increase order over time for a particular dlt schema loaded to particular destination and dataset."* It also joins to `_dlt_loads.load_id` (note the different name on that table, kept for backwards compatibility). Being per-*load* rather than per-*row*, it cannot break ties within a single load — the same coarseness `_airbyte_extracted_at` has, and not a problem for our dispositions, where `merge` dedups on the primary key within a load and `replace` leaves one row per key.

**Why `add_dlt_id` stays off.** On the pyarrow path `_dlt_id` is a random per-row value — `arrow.py` fills it via `generate_dlt_ids`, confirmed by running it twice and getting different values for the same input. The deterministic `key_hash` / `row_hash` variants exist only in the relational (dict) normalizer, chosen by `get_root_row_id_type()` from the merge strategy, and `arrow.py` carries an explicit `TODO` that they are not wired up there. So a row hash is not reachable from our backend, and would order nothing if it were — it is a content hash, not a version.

**Why this lands first.** Writing the column is inert until something orders by it, but ordering by a column no load has stamped yet is precisely the `COLUMN_NOT_FOUND` failure #2443 is about. Landing the write ahead of the read means the first load on this config answers the one thing I could not test locally: whether dlt's schema evolution cleanly adds the column to an **existing** Iceberg table.

</details>

### How can this be tested?

The config resolves through dlt's own provider:

```
cd src/ol_dlt && uv run python -c "import dlt; print(dlt.config['normalize.parquet_normalizer.add_dlt_load_id'])"
```

Observed `True`. Reading `extract.workers` back as `1` in the same call confirms the value came from this project's `config.toml` rather than a stray one.

**The validation this PR exists for, after merge and deploy.** Run any dlt ingest and confirm the column lands. A source whose tables already exist is the interesting case, since that exercises schema evolution rather than table creation — `keycloak_ingest` is the smallest such (14 tables, already Iceberg in QA, and no dbt model dedups on them, so nothing can break):

```
aws glue get-table --database-name ol_warehouse_qa_raw \
  --name raw__keycloak__app__postgres__client \
  --query 'Table.Parameters.metadata_location' --output text
# then read that metadata JSON and confirm a _dlt_load_id field in the current schema
```

Expected: `_dlt_load_id` present on rows written after this deploys; rows written before it carry null, which is correct and is why #2650 orders `NULLS LAST`.

### Additional Context

Split out of #2650 at review request specifically so this validation happens before the dbt side lands. #2650 keeps the `edxorg/mysql` transitional declaration that stops those 7 models ordering by the column until that unit has reloaded.
