### PR TITLE
feat(openedx): ingest django_content_type and the two organizations tables

### DIFF
--- a/ingestion/inventory/units/mitx__mysql.yml
+++ b/ingestion/inventory/units/mitx__mysql.yml
@@ -63,6 +63,7 @@ airbyte:
     - django_comment_common_coursediscussionsettings
     - django_comment_common_discussionsidmapping
     - django_comment_common_forumsconfig
+    - django_content_type
     - edxval_coursevideo
     - edxval_video
     - forum_abuseflagger
@@ -81,6 +82,8 @@ airbyte:
     - grades_persistentsubsectiongrade
     - grades_persistentsubsectiongradeoverride
     - grades_visibleblocks
+    - organizations_organization
+    - organizations_organizationcourse
     - student_anonymoususerid
     - student_courseaccessrole
     - student_courseenrollment
@@ -383,6 +386,13 @@ tables:
   primary_key:
   - - id
   modeled: false
+- name: django_content_type
+  raw_table: raw__mitx__openedx__mysql__django_content_type
+  sync_mode: full_refresh_overwrite
+  namespace: edxapp
+  primary_key:
+  - - id
+  modeled: true
 - name: edxval_coursevideo
   raw_table: raw__mitx__openedx__mysql__edxval_coursevideo
   sync_mode: full_refresh_overwrite
@@ -515,6 +525,20 @@ tables:
   primary_key:
   - - id
   modeled: false
+- name: organizations_organization
+  raw_table: raw__mitx__openedx__mysql__organizations_organization
+  sync_mode: full_refresh_overwrite
+  namespace: edxapp
+  primary_key:
+  - - id
+  modeled: true
+- name: organizations_organizationcourse
+  raw_table: raw__mitx__openedx__mysql__organizations_organizationcourse
+  sync_mode: full_refresh_overwrite
+  namespace: edxapp
+  primary_key:
+  - - id
+  modeled: true
 - name: student_anonymoususerid
   raw_table: raw__mitx__openedx__mysql__student_anonymoususerid
   sync_mode: full_refresh_overwrite

--- a/ingestion/inventory/units/mitxonline__mysql.yml
+++ b/ingestion/inventory/units/mitxonline__mysql.yml
@@ -50,6 +50,7 @@ airbyte:
     - credit_crediteligibility
     - django_comment_client_role
     - django_comment_client_role_users
+    - django_content_type
     - edxval_coursevideo
     - edxval_video
     - forum_abuseflagger
@@ -68,6 +69,8 @@ airbyte:
     - grades_persistentsubsectiongrade
     - grades_persistentsubsectiongradeoverride
     - grades_visibleblocks
+    - organizations_organization
+    - organizations_organizationcourse
     - student_anonymoususerid
     - student_courseaccessrole
     - student_courseenrollment
@@ -328,6 +331,13 @@ tables:
   primary_key:
   - - id
   modeled: true
+- name: django_content_type
+  raw_table: raw__mitxonline__openedx__mysql__django_content_type
+  sync_mode: full_refresh_overwrite
+  namespace: edxapp
+  primary_key:
+  - - id
+  modeled: true
 - name: edxval_coursevideo
   raw_table: raw__mitxonline__openedx__mysql__edxval_coursevideo
   sync_mode: full_refresh_overwrite
@@ -455,6 +465,20 @@ tables:
   modeled: true
 - name: grades_visibleblocks
   raw_table: raw__mitxonline__openedx__mysql__grades_visibleblocks
+  sync_mode: full_refresh_overwrite
+  namespace: edxapp
+  primary_key:
+  - - id
+  modeled: true
+- name: organizations_organization
+  raw_table: raw__mitxonline__openedx__mysql__organizations_organization
+  sync_mode: full_refresh_overwrite
+  namespace: edxapp
+  primary_key:
+  - - id
+  modeled: true
+- name: organizations_organizationcourse
+  raw_table: raw__mitxonline__openedx__mysql__organizations_organizationcourse
   sync_mode: full_refresh_overwrite
   namespace: edxapp
   primary_key:

--- a/ingestion/inventory/units/xpro__mysql.yml
+++ b/ingestion/inventory/units/xpro__mysql.yml
@@ -59,6 +59,7 @@ airbyte:
     - django_comment_common_coursediscussionsettings
     - django_comment_common_discussionsidmapping
     - django_comment_common_forumsconfig
+    - django_content_type
     - edxval_coursevideo
     - edxval_video
     - forum_abuseflagger
@@ -77,6 +78,8 @@ airbyte:
     - grades_persistentsubsectiongrade
     - grades_persistentsubsectiongradeoverride
     - grades_visibleblocks
+    - organizations_organization
+    - organizations_organizationcourse
     - student_anonymoususerid
     - student_courseaccessrole
     - student_courseenrollment
@@ -351,6 +354,13 @@ tables:
   primary_key:
   - - id
   modeled: false
+- name: django_content_type
+  raw_table: raw__xpro__openedx__mysql__django_content_type
+  sync_mode: full_refresh_overwrite
+  namespace: edxapp
+  primary_key:
+  - - id
+  modeled: true
 - name: edxval_coursevideo
   raw_table: raw__xpro__openedx__mysql__edxval_coursevideo
   sync_mode: full_refresh_overwrite
@@ -483,6 +493,20 @@ tables:
   primary_key:
   - - id
   modeled: false
+- name: organizations_organization
+  raw_table: raw__xpro__openedx__mysql__organizations_organization
+  sync_mode: full_refresh_overwrite
+  namespace: edxapp
+  primary_key:
+  - - id
+  modeled: true
+- name: organizations_organizationcourse
+  raw_table: raw__xpro__openedx__mysql__organizations_organizationcourse
+  sync_mode: full_refresh_overwrite
+  namespace: edxapp
+  primary_key:
+  - - id
+  modeled: true
 - name: student_anonymoususerid
   raw_table: raw__xpro__openedx__mysql__student_anonymoususerid
   sync_mode: full_refresh_overwrite

--- a/src/ol_dbt/models/staging/mitxonline/_mitxonline__sources.yml
+++ b/src/ol_dbt/models/staging/mitxonline/_mitxonline__sources.yml
@@ -2362,3 +2362,53 @@ sources:
       description: int, id of the row in the table named by content_type_id. Comment
         and CommentThread ids both start at 1 and overlap heavily, so this is only
         meaningful together with content_type_id
+
+  - name: raw__mitxonline__openedx__mysql__django_content_type
+    description: MITx Online open edX Django content types. Maps a content_type_id
+      used by Django generic foreign keys (e.g. on the forum-v2 tables) to its app
+      and model.
+    columns:
+    - name: id
+      description: int, primary key. Assigned by migration order, so the same model
+        has a different id on each deployment.
+    - name: app_label
+      description: str, Django app the model belongs to, e.g. forum
+    - name: model
+      description: str, lowercased model name, e.g. commentthread or comment
+
+  - name: raw__mitxonline__openedx__mysql__organizations_organization
+    description: MITx Online open edX organizations from the edx-organizations app
+    columns:
+    - name: id
+      description: int, primary key
+    - name: name
+      description: str, display name of the organization
+    - name: short_name
+      description: str, short name of the organization, used in course keys
+    - name: description
+      description: str, description of the organization
+    - name: logo
+      description: str, storage path of the organization logo
+    - name: active
+      description: boolean, whether the organization is active
+    - name: created
+      description: timestamp, when the row was created
+    - name: modified
+      description: timestamp, when the row was last modified
+
+  - name: raw__mitxonline__openedx__mysql__organizations_organizationcourse
+    description: MITx Online open edX links between course runs and organizations
+      from the edx-organizations app
+    columns:
+    - name: id
+      description: int, primary key
+    - name: course_id
+      description: str, open edX course ID formatted as course-v1:{org}+{course code}+{run_tag}
+    - name: organization_id
+      description: int, foreign key to organizations_organization
+    - name: active
+      description: boolean, whether the link is active
+    - name: created
+      description: timestamp, when the row was created
+    - name: modified
+      description: timestamp, when the row was last modified

--- a/src/ol_dbt/models/staging/mitxonline/_stg_mitxonline__models.yml
+++ b/src/ol_dbt/models/staging/mitxonline/_stg_mitxonline__models.yml
@@ -2427,3 +2427,85 @@ models:
     description: int, id of the row in the table named by content_type_id. Comment
       and CommentThread ids both start at 1 and overlap heavily, so this is only meaningful
       together with content_type_id
+- name: stg__mitxonline__openedx__mysql__django_content_type
+  description: MITx Online open edX Django content types. Use to resolve the content_type_id
+    of a generic foreign key by app_label and model rather than by a hardcoded id.
+  columns:
+  - name: contenttype_id
+    description: int, primary key. Differs per deployment for the same model.
+    tests:
+    - unique
+    - not_null
+  - name: contenttype_app_label
+    description: str, Django app the model belongs to, e.g. forum
+    tests:
+    - not_null
+  - name: contenttype_model
+    description: str, lowercased model name, e.g. commentthread or comment
+    tests:
+    - not_null
+  tests:
+  - dbt_expectations.expect_compound_columns_to_be_unique:
+      arguments:
+        column_list: ["contenttype_app_label", "contenttype_model"]
+
+- name: stg__mitxonline__openedx__mysql__organizations_organization
+  description: MITx Online open edX organizations from the edx-organizations app
+  columns:
+  - name: organization_id
+    description: int, primary key
+    tests:
+    - unique
+    - not_null
+  - name: organization_name
+    description: str, display name of the organization
+    tests:
+    - not_null
+  - name: organization_short_name
+    description: str, short name of the organization, used in course keys
+    tests:
+    - unique
+    - not_null
+  - name: organization_description
+    description: str, description of the organization
+  - name: organization_logo
+    description: str, storage path of the organization logo
+  - name: organization_is_active
+    description: boolean, whether the organization is active
+  - name: organization_created_on
+    description: timestamp, when the row was created
+  - name: organization_updated_on
+    description: timestamp, when the row was last modified
+
+- name: stg__mitxonline__openedx__mysql__organizations_organizationcourse
+  description: MITx Online open edX links between course runs and organizations. The
+    authoritative source for a course run's organization, which is not always the
+    org segment of its course key.
+  columns:
+  - name: organizationcourse_id
+    description: int, primary key
+    tests:
+    - unique
+    - not_null
+  - name: courserun_readable_id
+    description: str, open edX course ID formatted as course-v1:{org}+{course code}+{run_tag}
+    tests:
+    - not_null
+  - name: organization_id
+    description: int, foreign key to stg__mitxonline__openedx__mysql__organizations_organization
+    tests:
+    - not_null
+    - relationships:
+        arguments:
+          to: ref('stg__mitxonline__openedx__mysql__organizations_organization')
+          field: organization_id
+  - name: organizationcourse_is_active
+    description: boolean, whether the link is active
+  - name: organizationcourse_created_on
+    description: timestamp, when the row was created
+  - name: organizationcourse_updated_on
+    description: timestamp, when the row was last modified
+  tests:
+  - dbt_expectations.expect_compound_columns_to_be_unique:
+      arguments:
+        column_list: ["courserun_readable_id", "organization_id"]

--- a/src/ol_dbt/models/staging/mitxonline/stg__mitxonline__openedx__mysql__django_content_type.sql
+++ b/src/ol_dbt/models/staging/mitxonline/stg__mitxonline__openedx__mysql__django_content_type.sql
@@ -1,0 +1,18 @@
+-- MITx Online open edX Django content types, needed to resolve the generic foreign keys
+-- (content_type_id, content_object_id) on the forum-v2 tables. The ids are assigned by
+-- migration order and differ per deployment, so join on app_label/model, never on a literal id.
+
+with source as (
+    select * from {{ source('ol_warehouse_raw_data', 'raw__mitxonline__openedx__mysql__django_content_type') }}
+)
+
+, cleaned as (
+
+    select
+        id as contenttype_id
+        , app_label as contenttype_app_label
+        , model as contenttype_model
+    from source
+)
+
+select * from cleaned

--- a/src/ol_dbt/models/staging/mitxonline/stg__mitxonline__openedx__mysql__organizations_organization.sql
+++ b/src/ol_dbt/models/staging/mitxonline/stg__mitxonline__openedx__mysql__organizations_organization.sql
@@ -1,0 +1,22 @@
+-- MITx Online open edX organizations (edx-organizations). An organization is not always the
+-- org segment of a course key; organizations_organizationcourse is the authoritative link.
+
+with source as (
+    select * from {{ source('ol_warehouse_raw_data', 'raw__mitxonline__openedx__mysql__organizations_organization') }}
+)
+
+, cleaned as (
+
+    select
+        id as organization_id
+        , name as organization_name
+        , short_name as organization_short_name
+        , description as organization_description
+        , logo as organization_logo
+        , active as organization_is_active
+        , {{ cast_timestamp_to_iso8601('created') }} as organization_created_on
+        , {{ cast_timestamp_to_iso8601('modified') }} as organization_updated_on
+    from source
+)
+
+select * from cleaned

--- a/src/ol_dbt/models/staging/mitxonline/stg__mitxonline__openedx__mysql__organizations_organizationcourse.sql
+++ b/src/ol_dbt/models/staging/mitxonline/stg__mitxonline__openedx__mysql__organizations_organizationcourse.sql
@@ -1,0 +1,19 @@
+-- MITx Online open edX course run to organization links (edx-organizations)
+
+with source as (
+    select * from {{ source('ol_warehouse_raw_data', 'raw__mitxonline__openedx__mysql__organizations_organizationcourse') }}
+)
+
+, cleaned as (
+
+    select
+        id as organizationcourse_id
+        , course_id as courserun_readable_id
+        , organization_id
+        , active as organizationcourse_is_active
+        , {{ cast_timestamp_to_iso8601('created') }} as organizationcourse_created_on
+        , {{ cast_timestamp_to_iso8601('modified') }} as organizationcourse_updated_on
+    from source
+)
+
+select * from cleaned

--- a/src/ol_dbt/models/staging/mitxpro/_mitxpro__sources.yml
+++ b/src/ol_dbt/models/staging/mitxpro/_mitxpro__sources.yml
@@ -2567,3 +2567,52 @@ sources:
       description: int, id of the row in the table named by content_type_id. Comment
         and CommentThread ids both start at 1 and overlap heavily, so this is only
         meaningful together with content_type_id
+
+  - name: raw__xpro__openedx__mysql__django_content_type
+    description: xPro open edX Django content types. Maps a content_type_id used by
+      Django generic foreign keys (e.g. on the forum-v2 tables) to its app and model.
+    columns:
+    - name: id
+      description: int, primary key. Assigned by migration order, so the same model
+        has a different id on each deployment.
+    - name: app_label
+      description: str, Django app the model belongs to, e.g. forum
+    - name: model
+      description: str, lowercased model name, e.g. commentthread or comment
+
+  - name: raw__xpro__openedx__mysql__organizations_organization
+    description: xPro open edX organizations from the edx-organizations app
+    columns:
+    - name: id
+      description: int, primary key
+    - name: name
+      description: str, display name of the organization
+    - name: short_name
+      description: str, short name of the organization, used in course keys
+    - name: description
+      description: str, description of the organization
+    - name: logo
+      description: str, storage path of the organization logo
+    - name: active
+      description: boolean, whether the organization is active
+    - name: created
+      description: timestamp, when the row was created
+    - name: modified
+      description: timestamp, when the row was last modified
+
+  - name: raw__xpro__openedx__mysql__organizations_organizationcourse
+    description: xPro open edX links between course runs and organizations from the
+      edx-organizations app
+    columns:
+    - name: id
+      description: int, primary key
+    - name: course_id
+      description: str, open edX course ID formatted as course-v1:{org}+{course code}+{run_tag}
+    - name: organization_id
+      description: int, foreign key to organizations_organization
+    - name: active
+      description: boolean, whether the link is active
+    - name: created
+      description: timestamp, when the row was created
+    - name: modified
+      description: timestamp, when the row was last modified

--- a/src/ol_dbt/models/staging/mitxpro/_stg_mitxpro__models.yml
+++ b/src/ol_dbt/models/staging/mitxpro/_stg_mitxpro__models.yml
@@ -2563,3 +2563,85 @@ models:
     description: int, id of the row in the table named by content_type_id. Comment
       and CommentThread ids both start at 1 and overlap heavily, so this is only meaningful
       together with content_type_id
+- name: stg__mitxpro__openedx__mysql__django_content_type
+  description: xPro open edX Django content types. Use to resolve the content_type_id
+    of a generic foreign key by app_label and model rather than by a hardcoded id.
+  columns:
+  - name: contenttype_id
+    description: int, primary key. Differs per deployment for the same model.
+    tests:
+    - unique
+    - not_null
+  - name: contenttype_app_label
+    description: str, Django app the model belongs to, e.g. forum
+    tests:
+    - not_null
+  - name: contenttype_model
+    description: str, lowercased model name, e.g. commentthread or comment
+    tests:
+    - not_null
+  tests:
+  - dbt_expectations.expect_compound_columns_to_be_unique:
+      arguments:
+        column_list: ["contenttype_app_label", "contenttype_model"]
+
+- name: stg__mitxpro__openedx__mysql__organizations_organization
+  description: xPro open edX organizations from the edx-organizations app
+  columns:
+  - name: organization_id
+    description: int, primary key
+    tests:
+    - unique
+    - not_null
+  - name: organization_name
+    description: str, display name of the organization
+    tests:
+    - not_null
+  - name: organization_short_name
+    description: str, short name of the organization, used in course keys
+    tests:
+    - unique
+    - not_null
+  - name: organization_description
+    description: str, description of the organization
+  - name: organization_logo
+    description: str, storage path of the organization logo
+  - name: organization_is_active
+    description: boolean, whether the organization is active
+  - name: organization_created_on
+    description: timestamp, when the row was created
+  - name: organization_updated_on
+    description: timestamp, when the row was last modified
+
+- name: stg__mitxpro__openedx__mysql__organizations_organizationcourse
+  description: xPro open edX links between course runs and organizations. The authoritative
+    source for a course run's organization, which is not always the org segment of
+    its course key.
+  columns:
+  - name: organizationcourse_id
+    description: int, primary key
+    tests:
+    - unique
+    - not_null
+  - name: courserun_readable_id
+    description: str, open edX course ID formatted as course-v1:{org}+{course code}+{run_tag}
+    tests:
+    - not_null
+  - name: organization_id
+    description: int, foreign key to stg__mitxpro__openedx__mysql__organizations_organization
+    tests:
+    - not_null
+    - relationships:
+        arguments:
+          to: ref('stg__mitxpro__openedx__mysql__organizations_organization')
+          field: organization_id
+  - name: organizationcourse_is_active
+    description: boolean, whether the link is active
+  - name: organizationcourse_created_on
+    description: timestamp, when the row was created
+  - name: organizationcourse_updated_on
+    description: timestamp, when the row was last modified
+  tests:
+  - dbt_expectations.expect_compound_columns_to_be_unique:
+      arguments:
+        column_list: ["courserun_readable_id", "organization_id"]

--- a/src/ol_dbt/models/staging/mitxpro/stg__mitxpro__openedx__mysql__django_content_type.sql
+++ b/src/ol_dbt/models/staging/mitxpro/stg__mitxpro__openedx__mysql__django_content_type.sql
@@ -1,0 +1,18 @@
+-- xPro open edX Django content types, needed to resolve the generic foreign keys
+-- (content_type_id, content_object_id) on the forum-v2 tables. The ids are assigned by
+-- migration order and differ per deployment, so join on app_label/model, never on a literal id.
+
+with source as (
+    select * from {{ source('ol_warehouse_raw_data', 'raw__xpro__openedx__mysql__django_content_type') }}
+)
+
+, cleaned as (
+
+    select
+        id as contenttype_id
+        , app_label as contenttype_app_label
+        , model as contenttype_model
+    from source
+)
+
+select * from cleaned

--- a/src/ol_dbt/models/staging/mitxpro/stg__mitxpro__openedx__mysql__organizations_organization.sql
+++ b/src/ol_dbt/models/staging/mitxpro/stg__mitxpro__openedx__mysql__organizations_organization.sql
@@ -1,0 +1,22 @@
+-- xPro open edX organizations (edx-organizations). An organization is not always the
+-- org segment of a course key; organizations_organizationcourse is the authoritative link.
+
+with source as (
+    select * from {{ source('ol_warehouse_raw_data', 'raw__xpro__openedx__mysql__organizations_organization') }}
+)
+
+, cleaned as (
+
+    select
+        id as organization_id
+        , name as organization_name
+        , short_name as organization_short_name
+        , description as organization_description
+        , logo as organization_logo
+        , active as organization_is_active
+        , {{ cast_timestamp_to_iso8601('created') }} as organization_created_on
+        , {{ cast_timestamp_to_iso8601('modified') }} as organization_updated_on
+    from source
+)
+
+select * from cleaned

--- a/src/ol_dbt/models/staging/mitxpro/stg__mitxpro__openedx__mysql__organizations_organizationcourse.sql
+++ b/src/ol_dbt/models/staging/mitxpro/stg__mitxpro__openedx__mysql__organizations_organizationcourse.sql
@@ -1,0 +1,19 @@
+-- xPro open edX course run to organization links (edx-organizations)
+
+with source as (
+    select * from {{ source('ol_warehouse_raw_data', 'raw__xpro__openedx__mysql__organizations_organizationcourse') }}
+)
+
+, cleaned as (
+
+    select
+        id as organizationcourse_id
+        , course_id as courserun_readable_id
+        , organization_id
+        , active as organizationcourse_is_active
+        , {{ cast_timestamp_to_iso8601('created') }} as organizationcourse_created_on
+        , {{ cast_timestamp_to_iso8601('modified') }} as organizationcourse_updated_on
+    from source
+)
+
+select * from cleaned

--- a/src/ol_dbt/models/staging/mitxresidential/_mitxresidential__sources.yml
+++ b/src/ol_dbt/models/staging/mitxresidential/_mitxresidential__sources.yml
@@ -1314,3 +1314,54 @@ sources:
       description: int, id of the row in the table named by content_type_id. Comment
         and CommentThread ids both start at 1 and overlap heavily, so this is only
         meaningful together with content_type_id
+
+  - name: raw__mitx__openedx__mysql__django_content_type
+    description: MITx Residential open edX Django content types. Maps a content_type_id
+      used by Django generic foreign keys (e.g. on the forum-v2 tables) to its app
+      and model.
+    columns:
+    - name: id
+      description: int, primary key. Assigned by migration order, so the same model
+        has a different id on each deployment.
+    - name: app_label
+      description: str, Django app the model belongs to, e.g. forum
+    - name: model
+      description: str, lowercased model name, e.g. commentthread or comment
+
+  - name: raw__mitx__openedx__mysql__organizations_organization
+    description: MITx Residential open edX organizations from the edx-organizations
+      app
+    columns:
+    - name: id
+      description: int, primary key
+    - name: name
+      description: str, display name of the organization
+    - name: short_name
+      description: str, short name of the organization, used in course keys
+    - name: description
+      description: str, description of the organization
+    - name: logo
+      description: str, storage path of the organization logo
+    - name: active
+      description: boolean, whether the organization is active
+    - name: created
+      description: timestamp, when the row was created
+    - name: modified
+      description: timestamp, when the row was last modified
+
+  - name: raw__mitx__openedx__mysql__organizations_organizationcourse
+    description: MITx Residential open edX links between course runs and organizations
+      from the edx-organizations app
+    columns:
+    - name: id
+      description: int, primary key
+    - name: course_id
+      description: str, open edX course ID formatted as course-v1:{org}+{course code}+{run_tag}
+    - name: organization_id
+      description: int, foreign key to organizations_organization
+    - name: active
+      description: boolean, whether the link is active
+    - name: created
+      description: timestamp, when the row was created
+    - name: modified
+      description: timestamp, when the row was last modified

--- a/src/ol_dbt/models/staging/mitxresidential/_stg_mitxresidential__models.yml
+++ b/src/ol_dbt/models/staging/mitxresidential/_stg_mitxresidential__models.yml
@@ -741,3 +741,87 @@ models:
     description: int, id of the row in the table named by content_type_id. Comment
       and CommentThread ids both start at 1 and overlap heavily, so this is only meaningful
       together with content_type_id
+- name: stg__mitxresidential__openedx__mysql__django_content_type
+  description: MITx Residential open edX Django content types. Use to resolve the
+    content_type_id of a generic foreign key by app_label and model rather than by
+    a hardcoded id.
+  columns:
+  - name: contenttype_id
+    description: int, primary key. Differs per deployment for the same model.
+    tests:
+    - unique
+    - not_null
+  - name: contenttype_app_label
+    description: str, Django app the model belongs to, e.g. forum
+    tests:
+    - not_null
+  - name: contenttype_model
+    description: str, lowercased model name, e.g. commentthread or comment
+    tests:
+    - not_null
+  tests:
+  - dbt_expectations.expect_compound_columns_to_be_unique:
+      arguments:
+        column_list: ["contenttype_app_label", "contenttype_model"]
+
+- name: stg__mitxresidential__openedx__mysql__organizations_organization
+  description: MITx Residential open edX organizations from the edx-organizations
+    app
+  columns:
+  - name: organization_id
+    description: int, primary key
+    tests:
+    - unique
+    - not_null
+  - name: organization_name
+    description: str, display name of the organization
+    tests:
+    - not_null
+  - name: organization_short_name
+    description: str, short name of the organization, used in course keys
+    tests:
+    - unique
+    - not_null
+  - name: organization_description
+    description: str, description of the organization
+  - name: organization_logo
+    description: str, storage path of the organization logo
+  - name: organization_is_active
+    description: boolean, whether the organization is active
+  - name: organization_created_on
+    description: timestamp, when the row was created
+  - name: organization_updated_on
+    description: timestamp, when the row was last modified
+
+- name: stg__mitxresidential__openedx__mysql__organizations_organizationcourse
+  description: MITx Residential open edX links between course runs and organizations.
+    The authoritative source for a course run's organization, which is not always
+    the org segment of its course key.
+  columns:
+  - name: organizationcourse_id
+    description: int, primary key
+    tests:
+    - unique
+    - not_null
+  - name: courserun_readable_id
+    description: str, open edX course ID formatted as course-v1:{org}+{course code}+{run_tag}
+    tests:
+    - not_null
+  - name: organization_id
+    description: int, foreign key to stg__mitxresidential__openedx__mysql__organizations_organization
+    tests:
+    - not_null
+    - relationships:
+        arguments:
+          to: ref('stg__mitxresidential__openedx__mysql__organizations_organization')
+          field: organization_id
+  - name: organizationcourse_is_active
+    description: boolean, whether the link is active
+  - name: organizationcourse_created_on
+    description: timestamp, when the row was created
+  - name: organizationcourse_updated_on
+    description: timestamp, when the row was last modified
+  tests:
+  - dbt_expectations.expect_compound_columns_to_be_unique:
+      arguments:
+        column_list: ["courserun_readable_id", "organization_id"]

--- a/src/ol_dbt/models/staging/mitxresidential/stg__mitxresidential__openedx__mysql__django_content_type.sql
+++ b/src/ol_dbt/models/staging/mitxresidential/stg__mitxresidential__openedx__mysql__django_content_type.sql
@@ -1,0 +1,18 @@
+-- MITx Residential open edX Django content types, needed to resolve the generic foreign keys
+-- (content_type_id, content_object_id) on the forum-v2 tables. The ids are assigned by
+-- migration order and differ per deployment, so join on app_label/model, never on a literal id.
+
+with source as (
+    select * from {{ source('ol_warehouse_raw_data', 'raw__mitx__openedx__mysql__django_content_type') }}
+)
+
+, cleaned as (
+
+    select
+        id as contenttype_id
+        , app_label as contenttype_app_label
+        , model as contenttype_model
+    from source
+)
+
+select * from cleaned

--- a/src/ol_dbt/models/staging/mitxresidential/stg__mitxresidential__openedx__mysql__organizations_organization.sql
+++ b/src/ol_dbt/models/staging/mitxresidential/stg__mitxresidential__openedx__mysql__organizations_organization.sql
@@ -1,0 +1,22 @@
+-- MITx Residential open edX organizations (edx-organizations). An organization is not always the
+-- org segment of a course key; organizations_organizationcourse is the authoritative link.
+
+with source as (
+    select * from {{ source('ol_warehouse_raw_data', 'raw__mitx__openedx__mysql__organizations_organization') }}
+)
+
+, cleaned as (
+
+    select
+        id as organization_id
+        , name as organization_name
+        , short_name as organization_short_name
+        , description as organization_description
+        , logo as organization_logo
+        , active as organization_is_active
+        , {{ cast_timestamp_to_iso8601('created') }} as organization_created_on
+        , {{ cast_timestamp_to_iso8601('modified') }} as organization_updated_on
+    from source
+)
+
+select * from cleaned

--- a/src/ol_dbt/models/staging/mitxresidential/stg__mitxresidential__openedx__mysql__organizations_organizationcourse.sql
+++ b/src/ol_dbt/models/staging/mitxresidential/stg__mitxresidential__openedx__mysql__organizations_organizationcourse.sql
@@ -1,0 +1,19 @@
+-- MITx Residential open edX course run to organization links (edx-organizations)
+
+with source as (
+    select * from {{ source('ol_warehouse_raw_data', 'raw__mitx__openedx__mysql__organizations_organizationcourse') }}
+)
+
+, cleaned as (
+
+    select
+        id as organizationcourse_id
+        , course_id as courserun_readable_id
+        , organization_id
+        , active as organizationcourse_is_active
+        , {{ cast_timestamp_to_iso8601('created') }} as organizationcourse_created_on
+        , {{ cast_timestamp_to_iso8601('modified') }} as organizationcourse_updated_on
+    from source
+)
+
+select * from cleaned


### PR DESCRIPTION
### What are the relevant tickets?
Part of https://github.com/mitodl/ol-data-platform/issues/2359 (retire `legacy_openedx`).

### Description (What does it do?)
Adds three edxapp tables to the ingestion inventory for mitx, xpro and mitxonline, with sources and staging models. None of them is ingested from edxapp today.

**`django_content_type`** is the lookup the forum-v2 tables need. `forum_uservote`, `forum_mongocontent`, `forum_abuseflagger` and `forum_historicalabuseflagger` point at their target through a Django generic foreign key (`content_type_id`, `content_object_id`), so attaching a vote, flag or legacy Mongo ObjectId to a thread versus a comment depends on knowing which `content_type_id` is which. Neither shortcut works:
- Hardcoding: the ids are assigned by migration order and differ per deployment (CommentThread/Comment measured 2026-08-31 as mitx 688/695, xpro 606/613, mitxonline 570/577).
- Inferring by join: `forum_commentthread.id` and `forum_comment.id` both start at 1 and overlap, so an undiscriminated join matches both tables without erroring.

With this table the forum models can filter on `app_label = 'forum' and model in ('commentthread', 'comment')`.

**`organizations_organization` + `organizations_organizationcourse`** are what the legacy op joins to fill `org` in `role_users.csv`, the last uncovered column in the six-CSV contract (#2627 left it open). Deriving `org` from the course key disagrees with the delivered mitxonline file on 2,476 of 549,130 rows, so this takes the ingest route and the irx model can join exactly as the legacy op does.

All three are small, so they use `full_refresh_overwrite` with PK `id` on the existing `… Open edX DB → S3 Data Lake` connection, matching their `django_comment_*` siblings. Tests follow the Django constraints: `(app_label, model)` unique on content types, `short_name` unique on organizations, and `(course_id, organization)` unique on the link table (`unique_together` in edx-organizations).

### Merge ordering: prerequisite met
Since Airbyte config-as-code was struck (INGESTION_INVENTORY_SPEC §6.0), the streams had to be enabled by hand on the three connections before this could merge. Otherwise the sources would not exist and any dbt run selecting these models would fail. That is done: the streams were enabled and synced on 2026-09-11, and all nine `raw__{mitx,xpro,mitxonline}__openedx__mysql__{django_content_type,organizations_organization,organizations_organizationcourse}` tables are in Glue (created 17:20-17:21 UTC).

### How can this be tested?
Built on `dev_local` (DuckDB over prod Iceberg) after the first sync:

```
ol-dbt local register
dbt build -t dev_local --select <the nine stg models>
# Done. PASS=58 WARN=0 ERROR=0 SKIP=0   (9 models, 48 tests, 1 project hook)
```

| deployment | forum commentthread / comment `contenttype_id` | content types | organizations | organization-course links |
|---|---|---:|---:|---:|
| mitx | 688 / 695 | 810 | 4 | 492 |
| xpro | 606 / 613 | 692 | 15 | 504 |
| mitxonline | 570 / 577 | 704 | 93 | 4,249 |

The content-type ids match the values measured on 2026-08-31, and the org-course relationship and `unique_together` tests pass in all three deployments.

Also: `ol-dbt inventory validate` and `check-removals` 0 errors; `ol-dbt validate` on the nine models 0 errors, 0 warnings; pre-commit passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015yNbSMYdLsEnu56XR6iZ3C
