### PR TITLE
feat(openedx): build the IRx drop from the irx__ models

### DIFF
--- a/dg_projects/openedx/openedx/assets/irx_export.py
+++ b/dg_projects/openedx/openedx/assets/irx_export.py
@@ -1,0 +1,284 @@
+"""The nightly IRx drop, cut from the irx__ models instead of queried live.
+
+legacy_openedx queries each deployment's edxapp MySQL every night and uploads
+six CSVs for MIT Institutional Research. This writes the same six files, with
+the same headers and value formatting, from tables the warehouse already
+maintains. The column-level contract is in
+src/ol_dbt/models/external/IRX_SIMEON_MAPPING.md.
+"""
+
+import hashlib
+import io
+from collections.abc import Iterator, Mapping, Sequence
+from dataclasses import dataclass, field
+from typing import Any
+
+import polars as pl
+from dagster import (
+    AssetExecutionContext,
+    AssetKey,
+    AssetsDefinition,
+    AssetSpec,
+    DailyPartitionsDefinition,
+    DataVersion,
+    Failure,
+    MaterializeResult,
+    MetadataValue,
+    get_dagster_logger,
+    multi_asset,
+)
+from ol_orchestrate.lib.constants import DAGSTER_ENV
+from ol_orchestrate.lib.glue_helper import load_dbt_model_table, scan_dbt_model_table
+from upath import UPath
+
+IRX_EXPORT_GROUP = "irx_export"
+IRX_GLUE_DATABASE = "ol_warehouse_production_external"
+
+# end_offset=1 makes today the latest partition, so the scheduled run on
+# 2026-09-12 writes {deployment}/20260912/, which is the date legacy_openedx
+# names the same night's drop by.
+IRX_EXPORT_PARTITIONS = DailyPartitionsDefinition(start_date="2026-09-11", end_offset=1)
+
+IRX_EXPORT_ROOTS = {
+    "production": "s3://ol-irx-partners-storage-production",
+    "qa": "s3://ol-irx-partners-storage-qa",
+}
+IRX_EXPORT_SANDBOX_ROOT = "s3://ol-devops-sandbox/pipeline-storage/irx-export"
+
+LEGACY_DATETIME = "%Y-%m-%d %H:%M:%S"
+
+
+@dataclass(frozen=True)
+class IrxExportFile:
+    """One legacy CSV and the irx__ model it is cut from."""
+
+    name: str
+    model: str
+    columns: tuple[str, ...]
+    renames: Mapping[str, str] = field(default_factory=dict)
+    required: tuple[str, ...] = ()
+
+
+IRX_EXPORT_FILES = (
+    IrxExportFile(
+        name="users_query",
+        model="auth_user",
+        columns=(
+            "id",
+            "username",
+            "first_name",
+            "last_name",
+            "email",
+            "is_staff",
+            "is_active",
+            "is_superuser",
+            "last_login",
+            "date_joined",
+            "course_id",
+        ),
+    ),
+    IrxExportFile(
+        name="enrollment_query",
+        model="student_courseenrollment",
+        columns=("id", "user_id", "course_id", "created", "is_active", "mode"),
+    ),
+    IrxExportFile(
+        name="role_query",
+        model="student_courseaccessrole",
+        columns=("id", "user_id", "org", "course_id", "role"),
+    ),
+    IrxExportFile(
+        name="role_users",
+        model="django_comment_client_role_users",
+        columns=("id", "user_id", "org", "course_id", "role"),
+        renames={"name": "role"},
+        # Legacy reached org through an inner join on
+        # organizations_organizationcourse, so a course run with no organization
+        # link delivered no forum-role rows at all. The model keeps those rows.
+        required=("org",),
+    ),
+    IrxExportFile(
+        name="studentmodule_query",
+        model="courseware_studentmodule",
+        columns=(
+            "id",
+            "module_type",
+            "module_id",
+            "student_id",
+            "state",
+            "grade",
+            "created",
+            "modified",
+            "max_grade",
+            "done",
+            "course_id",
+        ),
+    ),
+)
+
+
+def irx_model_name(deployment: str, model: str) -> str:
+    return f"irx__{deployment}__openedx__mysql__{model}"
+
+
+def legacy_csv_columns(schema: pl.Schema, columns: Sequence[str]) -> list[pl.Expr]:
+    """Project columns so polars writes them the way legacy's csv.DictWriter did.
+
+    Legacy wrote MySQL rows through Python's csv module: booleans arrive as
+    tinyint 1/0, datetimes as str(datetime), which drops the fraction when the
+    microseconds are zero, and an empty string is written the same as NULL.
+    Left alone, polars writes true/false, a fixed-width fraction, and quotes
+    empty strings as "".
+    """
+    exprs = []
+    for name in columns:
+        column, dtype = pl.col(name), schema[name]
+        if dtype == pl.Boolean:
+            column = column.cast(pl.Int8)
+        elif isinstance(dtype, pl.Datetime):
+            column = (
+                pl.when(column.dt.microsecond() == 0)
+                .then(column.dt.strftime(LEGACY_DATETIME))
+                .otherwise(column.dt.strftime(f"{LEGACY_DATETIME}%.6f"))
+            )
+        elif dtype == pl.String:
+            column = pl.when(column == "").then(None).otherwise(column)
+        exprs.append(column.alias(name))
+    return exprs
+
+
+class _DigestingWriter(io.RawIOBase):
+    """Hash and count bytes on their way to the object store."""
+
+    def __init__(self, sink: Any):
+        self._sink = sink
+        self.digest = hashlib.sha256()
+        self.size = 0
+
+    def writable(self) -> bool:
+        return True
+
+    def write(self, data: Any) -> int:
+        self.digest.update(data)
+        self.size += len(data)
+        return self._sink.write(data)
+
+
+def write_legacy_csv(frame: pl.LazyFrame, destination: UPath) -> tuple[str, int]:
+    """Stream a frame to the drop as CSV and return its sha256 and size in bytes.
+
+    Streamed, never collected: studentmodule_query.csv runs to 59 GB for mitx,
+    and legacy_openedx needed a 32Gi memory limit for loading it whole.
+    """
+    with destination.open("wb") as sink:
+        writer = _DigestingWriter(sink)
+        frame.sink_csv(writer, line_terminator="\r\n")
+    return writer.digest.hexdigest(), writer.size
+
+
+def build_irx_export_asset(deployment: str) -> AssetsDefinition:
+    """Build the nightly IRx drop for one deployment as a single multi-asset.
+
+    One op rather than one asset per file, so all six files in a drop are cut
+    against the same course list, the way legacy's single job was.
+    """
+    course_ids_key = AssetKey([deployment, IRX_EXPORT_GROUP, "course_ids"])
+    specs = [
+        AssetSpec(
+            key=course_ids_key,
+            description="course_ids.csv: the course runs the Open edX API lists.",
+            code_version="irx_export_v1",
+        ),
+        *(
+            AssetSpec(
+                key=AssetKey([deployment, IRX_EXPORT_GROUP, export.name]),
+                deps=[AssetKey(["external", irx_model_name(deployment, export.model)])],
+                description=f"{export.name}.csv in the nightly IRx drop.",
+                code_version="irx_export_v1",
+            )
+            for export in IRX_EXPORT_FILES
+        ),
+    ]
+
+    @multi_asset(
+        name=f"{deployment}_irx_export",
+        specs=specs,
+        group_name=IRX_EXPORT_GROUP,
+        partitions_def=IRX_EXPORT_PARTITIONS,
+        required_resource_keys={"openedx"},
+    )
+    def irx_export(context: AssetExecutionContext) -> Iterator[MaterializeResult]:
+        root = UPath(IRX_EXPORT_ROOTS.get(DAGSTER_ENV, IRX_EXPORT_SANDBOX_ROOT))
+        drop_date = context.partition_time_window.start.strftime("%Y%m%d")
+        drop = root / deployment / drop_date
+
+        # The live API list, not the course-run partition set: the sensor that
+        # maintains those partitions only ever adds, so they accumulate runs
+        # the LMS no longer lists.
+        course_ids = [
+            course["id"]
+            for page in context.resources.openedx.client.get_edx_course_ids()
+            for course in page
+        ]
+        if not course_ids:
+            raise Failure(
+                description=(
+                    f"The {deployment} course API listed no course runs, so every "
+                    "file in the drop would be empty."
+                )
+            )
+        yield _export(
+            course_ids_key,
+            pl.LazyFrame({"course_id": course_ids}, schema={"course_id": pl.String}),
+            drop / "course_ids.csv",
+            {"row_count": len(course_ids)},
+        )
+
+        for export in IRX_EXPORT_FILES:
+            table_name = irx_model_name(deployment, export.model)
+            table = load_dbt_model_table(IRX_GLUE_DATABASE, table_name)
+            # Pinned so the row count and the file are read from the same
+            # snapshot even if dbt rebuilds the model mid-export.
+            snapshot_id = table.current_snapshot().snapshot_id
+            frame = (
+                scan_dbt_model_table(table, snapshot_id)
+                .rename(dict(export.renames))
+                .filter(pl.col("course_id").is_in(course_ids))
+                .drop_nulls(list(export.required))
+            )
+            yield _export(
+                AssetKey([deployment, IRX_EXPORT_GROUP, export.name]),
+                frame.select(
+                    legacy_csv_columns(frame.collect_schema(), export.columns)
+                ),
+                drop / f"{export.name}.csv",
+                {
+                    "row_count": frame.select(pl.len()).collect().item(),
+                    "source_table": f"{IRX_GLUE_DATABASE}.{table_name}",
+                    "source_snapshot_id": str(snapshot_id),
+                },
+            )
+
+    return irx_export
+
+
+def _export(
+    key: AssetKey,
+    frame: pl.LazyFrame,
+    destination: UPath,
+    metadata: Mapping[str, Any],
+) -> MaterializeResult:
+    sha256, size = write_legacy_csv(frame, destination)
+    get_dagster_logger().info(
+        "Wrote %s rows (%d bytes) to %s", metadata["row_count"], size, destination
+    )
+    return MaterializeResult(
+        asset_key=key,
+        data_version=DataVersion(sha256),
+        metadata={
+            **metadata,
+            "path": MetadataValue.path(str(destination)),
+            "size_bytes": size,
+            "sha256": sha256,
+        },
+    )

--- a/dg_projects/openedx/openedx/assets/irx_export.py
+++ b/dg_projects/openedx/openedx/assets/irx_export.py
@@ -239,7 +239,15 @@ def build_irx_export_asset(deployment: str) -> AssetsDefinition:
             table = load_dbt_model_table(IRX_GLUE_DATABASE, table_name)
             # Pinned so the row count and the file are read from the same
             # snapshot even if dbt rebuilds the model mid-export.
-            snapshot_id = table.current_snapshot().snapshot_id
+            snapshot = table.current_snapshot()
+            if snapshot is None:
+                raise Failure(
+                    description=(
+                        f"{IRX_GLUE_DATABASE}.{table_name} has no snapshot, so "
+                        "there is nothing to export."
+                    )
+                )
+            snapshot_id = snapshot.snapshot_id
             frame = (
                 scan_dbt_model_table(table, snapshot_id)
                 .rename(dict(export.renames))

--- a/dg_projects/openedx/openedx/components/openedx_deployment.py
+++ b/dg_projects/openedx/openedx/components/openedx_deployment.py
@@ -4,17 +4,26 @@ from typing import Literal
 
 from dagster import (
     AssetsDefinition,
+    AssetSelection,
     AutomationConditionSensorDefinition,
     ConfigurableResource,
+    DefaultScheduleStatus,
     DefaultSensorStatus,
     Definitions,
     SensorDefinition,
     SourceAsset,
+    build_schedule_from_partitioned_job,
+    define_asset_job,
 )
+from dagster._core.definitions.partitions.partitioned_schedule import (
+    UnresolvedPartitionedAssetScheduleDefinition,
+)
+from ol_orchestrate.lib.constants import DAGSTER_ENV
 from ol_orchestrate.resources.openedx import OpenEdxApiClientFactory
 from ol_orchestrate.resources.secrets.vault import Vault
 
 from openedx.assets.content_files import extract_course_document_text
+from openedx.assets.irx_export import build_irx_export_asset
 from openedx.assets.openedx import (
     build_courseware_source_asset,
     course_structure,
@@ -37,6 +46,7 @@ class OpenEdxDeploymentComponent:
     This component creates a complete set of Dagster definitions for a single OpenEdX
     deployment, including:
     - Assets for course data extraction (courseware, structure, XML, metadata)
+    - The nightly IRx drop and its schedule
     - Sensors for detecting new courses and course version changes
     - Resources for API client configuration
 
@@ -114,6 +124,7 @@ class OpenEdxDeploymentComponent:
             "course_content_webhook_asset": course_content_webhook_asset,
             "document_text_asset": document_text_asset,
             "transcript_text_asset": transcript_text_asset,
+            "irx_export_asset": build_irx_export_asset(self.deployment_name),
         }
 
     def build_sensors(
@@ -195,6 +206,50 @@ class OpenEdxDeploymentComponent:
             automation_sensor,
         ]
 
+    def build_schedules(
+        self, assets: dict[str, AssetsDefinition | SourceAsset]
+    ) -> list[UnresolvedPartitionedAssetScheduleDefinition]:
+        """Build the nightly IRx drop's schedule for the deployment.
+
+        Args:
+            assets: The deployment's assets, used to target the schedule.
+
+        Returns:
+            List of schedule definitions
+        """
+        irx_export_job = define_asset_job(
+            name=f"{self.deployment_name}_irx_export",
+            selection=AssetSelection.assets(assets["irx_export_asset"]),
+            tags={
+                # The ceiling legacy_openedx needed for loading studentmodule
+                # whole. The export streams it, so the real peak should be far
+                # lower; it has not been measured yet.
+                "dagster-k8s/config": {
+                    "container_config": {
+                        "resources": {
+                            "requests": {"memory": "2Gi"},
+                            "limits": {"memory": "32Gi"},
+                        }
+                    }
+                }
+            },
+        )
+        # Running by default in production rather than switched on by hand, so
+        # no instigator state is left behind if the drop moves to another code
+        # location. The files are only as fresh as the last edxapp sync and irx
+        # build, whatever the hour.
+        return [
+            build_schedule_from_partitioned_job(
+                irx_export_job,
+                hour_of_day=6,
+                default_status=(
+                    DefaultScheduleStatus.RUNNING
+                    if DAGSTER_ENV == "production"
+                    else DefaultScheduleStatus.STOPPED
+                ),
+            )
+        ]
+
     def build_resource(
         self,
     ) -> dict[str, ConfigurableResource[OpenEdxApiClientFactory]]:
@@ -222,7 +277,7 @@ class OpenEdxDeploymentComponent:
             shared_resources: Optional dict of shared resources to include.
 
         Returns:
-            Definitions object containing assets, sensors, and resources.
+            Definitions object containing assets, schedules, sensors, and resources.
         """
         assets = self.build_assets()
         sensors = self.build_sensors(assets)
@@ -235,6 +290,7 @@ class OpenEdxDeploymentComponent:
 
         return Definitions(
             assets=list(assets.values()),
+            schedules=self.build_schedules(assets),
             sensors=sensors,
             resources=all_resources,
         )

--- a/dg_projects/openedx/openedx/definitions.py
+++ b/dg_projects/openedx/openedx/definitions.py
@@ -277,6 +277,7 @@ def _create_deployment_repository(
     return create_repository_using_definitions_args(
         name=f"{deployment_name}_openedx",
         assets=with_failure_hooks(deployment_defs.assets or []),
+        schedules=deployment_defs.schedules,
         sensors=deployment_defs.sensors,
         resources=deployment_defs.resources,
     )

--- a/dg_projects/openedx/openedx_tests/test_components.py
+++ b/dg_projects/openedx/openedx_tests/test_components.py
@@ -102,11 +102,17 @@ def test_the_automation_sensor_targets_the_courseware_source_asset(
         sensor for sensor in sensors if sensor.name.endswith("_automation_sensor")
     )
 
-    graph = _asset_graph(component)
-    targeted = automation_sensor.asset_selection.resolve(graph)
+    targeted = automation_sensor.asset_selection.resolve(_asset_graph(component))
+    # The component's own keys, not the whole graph: the graph also holds the
+    # dbt models the IRx drop depends on, which the lakehouse location owns.
+    own_keys = {
+        key
+        for asset in assets.values()
+        for key in (asset.keys if isinstance(asset, AssetsDefinition) else [asset.key])
+    }
 
     assert assets["courseware_asset"].key in targeted
-    assert targeted == graph.get_all_asset_keys(), "nothing dropped from the target"
+    assert targeted == own_keys, "nothing dropped from the target"
 
 
 def test_the_discovery_sensor_does_not_target_the_source_asset(

--- a/dg_projects/openedx/openedx_tests/test_irx_export.py
+++ b/dg_projects/openedx/openedx_tests/test_irx_export.py
@@ -1,0 +1,94 @@
+"""Tests for the IRx facade export: byte parity with legacy, and asset wiring."""
+
+import csv
+import hashlib
+import io
+from datetime import datetime
+from typing import Any
+
+import polars as pl
+from dagster import AssetKey
+from openedx.assets.irx_export import (
+    IRX_EXPORT_FILES,
+    build_irx_export_asset,
+    legacy_csv_columns,
+    write_legacy_csv,
+)
+from upath import UPath
+
+# Naive, as MySQL DATETIME and Iceberg timestamp both are.
+ROWS: list[dict[str, Any]] = [
+    {
+        "id": 1,
+        "flag": True,
+        "ts": datetime.fromisoformat("2021-08-19 19:25:54"),
+        "g": None,
+    },
+    {
+        "id": 2,
+        "flag": False,
+        "ts": datetime.fromisoformat("2026-09-08 19:32:48.544749"),
+        "g": 1.0,
+    },
+    {"id": 3, "flag": None, "ts": None, "g": 0.5},
+    {
+        "id": 4,
+        "flag": True,
+        "ts": datetime.fromisoformat("2026-09-08 19:32:48.000005"),
+        "g": 0.3,
+    },
+]
+STRINGS = ['a,"b"', "line\nbreak", "", " lead"]
+COLUMNS = ["id", "flag", "ts", "g", "s"]
+
+
+def _legacy_bytes() -> bytes:
+    """Render the same rows through legacy_openedx's write_csv path."""
+    out = io.StringIO(newline="")
+    writer = csv.DictWriter(out, COLUMNS)
+    writer.writeheader()
+    for row, text in zip(ROWS, STRINGS, strict=True):
+        flag = None if row["flag"] is None else int(row["flag"])
+        writer.writerow({**row, "flag": flag, "s": text})
+    return out.getvalue().encode()
+
+
+def test_export_bytes_match_legacy_csv_module_output(tmp_path) -> None:
+    frame = pl.LazyFrame(
+        [{**row, "s": text} for row, text in zip(ROWS, STRINGS, strict=True)]
+    )
+    destination = UPath(tmp_path / "out.csv")
+
+    sha256, size = write_legacy_csv(
+        frame.select(legacy_csv_columns(frame.collect_schema(), COLUMNS)),
+        destination,
+    )
+
+    written = destination.read_bytes()
+    assert written == _legacy_bytes()
+    assert sha256 == hashlib.sha256(written).hexdigest()
+    assert size == len(written)
+
+
+def test_role_users_projects_name_to_the_role_header() -> None:
+    role_users = next(f for f in IRX_EXPORT_FILES if f.name == "role_users")
+
+    assert role_users.renames == {"name": "role"}
+    assert role_users.columns == ("id", "user_id", "org", "course_id", "role")
+
+
+def test_every_file_depends_on_its_irx_model() -> None:
+    asset = build_irx_export_asset("mitxonline")
+
+    deps = {
+        key.path[-1]: {dep.asset_key for dep in spec.deps}
+        for key, spec in asset.specs_by_key.items()
+    }
+
+    assert deps.pop("course_ids") == set()
+    assert deps == {
+        export.name: {
+            AssetKey(["external", f"irx__mitxonline__openedx__mysql__{export.model}"])
+        }
+        for export in IRX_EXPORT_FILES
+    }

--- a/packages/ol-orchestrate-lib/src/ol_orchestrate/lib/glue_helper.py
+++ b/packages/ol-orchestrate-lib/src/ol_orchestrate/lib/glue_helper.py
@@ -5,6 +5,7 @@ import types
 import boto3
 import polars as pl
 from pyiceberg.catalog.glue import GlueCatalog
+from pyiceberg.table import Table
 
 TYPE_RENAME = types.MappingProxyType(
     {
@@ -89,6 +90,51 @@ def create_or_update_table(
         glue_client.update_table(DatabaseName=database_name, TableInput=table_input)
 
 
+# Route pyiceberg I/O through fsspec/s3fs (aiobotocore) instead of the default
+# PyArrow S3 FileIO (aws-sdk-cpp). The native PyArrow reader leaves wedged
+# threads/connections on K8s that no S3 timeout interrupts, deadlocking the
+# run. fsspec honors the same s3.connect-timeout / s3.request-timeout keys.
+_PYICEBERG_S3_PROPERTIES = types.MappingProxyType(
+    {
+        "py-io-impl": "pyiceberg.io.fsspec.FsspecFileIO",
+        "s3.region": "us-east-1",
+        "s3.connect-timeout": "10",
+        "s3.request-timeout": "120",
+    }
+)
+# Polars 1.40+ maps s3.connect-timeout / s3.request-timeout to object_store's
+# `connect_timeout` / `timeout` for its native Rust S3 reader, preventing
+# CLOSE_WAIT connections from blocking Tokio runtime shutdown at process exit.
+# object_store requires Duration strings (e.g. "10s"), not bare integers.
+_POLARS_S3_STORAGE_OPTIONS = types.MappingProxyType(
+    {
+        "s3.region": "us-east-1",
+        "s3.connect-timeout": "10s",
+        "s3.request-timeout": "120s",
+    }
+)
+
+
+def load_dbt_model_table(database_name: str, table_name: str) -> Table:
+    """Load a dbt model's Iceberg table from the Glue catalog."""
+    glue = GlueCatalog(
+        "default",
+        client=boto3.client("glue", region_name="us-east-1"),
+        **_PYICEBERG_S3_PROPERTIES,
+    )
+    return glue.load_table(f"{database_name}.{table_name}")
+
+
+def scan_dbt_model_table(table: Table, snapshot_id: int | None = None) -> pl.LazyFrame:
+    """Scan an Iceberg table lazily, at the given snapshot or else the current one."""
+    return pl.scan_iceberg(
+        table,
+        snapshot_id=snapshot_id,
+        reader_override="pyiceberg",
+        storage_options=dict(_POLARS_S3_STORAGE_OPTIONS),
+    )
+
+
 def get_dbt_model_as_dataframe(database_name: str, table_name: str) -> pl.LazyFrame:
     """Retrieve a dbt model from AWS Glue as a Polars DataFrame.
 
@@ -106,32 +152,4 @@ def get_dbt_model_as_dataframe(database_name: str, table_name: str) -> pl.LazyFr
         KeyError: If the table metadata doesn't contain the expected fields
         boto3 exceptions: If the AWS Glue API call fails
     """
-    # Route pyiceberg I/O through fsspec/s3fs (aiobotocore) instead of the default
-    # PyArrow S3 FileIO (aws-sdk-cpp). The native PyArrow reader leaves wedged
-    # threads/connections on K8s that no S3 timeout interrupts, deadlocking the
-    # run. fsspec honors the same s3.connect-timeout / s3.request-timeout keys.
-    pyiceberg_s3_properties = {
-        "py-io-impl": "pyiceberg.io.fsspec.FsspecFileIO",
-        "s3.region": "us-east-1",
-        "s3.connect-timeout": "10",
-        "s3.request-timeout": "120",
-    }
-    # Polars 1.40+ maps s3.connect-timeout / s3.request-timeout to object_store's
-    # `connect_timeout` / `timeout` for its native Rust S3 reader, preventing
-    # CLOSE_WAIT connections from blocking Tokio runtime shutdown at process exit.
-    # object_store requires Duration strings (e.g. "10s"), not bare integers.
-    polars_s3_storage_options = {
-        "s3.region": "us-east-1",
-        "s3.connect-timeout": "10s",
-        "s3.request-timeout": "120s",
-    }
-    glue = GlueCatalog(
-        "default",
-        client=boto3.client("glue", region_name="us-east-1"),
-        **pyiceberg_s3_properties,
-    )
-    table = glue.load_table(f"{database_name}.{table_name}")
-
-    return pl.scan_iceberg(
-        table, reader_override="pyiceberg", storage_options=polars_s3_storage_options
-    )
+    return scan_dbt_model_table(load_dbt_model_table(database_name, table_name))

--- a/packages/ol-orchestrate-lib/src/ol_orchestrate/lib/glue_helper.py
+++ b/packages/ol-orchestrate-lib/src/ol_orchestrate/lib/glue_helper.py
@@ -4,8 +4,9 @@ import types
 
 import boto3
 import polars as pl
-from pyiceberg.catalog.glue import GlueCatalog
 from pyiceberg.table import Table
+
+from ol_orchestrate.lib.iceberg_maintenance import get_glue_catalog
 
 TYPE_RENAME = types.MappingProxyType(
     {
@@ -90,18 +91,6 @@ def create_or_update_table(
         glue_client.update_table(DatabaseName=database_name, TableInput=table_input)
 
 
-# Route pyiceberg I/O through fsspec/s3fs (aiobotocore) instead of the default
-# PyArrow S3 FileIO (aws-sdk-cpp). The native PyArrow reader leaves wedged
-# threads/connections on K8s that no S3 timeout interrupts, deadlocking the
-# run. fsspec honors the same s3.connect-timeout / s3.request-timeout keys.
-_PYICEBERG_S3_PROPERTIES = types.MappingProxyType(
-    {
-        "py-io-impl": "pyiceberg.io.fsspec.FsspecFileIO",
-        "s3.region": "us-east-1",
-        "s3.connect-timeout": "10",
-        "s3.request-timeout": "120",
-    }
-)
 # Polars 1.40+ maps s3.connect-timeout / s3.request-timeout to object_store's
 # `connect_timeout` / `timeout` for its native Rust S3 reader, preventing
 # CLOSE_WAIT connections from blocking Tokio runtime shutdown at process exit.
@@ -117,12 +106,7 @@ _POLARS_S3_STORAGE_OPTIONS = types.MappingProxyType(
 
 def load_dbt_model_table(database_name: str, table_name: str) -> Table:
     """Load a dbt model's Iceberg table from the Glue catalog."""
-    glue = GlueCatalog(
-        "default",
-        client=boto3.client("glue", region_name="us-east-1"),
-        **_PYICEBERG_S3_PROPERTIES,
-    )
-    return glue.load_table(f"{database_name}.{table_name}")
+    return get_glue_catalog().load_table(f"{database_name}.{table_name}")
 
 
 def scan_dbt_model_table(table: Table, snapshot_id: int | None = None) -> pl.LazyFrame:

--- a/packages/ol-orchestrate-lib/src/ol_orchestrate/lib/iceberg_maintenance.py
+++ b/packages/ol-orchestrate-lib/src/ol_orchestrate/lib/iceberg_maintenance.py
@@ -252,8 +252,7 @@ def get_glue_catalog(region: str = AWS_REGION) -> GlueCatalog:
     """Return a configured pyiceberg GlueCatalog backed by boto3.
 
     This is the single factory used by both the maintenance library and
-    ``glue_helper.get_dbt_model_as_dataframe``.  When the latter is refactored,
-    it should delegate here.
+    ``glue_helper.load_dbt_model_table``.
     """
     return GlueCatalog(
         "default",

--- a/src/ol_dbt/models/external/IRX_SIMEON_MAPPING.md
+++ b/src/ol_dbt/models/external/IRX_SIMEON_MAPPING.md
@@ -130,15 +130,19 @@ production has both `MITxt` and `MITxT`). Use the column, do not derive it.
   `raw__{d}__openedx__mysql__django_comment_client_role_users` and is now selected.
 - `name` → `role` — a rename the export applies when projecting the header. `name` stays correct
   for the source shape, so this is not a model change.
-- `org` — **not derivable from anything currently ingested.** The legacy op joins
-  `organizations_organizationcourse` and `organizations_organization`; neither table exists in
-  `ol_warehouse_production_raw` for any deployment. This is an *ingestion* gap, not a modelling one.
+- `org` — **closed.** The legacy op joins `organizations_organizationcourse` and
+  `organizations_organization`. Both are ingested since #2665, and the model now carries
+  `organization.name as org` through left joins on them.
 
-  Deriving `org` from the course key is a 99.55% approximation, not an equivalence: measured against
-  the delivered mitxonline `role_users.csv` (549,130 rows), 2,476 rows disagree, because the
-  organization a course belongs to is not always its course-key org (e.g.
-  `course-v1:UAI_ET+UAI.1+2025_C503` belongs to organization `UAI_SOURCE`). Either ingest the two
-  tables or agree the approximation with IRx explicitly.
+  Deriving `org` from the course key instead would have been a 99.55% approximation, not an
+  equivalence: measured against the delivered mitxonline `role_users.csv` (549,130 rows), 2,476 rows
+  disagree, because the organization a course belongs to is not always its course-key org (e.g.
+  `course-v1:UAI_ET+UAI.1+2025_C503` belongs to organization `UAI_SOURCE`).
+
+  The model left-joins where legacy inner-joined, so it keeps forum roles on course runs with no
+  organization link. The export drops those rows (`org` is required), which is what legacy
+  delivered. A course run linked to two organizations gets a row per organization in both. One
+  mitxonline course run is, as of 2026-09-11; none in mitx or xpro.
 
 ### `studentmodule_query.csv`
 `id,module_type,module_id,student_id,state,grade,created,modified,max_grade,done,course_id`
@@ -167,11 +171,10 @@ Size caution: `legacy_openedx` carries a 32Gi memory limit in ol-infrastructure 
 
 ### `course_ids.csv`
 `course_id` — single column. No `irx__` equivalent, and there does not need to be one. The legacy
-pipeline builds it from the Open edX course API via `list_courses`; the `openedx` code location
-already does the same enumeration in `sensors/openedx.py::course_run_sensor`, which calls
-`get_edx_course_ids()` and registers every course run as a dynamic partition
-(`{deployment}_openedx_course_run`). `course_ids.csv` is that partition set serialised — no new API
-call and no new source.
+pipeline builds it from the Open edX course API via `list_courses`, and the facade makes the same
+`get_edx_course_ids()` call at export time. It does not serialise the `{deployment}_openedx_course_run`
+dynamic partition set, even though `course_run_sensor` fills it from the same API: that sensor only
+ever adds partitions, so the set accumulates course runs the LMS no longer lists.
 
 ## Summary of gaps
 
@@ -182,8 +185,8 @@ call and no new source.
 | `student_courseenrollment` missing `user_id`, `created` | modelling | **closed** |
 | `student_courseaccessrole` missing `id` | modelling | **closed** |
 | `django_comment_client_role_users` missing `id` | modelling | **closed**; `name`→`role` is a projection the export applies, not a model change |
-| `django_comment_client_role_users` missing `org` | **ingestion** | **OPEN** — needs `organizations_organizationcourse` + `organizations_organization`, or an agreed 99.55% approximation |
-| `course_ids.csv` has no warehouse source | none | not a gap — the `{deployment}_openedx_course_run` dynamic partition set is the same API enumeration legacy makes |
+| `django_comment_client_role_users` missing `org` | ingestion | **closed** — both organizations tables ingested (#2665); the model left-joins them, the export drops rows with no organization as legacy's inner join did |
+| `course_ids.csv` has no warehouse source | none | not a gap — the export makes the same course API call legacy makes |
 | `forum.mongo` replacement | modelling | open — 12 `forum_*` tables are ingested but all `modeled: false` |
 
 The added columns are all additive: `ol-dbt impact` reports 0 breaking and 0 warnings across the 15
@@ -199,6 +202,6 @@ that claim whenever #2359 is next updated.
 Decided 2026-08-31. The `irx_export` code location #2359 proposes is blocked by the code-location
 freeze, and `openedx` already holds three of the thirteen Simeon files locally — `course_xml`,
 `course_structure`, and the course-run enumeration that `course_ids.csv` is. The remaining ten come
-from Glue via `get_dbt_model_as_dataframe`. The facade needs its own S3 io-manager key, because
+from Glue. The facade writes to the IRx bucket directly rather than through an io manager:
 `openedx`'s `s3file_io_manager` is bound to the landing-zone bucket
 (`openedx/definitions.py:155`), not to the IRx bucket.

--- a/src/ol_dbt/models/external/irx/mitx/_irx_mitx__models.yml
+++ b/src/ol_dbt/models/external/irx/mitx/_irx_mitx__models.yml
@@ -678,6 +678,10 @@ models:
     description: string, name of the discussion role e.g. Moderator
   - name: id
     description: int, the auto-incremented ID for this table
+  - name: org
+    description: string, name of the organization the course run belongs to, via organizations_organizationcourse.
+      Null when the course run has no organization link. A course run linked to more
+      than one organization has a row per organization, as in the legacy role_users.csv
 
 - name: irx__mitx__openedx__mysql__student_anonymoususerid
   description: Mapping of MITx OpenedX learners to their anonymous user IDs per course

--- a/src/ol_dbt/models/external/irx/mitx/irx__mitx__openedx__mysql__django_comment_client_role_users.sql
+++ b/src/ol_dbt/models/external/irx/mitx/irx__mitx__openedx__mysql__django_comment_client_role_users.sql
@@ -8,10 +8,23 @@ with dccr as (
     from {{ source('ol_warehouse_raw_data','raw__mitx__openedx__mysql__django_comment_client_role_users') }}
 )
 
+, organizationcourse as (
+    select *
+    from {{ source('ol_warehouse_raw_data','raw__mitx__openedx__mysql__organizations_organizationcourse') }}
+)
+
+, organization as (
+    select *
+    from {{ source('ol_warehouse_raw_data','raw__mitx__openedx__mysql__organizations_organization') }}
+)
+
 select
     dccr.course_id
     , dccru.user_id
     , dccr.name
     , dccru.id
+    , organization.name as org
 from dccr
 inner join dccru on dccr.id = dccru.role_id
+left join organizationcourse on dccr.course_id = organizationcourse.course_id
+left join organization on organizationcourse.organization_id = organization.id

--- a/src/ol_dbt/models/external/irx/mitxonline/_irx_mitxonline__models.yml
+++ b/src/ol_dbt/models/external/irx/mitxonline/_irx_mitxonline__models.yml
@@ -485,6 +485,10 @@ models:
     description: string, name of the discussion role e.g. Moderator
   - name: id
     description: int, the auto-incremented ID for this table
+  - name: org
+    description: string, name of the organization the course run belongs to, via organizations_organizationcourse.
+      Null when the course run has no organization link. A course run linked to more
+      than one organization has a row per organization, as in the legacy role_users.csv
 
 - name: irx__mitxonline__openedx__mysql__student_anonymoususerid
   description: Mapping of MITx Online OpenedX learners to their anonymous user IDs

--- a/src/ol_dbt/models/external/irx/mitxonline/irx__mitxonline__openedx__mysql__django_comment_client_role_users.sql
+++ b/src/ol_dbt/models/external/irx/mitxonline/irx__mitxonline__openedx__mysql__django_comment_client_role_users.sql
@@ -8,10 +8,23 @@ with dccr as (
     from {{ source('ol_warehouse_raw_data','raw__mitxonline__openedx__mysql__django_comment_client_role_users') }}
 )
 
+, organizationcourse as (
+    select *
+    from {{ source('ol_warehouse_raw_data','raw__mitxonline__openedx__mysql__organizations_organizationcourse') }}
+)
+
+, organization as (
+    select *
+    from {{ source('ol_warehouse_raw_data','raw__mitxonline__openedx__mysql__organizations_organization') }}
+)
+
 select
     dccr.course_id
     , dccru.user_id
     , dccr.name
     , dccru.id
+    , organization.name as org
 from dccr
 inner join dccru on dccr.id = dccru.role_id
+left join organizationcourse on dccr.course_id = organizationcourse.course_id
+left join organization on organizationcourse.organization_id = organization.id

--- a/src/ol_dbt/models/external/irx/xpro/_irx_xpro__models.yml
+++ b/src/ol_dbt/models/external/irx/xpro/_irx_xpro__models.yml
@@ -477,6 +477,10 @@ models:
     description: string, name of the discussion role e.g. Moderator
   - name: id
     description: int, the auto-incremented ID for this table
+  - name: org
+    description: string, name of the organization the course run belongs to, via organizations_organizationcourse.
+      Null when the course run has no organization link. A course run linked to more
+      than one organization has a row per organization, as in the legacy role_users.csv
 
 - name: irx__xpro__openedx__mysql__student_anonymoususerid
   description: Mapping of xPRO OpenedX learners to their anonymous user IDs per course

--- a/src/ol_dbt/models/external/irx/xpro/irx__xpro__openedx__mysql__django_comment_client_role_users.sql
+++ b/src/ol_dbt/models/external/irx/xpro/irx__xpro__openedx__mysql__django_comment_client_role_users.sql
@@ -8,10 +8,23 @@ with dccr as (
     from {{ source('ol_warehouse_raw_data','raw__xpro__openedx__mysql__django_comment_client_role_users') }}
 )
 
+, organizationcourse as (
+    select *
+    from {{ source('ol_warehouse_raw_data','raw__xpro__openedx__mysql__organizations_organizationcourse') }}
+)
+
+, organization as (
+    select *
+    from {{ source('ol_warehouse_raw_data','raw__xpro__openedx__mysql__organizations_organization') }}
+)
+
 select
     dccr.course_id
     , dccru.user_id
     , dccr.name
     , dccru.id
+    , organization.name as org
 from dccr
 inner join dccru on dccr.id = dccru.role_id
+left join organizationcourse on dccr.course_id = organizationcourse.course_id
+left join organization on organizationcourse.organization_id = organization.id


### PR DESCRIPTION
### What are the relevant tickets?
Part of https://github.com/mitodl/ol-data-platform/issues/2359 (retire `legacy_openedx`). This is the tabular half of the facade. The forum file, the course tarballs and tracking logs, and `_MANIFEST.json` are separate.

### Description (What does it do?)
Adds a `{deployment}_irx_export` multi-asset to each of the three deployment repositories in the `openedx` code location. It writes the six CSVs `legacy_openedx` delivers (`course_ids`, `users_query`, `enrollment_query`, `role_query`, `role_users`, `studentmodule_query`) into `ol-irx-partners-storage-{env}` at `{deployment}/{YYYYMMDD}/`. The files are cut from the `irx__` Iceberg tables instead of queried live from edxapp MySQL. It is one op per deployment, so every file in a drop is scoped by the same course list. That list is the live course API response, the same call legacy's `list_courses` makes. It is not the course-run partition set, because `course_run_sensor` only ever adds to that.

**The build target is the legacy files as delivered**, per `IRX_SIMEON_MAPPING.md`. Legacy is `csv.DictWriter` over pymysql rows, which polars does not match by default. `legacy_csv_columns` projects the legacy header by name and renders:
- booleans as `1`/`0`;
- datetimes as `str(datetime)`, with no fraction when the microseconds are zero;
- empty strings unquoted, the same as NULL (polars otherwise writes `""`);
- CRLF line endings.

**Streamed, not collected.** `studentmodule_query.csv` was 59.4 GB (mitx), 7.3 GB (xpro) and 25.8 GB (mitxonline) in the 20260910 drop. Each file goes from pyiceberg record batches through `sink_csv` into an s3fs multipart upload, and is hashed on the way for the `DataVersion`. It does not go through `FileObjectIOManager`, whose `handle_output` reads the whole file into memory. Each file's row count comes from the same pinned Iceberg snapshot it was cut from, which is why `glue_helper` gains `load_dbt_model_table`/`scan_dbt_model_table`. `get_dbt_model_as_dataframe` behaves as before. The job keeps legacy's 32Gi memory limit as a ceiling, with a 2Gi request. The real peak has not been measured.

**`role_users.org`.** Legacy reads `org` through `organizations_organizationcourse` → `organizations_organization`, ingested in #2665. The three `irx__..._django_comment_client_role_users` models now left-join them. The export drops rows with no organization, because legacy's inner join never delivered them. One mitxonline course run is linked to two organizations and gets a row per organization, as it does in legacy. None in mitx or xpro.

**Schedule.** 06:00 UTC daily, `RUNNING` by default in production only, so moving the drop to another code location later leaves no instigator state behind. Partitions use `end_offset=1`, so a run names its directory by its own date, as legacy does.

### How can this be tested?
- `pytest` in `dg_projects/openedx`: 135 passed. The new tests check byte parity against `csv.DictWriter` on the awkward cases and each file's dependency on its `irx__` model.
- `openedx.definitions` loads with `DAGSTER_ENVIRONMENT=production`. Each deployment has `{d}_irx_export_schedule` (`0 6 * * *`, RUNNING) and six assets under `{d}/irx_export/`.
- `ol-dbt validate -m irx`: 0 errors. The 264 warnings are all unresolved source column lists from running without a manifest. pre-commit passes.

**Dry run on production data.** I ran the asset's own frame pipeline for xpro against today's `irx__` tables, using legacy's `20260911/course_ids.csv` (803 runs) as the course list. Then I diffed the results line by line against the delivered `20260911` files:

| file | rows (facade / legacy) | identical lines | differing |
|---|---:|---:|---|
| `enrollment_query` | 72,619 / 72,619 | 72,619 | none |
| `role_query` | 10,722 / 10,722 | 10,722 | none |
| `users_query` | 72,619 / 72,619 | 72,577 | 42, all `last_login` newer in the facade (sync lag) |
| `studentmodule_query`, first 12,002 legacy rows by id | 12,002 / 12,002 | 12,000 | 2, `grade` precision (below) |

Headers are identical in all four. `role_users` was not in the dry run, because the model's `org` column is not built in production yet.

**Known differences for the parallel run:**
- Fractional `grade` values are stored in the warehouse at float32 precision. For example, `irx__xpro__..._courseware_studentmodule` id 8729152 holds exactly `0.14285715`, where legacy delivers `0.14285714285714285` from MySQL. The irx model is a plain select, so the loss is upstream of it, most likely at the Airbyte ingest. I could not read the raw row to confirm: pyiceberg rejects the raw table's equality deletes. This affects every warehouse reader of `grade`, and it is tracked separately.
- Polars writes `1e-7` where Python writes `1e-07`. This only happens below 1e-4.

### Merge considerations
- The schedule runs from the next 06:00 UTC after deploy. At the 20260910 sizes that is about 93 GB a night into the IRx bucket, about 8.3 TB at steady state under its 90-day expiry.
- `role_users` fails until the lakehouse has rebuilt the three models with `org`, and the four files before it in the same run are still written.
- Not verified yet: a real run writing to S3 from a pod, and its memory peak.
- `legacy_openedx` is untouched, and IRx cannot read the new bucket until ol-infrastructure#5833 applies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WnsLfWeogyWUMMzieEeUGx
