### PR TITLE
fix(openedx): treat Tika gateway 504 as a document-level failure

### DIFF
--- a/dg_projects/openedx/openedx/assets/content_files.py
+++ b/dg_projects/openedx/openedx/assets/content_files.py
@@ -184,6 +184,9 @@ def _content_type(relative_path: str) -> str:
 # Vault read failure leaves behind -- produces exactly this.
 _TIKA_AUTH_STATUSES = frozenset({401, 403})
 _SERVER_ERROR_FLOOR = 500
+# The APISIX gateway in front of Tika answers 504 when Tika is slower than its
+# read timeout, so this is the same slow-document timeout reported by the proxy.
+_GATEWAY_TIMEOUT_STATUS = 504
 
 
 class TikaUnavailableError(RuntimeError):
@@ -204,13 +207,19 @@ def raise_if_service_failure(error: Exception, relative_path: str) -> None:
     timeout stays a document-level failure because one oversized PDF times out
     on a perfectly healthy service; a genuinely dead service produces enough of
     them to trip the guard, which now also fires when every candidate failed.
+
+    A 504 gets the same treatment. It is the gateway in front of Tika giving up
+    on a slow parse before the client's own timeout does, so it arrives as an
+    HTTP status rather than a timeout exception but means the same thing.
+    Promoting it failed whole course partitions over one slow document, and the
+    automation sensor kept relaunching them.
     """
     status: int | None = None
     if isinstance(error, httpx.HTTPStatusError):
         status = error.response.status_code
     elif not isinstance(error, httpx.TransportError):
         return
-    if isinstance(error, httpx.TimeoutException):
+    if isinstance(error, httpx.TimeoutException) or status == _GATEWAY_TIMEOUT_STATUS:
         return
 
     if status is None or status in _TIKA_AUTH_STATUSES or status >= _SERVER_ERROR_FLOOR:

--- a/dg_projects/openedx/openedx_tests/test_content_files.py
+++ b/dg_projects/openedx/openedx_tests/test_content_files.py
@@ -337,6 +337,22 @@ def test_transport_errors_abort_but_timeouts_stay_per_document():
     assert [r["extraction_status"] for r in rows] == ["failed", "failed"]
 
 
+def test_gateway_timeout_stays_per_document():
+    """A 504 is the gateway timing out a slow parse, not a dead Tika.
+
+    It arrives as an HTTPStatusError rather than a TimeoutException, so it used
+    to hit the 5xx branch and fail the whole course partition over one slow file.
+    """
+
+    def gateway_timeout(_file_bytes, _content_type):
+        raise _http_error(504)
+
+    rows, counters = rows_for([("static/a.pdf", b"%PDF-fake")], extract=gateway_timeout)
+    assert counters["failed"] == 1
+    assert rows[0]["extraction_status"] == "failed"
+    assert rows[0]["content"] is None
+
+
 def test_document_level_failures_still_count_as_failures():
     """A 422 really is about this file, so it must not abort the course."""
 


### PR DESCRIPTION
### What are the relevant tickets?
Fixes DAGSTER-5G
- https://mit-office-of-digital-learning.sentry.io/issues/DAGSTER-5G
- Companion: https://github.com/mitodl/ol-infrastructure/pull/5815

### Description (What does it do?)
`openedx__processed_data__course_document_text` failed 22,716 times in production between 2026-09-03 and 2026-09-10 (DAGSTER-5G). The event I sampled:

```
TikaUnavailableError: Tika is unavailable (failed on static/SustainabilityLectureSlides.pdf): Server error '504 Gateway Time-out' for url 'https://tika-production.ol.mit.edu/tika'
```

- The APISIX route in front of Tika times out reads after 60s, but the Tika client waits 300s ([tika.py#L141-L147](https://github.com/mitodl/ol-data-platform/blob/ad395fde8/packages/ol-orchestrate-lib/src/ol_orchestrate/resources/tika.py#L141-L147)). A parse that runs longer than 60s therefore comes back as an HTTP 504, not an `httpx.TimeoutException`.
- `raise_if_service_failure` ([content_files.py](https://github.com/mitodl/ol-data-platform/blob/d684cb4b3/dg_projects/openedx/openedx/assets/content_files.py)) already counted a client timeout against the document. It promoted every 5xx, 504 included, to `TikaUnavailableError`, so one slow document failed the whole course partition, and the automation sensor and run retries kept relaunching it.
- A 504 is now handled the same way as a client timeout: it adds to the `failed` counter and emits a row with `extraction_status: "failed"`. 401/403 and 500/502/503 still abort the course.

This change alone stops the course-level failures. The slow documents themselves still come back `failed`, and still count toward the success-rate guard, until https://github.com/mitodl/ol-infrastructure/pull/5815 raises the gateway read timeout to 300s.

### How can this be tested?
- `uv run pytest openedx_tests/test_content_files.py` (from `dg_projects/openedx`): 46 passed.
  - New `test_gateway_timeout_stays_per_document`: a 504 counts as one failed document and emits a failed row.
  - Existing `test_service_level_failures_abort_instead_of_counting_as_documents` still requires 401, 403, 500, 502 and 503 to abort.
- `pre-commit run --files` on both changed files: passed (ruff, mypy).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YaS2hez2aw3LBTtmZAmwzX
