### PR TITLE
docs(feedback): make cluster assignment continuous, drop run promotion

### DIFF
--- a/docs/design/README_feedback_aggregation.md
+++ b/docs/design/README_feedback_aggregation.md
@@ -63,8 +63,9 @@ signals for four audiences (support, engineering, instructors, leadership).
 3. **ML is an additive consumer**, not a prerequisite: the warehouse layer ships useful with
    tag-seeded categories + CSAT-derived sentiment; summaries, embeddings and clustering fill nullable
    columns on `afact_feedback_conversation` later and touch nothing else (**superseded in part by 2d**:
-   the three-table per-turn sidecar is withdrawn; only `feedback_cluster_run` and a candidate table remain
-   alongside the aggregate fact). Embeddings persisted **once** (the one adopted lesson from prototype
+   the three-table per-turn sidecar is withdrawn; `feedback_cluster_run` and a candidate table remain
+   alongside the aggregate fact, joined on 2026-09-11 by `feedback_cluster`, `feedback_cluster_lineage` and
+   `feedback_cluster_membership` for continuous assignment). Embeddings persisted **once** (the one adopted lesson from prototype
    #10793).
 4. **Engine-portable AI compute via Fenic; embedding model chosen by effectiveness** (revised
    2026-07-10 rev. 4, ADR): because the strategic direction is to **retire Trino for StarRocks**,

--- a/docs/design/README_feedback_aggregation.md
+++ b/docs/design/README_feedback_aggregation.md
@@ -43,7 +43,10 @@ signals for four audiences (support, engineering, instructors, leadership).
    `sentiment_fk` are **removed from `tfact_feedback`**, which makes that fact **insert-only** — there is no
    post-insert write path to it at all. The per-turn ML sidecar (`feedback_embeddings`,
    `feedback_cluster_assignment`) is withdrawn; `feedback_cluster_run` survives and a small
-   `feedback_cluster_candidate` covers run-vs-run comparison.
+   `feedback_cluster_candidate` covers run-vs-run comparison. (Revised 2026-09-11: cluster assignment is
+   continuous. New conversations are placed into the live clusters as they are embedded, re-clustering is
+   automatic, and stable `cluster_key`s carry clusters and their categories across runs. No human promotes a
+   run; see `feedback_ml_approach.md` §C.1.)
    Rationale: a complaint usually emerges across several turns, so embedding turns independently splits one
    issue into several weak cluster members and scores sentiment off a fragment. This is *not* a return to
    ticket grain — the fact still records every turn, and the assembled conversation is built from all of
@@ -158,6 +161,12 @@ analysis fact (2d) and cut to a ~1,500-word read. Three rounds of feedback have 
   `@multi_asset`; `dim_user.user_pk`'s formula corrected to match current `main`; and `subject_user_ref`
   retained on `tfact_feedback` so identity can be re-matched later without a rebuild. Detail and rationale
   are in each doc's own rev. 4/5 changelog entry.
+- **Owner direction (2026-09-11)** ([#2662 review](https://github.com/mitodl/ol-data-platform/pull/2662)) —
+  assigning a conversation to a cluster must never wait on a person, since a human gate there guarantees a
+  backlog and stale data. The run-promotion step is withdrawn: new conversations are placed into the live
+  clusters as they are embedded, re-clustering is automatic, and stable `cluster_key`s carry clusters (and
+  their approved categories) across runs. Produced `feedback_ml_approach.md` rev. 4 (§C.1) and matching
+  revisions of the ERD, dimensional model and Dagster asset spec.
 
 Before flipping RFC → Accepted, the prerequisites above should be closed — particularly the
 `comment_author_user_id`/`ticket_requester_user_id` changes, both of which gate the turn grain. Then begin implementation per the build order in `feedback_dagster_asset_spec.md` §7 (dbt facts

--- a/docs/design/feedback_dagster_asset_spec.md
+++ b/docs/design/feedback_dagster_asset_spec.md
@@ -229,8 +229,10 @@ Register in `Definitions.resources` alongside the `vault` resource
 Two options, both in use in the repo:
 - **(recommend) Declarative automation:** put `automation_condition=upstream_or_code_changes()`
   (`ol_orchestrate.lib.automation_policies`) on the `feedback_summaries` asset so it re-runs
-  when `int__feedback__conversation` refreshes or the code version changes. Downstream embed/cluster/
-  label/sentiment assets chain off it. This is what `student_risk_probability` and the dbt
+  when `int__feedback__conversation` refreshes or the code version changes. Downstream embed, incremental
+  assignment (`feedback_cluster_assignment`) and sentiment assets chain off it. Re-clustering
+  (`feedback_clusters`, `feedback_cluster_identity`) does not; it follows the schedule and triggers below
+  (rev. 6), and `feedback_category_proposals` follows the keys identity matching produces. This is what `student_risk_probability` and the dbt
   assets use — no cron to maintain. **Caveat now that summarization costs money per conversation:** make the
   summarizer incremental on `feedback_conversation_pk` (only unsummarized or changed conversations), or an
   upstream refresh re-pays for the whole corpus.

--- a/docs/design/feedback_dagster_asset_spec.md
+++ b/docs/design/feedback_dagster_asset_spec.md
@@ -1,7 +1,8 @@
 # Feedback Aggregation — Dagster ML Asset Spec (MVP)
 
 Status: **spec** · Project: `wp-feedback-aggregation-clustering-system-2e9750`
-Date: 2026-08-13 (rev. 5 — `feedback_clusters` is a `@multi_asset`; see
+Date: 2026-09-11 (rev. 6, continuous cluster assignment) · rev. 5 (2026-08-13, `feedback_clusters` is a
+`@multi_asset`; see
 [#2422 review](https://github.com/mitodl/ol-data-platform/pull/2422)) · rev. 4 (2026-08-10, conversation
 grain) · Companion to [`feedback_zendesk_mvp_spec.md`](./feedback_zendesk_mvp_spec.md)
 and [`feedback_ml_approach.md`](./feedback_ml_approach.md)
@@ -11,6 +12,13 @@ LLM-proposed categories, and sentiment. Grounded in the existing repo orchestrat
 ships without this asset**; this is purely additive — it fills the generated columns on
 `afact_feedback_conversation` and writes `feedback_cluster_run` (see
 [`feedback_erd.md`](./feedback_erd.md) §4/§5).
+
+> **REVISED 2026-09-11 (rev. 6): no promotion step; cluster assignment is continuous**
+> (`feedback_ml_approach.md` §C.1). A new `feedback_cluster_assignment` asset places each newly embedded
+> conversation into the live clusters. `feedback_clusters` re-clusters on a schedule or trigger, and a new
+> `feedback_cluster_identity` asset carries stable `cluster_key`s across runs. The human "candidate → live"
+> promotion of a run is withdrawn, and `feedback_category_proposals` labels new, split and merged keys
+> without waiting on anyone.
 
 > **REVISED 2026-08-13 (rev. 5) — `feedback_clusters` is a `@multi_asset`.** §2 specified one stage
 > producing two target tables (`feedback_cluster_run`, `feedback_cluster_candidate`) through a single
@@ -90,19 +98,30 @@ feedback_summaries             @asset  → conversation_summary + summary_model_
    ▼
 feedback_embeddings            @asset  → embedding_vector, embedding_dim, embedding_input,
    │                                     embedding_model_version   [computed ONCE per version]
+   ├─────────────► feedback_sentiment           @asset → sentiment per conversation
+   │                                                     (explicit rating + kNN/classifier)
    ▼
-feedback_clusters              @multi_asset (two AssetOuts — fixed rev. 4, @copilot: a plain @asset has one
+feedback_clusters              @multi_asset (two AssetOuts, fixed rev. 4, @copilot: a plain @asset has one
    │                                     materialized output and cannot populate two target tables from one
-   │                                     DataFrame through PolarsIcebergIOManager)
+   │                                     DataFrame through PolarsIcebergIOManager). rev. 6: scheduled and
+   │                                     triggered (§6), not chained on every embedding refresh
    │           ├─ out: feedback_cluster_run       → one row: algorithm, params, cluster_count, noise_count,
-   │           │                                     silhouette   (UMAP→HDBSCAN, run-level)
-   │           └─ out: feedback_cluster_candidate → cluster_id / cluster_probability per conversation
-   │                                                 (per-conversation, this run only — §4f/design §4f)
-   ├─────────────► feedback_category_proposals  @asset → LLM-labels clusters → dim_feedback_category
-   │                                                     (category_source='llm_discovered', status='proposed',
-   │                                                      cluster_run_id = provenance)
-   └─────────────► feedback_sentiment           @asset → sentiment per conversation
-                                                          (explicit rating + kNN/classifier)
+   │           │                                     silhouette, run_status (completed | failed)
+   │           └─ out: feedback_cluster_candidate → run-local cluster_id / cluster_probability per conversation
+   │                                                 (this run only; the input to identity matching)
+   ▼
+feedback_cluster_identity      @multi_asset (rev. 6) → matches the run's clusters to existing cluster_keys by
+   │                                     membership overlap (ml §C.1)
+   │           ├─ out: feedback_cluster          → one row per cluster_key: centroid, radius, status
+   │           └─ out: feedback_cluster_lineage  → continued / split / merged / new / retired, per run
+   ▼
+feedback_cluster_assignment    @asset (rev. 6; also downstream of feedback_embeddings, runs on every refresh)
+   │                                     → feedback_cluster_membership, one row per conversation. After a new
+   │                                       run: rewritten from the run via lineage. Otherwise: newly embedded
+   │                                       conversations placed by nearest active centroid within its radius
+   └─────────────► feedback_category_proposals  @asset → LLM-labels new / split / merged cluster_keys
+                                                         → dim_feedback_category (category_source=
+                                                         'llm_discovered', status='proposed', cluster_key)
    ▼
 afact_feedback_conversation  ← the generated columns, one row per conversation
 ```
@@ -112,9 +131,11 @@ not turn) and the target (one fact table, not three sidecars). Each stage stamps
 re-running one stage does not invalidate the others: re-clustering reuses the stored vectors, and re-embedding
 reuses the stored summaries.
 
-**Unpromoted runs** go to `feedback_cluster_candidate`, not straight onto the fact — that is what lets a
-proposed run be compared against the live one during the embedding bake-off (`feedback_ml_approach.md` §B.1).
-Promotion copies the assignment onto `afact_feedback_conversation` and drops the candidate rows.
+**No promotion step** (rev. 6). Every completed run flows through identity matching into
+`feedback_cluster_membership` without a person in the loop. `feedback_cluster_candidate` keeps each run's raw
+output, for identity matching and for run-vs-run comparison when the configuration changes
+(`feedback_ml_approach.md` §B.1), retained for the last N runs. The human decisions are the configuration,
+made in code, and the category labels (`feedback_ml_approach.md` §D).
 
 - **Redaction placement (design §7 / MVP spec §3):** unchanged in substance — Presidio is Python, so
   redaction happens in a Python asset upstream of both the fact and this pipeline. **Decision for
@@ -139,10 +160,11 @@ Promotion copies the assignment onto `afact_feedback_conversation` and drops the
   (`PolarsIcebergIOManager`, configured in `definitions.py`) persists it to the target
   Iceberg table. `feedback_clusters` (§2) returns **two** DataFrames, one per `AssetOut`, since it is a
   `@multi_asset`. `feedback_cluster_run` and `feedback_cluster_candidate` are new Iceberg tables with the
-  schemas in `feedback_ml_approach.md` §A (ERD: [`feedback_erd.md`](./feedback_erd.md) §5).
+  schemas in `feedback_ml_approach.md` §A (ERD: [`feedback_erd.md`](./feedback_erd.md) §5), as are rev. 6's
+  `feedback_cluster`, `feedback_cluster_lineage` and `feedback_cluster_membership`.
 - **Getting the generated columns onto `afact_feedback_conversation`:** dbt owns that table, so the assets
   write per-stage Iceberg output tables (`feedback_summaries`, `feedback_embeddings`,
-  `feedback_cluster_assignments`, `feedback_sentiment_assignments`) keyed by `feedback_conversation_pk`, and
+  `feedback_cluster_membership`, `feedback_sentiment_assignments`) keyed by `feedback_conversation_pk`, and
   the dbt model left-joins them onto the conversation aggregate. Same pattern as rev. 3, one grain up — and
   because the target is a derived aggregate rather than a transactional fact, this join is a plain rebuild
   rather than an incremental `merge` into a fact with consumers.
@@ -218,6 +240,11 @@ Two options, both in use in the repo:
   data-driven triggering. MVP volume is ~198K Zendesk **conversations** (`feedback_ml_approach.md` §B.2),
   which runs comfortably in one nightly batch; only the first backfill is large, and it is bounded by the
   summarizer's throughput rather than the embedder's.
+- **Re-clustering is scheduled and triggered, not chained on every refresh** (rev. 6).
+  `feedback_cluster_assignment` runs on every embedding refresh (cheap: a centroid lookup per new
+  conversation). `feedback_clusters` runs on a cron (weekly as a starting point) plus a sensor that fires when
+  the unplaced share or the corpus growth since the last run crosses its threshold
+  (`feedback_ml_approach.md` §C.1). Neither needs a person to run or to take effect.
 
 ---
 
@@ -229,17 +256,20 @@ Two options, both in use in the repo:
 2. Scaffold `dg_projects/feedback_clustering/`; add deps; provision Vault path.
 3. `feedback_summaries` asset (multi-turn conversations only) — **sample-measure the cost first** (§4).
 4. `feedback_embeddings` asset → vectors keyed by `feedback_conversation_pk`.
-5. `feedback_clusters` asset (UMAP+HDBSCAN) → `feedback_cluster_run` + assignments.
+5. `feedback_clusters` (UMAP+HDBSCAN) → `feedback_cluster_run` + `feedback_cluster_candidate`; then
+   `feedback_cluster_identity` and `feedback_cluster_assignment` → stable keys and continuous membership
+   (rev. 6).
 6. `feedback_category_proposals` + `feedback_sentiment` assets → assignment tables.
 7. dbt join of the stage outputs onto `afact_feedback_conversation`'s generated columns.
-8. Human curation loop on `dim_feedback_category` (approve/merge proposed labels), and run promotion
-   (candidate → live cluster assignment).
+8. Human curation loop on `dim_feedback_category` (approve/merge proposed labels, keyed on `cluster_key`).
+   No run promotion: cluster assignment never waits on a person (rev. 6).
 
 ---
 
 ## 8. Explicit non-goals (MVP)
 
-- No online/real-time embedding or serving (batch only).
+- No online/real-time embedding or serving (batch only). "Continuous" cluster assignment (rev. 6) means every
+  batch refresh, not streaming.
 - No dedicated vector DB (Iceberg `ARRAY<float>` column on the conversation fact; revisit at Phase 2/serving
   need).
 - No GPU requirement (CPU batch at MVP scale; revisit at the full ~600K-conversation scale).

--- a/docs/design/feedback_dimensional_model.md
+++ b/docs/design/feedback_dimensional_model.md
@@ -1,8 +1,8 @@
 # Feedback Aggregation — Dimensional Model Design
 
 Status: **spec** · Project: `wp-feedback-aggregation-clustering-system-2e9750`
-Date: 2026-08-13 (rev. 4 — fixes from [#2422 review](https://github.com/mitodl/ol-data-platform/pull/2422);
-rev. 3 conversation-grain analysis fact; rev. 2 turn grain + conformance rule; original schema 2026-07-06) ·
+Date: 2026-09-11 (rev. 5, continuous cluster assignment; rev. 4 — fixes from
+[#2422 review](https://github.com/mitodl/ol-data-platform/pull/2422); rev. 3 conversation-grain analysis fact; rev. 2 turn grain + conformance rule; original schema 2026-07-06) ·
 See [`README_feedback_aggregation.md`](./README_feedback_aggregation.md) for the full spec set.
 
 Conforms to the existing Kimball layer in `src/ol_dbt/models/dimensional` (`tfact_*` transactional facts,
@@ -287,6 +287,7 @@ category_parent_slug   -- optional hierarchy (cluster → category → theme)
 category_status        -- proposed | approved | merged | deprecated
 category_source        -- 'llm_discovered' | 'seed' | 'manual'
 cluster_run_id         -- provenance: which cluster run proposed this category (§4d)
+cluster_key            -- rev. 5: the stable cluster this category labels (null for seed/manual; §4f)
 first_seen_at / updated_at
 ```
 Bootstrapped, **not cold-start**: seed from Zendesk `ticket_tags` (2,354 distinct) + `group_name`, then LLM-label
@@ -367,33 +368,48 @@ unnest.
 aggregate fact *is* the sidecar, promoted to a first-class dimensional table under the existing `afact_`
 convention (precedent: `afact_discussion_engagement`).
 
-Two tables survive alongside it, because they are genuinely different grains:
+The clustering tables alongside it sit at genuinely different grains (rev. 5; mechanics in
+`feedback_ml_approach.md` §C.1):
 
 ```
-feedback_cluster_run       -- grain (cluster_run_id) — one row per clustering run
+feedback_cluster_run        -- grain (cluster_run_id): one row per clustering run, an audit record
     embedding_model_version, algorithm, run_params, cluster_count, noise_count, silhouette,
-    run_status ('candidate'|'approved'), run_at
+    run_status ('completed'|'failed'), run_at
 
-feedback_cluster_candidate -- grain (feedback_conversation_pk, cluster_run_id)
+feedback_cluster_candidate  -- grain (feedback_conversation_pk, cluster_run_id)
     cluster_id, cluster_probability
-    -- ONLY for runs still in 'candidate' status. Promoting a run copies its assignment onto
-    -- afact_feedback_conversation and the candidate rows are dropped.
+    -- one run's raw, run-local HDBSCAN output; the input to identity matching, kept for the last N runs
+
+feedback_cluster            -- grain (cluster_key): stable cluster identity across runs
+    centroid, radius, embedding_model_version, member_count,
+    cluster_status ('active'|'retired'), first_seen_run_id, last_seen_run_id
+
+feedback_cluster_lineage    -- grain (cluster_run_id, cluster_key, prior_cluster_key)
+    relation ('continued'|'split'|'merged'|'new'|'retired'), jaccard
+
+feedback_cluster_membership -- grain (feedback_conversation_pk): the live assignment the fact joins
+    cluster_key (null = noise, or not yet near any cluster), cluster_similarity,
+    cluster_assignment_method ('recluster'|'incremental'), cluster_run_id, assigned_at
 ```
 
-`feedback_cluster_candidate` exists for one reason: comparing a proposed run against the live one, which is
-what the embedding-model bake-off (`feedback_ml_approach.md` §B.1) and every subsequent re-tune need. It is
-not a consumption table and nothing outside the ML pipeline should read it.
+**No run is promoted** (rev. 5). Rev. 3 kept unpromoted runs in `feedback_cluster_candidate` until a human
+approved one, which then copied onto the fact. That put a person between every new conversation and its
+cluster, so assignment would lag the corpus by however long the queue was. Membership is now maintained
+continuously: new conversations are placed into the live clusters as they are embedded, and each automatic
+re-cluster carries `cluster_key`s forward by membership overlap. `feedback_cluster_candidate` survives as a
+run's raw output. None of these tables is a consumption table; consumers read the fact.
 
 **What this trades away, stated plainly.** Rev. 2 split the sidecar so that re-clustering could never rewrite
-vector rows. Collapsing onto one row per conversation gives that up: a promoted run rewrites the afact row,
+vector rows. Collapsing onto one row per conversation gives that up: a re-cluster rewrites the afact row,
 vector column included. The cost is real but small — the *vector value* is carried forward, not recomputed, so
 nothing is re-embedded; what is lost is the ability to hold several model generations live in production at
 once, which is a bake-off need, and the candidate table covers it off the critical path. What is bought is
 that a consumer reads one table instead of joining four, and that `tfact_feedback` becomes insert-only (§2).
 
 `dim_feedback_category` remains the *curated, stable* projection of clusters that a human approved; the
-aggregate fact is the *churny* generated layer. That decoupling is unchanged and is what still lets clustering
-re-run freely.
+aggregate fact is the *churny* generated layer. That decoupling is unchanged. As of rev. 5 it rests on stable
+`cluster_key`s rather than on a promotion gate: clustering re-runs freely, and an approved category follows
+its cluster across runs.
 
 ---
 
@@ -480,9 +496,11 @@ embedded_at
 category_fk                 -> dim_feedback_category (nullable; §4a)
 sentiment_fk                -> dim_sentiment         (nullable; §4b)
 sentiment_source            -- 'explicit_rating' | 'model' — which tier produced it (§4b)
-cluster_run_id              -> feedback_cluster_run  (which run produced the assignment below)
-cluster_id                  -- -1 = noise = one-off, not systemic
-cluster_probability         -- cohesion signal for ranking systemic issues
+cluster_key                 -> feedback_cluster      (rev. 5: stable across re-clusters; null = noise, or not
+                                                      yet near any cluster)
+cluster_similarity          -- cosine similarity to the cluster centroid; cohesion signal for ranking
+cluster_assignment_method   -- 'recluster' | 'incremental': placed by a full run, or by nearest centroid
+cluster_run_id              -> feedback_cluster_run  (the run whose clusters it was placed into)
 
 -- audit
 conversation_ingested_at
@@ -657,6 +675,20 @@ moves the business key (§6).
 ---
 
 ## 11. Change log
+
+**rev. 5 (2026-09-11)**: cluster assignment is continuous and no human promotes a clustering run. Raised in
+review of [#2662](https://github.com/mitodl/ol-data-platform/pull/2662):
+
+- **Run promotion withdrawn** (§4f). Runs are no longer `candidate`/`approved`;
+  `feedback_cluster_run.run_status` is `completed`/`failed`, an audit value.
+- **Added `feedback_cluster`, `feedback_cluster_lineage` and `feedback_cluster_membership`** (§4f): stable
+  `cluster_key`s carried across runs by membership overlap, and a live one-row-per-conversation assignment
+  table maintained on every embedding refresh.
+- **`afact_feedback_conversation` carries `cluster_key`, `cluster_similarity` and
+  `cluster_assignment_method`** (§5a) in place of the run-local `cluster_id` / `cluster_probability`, which
+  stay on `feedback_cluster_candidate`.
+- **`dim_feedback_category.cluster_key`** (§4a): a category labels a stable cluster, so its approval
+  survives re-clustering.
 
 **rev. 4 (2026-08-13)** — implementation-blocking fixes from
 [#2422 review](https://github.com/mitodl/ol-data-platform/pull/2422), no grain/key/shape changes:

--- a/docs/design/feedback_dimensional_model.md
+++ b/docs/design/feedback_dimensional_model.md
@@ -381,11 +381,12 @@ feedback_cluster_candidate  -- grain (feedback_conversation_pk, cluster_run_id)
     -- one run's raw, run-local HDBSCAN output; the input to identity matching, kept for the last N runs
 
 feedback_cluster            -- grain (cluster_key): stable cluster identity across runs
-    centroid, radius, embedding_model_version, member_count,
+    centroid, radius, embedding_model_version, embedding_dim, member_count,
     cluster_status ('active'|'retired'), first_seen_run_id, last_seen_run_id
 
-feedback_cluster_lineage    -- grain (cluster_run_id, cluster_key, prior_cluster_key)
-    relation ('continued'|'split'|'merged'|'new'|'retired'), jaccard
+feedback_cluster_lineage    -- grain (cluster_lineage_pk): one row per prior → successor edge in a run
+    cluster_run_id, prior_cluster_key (null for 'new'), cluster_key (the successor; null for 'retired'),
+    relation ('continued'|'split'|'merged'|'new'|'retired'), jaccard (null for 'new'/'retired')
 
 feedback_cluster_membership -- grain (feedback_conversation_pk): the live assignment the fact joins
     cluster_key (null = noise, or not yet near any cluster), cluster_similarity,

--- a/docs/design/feedback_erd.md
+++ b/docs/design/feedback_erd.md
@@ -337,10 +337,10 @@ erDiagram
     feedback_cluster_run        ||--o{ feedback_cluster_candidate : "cluster_run_id"
     feedback_cluster_run        ||--o{ feedback_cluster_lineage : "cluster_run_id"
     feedback_cluster_run        |o--o{ dim_feedback_category : "cluster_run_id (provenance)"
-    feedback_cluster            ||--o{ feedback_cluster_lineage : "cluster_key, prior_cluster_key"
+    feedback_cluster            |o--o{ feedback_cluster_lineage : "cluster_key, prior_cluster_key (either may be null)"
     feedback_cluster            |o--o{ feedback_cluster_membership : "cluster_key (null = noise or unplaced)"
     feedback_cluster            |o--o{ dim_feedback_category : "cluster_key (the cluster a category labels)"
-    afact_feedback_conversation ||--|| feedback_cluster_membership : "feedback_conversation_pk"
+    afact_feedback_conversation ||--o| feedback_cluster_membership : "feedback_conversation_pk (none until embedded)"
     afact_feedback_conversation ||--o{ afact_feedback_cluster_daily : "aggregated"
 
     feedback_cluster_run {
@@ -367,6 +367,7 @@ erDiagram
         array centroid "per embedding_model_version"
         float radius "placement threshold - low percentile of member similarity"
         varchar embedding_model_version
+        integer embedding_dim "centroids are scoped by model and dim, not by embedding_input"
         integer member_count
         varchar cluster_status "active, retired"
         varchar first_seen_run_id
@@ -374,11 +375,12 @@ erDiagram
     }
 
     feedback_cluster_lineage {
-        varchar cluster_run_id PK "part of compound key"
-        varchar cluster_key PK "part of compound key"
-        varchar prior_cluster_key PK "part of compound key - null for new"
+        varchar cluster_lineage_pk PK "hash of run, prior key, successor key - nulls encoded"
+        varchar cluster_run_id FK
+        varchar prior_cluster_key FK "null for new"
+        varchar cluster_key FK "the successor - null for retired"
         varchar relation "continued, split, merged, new, retired"
-        float jaccard "membership overlap with the prior key"
+        float jaccard "membership overlap - null for new and retired"
     }
 
     feedback_cluster_membership {

--- a/docs/design/feedback_erd.md
+++ b/docs/design/feedback_erd.md
@@ -1,8 +1,9 @@
 # Feedback Aggregation — Entity-Relationship Diagrams
 
 Status: **spec** · Project: `wp-feedback-aggregation-clustering-system-2e9750`
-Date: 2026-08-13 (rev. 4 — fixes from [#2422 review](https://github.com/mitodl/ol-data-platform/pull/2422);
-rev. 3 conversation-grain analysis fact) · Companion to
+Date: 2026-09-11 (rev. 5, continuous cluster assignment; rev. 4 — fixes from
+[#2422 review](https://github.com/mitodl/ol-data-platform/pull/2422); rev. 3 conversation-grain analysis fact) ·
+Companion to
 [`feedback_dimensional_model.md`](./feedback_dimensional_model.md),
 [`feedback_event_contract_spec.md`](./feedback_event_contract_spec.md) and
 [`feedback_ml_approach.md`](./feedback_ml_approach.md).
@@ -264,7 +265,7 @@ erDiagram
     dim_user              |o--o{ afact_feedback_conversation : "opened_by_user_fk"
     dim_feedback_category |o--o{ afact_feedback_conversation : "category_fk (generated)"
     dim_sentiment         |o--o{ afact_feedback_conversation : "sentiment_fk (generated)"
-    feedback_cluster_run  |o--o{ afact_feedback_conversation : "cluster_run_id (which run assigned it)"
+    feedback_cluster      |o--o{ afact_feedback_conversation : "cluster_key (stable across re-clusters)"
 
     afact_feedback_conversation {
         varchar feedback_conversation_pk PK "surrogate_key(source_slug, conversation_ref)"
@@ -293,9 +294,10 @@ erDiagram
         varchar category_fk FK "GENERATED - nullable, a valid queryable state"
         varchar sentiment_fk FK "GENERATED - nullable"
         varchar sentiment_source "explicit_rating or model - which tier produced it"
-        varchar cluster_run_id FK "GENERATED - the approved run"
-        integer cluster_id "-1 = noise = one-off complaint, not systemic"
-        float cluster_probability "cohesion signal for ranking systemic issues"
+        varchar cluster_key FK "GENERATED - stable across re-clusters; null = noise or not yet near a cluster"
+        float cluster_similarity "cosine similarity to the centroid - cohesion signal for ranking"
+        varchar cluster_assignment_method "recluster or incremental"
+        varchar cluster_run_id "the run whose clusters it was placed into"
         timestamp conversation_ingested_at
     }
 ```
@@ -327,14 +329,18 @@ move when any of them arrive.
 ## 5. Run provenance and the strategic rollup
 
 The per-turn ML sidecar from rev. 2 (`feedback_embeddings`, `feedback_cluster_assignment`) is **withdrawn** —
-its contents live on `afact_feedback_conversation` (§4). Two tables remain, both genuinely different grains
-from the conversation fact:
+its contents live on `afact_feedback_conversation` (§4). The clustering tables below remain, all genuinely
+different grains from the conversation fact (rev. 5; mechanics in `feedback_ml_approach.md` §C.1):
 
 ```mermaid
 erDiagram
     feedback_cluster_run        ||--o{ feedback_cluster_candidate : "cluster_run_id"
+    feedback_cluster_run        ||--o{ feedback_cluster_lineage : "cluster_run_id"
     feedback_cluster_run        |o--o{ dim_feedback_category : "cluster_run_id (provenance)"
-    afact_feedback_conversation ||--o{ feedback_cluster_candidate : "feedback_conversation_pk"
+    feedback_cluster            ||--o{ feedback_cluster_lineage : "cluster_key, prior_cluster_key"
+    feedback_cluster            |o--o{ feedback_cluster_membership : "cluster_key (null = noise or unplaced)"
+    feedback_cluster            |o--o{ dim_feedback_category : "cluster_key (the cluster a category labels)"
+    afact_feedback_conversation ||--|| feedback_cluster_membership : "feedback_conversation_pk"
     afact_feedback_conversation ||--o{ afact_feedback_cluster_daily : "aggregated"
 
     feedback_cluster_run {
@@ -345,15 +351,43 @@ erDiagram
         integer cluster_count
         integer noise_count "the one-off bucket"
         float silhouette "only if the algorithm produces it"
-        varchar run_status "candidate, approved"
+        varchar run_status "completed, failed - an audit value, not a promotion state"
         timestamp run_at
     }
 
     feedback_cluster_candidate {
         varchar feedback_conversation_pk PK "part of compound key"
         varchar cluster_run_id PK "part of compound key"
-        integer cluster_id
+        integer cluster_id "run-local - meaningless across runs"
         float cluster_probability
+    }
+
+    feedback_cluster {
+        varchar cluster_key PK "minted on first appearance, carried forward by membership overlap"
+        array centroid "per embedding_model_version"
+        float radius "placement threshold - low percentile of member similarity"
+        varchar embedding_model_version
+        integer member_count
+        varchar cluster_status "active, retired"
+        varchar first_seen_run_id
+        varchar last_seen_run_id
+    }
+
+    feedback_cluster_lineage {
+        varchar cluster_run_id PK "part of compound key"
+        varchar cluster_key PK "part of compound key"
+        varchar prior_cluster_key PK "part of compound key - null for new"
+        varchar relation "continued, split, merged, new, retired"
+        float jaccard "membership overlap with the prior key"
+    }
+
+    feedback_cluster_membership {
+        varchar feedback_conversation_pk PK
+        varchar cluster_key FK "null = noise or not yet near any cluster"
+        float cluster_similarity
+        varchar cluster_assignment_method "recluster or incremental"
+        varchar cluster_run_id "the run whose clusters it was placed into"
+        timestamp assigned_at
     }
 
     afact_feedback_cluster_daily {
@@ -362,20 +396,22 @@ erDiagram
         varchar feedback_channel_fk FK
         varchar category_fk FK
         varchar sentiment_fk FK
-        integer cluster_id
+        varchar cluster_key "rev. 5 - stable, so trends continue across re-clusters"
         integer conversation_count "at conversation grain this IS the cluster size"
         integer distinct_user_count
         integer rated_conversation_count "coverage only - count with a non-null explicit_rating; replaces avg_explicit_rating (rev. 4, see note below)"
     }
 ```
 
-`feedback_cluster_candidate` holds **only runs that have not been promoted**. Promoting a run copies its
-assignment onto `afact_feedback_conversation` and drops the candidate rows; it exists so a proposed run can
-be compared against the live one during the embedding-model bake-off, and nothing outside the ML pipeline
-should read it.
+**No run is promoted** (rev. 5). `feedback_cluster_membership` is the live assignment and is maintained
+continuously: newly embedded conversations are placed by nearest centroid, and each automatic re-cluster
+rewrites it after identity matching carries `cluster_key`s forward (`feedback_ml_approach.md` §C.1).
+`feedback_cluster_candidate` holds one run's raw output, the input to that matching; nothing outside the ML
+pipeline should read it.
 
-`dim_feedback_category` remains the *curated, stable* projection — only an approved run advances it, which is
-what still lets clustering re-run freely.
+`dim_feedback_category` remains the *curated, stable* projection. A category attaches to a `cluster_key`, so it
+survives every re-cluster in which its cluster continues. That, not a promotion gate, is what lets clustering
+re-run freely.
 
 **Conversation grain simplifies the rollup.** Rev. 2 had to carry both `feedback_count` and
 `distinct_conversation_count`, and had to warn that `min_cluster_size` counted turns rather than tickets so
@@ -437,7 +473,7 @@ flowchart TD
     M --> H
     M -.->|Fenic / sklearn, engine-external| N["summarize -> embed -> cluster -> sentiment"]
     N -.->|writes generated columns| H
-    N -.-> J["feedback_cluster_run<br/>feedback_cluster_candidate"]
+    N -.-> J["feedback_cluster_run / _candidate<br/>feedback_cluster / _lineage / _membership<br/>(continuous, no promotion - rev. 5)"]
     N -.->|LLM label, human approve| K["dim_feedback_category"]
     K -.->|category_fk| H
     H --> I["afact_feedback_cluster_daily<br/>(Phase 2)"]
@@ -470,6 +506,16 @@ regardless, because it moves the business key.
 ---
 
 ## 8. Change log
+
+**rev. 5 (2026-09-11)**: cluster assignment is continuous and no human promotes a clustering run. Raised in
+review of [#2662](https://github.com/mitodl/ol-data-platform/pull/2662):
+
+- **Run promotion withdrawn** (§5). `feedback_cluster_run.run_status` is `completed`/`failed`, an audit value;
+  `feedback_cluster_candidate` holds each run's raw output rather than only unpromoted runs.
+- **Added `feedback_cluster`, `feedback_cluster_lineage` and `feedback_cluster_membership`** (§5): stable
+  `cluster_key`s carried across runs by membership overlap, and a live assignment table the fact joins.
+- **`afact_feedback_conversation`** (§4) carries `cluster_key`, `cluster_similarity` and
+  `cluster_assignment_method` in place of the run-local `cluster_id` / `cluster_probability`.
 
 **rev. 4 (2026-08-13)** — implementation-blocking fixes from
 [#2422 review](https://github.com/mitodl/ol-data-platform/pull/2422), no grain/key/shape changes:

--- a/docs/design/feedback_ml_approach.md
+++ b/docs/design/feedback_ml_approach.md
@@ -1,7 +1,8 @@
 # Feedback Aggregation — ML/LLM Approach Spec
 
 Status: **spec** · Project: `wp-feedback-aggregation-clustering-system-2e9750`
-Date: 2026-08-10 (rev. 3 — conversation-grain analysis) · Companion to
+Date: 2026-09-11 (rev. 4, continuous cluster assignment; rev. 3, 2026-08-10, conversation-grain analysis) ·
+Companion to
 [`feedback_dimensional_model.md`](./feedback_dimensional_model.md)
 
 Resolves the open items the dimensional-model design handed to downstream tasks:
@@ -15,6 +16,16 @@ The guiding principle from the RFC: **the durable artifact is the feedback fact;
 is a re-runnable derived layer.** Nothing here writes to `tfact_feedback` — as of rev. 3 that fact is
 insert-only and has no late-arriving update path at all. All ML output lands on
 `afact_feedback_conversation`.
+
+> **REVISED 2026-09-11 (rev. 4): cluster assignment is continuous, and no human promotes a clustering run**
+> (§C.1). A conversation is placed into the live clusters as soon as it is embedded. Re-clustering runs
+> automatically and carries cluster identity forward by membership overlap, so a cluster keeps a stable
+> `cluster_key` across runs and across embedding-model changes. The rev. 3 promotion step (a human approves
+> a run, which then copies its assignments onto the fact) is withdrawn: it put a person between every new
+> conversation and its cluster, which guarantees a backlog and stale assignments. People still choose the
+> clustering configuration, through code review, and curate category labels (§D). Labels now attach to
+> `cluster_key` instead of to one run's integer ids. Raised in review of
+> [#2662](https://github.com/mitodl/ol-data-platform/pull/2662).
 
 > **REVISED 2026-08-10 (rev. 3) — the analysis unit is the conversation, not the turn** (design §5a).
 > `tfact_feedback` keeps its turn grain, but summarization, embedding, sentiment and clustering all operate
@@ -37,8 +48,10 @@ insert-only and has no late-arriving update path at all. All ML output lands on
 int__feedback__conversation (redacted turns assembled per conversation) [dbt]
   → summarize    : turns → conversation_summary               [py; SKIPPED for single-turn/short — §A.1]
   → embed        : summary or turns → vector                  [py]
-  → cluster      : vectors → cluster_id per cluster_run       [py; + feedback_cluster_run]
-  → label        : cluster centroid/samples → category label  [py: dim_feedback_category (proposed)]
+  → assign       : new vector → nearest live cluster_key       [py; every embedding refresh, §C.1]
+  → recluster    : all vectors → new partition, matched to     [py; scheduled/triggered, + feedback_cluster_run]
+                   existing cluster_keys by membership overlap
+  → label        : new/split/merged cluster_key → label        [py: dim_feedback_category (proposed)]
   → sentiment    : rating or text/vector → sentiment_slug     [py]
   → write        : one row per conversation                   [afact_feedback_conversation]
 ```
@@ -50,13 +63,16 @@ overwrite of a derived row. **No stage writes to `tfact_feedback`.**
 **One target table, not a sidecar** (design §4f/§5a; ERD in [`feedback_erd.md`](./feedback_erd.md) §4). The
 rev. 2 sidecar split — `feedback_embeddings` at `(feedback_pk, model_version)` and
 `feedback_cluster_assignment` at `(feedback_pk, cluster_run_id)` — is withdrawn. All of it collapses onto one
-row per conversation, and two tables survive at genuinely different grains:
+row per conversation, and the clustering tables sit alongside it at genuinely different grains (rev. 4, §C.1):
 
 | Table | Grain | Holds |
 |---|---|---|
-| `afact_feedback_conversation` | `(feedback_conversation_pk)` | summary, `embedding_vector`, `embedding_dim`, `embedding_input`, `category_fk`, `sentiment_fk`, `cluster_id`, `cluster_probability` + version stamps |
-| `feedback_cluster_run` | `(cluster_run_id)` | `embedding_model_version`, `algorithm`, `run_params`, `cluster_count`, `noise_count`, `silhouette`, `run_status`, `run_at` |
-| `feedback_cluster_candidate` | `(feedback_conversation_pk, cluster_run_id)` | `cluster_id`, `cluster_probability` — **unpromoted runs only**, for run-vs-run comparison |
+| `afact_feedback_conversation` | `(feedback_conversation_pk)` | summary, `embedding_vector`, `embedding_dim`, `embedding_input`, `category_fk`, `sentiment_fk`, `cluster_key`, `cluster_similarity`, `cluster_assignment_method` + version stamps |
+| `feedback_cluster_run` | `(cluster_run_id)` | `embedding_model_version`, `algorithm`, `run_params`, `cluster_count`, `noise_count`, `silhouette`, `run_status` (`completed` \| `failed`, an audit value), `run_at` |
+| `feedback_cluster_candidate` | `(feedback_conversation_pk, cluster_run_id)` | run-local `cluster_id`, `cluster_probability`: one run's raw HDBSCAN output, the input to identity matching. Kept for the last N runs for run-vs-run comparison |
+| `feedback_cluster` | `(cluster_key)` | stable identity: `centroid`, `radius`, `embedding_model_version`, `member_count`, `cluster_status` (`active` \| `retired`), `first_seen_run_id`, `last_seen_run_id` |
+| `feedback_cluster_lineage` | `(cluster_run_id, cluster_key, prior_cluster_key)` | `relation` (`continued` \| `split` \| `merged` \| `new` \| `retired`), `jaccard` |
+| `feedback_cluster_membership` | `(feedback_conversation_pk)` | the live assignment: `cluster_key` (null = noise or not yet near a cluster), `cluster_similarity`, `cluster_assignment_method` (`recluster` \| `incremental`), `cluster_run_id`, `assigned_at` |
 
 **What the collapse costs, honestly.** Re-clustering now rewrites the afact row, vector column included — the
 property rev. 2's split was bought to preserve. The vector *value* is carried forward rather than recomputed,
@@ -247,21 +263,89 @@ cohesion signal that lets a human say "this is recurring."
   (silhouette + tag-agreement + human coherence). Adopt the summary as the embedding input only where the
   measured lift justifies its per-conversation LLM cost — expected to help most on long multi-turn Zendesk
   tickets and not at all on single-turn sources, which the §A.1 skip rule never summarizes anyway.
-- **Re-clustering is cheap and expected:** each run writes a new `cluster_run_id` to `feedback_cluster_run`;
-  an unpromoted run's assignments sit in `feedback_cluster_candidate` until approved, at which point they are
-  copied onto `afact_feedback_conversation`. `dim_feedback_category` (curated) only advances when a human
-  approves labels from a run (design §4a), decoupling churny clustering from the stable category dimension.
+- **Re-clustering is cheap, expected, and automatic** (rev. 4, §C.1): each run writes a new `cluster_run_id`
+  to `feedback_cluster_run` and its raw assignments to `feedback_cluster_candidate`. An identity-matching step
+  then maps the run's clusters onto the existing `cluster_key`s and rewrites `feedback_cluster_membership`.
+  No human approves a run. Stable keys, not a promotion gate, are what decouple churny clustering from the
+  curated category dimension: a cluster that continues across runs keeps its key, and therefore its category.
 - **Cross-source clustering (Phase 2):** because all sources share one embedding space in
   `int__feedback__conversation`, a cluster can span Zendesk + forum + tutor — this is the
   mechanism behind `afact_feedback_cluster_daily` (cluster × category × sentiment × date ×
   source). No algorithm change needed; just don't filter `source_slug` at cluster time.
 - **Deps:** `umap-learn`, `hdbscan` (or `scikit-learn`'s `HDBSCAN` ≥1.3 to avoid the
   separate compiled dep — decide at implementation based on the Dagster image's build
-  constraints). All CPU, no service.
+  constraints). All CPU, no service. (rev. 4: §C.1's incremental placement is nearest-centroid and needs
+  neither. If it is ever replaced by HDBSCAN's own out-of-sample prediction, that is `approximate_predict`
+  in the standalone `hdbscan` package; scikit-learn's `HDBSCAN` exposes only `fit_predict` as of 1.9.)
 
 **Cluster-quality columns** are added *only if the chosen algorithm produces them*:
-`cluster_id` + `cluster_probability` on `afact_feedback_conversation`; run-level `silhouette`,
-`cluster_count`, `noise_count` on `feedback_cluster_run` (§A) — persistence optional.
+`cluster_key` + `cluster_similarity` on `afact_feedback_conversation` (rev. 4; the run-local `cluster_id` and
+`cluster_probability` stay on `feedback_cluster_candidate`); run-level `silhouette`, `cluster_count`,
+`noise_count` on `feedback_cluster_run` (§A) — persistence optional.
+
+### C.1 Continuous assignment and stable cluster identity (rev. 4)
+
+**No human sits between a conversation and its cluster.** Assignment is a derived value, maintained as
+conversations are embedded and as the corpus grows. A human gate on assignment produces a backlog by
+construction, and every conversation embedded while the queue waits has no cluster. The decisions that need
+people are made elsewhere: the clustering configuration is chosen by the §B.1 bake-off and shipped as config
+through code review, and category labels are curated in §D.
+
+Three mechanisms keep assignment current:
+
+1. **Incremental placement.** A `feedback_cluster_assignment` asset runs on every `feedback_embeddings`
+   refresh. For each conversation whose embedding is newer than its membership row (new, re-embedded, or
+   never placed), it computes cosine similarity to every `active` centroid built from the same
+   `embedding_model_version` / `embedding_dim` / `embedding_input`, and assigns the nearest cluster if the
+   similarity clears that cluster's radius. Otherwise `cluster_key` stays null with
+   `cluster_assignment_method = 'incremental'`: the conversation is not near any live cluster yet. Placement
+   never moves an already-placed conversation, and needs no model state beyond `feedback_cluster`.
+   - *Radius* is per cluster: the similarity at a fixed low percentile of its members' similarities (p5 as a
+     starting point, so 95% of members are at least this close) as of the last re-cluster. A per-cluster
+     radius respects HDBSCAN's variable density, which one global threshold would not.
+   - *Why nearest centroid rather than out-of-sample HDBSCAN:* it is deterministic, explainable, and needs no
+     persisted UMAP/HDBSCAN models. A persisted UMAP `transform` plus `hdbscan.approximate_predict` is the
+     upgrade path if placement quality measurably needs it.
+2. **Automatic re-clustering.** `feedback_clusters` runs over the full embedded corpus on a schedule, and
+   early when either trigger fires: the share of conversations left unplaced since the last run crosses a
+   threshold, or the corpus has grown past a threshold since the last run. Unplaced conversations are where
+   new themes accumulate, and a re-cluster is what turns them into clusters. Runs use the configuration in
+   code; changing parameters or the embedding model is a PR, and the next run picks it up.
+3. **Identity matching.** After each completed run, the new partition is matched to the current
+   `cluster_key`s by membership, not by vectors:
+   - Build the contingency matrix of new clusters × current keys over conversations present in both, scoring
+     each pair by Jaccard overlap.
+   - A one-to-one best match above the match threshold (0.5 as a starting point) **continues** the old key.
+   - A new cluster drawn mostly from one old key whose best match continued elsewhere gets a new key, with
+     lineage `split` from that key.
+   - A new cluster holding the majority of two or more old keys gets a new key, with lineage `merged` from
+     each of them.
+   - Anything else gets a new key with lineage `new`. An old key with no successor is `retired`.
+   - `feedback_cluster_membership` is then rewritten for every conversation in the run
+     (`cluster_assignment_method = 'recluster'`; HDBSCAN noise gets a null `cluster_key`), and centroids and
+     radii are recomputed.
+
+   Matching compares members rather than vectors, so it works across an embedding-model change: re-embed,
+   re-cluster in the new space, and keys continue wherever the grouping does. Centroids are stored per
+   `embedding_model_version`, and placement only uses the current model's.
+
+**What a run is now.** A `feedback_cluster_run` row is an audit record: which configuration ran, over how many
+conversations, with what outcome (`completed` | `failed`). A failed run changes nothing downstream. There is
+no `candidate` / `approved` status to set.
+
+**Automated checks instead of a human gate.** Placement and re-clustering both emit asset metadata: the
+unplaced share, per-run continuity (the share of conversations that keep their key), and counts of
+continued / split / merged / new / retired keys. A blocking asset check holds the membership rewrite when
+continuity falls below a floor, so a bad configuration cannot silently reshuffle every cluster. The remedy is
+a configuration change, not a runtime approval.
+
+**A null `cluster_key` now means two things.** HDBSCAN noise from a re-cluster (the "one-off complaint"
+bucket) and a conversation that incremental placement could not put near any cluster both leave the key null.
+`cluster_assignment_method` tells them apart. Both are "not part of a systemic theme yet".
+
+**Open parameters**, calibrated on the labeled sample (§B.1): the radius percentile, the Jaccard match
+threshold, the re-cluster triggers and schedule, the continuity floor, and how many runs of
+`feedback_cluster_candidate` to retain.
 
 ---
 
@@ -273,7 +357,8 @@ cohesion signal that lets a human say "this is recurring."
    support `group_name` give an immediate, human-meaningful starter taxonomy. These become
    `category_source='seed'` rows with `category_status='proposed'`. This alone makes the
    MVP useful before any clustering runs.
-2. **LLM-label the clusters (§C output):** for each HDBSCAN cluster, sample N
+2. **LLM-label the clusters (§C output):** for each new, split or merged `cluster_key` (§C.1; a continued
+   key keeps its label and is not re-proposed), sample N
    representative (redacted) utterances near the centroid + the cluster's dominant seed
    tags, and prompt an LLM to propose a short `category_label` + a stable `category_slug`
    + a one-line description. `category_source='llm_discovered'`, `category_status='proposed'`
@@ -282,8 +367,14 @@ cohesion signal that lets a human say "this is recurring."
 **Key design invariants (from §4a):**
 - **SCD-lite on `category_slug`:** relabeling changes `category_label`, never the slug —
   so `category_fk` is stable across renames.
-- **Assignment lands on `afact_feedback_conversation`** (rev. 3), by mapping a conversation's `cluster_id` →
-  the approved category for that cluster. Uncategorized = `category_fk` null (a valid, queryable state).
+- **Assignment lands on `afact_feedback_conversation`** (rev. 3), by mapping a conversation's `cluster_key` →
+  the category for that key (rev. 4: the stable key replaces the run-local `cluster_id`, so an approval
+  survives every re-cluster in which its cluster continues; a split or merged key gets a fresh proposal, with
+  its predecessors' categories offered to the LLM as context). Uncategorized = `category_fk` null (a valid,
+  queryable state).
+- **Category approval never gates cluster assignment** (rev. 4). Open: whether `category_fk` is filled from a
+  `proposed` category or only from an `approved` one. The §C.1 backlog argument applies here too, and
+  `category_status` on the dimension already lets consumers filter to approved categories.
   This is no longer a "late-arriving update to the fact" — the fact has no update path; it is a rebuild of a
   derived column.
 - **LLM cost is bounded:** one LLM call *per cluster*, not per record (there are hundreds
@@ -294,7 +385,8 @@ cohesion signal that lets a human say "this is recurring."
 
 **Human-in-the-loop is required, not optional:** LLM proposes, a human curates the
 category dimension. The dimension is a *curated projection* of clusters (design §4d), which
-is why it is a dbt/warehouse dimension and not raw model output.
+is why it is a dbt/warehouse dimension and not raw model output. The loop curates *labels*; it never decides
+which cluster a conversation belongs to (§C.1).
 
 ---
 

--- a/docs/design/feedback_ml_approach.md
+++ b/docs/design/feedback_ml_approach.md
@@ -70,8 +70,8 @@ row per conversation, and the clustering tables sit alongside it at genuinely di
 | `afact_feedback_conversation` | `(feedback_conversation_pk)` | summary, `embedding_vector`, `embedding_dim`, `embedding_input`, `category_fk`, `sentiment_fk`, `cluster_key`, `cluster_similarity`, `cluster_assignment_method` + version stamps |
 | `feedback_cluster_run` | `(cluster_run_id)` | `embedding_model_version`, `algorithm`, `run_params`, `cluster_count`, `noise_count`, `silhouette`, `run_status` (`completed` \| `failed`, an audit value), `run_at` |
 | `feedback_cluster_candidate` | `(feedback_conversation_pk, cluster_run_id)` | run-local `cluster_id`, `cluster_probability`: one run's raw HDBSCAN output, the input to identity matching. Kept for the last N runs for run-vs-run comparison |
-| `feedback_cluster` | `(cluster_key)` | stable identity: `centroid`, `radius`, `embedding_model_version`, `member_count`, `cluster_status` (`active` \| `retired`), `first_seen_run_id`, `last_seen_run_id` |
-| `feedback_cluster_lineage` | `(cluster_run_id, cluster_key, prior_cluster_key)` | `relation` (`continued` \| `split` \| `merged` \| `new` \| `retired`), `jaccard` |
+| `feedback_cluster` | `(cluster_key)` | stable identity: `centroid`, `radius`, `embedding_model_version`, `embedding_dim`, `member_count`, `cluster_status` (`active` \| `retired`), `first_seen_run_id`, `last_seen_run_id` |
+| `feedback_cluster_lineage` | `(cluster_lineage_pk)`: one row per prior → successor edge in a run | `cluster_run_id`, `prior_cluster_key` (null for `new`), `cluster_key` (the successor; null for `retired`), `relation` (`continued` \| `split` \| `merged` \| `new` \| `retired`), `jaccard` (null for `new`/`retired`). `cluster_lineage_pk` hashes (`cluster_run_id`, `prior_cluster_key`, `cluster_key`) with nulls encoded as a fixed placeholder |
 | `feedback_cluster_membership` | `(feedback_conversation_pk)` | the live assignment: `cluster_key` (null = noise or not yet near a cluster), `cluster_similarity`, `cluster_assignment_method` (`recluster` \| `incremental`), `cluster_run_id`, `assigned_at` |
 
 **What the collapse costs, honestly.** Re-clustering now rewrites the afact row, vector column included — the
@@ -296,10 +296,16 @@ Three mechanisms keep assignment current:
 1. **Incremental placement.** A `feedback_cluster_assignment` asset runs on every `feedback_embeddings`
    refresh. For each conversation whose embedding is newer than its membership row (new, re-embedded, or
    never placed), it computes cosine similarity to every `active` centroid built from the same
-   `embedding_model_version` / `embedding_dim` / `embedding_input`, and assigns the nearest cluster if the
-   similarity clears that cluster's radius. Otherwise `cluster_key` stays null with
+   `embedding_model_version` and `embedding_dim`, and assigns the nearest cluster if the similarity clears
+   that cluster's radius. Centroids are not split by `embedding_input`. Summary and concatenated-turn vectors
+   from one model and dimension share one space, so a single-turn conversation, which is never summarized
+   (§A.1), is placed against the same clusters as a summarized one. `feedback_clusters`'
+   `embedding_input_filter` is a §B.1 bake-off knob; the live configuration clusters every conversation's
+   vector. Otherwise `cluster_key` stays null with
    `cluster_assignment_method = 'incremental'`: the conversation is not near any live cluster yet. Placement
-   never moves an already-placed conversation, and needs no model state beyond `feedback_cluster`.
+   never moves a conversation whose embedding is unchanged since it was placed. A re-embedded conversation
+   (new text, or a new model) is placed again against the current centroids, and only a re-cluster reassigns
+   unchanged conversations. Placement needs no model state beyond `feedback_cluster`.
    - *Radius* is per cluster: the similarity at a fixed low percentile of its members' similarities (p5 as a
      starting point, so 95% of members are at least this close) as of the last re-cluster. A per-cluster
      radius respects HDBSCAN's variable density, which one global threshold would not.
@@ -315,19 +321,33 @@ Three mechanisms keep assignment current:
    `cluster_key`s by membership, not by vectors:
    - Build the contingency matrix of new clusters × current keys over conversations present in both, scoring
      each pair by Jaccard overlap.
-   - A one-to-one best match above the match threshold (0.5 as a starting point) **continues** the old key.
-   - A new cluster drawn mostly from one old key whose best match continued elsewhere gets a new key, with
-     lineage `split` from that key.
-   - A new cluster holding the majority of two or more old keys gets a new key, with lineage `merged` from
-     each of them.
-   - Anything else gets a new key with lineage `new`. An old key with no successor is `retired`.
+   - The rules apply in this order, and each cluster takes the first one that fits:
+     1. **Continued.** Pairs at or above the match threshold (0.5 as a starting point) are assigned
+        one-to-one by global maximum total Jaccard (linear assignment over the thresholded matrix), not
+        greedily per cluster. Ties break on the larger intersection, then the old key's earlier
+        `first_seen_run_id`, then `cluster_key` order, so every implementation lands on the same keys. The
+        new cluster keeps the old key.
+     2. **Merged.** An old key that did not continue, and whose majority of members landed in one new
+        cluster, gets a `merged` edge to that cluster's key and its `cluster_status` becomes `retired`.
+        Continuation wins: if that new cluster continued another key, it keeps that key, so the continuing
+        cluster's category is preserved and the absorbed cluster's conversations inherit it. If it continued
+        nothing, it gets a new key, with a `merged` edge from every old key whose majority it holds.
+     3. **Split.** A new cluster that continued nothing and holds no old key's majority, but draws most of
+        its members from one old key, gets a new key with a `split` edge from that key.
+     4. **New.** Any other new cluster gets a new key.
+   - An old key that neither continued nor merged is `retired`.
    - `feedback_cluster_membership` is then rewritten for every conversation in the run
      (`cluster_assignment_method = 'recluster'`; HDBSCAN noise gets a null `cluster_key`), and centroids and
      radii are recomputed.
 
    Matching compares members rather than vectors, so it works across an embedding-model change: re-embed,
    re-cluster in the new space, and keys continue wherever the grouping does. Centroids are stored per
-   `embedding_model_version`, and placement only uses the current model's.
+   `embedding_model_version` and `embedding_dim`, and placement only uses the current configuration's.
+
+   Lineage is one `feedback_cluster_lineage` row per edge. `continued`, `split` and `merged` rows carry both
+   `prior_cluster_key` and `cluster_key`; a `new` row carries only `cluster_key`; a `retired` row carries only
+   `prior_cluster_key`. A merge writes one row per absorbed key, and a split one row per child. These shapes
+   are asset checks on the identity asset.
 
 **What a run is now.** A `feedback_cluster_run` row is an audit record: which configuration ran, over how many
 conversations, with what outcome (`completed` | `failed`). A failed run changes nothing downstream. There is
@@ -369,8 +389,9 @@ threshold, the re-cluster triggers and schedule, the continuity floor, and how m
   so `category_fk` is stable across renames.
 - **Assignment lands on `afact_feedback_conversation`** (rev. 3), by mapping a conversation's `cluster_key` →
   the category for that key (rev. 4: the stable key replaces the run-local `cluster_id`, so an approval
-  survives every re-cluster in which its cluster continues; a split or merged key gets a fresh proposal, with
-  its predecessors' categories offered to the LLM as context). Uncategorized = `category_fk` null (a valid,
+  survives every re-cluster in which its cluster continues. A newly minted split or merged key gets a fresh
+  proposal, with its predecessors' categories offered to the LLM as context. An old key absorbed into a
+  continuing cluster triggers none: its conversations take the continuing key's category). Uncategorized = `category_fk` null (a valid,
   queryable state).
 - **Category approval never gates cluster assignment** (rev. 4). Open: whether `category_fk` is filled from a
   `proposed` category or only from an `approved` one. The §C.1 backlog argument applies here too, and

--- a/docs/design/feedback_zendesk_mvp_spec.md
+++ b/docs/design/feedback_zendesk_mvp_spec.md
@@ -393,7 +393,8 @@ Two column groups:
   exception — sourced from the ticket's unfiltered comment history, not from `tfact_feedback`'s
   requester-only turns (§5 note above), since aggregating the kept turns alone would always yield one.
 - **Generated (rev. 3)** — `conversation_summary`, `embedding_vector`, `category_fk`, `sentiment_fk`,
-  `cluster_id` and their version stamps, left-joined from the ML asset's per-stage output tables
+  `cluster_key` (the stable cluster id, `feedback_ml_approach.md` §C.1) and their version stamps, left-joined
+  from the ML asset's per-stage output tables
   (`feedback_dagster_asset_spec.md` §3). All nullable; the table is queryable and useful before any of them
   are populated.
 
@@ -489,7 +490,7 @@ Mirror the `tfact_discussion_events` yml style:
   row must have at least one turn, so a conversation cannot go missing from the analysis fact and quietly
   drop its turns out of every cluster.
   Generated columns are all nullable (description-only): `conversation_summary`, `embedding_vector`,
-  `category_fk`, `sentiment_fk`, `cluster_id`. Two consistency tests worth having once the ML asset lands:
+  `category_fk`, `sentiment_fk`, `cluster_key`. Two consistency tests worth having once the ML asset lands:
   `embedding_model_version` is not null wherever `embedding_vector` is, and `summary_model_version` is null
   exactly where the §A.1 skip rule applies (`turn_count = 1` or under the length threshold) — that second one
   is the guard that a silent summarizer failure doesn't read as "short conversation".

--- a/docs/design/feedback_zendesk_mvp_spec.md
+++ b/docs/design/feedback_zendesk_mvp_spec.md
@@ -393,7 +393,8 @@ Two column groups:
   exception — sourced from the ticket's unfiltered comment history, not from `tfact_feedback`'s
   requester-only turns (§5 note above), since aggregating the kept turns alone would always yield one.
 - **Generated (rev. 3)** — `conversation_summary`, `embedding_vector`, `category_fk`, `sentiment_fk`,
-  `cluster_key` (the stable cluster id, `feedback_ml_approach.md` §C.1) and their version stamps, left-joined
+  `cluster_key` (the stable cluster id, `feedback_ml_approach.md` §C.1), `cluster_similarity`,
+  `cluster_assignment_method` and their version stamps, left-joined
   from the ML asset's per-stage output tables
   (`feedback_dagster_asset_spec.md` §3). All nullable; the table is queryable and useful before any of them
   are populated.
@@ -490,7 +491,8 @@ Mirror the `tfact_discussion_events` yml style:
   row must have at least one turn, so a conversation cannot go missing from the analysis fact and quietly
   drop its turns out of every cluster.
   Generated columns are all nullable (description-only): `conversation_summary`, `embedding_vector`,
-  `category_fk`, `sentiment_fk`, `cluster_key`. Two consistency tests worth having once the ML asset lands:
+  `category_fk`, `sentiment_fk`, `cluster_key`, `cluster_similarity`, `cluster_assignment_method`. Two
+  consistency tests worth having once the ML asset lands:
   `embedding_model_version` is not null wherever `embedding_vector` is, and `summary_model_version` is null
   exactly where the §A.1 skip rule applies (`turn_count = 1` or under the length threshold) — that second one
   is the guard that a silent summarizer failure doesn't read as "short conversation".


### PR DESCRIPTION
### What are the relevant tickets?
Refs #2544

### Description (What does it do?)
Revises the feedback spec set so that assigning a conversation to a cluster never waits on a person. This came out of review of #2662, where a human-promoted clustering run was the only path from clustering to `afact_feedback_conversation`. That guarantees a backlog, and stale assignments as the corpus grows.

- New `feedback_ml_approach.md` §C.1. Covers:
  - nearest-centroid placement of each newly embedded conversation on every embedding refresh
  - automatic re-clustering, on a schedule plus unplaced-share and growth triggers
  - identity matching by membership overlap, so a cluster keeps a stable `cluster_key` across runs and across embedding-model changes
- Run promotion is withdrawn. `feedback_cluster_run.run_status` becomes an audit value (`completed`/`failed`), and `feedback_cluster_candidate` holds each run's raw output.
- New tables: `feedback_cluster`, `feedback_cluster_lineage`, `feedback_cluster_membership`. `afact_feedback_conversation` carries `cluster_key`, `cluster_similarity` and `cluster_assignment_method` instead of the run-local `cluster_id` / `cluster_probability`.
- Categories attach to `cluster_key`, so an approval survives every re-cluster in which its cluster continues. People choose the clustering configuration (in code) and curate labels; neither gates assignment.
- Dagster asset spec: new `feedback_cluster_identity` and `feedback_cluster_assignment` assets, and re-clustering moves from per-refresh chaining to schedule plus trigger.

### How can this be tested?
Docs only. Pre-commit passes on the changed files. The Mermaid diagrams in `feedback_erd.md` §5 are worth checking in the rendered view.

### Additional Context
Open parameters to calibrate on the labeled sample: the placement radius percentile, the Jaccard match threshold, the re-cluster triggers, the continuity floor, and how many candidate runs to retain. Also still open (§D): whether `category_fk` is filled from `proposed` categories or only from `approved` ones.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TJV252XExQ39SmC2NVfxMC
