### PR TITLE
fix(raw-migration): read JSONL with Glue's column types, falling back to inference

### DIFF
--- a/bin/migrate-raw-jsonl-to-iceberg.py
+++ b/bin/migrate-raw-jsonl-to-iceberg.py
@@ -144,9 +144,8 @@ def _list_json_files(
 
 # Every scalar Glue type found on the legacy JSONL tables in qa and production
 # raw (2026-09-10). array and struct columns are left to inference because
-# their Glue types are not trustworthy: production's
-# raw__thirdparty__github__workflow_runs declares pull_requests as
-# array<string> and holds objects.
+# their Glue types are not trustworthy: a production GitHub table declared
+# pull_requests as array<string> over a list of objects.
 _GLUE_SCALAR_TYPES = {
     "string": pa.large_utf8(),
     "boolean": pa.bool_(),

--- a/bin/migrate-raw-jsonl-to-iceberg.py
+++ b/bin/migrate-raw-jsonl-to-iceberg.py
@@ -31,6 +31,7 @@ Safety:
 """
 
 import logging
+import re
 import sys
 from typing import TYPE_CHECKING, Annotated, Any
 
@@ -39,6 +40,7 @@ import cyclopts
 import pyarrow as pa
 import pyarrow.dataset as ds
 import pyarrow.fs as pafs
+import pyarrow.json as pj
 from pyiceberg.catalog.glue import GlueCatalog
 
 if TYPE_CHECKING:
@@ -140,14 +142,128 @@ def _list_json_files(
     return files, total_bytes
 
 
-def _schema_from_glue_columns(columns: list[dict[str, Any]]) -> pa.Schema:
-    """Build a minimal PyArrow schema from Glue column definitions.
+# Every scalar Glue type found on the legacy JSONL tables in qa and production
+# raw (2026-09-10). array and struct columns are left to inference because
+# their Glue types are not trustworthy: production's
+# raw__thirdparty__github__workflow_runs declares pull_requests as
+# array<string> and holds objects.
+_GLUE_SCALAR_TYPES = {
+    "string": pa.large_utf8(),
+    "boolean": pa.bool_(),
+    "int": pa.int32(),
+    "bigint": pa.int64(),
+    # Glue could only type the column as null, so it holds no values; Iceberg
+    # v2 has no null type, and string is the least committal concrete one.
+    "null": pa.large_utf8(),
+}
+# An omitted scale means 0; two QA columns are declared as decimal(38).
+_GLUE_DECIMAL = re.compile(r"decimal\((\d+)(?:,\s*(\d+))?\)")
 
-    Used only for empty tables that have no data files to infer a schema from.
-    Every field defaults to large_utf8 (string) since Glue type fidelity for
-    legacy JSONL tables is often poor.
+
+def _arrow_type(glue_type: str) -> pa.DataType | None:
+    if match := _GLUE_DECIMAL.fullmatch(glue_type):
+        return pa.decimal128(int(match[1]), int(match[2] or 0))
+    return _GLUE_SCALAR_TYPES.get(glue_type)
+
+
+def _empty_schema(columns: list[dict[str, Any]]) -> pa.Schema:
+    """Build the schema for a table with no data files to infer one from."""
+    return pa.schema(
+        [
+            pa.field(c["Name"], _arrow_type(c["Type"]) or pa.large_utf8())
+            for c in columns
+        ]
+    )
+
+
+def _parse_options(columns: list[dict[str, Any]]) -> pj.ParseOptions:
+    """Build parse options that take scalar column types from Glue, not inference.
+
+    pyarrow infers a column's type from the first block it reads. A decimal
+    column whose early rows are whole numbers becomes int64 and fails on the
+    first fractional value ("couldn't parse: 987.65"), and a column that is null
+    in every row becomes pa.null(), which Iceberg v2 rejects. Glue already
+    carries each column's type, so the scalar ones are declared up front.
+
+    Declaring every column as string would be simpler and does not work: the
+    reader refuses a JSON number or boolean in a string column.
     """
-    return pa.schema([pa.field(col["Name"], pa.large_utf8()) for col in columns])
+    declared = pa.schema(
+        [pa.field(c["Name"], t) for c in columns if (t := _arrow_type(c["Type"]))]
+    )
+    return pj.ParseOptions(explicit_schema=declared, unexpected_field_behavior="infer")
+
+
+def _without_null(arrow_type: pa.DataType) -> pa.DataType:
+    """Replace pa.null() with string, including inside structs and lists."""
+    if pa.types.is_null(arrow_type):
+        return pa.large_utf8()
+    if pa.types.is_struct(arrow_type):
+        return pa.struct(
+            [f.with_type(_without_null(f.type)) for f in arrow_type.fields]
+        )
+    if pa.types.is_large_list(arrow_type):
+        return pa.large_list(
+            arrow_type.value_field.with_type(_without_null(arrow_type.value_type))
+        )
+    if pa.types.is_list(arrow_type):
+        return pa.list_(
+            arrow_type.value_field.with_type(_without_null(arrow_type.value_type))
+        )
+    return arrow_type
+
+
+def _read_typed(
+    files: list[str],
+    columns: list[dict[str, Any]],
+    arrow_fs: pafs.FileSystem,
+) -> pa.Table:
+    # File by file: pyarrow.dataset's JsonFileFormat ignores explicit_schema
+    # (pyarrow 25), so a dataset scan would infer every column regardless. A
+    # key Glue never declared can infer differently per file; permissive
+    # concat widens it.
+    options = _parse_options(columns)
+    tables = []
+    for path in files:
+        with arrow_fs.open_input_stream(path) as stream:
+            tables.append(pj.read_json(stream, parse_options=options))
+    return pa.concat_tables(tables, promote_options="permissive")
+
+
+def _has_case_collision(schema: pa.Schema) -> bool:
+    return len({name.lower() for name in schema.names}) < len(schema.names)
+
+
+def _read_jsonl(
+    files: list[str],
+    columns: list[dict[str, Any]],
+    arrow_fs: pafs.FileSystem,
+) -> pa.Table:
+    """Read a table with Glue's column types, falling back to inference.
+
+    Glue's types beat inference on most tables but are sometimes wrong, and a
+    declared type the data contradicts fails the read outright. Falling back to
+    plain inference, which is all this script did before, keeps every table
+    that converted before converting. Salesforce tables take the fallback too:
+    their JSON keys (Id) differ from Glue's lowercased names (id) only by case,
+    so a typed read yields both columns.
+    """
+    table = None
+    try:
+        table = _read_typed(files, columns, arrow_fs)
+    except (pa.ArrowInvalid, pa.ArrowNotImplementedError) as exc:
+        log.info("  Glue-typed read failed, inferring types instead: %s", exc)
+    if table is not None and _has_case_collision(table.schema):
+        log.info("  JSON keys match Glue columns only by case; inferring types")
+        table = None
+    if table is None:
+        table = ds.dataset(files, format="json", filesystem=arrow_fs).to_table()
+    # A key Glue never declared, or a field nested in an array or struct, can
+    # still be null in every row and infer as pa.null(); give it the same
+    # string type as a Glue null column.
+    return table.cast(
+        pa.schema([f.with_type(_without_null(f.type)) for f in table.schema])
+    )
 
 
 def _restore_glue_table(
@@ -160,7 +276,7 @@ def _restore_glue_table(
     log.info("  restored original JSONL Glue entry")
 
 
-def _migrate_one(  # noqa: PLR0913, C901, PLR0912, PLR0915
+def _migrate_one(  # noqa: PLR0913, C901, PLR0912
     *,
     glue: "botocore.client.Glue",
     s3: "botocore.client.S3",
@@ -196,30 +312,30 @@ def _migrate_one(  # noqa: PLR0913, C901, PLR0912, PLR0915
         )
         return False
 
+    glue_cols = original_def["StorageDescriptor"].get("Columns", [])
+
     if dry_run:
         log.info("  [dry-run] would migrate %d file(s)", len(files))
         if files:
-            sample = ds.dataset(files[:1], format="json", filesystem=arrow_fs)
-            log.info("  [dry-run] inferred schema from sample: %s", sample.schema)
-            log.info("  [dry-run] estimated rows: %d", sample.count_rows())
+            sample = _read_jsonl(files[:1], glue_cols, arrow_fs)
+            log.info("  [dry-run] schema from first file: %s", sample.schema)
+            log.info("  [dry-run] rows in first file: %d", len(sample))
         return True
 
     # ── Read ──────────────────────────────────────────────────────────────────
     if not files:
-        glue_cols = original_def["StorageDescriptor"].get("Columns", [])
         if not glue_cols:
             log.warning("  no data files and no column definitions — skipping")
             return False
         log.info(
             "  empty table; building schema from %d Glue column(s)", len(glue_cols)
         )
-        arrow_schema = _schema_from_glue_columns(glue_cols)
+        arrow_schema = _empty_schema(glue_cols)
         arrow_table = arrow_schema.empty_table()
     else:
         try:
-            dataset = ds.dataset(files, format="json", filesystem=arrow_fs)
-            arrow_schema = dataset.schema
-            arrow_table = dataset.to_table()
+            arrow_table = _read_jsonl(files, glue_cols, arrow_fs)
+            arrow_schema = arrow_table.schema
         except Exception:
             log.exception("  failed to read JSONL data — skipping table")
             return False


### PR DESCRIPTION
### What are the relevant tickets?

N/A. Follow-up to #2649, from converting the legacy JSONL tables in `ol_warehouse_qa_raw` for [RFC 12711](https://github.com/mitodl/hq/discussions/12711).

### Description (What does it do?)

`bin/migrate-raw-jsonl-to-iceberg.py` let pyarrow infer every column's type from the first block it reads, which fails two ways on these tables:

```
Failed to convert JSON to int64, couldn't parse: 987.65
Null type (pa.null()) is not supported in Iceberg format version 2. Field: original-message.header_image_id
```

- Parse with each scalar Glue column's declared type (`decimal(p[,s])`, `bigint`, `int`, `boolean`, `string`). Glue has `klasses_installment.amount` as `decimal(38,5)`; inference called it int64.
- Read each file with `pyarrow.json.read_json` and concat with permissive promotion. `pyarrow.dataset.JsonFileFormat` ignores `explicit_schema` in pyarrow 25, so a dataset scan keeps inferring no matter what it is given.
- Fall back to the previous inference read when the typed read fails or produces columns that differ only by case. Glue's types are sometimes wrong: production `raw__irx__edxorg__bigquery__user_info_combo` declares `_airbyte_emitted_at` as `string` over numeric values, and without the fallback that table (5,901,075 rows, converts on `main`) stops converting. Salesforce tables take the fallback because their JSON keys (`Id`) differ from Glue's lowercased column names (`id`) only by case.
- Replace `pa.null()` with string recursively, including inside the structs and lists of Airbyte's `original-message` wrappers.
- Empty tables get Glue types instead of all-string.

The obvious alternative, declaring every column as string, does not work: pyarrow refuses a JSON number in a string-typed column (`changed from string to number`).

### How can this be tested?

Dry-run (the default) reads the first file through the new path and makes no Glue writes:

```
uv run python bin/migrate-raw-jsonl-to-iceberg.py qa --table raw__bootcamps__app__postgres__klasses_installment
```
```
INFO   [dry-run] schema from first file: deadline: large_string
...
amount: decimal128(38, 5)
```

A Salesforce table shows the fallback:

```
uv run python bin/migrate-raw-jsonl-to-iceberg.py qa --table raw__thirdparty__salesforce__apexpage
```
```
INFO   JSON keys match Glue columns only by case; inferring types
INFO   [dry-run] schema from first file: _airbyte_ab_id: string
Id: string
...
```

I compared the `main` read path and the new `_read_jsonl` side by side, read-only, on the legacy tables each environment still has as JSONL, and ran each resulting schema through pyiceberg's schema conversion (the first step of `create_table`). Only outcomes and row counts were kept.

| Tables compared | Count | Convert on `main` | Convert with this PR |
|---|---|---|---|
| QA legacy tables, excluding the 72 with archived objects | 141 | 0 | 110 |
| Production, non-empty and not Salesforce | 22 | 17 | 20 |

No table that converts on `main` fails with this change, and row counts are identical wherever both paths read a table. 21 of the 22 production tables were rerun on the final code; `raw__thirdparty__mailgun__events` (5.2 GiB) was not, because both of its possible reads already failed (see below) and the fallback is the `main` read. All 5 QA legacy tables that dbt sources declare and whose objects are readable now convert: `bootcamps klasses_installment`, micromasters `courses_courserun`, `grades_combinedfinalgrade` and `wagtailcore_page`, and mitx `grades_persistentcoursegrade`.

The 31 QA tables that still fail: 21 Salesforce tables where the fallback's inference meets a column that is null in early blocks and a string later (`changed from null to string`), 5 with objects in an S3 archive tier, and 5 that return `ACCESS_DENIED` on `GetObject`. In production the 3 new conversions are `github__organizations`, `github__comments` and `hubspot__contacts_property_history`; the GitHub tables are being deleted separately, as nothing uses them.

### Additional Context

What this does not fix, from a read-only classification of all 213 QA and 740 production legacy tables:

- **72 QA tables are unreadable without an S3 restore** and were not part of the comparison. Their objects are `INTELLIGENT_TIERING` with `ArchiveStatus: ARCHIVE_ACCESS`, so `GetObject` returns `InvalidObjectState`. 11 of them are dbt sources. This corrects #2649's description, which counted these among the "107 that failed pyarrow JSON type inference". Neither raw bucket has an Intelligent-Tiering configuration today; the objects stayed archived after it was removed. Production has none archived.
- **Salesforce:** 81 of QA's 110 now convert through the fallback, keeping the JSON key casing (`Id`). The other 29 are the 21 inference failures above plus 8 unreadable tables. Production's 217 were not read. No dbt model reads any of them.
- **`raw__thirdparty__mailgun__events`** (production, 5.2 GiB) fails both ways: inference hits `changed from null to string` on `tags`, and Glue's `decimal(38,4)` on `timestamp` is too narrow for values like `1.68289920082108E9`.

Production also has 501 legacy tables with no data files, which the empty-table path already handles; every one of their Glue-typed schemas passes pyiceberg's conversion. Only one of the 740 production legacy tables is a dbt source (`raw__bootcamps__app__postgres__profiles_profile`), and it converts both ways with the same 66,447 rows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01844n23tr9jeQ9WV2s9L1cj
