### PR TITLE
fix(dlt): declare _dlt_load_id nullable so existing tables can evolve

### DIFF
--- a/src/ol_dlt/ol_dlt/config.py
+++ b/src/ol_dlt/ol_dlt/config.py
@@ -47,6 +47,47 @@ TableFormat = Literal["iceberg", "delta", "hive", "native"]
 # per-source [destination.*] blocks that used to live in .dlt/config.toml).
 _LAYOUT = "{table_name}/{load_id}.{file_id}.{ext}"
 
+# `_dlt_load_id` declared NULLABLE, overriding dlt's own definition.
+#
+# dlt defines the column as `nullable: False` (schema/utils.py dlt_load_id_column)
+# and falls back to that definition only when a resource has not declared the
+# column itself (extract/extractors.py). The nullability flows straight through
+# to the Arrow field (libs/pyarrow.py add_dlt_load_id_column), and dlt evolves an
+# Iceberg table with `update.union_by_name(arrow_schema)` -- so a non-nullable
+# Arrow field asks pyiceberg to add a REQUIRED column.
+#
+# pyiceberg refuses that on any table that already holds rows:
+#
+#     ValueError: Incompatible change: cannot add required column: _dlt_load_id
+#
+# because format-version 1 and 2 carry no initial-value to backfill existing rows
+# with (table/update/schema.py). Every raw table we already load is v2 with rows,
+# so leaving dlt's default in place breaks the first load of every existing
+# source the moment `add_dlt_load_id` is on. Verified both ways against pyiceberg
+# 0.11.1: a nullable Arrow field unions in as optional and leaves existing rows
+# null; a non-nullable one is refused.
+#
+# Nullable is also the honest declaration. Rows written before a unit turned the
+# flag on genuinely have no load id, which is why the dbt dedup macro orders
+# `NULLS LAST` -- a stamped row wins over an unstamped one.
+DLT_LOAD_ID_COLUMN: dict[str, dict[str, Any]] = {
+    "_dlt_load_id": {"data_type": "text", "nullable": True, "precision": 64},
+}
+
+
+def with_nullable_load_id(source: Any) -> Any:  # noqa: ANN401
+    """Declare `_dlt_load_id` nullable on every resource of ``source``.
+
+    Applied by each source's ``build_source()`` rather than at each resource: a
+    source that misses this does not fail at import, it fails on its next load
+    against an existing table, which is the failure mode this exists to remove.
+    ``tests/test_load_id_column.py`` asserts every source applies it.
+    """
+    for resource in source.resources.values():
+        resource.apply_hints(columns=DLT_LOAD_ID_COLUMN)
+    return source
+
+
 # Schema contract for JSON API sources (mit_climate, mitpe, mit_edx_programs).
 # New tables/columns evolve freely — upstream APIs add fields routinely and
 # dropping them would be worse than a wider raw table. A TYPE FLIP on an

--- a/src/ol_dlt/ol_dlt/database.py
+++ b/src/ol_dlt/ol_dlt/database.py
@@ -255,6 +255,10 @@ def build_table_resource(
     return resource.with_name(raw_name).apply_hints(
         table_name=raw_name,
         table_format=config.active_table_format(resolved_profile),
+        # Nullable, overriding dlt's required default -- see
+        # config.DLT_LOAD_ID_COLUMN for why a required column cannot be added to
+        # an Iceberg table that already holds rows.
+        columns=config.DLT_LOAD_ID_COLUMN,
     )
 
 

--- a/src/ol_dlt/ol_dlt/sources/edxorg_s3/__init__.py
+++ b/src/ol_dlt/ol_dlt/sources/edxorg_s3/__init__.py
@@ -283,6 +283,11 @@ def edxorg_s3_source(
                 write_disposition="merge",
                 primary_key=_EDXORG_PRIMARY_KEY,
                 table_format=resolved_format,
+                # Nullable, overriding dlt's required default -- see
+                # config.DLT_LOAD_ID_COLUMN. This source has no build_source()
+                # to route through config.with_nullable_load_id, so it declares
+                # the column on the resource directly.
+                columns=config.DLT_LOAD_ID_COLUMN,
             )
         )
 

--- a/src/ol_dlt/ol_dlt/sources/mit_climate/__init__.py
+++ b/src/ol_dlt/ol_dlt/sources/mit_climate/__init__.py
@@ -73,4 +73,6 @@ def build_source() -> Any:  # noqa: ANN401
     """Instantiate the source, honouring URL overrides from the environment."""
     explainers = os.getenv("MIT_CLIMATE_EXPLAINERS_API_URL", _EXPLAINERS_URL_DEFAULT)
     ask = os.getenv("ASK_MIT_CLIMATE_API_URL", _ASK_URL_DEFAULT)
-    return mit_climate_source(explainers_url=explainers, ask_url=ask)
+    return config.with_nullable_load_id(
+        mit_climate_source(explainers_url=explainers, ask_url=ask)
+    )

--- a/src/ol_dlt/ol_dlt/sources/mit_edx_programs/__init__.py
+++ b/src/ol_dlt/ol_dlt/sources/mit_edx_programs/__init__.py
@@ -138,4 +138,4 @@ mit_edx_programs_pipeline = config.pipeline_for("mit_edx_programs")
 
 def build_source() -> Any:  # noqa: ANN401
     """Instantiate the source (uniform entrypoint for the Dagster wrapper)."""
-    return mit_edx_programs_source()
+    return config.with_nullable_load_id(mit_edx_programs_source())

--- a/src/ol_dlt/ol_dlt/sources/mitpe/__init__.py
+++ b/src/ol_dlt/ol_dlt/sources/mitpe/__init__.py
@@ -79,4 +79,6 @@ mitpe_pipeline = config.pipeline_for("mitpe")
 
 def build_source() -> Any:  # noqa: ANN401
     """Instantiate the source, honouring the base-URL override from the env."""
-    return mitpe_source(base_url=os.getenv("MITPE_BASE_URL", _MITPE_BASE_URL_DEFAULT))
+    return config.with_nullable_load_id(
+        mitpe_source(base_url=os.getenv("MITPE_BASE_URL", _MITPE_BASE_URL_DEFAULT))
+    )

--- a/src/ol_dlt/ol_dlt/sources/oll/__init__.py
+++ b/src/ol_dlt/ol_dlt/sources/oll/__init__.py
@@ -65,4 +65,4 @@ oll_pipeline = config.pipeline_for("oll")
 
 def build_source() -> Any:  # noqa: ANN401
     """Instantiate the OLL source (uniform entrypoint for the Dagster wrapper)."""
-    return oll_source()
+    return config.with_nullable_load_id(oll_source())

--- a/src/ol_dlt/ol_dlt/sources/podcast_rss/__init__.py
+++ b/src/ol_dlt/ol_dlt/sources/podcast_rss/__init__.py
@@ -289,4 +289,4 @@ podcast_rss_pipeline = config.pipeline_for("podcast", pipeline_name="podcast_rss
 
 def build_source() -> Any:  # noqa: ANN401
     """Instantiate the podcast source (uniform entrypoint for the wrapper)."""
-    return podcast_rss_source()
+    return config.with_nullable_load_id(podcast_rss_source())

--- a/src/ol_dlt/ol_dlt/sources/youtube/__init__.py
+++ b/src/ol_dlt/ol_dlt/sources/youtube/__init__.py
@@ -378,4 +378,4 @@ youtube_pipeline = config.pipeline_for("youtube")
 
 def build_source() -> Any:  # noqa: ANN401
     """Instantiate the source (uniform entrypoint for the Dagster wrapper)."""
-    return youtube_source()
+    return config.with_nullable_load_id(youtube_source())

--- a/src/ol_dlt/tests/test_load_id_column.py
+++ b/src/ol_dlt/tests/test_load_id_column.py
@@ -1,0 +1,87 @@
+"""Every ol_dlt source must declare `_dlt_load_id` nullable.
+
+dlt defines the column as non-nullable and adds it to the Arrow schema it evolves
+Iceberg tables from, so a source that leaves the default in place asks pyiceberg
+to add a REQUIRED column. pyiceberg refuses that on any format-v1/v2 table that
+already holds rows:
+
+    ValueError: Incompatible change: cannot add required column: _dlt_load_id
+
+That is not caught at import or by a unit test of the source itself -- it
+surfaces on the source's next load against an existing table, in whichever
+environment deploys first. This module is the guard: a new source that forgets
+the declaration fails here instead.
+"""
+
+from __future__ import annotations
+
+import importlib
+import inspect
+import pkgutil
+
+import pytest
+
+import ol_dlt.sources
+from ol_dlt.config import DLT_LOAD_ID_COLUMN
+
+LOAD_ID = "_dlt_load_id"
+
+
+def _source_modules() -> list[str]:
+    return sorted(
+        m.name for m in pkgutil.iter_modules(ol_dlt.sources.__path__) if m.ispkg
+    )
+
+
+def test_the_declaration_is_nullable() -> None:
+    """The whole point of the override -- guard against it being flipped back."""
+    assert DLT_LOAD_ID_COLUMN[LOAD_ID]["nullable"] is True
+
+
+def test_every_source_package_is_covered() -> None:
+    """Fail when a new source package appears without being considered here."""
+    known = {
+        "edxorg_s3",
+        "keycloak",
+        "mit_climate",
+        "mit_edx_programs",
+        "mitpe",
+        "mitxonline_app",
+        "oll",
+        "podcast_rss",
+        "youtube",
+    }
+    assert set(_source_modules()) == known, (
+        "A source package was added or removed. Make sure it declares "
+        f"{LOAD_ID} nullable (config.with_nullable_load_id, or columns= on its "
+        "resource hints), then update this list."
+    )
+
+
+@pytest.mark.parametrize("module_name", _source_modules())
+def test_source_declares_nullable_load_id(module_name: str) -> None:
+    """Each source routes the declaration through one of the two seams.
+
+    Checked statically rather than by building the source: several need Vault
+    credentials or network access to instantiate, and this assertion is about
+    the wiring, not about a live connection.
+    """
+    module = importlib.import_module(f"ol_dlt.sources.{module_name}")
+    src = inspect.getsource(module)
+    assert (
+        "with_nullable_load_id" in src
+        or "DLT_LOAD_ID_COLUMN" in src
+        or "build_database_source" in src
+    ), (
+        f"{module_name} does not declare {LOAD_ID} as nullable. Wrap its "
+        "build_source() in config.with_nullable_load_id, or pass "
+        "columns=config.DLT_LOAD_ID_COLUMN to its resource hints."
+    )
+
+
+def test_database_backed_sources_get_it_from_the_shared_builder() -> None:
+    """build_table_resource is the seam for every DatabaseSourceSpec source."""
+    import ol_dlt.database
+
+    src = inspect.getsource(ol_dlt.database)
+    assert "columns=config.DLT_LOAD_ID_COLUMN" in src


### PR DESCRIPTION
### What are the relevant tickets?

Fixes the regression introduced by #2651. Prerequisite for #2650.

### Description (What does it do?)

**#2651 broke the first load of every dlt source that has pre-existing tables.** QA `keycloak_ingest` fails with:

```
ValueError: Incompatible change: cannot add required column: _dlt_load_id
```

This declares the column **nullable**, which is all that is needed. New rows get a load id; rows written before the flag keep null.

- Applied at the two seams every source passes through: `build_table_resource` (all `DatabaseSourceSpec` sources) and `config.with_nullable_load_id` (the rest), plus `columns=` on `edxorg_s3`, which builds its resource inline.
- `tests/test_load_id_column.py` fails when a new source package appears without the declaration.

Production is **not** affected yet — `data-loading` there is still on `58b68dd1`. It would break on its next deploy, across every dlt source, since all their production tables already exist.

<details>
<summary><b>Implementation details</b></summary>
<br>

**The chain.** dlt defines the column `nullable: False` (`schema/utils.py` `dlt_load_id_column`) and falls back to that definition only when the resource has not declared it (`extract/extractors.py`). The nullability flows into the Arrow field (`libs/pyarrow.py` `add_dlt_load_id_column`, which reads `columns[...]["nullable"]`), and dlt evolves Iceberg with `update.union_by_name(arrow_schema)` (`libs/pyiceberg.py` `evolve_table`) — so a non-nullable Arrow field asks pyiceberg to add a **required** column.

pyiceberg refuses that whenever `required and initial_default is None` (`table/update/schema.py`): format-version 1 and 2 have no initial value to backfill existing rows with. Every raw table we load is v2 and has rows. Note the gate is on the missing initial value, not on the version — **upgrading tables to format-version 3 would not fix this on its own.**

**Why nullable rather than a migration.** It needs no backfill, no table rewrite, and no drop/recreate — which would not be available to `merge`-disposition units like `edxorg/mysql` without losing history. It is also the honest declaration: rows written before a unit turned the flag on genuinely have no load id, which is exactly why #2650's dedup macro orders `NULLS LAST`.

**Why the seams, and why a test guards them.** A source that misses the declaration does not fail at import or in its own unit tests. It fails on its next load against an existing table, in whichever environment deploys first — which is how this reached QA. The test asserts the set of source packages is fully covered, so a new source cannot quietly miss it.

</details>

### How can this be tested?

```
cd src/ol_dlt && uv run pytest tests/
```

125 pass, including 12 new ones.

**The behavioural proof**, run against the deployed versions (dlt 1.30.0, pyiceberg 0.11.1), loading Iceberg into a table that already held rows:

| scenario | result |
| --- | --- |
| 1. existing table, flag off (today's tables) | OK, `cols=['id']` |
| 2. flag on, dlt's required default | **FAIL** — `Incompatible change: cannot add required column: _dlt_load_id` |
| 3. fresh pod, flag on + nullable hint | **OK** — `required=False rows=6 nulls=3` |

Round 2 reproduces QA's failure exactly. Round 3 running *after* round 2 also shows a failed attempt does **not** poison the fix: no state clearing and no table migration are needed, just this change and the next load.

Isolating the two layers separately gave the same answer — on pyiceberg 0.11.1, `union_by_name` with a nullable Arrow field adds an optional column and leaves pre-existing rows null, while a non-nullable one is refused.

**After merge and deploy**, confirm on the source that failed:

```
# re-run keycloak_ingest in QA, then:
aws glue get-table --database-name ol_warehouse_qa_raw \
  --name raw__keycloak__app__postgres__client \
  --query 'Table.Parameters.metadata_location' --output text
# read that metadata JSON; expect _dlt_load_id present with required=false
```

### Additional Context

`keycloak_ingest`'s daily schedule is `RUNNING` in QA and will keep failing nightly until this lands. The failed run wrote nothing — all 14 keycloak tables still show their last successful 00:30 run — so there is no data damage to repair.

I recommended landing #2651 on the argument that pre-flag rows would simply carry null. That was wrong in a way worth recording: dlt never permits those nulls, so the load fails instead of backfilling. Splitting the config out from #2650 is what confined the blast radius to QA — had they merged together, we would have had failing ingests *and* models pointing at a column that never appeared.
