### PR TITLE
feat(dimensional): add a user_fk-keyed learner x course run x day activity fact

### DIFF
--- a/src/ol_dbt/models/dimensional/_dim__models.yml
+++ b/src/ol_dbt/models/dimensional/_dim__models.yml
@@ -1225,7 +1225,7 @@ models:
         - platform
         - user_fk
         - courserun_readable_id
-        - activity_date
+        - activity_date_key
   columns:
   - name: activity_key
     description: string, surrogate key over (platform, user_fk, courserun_readable_id,
@@ -1255,11 +1255,18 @@ models:
     description: string, course run id as recorded on the event.
     tests:
     - not_null
-  - name: activity_date
-    description: date, cast(event_timestamp as date) -- the same day boundary organization_administration_report
-      uses.
+  - name: activity_date_key
+    description: >
+      integer, foreign key to dim_date in YYYYMMDD format -- the event's own
+      date_fk, which the event facts derive from event_timestamp_iso8601 in the
+      source's timezone. Not a UTC day: 15.2M of tfact_discussion_events' rows
+      carry a local offset, and 2.9M of those fall on a different UTC day. Read
+      as a date via dim_date rather than casting the integer.
     tests:
     - not_null
+    - relationships:
+        to: ref('dim_date')
+        field: date_key
   - name: videos_played
     description: int, distinct video blocks with a play_video event that day. Same
       definition as the report's videos_watched.

--- a/src/ol_dbt/models/dimensional/_dim__models.yml
+++ b/src/ol_dbt/models/dimensional/_dim__models.yml
@@ -1204,3 +1204,73 @@ models:
     - not_null
     - accepted_values:
         values: ['Night', 'Morning', 'Afternoon', 'Evening']
+
+- name: afact_learner_courserun_daily_activity
+  description: >
+    One row per (platform, learner, course run, day) with any tracked course
+    activity -- video plays, problem checks, course navigation, discussion
+    events, and Open edX chatbot submits. The user_fk-keyed replacement for the
+    per-learner activity in organization_administration_report, which groups
+    by dim_user.email and so drops or mis-attributes learners whose coalesced
+    email moves. A learner's last_active_on is max(activity_date) and
+    days_active is count(distinct activity_date) over this table. Days with no
+    tracked activity have no row. Certificates and enrollments are not activity
+    here, although the report's active_count counts them. Rebuilt in full every
+    run, because user_pk can still re-key and an incremental table would keep
+    old days under a stale key.
+  tests:
+  - dbt_utils.unique_combination_of_columns:
+      arguments:
+        combination_of_columns:
+        - platform
+        - user_fk
+        - courserun_readable_id
+        - activity_date
+  columns:
+  - name: activity_key
+    description: string, surrogate key over (platform, user_fk, courserun_readable_id,
+      activity_date).
+    tests:
+    - unique
+    - not_null
+  - name: user_fk
+    description: string, foreign key to dim_user.
+    tests:
+    - not_null
+    - relationships:
+        to: ref('dim_user')
+        field: user_pk
+        config:
+          severity: warn
+  - name: courserun_fk
+    description: string, foreign key to dim_course_run, matched on (courserun_readable_id,
+      platform) against the current run. Null where the event's course id has no current
+      course run.
+  - name: platform
+    description: string, platform the activity happened on (mitxonline, mitxpro, residential,
+      edxorg).
+    tests:
+    - not_null
+  - name: courserun_readable_id
+    description: string, course run id as recorded on the event.
+    tests:
+    - not_null
+  - name: activity_date
+    description: date, cast(event_timestamp as date) -- the same day boundary organization_administration_report
+      uses.
+    tests:
+    - not_null
+  - name: videos_played
+    description: int, distinct video blocks with a play_video event that day. Same
+      definition as the report's videos_watched.
+  - name: problems_attempted
+    description: int, distinct problem blocks with a problem_check event that day.
+      Excludes showanswer, which the report's problems_count includes.
+  - name: navigation_events
+    description: int, course navigation events that day.
+  - name: discussion_events
+    description: int, discussion forum events that day.
+  - name: chatbot_interactions
+    description: int, distinct (session, block) pairs with an ol_openedx_chat.drawer.submit
+      event that day, Open edX chatbot only. Unlike the report, submits with no block_id
+      count.

--- a/src/ol_dbt/models/dimensional/afact_learner_courserun_daily_activity.sql
+++ b/src/ol_dbt/models/dimensional/afact_learner_courserun_daily_activity.sql
@@ -91,7 +91,8 @@ with video_days as (
       and courserun_readable_id is not null
       and user_fk is not null
     group by
-        user_fk
+        'mitxonline'
+        , user_fk
         , courserun_readable_id
         , cast(event_timestamp as date)
 )

--- a/src/ol_dbt/models/dimensional/afact_learner_courserun_daily_activity.sql
+++ b/src/ol_dbt/models/dimensional/afact_learner_courserun_daily_activity.sql
@@ -89,6 +89,7 @@ with video_days as (
     where event_type = 'ol_openedx_chat.drawer.submit'
       and chatbot_source = 'open_edx'
       and courserun_readable_id is not null
+      and user_fk is not null
     group by
         user_fk
         , courserun_readable_id

--- a/src/ol_dbt/models/dimensional/afact_learner_courserun_daily_activity.sql
+++ b/src/ol_dbt/models/dimensional/afact_learner_courserun_daily_activity.sql
@@ -1,0 +1,171 @@
+-- Grain: one row per (platform, user, course run, day) with any tracked course activity.
+-- Keyed on user_fk, which organization_administration_report cannot offer: it groups
+-- by dim_user.email, a coalesce across a person's accounts that moves when they edit
+-- it. Rebuilt in full (the dimensional default) rather than incremental because
+-- user_pk can still re-key, and an incremental table would keep old days under the
+-- stale key.
+-- Day boundary and metric definitions follow organization_administration_report,
+-- except where noted below.
+with video_days as (
+    select
+        platform
+        , user_fk
+        , courserun_readable_id
+        , cast(event_timestamp as date) as activity_date
+        , count(distinct video_block_fk) as videos_played
+    from {{ ref('tfact_video_events') }}
+    where event_type = 'play_video'
+      and user_fk is not null
+    group by
+        platform
+        , user_fk
+        , courserun_readable_id
+        , cast(event_timestamp as date)
+)
+
+-- problem_check only: showanswer is viewing a solution, not attempting the problem.
+-- The report's problems_count counts both.
+, problem_days as (
+    select
+        platform
+        , user_fk
+        , courserun_readable_id
+        , cast(event_timestamp as date) as activity_date
+        , count(distinct problem_block_fk) as problems_attempted
+    from {{ ref('tfact_problem_events') }}
+    where event_type = 'problem_check'
+      and user_fk is not null
+    group by
+        platform
+        , user_fk
+        , courserun_readable_id
+        , cast(event_timestamp as date)
+)
+
+, navigation_days as (
+    select
+        platform
+        , user_fk
+        , courserun_readable_id
+        , cast(event_timestamp as date) as activity_date
+        , count(*) as navigation_events
+    from {{ ref('tfact_course_navigation_events') }}
+    where user_fk is not null
+    group by
+        platform
+        , user_fk
+        , courserun_readable_id
+        , cast(event_timestamp as date)
+)
+
+, discussion_days as (
+    select
+        platform
+        , user_fk
+        , courserun_readable_id
+        , cast(event_timestamp as date) as activity_date
+        , count(*) as discussion_events
+    from {{ ref('tfact_discussion_events') }}
+    where user_fk is not null
+    group by
+        platform
+        , user_fk
+        , courserun_readable_id
+        , cast(event_timestamp as date)
+)
+
+-- Open edX chatbot events only, which all come from MITx Online's Open edX (see
+-- tfact_chatbot_events). Canvas course ids are not Open edX course runs. A submit is
+-- one interaction per (session, block); the coalesce keeps submits with no block_id,
+-- which the report's `session_id || block_id` turns into null and drops.
+, chatbot_days as (
+    select
+        'mitxonline' as platform
+        , user_fk
+        , courserun_readable_id
+        , cast(event_timestamp as date) as activity_date
+        , count(distinct concat(session_id, '|', coalesce(block_id, ''))) as chatbot_interactions
+    from {{ ref('tfact_chatbot_events') }}
+    where event_type = 'ol_openedx_chat.drawer.submit'
+      and chatbot_source = 'open_edx'
+      and courserun_readable_id is not null
+    group by
+        user_fk
+        , courserun_readable_id
+        , cast(event_timestamp as date)
+)
+
+, activity as (
+    select
+        platform, user_fk, courserun_readable_id, activity_date
+        , videos_played, 0 as problems_attempted, 0 as navigation_events
+        , 0 as discussion_events, 0 as chatbot_interactions
+    from video_days
+    union all
+    select
+        platform, user_fk, courserun_readable_id, activity_date
+        , 0, problems_attempted, 0, 0, 0
+    from problem_days
+    union all
+    select
+        platform, user_fk, courserun_readable_id, activity_date
+        , 0, 0, navigation_events, 0, 0
+    from navigation_days
+    union all
+    select
+        platform, user_fk, courserun_readable_id, activity_date
+        , 0, 0, 0, discussion_events, 0
+    from discussion_days
+    union all
+    select
+        platform, user_fk, courserun_readable_id, activity_date
+        , 0, 0, 0, 0, chatbot_interactions
+    from chatbot_days
+)
+
+, activity_days as (
+    select
+        platform
+        , user_fk
+        , courserun_readable_id
+        , activity_date
+        , sum(videos_played) as videos_played
+        , sum(problems_attempted) as problems_attempted
+        , sum(navigation_events) as navigation_events
+        , sum(discussion_events) as discussion_events
+        , sum(chatbot_interactions) as chatbot_interactions
+    from activity
+    group by
+        platform
+        , user_fk
+        , courserun_readable_id
+        , activity_date
+)
+
+, dim_course_run as (
+    select courserun_pk, courserun_readable_id, platform
+    from {{ ref('dim_course_run') }}
+    where is_current = true
+)
+
+select
+    {{ dbt_utils.generate_surrogate_key([
+        'activity_days.platform',
+        'activity_days.user_fk',
+        'activity_days.courserun_readable_id',
+        'activity_days.activity_date'
+    ]) }} as activity_key
+    , activity_days.user_fk
+    , dim_course_run.courserun_pk as courserun_fk
+    , activity_days.platform
+    , activity_days.courserun_readable_id
+    , activity_days.activity_date
+    , activity_days.videos_played
+    , activity_days.problems_attempted
+    , activity_days.navigation_events
+    , activity_days.discussion_events
+    , activity_days.chatbot_interactions
+from activity_days
+left join dim_course_run
+    on activity_days.courserun_readable_id = dim_course_run.courserun_readable_id
+    and activity_days.platform = dim_course_run.platform

--- a/src/ol_dbt/models/dimensional/afact_learner_courserun_daily_activity.sql
+++ b/src/ol_dbt/models/dimensional/afact_learner_courserun_daily_activity.sql
@@ -4,14 +4,19 @@
 -- it. Rebuilt in full (the dimensional default) rather than incremental because
 -- user_pk can still re-key, and an incremental table would keep old days under the
 -- stale key.
--- Day boundary and metric definitions follow organization_administration_report,
--- except where noted below.
+-- The day comes from each event's date_fk, the dim_date key the event facts derive
+-- from event_timestamp_iso8601 in the source's own timezone. `cast(event_timestamp as
+-- date)` would read the same on Trino but not on DuckDB, which buckets a
+-- timestamp-with-timezone by the session zone: 15.2M of tfact_discussion_events' 17.5M
+-- rows carry a local offset rather than Z, and 2.9M of them fall on a different day
+-- under UTC.
+-- Metric definitions follow organization_administration_report, except where noted.
 with video_days as (
     select
         platform
         , user_fk
         , courserun_readable_id
-        , cast(event_timestamp as date) as activity_date
+        , date_fk as activity_date_key
         , count(distinct video_block_fk) as videos_played
     from {{ ref('tfact_video_events') }}
     where event_type = 'play_video'
@@ -20,7 +25,7 @@ with video_days as (
         platform
         , user_fk
         , courserun_readable_id
-        , cast(event_timestamp as date)
+        , date_fk
 )
 
 -- problem_check only: showanswer is viewing a solution, not attempting the problem.
@@ -30,7 +35,7 @@ with video_days as (
         platform
         , user_fk
         , courserun_readable_id
-        , cast(event_timestamp as date) as activity_date
+        , date_fk as activity_date_key
         , count(distinct problem_block_fk) as problems_attempted
     from {{ ref('tfact_problem_events') }}
     where event_type = 'problem_check'
@@ -39,7 +44,7 @@ with video_days as (
         platform
         , user_fk
         , courserun_readable_id
-        , cast(event_timestamp as date)
+        , date_fk
 )
 
 , navigation_days as (
@@ -47,7 +52,7 @@ with video_days as (
         platform
         , user_fk
         , courserun_readable_id
-        , cast(event_timestamp as date) as activity_date
+        , date_fk as activity_date_key
         , count(*) as navigation_events
     from {{ ref('tfact_course_navigation_events') }}
     where user_fk is not null
@@ -55,7 +60,7 @@ with video_days as (
         platform
         , user_fk
         , courserun_readable_id
-        , cast(event_timestamp as date)
+        , date_fk
 )
 
 , discussion_days as (
@@ -63,7 +68,7 @@ with video_days as (
         platform
         , user_fk
         , courserun_readable_id
-        , cast(event_timestamp as date) as activity_date
+        , date_fk as activity_date_key
         , count(*) as discussion_events
     from {{ ref('tfact_discussion_events') }}
     where user_fk is not null
@@ -71,7 +76,7 @@ with video_days as (
         platform
         , user_fk
         , courserun_readable_id
-        , cast(event_timestamp as date)
+        , date_fk
 )
 
 -- Open edX chatbot events only, which all come from MITx Online's Open edX (see
@@ -83,7 +88,7 @@ with video_days as (
         'mitxonline' as platform
         , user_fk
         , courserun_readable_id
-        , cast(event_timestamp as date) as activity_date
+        , date_fk as activity_date_key
         , count(distinct concat(session_id, '|', coalesce(block_id, ''))) as chatbot_interactions
     from {{ ref('tfact_chatbot_events') }}
     where event_type = 'ol_openedx_chat.drawer.submit'
@@ -94,33 +99,33 @@ with video_days as (
         'mitxonline'
         , user_fk
         , courserun_readable_id
-        , cast(event_timestamp as date)
+        , date_fk
 )
 
 , activity as (
     select
-        platform, user_fk, courserun_readable_id, activity_date
+        platform, user_fk, courserun_readable_id, activity_date_key
         , videos_played, 0 as problems_attempted, 0 as navigation_events
         , 0 as discussion_events, 0 as chatbot_interactions
     from video_days
     union all
     select
-        platform, user_fk, courserun_readable_id, activity_date
+        platform, user_fk, courserun_readable_id, activity_date_key
         , 0, problems_attempted, 0, 0, 0
     from problem_days
     union all
     select
-        platform, user_fk, courserun_readable_id, activity_date
+        platform, user_fk, courserun_readable_id, activity_date_key
         , 0, 0, navigation_events, 0, 0
     from navigation_days
     union all
     select
-        platform, user_fk, courserun_readable_id, activity_date
+        platform, user_fk, courserun_readable_id, activity_date_key
         , 0, 0, 0, discussion_events, 0
     from discussion_days
     union all
     select
-        platform, user_fk, courserun_readable_id, activity_date
+        platform, user_fk, courserun_readable_id, activity_date_key
         , 0, 0, 0, 0, chatbot_interactions
     from chatbot_days
 )
@@ -130,7 +135,7 @@ with video_days as (
         platform
         , user_fk
         , courserun_readable_id
-        , activity_date
+        , activity_date_key
         , sum(videos_played) as videos_played
         , sum(problems_attempted) as problems_attempted
         , sum(navigation_events) as navigation_events
@@ -141,7 +146,7 @@ with video_days as (
         platform
         , user_fk
         , courserun_readable_id
-        , activity_date
+        , activity_date_key
 )
 
 , dim_course_run as (
@@ -155,13 +160,13 @@ select
         'activity_days.platform',
         'activity_days.user_fk',
         'activity_days.courserun_readable_id',
-        'activity_days.activity_date'
+        'activity_days.activity_date_key'
     ]) }} as activity_key
     , activity_days.user_fk
     , dim_course_run.courserun_pk as courserun_fk
     , activity_days.platform
     , activity_days.courserun_readable_id
-    , activity_days.activity_date
+    , activity_days.activity_date_key
     , activity_days.videos_played
     , activity_days.problems_attempted
     , activity_days.navigation_events

--- a/src/ol_dbt/models/dimensional/tfact_problem_events.sql
+++ b/src/ol_dbt/models/dimensional/tfact_problem_events.sql
@@ -268,6 +268,11 @@ with mitxonline_problem_events as (
 -- equality rather than an OR across every platform's key pair.
 -- Restricted to rows at or below the watermark so an event the source CTEs also
 -- re-select cannot arrive twice and double-insert.
+-- `users.user_pk is not null` matters: the join is a left join, so a learner who
+-- no longer resolves (removed from dim_user, or a username change that moves the
+-- join keys) would otherwise be "distinct from" the stored key and get re-inserted
+-- with a null user_fk, replacing a good key with nothing. A row can be corrected
+-- here, never nulled.
 , stale_key_mitxonline as (
     select
         stored.platform
@@ -296,6 +301,7 @@ with mitxonline_problem_events as (
     where
         stored.platform = 'mitxonline'
         and stored.event_timestamp <= watermarks.max_ts
+        and users.user_pk is not null
         and users.user_pk is distinct from stored.user_fk
 )
 
@@ -327,6 +333,7 @@ with mitxonline_problem_events as (
     where
         stored.platform = 'mitxpro'
         and stored.event_timestamp <= watermarks.max_ts
+        and users.user_pk is not null
         and users.user_pk is distinct from stored.user_fk
 )
 
@@ -358,6 +365,7 @@ with mitxonline_problem_events as (
     where
         stored.platform = 'residential'
         and stored.event_timestamp <= watermarks.max_ts
+        and users.user_pk is not null
         and users.user_pk is distinct from stored.user_fk
 )
 
@@ -389,6 +397,7 @@ with mitxonline_problem_events as (
     where
         stored.platform = 'edxorg'
         and stored.event_timestamp <= watermarks.max_ts
+        and users.user_pk is not null
         and users.user_pk is distinct from stored.user_fk
 )
 

--- a/src/ol_dbt/models/dimensional/tfact_problem_events.sql
+++ b/src/ol_dbt/models/dimensional/tfact_problem_events.sql
@@ -257,6 +257,152 @@ with mitxonline_problem_events as (
     select * from {{ ref('dim_platform') }}
 )
 
+{% if is_incremental() %}
+-- Rows already in the target whose stored user_fk no longer matches what dim_user
+-- resolves today. The watermarks above only re-select events newer than the last run,
+-- so without this a dim_user re-key strands historical activity under the obsolete
+-- key -- the same hazard tfact_grade and tfact_certificate guard against with their
+-- stale_user_fk_lookup. delete+insert on event_id replaces the row in place.
+-- One CTE per platform because the dim_user join keys differ per platform; each
+-- prunes to one partition (the model is partitioned by platform) and joins by
+-- equality rather than an OR across every platform's key pair.
+-- Restricted to rows at or below the watermark so an event the source CTEs also
+-- re-select cannot arrive twice and double-insert.
+, stale_key_mitxonline as (
+    select
+        stored.platform
+        , users.user_pk as user_fk
+        , stored.openedx_user_id
+        , stored.user_username
+        , stored.courserun_readable_id
+        , stored.event_type
+        , stored.event_json
+        , stored.problem_block_fk as problem_block_id
+        , stored.answers
+        , stored.attempt
+        , stored.success
+        , stored.grade
+        , stored.max_grade
+        , stored.event_timestamp
+        , stored.event_timestamp_iso8601
+        , stored.time_fk
+        , stored.date_fk
+    from {{ this }} as stored
+    inner join watermarks on watermarks.platform = stored.platform
+    left join users
+        on
+            stored.openedx_user_id = users.mitxonline_openedx_user_id
+            and stored.user_username = users.user_mitxonline_username
+    where
+        stored.platform = 'mitxonline'
+        and stored.event_timestamp <= watermarks.max_ts
+        and users.user_pk is distinct from stored.user_fk
+)
+
+, stale_key_mitxpro as (
+    select
+        stored.platform
+        , users.user_pk as user_fk
+        , stored.openedx_user_id
+        , stored.user_username
+        , stored.courserun_readable_id
+        , stored.event_type
+        , stored.event_json
+        , stored.problem_block_fk as problem_block_id
+        , stored.answers
+        , stored.attempt
+        , stored.success
+        , stored.grade
+        , stored.max_grade
+        , stored.event_timestamp
+        , stored.event_timestamp_iso8601
+        , stored.time_fk
+        , stored.date_fk
+    from {{ this }} as stored
+    inner join watermarks on watermarks.platform = stored.platform
+    left join users
+        on
+            stored.openedx_user_id = users.mitxpro_openedx_user_id
+            and stored.user_username = users.user_mitxpro_username
+    where
+        stored.platform = 'mitxpro'
+        and stored.event_timestamp <= watermarks.max_ts
+        and users.user_pk is distinct from stored.user_fk
+)
+
+, stale_key_residential as (
+    select
+        stored.platform
+        , users.user_pk as user_fk
+        , stored.openedx_user_id
+        , stored.user_username
+        , stored.courserun_readable_id
+        , stored.event_type
+        , stored.event_json
+        , stored.problem_block_fk as problem_block_id
+        , stored.answers
+        , stored.attempt
+        , stored.success
+        , stored.grade
+        , stored.max_grade
+        , stored.event_timestamp
+        , stored.event_timestamp_iso8601
+        , stored.time_fk
+        , stored.date_fk
+    from {{ this }} as stored
+    inner join watermarks on watermarks.platform = stored.platform
+    left join users
+        on
+            stored.openedx_user_id = users.residential_openedx_user_id
+            and stored.user_username = users.user_residential_username
+    where
+        stored.platform = 'residential'
+        and stored.event_timestamp <= watermarks.max_ts
+        and users.user_pk is distinct from stored.user_fk
+)
+
+, stale_key_edxorg as (
+    select
+        stored.platform
+        , users.user_pk as user_fk
+        , stored.openedx_user_id
+        , stored.user_username
+        , stored.courserun_readable_id
+        , stored.event_type
+        , stored.event_json
+        , stored.problem_block_fk as problem_block_id
+        , stored.answers
+        , stored.attempt
+        , stored.success
+        , stored.grade
+        , stored.max_grade
+        , stored.event_timestamp
+        , stored.event_timestamp_iso8601
+        , stored.time_fk
+        , stored.date_fk
+    from {{ this }} as stored
+    inner join watermarks on watermarks.platform = stored.platform
+    left join users
+        on
+            stored.openedx_user_id = users.edxorg_openedx_user_id
+            and stored.user_username = users.user_edxorg_username
+    where
+        stored.platform = 'edxorg'
+        and stored.event_timestamp <= watermarks.max_ts
+        and users.user_pk is distinct from stored.user_fk
+)
+
+, stale_key_rows as (
+    select * from stale_key_mitxonline
+    union all
+    select * from stale_key_mitxpro
+    union all
+    select * from stale_key_residential
+    union all
+    select * from stale_key_edxorg
+)
+{% endif %}
+
 -- Studentmodule rows pre-aggregated to one row per (platform, user, course, problem, attempt)
 -- before the union. tfact_studentmodule_problems is at per-submission grain (one row per
 -- history record); aggregating here collapses multiple submissions for the same attempt to
@@ -442,6 +588,30 @@ with mitxonline_problem_events as (
         , time_fk
         , date_fk
     from combined_studentmodule
+
+    {% if is_incremental() %}
+    union all
+
+    select
+        platform
+        , user_fk
+        , openedx_user_id
+        , user_username
+        , courserun_readable_id
+        , event_type
+        , event_json
+        , problem_block_id
+        , answers
+        , attempt
+        , success
+        , grade
+        , max_grade
+        , event_timestamp
+        , event_timestamp_iso8601
+        , time_fk
+        , date_fk
+    from stale_key_rows
+    {% endif %}
 )
 
 -- Deduplicate on (platform, user, course, problem, attempt):


### PR DESCRIPTION
### What are the relevant tickets?
N/A. Part of the learner-records API work (spec: https://github.com/mitodl/ol-analytics-api/pull/55, `docs/b2b-learner-records-design.md` §1 gap 2).

### Description (What does it do?)
Adds `afact_learner_courserun_daily_activity`: one row per (platform, `user_fk`, course run, day) with any tracked course activity, rolled up from the five event facts.

Per-learner activity exists today only in `organization_administration_report`, which groups by `dim_user.email`. That email is a coalesce across a person's accounts and moves when they edit it, so joining the report back to a learner drops or mis-attributes some. The learner-records API needs `last_active_on`, `days_active` and per-run activity counts keyed on the same `user_fk` as the enrollment, grade and certificate facts.

Columns: `videos_played`, `problems_attempted`, `navigation_events`, `discussion_events`, `chatbot_interactions`. `last_active_on` is `max(activity_date_key)` and `days_active` is `count(distinct activity_date_key)` over this table.

The day is each event's `date_fk` (int YYYYMMDD, FK to `dim_date`), emitted as `activity_date_key`. It started as `cast(event_timestamp as date)`, which Trino evaluates in each value's own offset but DuckDB evaluates in the session zone, so the same input produced different rows per engine. `date_fk` is derived from `event_timestamp_iso8601` in the source's own timezone, which is the day Trino's cast already produced.

Metric definitions follow the report, except:
- `problems_attempted` counts `problem_check` only. The report's `problems_count` also counts `showanswer`.
- Chatbot submits with no `block_id` still count. The report's `session_id || block_id` makes them null and drops them.
- Canvas chatbot events are excluded, since their course ids aren't Open edX runs.
- Certificate and enrollment days aren't activity here. The report's `active_count` counts certificates.

It's a full-rebuild table (the dimensional default), not incremental, because `user_pk` can still re-key and an incremental table would keep old days under a stale key.

**This also changes `tfact_problem_events`** (from review). It is incremental, and its watermarks only re-select events newer than the last run, so a `dim_user` re-key left historical rows under the obsolete `user_fk` — the hazard `tfact_grade` and `tfact_certificate` already guard against with a `stale_user_fk_lookup`. It now reads back rows at or below the watermark whose stored `user_fk` no longer matches what `dim_user` resolves, re-resolves the key per platform (one equi-join CTE per platform, each pruning to one partition), and unions them in; `delete+insert` on `event_id` replaces them. Rows above the watermark are excluded so an event the source CTEs re-select cannot also arrive from there and double-insert. It is meant to take effect on ordinary incremental runs, without a full refresh.

### How can this be tested?
- `ol-dbt validate`: 0 errors. Pre-commit (sqlfluff, yamlfmt, yamllint) passes. CI is green on this branch.
- **Not exercised locally or in CI:** the new `tfact_problem_events` CTEs sit inside `{% if is_incremental() %}`, and both `dbt parse` and sqlfluff render `is_incremental()` as false. That branch has not been run against a real target.
- I reconciled the model against the production `organization_administration_report` per (email, day, run) in DuckDB, over production dimensional Iceberg tables scoped to MITx Online course runs under a B2B contract. It has not been built on Trino.
  - 80,469 rows, unique on the grain and on `activity_key`. 0 null `courserun_fk`. 8,612 learners, 866 runs.
  - 80,028 (email, day, run) rows appeared in both. `videos_played` equalled the report's `videos_watched` on 79,989 of them (99.95%). Chatbot interactions were at least the report's on all 80,028.
  - 420 days appeared only in the fact, and 1,930 active days only in the report. None of the 1,930 had video or chatbot activity in the report, which fits the definition differences above (certificate days, `showanswer`-only days) or email attribution.
  - Those numbers were measured on the earlier revision, which bucketed with `cast(event_timestamp as date)` and DuckDB pinned to UTC. Rather than rebuild the fact after rebucketing onto `date_fk`, I checked the two are the same day: across all five event facts over the same B2B-scoped rows (5,420,066 rows), `date_fk` equals the calendar date at the front of `event_timestamp_iso8601` on every row, with none null. That is the date Trino's cast returns, so the rebucketing leaves production output for this population unchanged.
- Run it yourself: `dbt build --select afact_learner_courserun_daily_activity`, which runs the uniqueness and `not_null` tests with it.

### Additional Context
- Day boundaries are not UTC. Measured on production: 15.2M of `tfact_discussion_events`' 17.5M rows carry a local offset (`-04:00`/`-05:00`) rather than `Z`, and 2.9M of those fall on a different day under UTC. Bucketing on `date_fk` keeps the source-local day the existing report already uses; converting to UTC would have changed production days for those rows.
- Reading `activity_date_key` as a date: join `dim_date` rather than casting the integer.
- Wiring this into the learner-records MVs (#2669) is a follow-up. Those MVs aren't merged yet, and the fact has to exist in Glue first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017FmjwANjfgtuKAtsRPf6Ly
