### PR TITLE
fix(marimo): hoist the third-party imports above their call sites

### DIFF
--- a/images/marimo-jupyterlab/templates/demo.py
+++ b/images/marimo-jupyterlab/templates/demo.py
@@ -25,6 +25,16 @@ def _():
 
 
 @app.cell
+def _():
+    import altair as alt
+    import numpy as np
+    import pandas as pd
+    import polars as pl
+
+    return alt, pl
+
+
+@app.cell
 def _(mo):
     mo.md(r"""
     # A tour of the OL warehouse in marimo
@@ -953,16 +963,6 @@ def _(mo):
     | `ModuleNotFoundError` after `pip install` | Sandbox mode. Add the package to the `/// script` header and restart the kernel. |
     """)
     return
-
-
-@app.cell
-def _():
-    import altair as alt
-    import numpy as np
-    import pandas as pd
-    import polars as pl
-
-    return alt, pl
 
 
 if __name__ == "__main__":

--- a/images/marimo-jupyterlab/templates/getting_started.py
+++ b/images/marimo-jupyterlab/templates/getting_started.py
@@ -25,6 +25,16 @@ def _():
 
 
 @app.cell
+def _():
+    import altair as alt
+    import numpy as np
+    import pandas as pd
+    import polars as pl
+
+    return
+
+
+@app.cell
 def _(mo):
     mo.md(r"""
     # Warehouse notebook
@@ -222,16 +232,6 @@ def _(mo, warehouse):
         """,
         engine=warehouse,
     )
-    return
-
-
-@app.cell
-def _():
-    import altair as alt
-    import numpy as np
-    import pandas as pd
-    import polars as pl
-
     return
 
 


### PR DESCRIPTION
## What

Moves the `altair`/`numpy`/`pandas`/`polars` import cell in both notebook templates from the very bottom of the file to directly after the `import marimo as mo` cell. The block is moved verbatim — no content change.

Refs #2624.

## Why

Reported from a live run of `demo.py`: the polars and altair call sites raise `NameError`.

The imports were present all along, but the cell holding them was **dead last** — line 958 of 969 in `demo.py`, while the first `pl.DataFrame` is at line 341.

**As a marimo file this was correct, and still is.** Every consuming cell already declared `pl`/`alt` as a parameter, the import cell returned them, and the reactive DAG supplies them regardless of where they sit in the file. `marimo check --strict` exits 0 both before and after this change, which is exactly why it was not caught.

What it broke is the way a template actually gets used. These notebooks are meant to be read top to bottom and pasted cell by cell into a running notebook — that is how both were tested against Galaxy in the first place — and pasted in order, a consumer cell runs long before the import cell exists. A reader who scrolls to section 5 also sees `pl.DataFrame(...)` with no import anywhere above it.

## Verification

- Cell count unchanged: 43 in `demo.py`, before and after.
- All four `pl`/`alt` consumers (lines 339, 703, 753, 862) still take them as parameters, and the import cell at line 28 now precedes every one of them in file order.
- `marimo check --strict` exit 0 on both templates (marimo 0.24.0, the version they were generated with).
- Both files parse; `pre-commit run` green — ruff format, ruff check, mypy, detect-secrets.
- `git diff` is a pure relocation: 20 insertions, 20 deletions, identical block.

## Scope note

`getting_started.py` was never broken — it uses none of the four imports. That cell exists to advertise the libraries available in the environment and returns nothing. It gets the same move for consistency, and because the top of the file is where a reader adds their own imports.

## Rollout

Merging republishes `ghcr.io/mitodl/marimo-jupyterlab:latest` via `build_marimo_jupyterlab.yaml`. The standing `cp -n` caveat applies: the singleuser postStart hook never overwrites, so anyone with an existing `~/notebooks/demo.py` keeps the broken copy until they delete it. That recovery step is the first row of the troubleshooting table in the [notebooks guide](https://github.com/mitodl/platform-engineering-site/pull/71).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Drmv2eP7vPaTWfwtFQ2dUP
