### PR TITLE
fix(dlt): commit a snapshot under the new schema before Iceberg upserts

### DIFF
--- a/src/ol_dlt/ol_dlt/__init__.py
+++ b/src/ol_dlt/ol_dlt/__init__.py
@@ -4,3 +4,6 @@ This package contains pure-dlt sources, resources, and the profile-based
 pipeline/destination configuration. It must never import Dagster — Dagster
 wiring lives in the ``data_loading`` code location, which imports this package.
 """
+
+# Imported for its side effect: it wraps dlt's Iceberg merge for every source.
+from ol_dlt import iceberg_upsert_guard  # noqa: F401

--- a/src/ol_dlt/ol_dlt/iceberg_upsert_guard.py
+++ b/src/ol_dlt/ol_dlt/iceberg_upsert_guard.py
@@ -1,0 +1,51 @@
+"""Keep pyiceberg's upsert from reading matched rows at a stale schema.
+
+pyiceberg's ``Transaction.upsert`` reads the rows its batch matches through a
+scan pinned to the branch head (``use_ref``), and a pinned scan projects the
+head *snapshot's* schema rather than the table's current one. dlt evolves the
+table (``union_by_name``) before upserting, which commits a new schema but no
+new snapshot. Until something writes a snapshot under that schema, any upsert
+whose batch matches existing rows reads them without the new column and fails:
+
+    ValueError: Target schema's field names are not matching the table's field
+    names
+
+That is how adding ``_dlt_load_id`` stuck three production merge tables
+(DAGSTER-5Y). An empty append commits a snapshot under the current schema
+without changing any rows, after which the upsert reads matched rows correctly.
+
+Remove this module once a pyiceberg release fixes apache/iceberg-python#3105;
+``tests/test_iceberg_upsert_guard.py`` fails as soon as the unguarded path
+stops raising.
+"""
+
+import pyarrow as pa
+from dlt.common.libs import pyiceberg as dlt_pyiceberg
+from dlt.common.schema.typing import TTableSchema
+from pyiceberg.table import Table as IcebergTable
+
+_dlt_merge_iceberg_table = dlt_pyiceberg.merge_iceberg_table
+
+
+def merge_iceberg_table(
+    table: IcebergTable,
+    data: pa.Table,
+    schema: TTableSchema,
+    load_table_name: str,
+) -> None:
+    """Run dlt's merge after bringing the head snapshot up to the current schema."""
+    with table.update_schema() as update:
+        update.union_by_name(
+            dlt_pyiceberg.ensure_iceberg_compatible_arrow_schema(data.schema)
+        )
+    snapshot = table.current_snapshot()
+    if snapshot is not None and snapshot.schema_id != table.schema().schema_id:
+        table.append(table.schema().as_arrow().empty_table())
+    _dlt_merge_iceberg_table(
+        table=table, data=data, schema=schema, load_table_name=load_table_name
+    )
+
+
+# dlt imports merge_iceberg_table inside IcebergLoadFilesystemJob.run at call
+# time, so replacing the module attribute reaches every Iceberg merge load.
+dlt_pyiceberg.merge_iceberg_table = merge_iceberg_table

--- a/src/ol_dlt/tests/test_iceberg_upsert_guard.py
+++ b/src/ol_dlt/tests/test_iceberg_upsert_guard.py
@@ -1,0 +1,90 @@
+"""The pyiceberg upsert guard: see ol_dlt.iceberg_upsert_guard for the bug."""
+
+from pathlib import Path
+from typing import Any
+
+import pyarrow as pa
+import pytest
+from dlt.common.libs import pyiceberg as dlt_pyiceberg
+from pyiceberg.catalog.sql import SqlCatalog
+from pyiceberg.table import Table as IcebergTable
+
+from ol_dlt import iceberg_upsert_guard
+
+_DLT_TABLE_SCHEMA: Any = {
+    "name": "t",
+    "x-merge-strategy": "upsert",
+    "columns": {
+        "row_hash": {
+            "name": "row_hash",
+            "data_type": "text",
+            "nullable": False,
+            "primary_key": True,
+        },
+        "extracted_course_key": {
+            "name": "extracted_course_key",
+            "data_type": "text",
+            "nullable": False,
+            "primary_key": True,
+        },
+        "grade": {"name": "grade", "data_type": "text", "nullable": True},
+        "_dlt_load_id": {"name": "_dlt_load_id", "data_type": "text", "nullable": True},
+    },
+}
+_EXISTING = pa.table(
+    {
+        "row_hash": ["h1", "h2"],
+        "extracted_course_key": ["c1", "c1"],
+        "grade": ["0.5", "0.7"],
+    }
+)
+# Matches h2 (an update) and adds h3 (an insert), carrying the new column.
+_BATCH = pa.table(
+    {
+        "row_hash": ["h2", "h3"],
+        "extracted_course_key": ["c1", "c1"],
+        "grade": ["0.9", "0.1"],
+        "_dlt_load_id": ["L1", "L1"],
+    }
+)
+
+
+@pytest.fixture
+def table(tmp_path: Path) -> IcebergTable:
+    """A table left the way production was: new column, no snapshot under it."""
+    catalog = SqlCatalog(
+        "test", uri=f"sqlite:///{tmp_path}/catalog.db", warehouse=f"file://{tmp_path}"
+    )
+    catalog.create_namespace("ns")
+    table = catalog.create_table("ns.t", schema=_EXISTING.schema)
+    table.append(_EXISTING)
+    with table.update_schema() as update:
+        update.union_by_name(_BATCH.schema)
+    return table
+
+
+def test_dlt_merges_go_through_the_guard() -> None:
+    assert dlt_pyiceberg.merge_iceberg_table is iceberg_upsert_guard.merge_iceberg_table
+
+
+def test_unguarded_upsert_still_fails(table: IcebergTable) -> None:
+    """If this stops raising, pyiceberg fixed #3105 and the guard can be removed."""
+    with pytest.raises(ValueError, match="field names are not matching"):
+        iceberg_upsert_guard._dlt_merge_iceberg_table(  # noqa: SLF001
+            table=table, data=_BATCH, schema=_DLT_TABLE_SCHEMA, load_table_name="t"
+        )
+
+
+def test_guarded_upsert_updates_matches_and_inserts_new_rows(
+    table: IcebergTable,
+) -> None:
+    dlt_pyiceberg.merge_iceberg_table(
+        table=table, data=_BATCH, schema=_DLT_TABLE_SCHEMA, load_table_name="t"
+    )
+
+    rows = sorted(table.scan().to_arrow().to_pylist(), key=lambda r: r["row_hash"])
+    assert [(r["row_hash"], r["grade"], r["_dlt_load_id"]) for r in rows] == [
+        ("h1", "0.5", None),
+        ("h2", "0.9", "L1"),
+        ("h3", "0.1", "L1"),
+    ]


### PR DESCRIPTION
### What are the relevant tickets?
Fixes DAGSTER-5Y
- https://mit-office-of-digital-learning.sentry.io/issues/DAGSTER-5Y
- Upstream: https://github.com/apache/iceberg-python/issues/3105 (open; https://github.com/apache/iceberg-python/issues/2467 is the same bug)

### Description (What does it do?)
A fresh `edxorg_s3_ingest_job` run failed loading `certificates_generatedcertificate`. dlt gave up after 5 retries:

```
ValueError: Target schema's field names are not matching the table's field names:
[... 'row_hash', '_dlt_load_id'], [... 'row_hash']
```

This is a pyiceberg 0.12.0 bug (0.12.0 is the latest release):

- `Transaction.upsert` reads the rows its batch matches through a scan pinned to the branch head (`use_ref`). A pinned scan projects the head *snapshot's* schema, not the table's current schema (`TableScan.projection`).
- dlt's merge adds new columns with `union_by_name` before upserting. That commits a new schema but no snapshot, so the matched rows come back without the new column, and the cast in `get_rows_to_update` fails.
- A batch that matches no existing rows never reaches that cast, so a table can load fine after gaining a column. Retries of a batch that does match fail the same way every time.

Adding `_dlt_load_id` (#2651) triggered this in production. A sweep of the 46 production tables written by dlt sources found:

- **3 stuck:** `raw__edxorg__s3__tables__certificates_generatedcertificate`, `raw__podcast__rss__channels` and `raw__podcast__rss__episodes`. Each had schema 1 with `_dlt_load_id`, but its head snapshot was still on schema 0.
- **26 at risk:** every other edxorg table has no `_dlt_load_id` yet. Each one fails the first time it loads new files whose rows overlap rows it already holds.
- **17 fine:** the keycloak, mit_climate, mitpe and oll tables already have a snapshot under their current schema.

The fix:

- `ol_dlt/iceberg_upsert_guard.py` wraps dlt's `merge_iceberg_table`. After the schema change, if the head snapshot's schema is behind the table's current schema, it commits an empty append first. That writes a snapshot under the current schema and changes no rows.
- It replaces `dlt.common.libs.pyiceberg.merge_iceberg_table`. That's enough because dlt imports that name inside `IcebergLoadFilesystemJob.run` at call time. `ol_dlt/__init__.py` imports the guard, so every source gets it.
- Remove the guard once a pyiceberg release fixes #3105. `test_unguarded_upsert_still_fails` starts failing when that happens.

### How can this be tested?
- Local repro with pyiceberg's SQLite catalog: rows loaded, then the column added with no snapshot under it.
  - An overlapping upsert through dlt's merge raises the production `ValueError`.
  - After an empty append, the same upsert succeeds.
  - An insert of a key that isn't in the table yet clears it too.
- `uv run --project src/ol_dlt pytest src/ol_dlt/tests`: 133 passed. The new `test_iceberg_upsert_guard.py` checks three things:
  - dlt's merge now goes through the guard
  - the unguarded path still raises
  - the guarded merge updates the matched row, inserts the new one, and leaves the old row's `_dlt_load_id` null
- In a fresh interpreter, `python -c 'import ol_dlt, dlt.common.libs.pyiceberg as m; print(m.merge_iceberg_table.__module__)'` prints `ol_dlt.iceberg_upsert_guard`.
- `uv run --project dg_projects/data_loading pytest dg_projects/data_loading/data_loading_tests`: 22 passed.
- pre-commit (ruff, mypy) is clean.

Not tested: a production load going through the guard. That happens on the first edxorg table to receive new files after deploy.

### Additional Context
- The 3 stuck tables were repaired by hand on 2026-09-11 with the same empty append. Each now has a snapshot under schema 1, and row counts are unchanged: 439,342, 37 and 2,008. `edxorg_s3_certificates_generatedcertificate` can be re-run without waiting for this PR.
- `podcast_rss_ingest` has also been failing at extract (DAGSTER-2T); the most recent event was GitHub's API rate limit. The repaired podcast tables only matter once it gets past extract.
- `mit_edx_programs_ingest` (DAGSTER-2S) is a separate problem: `Missing required credentials: client_id, client_secret, access_token_url, programs_api_url`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YaS2hez2aw3LBTtmZAmwzX
